### PR TITLE
fix: obtain all enabled audits

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -24,6 +24,29 @@ import { triggerAuditForSite } from '../../utils.js';
 
 const PHRASES = ['run audit'];
 const LHS_MOBILE = 'lhs-mobile';
+const ALL_AUDITS = [
+  'apex',
+  'cwv',
+  'lhs-mobile',
+  'lhs-desktop',
+  '404',
+  'sitemap',
+  'canonical',
+  'broken-backlinks',
+  'broken-internal-links',
+  'experimentation',
+  'conversion',
+  'experimentation-ess-daily',
+  'experimentation-ess-all',
+  'experimentation-opportunities',
+  'meta-tags',
+  'costs',
+  'structured-data',
+  'forms-opportunities',
+  'site-detection',
+  'guidance:high-organic-low-ctr',
+  'alt-text',
+];
 
 /**
  * Factory function to create the RunAuditCommand object.
@@ -64,7 +87,10 @@ function RunAuditCommand(context) {
       }
 
       if (auditType === 'all') {
-        const enabledAudits = configuration.getEnabledAuditsForSite(site);
+        // const enabledAudits = configuration.getEnabledAuditsForSite(site);
+        const enabledAudits = ALL_AUDITS.filter(
+          (audit) => configuration.isHandlerEnabledForSite(audit, site),
+        );
 
         if (!isNonEmptyArray(enabledAudits)) {
           await say(`:warning: No audits configured for site \`${baseURL}\``);

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -114,11 +114,13 @@ describe('RunAuditCommand', () => {
     });
 
     it('trigger all audits for a valid site', async () => {
+      const handlerEnabledStub = sinon.stub().onCall(0).returns(true).onCall(1)
+        .returns(true);
       dataAccessStub.Site.findByBaseURL.resolves({
         getId: () => '123',
       });
       dataAccessStub.Configuration.findLatest.resolves({
-        getEnabledAuditsForSite: () => ['lhs-mobile', 'lhs-desktop'],
+        isHandlerEnabledForSite: handlerEnabledStub,
       });
 
       const command = RunAuditCommand(context);
@@ -130,11 +132,15 @@ describe('RunAuditCommand', () => {
     });
 
     it('triggers all audits for all sites specified in a CSV file', async () => {
+      const handlerEnabledStub = sinon.stub().onCall(0).returns(true).onCall(1)
+        .returns(true)
+        .onCall(22)
+        .returns(true);
       dataAccessStub.Site.findByBaseURL.resolves({
         getId: () => '123',
       });
       dataAccessStub.Configuration.findLatest.resolves({
-        getEnabledAuditsForSite: () => ['lhs-mobile', 'lhs-desktop'],
+        isHandlerEnabledForSite: handlerEnabledStub,
       });
       const fileUrl = 'https://example.com/sites.csv';
       slackContext.files = [
@@ -214,11 +220,12 @@ describe('RunAuditCommand', () => {
     });
 
     it('handles site with no enable audits', async () => {
+      const handlerEnabledStub = sinon.stub().onCall(0).returns(false);
       dataAccessStub.Site.findByBaseURL.resolves({
         getId: () => '123',
       });
       dataAccessStub.Configuration.findLatest.resolves({
-        getEnabledAuditsForSite: () => [],
+        isHandlerEnabledForSite: handlerEnabledStub,
       });
 
       const command = RunAuditCommand(context);
@@ -229,12 +236,13 @@ describe('RunAuditCommand', () => {
     });
 
     it('handles error while triggering audits', async () => {
-      const errorMessage = 'Failed to send message';
+      const errorMessage = 'Failed to trigger';
+      const handlerEnabledStub = sinon.stub().onCall(0).returns(true);
       dataAccessStub.Site.findByBaseURL.resolves({
         getId: () => '123',
       });
       dataAccessStub.Configuration.findLatest.resolves({
-        getEnabledAuditsForSite: () => ['lhs-mobile', 'lhs-desktop'],
+        isHandlerEnabledForSite: handlerEnabledStub,
       });
       sqsStub.sendMessage.rejects(new Error(errorMessage));
 


### PR DESCRIPTION
`getEnabledAudits` does rely on the wrong configurations hence adding a list of all audits