### PR TITLE
fix: SITES-26996 [Import Assistant] Context ImsOrg not being used by Firefall Client

### DIFF
--- a/test/controllers/assistant.test.js
+++ b/test/controllers/assistant.test.js
@@ -177,18 +177,18 @@ describe('AssistantController tests', () => {
       // Check client error - which means the imsOrgId is missing, but it will continue.
       await testParameterWithCommand(
         'findMainContent',
-        'Error creating FirefallClient: Context param must include properties: imsHost, clientId, clientCode, and clientSecret.',
+        'Invalid request: A valid ims-org-id is not associated with your api-key.',
         { prompt: 'nav and some text' },
-        500,
+        STATUS.UNAUTHORIZED,
       );
-      expect(baseContext.log.info.getCall(0).args[0]).to.equal('Running assistant command findMainContent using key "testName" for org N/A.');
+      expect(baseContext.log.error.getCall(0).args[0]).to.contain('Invalid request: A valid ims-org-id is not associated with your api-key.');
     });
     it('missing profile in request test', async () => {
-      const profilelessContext = { ...baseContext };
-      delete profilelessContext.attributes.authInfo.profile;
+      const noProfileContext = { ...baseContext };
+      delete noProfileContext.attributes.authInfo.profile;
       const response = await assistantController.processImportAssistant(
         {
-          ...profilelessContext,
+          ...noProfileContext,
           data: {
             command: 'findMainContent',
             prompt: 'nav and some text',


### PR DESCRIPTION
When making the call to Firefall, we use the IMS Org Id associated with the Importer API KEY.  If it is not present, or was not processed correctly by the `ScopedApiKeyHandler`, the Assistant Service will return a 401 (UNAUTHORIZED).
For now, we also allow it to be specified in the 'x-gw-ims-org-id' header, although that may be removed in Phase 2.

## Related Issues
https://jira.corp.adobe.com/browse/SITES-26996

