### PR TITLE
feat: Restrict importing URLs which are not allowlisted (by domain) for the API key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@aws-sdk/s3-request-presigner": "3.654.0",
         "@slack/bolt": "3.21.4",
         "busboy": "1.6.0",
+        "psl": "^1.9.0",
         "slack-block-builder": "2.8.0"
       },
       "devDependencies": {
@@ -18606,6 +18607,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.3",
         "@adobe/helix-universal-logger": "3.0.20",
-        "@adobe/spacecat-shared-data-access": "1.45.2",
+        "@adobe/spacecat-shared-data-access": "1.45.3",
         "@adobe/spacecat-shared-http-utils": "1.6.10",
         "@adobe/spacecat-shared-ims-client": "1.3.16",
         "@adobe/spacecat-shared-rum-api-client": "2.9.4",
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "1.45.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-1.45.2.tgz",
-      "integrity": "sha512-xagUKxX0AXt7ehF7sf2vbtD1GluZ7mRCX6e4NGEl9x7LkgnZ5nqtNjxJc+x2ks1ybT4mf/C4Nsw/RpHZIV0C4Q==",
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-1.45.3.tgz",
+      "integrity": "sha512-2AUVLLRXBVy+ayJY+7q8T+CBTs3Lf52HwvOtH/eKmTWxShyhNs66v5tHtg21SCXHVgGeGS9fgsbOIsEgd5XPsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@aws-sdk/s3-request-presigner": "3.654.0",
     "@slack/bolt": "3.21.4",
     "busboy": "1.6.0",
+    "psl": "^1.9.0",
     "slack-block-builder": "2.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.3",
     "@adobe/helix-universal-logger": "3.0.20",
-    "@adobe/spacecat-shared-data-access": "1.45.2",
+    "@adobe/spacecat-shared-data-access": "1.45.3",
     "@adobe/spacecat-shared-http-utils": "1.6.10",
     "@adobe/spacecat-shared-ims-client": "1.3.16",
     "@adobe/spacecat-shared-rum-api-client": "2.9.4",

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -157,8 +157,8 @@ function ImportController(context) {
 
   /**
    * Check if the URLs in urlList belong to any of the base domains.
-   * @param urlList
-   * @param baseDomainList
+   * @param urlList the list of URLs to check.
+   * @param baseDomainList the list of base domains to check against.
    * @return {true} if all URLs belong to an allowed base domain
    * @throws {ErrorWithStatusCode} if any URL does not belong to an allowed base domain
    */

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -197,7 +197,12 @@ function ImportController(context) {
       if (!scopes.some((scope) => scope.name === SCOPE.ALL_DOMAINS)) {
         const allowedDomains = scopes
           .filter((scope) => scope.name === SCOPE.WRITE)
-          .map((scope) => scope.domains.map(getDomain))
+          .map((scope) => {
+            if (!scope.domains || scope.domains.length === 0) {
+              throw new ErrorWithStatusCode('Missing domain information', STATUS_UNAUTHORIZED);
+            }
+            return scope.domains.map(getDomain);
+          })
           .flat();
         isUrlInBaseDomains(urls, allowedDomains);
       }

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -131,7 +131,7 @@ function ImportController(context) {
 
   /**
    * Extract the domain from a URL.
-   * @param inputUrl the URL to extract the domain from.
+   * @param {string} inputUrl the URL to extract the domain from.
    * @return {string} the domain extracted from the URL.
    */
   function getDomain(inputUrl) {
@@ -142,8 +142,8 @@ function ImportController(context) {
 
   /**
    * Check if the URLs in urlList belong to any of the base domains.
-   * @param urlList the list of URLs to check.
-   * @param baseDomainList the list of base domains to check against.
+   * @param {string[]} urlList the list of URLs to check.
+   * @param {string[]} baseDomainList the list of base domains to check against.
    * @return {true} if all URLs belong to an allowed base domain
    * @throws {ErrorWithStatusCode} if any URL does not belong to an allowed base domain
    */

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -170,6 +170,7 @@ function ImportController(context) {
   async function createImportJob(requestContext) {
     const { multipartFormData, pathInfo: { headers } } = requestContext;
     const { 'x-api-key': importApiKey, 'user-agent': userAgent } = headers;
+
     try {
       // The API scope imports.write is required to create a new import job
       validateAccessScopes([SCOPE.WRITE]);

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -157,12 +157,12 @@ function ImportController(context) {
   }
 
   /**
-   * Validate the URLs by domain.
+   * Check if the URLs in the request belong to the allowed domains.
    * @param urls
    * @param scopes
    */
   function validateUrlsByDomain(urls, scopes) {
-    // We do not need to check the domains for users with the write_all_domains scope
+    // We do not need to check the domains for users with scope: write_all_domains
     if (scopes.some((scope) => scope.name === SCOPE.WRITE_ALL_DOMAINS)) {
       return;
     }

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -196,14 +196,14 @@ function ImportController(context) {
       // We do not need to check the domains for users with scope: all_domains
       if (!scopes.some((scope) => scope.name === SCOPE.ALL_DOMAINS)) {
         const allowedDomains = scopes
-          .filter((scope) => scope.name === SCOPE.WRITE)
-          .map((scope) => {
-            if (!scope.domains || scope.domains.length === 0) {
-              throw new ErrorWithStatusCode('Missing domain information', STATUS_UNAUTHORIZED);
-            }
-            return scope.domains.map(getDomain);
-          })
-          .flat();
+          .filter((scope) => scope.name === SCOPE.WRITE
+              && scope.domains && scope.domains.length > 0)
+          .flatMap((scope) => scope.domains.map(getDomain));
+
+        if (allowedDomains.length === 0) {
+          throw new ErrorWithStatusCode('Missing domain information', STATUS_UNAUTHORIZED);
+        }
+
         isUrlInBaseDomains(urls, allowedDomains);
       }
 

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -205,8 +205,8 @@ describe('ImportController tests', () => {
       baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.write', domains: [] }];
       const response = await importController.createImportJob(baseContext);
 
-      expect(response.status).to.equal(401);
-      expect(response.headers.get('x-error')).to.equal('Missing domain information');
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('x-error')).to.equal('Invalid request: URLs not allowed: https://example.com/page1, https://example.com/page2, https://example.com/page3');
     });
 
     it('should create an import job for the user scope imports.write', async () => {
@@ -216,8 +216,8 @@ describe('ImportController tests', () => {
       expect(response.status).to.equal(202);
     });
 
-    it('should create an import job for the user scope imports.write_all_domains', async () => {
-      baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.write_all_domains', domains: [] }];
+    it('should create an import job for the user scope imports.all_domains', async () => {
+      baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.all_domains', domains: [] }, { name: 'imports.write', domains: [] }];
       const response = await importController.createImportJob(baseContext);
 
       expect(response.status).to.equal(202);

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -209,6 +209,13 @@ describe('ImportController tests', () => {
       expect(response.headers.get('x-error')).to.equal('Missing domain information');
     });
 
+    it('should create an import job for the user scope imports.write', async () => {
+      baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.write', domains: ['https://www.example.com'] }, { name: 'imports.read', domains: ['https://www.example.com'] }];
+      const response = await importController.createImportJob(baseContext);
+
+      expect(response.status).to.equal(202);
+    });
+
     it('should create an import job for the user scope imports.write_all_domains', async () => {
       baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.write_all_domains', domains: [] }];
       const response = await importController.createImportJob(baseContext);

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -198,7 +198,7 @@ describe('ImportController tests', () => {
       const response = await importController.createImportJob(baseContext);
 
       expect(response.status).to.equal(400);
-      expect(response.headers.get('x-error')).to.equal('Invalid request: URL: https://test.com/page1 not allowed');
+      expect(response.headers.get('x-error')).to.equal('Invalid request: URLs not allowed: https://test.com/page1');
     });
 
     it('should fail when there are no domains listed for the user scope imports.write', async () => {

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -205,8 +205,8 @@ describe('ImportController tests', () => {
       baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.write', domains: [] }];
       const response = await importController.createImportJob(baseContext);
 
-      expect(response.status).to.equal(400);
-      expect(response.headers.get('x-error')).to.equal('Invalid request: URLs not allowed: https://example.com/page1, https://example.com/page2, https://example.com/page3');
+      expect(response.status).to.equal(401);
+      expect(response.headers.get('x-error')).to.equal('Missing domain information');
     });
 
     it('should create an import job for the user scope imports.write', async () => {

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -217,10 +217,19 @@ describe('ImportController tests', () => {
     });
 
     it('should create an import job for the user scope imports.all_domains', async () => {
-      baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.all_domains', domains: [] }, { name: 'imports.write', domains: [] }];
+      baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.all_domains' }, { name: 'imports.write' }];
       const response = await importController.createImportJob(baseContext);
 
       expect(response.status).to.equal(202);
+    });
+
+    it('should fail when the domains listed for imports.write do not match the URL', async () => {
+      baseContext.attributes.authInfo.profile.getScopes = () => [{ name: 'imports.read', domains: ['https://www.example.com'] }, { name: 'imports.write', domains: ['https://www.test.com'] }];
+
+      const response = await importController.createImportJob(baseContext);
+
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('x-error')).to.equal('Invalid request: URLs not allowed: https://example.com/page1, https://example.com/page2, https://example.com/page3');
     });
 
     it('should respond with an error code when custom header is not an object', async () => {


### PR DESCRIPTION
## Related Issues
[SITES-22756](https://jira.corp.adobe.com/browse/SITES-22756)

An API key owner has to specifically allowlist domains before they can be processed by Import as a Service.
We do not want to allow imports on domains which are not part of the allowlist for a given user.