### PR TITLE
fix: Remove API key from import job status response

### DIFF
--- a/src/dto/import-job.js
+++ b/src/dto/import-job.js
@@ -20,7 +20,6 @@ export const ImportJobDto = {
   toJSON: (importJob) => ({
     id: importJob.getId(),
     baseURL: importJob.getBaseURL(),
-    apiKey: importJob.getApiKey(),
     options: importJob.getOptions(),
     startTime: importJob.getStartTime(),
     endTime: importJob.getEndTime(),

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -276,7 +276,7 @@ describe('ImportController tests', () => {
       expect(response.status).to.equal(200);
       const jobStatus = await response.json();
       expect(jobStatus.id).to.equal('f91afda0-afc8-467e-bfa3-fdbeba3037e8');
-      expect(jobStatus.apiKey).to.equal('b9ebcfb5-80c9-4236-91ba-d50e361db71d');
+      expect(jobStatus.apiKey).to.be.undefined;
       expect(jobStatus.baseURL).to.equal('https://www.example.com');
       expect(jobStatus.importQueueId).to.equal('spacecat-import-queue-1');
       expect(jobStatus.status).to.equal('RUNNING');


### PR DESCRIPTION
## Related Issues

fixes #347 

Updated response example:

<img width="924" alt="Screenshot 2024-06-11 at 1 53 41 PM" src="https://github.com/adobe/spacecat-api-service/assets/1048207/b37dcca6-6ffd-438f-af7a-11b197c1d421">

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```