### PR TITLE
fix: all audit command triggers only lhs

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -115,12 +115,11 @@ function RunAuditCommand(context) {
     const { say, files, botToken } = slackContext;
 
     try {
-      const [baseURLInput, auditTypeInput] = args;
+      const [baseURLInputArg, auditTypeInputArg] = args;
 
-      const baseURL = extractURLFromSlackInput(baseURLInput);
-      const hasValidBaseURL = isValidUrl(baseURL);
       const hasFiles = isNonEmptyArray(files);
-      const auditType = auditTypeInput || LHS_MOBILE;
+      const baseURL = extractURLFromSlackInput(baseURLInputArg);
+      const hasValidBaseURL = isValidUrl(baseURL);
 
       if (!hasValidBaseURL && !hasFiles) {
         await say(baseCommand.usage());
@@ -133,6 +132,9 @@ function RunAuditCommand(context) {
       }
 
       if (hasFiles) {
+        const [, auditTypeInput] = ['', baseURLInputArg];
+        const auditType = auditTypeInput || LHS_MOBILE;
+
         if (files.length > 1) {
           await say(':warning: Please provide only one CSV file.');
           return;
@@ -159,6 +161,7 @@ function RunAuditCommand(context) {
           }),
         );
       } else if (hasValidBaseURL) {
+        const auditType = auditTypeInputArg || LHS_MOBILE;
         await runAuditForSite(baseURL, auditType, slackContext);
       }
     } catch (error) {

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -149,7 +149,7 @@ describe('RunAuditCommand', () => {
           + 'https://valid.url,uuidv4');
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['', 'all'], slackContext);
+      await command.handleExecution(['all'], slackContext);
 
       expect(slackContext.say.called).to.be.true;
       expect(slackContext.say.firstCall.args[0]).to.equal(':adobe-run: Triggering all audit for 2 sites.');


### PR DESCRIPTION
fix `run audit all` executing only lhs audits