### PR TITLE
feat: Update spacecat-service to send hashedApiKey during createImportJob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.2",
         "@adobe/helix-universal-logger": "3.0.18",
-        "@adobe/spacecat-shared-data-access": "1.39.1",
+        "@adobe/spacecat-shared-data-access": "1.40.0",
         "@adobe/spacecat-shared-http-utils": "1.4.0",
         "@adobe/spacecat-shared-ims-client": "1.3.12",
         "@adobe/spacecat-shared-rum-api-client": "2.7.0",
@@ -276,10 +276,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-1.39.1.tgz",
-      "integrity": "sha512-ovvp1mqennxbPXMs+wV+aqOCK17hxjzrz/PDihxdzLpHYHQkboqMXUnySaQlP+lpQ+w39mrHzJFSj4BqoAwoPQ==",
-      "license": "Apache-2.0",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-1.40.0.tgz",
+      "integrity": "sha512-Ybb0Khx4yeDaGavpHXngivLK+tgejNLRoN9AVo4SgxV480r8sm01NAZkBsv9ZlFmyKKV0zVaJOj5xelnClHlag==",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
         "@adobe/spacecat-shared-utils": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.2",
     "@adobe/helix-universal-logger": "3.0.18",
-    "@adobe/spacecat-shared-data-access": "1.39.1",
+    "@adobe/spacecat-shared-data-access": "1.40.0",
     "@adobe/spacecat-shared-http-utils": "1.4.0",
     "@adobe/spacecat-shared-ims-client": "1.3.12",
     "@adobe/spacecat-shared-rum-api-client": "2.7.0",

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -63,7 +63,9 @@ function ImportSupervisor(services, config) {
 
     // Check that this import API key has capacity to start an import job
     for (const job of runningImportJobs) {
-      if (job.getApiKey() === importApiKey) {
+      // TODO: change it to hashWithSHA256(importApiKey) when the function is available
+      const hashedApiKey = crypto.createHash('sha256').update(importApiKey).digest('hex');
+      if (job.getHashedApiKey() === hashedApiKey) {
         throw new ErrorWithStatusCode(`Too Many Requests: API key ${importApiKey} cannot be used to start any more import jobs`, 429);
       }
     }
@@ -100,7 +102,7 @@ function ImportSupervisor(services, config) {
       baseURL: determineBaseURL(urls),
       importQueueId,
       // TODO: Change it to hashedApiKey once the spacecat-shared PR is merged in
-      apiKey: hashedApiKey,
+      hashedApiKey,
       options,
       urlCount: urls.length,
       status: ImportJobStatus.RUNNING,

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -42,7 +42,7 @@ describe('ImportController tests', () => {
     status: 'RUNNING',
     options: {},
     baseURL: 'https://www.example.com',
-    apiKey: 'b9ebcfb5-80c9-4236-91ba-d50e361db71d',
+    hashedApiKey: 'c0fd7780368f08e883651422e6b96cf2320cc63e17725329496e27eb049a5441',
     importQueueId: 'spacecat-import-queue-1',
   };
 
@@ -183,7 +183,7 @@ describe('ImportController tests', () => {
       context.dataAccess.getImportJobsByStatus = sandbox.stub().resolves([
         createImportJob({
           ...exampleJob,
-          apiKey: requestContext.pathInfo.headers['x-import-api-key'],
+          hashedApiKey: 'c0fd7780368f08e883651422e6b96cf2320cc63e17725329496e27eb049a5441',
         }),
       ]);
       const response = await importController.createImportJob(requestContext);
@@ -228,7 +228,7 @@ describe('ImportController tests', () => {
       context.dataAccess.getImportJobsByStatus = sandbox.stub().resolves([
         createImportJob({
           ...exampleJob,
-          apiKey: '18149FB2-5B83-41E6-B8D2-C7F50ADF110E', // Queue is in use by another API key
+          hashedApiKey: 'ac90ae98768efdb4c6349f23e63fc35e465333ca21bd30dd2838a100d1fd09d7', // Queue is in use by another API key
         }),
       ]);
       importController = ImportController(context);
@@ -249,12 +249,12 @@ describe('ImportController tests', () => {
         createImportJob({
           ...exampleJob,
           importQueueId: 'spacecat-import-queue-1',
-          apiKey: '50E8BD06-20AD-46FE-8D80-382DDF24E982', // Queue is in use by another API key
+          hashedApiKey: 'b76319539c6c50113d425259385cd1a382a369441d9242e641be22ed8c2d8069', // Queue is in use by another API key
         }),
         createImportJob({
           ...exampleJob,
           importQueueId: 'spacecat-import-queue-2',
-          apiKey: '8B68CCE5-9A56-4952-9413-ED796135937A', // Queue is in use by another API key
+          hashedApiKey: '23306638a0b7ed823e4da979b73592bf2a7ddd0ee027a58b1fc75b337b97cd9d', // Queue is in use by another API key
         }),
       ]);
       importController = ImportController(context);


### PR DESCRIPTION
## Related Issues
[SITES-23948](https://jira.corp.adobe.com/browse/SITES-23948)

Update spacecat-service to send hashedApiKey instead of apiKey while creating a new import job

PR: https://github.com/adobe/spacecat-shared/pull/318/files needs to be merged in before I modify the unit tests for this one.