### PR TITLE
feat: toggle-site-imports Slack command for enabling/disabling imports

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -25,6 +25,7 @@ import help from './commands/help.js';
 import toggleSiteAudit from './commands/toggle-site-audit.js';
 import onboard from './commands/onboard.js';
 import setSiteOrganizationCommand from './commands/set-ims-org.js';
+import toggleSiteImport from './commands/toggle-site-import.js';
 
 /**
  * Returns all commands.
@@ -48,4 +49,5 @@ export default (context) => [
   toggleSiteAudit(context),
   onboard(context),
   setSiteOrganizationCommand(context),
+  toggleSiteImport(context),
 ];

--- a/src/support/slack/commands/toggle-site-import.js
+++ b/src/support/slack/commands/toggle-site-import.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Adobe. All rights reserved.
+ * Copyright 2025 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/support/slack/commands/toggle-site-import.js
+++ b/src/support/slack/commands/toggle-site-import.js
@@ -64,9 +64,6 @@ export default (context) => {
   const validateCSVFile = async (fileContent, botToken) => {
     const urls = [];
     const invalidUrls = [];
-    if (hasText(fileContent) === false) {
-      throw new Error('The CSV file is empty.');
-    }
     const csvData = await parseCSV(fileContent, botToken);
 
     if (!isNonEmptyArray(csvData)) {
@@ -105,12 +102,6 @@ export default (context) => {
 
     validateInput(enableImport, importType);
 
-    if (isValidUrl(baseURL) === false) {
-      await say(`${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.`);
-      result.error = 'Invalid baseURL';
-      return result;
-    }
-
     try {
       const site = await Site.findByBaseURL(baseURL);
       if (!site) {
@@ -142,6 +133,7 @@ export default (context) => {
       result.success = true;
       return result;
     } catch (error) {
+      console.log('debug1', error);
       log.error(error);
       result.error = error.message;
       return result;
@@ -183,26 +175,22 @@ export default (context) => {
 
       let importTypes;
       let isProfile = false;
-      try {
+
       // Check if it's a profile by attempting to load it
-        try {
-          const profile = loadProfileConfig(importTypeOrProfile);
+      try {
+        const profile = loadProfileConfig(importTypeOrProfile);
 
-          importTypes = Object.keys(profile.imports);
-          isProfile = true;
-        } catch (e) {
+        importTypes = Object.keys(profile.imports);
+        isProfile = true;
+      } catch (e) {
         // If loading profile fails, it's a single import type
-          importTypes = [importTypeOrProfile];
-          isProfile = false;
-        }
-
-        const typeDescription = isProfile ? `profile "${importTypeOrProfile}"` : `import type "${importTypeOrProfile}"`;
-
-        await say(`:information_source: Processing ${typeDescription} with ${importTypes.length} import type${importTypes.length > 1 ? 's' : ''}: ${importTypes.join(', ')}`);
-      } catch (error) {
-        await say(`${ERROR_MESSAGE_PREFIX}${error.message}`);
-        return;
+        importTypes = [importTypeOrProfile];
+        isProfile = false;
       }
+
+      const typeDescription = isProfile ? `profile "${importTypeOrProfile}"` : `import type "${importTypeOrProfile}"`;
+
+      await say(`:information_source: Processing ${typeDescription} with ${importTypes.length} import type${importTypes.length > 1 ? 's' : ''}: ${importTypes.join(', ')}`);
 
       const file = files[0];
 
@@ -247,6 +235,7 @@ export default (context) => {
         if (result.success) {
           results.successful.push(result.baseURL);
         } else {
+          console.log('debug2', result);
           results.failed.push({ baseURL, error: result.error });
         }
       });
@@ -283,6 +272,7 @@ export default (context) => {
         message += '```';
       }
 
+      console.log(message);
       await say(message);
     } catch (error) {
       log.error(error);

--- a/src/support/slack/commands/toggle-site-import.js
+++ b/src/support/slack/commands/toggle-site-import.js
@@ -133,8 +133,8 @@ export default (context) => {
       result.success = true;
       return result;
     } catch (error) {
-      console.log('debug1', error);
       log.error(error);
+      result.success = false;
       result.error = error.message;
       return result;
     }
@@ -235,7 +235,6 @@ export default (context) => {
         if (result.success) {
           results.successful.push(result.baseURL);
         } else {
-          console.log('debug2', result);
           results.failed.push({ baseURL, error: result.error });
         }
       });

--- a/src/support/slack/commands/toggle-site-import.js
+++ b/src/support/slack/commands/toggle-site-import.js
@@ -72,7 +72,7 @@ export default (context) => {
 
     for (const row of csvData) {
       const [baseURL] = row;
-      if (isValidUrl(baseURL) === false) {
+      if (!isValidUrl(baseURL)) {
         invalidUrls.push(baseURL);
       } else {
         urls.push(baseURL);
@@ -103,6 +103,10 @@ export default (context) => {
     validateInput(enableImport, importType);
 
     try {
+      if (!isValidUrl(baseURL)) {
+        throw new Error(`Invalid URL: ${baseURL}`);
+      }
+
       const site = await Site.findByBaseURL(baseURL);
       if (!site) {
         await say(`${ERROR_MESSAGE_PREFIX}Cannot update site with baseURL: "${baseURL}", site not found.`);
@@ -152,10 +156,9 @@ export default (context) => {
         ? importTypeOrProfileInput.toLowerCase() : null;
 
       // single URL behavior
-      if (isNonEmptyArray(files) === false) {
+      if (!isNonEmptyArray(files)) {
         const [, baseURLInput, singleImportType] = args;
 
-        await say('No CSV Provided, entering single URL behavior');
         const result = await handleSingleURL(
           baseURLInput,
           singleImportType,
@@ -271,7 +274,6 @@ export default (context) => {
         message += '```';
       }
 
-      console.log(message);
       await say(message);
     } catch (error) {
       log.error(error);

--- a/src/support/slack/commands/toggle-site-import.js
+++ b/src/support/slack/commands/toggle-site-import.js
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import {
+  isValidUrl, isNonEmptyArray, hasText, tracingFetch as fetch,
+} from '@adobe/spacecat-shared-utils';
+import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
+
+import { parseCSV, extractURLFromSlackInput, loadProfileConfig } from '../../../utils/slack/base.js';
+import BaseCommand from './base.js';
+
+const PHRASE = 'import';
+const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
+const ERROR_MESSAGE_PREFIX = ':x: ';
+
+export default (context) => {
+  const baseCommand = BaseCommand({
+    id: 'configurations-sites--toggle-site-import',
+    name: 'Enable/Disable the Site Import',
+    description: `Enables or disables an import functionality for a site. 
+    Supports single URL or CSV file upload.
+    CSV file must be in the format of baseURL per line(no headers).
+    Profiles are defined in the config/profiles.json file.`,
+    phrases: [PHRASE],
+    usageText: `${PHRASE} {enable/disable} {site} {importType} for singleURL, 
+    or ${PHRASE} {enable/disable} {profile/importType} with CSV file uploaded.`,
+  });
+
+  const { log, dataAccess } = context;
+  const { Site } = dataAccess;
+
+  /**
+   * Validates the command input parameters for enabling/disabling imports.
+   *
+   * @param {string} enableImport - The action to perform, must be either 'enable' or 'disable'
+   * @param {string} importType - The type of import or profile to enable/disable
+   * @throws {Error} If enableImport is invalid or if importType is empty/not a string
+   */
+  const validateInput = (enableImport, importType) => {
+    if (hasText(enableImport) === false || ['enable', 'disable'].includes(enableImport) === false) {
+      throw new Error('The "enableImport" parameter is required and must be set to "enable" or "disable".');
+    }
+
+    if (hasText(importType) === false || importType.length === 0) {
+      throw new Error('The import type parameter is required.');
+    }
+  };
+
+  /**
+   * Validates the content of a CSV file by checking for non-empty content and valid URLs.
+   *
+   * @param {string} fileContent - The raw CSV file content to validate
+   * @returns {Promise<string[]>} A promise that resolves to an array of validated URLs
+   * @throws {Error} If the file is empty or contains invalid URLs
+   */
+  const validateCSVFile = async (fileContent, botToken) => {
+    const urls = [];
+    const invalidUrls = [];
+    if (hasText(fileContent) === false) {
+      throw new Error('The CSV file is empty.');
+    }
+    const csvData = await parseCSV(fileContent, botToken);
+
+    if (!isNonEmptyArray(csvData)) {
+      throw new Error('The parsed CSV data is empty.');
+    }
+
+    for (const row of csvData) {
+      const [baseURL] = row;
+      if (isValidUrl(baseURL) === false) {
+        invalidUrls.push(baseURL);
+      } else {
+        urls.push(baseURL);
+      }
+    }
+
+    if (isNonEmptyArray(invalidUrls)) {
+      throw new Error(`Invalid URLs found in CSV:\n${invalidUrls.join('\n')}`);
+    }
+    return urls;
+  };
+
+  const handleSingleURL = async (
+    baseURLInput,
+    importType,
+    enableImport,
+    say,
+    isEnableImport,
+    isProfile = false,
+  ) => {
+    const result = {
+      baseURL: baseURLInput,
+      success: false,
+      error: null,
+    };
+    const baseURL = extractURLFromSlackInput(baseURLInput);
+
+    validateInput(enableImport, importType);
+
+    if (isValidUrl(baseURL) === false) {
+      await say(`${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.`);
+      result.error = 'Invalid baseURL';
+      return result;
+    }
+
+    try {
+      const site = await Site.findByBaseURL(baseURL);
+      if (!site) {
+        await say(`${ERROR_MESSAGE_PREFIX}Cannot update site with baseURL: "${baseURL}", site not found.`);
+        result.error = 'Site not found';
+        return result;
+      }
+
+      const siteConfig = site.getConfig();
+      let importTypes = [];
+
+      if (isProfile) {
+        importTypes = importType;
+      } else {
+        importTypes = [importType];
+      }
+
+      for (const importTypeItem of importTypes) {
+        if (isEnableImport) {
+          siteConfig.enableImport(importTypeItem);
+        } else {
+          siteConfig.disableImport(importTypeItem);
+        }
+      }
+
+      site.setConfig(Config.toDynamoItem(siteConfig));
+      await site.save();
+
+      result.success = true;
+      return result;
+    } catch (error) {
+      log.error(error);
+      result.error = error.message;
+      return result;
+    }
+  };
+
+  const handleExecution = async (args, slackContext) => {
+    const { say, files, botToken } = slackContext;
+
+    try {
+      const [enableImportInput, importTypeOrProfileInput] = args;
+
+      const enableImport = enableImportInput.toLowerCase();
+      const isEnableImport = enableImport === 'enable';
+      const importTypeOrProfile = importTypeOrProfileInput
+        ? importTypeOrProfileInput.toLowerCase() : null;
+
+      // single URL behavior
+      if (isNonEmptyArray(files) === false) {
+        const [, baseURLInput, singleImportType] = args;
+
+        await say('No CSV Provided, entering single URL behavior');
+        const result = await handleSingleURL(
+          baseURLInput,
+          singleImportType,
+          enableImport,
+          say,
+          isEnableImport,
+        );
+        if (result.success) {
+          await say(`${SUCCESS_MESSAGE_PREFIX}The import "${singleImportType}" has been *${enableImport}d* for "${baseURLInput}".`);
+        } else {
+          await say(`${ERROR_MESSAGE_PREFIX}${result.error}`);
+        }
+        return;
+      }
+
+      validateInput(enableImport, importTypeOrProfile);
+
+      let importTypes;
+      let isProfile = false;
+      try {
+      // Check if it's a profile by attempting to load it
+        try {
+          const profile = loadProfileConfig(importTypeOrProfile);
+
+          importTypes = Object.keys(profile.imports);
+          isProfile = true;
+        } catch (e) {
+        // If loading profile fails, it's a single import type
+          importTypes = [importTypeOrProfile];
+          isProfile = false;
+        }
+
+        const typeDescription = isProfile ? `profile "${importTypeOrProfile}"` : `import type "${importTypeOrProfile}"`;
+
+        await say(`:information_source: Processing ${typeDescription} with ${importTypes.length} import type${importTypes.length > 1 ? 's' : ''}: ${importTypes.join(', ')}`);
+      } catch (error) {
+        await say(`${ERROR_MESSAGE_PREFIX}${error.message}`);
+        return;
+      }
+
+      const file = files[0];
+
+      const response = await fetch(file.url_private, {
+        headers: {
+          Authorization: `Bearer ${context.env.SLACK_BOT_TOKEN}`,
+        },
+      });
+
+      if (!response.ok) {
+        await say(`${ERROR_MESSAGE_PREFIX}Failed to download the CSV file.`);
+        return;
+      }
+
+      const fileContent = await response.text();
+
+      let baseURLs;
+      try {
+        baseURLs = await validateCSVFile(fileContent, botToken);
+      } catch (error) {
+        await say(`${ERROR_MESSAGE_PREFIX}${error.message}`);
+        return;
+      }
+
+      const results = {
+        successful: [],
+        failed: [],
+      };
+
+      await say(`:hourglass_flowing_sand: Processing ${baseURLs.length} URLs...`);
+
+      const processPromises = baseURLs.map(async (baseURL) => {
+        const result = await handleSingleURL(
+          baseURL,
+          importTypeOrProfile,
+          enableImport,
+          say,
+          isEnableImport,
+          true,
+        );
+
+        if (result.success) {
+          results.successful.push(result.baseURL);
+        } else {
+          results.failed.push({ baseURL, error: result.error });
+        }
+      });
+
+      const processedResults = await Promise.all(processPromises);
+
+      results.successful = processedResults
+        .filter((result) => result.success)
+        .map((result) => result.baseURL);
+
+      results.failed = processedResults
+        .filter((result) => !result.success)
+        .map(({ baseURL, error }) => ({ baseURL, error }));
+
+      let message = ':clipboard: *Bulk Update Results*\n';
+      if (isProfile) {
+        message += `\nProfile: \`${importTypeOrProfile}\` with ${importTypes.length} import types:`;
+        message += `\n\`\`\`${importTypes.join('\n')}\`\`\``;
+      } else {
+        message += `\nImport Type: \`${importTypeOrProfile}\``;
+      }
+
+      if (isNonEmptyArray(results.successful)) {
+        message += `\n${SUCCESS_MESSAGE_PREFIX}Successfully ${enableImport}d for ${results.successful.length} sites:`;
+        message += `\n\`\`\`${results.successful.join('\n')}\`\`\``;
+      }
+
+      if (isNonEmptyArray(results.failed)) {
+        message += `\n${ERROR_MESSAGE_PREFIX}Failed to process ${results.failed.length} sites:`;
+        message += '\n```';
+        results.failed.forEach(({ baseURL, error }) => {
+          message += `${baseURL}: ${error}\n`;
+        });
+        message += '```';
+      }
+
+      await say(message);
+    } catch (error) {
+      log.error(error);
+      await say(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: ${error.message}`);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+};

--- a/test/support/slack/commands/toggle-site-import.test.js
+++ b/test/support/slack/commands/toggle-site-import.test.js
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import sinon from 'sinon';
+import { expect } from 'chai';
+import esmock from 'esmock';
+
+const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
+const ERROR_MESSAGE_PREFIX = ':x: ';
+
+describe('ToggleSiteImportCommand', () => {
+  const sandbox = sinon.createSandbox();
+
+  const siteConfig = {
+    enableImport: sandbox.stub(),
+    disableImport: sandbox.stub(),
+  };
+
+  const site = {
+    getId: () => 'site0',
+    getBaseURL: () => 'https://site0.com',
+    getDeliveryType: () => 'aem_edge',
+    getConfig: () => siteConfig,
+    setConfig: sandbox.stub(),
+    save: sandbox.stub(),
+  };
+
+  let dataAccessMock;
+  let logMock;
+  let contextMock;
+  let slackContextMock;
+  let ToggleSiteImportCommand;
+  let fetchStub;
+  let parseCSVStub;
+  let configToDynamoItemStub;
+
+  const expectsAtBadRequest = () => {
+    expect(
+      siteConfig.enableImport.called,
+      'Expected enableImport to not be called, but it was',
+    ).to.be.false;
+    expect(
+      siteConfig.disableImport.called,
+      'Expected disableImport to not be called, but it was',
+    ).to.be.false;
+    expect(
+      site.save.called,
+      'Expected site.save to not be called, but it was',
+    ).to.be.false;
+  };
+
+  beforeEach(async () => {
+    siteConfig.enableImport.reset();
+    siteConfig.disableImport.reset();
+    site.setConfig.reset();
+    site.save.reset();
+
+    dataAccessMock = {
+      Site: {
+        findByBaseURL: sandbox.stub().resolves(),
+      },
+    };
+
+    logMock = {
+      error: sandbox.stub(),
+    };
+
+    contextMock = {
+      log: logMock,
+      dataAccess: dataAccessMock,
+      env: {
+        SLACK_BOT_TOKEN: 'mock-token',
+      },
+    };
+
+    slackContextMock = {
+      say: sinon.stub(),
+      botToken: 'mock-token',
+    };
+
+    fetchStub = sinon.stub().resolves({
+      ok: true,
+      text: () => Promise.resolve('https://site1.com\nhttps://site2.com'),
+    });
+
+    parseCSVStub = sinon.stub().resolves([
+      ['https://site1.com'],
+      ['https://site2.com'],
+    ]);
+
+    configToDynamoItemStub = sinon.stub().returns({ importConfig: 'mockConfig' });
+
+    ToggleSiteImportCommand = await esmock('../../../../src/support/slack/commands/toggle-site-import.js', {
+      '@adobe/spacecat-shared-utils': {
+        tracingFetch: fetchStub,
+        isValidUrl: (url) => url.startsWith('http'),
+        isNonEmptyArray: (arr) => Array.isArray(arr) && arr.length > 0,
+        hasText: (text) => typeof text === 'string' && text.trim().length > 0,
+      },
+      '../../../../src/utils/slack/base.js': {
+        parseCSV: parseCSVStub,
+        extractURLFromSlackInput: (url) => (url.startsWith('http') ? url : `https://${url}`),
+        loadProfileConfig: (profile) => {
+          if (profile === 'default') {
+            return {
+              imports: {
+                content: { enabled: true },
+                assets: { enabled: true },
+              },
+            };
+          }
+          throw new Error(`Invalid profile: ${profile}`);
+        },
+      },
+      '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
+        Config: {
+          toDynamoItem: configToDynamoItemStub,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('enable an import type for a site', async () => {
+    dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(site);
+
+    const command = ToggleSiteImportCommand(contextMock);
+    const args = ['enable', 'https://site0.com', 'content'];
+    await command.handleExecution(args, slackContextMock);
+
+    expect(
+      dataAccessMock.Site.findByBaseURL.calledWith('https://site0.com'),
+      'Expected dataAccess.Site.findByBaseURL to be called with "https://site0.com", but it was not',
+    ).to.be.true;
+    expect(
+      site.save.called,
+      'Expected site.save to be called, but it was not',
+    ).to.be.true;
+    expect(
+      siteConfig.enableImport.calledWith('content'),
+      'Expected siteConfig.enableImport to be called with "content", but it was not',
+    ).to.be.true;
+    expect(
+      slackContextMock.say.calledWith(`${SUCCESS_MESSAGE_PREFIX}The import "content" has been *enabled* for "https://site0.com".`),
+      'Expected Slack message to be sent confirming "content" was enabled for "https://site0.com", but it was not',
+    ).to.be.true;
+  });
+
+  it('disable an import type for a site', async () => {
+    dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(site);
+
+    const command = ToggleSiteImportCommand(contextMock);
+    const args = ['disable', 'https://site0.com', 'content'];
+    await command.handleExecution(args, slackContextMock);
+
+    expect(
+      dataAccessMock.Site.findByBaseURL.calledWith('https://site0.com'),
+      'Expected dataAccess.Site.findByBaseURL to be called with "https://site0.com", but it was not',
+    ).to.be.true;
+    expect(
+      site.save.called,
+      'Expected site.save to be called, but it was not',
+    ).to.be.true;
+    expect(
+      siteConfig.disableImport.calledWith('content'),
+      'Expected siteConfig.disableImport to be called with "content", but it was not',
+    ).to.be.true;
+    expect(
+      slackContextMock.say.calledWith(`${SUCCESS_MESSAGE_PREFIX}The import "content" has been *disabled* for "https://site0.com".`),
+      'Expected Slack message to be sent confirming "content" was disabled for "https://site0.com", but it was not',
+    ).to.be.true;
+  });
+
+  it('if site base URL without scheme should be added "https://"', async () => {
+    dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(site);
+
+    const command = ToggleSiteImportCommand(contextMock);
+    const args = ['disable', 'site0.com', 'content'];
+    await command.handleExecution(args, slackContextMock);
+
+    expect(
+      dataAccessMock.Site.findByBaseURL.calledWith('https://site0.com'),
+      'Expected dataAccess.Site.findByBaseURL to be called with "https://site0.com", but it was not',
+    ).to.be.true;
+  });
+
+  describe('Internal errors', () => {
+    it('error during execution', async () => {
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(site);
+
+      const error = new Error('Test error');
+      site.save.rejects(error);
+
+      const command = ToggleSiteImportCommand(contextMock);
+      const args = ['enable', 'http://site0.com', 'content'];
+      await command.handleExecution(args, slackContextMock);
+
+      expect(
+        contextMock.log.error.calledWith(error),
+        'Expected log.error to be called with the provided error, but it was not',
+      ).to.be.true;
+      expect(
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: Test error`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: Test error"`,
+      ).to.be.true;
+    });
+  });
+
+  describe('Bad Request Errors', () => {
+    it('if "enableImport" parameter is missed', async () => {
+      const command = ToggleSiteImportCommand(contextMock);
+      const args = ['', 'http://site0.com', 'content'];
+
+      await command.handleExecution(args, slackContextMock);
+
+      expectsAtBadRequest();
+      expect(
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: The "enableImport" parameter is required and must be set to "enable" or "disable".`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: The "enableImport" parameter is required and must be set to "enable" or "disable"."`,
+      ).to.be.true;
+    });
+
+    it('if "enableImport" parameter has wrong value', async () => {
+      const command = ToggleSiteImportCommand(contextMock);
+      const args = ['wrong_value', 'http://site0.com', 'content'];
+
+      await command.handleExecution(args, slackContextMock);
+
+      expectsAtBadRequest();
+      expect(
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: The "enableImport" parameter is required and must be set to "enable" or "disable".`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: The "enableImport" parameter is required and must be set to "enable" or "disable"."`,
+      ).to.be.true;
+    });
+
+    it('if "baseURL" is not provided', async () => {
+      const command = ToggleSiteImportCommand(contextMock);
+      const args = ['enable', '', 'content'];
+
+      await command.handleExecution(args, slackContextMock);
+
+      expectsAtBadRequest();
+      expect(
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.", but it was not called with that message.`,
+      ).to.be.true;
+    });
+
+    it('if "baseURL" has wrong site format', async () => {
+      const command = ToggleSiteImportCommand(contextMock);
+      const args = ['enable', 'wrong_site_format', 'content'];
+
+      await command.handleExecution(args, slackContextMock);
+
+      expectsAtBadRequest();
+      expect(
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL.`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}Please provide either a CSV file or a single baseURL."`,
+      ).to.be.true;
+    });
+
+    it('if a site is not found', async () => {
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(null);
+
+      const command = ToggleSiteImportCommand(contextMock);
+      const args = ['enable', 'https://site0.com', 'content'];
+
+      await command.handleExecution(args, slackContextMock);
+
+      expectsAtBadRequest();
+      expect(
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}Cannot update site with baseURL: "https://site0.com", site not found.`),
+        'Expected slackContextMock.say to be called with the specified error message, but it was not.',
+      ).to.be.true;
+    });
+
+    it('if "importType" parameter is missing', async () => {
+      const command = ToggleSiteImportCommand(contextMock);
+      const args = ['enable', 'http://site0.com', ''];
+      await command.handleExecution(args, slackContextMock);
+
+      expectsAtBadRequest();
+      expect(
+        slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: The import type parameter is required.`),
+        `Expected say method to be called with error message "${ERROR_MESSAGE_PREFIX}An error occurred while trying to enable or disable imports: The import type parameter is required.", but it was not called with that message.`,
+      ).to.be.true;
+    });
+  });
+
+  describe('CSV bulk operations', () => {
+    beforeEach(() => {
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'https://mock-url',
+      }];
+    });
+
+    it('should process CSV file to enable with profile', async () => {
+      const args = ['enable', 'default'];
+      const command = ToggleSiteImportCommand(contextMock);
+
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves({ ...site });
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves({ ...site });
+
+      await command.handleExecution(args, slackContextMock);
+
+      expect(siteConfig.enableImport.callCount).to.equal(4);
+      expect(site.save.callCount).to.equal(2);
+      expect(slackContextMock.say.calledWith(sinon.match('Successfully'))).to.be.true;
+    });
+
+    it('should process CSV file to disable with profile', async () => {
+      const args = ['disable', 'default'];
+      const command = ToggleSiteImportCommand(contextMock);
+
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves({ ...site });
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves({ ...site });
+
+      await command.handleExecution(args, slackContextMock);
+
+      expect(siteConfig.disableImport.callCount).to.equal(4);
+      expect(site.save.callCount).to.equal(2);
+      expect(slackContextMock.say.calledWith(sinon.match('Successfully'))).to.be.true;
+    });
+
+    it('should handle errors during import enabling/disabling in bulk processing', async () => {
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves({ ...site });
+
+      // Create a problematic site that will throw an error
+      const problemSite = { ...site };
+      problemSite.save = sinon.stub().rejects(new Error('Test error during save'));
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves(problemSite);
+
+      const command = ToggleSiteImportCommand(contextMock);
+      await command.handleExecution(['enable', 'content'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(
+        sinon.match((value) => value.includes(':clipboard: *Bulk Update Results*')
+          && value.includes('Successfully enabled for 1 sites')
+          && value.includes('https://site1.com')
+          && value.includes('Failed to process 1 sites')
+          && value.includes('https://site2.com: Test error during save')),
+      )).to.be.true;
+    });
+
+    it('should handle CSV file with invalid URLs', async () => {
+      parseCSVStub.resolves([
+        ['invalid-url'],
+        ['https://valid.com'],
+      ]);
+
+      const command = ToggleSiteImportCommand(contextMock);
+      await command.handleExecution(['enable', 'content'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Invalid URLs found'))).to.be.true;
+    });
+
+    it('should handle empty CSV file', async () => {
+      parseCSVStub.resolves([]);
+
+      const command = ToggleSiteImportCommand(contextMock);
+      await command.handleExecution(['enable', 'content'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('The parsed CSV data is empty'))).to.be.true;
+    });
+
+    it('should handle CSV download failure', async () => {
+      fetchStub.resolves({
+        ok: false,
+      });
+
+      const command = ToggleSiteImportCommand(contextMock);
+      await command.handleExecution(['enable', 'content'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Failed to download'))).to.be.true;
+    });
+
+    it('should handle sites that are not found during bulk processing', async () => {
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves({ ...site });
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves(null);
+
+      const command = ToggleSiteImportCommand(contextMock);
+      await command.handleExecution(['enable', 'content'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(
+        sinon.match((value) => value.includes(':clipboard: *Bulk Update Results*')
+          && value.includes('Successfully enabled for 1 sites')
+          && value.includes('https://site1.com')
+          && value.includes('Failed to process 1 sites')
+          && value.includes('https://site2.com: Site not found')),
+      )).to.be.true;
+    });
+  });
+
+  describe('profile handling', () => {
+    beforeEach(() => {
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'https://mock-url',
+      }];
+    });
+
+    it('should handle invalid profile name', async () => {
+      const command = ToggleSiteImportCommand(contextMock);
+      await command.handleExecution(['enable', 'invalid-profile'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Invalid profile: invalid-profile'))).to.be.true;
+    });
+
+    it('should process multiple import types from a profile', async () => {
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves({ ...site });
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves({ ...site });
+
+      const command = ToggleSiteImportCommand(contextMock);
+      await command.handleExecution(['enable', 'default'], slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match('Processing profile "default" with 2 import types'))).to.be.true;
+      expect(siteConfig.enableImport.callCount).to.equal(4);
+    });
+  });
+});


### PR DESCRIPTION
- Added Enable/Disable feature for imports for single url and CSV for single import type or profile based