### PR TITLE
feat: Endpoint to request an invite to an organization's Slack channel by user ID - API spec update

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -85,8 +85,8 @@ paths:
     $ref: './audits-api.yaml#/audits-for-site'
   /sites/{siteId}/latest-audit/{auditType}:
     $ref: './audit-api.yaml#/latest-audit-for-site'
-  /slack/channels/invite-by-email:
-    $ref: './slack-api.yaml#/invite-by-email'
+  /slack/channels/invite-by-user-id:
+    $ref: './slack-api.yaml#/invite-by-user-id'
   /trigger:
     $ref: './trigger-api.yaml#/trigger'
 

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -37,6 +37,9 @@ Domain:
 ImsOrganizationId:
   type: string
   example: '1234567890ABCDEF12345678@AdobeOrg'
+ImsUserAccessToken:
+  type: string
+  example: 'eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjEyMzQ1IiwidHlwZSI6ImFjY2Vzc190b2tlbiIsImNsaWVudF9pZCI6ImV4YW1wbGVfYXBwIiwidXNlcl9pZCI6Ijk4NzY1NDc4OTBBQkNERUYxMjM0NTY3OEBhYmNkZWYxMjM0NTY3ODkuZSIsImFzIjoiaW1zLW5hMSIsImFhX2lkIjoiMTIzNDU2Nzg5MEFCQ0RFRjEyMzQ1Njc4QGFkb2JlLmNvbSIsImNyZWF0ZWRfYXQiOiIxNzEwMjQ3MDAwMDAwIn0.MRDpxgxSHDj4DmA182hPnjMAnKkly-VUJ_bXpQ-J8EQ'
 EmailAddress:
   type: string
   format: email
@@ -639,20 +642,18 @@ RUMDomainDiscoveryAlert:
     domain:
       description: Domain of the page which triggered the domain discovery alert
       $ref: '#/Domain'
-SlackInviteToChannelByEmailRequest:
+SlackInviteToChannelByUserIdRequest:
   type: object
   required:
     - imsOrgId
-    - emails
+    - imsUserAccessToken
   properties:
     imsOrgId:
       description: The ID of the Adobe IMS organization
       $ref: '#/ImsOrganizationId'
-    emails:
-      description: Email addresses to invite to the Slack channel. Must be members of the IMS org
-      type: array
-      items:
-        $ref: '#/EmailAddress'
+    imsUserAccessToken:
+      description: The IMS access token of the user to invite to the Slack channel
+      $ref: '#/ImsUserAccessToken'
 Configuration:
   type: object
   properties:

--- a/docs/openapi/slack-api.yaml
+++ b/docs/openapi/slack-api.yaml
@@ -1,4 +1,4 @@
-invite-by-email:
+invite-by-user-id:
   post:
     tags:
       - slack
@@ -6,10 +6,11 @@ invite-by-email:
     description: |
       Not implemented yet.
       
-      This endpoint can be used to invite users to an organization's Slack 
-      channel by email address. As a prerequisite, there must be an existing
-      Spacecat organization and Slack channel for the given IMS org ID.
-    operationId: inviteToSlackChannelByEmail
+      This endpoint can be used to invite a user to their organization's Slack 
+      channel by IMS user ID, which is read from the IMS user token. As a 
+      prerequisite, there must be an existing Spacecat organization and Slack 
+      channel for the given IMS org ID.
+    operationId: inviteToSlackChannelByUserId
     security:
       - admin_key: [ ]
     requestBody:
@@ -17,7 +18,7 @@ invite-by-email:
       content:
         application/json:
           schema:
-            $ref: './schemas.yaml#/SlackInviteToChannelByEmailRequest'
+            $ref: './schemas.yaml#/SlackInviteToChannelByUserIdRequest'
     responses:
       '202':
         description: Request accepted, invite(s) to follow by email if successful


### PR DESCRIPTION
Spec update for #207 

Update the API spec to replace `email` based invitation mechanism with one based upon IMS user ID, as read from the IMS user token.