### PR TITLE
fix: Bump node version used by importer E2E test workflow

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.16
+          node-version: 22.12
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Fixes the E2E tests which have been failing, for example: https://github.com/adobe/spacecat-api-service/actions/runs/12583579509/job/35071446280

Error message:

```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: @adobe/spacecat-shared-data-access@1.[6](https://github.com/adobe/spacecat-api-service/actions/runs/12583579509/job/35071446280#step:4:7)1.12
npm error notsup Not compatible with your version of node/npm: @adobe/spacecat-shared-data-access@1.61.12
npm error notsup Required: {"node":">=22.0.0 <23.0.0","npm":">=10.9.0 <12.0.0"}
npm error notsup Actual:   {"npm":"10.[8](https://github.com/adobe/spacecat-api-service/actions/runs/12583579509/job/35071446280#step:4:9).1","node":"v20.16.0"}
```