### PR TITLE
feat: enable agentic traffic audits on onboard

### DIFF
--- a/src/support/slack/commands/llmo-onboard.js
+++ b/src/support/slack/commands/llmo-onboard.js
@@ -22,6 +22,8 @@ import BaseCommand from './base.js';
 
 const REFERRAL_TRAFFIC_AUDIT = 'llmo-referral-traffic';
 const REFERRAL_TRAFFIC_IMPORT = 'traffic-analysis';
+const AGENTIC_TRAFFIC_ANALYSIS_AUDIT = 'cdn-analysis';
+const AGENTIC_TRAFFIC_REPORT_AUDIT = 'cdn-logs-report';
 
 const PHRASES = ['onboard-llmo'];
 
@@ -132,6 +134,25 @@ function LlmoOnboardCommand(context) {
       const configuration = await Configuration.findLatest();
       configuration.enableHandlerForSite(REFERRAL_TRAFFIC_AUDIT, site);
       configuration.enableHandlerForSite('geo-brand-presence', site);
+
+      // enable the cdn-analysis only if no other site in this organization already has it enabled
+      const organizationId = site.getOrganizationId();
+      const sitesInOrg = await Site.allByOrganizationId(organizationId);
+
+      const hasAgenticTrafficEnabled = sitesInOrg.some((orgSite) => {
+        const eachSiteConfig = orgSite.getConfig();
+        return eachSiteConfig.isHandlerEnabledForSite(AGENTIC_TRAFFIC_ANALYSIS_AUDIT);
+      });
+
+      if (!hasAgenticTrafficEnabled) {
+        log.info(`Enabling agentic traffic audits for organization ${organizationId} (first site in org)`);
+        configuration.enableHandlerForSite(AGENTIC_TRAFFIC_ANALYSIS_AUDIT, site);
+      } else {
+        log.info(`Agentic traffic audits already enabled for organization ${organizationId}, skipping`);
+      }
+
+      // enable the cdn-logs-report audits for agentic traffic
+      configuration.enableHandlerForSite(AGENTIC_TRAFFIC_REPORT_AUDIT, site);
 
       try {
         await configuration.save();

--- a/src/support/slack/commands/llmo-onboard.js
+++ b/src/support/slack/commands/llmo-onboard.js
@@ -139,10 +139,9 @@ function LlmoOnboardCommand(context) {
       const organizationId = site.getOrganizationId();
       const sitesInOrg = await Site.allByOrganizationId(organizationId);
 
-      const hasAgenticTrafficEnabled = sitesInOrg.some((orgSite) => {
-        const eachSiteConfig = orgSite.getConfig();
-        return eachSiteConfig.isHandlerEnabledForSite(AGENTIC_TRAFFIC_ANALYSIS_AUDIT);
-      });
+      const hasAgenticTrafficEnabled = sitesInOrg.some(
+        (orgSite) => configuration.isHandlerEnabledForSite(AGENTIC_TRAFFIC_ANALYSIS_AUDIT, orgSite),
+      );
 
       if (!hasAgenticTrafficEnabled) {
         log.info(`Enabling agentic traffic audits for organization ${organizationId} (first site in org)`);

--- a/test/support/slack/commands/llmo-onboard.test.js
+++ b/test/support/slack/commands/llmo-onboard.test.js
@@ -49,6 +49,7 @@ describe('LlmoOnboardCommand', () => {
       enableHandlerForSite: sinon.stub(),
       save: sinon.stub().resolves(),
       getQueues: sinon.stub().returns({ imports: 'queue-imports' }),
+      isHandlerEnabledForSite: sinon.stub().returns(false),
     };
 
     // Create mock data access
@@ -187,7 +188,6 @@ describe('LlmoOnboardCommand', () => {
 
     it('should skip enabling cdn-analysis when already enabled in organization', async () => {
       const existingSiteConfig = {
-        isHandlerEnabledForSite: sinon.stub().returns(true), // returns true for cdn-analysis
         getLlmoConfig: sinon.stub().returns(null),
         toJSON: sinon.stub().returns({}),
         getSlackConfig: sinon.stub().returns(null),
@@ -206,6 +206,8 @@ describe('LlmoOnboardCommand', () => {
         setConfig: sinon.stub(),
         save: sinon.stub().resolves(),
       };
+
+      mockConfiguration.isHandlerEnabledForSite.callsFake((auditType, site) => auditType === 'cdn-analysis' && site.getId() === 'existing-site-id');
 
       mockDataAccess.Site.allByOrganizationId.resolves([existingSite, mockSite]);
 

--- a/test/support/slack/commands/llmo-onboard.test.js
+++ b/test/support/slack/commands/llmo-onboard.test.js
@@ -187,22 +187,10 @@ describe('LlmoOnboardCommand', () => {
     });
 
     it('should skip enabling cdn-analysis when already enabled in organization', async () => {
-      const existingSiteConfig = {
-        getLlmoConfig: sinon.stub().returns(null),
-        toJSON: sinon.stub().returns({}),
-        getSlackConfig: sinon.stub().returns(null),
-        getHandlers: sinon.stub().returns({}),
-        getHandlerConfig: sinon.stub().returns({}),
-        getContentAiConfig: sinon.stub().returns({}),
-        getImports: sinon.stub().returns([]),
-        getCdnLogsConfig: sinon.stub().returns({}),
-        enableImport: sinon.stub(),
-      };
-
       const existingSite = {
         getId: sinon.stub().returns('existing-site-id'),
         getOrganizationId: sinon.stub().returns('test-org-id'),
-        getConfig: sinon.stub().returns(existingSiteConfig),
+        getConfig: sinon.stub().returns(mockConfig),
         setConfig: sinon.stub(),
         save: sinon.stub().resolves(),
       };


### PR DESCRIPTION
Enable agentic traffic audits on onboard-llmo

`cdn-analysis` is per bucket/org, we need to enable only once per org.