### PR TITLE
fix: enable imports for sites

### DIFF
--- a/src/support/slack/commands/onboard.js
+++ b/src/support/slack/commands/onboard.js
@@ -181,6 +181,8 @@ function OnboardCommand(context) {
 
       for (const importType of importTypes) {
         /* eslint-disable no-await-in-loop */
+        site.enableImport(importType);
+        await site.save();
         await triggerImportRun(
           configuration,
           importType,


### PR DESCRIPTION
Enable imports for each site using the default config