### PR TITLE
fix: docs linting, openapi version upgrade and multiple examples support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
           name: Lint
           command: npm run lint
       - run:
+          name: Docs Lint
+          command: npm run docs:lint
+      - run:
           name: Getting Code Coverage
           command: npm run test
       - codecov/upload

--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   version:
     $ref: '../../package.json#/version'

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -804,11 +804,11 @@ AnalyticsSiteIntegration:
           additionalProperties:
             type: string
   examples:
-    analytics-site-integration-aa-tags:
-      $ref: './examples.yaml#/analytics-site-integration-aa-tags'
-    analytics-site-integration-aa-aep-websdk:
-      $ref: './examples.yaml#/analytics-site-integration-aa-aep-websdk'
-    analytics-site-integration-cja-tags:
-      $ref: './examples.yaml#/analytics-site-integration-cja-tags'
-    analytics-site-integration-cja-websdk:
-      $ref: './examples.yaml#/analytics-site-integration-cja-websdk'
+    - analytics-site-integration-aa-tags:
+        $ref: './examples.yaml#/analytics-site-integration-aa-tags'
+    - analytics-site-integration-aa-aep-websdk:
+        $ref: './examples.yaml#/analytics-site-integration-aa-aep-websdk'
+    - analytics-site-integration-cja-tags:
+        $ref: './examples.yaml#/analytics-site-integration-cja-tags'
+    - analytics-site-integration-cja-websdk:
+        $ref: './examples.yaml#/analytics-site-integration-cja-websdk'


### PR DESCRIPTION
Upgrades openapi to version 3.1.0
Fixes multiple examples use
Add docs linting to PR checks

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

## Related Issues

Fixes: https://github.com/adobe/spacecat-api-service/issues/263