### PR TITLE
feat: slack 'run audit' command supports extra arg 

### DIFF
--- a/src/support/slack/commands/add-repo.js
+++ b/src/support/slack/commands/add-repo.js
@@ -125,7 +125,7 @@ function AddRepoCommand(context) {
       const isAuditEnabled = configuration.isHandlerEnabledForSite(auditType, site);
 
       if (isAuditEnabled) {
-        await triggerAuditForSite(site, auditType, slackContext, context);
+        await triggerAuditForSite(site, auditType, undefined, slackContext, context);
       }
 
       await say(`

--- a/src/support/slack/commands/add-site.js
+++ b/src/support/slack/commands/add-site.js
@@ -98,7 +98,7 @@ function AddSiteCommand(context) {
 
       // we still check for auditConfig.auditsDisabled() here as the default audit config may change
       if (configuration.isHandlerEnabledForSite(auditType, newSite)) {
-        await triggerAuditForSite(newSite, auditType, slackContext, context);
+        await triggerAuditForSite(newSite, auditType, undefined, slackContext, context);
         message += 'First PSI check is triggered! :adobe-run:\'\n';
         message += `In a minute, you can run _@spacecat get site ${baseURL}_`;
       } else {

--- a/src/support/slack/commands/onboard.js
+++ b/src/support/slack/commands/onboard.js
@@ -351,6 +351,7 @@ function OnboardCommand(context) {
           await triggerAuditForSite(
             site,
             auditType,
+            undefined,
             slackContext,
             context,
           );

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -39,6 +39,7 @@ export const isAuditForAllDeliveryTypes = (deliveryType) => deliveryType.toUpper
  * @param {string} type - The type of audit.
  * @param {Object} auditContext - The audit context object.
  * @param {string} siteId - The site ID to audit.
+ * @param {string} [auditData] - Optional audit data.
  * @returns {Promise} A promise representing the message sending operation.
  */
 export const sendAuditMessage = async (
@@ -47,7 +48,13 @@ export const sendAuditMessage = async (
   type,
   auditContext,
   siteId,
-) => sqs.sendMessage(queueUrl, { type, siteId, auditContext });
+  auditData,
+) => sqs.sendMessage(queueUrl, {
+  type,
+  siteId,
+  auditContext,
+  data: auditData,
+});
 
 // todo: prototype - untested
 /* c8 ignore start */
@@ -165,6 +172,7 @@ export const sendAuditMessages = async (
  * Triggers an audit for a site.
  * @param {Site} site - The site to audit.
  * @param {string} auditType - The type of audit.
+ * @param {undefined|string} auditData - Optional audit data.
  * @param {Object} slackContext - The Slack context object.
  * @param {Object} lambdaContext - The Lambda context object.
  * @return {Promise} - A promise representing the audit trigger operation.
@@ -172,6 +180,7 @@ export const sendAuditMessages = async (
 export const triggerAuditForSite = async (
   site,
   auditType,
+  auditData,
   slackContext,
   lambdaContext,
 ) => sendAuditMessage(
@@ -185,6 +194,7 @@ export const triggerAuditForSite = async (
     },
   },
   site.getId(),
+  auditData,
 );
 
 // todo: prototype - untested

--- a/test/support/slack/commands/add-repo.test.js
+++ b/test/support/slack/commands/add-repo.test.js
@@ -119,7 +119,7 @@ describe('AddRepoCommand', () => {
 
       await command.handleExecution(args, slackContext);
 
-      expect(slackContext.say.calledWith('\n'
+      expect(slackContext.say).calledWith('\n'
         + '      :white_check_mark: *GitHub repo added for <undefined|undefined>*\n'
         + '      \n'
         + '\n'
@@ -131,7 +131,7 @@ describe('AddRepoCommand', () => {
         + '    \n'
         + '      \n'
         + '      First PSI check with new repo is triggered! :adobe-run:\n'
-        + '      ')).to.be.true;
+        + '      ');
     });
 
     it('handles missing site URL', async () => {
@@ -190,7 +190,7 @@ describe('AddRepoCommand', () => {
       await command.handleExecution(args, slackContext);
 
       // Assertions to confirm repo info was fetched and handled correctly
-      expect(slackContext.say.calledWithMatch(/GitHub repo added/)).to.be.true;
+      expect(slackContext.say).calledWithMatch(/GitHub repo added/);
     });
 
     it('handles non-existent repository (404 error)', async () => {

--- a/test/support/slack/commands/add-site.test.js
+++ b/test/support/slack/commands/add-site.test.js
@@ -155,7 +155,7 @@ describe('AddSiteCommand', () => {
       expect(dataAccessStub.Site.create).to.have.been.calledWith({
         baseURL: 'https://example.com', deliveryType: 'other', isLive: false, organizationId: 'default',
       });
-      expect(sqsStub.sendMessage.called).to.be.true;
+      expect(sqsStub.sendMessage).called;
     });
 
     it('does not trigger audit after adding site when audits are disabled', async () => {

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -67,7 +67,7 @@ describe('RunAuditCommand', () => {
 
       expect(slackContext.say.called).to.be.true;
       expect(slackContext.say.firstCall.args[0]).to.include(':adobe-run: Triggering lhs-mobile audit for https://validsite.com');
-      expect(sqsStub.sendMessage.called).to.be.true;
+      expect(sqsStub.sendMessage).called;
     });
 
     it('does not trigger an audit when audit for type is disabled', async () => {
@@ -129,7 +129,7 @@ describe('RunAuditCommand', () => {
 
       expect(slackContext.say.called).to.be.true;
       expect(slackContext.say.firstCall.args[0]).to.equal(':adobe-run: Triggering all audit for https://validsite.com');
-      expect(sqsStub.sendMessage.called).to.be.true;
+      expect(sqsStub.sendMessage).called;
     });
 
     it('triggers all audits for all sites specified in a CSV file', async () => {
@@ -160,7 +160,7 @@ describe('RunAuditCommand', () => {
 
       expect(slackContext.say.called).to.be.true;
       expect(slackContext.say.firstCall.args[0]).to.equal(':adobe-run: Triggering all audit for 2 sites.');
-      expect(sqsStub.sendMessage.called).to.be.true;
+      expect(sqsStub.sendMessage).called;
     });
 
     it('handles both site URL and CSV file', async () => {


### PR DESCRIPTION
Adds an optional extra arg to our Slack bot that allows to pass a string
argument when running an audit.

Useful e.g. to pass a date for backfilling

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-19
https://jira.corp.adobe.com/browse/LLMO-36
https://jira.corp.adobe.com/browse/LLMO-185

Thanks for contributing!
