### PR TITLE
fix: Support SQS Queue Names

### DIFF
--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -9,25 +9,38 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { SendMessageCommand, SQSClient, PurgeQueueCommand } from '@aws-sdk/client-sqs';
+import {
+  SendMessageCommand, SQSClient, PurgeQueueCommand, GetQueueUrlCommand,
+} from '@aws-sdk/client-sqs';
 
 /**
  * @class SQS utility to send messages to SQS
  * @param {string} region - AWS region
  * @param {object} log - log object
  */
-class SQS {
+export class SQS {
+  /** @type {Map<string, Promise<string>>} */
+  #namedQueueURLs = new Map();
+
   constructor(region, log) {
     this.sqsClient = new SQSClient({ region });
     this.log = log;
   }
 
-  async sendMessage(queueUrl, message) {
+  /**
+   * Send a message to the specified SQS queue.
+   *
+   * @param {string|URL} queueNameOrUrl - The name or URL of the SQS queue.
+   * @param {object} message - The message to send.
+   * @returns {Promise<void>} - Promise that resolves when the message is sent.
+   */
+  async sendMessage(queueNameOrUrl, message) {
     const body = {
       ...message,
       timestamp: new Date().toISOString(),
     };
 
+    const queueUrl = await this.#toQueueUrl(queueNameOrUrl);
     const msgCommand = new SendMessageCommand({
       MessageBody: JSON.stringify(body),
       QueueUrl: queueUrl,
@@ -45,11 +58,13 @@ class SQS {
 
   /**
    * Purge the queue identified by its queueUrl.
-   * @param {string} queueUrl - URL of the queue to be purged
+   * @param {string} queueNameOrUrl - The name or URL of the queue to be purged.
    * @returns {Promise<void>} - Promise that resolves when the queue is purged
    */
-  async purgeQueue(queueUrl) {
+  async purgeQueue(queueNameOrUrl) {
+    const queueUrl = await this.#toQueueUrl(queueNameOrUrl);
     const purgeQueueCommand = new PurgeQueueCommand({ QueueUrl: queueUrl });
+
     try {
       await this.sqsClient.send(purgeQueueCommand);
       this.log.info(`Success, queue purged. QueueUrl: ${queueUrl}`);
@@ -58,6 +73,44 @@ class SQS {
       this.log.error(`Queue purge failed. Type: ${type}, Code: ${code}, Message: ${msg}`);
       throw e;
     }
+  }
+
+  /**
+   * Retrieve the URL for a queue if it's not a URL already.
+   *
+   * If a queue name is passed in rather than a URL, the URL for that queue is retrieved
+   * from AWS and returned.
+   * @param {string|URL} queueNameOrUrl - The name or URL of the queue.
+   * @returns {Promise<string>} - The URL of the queue.
+   */
+  async #toQueueUrl(queueNameOrUrl) {
+    if (typeof queueNameOrUrl !== 'string' || URL.canParse(queueNameOrUrl)) {
+      return String(queueNameOrUrl);
+    }
+
+    const namedQueueURLs = this.#namedQueueURLs;
+    let queueUrl = namedQueueURLs.get(queueNameOrUrl);
+    if (!queueUrl) {
+      queueUrl = this.#retrieveQueueUrl(queueNameOrUrl);
+      namedQueueURLs.set(queueNameOrUrl, queueUrl);
+    }
+
+    return queueUrl;
+  }
+
+  /**
+   * Retrieve the URL for a queue by its name.
+   *
+   * @param {string} queueName - The name of the queue.
+   * @returns {Promise<string>} - The URL of the queue.
+   */
+  async #retrieveQueueUrl(queueName) {
+    const response = await this.sqsClient.send(new GetQueueUrlCommand({ QueueName: queueName }));
+    const url = response.QueueUrl;
+    if (!url || !URL.canParse(url)) {
+      throw new Error(`Unknown queue name: ${queueName}`);
+    }
+    return url;
   }
 }
 

--- a/test/support/sqs.test.js
+++ b/test/support/sqs.test.js
@@ -11,6 +11,7 @@
  */
 
 /* eslint-env mocha */
+/* eslint-disable no-use-before-define */
 
 import wrap from '@adobe/helix-shared-wrap';
 import sinon from 'sinon';
@@ -19,7 +20,8 @@ import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';
 import crypto from 'crypto';
-import sqsWrapper from '../../src/support/sqs.js';
+import { SendMessageCommand, GetQueueUrlCommand, PurgeQueueCommand } from '@aws-sdk/client-sqs';
+import sqsWrapper, { SQS } from '../../src/support/sqs.js';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -28,12 +30,14 @@ const sandbox = sinon.createSandbox();
 
 describe('sqs', () => {
   let context;
+  const AWS_REGION = 'us-east-1';
+  const QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue';
 
   beforeEach('setup', () => {
     context = {
       log: console,
       runtime: {
-        region: 'us-east-1',
+        region: AWS_REGION,
       },
     };
   });
@@ -49,7 +53,7 @@ describe('sqs', () => {
     context.sqs = instance;
 
     await wrap(async (req, ctx) => {
-      await ctx.sqs.sendMessage('queue', 'message');
+      await ctx.sqs.sendMessage(QUEUE_URL, 'message');
     }).with(sqsWrapper)({}, context);
 
     expect(instance.sendMessage).to.have.been.calledOnce;
@@ -68,7 +72,7 @@ describe('sqs', () => {
       .reply(400, errorResponse);
 
     const action = wrap(async (req, ctx) => {
-      await ctx.sqs.sendMessage('queue-url', { key: 'value' });
+      await ctx.sqs.sendMessage(QUEUE_URL, { key: 'value' });
     }).with(sqsWrapper);
 
     await expect(action({}, context)).to.be.rejectedWith(errorResponse.message);
@@ -100,7 +104,6 @@ describe('sqs', () => {
   });
 
   it('purging queue is successful', async () => {
-    const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue';
     const logSpy = sandbox.spy(context.log, 'info');
 
     nock('https://sqs.us-east-1.amazonaws.com')
@@ -108,23 +111,22 @@ describe('sqs', () => {
       .reply(200, {});
 
     await wrap(async (req, ctx) => {
-      await ctx.sqs.purgeQueue(queueUrl);
+      await ctx.sqs.purgeQueue(QUEUE_URL);
     }).with(sqsWrapper)({}, context);
 
-    expect(logSpy).to.have.been.calledWith(`Success, queue purged. QueueUrl: ${queueUrl}`);
+    expect(logSpy).to.have.been.calledWith(`Success, queue purged. QueueUrl: ${QUEUE_URL}`);
   });
 
   it('initialize and use a new sqs if not initialized before', async () => {
     const messageId = 'message-id';
     const message = { key: 'value' };
-    const queueUrl = 'queue-url';
     const logSpy = sandbox.spy(context.log, 'info');
 
     nock('https://sqs.us-east-1.amazonaws.com')
       .post('/')
       .reply(200, (_, body) => {
         const { MessageBody, QueueUrl } = JSON.parse(body);
-        expect(QueueUrl).to.equal(queueUrl);
+        expect(QueueUrl).to.equal(QUEUE_URL);
         expect(JSON.parse(MessageBody).key).to.equal(message.key);
         return {
           MessageId: 'message-id',
@@ -133,9 +135,48 @@ describe('sqs', () => {
       });
 
     await wrap(async (req, ctx) => {
-      await ctx.sqs.sendMessage(queueUrl, message);
+      await ctx.sqs.sendMessage(QUEUE_URL, message);
     }).with(sqsWrapper)({}, context);
 
     expect(logSpy).to.have.been.calledWith(`Success, message sent. MessageID:  ${messageId}`);
   });
+
+  describe('Named queues', () => {
+    let sqs;
+    let sendStub;
+
+    beforeEach(() => {
+      sqs = new SQS(AWS_REGION, console);
+      sendStub = sinon.stub(sqs.sqsClient, 'send')
+        .callsFake(console.warn.bind(null, 'Unexpected Command')) // eslint-disable-line no-console -- useful for debugging tests
+        .withArgs(matchCmd(new GetQueueUrlCommand({ QueueName: 'the-queue-name' })))
+        .resolves({ QueueUrl: QUEUE_URL });
+    });
+
+    it('supports sending to named queues', async () => {
+      // @ts-ignore
+      const expectedCmd = matchCmd(new SendMessageCommand({ QueueUrl: QUEUE_URL }));
+      sendStub
+        .withArgs(expectedCmd)
+        .resolves({ MessageId: 'arbitrary' });
+      await sqs.sendMessage('the-queue-name', { value: 1234 });
+      expect(sqs.sqsClient.send).to.have.been.calledWith(expectedCmd);
+    });
+
+    it('supports purging named queues', async () => {
+      const expectedCmd = matchCmd(new PurgeQueueCommand({ QueueUrl: QUEUE_URL }));
+      sendStub
+        .withArgs(expectedCmd)
+        .resolves();
+      await sqs.purgeQueue('the-queue-name');
+      expect(sqs.sqsClient.send).to.have.been.calledWith(expectedCmd);
+    });
+  });
 });
+
+/**
+ * @param {{input: any}} cmd
+ */
+function matchCmd({ constructor, input }) {
+  return sinon.match.instanceOf(constructor).and(sinon.match({ input: sinon.match(input) }));
+}

--- a/test/support/sqs.test.js
+++ b/test/support/sqs.test.js
@@ -171,6 +171,15 @@ describe('sqs', () => {
       await sqs.purgeQueue('the-queue-name');
       expect(sqs.sqsClient.send).to.have.been.calledWith(expectedCmd);
     });
+
+    it('errors if AWS does not return a queue URL', async () => {
+      sendStub
+        .withArgs(matchCmd(new GetQueueUrlCommand({ QueueName: 'queue-that-does-not-exist' })))
+        .resolves({ QueueUrl: undefined });
+
+      await expect(sqs.sendMessage('queue-that-does-not-exist', { value: 1234 }))
+        .to.be.rejectedWith('Unknown queue name: queue-that-does-not-exist');
+    });
   });
 });
 


### PR DESCRIPTION
We run with a mixture of SQS queue names and urls in all environment.

Since we have been passing queue URLs through to the AWS SDK as is, raw queue names lead to errors rather than successful queue operations.

The changes introduced here first check whether the provided queue url _or name_ can be parsed as URL, and if not, tries to retrieve the url for the named queue.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
 
## Related Issues

https://jira.corp.adobe.com/browse/SITES-30735
