### PR TITLE
feat: add mcp endpoint to return all audits for historical analysis

### DIFF
--- a/src/mcp/registry/resources/audits.js
+++ b/src/mcp/registry/resources/audits.js
@@ -35,6 +35,21 @@ export function createAuditResources(auditsController) {
       }),
       notFoundMessage: ({ auditType, siteId }) => `Audit of ${auditType} for site ${siteId} not found`,
     }),
+    allAuditsBySiteIdAndType: createProxyResource({
+      name: 'allAuditsBySiteIdAndType',
+      description: '\n'
+        + '<use_case>Use this resource template to obtain the all audit results of a given audit type for a site you know its ID of.</use_case>\n'
+        + '<important_notes>'
+        + '1. You may need a tool to obtain site information that yields the site\'s ID.\n'
+        + '2. The audit type must be one of the supported types. Ask the user to provide it.\n'
+        + '</important_notes>\n'
+        + '',
+      uriTemplate: 'spacecat-data://audits/all/{auditType}/{siteId}',
+      fetchFn: ({ auditType, siteId }) => auditsController.getAllForSite({
+        params: { auditType, siteId },
+      }),
+      notFoundMessage: ({ auditType, siteId }) => `Audit of ${auditType} for site ${siteId} not found`,
+    }),
   };
 }
 

--- a/src/mcp/registry/tools/audits.js
+++ b/src/mcp/registry/tools/audits.js
@@ -46,8 +46,35 @@ export function createAuditTools(auditsController) {
     notFoundMessage: ({ baseURL }) => `Audit with base URL ${baseURL} not found`,
   });
 
+  /* ------------- getAllAuditsByBaseURL ---------------- */
+  const getAllAuditsBySiteIdAndTypeTool = createProxyTool({
+    annotations: {
+      title: 'Get All Audits By Site ID and Type',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    description: '\n'
+      + '<use_case>Use this tool to obtain all audit results of a given audit type for a site you know its ID of.</use_case>\n'
+      + '<important_notes>'
+      + '1. You may need another tool to obtain site information that yields the site\'s ID.\n'
+      + '2. The audit type must be one of the supported types. Ask the user to provide it.\n'
+      + '</important_notes>\n'
+      + '',
+    inputSchema: z.object({
+      auditType: z.string().describe('The type of the audit to fetch'),
+      siteId: z.string().uuid().describe('The UUID of the site to fetch'),
+    }).strict(),
+    fetchFn: ({ auditType, siteId }) => auditsController.getAllForSite({
+      params: { auditType, siteId },
+    }),
+    notFoundMessage: ({ baseURL }) => `Audit with base URL ${baseURL} not found`,
+  });
+
   return {
     getLatestAuditBySiteIdAndType: getLatestAuditBySiteIdAndTypeTool,
+    getAllAuditsBySiteIdAndType: getAllAuditsBySiteIdAndTypeTool,
   };
 }
 

--- a/src/mcp/registry/tools/audits.js
+++ b/src/mcp/registry/tools/audits.js
@@ -43,7 +43,7 @@ export function createAuditTools(auditsController) {
     fetchFn: ({ auditType, siteId }) => auditsController.getLatestForSite({
       params: { auditType, siteId },
     }),
-    notFoundMessage: ({ baseURL }) => `Audit with base URL ${baseURL} not found`,
+    notFoundMessage: ({ siteId }) => `Audit with base URL ${siteId} not found`,
   });
 
   /* ------------- getAllAuditsByBaseURL ---------------- */
@@ -69,7 +69,7 @@ export function createAuditTools(auditsController) {
     fetchFn: ({ auditType, siteId }) => auditsController.getAllForSite({
       params: { auditType, siteId },
     }),
-    notFoundMessage: ({ baseURL }) => `Audit with base URL ${baseURL} not found`,
+    notFoundMessage: ({ siteId }) => `Audit with base URL ${siteId} not found`,
   });
 
   return {

--- a/test/controllers/mcp.test.js
+++ b/test/controllers/mcp.test.js
@@ -52,6 +52,21 @@ describe('MCP Controller', () => {
           someProperty: 'somePreviousValue',
         },
       })),
+      getAllForSite: sandbox.stub().resolves(ok({
+        siteId: 'a1b2c3d4-e5f6-7g8h-9i0j-k11l12m13n14',
+        auditedAt: '2024-01-20T12:00:00Z',
+        expiresAt: '2024-07-20T12:00:00Z',
+        auditType: 'cwv',
+        isError: false,
+        deliveryType: 'aem_edge',
+        fullAuditRef: 'https://some-audit-system/full-report/1234',
+        auditResult: {
+          someProperty: 'someValue',
+        },
+        previousAuditResult: {
+          someProperty: 'somePreviousValue',
+        },
+      })),
     };
 
     sitesController = {
@@ -244,6 +259,43 @@ describe('MCP Controller', () => {
     expect(body).to.have.property('result');
     const [first] = body.result.contents;
     expect(first).to.have.property('uri', `spacecat-data://audits/latest/${auditType}/${siteId}`);
+    expect(JSON.parse(first.text)).to.deep.include({
+      siteId: 'a1b2c3d4-e5f6-7g8h-9i0j-k11l12m13n14',
+      auditedAt: '2024-01-20T12:00:00Z',
+      expiresAt: '2024-07-20T12:00:00Z',
+      auditType: 'cwv',
+      isError: false,
+      deliveryType: 'aem_edge',
+      fullAuditRef: 'https://some-audit-system/full-report/1234',
+      auditResult: {
+        someProperty: 'someValue',
+      },
+      previousAuditResult: {
+        someProperty: 'somePreviousValue',
+      },
+    });
+  });
+
+  it('retrieves all audits by audit type and site ID', async () => {
+    const siteId = 'a1b2c3d4-e5f6-7g8h-9i0j-k11l12m13n14';
+    const auditType = 'cwv';
+    const payload = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'resources/read',
+      params: {
+        uri: `spacecat-data://audits/all/${auditType}/${siteId}`,
+      },
+    };
+
+    context.data = payload;
+    const resp = await mcpController.handleRpc(context);
+
+    expect(resp.status).to.equal(200);
+    const body = await resp.json();
+    expect(body).to.have.property('result');
+    const [first] = body.result.contents;
+    expect(first).to.have.property('uri', `spacecat-data://audits/all/${auditType}/${siteId}`);
     expect(JSON.parse(first.text)).to.deep.include({
       siteId: 'a1b2c3d4-e5f6-7g8h-9i0j-k11l12m13n14',
       auditedAt: '2024-01-20T12:00:00Z',


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- some mcp clients may need to analyze how a change has effected CWV; so we need to return all audits to build an analysis of the effect of a change overtime!

## Related Issues


Thanks for contributing!
