### PR TITLE
fix: range may be undefined

### DIFF
--- a/src/support/slack/commands/run-import.js
+++ b/src/support/slack/commands/run-import.js
@@ -110,7 +110,7 @@ function RunImportCommand(context) {
         context,
       );
 
-      const message = `:adobe-run: Triggered import run of type ${importType} for site \`${baseURL}\` and interval ${startDate}-${endDate}\n`;
+      const message = `:adobe-run: Triggered import run of type ${importType} for site \`${baseURL}\`${startDate && endDate ? ` and interval ${startDate}-${endDate}` : ''}\n`;
       // message += 'Stand by for results. I will post them here when they are ready.';
 
       await say(message);


### PR DESCRIPTION
Make sure the confirming slack message does not contain "undefined-undefined" when no start and end dates are given for an iport command.