### PR TITLE
chore: initial Slack channel management APIs

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -37,6 +37,8 @@ tags:
     description: Trigger operations
   - name: hooks
     description: Webhooks for receiving events
+  - name: slack
+    description: Slack channel management
 
 paths:
   /audits/latest/{auditType}:
@@ -77,6 +79,10 @@ paths:
     $ref: './audits-api.yaml#/audits-for-site'
   /sites/{siteId}/latest-audit/{auditType}:
     $ref: './audit-api.yaml#/latest-audit-for-site'
+  /slack/create:
+    $ref: './slack-api.yaml#/create'
+  /slack/invite:
+    $ref: './slack-api.yaml#/invite'
   /trigger:
     $ref: './trigger-api.yaml#/trigger'
 

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -36,6 +36,9 @@ Domain:
 ImsOrganizationId:
   type: string
   example: '1234567890ABCDEF12345678@AdobeOrg'
+EmailAddress:
+  type: string
+  example: 'user@example.com'
 SlackMentionConfig:
   type: object
   additionalProperties: true
@@ -634,3 +637,35 @@ RUMDomainDiscoveryAlert:
     domain:
       description: Domain of the page which triggered the domain discovery alert
       $ref: '#/Domain'
+SlackChannelCreateRequest:
+  type: object
+  required:
+    - imsOrgId
+    - users
+  properties:
+    imsOrgId:
+      description: The ID of the Adobe IMS organization
+      $ref: '#/ImsOrganizationId'
+    users:
+      description: Email addresses to invite to the Slack channel. Must be members of the IMS org
+      type: array
+      items:
+        $ref: '#/EmailAddress'
+    channelSuffix:
+      description: Optional. The suffix to append to the channel name, after `#aem-<tenantId>-`
+      type: string
+      example: 'new-project'
+SlackChannelInviteRequest:
+  type: object
+  required:
+    - imsOrgId
+    - users
+  properties:
+    imsOrgId:
+      description: The ID of the Adobe IMS organization
+      $ref: '#/ImsOrganizationId'
+    users:
+      description: Email addresses to invite to the Slack channel. Must be members of the IMS org
+      type: array
+      items:
+        $ref: '#/EmailAddress'

--- a/docs/openapi/slack-api.yaml
+++ b/docs/openapi/slack-api.yaml
@@ -1,0 +1,54 @@
+create:
+  post:
+    tags:
+      - slack
+    summary: Request a new Slack channel
+    description: |
+      This endpoint can be used to request the creation of a new Slack channel 
+      for the given organization. As a prerequisite, there must be an existing 
+      Spacecat organization for the given IMS org ID in order to create the channel.
+    operationId: createSlackChannel
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: './schemas.yaml#/SlackChannelCreateRequest'
+    responses:
+      '202':
+        description: Request accepted, invite(s) to follow by email if successful
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '404':
+        $ref: './responses.yaml#/404-organization-not-found-with-id'
+      '500':
+        $ref: './responses.yaml#/500'
+invite:
+  post:
+    tags:
+      - slack
+    summary: Request invitation to an existing Slack channel
+    description: |
+      This endpoint can be used to invite users to an organization's Slack 
+      channel. As a prerequisite, there must be an existing Spacecat organization
+      and Slack channel for the given IMS org ID.
+    operationId: inviteToSlackChannel
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: './schemas.yaml#/SlackChannelInviteRequest'
+    responses:
+      '202':
+        description: Request accepted, invite(s) to follow by email if successful
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '404':
+        $ref: './responses.yaml#/404-organization-not-found-with-id'
+      '500':
+        $ref: './responses.yaml#/500'


### PR DESCRIPTION
SITES-20026 - SpaceCat endpoints to support Slack channel management

There are 3 use cases that we need to support initially:

1. The customer's project collaboration channel is missing; enable the user to create one (`POST /slack/create`)
2. A collab channel is present, but the user wants to request another one for a specific use case / project (`POST /slack/create` with additional metadata to request a specific channel name)
3. A collab channel is present, but the user is not a member of it (request an invitation) `POST /slack/invite`

For use cases 1 & 2 above, the endpoint will be the same but the presence of an optional property in the request body can be provided to customize the channel name suffix, up to an 80 character Slack limit. 