### PR TITLE
fix: undefined import status route hander

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -108,7 +108,7 @@ export default function getRouteHandlers(
     'POST /slack/channels/invite-by-user-id': slackController.inviteUserToChannel,
     'GET /trigger': triggerHandler,
     'POST /tools/import': importController.createImportJob,
-    'GET /tools/import/:jobId': importController.getJobStatus,
+    'GET /tools/import/:jobId': importController.getImportJobStatus,
     'GET /tools/import/:jobId/import-result.zip': importController.getImportJobResult,
   };
 


### PR DESCRIPTION
Currently, checking the status of an import job results in the following error: `handler is not a function`

<img width="526" alt="Screenshot 2024-06-11 at 9 57 53 AM" src="https://github.com/adobe/spacecat-api-service/assets/1048207/0722bd4d-bea2-4489-aba5-ca208bdecc8f">

This is due to using an outdated function name in `src/routes/index.js`.

With this change deployed on dev, and a small update to the underlying table, we are able to both query the job status as well as generate a link to download the import-result.zip archive from S3:

<img width="917" alt="Screenshot 2024-06-11 at 1 25 47 PM" src="https://github.com/adobe/spacecat-api-service/assets/1048207/fd18bf6f-f6b3-4566-98ac-6a15dd7bcf75">

<img width="1106" alt="Screenshot 2024-06-11 at 1 26 11 PM" src="https://github.com/adobe/spacecat-api-service/assets/1048207/aa46a826-e303-47af-af9e-b6cdeb042c29">

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```