### PR TITLE
fix: add support for batchSize and allowCache options to scrape slack command

### DIFF
--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -138,7 +138,7 @@ function RunScrapeCommand(context) {
           }),
         );
       } else if (isValidBaseURL) {
-        say(`:adobe-run: Triggering scrape run for site \`${baseURL}\` with allowCache: ${allowCache}`);
+        say(`:adobe-run: Triggering scrape run for site \`${baseURL}\` with batchSize: ${batchSize} and allowCache: ${allowCache}`);
         await scrapeSite(baseURL, batchSize, allowCache, slackContext);
         say(`:white_check_mark: Completed triggering scrape for \`${baseURL}\`.`);
       }

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -97,8 +97,8 @@ function RunScrapeCommand(context) {
     }
     */
     try {
-      const [baseURLInput, batchSize = 50, allowCache = false] = args;
-      const batchSizeNum = parseInt(batchSize, 10);
+      const [baseURLInput, batchSize = 20, allowCache = false] = args;
+      const batchSizeNum = parseInt(batchSize, 20);
       const baseURL = extractURLFromSlackInput(baseURLInput);
       const isValidBaseURL = isValidUrl(baseURL);
       const hasFiles = isNonEmptyArray(files);

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -64,6 +64,7 @@ function RunScrapeCommand(context) {
 
     const urls = topPages.map((page) => ({ url: page.getUrl() }));
     log.info(`Found top pages for site \`${baseURL}\`, total ${topPages.length} pages.`);
+    log.info(`Batch size: ${batchSize}, allowCache: ${allowCache}`);
 
     const batches = [];
     for (let i = 0; i < urls.length; i += batchSize) {

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -98,7 +98,7 @@ function RunScrapeCommand(context) {
     */
     try {
       const [baseURLInput, batchSize = 20, allowCache = false] = args;
-      const batchSizeNum = parseInt(batchSize, 20);
+      const batchSizeNum = parseInt(batchSize, 10);
       const baseURL = extractURLFromSlackInput(baseURLInput);
       const isValidBaseURL = isValidUrl(baseURL);
       const hasFiles = isNonEmptyArray(files);

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -138,7 +138,7 @@ function RunScrapeCommand(context) {
           }),
         );
       } else if (isValidBaseURL) {
-        say(`:adobe-run: Triggering scrape run for site \`${baseURL}\``);
+        say(`:adobe-run: Triggering scrape run for site \`${baseURL}\` with allowCache: ${allowCache}`);
         await scrapeSite(baseURL, allowCache, slackContext);
         say(`:white_check_mark: Completed triggering scrape for \`${baseURL}\`.`);
       }

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -68,6 +68,7 @@ function RunScrapeCommand(context) {
 
     const batches = [];
     for (let i = 0; i < urls.length; i += batchSize) {
+      log.info(`creating batch with size ${batchSize} from ${i} to ${i + batchSize}`);
       batches.push(urls.slice(i, i + batchSize));
     }
 

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -98,7 +98,7 @@ function RunScrapeCommand(context) {
     */
     try {
       const [baseURLInput, batchSize = 20, allowCache = false] = args;
-      const batchSizeNum = parseInt(batchSize, 10);
+      const batchSizeNum = Number(batchSize);
       const baseURL = extractURLFromSlackInput(baseURLInput);
       const isValidBaseURL = isValidUrl(baseURL);
       const hasFiles = isNonEmptyArray(files);

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -69,8 +69,10 @@ export const sentRunScraperMessage = async (
   jobId,
   urls,
   slackContext,
+  allowCache = false,
 ) => sqs.sendMessage(queueUrl, {
   processingType: 'default',
+  allowCache,
   jobId,
   urls: [...urls],
   slackContext,
@@ -207,6 +209,7 @@ export const triggerScraperRun = async (
   urls,
   slackContext,
   lambdaContext,
+  allowCache = false,
 ) => sentRunScraperMessage(
   lambdaContext.sqs,
   lambdaContext.env.SCRAPING_JOBS_QUEUE_URL,
@@ -216,6 +219,7 @@ export const triggerScraperRun = async (
     channelId: slackContext.channelId,
     threadTs: slackContext.threadTs,
   },
+  allowCache,
 );
 // todo: prototype - untested
 /* c8 ignore start */

--- a/test/support/slack/commands/run-scrape.test.js
+++ b/test/support/slack/commands/run-scrape.test.js
@@ -275,5 +275,11 @@ describe('RunScrapeCommand', () => {
 
       expect(slackContext.say.calledWith(':warning: Failed scrape for `https://valid.url`: Test Error')).to.be.true;
     });
+
+    it('handles invalid batch size', async () => {
+      const command = RunScrapeCommand(context);
+      await command.handleExecution(['https://example.com', 'invalid', 'true'], slackContext);
+      expect(slackContext.say.calledWith(':error: Batch size must be a number.')).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
For certain domains, we've seen the default concurrency used in the scraper not sufficient and lambda is timing out. In those cases, running the spacecat command with lower batchSize and allowCache will allow the scrape to be completed with one command, then since the audit uses the allowCache, scrape triggered from the audit will complete fast (as the urls are already scraped using slack command) and audits will proceed.

Relates to https://github.com/adobe/spacecat-content-scraper/pull/404
Fixes https://jira.corp.adobe.com/browse/SITES-32535

Example run
```
@spacecat run scrape [test.com](http://test.com/) 5 true
```