### PR TITLE
fix: temporarily disable role check

### DIFF
--- a/src/support/slack/commands/run-import.js
+++ b/src/support/slack/commands/run-import.js
@@ -57,14 +57,18 @@ function RunImportCommand(context) {
    * @returns {Promise} A promise that resolves when the operation is complete.
    */
   const handleExecution = async (args, slackContext) => {
-    const { say, user } = slackContext;
+    const { say } = slackContext;
 
-    const admins = JSON.parse(context?.env?.SLACK_IDS_RUN_IMPORT || '[]');
+    const config = await Configuration.findLatest();
+    /* todo: uncomment after summit and back-office-UI support for configuration setting (roles)
+    const slackRoles = config.getSlackRoles() || {};
+    const admins = slackRoles?.import || [];
 
     if (!admins.includes(user)) {
-      await say(':error: Only selected SpaceCat fluid team members can run imports.');
+      await say(':error: Only members of role "import" can run this command.');
       return;
     }
+    */
 
     try {
       const [importType, baseURLInput, startDate, endDate] = args;
@@ -82,7 +86,6 @@ function RunImportCommand(context) {
         return;
       }
 
-      const config = await Configuration.findLatest();
       const jobConfig = config.getJobs().filter((job) => job.group === 'imports' && job.type === importType);
 
       if (!Array.isArray(jobConfig) || jobConfig.length === 0) {

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -40,7 +40,7 @@ function RunScrapeCommand(context) {
   });
 
   const { dataAccess, log } = context;
-  const { Configuration, Site } = dataAccess;
+  const { Site } = dataAccess;
 
   /**
      * Validates input and triggers a new scrape run for the given site.
@@ -51,7 +51,9 @@ function RunScrapeCommand(context) {
      * @returns {Promise} A promise that resolves when the operation is complete.
      */
   const handleExecution = async (args, slackContext) => {
-    const { say, user } = slackContext;
+    const { say } = slackContext;
+
+    /* todo: uncomment after summit and back-office-UI support for configuration setting (roles)
     const config = await Configuration.findLatest();
     const slackRoles = config.getSlackRoles() || {};
     const admins = slackRoles?.scrape || [];
@@ -60,6 +62,7 @@ function RunScrapeCommand(context) {
       await say(':error: Only members of role "scrape" can run this command.');
       return;
     }
+    */
 
     try {
       const [baseURLInput] = args;

--- a/test/support/slack/commands/run-scrape.test.js
+++ b/test/support/slack/commands/run-scrape.test.js
@@ -99,12 +99,6 @@ describe('RunScrapeCommand', () => {
       expect(slackContext.say.calledWith(':error: Only members of role "scrape" can run this command.')).to.be.false;
     });
 
-    it('handles missing SLACK_IDS_RUN_IMPORT', async () => {
-      dataAccessStub.Configuration.findLatest.resolves({ getSlackRoles: () => null });
-      const command = RunScrapeCommand(context);
-      await command.handleExecution(['https://example.com'], { ...slackContext, user: 'ANYUSER' });
-      expect(slackContext.say.calledWith(':error: Only members of role "scrape" can run this command.')).to.be.true;
-    });
     it('triggers a scrape for a valid site with top pages', async () => {
       dataAccessStub.Site.findByBaseURL.resolves({
         getId: () => '123',
@@ -124,14 +118,18 @@ describe('RunScrapeCommand', () => {
       expect(slackContext.say.thirdCall.args[0]).to.include('white_check_mark: Completed triggering scrape runs for site `https://example.com` — Total URLs: 2');
     });
 
+    /* todo: uncomment after summit and back-office-UI support
+      for configuration setting (roles)
     it('does not trigger a scrape when user is not authorized', async () => {
       slackContext.user = 'UNAUTHORIZED_USER';
       const command = RunScrapeCommand(context);
 
       await command.handleExecution(['https://example.com'], slackContext);
 
-      expect(slackContext.say.calledWith(':error: Only members of role "scrape" can run this command.')).to.be.true;
+      expect(slackContext.say.calledWith(':error: Only members of role
+      "scrape" can run this command.')).to.be.true;
     });
+    */
 
     it('responds with a warning for an invalid site url', async () => {
       const command = RunScrapeCommand(context);


### PR DESCRIPTION
Until BO office has convenient configuration setting (slack roles), disable role check to facilitate easy Summit/GA site onboarding.
