### PR TITLE
feat: filter friends and family organization from get all sites command

### DIFF
--- a/src/support/slack/commands/get-sites.js
+++ b/src/support/slack/commands/get-sites.js
@@ -87,6 +87,11 @@ function GetSitesCommand(context) {
   async function fetchAndFormatSites(threadTs, filterStatus, psiStrategy, deliveryType) {
     let sites = await dataAccess.getSitesWithLatestAudit(`lhs-${psiStrategy}`, true, deliveryType);
 
+    // filter sites from friends and family org
+    sites = sites.filter(
+      (site) => site.getOrganizationId() !== process.env.ORGANIZATION_ID_FRIENDS_FAMILY,
+    );
+
     if (filterStatus !== 'all') {
       sites = sites.filter((site) => (filterStatus === 'live' ? site.isLive() : !site.isLive()));
     }

--- a/src/support/slack/commands/get-sites.js
+++ b/src/support/slack/commands/get-sites.js
@@ -89,7 +89,7 @@ function GetSitesCommand(context) {
 
     // filter sites from friends and family org
     sites = sites.filter(
-      (site) => site.getOrganizationId() !== process.env.ORGANIZATION_ID_FRIENDS_FAMILY,
+      (site) => site.getOrganizationId() !== context.env.ORGANIZATION_ID_FRIENDS_FAMILY,
     );
 
     if (filterStatus !== 'all') {

--- a/test/support/slack/commands/get-sites.test.js
+++ b/test/support/slack/commands/get-sites.test.js
@@ -84,7 +84,9 @@ describe('GetSitesCommand', () => {
       info: sinon.stub(),
     };
 
-    context = { dataAccess: dataAccessStub, boltApp: boltAppStub, log: logStub };
+    context = {
+      dataAccess: dataAccessStub, boltApp: boltAppStub, log: logStub, env: { ORGANIZATION_ID_FRIENDS_FAMILY: 'F&F' },
+    };
     slackContext = {
       say: sinon.spy(),
       client: {


### PR DESCRIPTION
Sites from the Friends and Family organization are no longer audited and are not relevant for customer queries. Therefore, we will exclude them from the "get all sites" command list using a filter.