### PR TITLE
feat: adding client type header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ async function run(request, context) {
     return noContent({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
       'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type',
-      'access-control-max-age': '86400',
+      'access-control-max-age': '0',
       'access-control-allow-origin': '*',
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ async function run(request, context) {
   if (method === 'OPTIONS') {
     return noContent({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
     });

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ async function run(request, context) {
     return noContent({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
       'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type',
-      'access-control-max-age': '0',
+      'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
     });
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -131,7 +131,7 @@ describe('Index Tests', () => {
     expect(resp.headers.plain()).to.eql({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
       'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type',
-      'access-control-max-age': '0',
+      'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
       'content-type': 'application/json; charset=utf-8',
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -130,7 +130,7 @@ describe('Index Tests', () => {
     expect(resp.status).to.equal(204);
     expect(resp.headers.plain()).to.eql({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
       'content-type': 'application/json; charset=utf-8',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -131,7 +131,7 @@ describe('Index Tests', () => {
     expect(resp.headers.plain()).to.eql({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
       'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type',
-      'access-control-max-age': '86400',
+      'access-control-max-age': '0',
       'access-control-allow-origin': '*',
       'content-type': 'application/json; charset=utf-8',
     });


### PR DESCRIPTION
Allows `x-client-type` header. This is required to distinguish between API clients. 

JIRA: https://jira.corp.adobe.com/browse/SITES-30942