### PR TITLE
feat(bulk-audit-enable-disable): bulk enable/disable audits with csv support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@octokit/rest": "21.1.1",
         "@slack/bolt": "4.2.0",
         "busboy": "1.6.0",
+        "csv": "6.3.11",
         "fuse.js": "7.1.0",
         "js-yaml": "4.1.0",
         "jsdom": "26.0.0",
@@ -17300,6 +17301,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/csv": {
+      "version": "6.3.11",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-6.3.11.tgz",
+      "integrity": "sha512-a8bhT76Q546jOElHcTrkzWY7Py925mfLO/jqquseH61ThOebYwOjLbWHBqdRB4K1VpU36sTyIei6Jwj7QdEZ7g==",
+      "license": "MIT",
+      "dependencies": {
+        "csv-generate": "^4.4.2",
+        "csv-parse": "^5.6.0",
+        "csv-stringify": "^6.5.2",
+        "stream-transform": "^3.3.3"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
+      }
+    },
+    "node_modules/csv-generate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.4.2.tgz",
+      "integrity": "sha512-W6nVsf+rz0J3yo9FOjeer7tmzBJKaTTxf7K0uw6GZgRocZYPVpuSWWa5/aoWWrjQZj4/oNIKTYapOM7hiNjVMA==",
+      "license": "MIT"
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.2.tgz",
+      "integrity": "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==",
+      "license": "MIT"
+    },
     "node_modules/cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
@@ -28772,6 +28806,12 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-transform": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.3.3.tgz",
+      "integrity": "sha512-dALXrXe+uq4aO5oStdHKlfCM/b3NBdouigvxVPxCdrMRAU6oHh3KNss20VbTPQNQmjAHzZGKGe66vgwegFEIog==",
       "license": "MIT"
     },
     "node_modules/streamsearch": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@octokit/rest": "21.1.1",
     "@slack/bolt": "4.2.0",
     "busboy": "1.6.0",
+    "csv": "6.3.11",
     "fuse.js": "7.1.0",
     "js-yaml": "4.1.0",
     "jsdom": "26.0.0",

--- a/src/support/slack/commands/toggle-site-audit.js
+++ b/src/support/slack/commands/toggle-site-audit.js
@@ -9,9 +9,13 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { isString } from '@adobe/spacecat-shared-utils';
+import {
+  isString, isValidUrl, isNonEmptyArray, hasText, tracingFetch as fetch,
+} from '@adobe/spacecat-shared-utils';
+import { Readable } from 'stream';
+import { parse } from 'csv';
 import BaseCommand from './base.js';
-import { extractURLFromSlackInput } from '../../../utils/slack/base.js';
+import { extractURLFromSlackInput, loadProfileConfig } from '../../../utils/slack/base.js';
 
 const PHRASE = 'audit';
 const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
@@ -21,21 +25,21 @@ export default (context) => {
   const baseCommand = BaseCommand({
     id: 'configurations-sites--toggle-site-audit',
     name: 'Enable/Disable the Site Audit',
-    description: 'Enables or disables an audit functionality for a site.',
+    description: `Enables or disables an audit functionality for a site. 
+    Supports single URL or CSV file upload.
+    CSV file must be in the format of baseURL per line(no headers).
+    Profiles are defined in the config/profiles.json file.`,
     phrases: [PHRASE],
-    usageText: `${PHRASE} {enable/disable} {site} {auditType}`,
+    usageText: `${PHRASE} {enable/disable} {site} {auditType} for singleURL, 
+    or ${PHRASE} {enable/disable} {profile/auditType} with CSV file uploaded.`,
   });
 
   const { log, dataAccess } = context;
   const { Configuration, Site } = dataAccess;
 
-  const validateInput = (enableAudit, baseURL, auditType) => {
+  const validateInput = (enableAudit, auditType) => {
     if (isString(enableAudit) === false || ['enable', 'disable'].includes(enableAudit) === false) {
       throw new Error('The "enableAudit" parameter is required and must be set to "enable" or "disable".');
-    }
-
-    if (isString(baseURL) === false || baseURL.length === 0) {
-      throw new Error('The site URL is missing or in the wrong format.');
     }
 
     if (isString(auditType) === false || auditType.length === 0) {
@@ -43,51 +47,231 @@ export default (context) => {
     }
   };
 
-  const handleExecution = async (args, slackContext) => {
-    const { say } = slackContext;
-    const [enableAuditInput, baseURLInput, auditTypeInput] = args;
+  const processCSVContent = async (fileContent) => {
+    const csvString = fileContent.trim();
+    const csvStream = Readable.from(csvString);
 
-    const enableAudit = enableAuditInput.toLowerCase();
-    const baseURL = extractURLFromSlackInput(baseURLInput);
-    const auditType = auditTypeInput.toLowerCase();
+    return new Promise((resolve, reject) => {
+      const urls = [];
 
-    try {
-      validateInput(enableAudit, baseURL, auditType);
-    } catch (error) {
-      await say(`${ERROR_MESSAGE_PREFIX}${error.message}`);
-      return;
+      csvStream
+        .pipe(parse({ skipEmptyLines: true }))
+        .on('data', (row) => {
+          if (row[0]?.trim()) {
+            urls.push(row[0].trim());
+          }
+        })
+        .on('end', () => {
+          if (urls.length === 0) {
+            reject(new Error('No valid URLs found in the CSV file.'));
+          } else {
+            resolve(urls);
+          }
+        })
+        .on('error', (error) => reject(new Error(`CSV processing failed: ${error.message}`)));
+    });
+  };
+
+  const validateCSVFile = async (file, fileContent) => {
+  // Check file extension
+
+    // Check if file is empty
+    if (hasText(fileContent) === false) {
+      throw new Error('The CSV file is empty.');
     }
 
+    // Process and validate content
+    const urls = await processCSVContent(fileContent);
+
+    // Check for valid URL format in each line
+    const invalidUrls = urls.filter((url) => !isValidUrl(url));
+
+    if (isNonEmptyArray(invalidUrls)) {
+      throw new Error(`Invalid URLs found in CSV:\n${invalidUrls.join('\n')}`);
+    }
+
+    return urls;
+  };
+
+  const handleExecution = async (args, slackContext) => {
+    const { say, files } = slackContext;
+
     try {
+      const [enableAuditInput, auditTypeOrProfileInput] = args;
+
+      const enableAudit = enableAuditInput.toLowerCase();
+      const auditTypeOrProfile = auditTypeOrProfileInput
+        ? auditTypeOrProfileInput.toLowerCase() : null;
+
       const configuration = await Configuration.findLatest();
-      const site = await Site.findByBaseURL(baseURL);
 
-      if (site === null) {
-        await say(`${ERROR_MESSAGE_PREFIX}Cannot update site with baseURL: "${baseURL}", site not found.`);
+      // single URL behavior
+      if (isNonEmptyArray(files) === false) {
+        const [, baseURLInput, singleAuditType] = args;
+
+        await say('No CSV Provided, entering single URL behavior');
+        const baseURL = extractURLFromSlackInput(baseURLInput);
+
+        validateInput(enableAudit, singleAuditType);
+
+        if (isValidUrl(baseURL) === false) {
+          await say(`${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.`);
+          return;
+        }
+
+        // Process single site
+        try {
+          const site = await Site.findByBaseURL(baseURL);
+          if (!site) {
+            await say(`${ERROR_MESSAGE_PREFIX}Cannot update site with baseURL: "${baseURL}", site not found.`);
+            return;
+          }
+
+          const registeredAudits = configuration.getHandlers();
+          if (!registeredAudits[singleAuditType]) {
+            await say(`${ERROR_MESSAGE_PREFIX}The "${singleAuditType}" is not present in the configuration.\nList of allowed audits:\n${Object.keys(registeredAudits).join('\n')}.`);
+            return;
+          }
+
+          if (enableAudit === 'enable') {
+            configuration.enableHandlerForSite(singleAuditType, site);
+          } else {
+            configuration.disableHandlerForSite(singleAuditType, site);
+          }
+
+          await configuration.save();
+          await say(`${SUCCESS_MESSAGE_PREFIX}The audit "${singleAuditType}" has been *${enableAudit}d* for "${site.getBaseURL()}".`);
+        } catch (error) {
+          log.error(error);
+          await say(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: ${error.message}`);
+        }
         return;
       }
 
-      const registeredAudits = configuration.getHandlers();
-      if (!registeredAudits[auditType]) {
-        await say(`${ERROR_MESSAGE_PREFIX}The "${auditType}" is not present in the configuration.\nList of allowed`
-            + ` audits:\n${Object.keys(registeredAudits).join('\n')}.`);
+      // Validate inputs and get audit types
+      validateInput(enableAudit, auditTypeOrProfile);
+
+      let auditTypes;
+      let isProfile = false;
+      try {
+      // Check if it's a profile by attempting to load it
+        try {
+          const profile = loadProfileConfig(auditTypeOrProfile);
+
+          auditTypes = Object.keys(profile.audits);
+          isProfile = true;
+        } catch (e) {
+        // If loading profile fails, it's a single audit type
+          const registeredAudits = configuration.getHandlers();
+          if (!registeredAudits[auditTypeOrProfile]) {
+            throw new Error(`Invalid audit type or profile: "${auditTypeOrProfile}"`);
+          }
+
+          auditTypes = [auditTypeOrProfile];
+
+          isProfile = false;
+        }
+
+        const typeDescription = isProfile ? `profile "${auditTypeOrProfile}"` : `audit type "${auditTypeOrProfile}"`;
+
+        await say(`:information_source: Processing ${typeDescription} with ${auditTypes.length} audit type${auditTypes.length > 1 ? 's' : ''}: ${auditTypes.join(', ')}`);
+      } catch (error) {
+        await say(`${ERROR_MESSAGE_PREFIX}${error.message}`);
         return;
       }
 
-      let successMessage;
-      if (enableAudit === 'enable') {
-        configuration.enableHandlerForSite(auditType, site);
-        successMessage = `${SUCCESS_MESSAGE_PREFIX}The audit "${auditType}" has been *enabled* for the "${site.getBaseURL()}".`;
-      } else {
-        configuration.disableHandlerForSite(auditType, site);
-        successMessage = `${SUCCESS_MESSAGE_PREFIX}The audit "${auditType}" has been *disabled* for the "${site.getBaseURL()}".`;
+      // Process the CSV file
+      const file = files[0];
+
+      const response = await fetch(file.url_private, {
+        headers: {
+          Authorization: `Bearer ${context.env.SLACK_BOT_TOKEN}`,
+        },
+      });
+
+      if (!response.ok) {
+        await say(`${ERROR_MESSAGE_PREFIX}Failed to download the CSV file.`);
+        return;
       }
 
+      const fileContent = await response.text();
+
+      let baseURLs;
+      try {
+        baseURLs = await validateCSVFile(file, fileContent);
+      } catch (error) {
+        await say(`${ERROR_MESSAGE_PREFIX}${error.message}`);
+        return;
+      }
+
+      // Process all URLs with the specified audit types
+      const results = {
+        successful: [],
+        failed: [],
+      };
+
+      await say(`:hourglass_flowing_sand: Processing ${baseURLs.length} URLs...`);
+
+      const processPromises = baseURLs.map(async (baseURL) => {
+        try {
+          const site = await Site.findByBaseURL(baseURL);
+          if (!site) {
+            return { baseURL, success: false, error: 'Site not found' };
+          }
+
+          auditTypes.forEach((auditType) => {
+            if (enableAudit === 'enable') {
+              configuration.enableHandlerForSite(auditType, site);
+            } else {
+              configuration.disableHandlerForSite(auditType, site);
+            }
+          });
+
+          return { baseURL, success: true };
+        } catch (error) {
+          return { baseURL, success: false, error: error.message };
+        }
+      });
+
+      const processedResults = await Promise.all(processPromises);
+
+      results.successful = processedResults
+        .filter((result) => result.success)
+        .map((result) => result.baseURL);
+
+      results.failed = processedResults
+        .filter((result) => !result.success)
+        .map(({ baseURL, error }) => ({ baseURL, error }));
+
+      // Save configuration after processing all sites
       await configuration.save();
-      await say(successMessage);
+
+      // Format and send results message
+      let message = ':clipboard: *Bulk Update Results*\n';
+      if (isProfile) {
+        message += `\nProfile: \`${auditTypeOrProfile}\` with ${auditTypes.length} audit types:`;
+        message += `\n\`\`\`${auditTypes.join('\n')}\`\`\``;
+      } else {
+        message += `\nAudit Type: \`${auditTypeOrProfile}\``;
+      }
+
+      if (results.successful.length > 0) {
+        message += `\n${SUCCESS_MESSAGE_PREFIX}Successfully ${enableAudit}d for ${results.successful.length} sites:`;
+        message += `\n\`\`\`${results.successful.join('\n')}\`\`\``;
+      }
+
+      if (results.failed.length > 0) {
+        message += `\n${ERROR_MESSAGE_PREFIX}Failed to process ${results.failed.length} sites:`;
+        message += '\n```';
+        results.failed.forEach(({ baseURL, error }) => {
+          message += `${baseURL}: ${error}\n`;
+        });
+        message += '```';
+      }
+
+      await say(message);
     } catch (error) {
       log.error(error);
-      // In the Slack command case, we shared the internal error with the user
       await say(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: ${error.message}`);
     }
   };

--- a/test/support/slack/commands/toggle-site-audit.test.js
+++ b/test/support/slack/commands/toggle-site-audit.test.js
@@ -14,7 +14,7 @@
 
 import sinon from 'sinon';
 import { expect } from 'chai';
-import ToggleSiteAuditCommand from '../../../../src/support/slack/commands/toggle-site-audit.js';
+import esmock from 'esmock';
 
 const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
 const ERROR_MESSAGE_PREFIX = ':x: ';
@@ -34,7 +34,8 @@ describe('UpdateSitesAuditsCommand', () => {
   let logMock;
   let contextMock;
   let slackContextMock;
-
+  let ToggleSiteAuditCommand;
+  let fetchStub;
   const exceptsAtBadRequest = () => {
     expect(
       configurationMock.enableHandlerForSite.called,
@@ -78,11 +79,24 @@ describe('UpdateSitesAuditsCommand', () => {
     contextMock = {
       log: logMock,
       dataAccess: dataAccessMock,
+      env: {
+        SLACK_BOT_TOKEN: 'mock-token',
+      },
     };
 
     slackContextMock = {
       say: sinon.stub(),
     };
+
+    fetchStub = sinon.stub().resolves({
+      ok: true,
+      text: () => Promise.resolve('https://site1.com\nhttps://site2.com'),
+    });
+    ToggleSiteAuditCommand = await esmock('../../../../src/support/slack/commands/toggle-site-audit.js', {
+      '@adobe/spacecat-shared-utils': {
+        tracingFetch: fetchStub,
+      },
+    });
   });
 
   afterEach(() => {
@@ -109,7 +123,7 @@ describe('UpdateSitesAuditsCommand', () => {
       'Expected configuration.enableHandlerForSite to be called with "some_audit" and site, but it was not',
     ).to.be.true;
     expect(
-      slackContextMock.say.calledWith(`${SUCCESS_MESSAGE_PREFIX}The audit "some_audit" has been *enabled* for the "https://site0.com".`),
+      slackContextMock.say.calledWith(`${SUCCESS_MESSAGE_PREFIX}The audit "some_audit" has been *enabled* for "https://site0.com".`),
       'Expected Slack message to be sent confirming "some_audit" was enabled for "https://site0.com", but it was not',
     ).to.be.true;
   });
@@ -134,7 +148,7 @@ describe('UpdateSitesAuditsCommand', () => {
       'Expected configuration.disableHandlerForSite to be called with "some_audit" and site, but it was not',
     ).to.be.true;
     expect(
-      slackContextMock.say.calledWith(`${SUCCESS_MESSAGE_PREFIX}The audit "some_audit" has been *disabled* for the "https://site0.com".`),
+      slackContextMock.say.calledWith(`${SUCCESS_MESSAGE_PREFIX}The audit "some_audit" has been *disabled* for "https://site0.com".`),
       'Expected Slack message to be sent confirming "some_audit" was disabled for "https://site0.com", but it was not',
     ).to.be.true;
   });
@@ -149,18 +163,6 @@ describe('UpdateSitesAuditsCommand', () => {
     expect(
       dataAccessMock.Site.findByBaseURL.calledWith('https://site0.com'),
       'Expected dataAccess.getSiteByBaseURL to be called with "site0.com", but it was not',
-    ).to.be.true;
-    expect(
-      configurationMock.save.called,
-      'Expected dataAccess.updateConfiguration to be called, but it was not',
-    ).to.be.true;
-    expect(
-      configurationMock.disableHandlerForSite.calledWith('some_audit', site),
-      'Expected configuration.disableHandlerForSite to be called with "some_audit" and site, but it was not',
-    ).to.be.true;
-    expect(
-      slackContextMock.say.calledWith(`${SUCCESS_MESSAGE_PREFIX}The audit "some_audit" has been *disabled* for the "https://site0.com".`),
-      'Expected Slack message to be sent confirming "some_audit" was disabled for "https://site0.com", but it was not',
     ).to.be.true;
   });
 
@@ -195,8 +197,8 @@ describe('UpdateSitesAuditsCommand', () => {
 
       exceptsAtBadRequest();
       expect(
-        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}The "enableAudit" parameter is required and must be set to "enable" or "disable".`),
-        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}The 'enableAudits' parameter is required and must be set to 'enable' or 'disable'."`,
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: The "enableAudit" parameter is required and must be set to "enable" or "disable".`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: The "enableAudit" parameter is required and must be set to "enable" or "disable"."`,
       ).to.be.true;
     });
 
@@ -208,8 +210,8 @@ describe('UpdateSitesAuditsCommand', () => {
 
       exceptsAtBadRequest();
       expect(
-        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}The "enableAudit" parameter is required and must be set to "enable" or "disable".`),
-        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}The 'enableAudits' parameter is required and must be set to 'enable' or 'disable'."`,
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: The "enableAudit" parameter is required and must be set to "enable" or "disable".`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: The "enableAudit" parameter is required and must be set to "enable" or "disable"."`,
       ).to.be.true;
     });
 
@@ -221,8 +223,8 @@ describe('UpdateSitesAuditsCommand', () => {
 
       exceptsAtBadRequest();
       expect(
-        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}The site URL is missing or in the wrong format.`),
-        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}The site URL is missing or in the wrong format.", but it was not called with that message.`,
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.", but it was not called with that message.`,
       ).to.be.true;
     });
 
@@ -234,8 +236,8 @@ describe('UpdateSitesAuditsCommand', () => {
 
       exceptsAtBadRequest();
       expect(
-        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}The site URL is missing or in the wrong format.`),
-        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}The site URL is missing or in the wrong format.", but it was not called with that message.`,
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL."`,
       ).to.be.true;
     });
 
@@ -261,8 +263,8 @@ describe('UpdateSitesAuditsCommand', () => {
 
       exceptsAtBadRequest();
       expect(
-        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}The audit type parameter is required.`),
-        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}The audit type parameter is required.", but it was not called with that message.`,
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: The audit type parameter is required.`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable audits: The audit type parameter is required.", but it was not called with that message.`,
       ).to.be.true;
     });
 
@@ -281,6 +283,218 @@ describe('UpdateSitesAuditsCommand', () => {
           + ` audits:\n${Object.keys(handlers).join('\n')}.`),
         'Expected error message was not called',
       ).to.be.true;
+    });
+  });
+
+  describe('CSV bulk operations', () => {
+    it('should process CSV file to enable with profile', async () => {
+      const args = ['enable', 'default'];
+      const command = ToggleSiteAuditCommand(contextMock);
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'https://mock-url',
+      }];
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves(site);
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves(site);
+
+      await command.handleExecution(args, slackContextMock);
+
+      expect(configurationMock.enableHandlerForSite.callCount)
+        .to.equal(14);
+      expect(configurationMock.save.calledOnce).to.be.true;
+      expect(slackContextMock.say.calledWith(sinon.match('Successfully'))).to.be.true;
+    });
+
+    it('should process CSV file to disable with profile', async () => {
+      const args = ['disable', 'default'];
+      const command = ToggleSiteAuditCommand(contextMock);
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'https://mock-url',
+      }];
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves(site);
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves(site);
+
+      await command.handleExecution(args, slackContextMock);
+
+      expect(configurationMock.disableHandlerForSite.callCount)
+        .to.equal(14);
+      expect(configurationMock.save.calledOnce).to.be.true;
+      expect(slackContextMock.say.calledWith(sinon.match('Successfully'))).to.be.true;
+    });
+
+    it('should handle errors during audit enabling/disabling in bulk processing', async () => {
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves(site);
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves(site);
+
+      configurationMock.enableHandlerForSite
+        .withArgs('cwv', site)
+        .onFirstCall().returns()
+        .onSecondCall()
+        .throws(new Error('Test error during enable'));
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(
+        sinon.match((value) => value.includes(':clipboard: *Bulk Update Results*')
+          && value.includes('Successfully enabled for 1 sites')
+          && value.includes('https://site1.com')
+          && value.includes('Failed to process 1 sites')
+          && value.includes('https://site2.com: Test error during enable')),
+      )).to.be.true;
+
+      expect(configurationMock.save.calledOnce).to.be.true;
+    });
+
+    it('should handle CSV file with invalid URLs', async () => {
+      fetchStub.resolves({
+        ok: true,
+        text: () => Promise.resolve('invalid-url\nhttps://valid.com'),
+      });
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Invalid URLs found'))).to.be.true;
+    });
+
+    it('should handle CSV file with only invalid URLs', async () => {
+      fetchStub.resolves({
+        ok: true,
+        text: () => Promise.resolve(' \n  '),
+      });
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match(':x: No valid URLs found in the CSV file.'))).to.be.true;
+    });
+
+    it('should handle empty CSV file', async () => {
+      fetchStub.resolves({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('CSV file is empty'))).to.be.true;
+    });
+
+    it('should handle CSV download failure', async () => {
+      fetchStub.resolves({
+        ok: false,
+      });
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Failed to download'))).to.be.true;
+    });
+
+    it('should handle CSV file with invalid URLs', async () => {
+      fetchStub.resolves({
+        ok: true,
+        text: () => Promise.resolve('invalid-url1\ninvalid-url2'),
+      });
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Invalid URLs found'))).to.be.true;
+    });
+
+    it('should handle sites that are not found during bulk processing', async () => {
+      fetchStub.resolves({
+        ok: true,
+        text: () => Promise.resolve('https://site1.com\nhttps://nonexistent-site.com'),
+      });
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves(site);
+      dataAccessMock.Site.findByBaseURL.withArgs('https://nonexistent-site.com').resolves(null);
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(
+        sinon.match((value) => value.includes(':clipboard: *Bulk Update Results*')
+          && value.includes('Successfully enabled for 1 sites')
+          && value.includes('https://site1.com')
+          && value.includes('Failed to process 1 sites')
+          && value.includes('https://nonexistent-site.com: Site not found')),
+      )).to.be.true;
+
+      expect(configurationMock.save.calledOnce).to.be.true;
+    });
+
+    it('should throw an error when CSV processing fails', async () => {
+      fetchStub.resolves({
+        ok: true,
+        text: () => Promise.resolve('"unclosed quote\nhttp://example.com'),
+      });
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'cwv'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('CSV processing failed:'))).to.be.true;
+    });
+  });
+
+  describe('profile handling', () => {
+    it('should handle invalid profile name', async () => {
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'http://mock-url',
+      }];
+
+      const command = ToggleSiteAuditCommand(contextMock);
+      await command.handleExecution(['enable', 'invalid-profile'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Invalid audit type or profile'))).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Changes:
- Added csv support for toggle-site-audit
- bulk enable/disable based on profile/auditType
- Changed usage and description for the command
- Unit tests for the enhanced toggle-site-audit