### PR TITLE
feat: Enforce a maximum number of URLs that can be imported per job

### DIFF
--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -66,7 +66,7 @@ function ImportController(context) {
     }
 
     if (data.urls.length > maxUrlsPerJob) {
-      throw new ErrorWithStatusCode(`Invalid request: number of URLs provided exceeds the maximum allowed (${maxUrlsPerJob})`, STATUS_BAD_REQUEST);
+      throw new ErrorWithStatusCode(`Invalid request: number of URLs provided (${data.urls.length}) exceeds the maximum allowed (${maxUrlsPerJob})`, STATUS_BAD_REQUEST);
     }
 
     data.urls.forEach((url) => {

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -50,7 +50,7 @@ function ImportController(context) {
   }
 
   const importSupervisor = new ImportSupervisor(services, importConfiguration);
-  const { allowedApiKeys = [] } = importConfiguration;
+  const { allowedApiKeys = [], maxUrlsPerJob = 1 } = importConfiguration;
 
   const HEADER_ERROR = 'x-error';
   const STATUS_BAD_REQUEST = 400;
@@ -63,6 +63,10 @@ function ImportController(context) {
 
     if (!Array.isArray(data.urls) || !data.urls.length > 0) {
       throw new ErrorWithStatusCode('Invalid request: urls must be provided as a non-empty array', STATUS_BAD_REQUEST);
+    }
+
+    if (data.urls.length > maxUrlsPerJob) {
+      throw new ErrorWithStatusCode(`Invalid request: number of URLs provided exceeds the maximum allowed (${maxUrlsPerJob})`, STATUS_BAD_REQUEST);
     }
 
     data.urls.forEach((url) => {

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -101,6 +101,7 @@ describe('ImportController tests', () => {
         saveAsDocs: true,
         transformationFileUrl: 'https://example.com/transform.js',
       },
+      maxUrlsPerJob: 3,
     };
 
     context = {
@@ -311,6 +312,32 @@ describe('ImportController tests', () => {
         saveAsDocs: true,
         transformationFileUrl: 'https://example.com/transform.js',
       });
+    });
+
+    it('should fail when the number of URLs exceeds the maximum allowed', async () => {
+      requestContext.data.urls = [
+        'https://example.com/page1',
+        'https://example.com/page2',
+        'https://example.com/page3',
+        'https://example.com/page4',
+      ];
+      const response = await importController.createImportJob(requestContext);
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('x-error')).to.equal('Invalid request: number of URLs provided exceeds the maximum allowed (3)');
+    });
+
+    it('should fail when the number of URLs exceeds the (default) maximum allowed', async () => {
+      delete importConfiguration.maxUrlsPerJob; // Should fall back to 1
+      context.env.IMPORT_CONFIGURATION = JSON.stringify(importConfiguration);
+      importController = ImportController(context);
+
+      requestContext.data.urls = [
+        'https://example.com/page1',
+        'https://example.com/page2',
+      ];
+      const response = await importController.createImportJob(requestContext);
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('x-error')).to.equal('Invalid request: number of URLs provided exceeds the maximum allowed (1)');
     });
   });
 

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -323,7 +323,7 @@ describe('ImportController tests', () => {
       ];
       const response = await importController.createImportJob(requestContext);
       expect(response.status).to.equal(400);
-      expect(response.headers.get('x-error')).to.equal('Invalid request: number of URLs provided exceeds the maximum allowed (3)');
+      expect(response.headers.get('x-error')).to.equal('Invalid request: number of URLs provided (4) exceeds the maximum allowed (3)');
     });
 
     it('should fail when the number of URLs exceeds the (default) maximum allowed', async () => {
@@ -337,7 +337,7 @@ describe('ImportController tests', () => {
       ];
       const response = await importController.createImportJob(requestContext);
       expect(response.status).to.equal(400);
-      expect(response.headers.get('x-error')).to.equal('Invalid request: number of URLs provided exceeds the maximum allowed (1)');
+      expect(response.headers.get('x-error')).to.equal('Invalid request: number of URLs provided (2) exceeds the maximum allowed (1)');
     });
   });
 


### PR DESCRIPTION
Add a new property to the `IMPORT_CONFIGURATION` env to support limiting imports to a maximum number of URLs per job.

## Related Issues

- https://jira.corp.adobe.com/browse/SITES-23365
