### PR TITLE
feat: add run import slack command

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -17,6 +17,7 @@ import getSite from './commands/get-site.js';
 import getSites from './commands/get-sites.js';
 import martechImpact from './commands/martech-impact.js';
 import runAudit from './commands/run-audit.js';
+import runImport from './commands/run-import.js';
 import setLiveStatus from './commands/set-live-status.js';
 import help from './commands/help.js';
 
@@ -34,6 +35,7 @@ export default (context) => [
   getSites(context),
   martechImpact(context),
   runAudit(context),
+  runImport(context),
   setLiveStatus(context),
   help(context),
 ];

--- a/src/support/slack/commands/run-import.js
+++ b/src/support/slack/commands/run-import.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// todo: prototype - untested
+/* c8 ignore start */
+
+import { hasText } from '@adobe/spacecat-shared-utils';
+
+import BaseCommand from './base.js';
+
+import { postErrorMessage } from '../../../utils/slack/base.js';
+
+const PHRASES = ['run import'];
+
+/**
+ * Factory function to create the RunImportCommand object.
+ *
+ * @param {Object} context - The context object.
+ * @returns {RunImportCommand} The RunImportCommand object.
+ * @constructor
+ */
+function RunImportCommand(context) {
+  const baseCommand = BaseCommand({
+    id: 'run-import',
+    name: 'Run Import',
+    description: 'Runs the specified import.',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {importType}`,
+  });
+
+  const { log } = context;
+
+  /**
+   * Validates input and triggers the experimentation candidates for the given URL.
+   *
+   * @param {string[]} args - The arguments provided to the command ([site]).
+   * @param {Object} slackContext - The Slack context object.
+   * @param {Function} slackContext.say - The Slack say function.
+   * @returns {Promise} A promise that resolves when the operation is complete.
+   */
+  const handleExecution = async (args, slackContext) => {
+    const { say } = slackContext;
+
+    try {
+      const [importType] = args;
+
+      if (!hasText(importType)) {
+        await say(':warning: Please provide a valid import type.');
+        return;
+      }
+
+      // await triggerImportRun(importType, slackContext, context);
+
+      let message = `:adobe-run: Triggered import run of type ${importType}\n`;
+      message += 'Stand by for results. I will post them here when they are ready.';
+
+      await say(message);
+    } catch (error) {
+      log.error(error);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+}
+
+export default RunImportCommand;
+/* c8 ignore end */

--- a/src/support/slack/commands/run-import.js
+++ b/src/support/slack/commands/run-import.js
@@ -13,7 +13,7 @@
 // todo: prototype - untested
 /* c8 ignore start */
 
-import { hasText, isIsoDate, isObject } from '@adobe/spacecat-shared-utils';
+import { hasText, isObject } from '@adobe/spacecat-shared-utils';
 
 import BaseCommand from './base.js';
 import { triggerImportRun } from '../../utils.js';
@@ -36,8 +36,7 @@ function RunImportCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-import',
     name: 'Run Import',
-    description: 'Runs the specified import type for the site identified with its id, and optionally for a date range specified by'
-      + ' ISO date strings in Zulu (UTC) timezone',
+    description: 'Runs the specified import type for the site identified with its id, and optionally for a date range',
     phrases: PHRASES,
     usageText: `${PHRASES[0]} {importType} {baseURL} {startDate} {endDate}`,
   });
@@ -60,16 +59,6 @@ function RunImportCommand(context) {
       const baseURL = extractURLFromSlackInput(baseURLInput);
 
       if (!hasText(importType) || !hasText(baseURL)) {
-        await say(baseCommand.usage());
-        return;
-      }
-
-      if (startDate && !isIsoDate(startDate)) {
-        await say(baseCommand.usage());
-        return;
-      }
-
-      if (endDate && !isIsoDate(endDate)) {
         await say(baseCommand.usage());
         return;
       }

--- a/src/support/slack/commands/run-import.js
+++ b/src/support/slack/commands/run-import.js
@@ -25,6 +25,27 @@ import {
 
 const PHRASES = ['run import'];
 
+function isValidDateInterval(startDate, endDate) {
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRegex.test(startDate)) {
+    return false;
+  }
+  if (!dateRegex.test(endDate)) {
+    return false;
+  }
+  const parsedStartDate = new Date(startDate);
+  if (Number.isNaN(parsedStartDate.getTime())) {
+    return false;
+  }
+  const parsedEndDate = new Date(endDate);
+  if (Number.isNaN(parsedEndDate.getTime())) {
+    return false;
+  }
+
+  return parsedStartDate < parsedEndDate
+    && (parsedEndDate - parsedStartDate) <= 1000 * 60 * 60 * 24 * 365 * 2; // 2 years
+}
+
 /**
  * Factory function to create the RunImportCommand object.
  *
@@ -60,6 +81,13 @@ function RunImportCommand(context) {
 
       if (!hasText(importType) || !hasText(baseURL)) {
         await say(baseCommand.usage());
+        return;
+      }
+
+      if ((startDate || endDate) && !isValidDateInterval(startDate, endDate)) {
+        await say(':error: Invalid date interval. '
+        + 'Please provide valid dates in the format YYYY-MM-DD. '
+        + 'The end date must be after the start date and within a two-year range.');
         return;
       }
 

--- a/src/support/slack/commands/run-import.js
+++ b/src/support/slack/commands/run-import.js
@@ -32,12 +32,12 @@ function RunImportCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-import',
     name: 'Run Import',
-    description: 'Runs the specified import.',
+    description: 'Runs the specified import type for the site identified with its id.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {importType}`,
+    usageText: `${PHRASES[0]} {importType} {siteId}`,
   });
 
-  const { log } = context;
+  const { dataAccess, log } = context;
 
   /**
    * Validates input and triggers the experimentation candidates for the given URL.
@@ -51,17 +51,25 @@ function RunImportCommand(context) {
     const { say } = slackContext;
 
     try {
-      const [importType] = args;
+      const [importType, siteId] = args;
 
       if (!hasText(importType)) {
         await say(':warning: Please provide a valid import type.');
         return;
       }
 
-      // await triggerImportRun(importType, slackContext, context);
+      if (!hasText(siteId)) {
+        await say(':warning: Please provide a valid import type.');
+        return;
+      }
 
-      let message = `:adobe-run: Triggered import run of type ${importType}\n`;
-      message += 'Stand by for results. I will post them here when they are ready.';
+      const config = await dataAccess.getConfiguration();
+      const queueName = config.getQueues().imports;
+
+      // await triggerImportRun(config, importType, slackContext, context);
+
+      let message = `:adobe-run: Triggered import run of type ${importType} for site ${siteId}\n`;
+      message += `Stand by for results. I will post them here when they are ready. (${queueName})`;
 
       await say(message);
     } catch (error) {

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -63,6 +63,21 @@ export const sendExperimentationCandidatesMessage = async (
 });
 /* c8 ignore end */
 
+// todo: prototype - untested
+/* c8 ignore start */
+export const sendRunImportMessage = async (
+  sqs,
+  queueUrl,
+  importType,
+  siteId,
+  slackContext,
+) => sqs.sendMessage(queueUrl, {
+  type: importType,
+  siteId,
+  slackContext,
+});
+/* c8 ignore end */
+
 /**
  * Sends audit messages for each URL.
  *
@@ -123,6 +138,25 @@ export const triggerExperimentationCandidates = async (
   lambdaContext.sqs,
   lambdaContext.env.SCRAPING_JOBS_QUEUE_URL,
   url,
+  {
+    channelId: slackContext.channelId,
+    threadTs: slackContext.threadTs,
+  },
+);
+/* c8 ignore end */
+
+// todo: prototype - untested
+/* c8 ignore start */
+export const triggerImportRun = async (
+  importType,
+  siteId,
+  slackContext,
+  lambdaContext,
+) => sendRunImportMessage(
+  lambdaContext.sqs,
+  lambdaContext.env.IMPORT_JOBS_QUEUE_URL,
+  importType,
+  siteId,
   {
     channelId: slackContext.channelId,
     threadTs: slackContext.threadTs,

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -70,10 +70,14 @@ export const sendRunImportMessage = async (
   queueUrl,
   importType,
   siteId,
+  startDate,
+  endDate,
   slackContext,
 ) => sqs.sendMessage(queueUrl, {
   type: importType,
   siteId,
+  startDate,
+  endDate,
   slackContext,
 });
 /* c8 ignore end */

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -151,6 +151,8 @@ export const triggerImportRun = async (
   config,
   importType,
   siteId,
+  startDate,
+  endDate,
   slackContext,
   lambdaContext,
 ) => sendRunImportMessage(
@@ -158,6 +160,8 @@ export const triggerImportRun = async (
   config.getQueues().imports,
   importType,
   siteId,
+  startDate,
+  endDate,
   {
     channelId: slackContext.channelId,
     threadTs: slackContext.threadTs,

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -148,13 +148,14 @@ export const triggerExperimentationCandidates = async (
 // todo: prototype - untested
 /* c8 ignore start */
 export const triggerImportRun = async (
+  config,
   importType,
   siteId,
   slackContext,
   lambdaContext,
 ) => sendRunImportMessage(
   lambdaContext.sqs,
-  lambdaContext.env.IMPORT_JOBS_QUEUE_URL,
+  config.getQueues().imports,
   importType,
   siteId,
   {


### PR DESCRIPTION
Add a temporary / prototype `run import` slack command to allow folks to run an import outside of a schedule and without needing access to AWS.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Iulia Grumaz"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```