### PR TITLE
Update site.jsAdd delivery configuration object to site object 

### DIFF
--- a/src/dto/site.js
+++ b/src/dto/site.js
@@ -37,6 +37,7 @@ export const SiteDto = {
     baseURL: site.getBaseURL(),
     hlxConfig: site.getHlxConfig(),
     deliveryType: site.getDeliveryType(),
+    deliveryConfig: site.getDeliveryConfig();
     gitHubURL: site.getGitHubURL(),
     organizationId: site.getOrganizationId(),
     isLive: site.getIsLive(),


### PR DESCRIPTION
For AEM CS we need additional configuration similar to hlxConfig.
For now we need programId, environmentId, authorURL, and siteId (which is an AEM CS id for the site).
I assume the easiest is to just add a container object to the site object - the contents is then delivery type specific

This is a continuation of https://github.com/adobe/spacecat-shared/pull/598