### PR TITLE
feat: trigger top pages import when adding a site (draft)

### DIFF
--- a/src/support/slack/commands/add-site.js
+++ b/src/support/slack/commands/add-site.js
@@ -16,7 +16,7 @@ import {
   postErrorMessage,
 } from '../../../utils/slack/base.js';
 
-import { findDeliveryType, triggerAuditForSite } from '../../utils.js';
+import { findDeliveryType, triggerAuditForSite, triggerImportForSite } from '../../utils.js';
 
 import BaseCommand from './base.js';
 
@@ -98,6 +98,13 @@ function AddSiteCommand(context) {
       }
 
       await say(message);
+
+      if (newSite.isLive() && newSite.getDeliveryType() === DELIVERY_TYPES.AEM_EDGE) {
+        await triggerImportForSite(newSite, 'top-pages', slackContext, context);
+        message = 'First top pages import is triggered! :adobe-run:\'\n';
+        message += `In a minute, you can run _@spacecat get site ${baseURL} top pages_`;
+        await say(message);
+      }
     } catch (error) {
       log.error(error);
       await postErrorMessage(say, error);

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -49,6 +49,14 @@ export const sendAuditMessage = async (
   siteId,
 ) => sqs.sendMessage(queueUrl, { type, url: siteId, auditContext });
 
+export const sendImportMessage = async (
+  sqs,
+  queueUrl,
+  type,
+  importContext,
+  siteId,
+) => sqs.sendMessage(queueUrl, { type, siteId, importContext });
+
 /**
  * Sends audit messages for each URL.
  *
@@ -90,6 +98,24 @@ export const triggerAuditForSite = async (
   lambdaContext.sqs,
   lambdaContext.env.AUDIT_JOBS_QUEUE_URL,
   auditType,
+  {
+    slackContext: {
+      channelId: slackContext.channelId,
+      threadTs: slackContext.threadTs,
+    },
+  },
+  site.getId(),
+);
+
+export const triggerImportForSite = async (
+  site,
+  importType,
+  slackContext,
+  lambdaContext,
+) => sendImportMessage(
+  lambdaContext.sqs,
+  lambdaContext.env.IMPORT_JOBS_QUEUE_URL,
+  importType,
   {
     slackContext: {
       channelId: slackContext.channelId,


### PR DESCRIPTION
Trigger the import of top pages implemented via SITES-21274, when adding a site via slack or when calling a specific slack command.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

## Related Issues


Thanks for contributing!
