### PR TITLE
feat: add api-key metadata as part of import-job status

### DIFF
--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -138,14 +138,7 @@ function ImportController(context) {
 
     try {
       validateImportApiKey(importApiKey);
-      let job = await importSupervisor.getImportJob(jobId, importApiKey);
-      // TODO: Modify importApiKey to hashedApiKey
-      const metadata = await importSupervisor.getApiKeyMetadata(importApiKey);
-      if (!metadata) {
-        log.error(`Could not retrieve metadata for the import jobId: ${jobId}`);
-      } else {
-        job = { ...job, metadata };
-      }
+      const job = await importSupervisor.getImportJob(jobId, importApiKey);
       return ok(ImportJobDto.toJSON(job));
     } catch (error) {
       log.error(`Failed to fetch import job status for jobId: ${jobId}, message: ${error.message}`);

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -139,7 +139,7 @@ function ImportController(context) {
     try {
       validateImportApiKey(importApiKey);
       let job = await importSupervisor.getImportJob(jobId, importApiKey);
-      // TODO: Modify importApiKey to hashedKey
+      // TODO: Modify importApiKey to hashedApiKey
       const metadata = await importSupervisor.getApiKeyMetadata(importApiKey);
       if (!metadata) {
         log.error(`Could not retrieve metadata for the import jobId: ${jobId}`);

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -138,7 +138,14 @@ function ImportController(context) {
 
     try {
       validateImportApiKey(importApiKey);
-      const job = await importSupervisor.getImportJob(jobId, importApiKey);
+      let job = await importSupervisor.getImportJob(jobId, importApiKey);
+      // TODO: Modify importApiKey to hashedKey
+      const metadata = await importSupervisor.getApiKeyMetadata(importApiKey);
+      if (!metadata) {
+        log.error(`Could not retrieve metadata for the import jobId: ${jobId}`);
+      } else {
+        job = { ...job, metadata };
+      }
       return ok(ImportJobDto.toJSON(job));
     } catch (error) {
       log.error(`Failed to fetch import job status for jobId: ${jobId}, message: ${error.message}`);

--- a/src/dto/import-job.js
+++ b/src/dto/import-job.js
@@ -29,5 +29,6 @@ export const ImportJobDto = {
     successCount: importJob.getSuccessCount(),
     failedCount: importJob.getFailedCount(),
     importQueueId: importJob.getImportQueueId(),
+    metadata: importJob.metadata,
   }),
 };

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -235,6 +235,23 @@ function ImportSupervisor(services, config) {
   }
 
   /**
+   * Gets the Api Key metadata based on the hashed key.
+   * @param hashedKey
+   * @return {Promise<null|{name: *, imsUserId: *, imsOrgId: *}>}
+   */
+  async function getApiKeyMetadata(hashedKey) {
+    const metadata = await dataAccess.getApiKeyByHashedKey(hashedKey);
+    if (metadata) {
+      return {
+        imsOrgId: metadata.imsOrgId,
+        name: metadata.name,
+        imsUserId: metadata.imsUserId,
+      };
+    }
+    return null;
+  }
+
+  /**
    * For COMPLETE jobs, get a pre-signed URL for the import archive file stored in S3.
    * @param {ImportJob} job - The import job.
    * @returns {Promise<string>}
@@ -259,6 +276,7 @@ function ImportSupervisor(services, config) {
     startNewJob,
     getImportJob,
     getJobArchiveSignedUrl,
+    getApiKeyMetadata,
   };
 }
 

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -239,8 +239,8 @@ function ImportSupervisor(services, config) {
    * @param hashedKey
    * @return {Promise<null|{name: *, imsUserId: *, imsOrgId: *}>}
    */
-  async function getApiKeyMetadata(hashedKey) {
-    const metadata = await dataAccess.getApiKeyByHashedKey(hashedKey);
+  async function getApiKeyMetadata(hashedApiKey) {
+    const metadata = await dataAccess.getApiKeyByHashedKey(hashedApiKey);
     if (metadata) {
       return {
         imsOrgId: metadata.imsOrgId,

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -249,14 +249,9 @@ function ImportSupervisor(services, config) {
       throw new ErrorWithStatusCode('Not found', 404);
     }
 
-    const metadata = await getApiKeyMetadata(importApiKey);
-    if (!metadata) {
-      throw new ErrorWithStatusCode('Server error', 500);
-    }
+    const apiKeyMetadata = await getApiKeyMetadata(importApiKey);
 
-    job = { ...job, metadata };
-
-    return job;
+    return { ...job, metadata: apiKeyMetadata || {} };
   }
 
   /**

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -71,6 +71,7 @@ describe('ImportController tests', () => {
       createNewImportJob: (data) => createImportJob(data),
       createNewImportUrl: (data) => createImportUrl(data),
       getImportJobByID: sandbox.stub(),
+      getApiKeyByHashedKey: sandbox.stub(),
     };
 
     mockDataAccess.getImportJobByID.callsFake(async (jobId) => {
@@ -371,6 +372,8 @@ describe('ImportController tests', () => {
 
     it('should return job details for a valid jobId', async () => {
       requestContext.params.jobId = exampleJob.id;
+      mockDataAccess.getApiKeyByHashedKey.resolves(null);
+
       const response = await importController.getImportJobStatus(requestContext);
       expect(response).to.be.an.instanceOf(Response);
       expect(response.status).to.equal(200);
@@ -381,6 +384,24 @@ describe('ImportController tests', () => {
       expect(jobStatus.importQueueId).to.equal('spacecat-import-queue-1');
       expect(jobStatus.status).to.equal('RUNNING');
       expect(jobStatus.options).to.deep.equal({});
+    });
+
+    it('should return job details with metadata for a valid jobId', async () => {
+      const mockApiKey = {
+        id: 'test-id',
+        hashedKey: 'b9ebcfb5-8989-4236-91ba-d50e361db71d',
+        name: 'Test',
+        imsOrgId: 'Test Org',
+      };
+      requestContext.params.jobId = exampleJob.id;
+      mockDataAccess.getApiKeyByHashedKey.resolves(mockApiKey);
+
+      const response = await importController.getImportJobStatus(requestContext);
+      expect(response).to.be.an.instanceOf(Response);
+      expect(response.status).to.equal(200);
+      const jobStatus = await response.json();
+      expect(jobStatus.metadata.name).to.equal('Test');
+      expect(jobStatus.metadata.imsOrgId).to.equal('Test Org');
     });
   });
 

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -370,20 +370,13 @@ describe('ImportController tests', () => {
       expect(response.headers.get('x-error')).to.equal('Not found');
     });
 
-    it('should return job details for a valid jobId', async () => {
+    it('should throw server error if metadata is missing', async () => {
       requestContext.params.jobId = exampleJob.id;
       mockDataAccess.getApiKeyByHashedKey.resolves(null);
 
       const response = await importController.getImportJobStatus(requestContext);
       expect(response).to.be.an.instanceOf(Response);
-      expect(response.status).to.equal(200);
-      const jobStatus = await response.json();
-      expect(jobStatus.id).to.equal('f91afda0-afc8-467e-bfa3-fdbeba3037e8');
-      expect(jobStatus.apiKey).to.be.undefined;
-      expect(jobStatus.baseURL).to.equal('https://www.example.com');
-      expect(jobStatus.importQueueId).to.equal('spacecat-import-queue-1');
-      expect(jobStatus.status).to.equal('RUNNING');
-      expect(jobStatus.options).to.deep.equal({});
+      expect(response.status).to.equal(500);
     });
 
     it('should return job details with metadata for a valid jobId', async () => {
@@ -400,6 +393,12 @@ describe('ImportController tests', () => {
       expect(response).to.be.an.instanceOf(Response);
       expect(response.status).to.equal(200);
       const jobStatus = await response.json();
+      expect(jobStatus.id).to.equal('f91afda0-afc8-467e-bfa3-fdbeba3037e8');
+      expect(jobStatus.apiKey).to.be.undefined;
+      expect(jobStatus.baseURL).to.equal('https://www.example.com');
+      expect(jobStatus.importQueueId).to.equal('spacecat-import-queue-1');
+      expect(jobStatus.status).to.equal('RUNNING');
+      expect(jobStatus.options).to.deep.equal({});
       expect(jobStatus.metadata.name).to.equal('Test');
       expect(jobStatus.metadata.imsOrgId).to.equal('Test Org');
     });
@@ -407,8 +406,15 @@ describe('ImportController tests', () => {
 
   describe('getImportJobResult', () => {
     beforeEach(() => {
+      const mockApiKey = {
+        id: 'test-id',
+        hashedKey: 'b9ebcfb5-8989-4236-91ba-d50e361db71d',
+        name: 'Test',
+        imsOrgId: 'Test Org',
+      };
       requestContext.pathInfo.headers['x-import-api-key'] = 'b9ebcfb5-80c9-4236-91ba-d50e361db71d';
       requestContext.params.jobId = exampleJob.id;
+      mockDataAccess.getApiKeyByHashedKey.resolves(mockApiKey);
     });
 
     it('should fail to fetch the import result for a running job', async () => {


### PR DESCRIPTION
## Related Issues


[SITES-23950](https://jira.corp.adobe.com/browse/SITES-23950)

Return API key metadata as part of the import-job status response.
This can then be used by the analytics api to identify the customer.
We want the new import-job status response to be:
```
{
	"id": "56d89f68e-f2344-4ca5-b169-3dcdc6e99e51",
	"baseURL": "https://www.testurl.ca",
	"options": {
		"enableJavascript": false,
		"scrollToBottom": true
	},
	"startTime": "2024-07-29T14:28:27.552Z",
	"endTime": "2024-07-29T14:28:38.737Z",
	"duration": 11185,
	"status": "COMPLETE",
	"urlCount": 1,
	"successCount": 1,
	"failedCount": 0,
	"importQueueId": "spacecat-import-queue-1",
        "metadata": {
            "name": "Test",
            "imsOrgId": "Test Org",
             "imsUserId": "<UserId>",
        }
}
```
