### PR TITLE
fix: configure /event/fulfillment as one of the ADMIN_ENDPOINTS

### DIFF
--- a/docs/openapi/event-api.yaml
+++ b/docs/openapi/event-api.yaml
@@ -30,4 +30,4 @@ process-fulfillment-events:
       '500':
         $ref: './responses.yaml#/500'
     security:
-      - api_key: [ ]
+      - admin_key: [ ]

--- a/src/support/auth.js
+++ b/src/support/auth.js
@@ -21,6 +21,7 @@ const ANONYMOUS_ENDPOINTS = [
 const ADMIN_ENDPOINTS = [
   'GET /trigger',
   'POST /sites',
+  'POST /event/fulfillment',
 ];
 
 /*

--- a/test/support/auth.test.js
+++ b/test/support/auth.test.js
@@ -169,4 +169,28 @@ describe('auth', () => {
     expect(await resp.text()).to.equal('Server configuration error');
     expect(resp.status).to.equal(500);
   });
+
+  it('checks that an admin endpoint CANNOT be reached with the user API key', async () => {
+    context.pathInfo.suffix = '/event/fulfillment';
+    const resp = await action(new Request('https://space.cat/', {
+      headers: {
+        'x-api-key': context.env.USER_API_KEY,
+      },
+      method: 'POST',
+    }), context);
+
+    expect(resp.status).to.equal(401);
+  });
+
+  it('checks that an admin endpoint can be reached with the admin API key', async () => {
+    context.pathInfo.suffix = '/event/fulfillment';
+    const resp = await action(new Request('https://space.cat/', {
+      headers: {
+        'x-api-key': context.env.ADMIN_API_KEY,
+      },
+      method: 'POST',
+    }), context);
+
+    expect(resp).to.equal(42);
+  });
 });


### PR DESCRIPTION
Ticket: SITES-20314 - Configure /event/fulfillment endpoint as one of the ADMIN_ENDPOINTS

Prevent user level access to the Fulfillment Handler endpoint.