### PR TITLE
fix: API should return audit result for broken backlinks also in abbreviated JSON

### DIFF
--- a/src/dto/audit.js
+++ b/src/dto/audit.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { createAudit } from '@adobe/spacecat-shared-data-access/src/models/audit.js';
+import { createAudit, AUDIT_TYPE_BROKEN_BACKLINKS } from '@adobe/spacecat-shared-data-access/src/models/audit.js';
 
 /**
  * Data transfer object for Site.
@@ -74,27 +74,33 @@ export const AuditDto = {
    * siteId: string
    * }} JSON object.
    */
-  toAbbreviatedJSON: (audit) => ({
-    auditResult: {
-      finalUrl: audit.getAuditResult()?.finalUrl,
-      runtimeError: audit.getAuditResult()?.runtimeError,
-      scores: audit.getAuditResult()?.scores,
-      totalBlockingTime: audit.getAuditResult()?.totalBlockingTime,
-    },
-    previousAuditResult: {
-      finalUrl: audit.getPreviousAuditResult()?.finalUrl,
-      runtimeError: audit.getPreviousAuditResult()?.runtimeError,
-      scores: audit.getPreviousAuditResult()?.scores,
-      totalBlockingTime: audit.getPreviousAuditResult()?.totalBlockingTime,
-      fullAuditRef: audit.getPreviousAuditResult()?.fullAuditRef,
-      auditedAt: audit.getPreviousAuditResult()?.auditedAt,
-    },
-    auditType: audit.getAuditType(),
-    auditedAt: audit.getAuditedAt(),
-    expiresAt: audit.getExpiresAt().toISOString(),
-    fullAuditRef: audit.getFullAuditRef(),
-    isLive: audit.isLive(),
-    isError: audit.isError(),
-    siteId: audit.getSiteId(),
-  }),
+  toAbbreviatedJSON: (audit) => {
+    if (audit.getAuditType() === AUDIT_TYPE_BROKEN_BACKLINKS) {
+      return AuditDto.toJSON(audit);
+    }
+    return {
+      auditResult: {
+        finalUrl: audit.getAuditResult()?.finalUrl,
+        runtimeError: audit.getAuditResult()?.runtimeError,
+        scores: audit.getAuditResult()?.scores,
+        totalBlockingTime: audit.getAuditResult()?.totalBlockingTime,
+      },
+      previousAuditResult: {
+        finalUrl: audit.getPreviousAuditResult()?.finalUrl,
+        runtimeError: audit.getPreviousAuditResult()?.runtimeError,
+        scores: audit.getPreviousAuditResult()?.scores,
+        totalBlockingTime: audit.getPreviousAuditResult()?.totalBlockingTime,
+        fullAuditRef: audit.getPreviousAuditResult()?.fullAuditRef,
+        auditedAt: audit.getPreviousAuditResult()?.auditedAt,
+      },
+      auditType: audit.getAuditType(),
+      auditedAt: audit.getAuditedAt(),
+      expiresAt: audit.getExpiresAt()
+        .toISOString(),
+      fullAuditRef: audit.getFullAuditRef(),
+      isLive: audit.isLive(),
+      isError: audit.isError(),
+      siteId: audit.getSiteId(),
+    };
+  },
 };

--- a/test/dto/audit.test.js
+++ b/test/dto/audit.test.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { createAudit } from '@adobe/spacecat-shared-data-access/src/models/audit.js';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { AuditDto } from '../../src/dto/audit.js';
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe('Audit DTO', () => {
+  it('toAbbreviatedJSON returns all broken backlinks in the JSON', () => {
+    const now = new Date();
+    const fullAuditResult = {
+      'https://www.test.com': {
+        brokenBacklinks: [
+          {
+            title: 'backlink title',
+            url_from: 'url-from',
+            url_to: 'url-to',
+          },
+          {
+            title: 'backlink title 2',
+            url_from: 'url-from-2',
+            url_to: 'url-to-2',
+          },
+        ],
+        fullAuditRef: 'full-audit-ref',
+      },
+    };
+    const fullPreviousAuditResult = {
+      'https://www.test.com': {
+        brokenBacklinks: [],
+        fullAuditRef: 'full-audit-ref',
+      },
+    };
+    const audit = createAudit({
+      auditResult: fullAuditResult,
+      previousAuditResult: fullPreviousAuditResult,
+      auditType: 'broken-backlinks',
+      auditedAt: now.toISOString(),
+      expiresAt: now,
+      fullAuditRef: 'full-audit-ref',
+      isLive: true,
+      isError: false,
+      siteId: 'site-id',
+    });
+
+    const auditJson = AuditDto.toAbbreviatedJSON(audit);
+
+    expect(auditJson).to.deep.equal({
+      auditResult: fullAuditResult,
+      previousAuditResult: fullPreviousAuditResult,
+      auditType: 'broken-backlinks',
+      auditedAt: now.toISOString(),
+      expiresAt: now.toISOString(),
+      fullAuditRef: 'full-audit-ref',
+      isLive: true,
+      isError: false,
+      siteId: 'site-id',
+    });
+  });
+});


### PR DESCRIPTION
APIs such as Retrieve all latest audits of a given type were not returning the content of the broken backlinks audit result, as it has a different format than the one existing (with scores, runtime error etc.).