### PR TITLE
fix: Update Importer E2E test workflow to use the existing Setup Node & NPM action

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,13 +16,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.12
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Setup Node & NPM
+        uses: ./.github/actions/setup-node-npm
 
       - name: Run tests
         env:


### PR DESCRIPTION
We have an error running our E2E test workflow that started this morning (https://github.com/adobe/spacecat-api-service/actions/runs/13523022713/job/37796886455). I cannot reproduce it locally: 

```
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.
npm error code E401
npm error Incorrect or missing password.
npm error If you were trying to login, change your password, create an
npm error authentication token or enable two-factor authentication then
npm error that means you likely typed your password in incorrectly.
npm error Please try again, or recover your password at:
npm error   https://www.npmjs.com/forgot
```

This PR is an attempt to use the existing `Setup Node & NPM` action which appears to be working well in other workflows.
