### PR TITLE
fix: Import job progress endpoint

### DIFF
--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -288,7 +288,7 @@ function ImportSupervisor(services, config) {
     return urls.reduce((acc, url) => {
       // intentionally ignore RUNNING as currently no code will flip the url to a running state
       // eslint-disable-next-line default-case
-      switch (url.state.status) {
+      switch (url.getStatus()) {
         case ImportUrlStatus.PENDING:
           acc.pending += 1;
           break;

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -484,15 +484,15 @@ describe('ImportController tests', () => {
       // only need to provide enough import url data to satisfy the import-supervisor, no need
       // for all the other properties of a ImportUrl object.
       baseContext.dataAccess.ImportUrl.allByImportJobId = sandbox.stub().resolves([
-        { state: { status: ImportUrlStatus.COMPLETE } },
-        { state: { status: ImportUrlStatus.COMPLETE } },
+        createImportUrl({ status: ImportUrlStatus.COMPLETE }),
+        createImportUrl({ status: ImportUrlStatus.COMPLETE }),
         // setting a status to RUNNING should not affect the result
         // as no process will flip a ImportUrl status to running at this time, therefore
         // the code will ignore running in the results
-        { state: { status: ImportUrlStatus.RUNNING } },
-        { state: { status: ImportUrlStatus.PENDING } },
-        { state: { status: ImportUrlStatus.REDIRECT } },
-        { state: { status: ImportUrlStatus.FAILED } },
+        createImportUrl({ status: ImportUrlStatus.RUNNING }),
+        createImportUrl({ status: ImportUrlStatus.PENDING }),
+        createImportUrl({ status: ImportUrlStatus.REDIRECT }),
+        createImportUrl({ status: ImportUrlStatus.FAILED }),
       ]);
 
       baseContext.params.jobId = exampleJob.importJobId;

--- a/test/controllers/import.test.js
+++ b/test/controllers/import.test.js
@@ -484,15 +484,15 @@ describe('ImportController tests', () => {
       // only need to provide enough import url data to satisfy the import-supervisor, no need
       // for all the other properties of a ImportUrl object.
       baseContext.dataAccess.ImportUrl.allByImportJobId = sandbox.stub().resolves([
-        createImportUrl({ status: ImportUrlStatus.COMPLETE }),
-        createImportUrl({ status: ImportUrlStatus.COMPLETE }),
+        { getStatus: () => ImportUrlStatus.COMPLETE },
+        { getStatus: () => ImportUrlStatus.COMPLETE },
         // setting a status to RUNNING should not affect the result
         // as no process will flip a ImportUrl status to running at this time, therefore
         // the code will ignore running in the results
-        createImportUrl({ status: ImportUrlStatus.RUNNING }),
-        createImportUrl({ status: ImportUrlStatus.PENDING }),
-        createImportUrl({ status: ImportUrlStatus.REDIRECT }),
-        createImportUrl({ status: ImportUrlStatus.FAILED }),
+        { getStatus: () => ImportUrlStatus.RUNNING },
+        { getStatus: () => ImportUrlStatus.PENDING },
+        { getStatus: () => ImportUrlStatus.REDIRECT },
+        { getStatus: () => ImportUrlStatus.FAILED },
       ]);
 
       baseContext.params.jobId = exampleJob.importJobId;


### PR DESCRIPTION
Post V2 data access update, we are unable to poll for job status using the `/tools/import/jobs/{{jobId}}/progress` endpoint. 