### PR TITLE
fix: Use of .id instead of .getId() results in undefined in logs #256

### DIFF
--- a/src/controllers/slack.js
+++ b/src/controllers/slack.js
@@ -181,7 +181,7 @@ function SlackController(SlackApp) {
       return notFound('Slack channel not found for this organization.');
     }
 
-    log.info(`Inviting userId: ${userProfile.userId} to the Slack channel for IMS org ID: ${imsOrgId} (organizationId ${spaceCatOrg.id}).`);
+    log.info(`Inviting userId: ${userProfile.userId} to the Slack channel for IMS org ID: ${imsOrgId} (organizationId ${spaceCatOrg.getId()}).`);
 
     try {
       await elevatedClient.inviteUsersByEmail(orgSlackChannelId, [userProfile]);


### PR DESCRIPTION
## Related Issue
#256 - Use of .id instead of .getId() results in undefined in logs

