### PR TITLE
fix: Include x-import-api-key header in Access-Control-Allow-Headers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ async function run(request, context) {
   if (method === 'OPTIONS') {
     return noContent({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,7 +126,7 @@ describe('Index Tests', () => {
     expect(resp.status).to.equal(204);
     expect(resp.headers.plain()).to.eql({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
       'content-type': 'application/json; charset=utf-8',


### PR DESCRIPTION
Enables browser preflight, which currently is blocked: "Request header field x-import-api-key is not allowed by Access-Control-Allow-Headers in preflight response."