### PR TITLE
fix: message format for exp candidates

### DIFF
--- a/src/support/slack/commands/get-exp-candidates.js
+++ b/src/support/slack/commands/get-exp-candidates.js
@@ -62,7 +62,7 @@ function GetExperimentationCandidatesCommand(context) {
 
       await triggerExperimentationCandidates(url, slackContext, context);
 
-      let message = `:white_check_mark: Scraping and determining experimentation candidates for ${url}\n`;
+      let message = `:white_check_mark: Scraping and determining desktop experimentation candidates for ${url}\n`;
       message += ':adobe-run: Stand by for results. I will post them here when they are ready.';
 
       await say(message);

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -57,7 +57,7 @@ export const sendExperimentationCandidatesMessage = async (
   url,
   slackContext,
 ) => sqs.sendMessage(queueUrl, {
-  processingType: 'experimentation-candidates',
+  processingType: 'experimentation-candidates-desktop',
   urls: [{ url }],
   slackContext,
 });

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -58,7 +58,7 @@ export const sendExperimentationCandidatesMessage = async (
   slackContext,
 ) => sqs.sendMessage(queueUrl, {
   processingType: 'experimentation-candidates',
-  url,
+  urls: [{ url }],
   slackContext,
 });
 /* c8 ignore end */


### PR DESCRIPTION
Adjust to the new message format expected by the content scraper.