### PR TITLE
fix: sse related errors by not allowing get method

### DIFF
--- a/src/controllers/mcp.js
+++ b/src/controllers/mcp.js
@@ -90,7 +90,14 @@ export default function McpController(ctx, registry) {
     }
   };
 
-  return { handleRpc, close: closeSdkServer };
+  /* ----- GET endpoint for SSE (returns 405 Method Not Allowed) ----- */
+  // https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server
+  const handleSseRequest = async () => send(405, {
+    error: 'Method Not Allowed',
+    message: 'SSE streaming is not supported by this MCP server. Use POST requests instead.',
+  });
+
+  return { handleRpc, handleSseRequest, close: closeSdkServer };
 }
 
 /* c8 ignore end */

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -170,6 +170,7 @@ export default function getRouteHandlers(
     'POST /screenshots': demoController.takeScreenshots,
     'GET /sites/:siteId/scraped-content/:type': scrapeController.listScrapedContentFiles,
     'GET /sites/:siteId/files': scrapeController.getFileByKey,
+    'GET /mcp': mcpController.handleSseRequest,
     'POST /mcp': mcpController.handleRpc,
 
     // Fixes

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -118,7 +118,8 @@ describe('getRouteHandlers', () => {
   };
 
   const mockMcpController = {
-    handleRcp: sinon.stub(),
+    handleRpc: sinon.stub(),
+    handleSseRequest: sinon.stub(),
   };
 
   const mockScrapeController = {
@@ -183,6 +184,7 @@ describe('getRouteHandlers', () => {
       'POST /tools/import/jobs',
       'GET /screenshots',
       'POST /screenshots',
+      'GET /mcp',
       'POST /mcp',
     );
 
@@ -200,6 +202,8 @@ describe('getRouteHandlers', () => {
     expect(staticRoutes['POST /tools/api-keys']).to.equal(mockApiKeyController.createApiKey);
     expect(staticRoutes['GET /tools/api-keys']).to.equal(mockApiKeyController.getApiKeys);
     expect(staticRoutes['GET /screenshots']).to.equal(mockDemoController.getScreenshots);
+    expect(staticRoutes['GET /mcp']).to.equal(mockMcpController.handleSseRequest);
+    expect(staticRoutes['POST /mcp']).to.equal(mockMcpController.handleRpc);
 
     expect(dynamicRoutes).to.have.all.keys(
       'GET /audits/latest/:auditType',


### PR DESCRIPTION
Issue:

When connecting to MCP server we can see errors in logs
`[73003] Error from remote server: StreamableHTTPError: Streamable HTTP error: Failed to open SSE stream: Not Found`

Fix is to not allow this method for sse connection as described in docs:
https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server