### PR TITLE
feat: API to get all import jobs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.2",
         "@adobe/helix-universal-logger": "3.0.18",
-        "@adobe/spacecat-shared-data-access": "1.42.0",
+        "@adobe/spacecat-shared-data-access": "1.43.0",
         "@adobe/spacecat-shared-http-utils": "1.6.7",
         "@adobe/spacecat-shared-ims-client": "1.3.12",
         "@adobe/spacecat-shared-rum-api-client": "2.7.3",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-1.42.0.tgz",
-      "integrity": "sha512-HV7dTyLeCNrFYHopnwiVHFZUpfCyAk69zViwTIv92vN9XE0gbXXHboJQc73Z/9XsVmpz6v3F/R5Hrud+kQx48w==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-1.43.0.tgz",
+      "integrity": "sha512-CmgKKuWnEPAdEpb7rc4mVTOmjM/CuTeTA9CKQeyJmgJ0V3Sc9rSLVZoGFLMyUsVNAgO9eZTGiK/HGGajubsmMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -291,6 +291,10 @@
         "@types/joi": "17.2.3",
         "joi": "17.13.3",
         "uuid": "10.0.0"
+      },
+      "engines": {
+        "node": "^20.0.0 <21.0.0",
+        "npm": "^10.0.0 <11.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access/node_modules/@adobe/spacecat-shared-utils": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.2",
     "@adobe/helix-universal-logger": "3.0.18",
-    "@adobe/spacecat-shared-data-access": "1.42.0",
+    "@adobe/spacecat-shared-data-access": "1.43.0",
     "@adobe/spacecat-shared-http-utils": "1.6.7",
     "@adobe/spacecat-shared-ims-client": "1.3.12",
     "@adobe/spacecat-shared-rum-api-client": "2.7.3",

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -146,6 +146,7 @@ function ImportController(context) {
   async function getImportJobsByDateRange(requestContext) {
     const { query: { startDate, endDate }, pathInfo: { headers } } = requestContext;
     const { 'x-api-key': importApiKey } = headers;
+    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}`);
 
     try {
       validateImportApiKey(importApiKey, 'imports.read_all');

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -147,7 +147,7 @@ function ImportController(context) {
    */
   async function getImportJobsByDateRange(requestContext) {
     const { startDate, endDate, importApiKey } = parseRequestContext(requestContext);
-    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}`);
+    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate} for analytics`);
 
     try {
       validateImportApiKey(importApiKey, ['imports.read_all']);

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -131,6 +131,8 @@ function ImportController(context) {
   function parseRequestContext(requestContext) {
     return {
       jobId: requestContext.params.jobId,
+      startDate: requestContext.params.startDate,
+      endDate: requestContext.params.endDate,
       importApiKey: requestContext.pathInfo.headers['x-api-key'],
     };
   }
@@ -144,8 +146,7 @@ function ImportController(context) {
    * @returns {Promise<Response>} 200 OK with a JSON representation of the import jobs.
    */
   async function getImportJobsByDateRange(requestContext) {
-    const { query: { startDate, endDate }, pathInfo: { headers } } = requestContext;
-    const { 'x-api-key': importApiKey } = headers;
+    const { startDate, endDate, importApiKey } = parseRequestContext(requestContext);
     log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}`);
 
     try {

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -140,22 +140,21 @@ function ImportController(context) {
    * @param {object} requestContext - Context of the request.
    * @param {string} requestContext.params.startDate - The start date of the range.
    * @param {string} requestContext.params.endDate - The end date of the range.
-   * @param {string} requestContext.pathInfo.headers.x-import-api-key - API key to use for the job.
+   * @param {string} requestContext.pathInfo.headers.x-api-key - API key to use for the job.
    * @returns {Promise<Response>} 200 OK with a JSON representation of the import jobs.
    */
   async function getImportJobsByDateRange(requestContext) {
     const { data: { startDate, endDate }, pathInfo: { headers } } = requestContext;
-    const { 'x-import-api-key': importApiKey } = headers;
+    const { 'x-api-key': importApiKey } = headers;
 
     try {
-      // TODO: Once the controller auth changes are implemented, verify the relevant scopes
-      validateImportApiKey(importApiKey);
+      validateImportApiKey(importApiKey, 'imports.read_all');
       validateIsoDates(startDate, endDate);
       const jobs = await importSupervisor.getImportJobsByDateRange(startDate, endDate);
       const importJobs = jobs.map(async (job) => {
         const hashedApiKey = hashWithSHA256(importApiKey);
         const { name, imsOrgId, imsUserId } = await dataAccess
-          .getApiKeyByHashedKey(hashedApiKey);
+          .getApiKeyByHashedApiKey(hashedApiKey);
         const metadata = { apiKeyName: name, imsOrgId, imsUserId };
         return { ...ImportJobDto.toJSON(job), metadata };
       });

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -144,7 +144,7 @@ function ImportController(context) {
    * @returns {Promise<Response>} 200 OK with a JSON representation of the import jobs.
    */
   async function getImportJobsByDateRange(requestContext) {
-    const { data: { startDate, endDate }, pathInfo: { headers } } = requestContext;
+    const { query: { startDate, endDate }, pathInfo: { headers } } = requestContext;
     const { 'x-api-key': importApiKey } = headers;
 
     try {

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -164,7 +164,7 @@ function ImportController(context) {
    */
   async function getImportJobsByDateRange(requestContext) {
     const { startDate, endDate, importApiKey } = parseRequestContext(requestContext);
-    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}`);
+    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}.`);
 
     try {
       validateImportApiKey(importApiKey, ['imports.read_all']);

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -147,7 +147,7 @@ function ImportController(context) {
    */
   async function getImportJobsByDateRange(requestContext) {
     const { startDate, endDate, importApiKey } = parseRequestContext(requestContext);
-    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate} for analytics`);
+    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}`);
 
     try {
       validateImportApiKey(importApiKey, ['imports.read_all']);

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -150,7 +150,7 @@ function ImportController(context) {
     log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}`);
 
     try {
-      validateImportApiKey(importApiKey, 'imports.read_all');
+      validateImportApiKey(importApiKey, ['imports.read_all']);
       validateIsoDates(startDate, endDate);
       const jobs = await importSupervisor.getImportJobsByDateRange(startDate, endDate);
       const importJobs = jobs.map(async (job) => {

--- a/src/dto/import-job.js
+++ b/src/dto/import-job.js
@@ -29,5 +29,6 @@ export const ImportJobDto = {
     successCount: importJob.getSuccessCount(),
     failedCount: importJob.getFailedCount(),
     importQueueId: importJob.getImportQueueId(),
+    initiatedBy: importJob.getInitiatedBy(),
   }),
 };

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ async function run(request, context) {
     const routeMatch = matchPath(method, suffix, routeHandlers);
 
     if (routeMatch) {
-      const { handler, params, query } = routeMatch;
+      const { handler, params } = routeMatch;
       //
       if (params.siteId && !isValidUUIDV4(params.siteId)) {
         return badRequest('Site Id is invalid. Please provide a valid UUID.');
@@ -108,7 +108,6 @@ async function run(request, context) {
         return badRequest('Organization Id is invalid. Please provide a valid UUID.');
       }
       context.params = params;
-      context.query = query;
 
       return await handler(context);
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ async function run(request, context) {
     const routeMatch = matchPath(method, suffix, routeHandlers);
 
     if (routeMatch) {
-      const { handler, params } = routeMatch;
+      const { handler, params, query } = routeMatch;
       //
       if (params.siteId && !isValidUUIDV4(params.siteId)) {
         return badRequest('Site Id is invalid. Please provide a valid UUID.');
@@ -108,6 +108,7 @@ async function run(request, context) {
         return badRequest('Organization Id is invalid. Please provide a valid UUID.');
       }
       context.params = params;
+      context.query = query;
 
       return await handler(context);
     } else {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -114,7 +114,7 @@ export default function getRouteHandlers(
     'POST /tools/import/jobs': importController.createImportJob,
     'GET /tools/import/jobs/:jobId': importController.getImportJobStatus,
     'POST /tools/import/jobs/:jobId/result': importController.getImportJobResult,
-    'GET /tools/import/jobs/by-date-range': importController.getImportJobsByDateRange,
+    'GET /tools/import/jobs/by-date-range/:startDate/:endDate': importController.getImportJobsByDateRange,
   };
 
   // Initialization of static and dynamic routes

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -114,6 +114,7 @@ export default function getRouteHandlers(
     'POST /tools/import/jobs': importController.createImportJob,
     'GET /tools/import/jobs/:jobId': importController.getImportJobStatus,
     'POST /tools/import/jobs/:jobId/result': importController.getImportJobResult,
+    'GET /tools/import/jobs/by-date-range': importController.getImportJobsByDateRange,
   };
 
   // Initialization of static and dynamic routes

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -114,7 +114,7 @@ export default function getRouteHandlers(
     'POST /tools/import/jobs': importController.createImportJob,
     'GET /tools/import/jobs/:jobId': importController.getImportJobStatus,
     'POST /tools/import/jobs/:jobId/result': importController.getImportJobResult,
-    'GET /tools/import/jobs/by-date-range/:startDate/:endDate': importController.getImportJobsByDateRange,
+    'GET /tools/import/jobs/by-date-range/:startDate/:endDate/all-jobs': importController.getImportJobsByDateRange,
   };
 
   // Initialization of static and dynamic routes

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -114,11 +114,10 @@ function ImportSupervisor(services, config) {
    * @param {string} startDate - The start date of the range.
    * @param {string} endDate - The end date of the range.
    * @param {string} importApiKey - The API
-   * @returns {Promise<Array<ImportJobDto>>}
+   * @returns {Promise<ImportJob[]>}
    */
   async function getImportJobsByDateRange(startDate, endDate) {
-    const jobs = await dataAccess.getImportJobsByDateRange(startDate, endDate);
-    return jobs;
+    return dataAccess.getImportJobsByDateRange(startDate, endDate);
   }
 
   /**

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -110,6 +110,18 @@ function ImportSupervisor(services, config) {
   }
 
   /**
+   * Get all import jobs between the specified start and end dates.
+   * @param {string} startDate - The start date of the range.
+   * @param {string} endDate - The end date of the range.
+   * @param {string} importApiKey - The API
+   * @returns {Promise<Array<ImportJobDto>>}
+   */
+  async function getImportJobsByDateRange(startDate, endDate) {
+    const jobs = await dataAccess.getImportJobsByDateRange(startDate, endDate);
+    return jobs;
+  }
+
+  /**
    * Persist the URLs to import in the data layer, each as an import URL record.
    */
   async function persistUrls(jobId, urls) {
@@ -269,6 +281,7 @@ function ImportSupervisor(services, config) {
     startNewJob,
     getImportJob,
     getJobArchiveSignedUrl,
+    getImportJobsByDateRange,
   };
 }
 

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -114,7 +114,6 @@ function ImportSupervisor(services, config) {
    * Get all import jobs between the specified start and end dates.
    * @param {string} startDate - The start date of the range.
    * @param {string} endDate - The end date of the range.
-   * @param {string} importApiKey - The API
    * @returns {Promise<ImportJob[]>}
    */
   async function getImportJobsByDateRange(startDate, endDate) {

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -96,7 +96,7 @@ function ImportSupervisor(services, config) {
    * @param {object} options - Client provided options for the import job.
    * @returns {Promise<ImportJob>}
    */
-  async function createNewImportJob(urls, importQueueId, hashedApiKey, options) {
+  async function createNewImportJob(urls, importQueueId, hashedApiKey, options, initiatedBy) {
     const newJob = {
       id: crypto.randomUUID(),
       baseURL: determineBaseURL(urls),
@@ -105,6 +105,7 @@ function ImportSupervisor(services, config) {
       options,
       urlCount: urls.length,
       status: ImportJobStatus.RUNNING,
+      initiatedBy,
     };
     return dataAccess.createNewImportJob(newJob);
   }
@@ -202,7 +203,7 @@ function ImportSupervisor(services, config) {
    * @param {string} importScript - Optional custom Base64 encoded import script.
    * @returns {Promise<ImportJob>}
    */
-  async function startNewJob(urls, importApiKey, options, importScript) {
+  async function startNewJob(urls, importApiKey, options, importScript, initiatedBy) {
     log.info(`Import requested for ${urls.length} URLs, using import API key: ${importApiKey}`);
 
     // Determine if there is a free import queue
@@ -212,7 +213,13 @@ function ImportSupervisor(services, config) {
     const hashedApiKey = hashWithSHA256(importApiKey);
 
     // If a queue is available, create the import-job record in dataAccess:
-    const newImportJob = await createNewImportJob(urls, importQueueId, hashedApiKey, options);
+    const newImportJob = await createNewImportJob(
+      urls,
+      importQueueId,
+      hashedApiKey,
+      options,
+      initiatedBy,
+    );
 
     log.info(`New import job created for hashed API key: ${hashedApiKey} with jobId: ${newImportJob.getId()}, baseUrl: ${newImportJob.getBaseURL()}, claiming importQueueId: ${importQueueId}`);
 

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -439,7 +439,7 @@ describe('ImportController tests', () => {
 
   describe('getImportJobsByDateRange', () => {
     it('should throw an error when startDate is not present', async () => {
-      requestContext.query.endDate = '2024-05-29T14:26:00.000Z';
+      requestContext.params.endDate = '2024-05-29T14:26:00.000Z';
       const response = await importController.getImportJobsByDateRange(requestContext);
       expect(response).to.be.an.instanceOf(Response);
       expect(response.status).to.equal(400);
@@ -447,7 +447,7 @@ describe('ImportController tests', () => {
     });
 
     it('should throw an error when endDate is not present', async () => {
-      requestContext.query.startDate = '2024-05-29T14:26:00.000Z';
+      requestContext.params.startDate = '2024-05-29T14:26:00.000Z';
       const response = await importController.getImportJobsByDateRange(requestContext);
       expect(response).to.be.an.instanceOf(Response);
       expect(response.status).to.equal(400);
@@ -457,8 +457,8 @@ describe('ImportController tests', () => {
     it('should return an array of import jobs', async () => {
       const job = createImportJob(exampleJob);
       context.dataAccess.getImportJobsByDateRange = sandbox.stub().resolves([job]);
-      requestContext.query.startDate = '2022-10-05T14:48:00.000Z';
-      requestContext.query.endDate = '2022-10-07T14:48:00.000Z';
+      requestContext.params.startDate = '2022-10-05T14:48:00.000Z';
+      requestContext.params.endDate = '2022-10-07T14:48:00.000Z';
 
       const response = await importController.getImportJobsByDateRange(requestContext);
       expect(response).to.be.an.instanceOf(Response);

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -48,7 +48,7 @@ describe('ImportController tests', () => {
   };
 
   const exampleApiKeyMetadata = {
-    hashedKey: 'c0fd7780368f08e883651422e6b96cf2320cc63e17725329496e27eb049a5441',
+    hashedApiKey: 'c0fd7780368f08e883651422e6b96cf2320cc63e17725329496e27eb049a5441',
     name: 'Test API Key',
     imsOrgId: 'Test Org',
   };
@@ -82,7 +82,7 @@ describe('ImportController tests', () => {
       createNewImportJob: (data) => createImportJob(data),
       createNewImportUrl: (data) => createImportUrl(data),
       getImportJobByID: sandbox.stub(),
-      getApiKeyByHashedKey: sandbox.stub().resolves(exampleApiKeyMetadata),
+      getApiKeyByHashedApiKey: sandbox.stub().resolves(exampleApiKeyMetadata),
     };
 
     mockDataAccess.getImportJobByID.callsFake(async (jobId) => {

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -75,6 +75,7 @@ describe('ImportController tests', () => {
           'x-api-key': 'b9ebcfb5-80c9-4236-91ba-d50e361db71d',
         },
       },
+      query: {},
     };
 
     mockDataAccess = {
@@ -438,7 +439,7 @@ describe('ImportController tests', () => {
 
   describe('getImportJobsByDateRange', () => {
     it('should throw an error when startDate is not present', async () => {
-      requestContext.data.endDate = '2024-05-29T14:26:00.000Z';
+      requestContext.query.endDate = '2024-05-29T14:26:00.000Z';
       const response = await importController.getImportJobsByDateRange(requestContext);
       expect(response).to.be.an.instanceOf(Response);
       expect(response.status).to.equal(400);
@@ -446,7 +447,7 @@ describe('ImportController tests', () => {
     });
 
     it('should throw an error when endDate is not present', async () => {
-      requestContext.data.startDate = '2024-05-29T14:26:00.000Z';
+      requestContext.query.startDate = '2024-05-29T14:26:00.000Z';
       const response = await importController.getImportJobsByDateRange(requestContext);
       expect(response).to.be.an.instanceOf(Response);
       expect(response.status).to.equal(400);
@@ -456,8 +457,8 @@ describe('ImportController tests', () => {
     it('should return an array of import jobs', async () => {
       const job = createImportJob(exampleJob);
       context.dataAccess.getImportJobsByDateRange = sandbox.stub().resolves([job]);
-      requestContext.data.startDate = '2022-10-05T14:48:00.000Z';
-      requestContext.data.endDate = '2022-10-07T14:48:00.000Z';
+      requestContext.query.startDate = '2022-10-05T14:48:00.000Z';
+      requestContext.query.endDate = '2022-10-07T14:48:00.000Z';
 
       const response = await importController.getImportJobsByDateRange(requestContext);
       expect(response).to.be.an.instanceOf(Response);

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -37,6 +37,7 @@ describe('ImportController tests', () => {
   let mockS3;
   let importConfiguration;
   let mockAuth;
+  let mockAttributes;
 
   const exampleJob = {
     id: 'f91afda0-afc8-467e-bfa3-fdbeba3037e8',
@@ -45,6 +46,9 @@ describe('ImportController tests', () => {
     baseURL: 'https://www.example.com',
     hashedApiKey: 'c0fd7780368f08e883651422e6b96cf2320cc63e17725329496e27eb049a5441',
     importQueueId: 'spacecat-import-queue-1',
+    initiatedBy: {
+      apiKeyName: 'Test key',
+    },
   };
 
   const exampleApiKeyMetadata = {
@@ -73,9 +77,19 @@ describe('ImportController tests', () => {
       pathInfo: {
         headers: {
           'x-api-key': 'b9ebcfb5-80c9-4236-91ba-d50e361db71d',
+          'user-agent': 'Unit test',
         },
       },
-      query: {},
+    };
+
+    mockAttributes = {
+      authInfo: {
+        profile: {
+          getName: () => 'Test User',
+          getImsOrgId: () => 'TestOrgId',
+          getImsUserId: () => 'TestUserId',
+        },
+      },
     };
 
     mockDataAccess = {
@@ -126,6 +140,7 @@ describe('ImportController tests', () => {
       s3: mockS3,
       dataAccess: mockDataAccess,
       auth: mockAuth,
+      attributes: mockAttributes,
     };
 
     importController = ImportController(context);
@@ -464,9 +479,8 @@ describe('ImportController tests', () => {
       expect(response).to.be.an.instanceOf(Response);
       expect(response.status).to.equal(200);
       const responseResult = await response.json();
-      expect(responseResult[0].metadata).to.deep.equal({
-        apiKeyName: 'Test API Key',
-        imsOrgId: 'Test Org',
+      expect(responseResult[0].initiatedBy).to.deep.equal({
+        apiKeyName: 'Test key',
       });
       expect(responseResult[0].baseURL).to.equal('https://www.example.com');
     });

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -70,6 +70,7 @@ describe('getRouteHandlers', () => {
     createImportJob: sinon.stub(),
     getImportJobStatus: sinon.stub(),
     getImportJobResult: sinon.stub(),
+    getImportJobsByDateRange: sinon.stub(),
   };
 
   it('segregates static and dynamic routes', () => {
@@ -102,6 +103,7 @@ describe('getRouteHandlers', () => {
       'POST /event/fulfillment',
       'POST /slack/channels/invite-by-user-id',
       'POST /tools/import/jobs',
+      'GET /tools/import/jobs/by-date-range',
     );
 
     expect(staticRoutes['GET /configurations']).to.equal(mockConfigurationController.getAll);

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -103,7 +103,6 @@ describe('getRouteHandlers', () => {
       'POST /event/fulfillment',
       'POST /slack/channels/invite-by-user-id',
       'POST /tools/import/jobs',
-      'GET /tools/import/jobs/by-date-range',
     );
 
     expect(staticRoutes['GET /configurations']).to.equal(mockConfigurationController.getAll);
@@ -147,6 +146,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/metrics/:metric/:source',
       'GET /tools/import/jobs/:jobId',
       'POST /tools/import/jobs/:jobId/result',
+      'GET /tools/import/jobs/by-date-range/:startDate/:endDate',
     );
 
     expect(dynamicRoutes['GET /audits/latest/:auditType'].handler).to.equal(mockAuditsController.getAllLatest);

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -146,7 +146,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/metrics/:metric/:source',
       'GET /tools/import/jobs/:jobId',
       'POST /tools/import/jobs/:jobId/result',
-      'GET /tools/import/jobs/by-date-range/:startDate/:endDate',
+      'GET /tools/import/jobs/by-date-range/:startDate/:endDate/all-jobs',
     );
 
     expect(dynamicRoutes['GET /audits/latest/:auditType'].handler).to.equal(mockAuditsController.getAllLatest);


### PR DESCRIPTION
## Related Issues
[SITES-23126](https://jira.corp.adobe.com/browse/SITES-23126)

Build out the API to get all the import jobs data for representation in PowerBI

- getAllImportJobs - To retrieve all the import jobs started between a specified startDate and endDate


Sample response:
```

[{
		"id": "50ad5e05-bc98-4810-a264-e1043bf7847b",
		"baseURL": "https://www.testing.ca",
		"options": {
			"enableJavascript": false,
			"scrollToBottom": true
		},
		"startTime": "2024-08-21T16:38:05.446Z",
		"status": "RUNNING",
		"urlCount": 1,
		"importQueueId": "spacecat-import-queue-1-dev",
		"initiatedBy": {
			"apiKeyName": "Dev Key",
			"userAgent": "insomnia/2023.5.8-adobe",
			"imsUserId": "Ottawa-team",
			"imsOrgId": "Adobe"
		}
}]
```


