### PR TITLE
feat: add slack command to backfill llmo reports

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -30,7 +30,7 @@ import llmoOnboard from './commands/llmo-onboard.js';
 import setSiteOrganizationCommand from './commands/set-ims-org.js';
 import toggleSiteImport from './commands/toggle-site-import.js';
 import runTrafficAnalysisBackfill from './commands/run-traffic-analysis-backfill.js';
-import runAgenticTrafficBackfill from './commands/run-agentic-traffic-backfill.js';
+import backfillLlmo from './commands/backfill-llmo.js';
 
 /**
  * Returns all commands.
@@ -59,5 +59,5 @@ export default (context) => [
   llmoOnboard(context),
   setSiteOrganizationCommand(context),
   toggleSiteImport(context),
-  runAgenticTrafficBackfill(context),
+  backfillLlmo(context),
 ];

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Adobe. All rights reserved.
+ * Copyright 2025 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -16,11 +16,11 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 
-import RunAgenticTrafficBackfillCommand from '../../../../src/support/slack/commands/run-agentic-traffic-backfill.js';
+import BackfillLlmoCommand from '../../../../src/support/slack/commands/backfill-llmo.js';
 
 use(sinonChai);
 
-describe('RunAgenticTrafficBackfillCommand', () => {
+describe('BackfillLlmoCommand', () => {
   let context;
   let slackContext;
   let dataAccessStub;
@@ -59,43 +59,43 @@ describe('RunAgenticTrafficBackfillCommand', () => {
 
   describe('Initialization and BaseCommand Integration', () => {
     it('initializes correctly with base command properties', () => {
-      const command = RunAgenticTrafficBackfillCommand(context);
-      expect(command.id).to.equal('run-agentic-traffic-backfill');
-      expect(command.name).to.equal('Run Agentic Traffic Backfill');
-      expect(command.description).to.equal('Backfills agentic traffic for the last given number of weeks (max: 4 weeks).');
+      const command = BackfillLlmoCommand(context);
+      expect(command.id).to.equal('backfill-llmo');
+      expect(command.name).to.equal('Backfill LLMO');
+      expect(command.description).to.equal('Backfills LLMO streams for the last given number of weeks (max: 4 weeks).');
     });
   });
 
   describe('Handle Execution Method', () => {
-    it('triggers agentic traffic backfill for a valid site with default weeks', async () => {
+    it('triggers agentic backfill for a valid site with default weeks', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['https://example.com'], slackContext);
+      await command.handleExecution(['https://example.com', 'agentic'], slackContext);
 
       expect(slackContext.say.called).to.be.true;
-      expect(slackContext.say.firstCall.args[0]).to.include(':gear: Starting agentic traffic backfill for site https://example.com (4 weeks)...');
+      expect(slackContext.say.firstCall.args[0]).to.include(':gear: Starting agentic backfill for site https://example.com (4 weeks)...');
       expect(sqsStub.sendMessage.called).to.be.true;
       expect(sqsStub.sendMessage.callCount).to.equal(4);
     });
 
-    it('triggers agentic traffic backfill for a valid site with custom weeks', async () => {
+    it('triggers agentic backfill for a valid site with custom weeks', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['https://example.com', '2'], slackContext);
+      await command.handleExecution(['https://example.com', 'agentic', '2'], slackContext);
 
       expect(slackContext.say.called).to.be.true;
-      expect(slackContext.say.firstCall.args[0]).to.include(':gear: Starting agentic traffic backfill for site https://example.com (2 weeks)...');
+      expect(slackContext.say.firstCall.args[0]).to.include(':gear: Starting agentic backfill for site https://example.com (2 weeks)...');
       expect(sqsStub.sendMessage.called).to.be.true;
       expect(sqsStub.sendMessage.callCount).to.equal(2);
     });
 
     it('sends correct SQS message structure', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['https://example.com', '1'], slackContext);
+      await command.handleExecution(['https://example.com', 'agentic', '1'], slackContext);
 
       expect(sqsStub.sendMessage.called).to.be.true;
       const [queueUrl, message] = sqsStub.sendMessage.firstCall.args;
@@ -107,54 +107,62 @@ describe('RunAgenticTrafficBackfillCommand', () => {
     });
 
     it('responds with usage when no arguments provided', async () => {
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
       await command.handleExecution([], slackContext);
 
-      expect(slackContext.say.firstCall.args[0]).to.include(':warning: Missing required arguments. Please provide: `baseURL`.');
+      expect(slackContext.say.firstCall.args[0]).to.include(':warning: Missing required arguments. Please provide: `baseURL` and `streamType`.');
     });
 
     it('responds with error for invalid site url', async () => {
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['invalid-url'], slackContext);
+      await command.handleExecution(['invalid-url', 'agentic'], slackContext);
 
       expect(slackContext.say.calledWith(':warning: Please provide a valid site base URL.')).to.be.true;
     });
 
     it('informs user if the site was not found', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(null);
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['https://unknownsite.com'], slackContext);
+      await command.handleExecution(['https://unknownsite.com', 'agentic'], slackContext);
 
       expect(slackContext.say.calledWith(':x: Site \'https://unknownsite.com\' not found.')).to.be.true;
     });
 
     it('rejects weeks parameter greater than 4', async () => {
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['https://example.com', '5'], slackContext);
+      await command.handleExecution(['https://example.com', 'agentic', '5'], slackContext);
 
       expect(slackContext.say.calledWith(':warning: Please provide a valid number of weeks (1-4).')).to.be.true;
     });
 
     it('rejects invalid weeks parameter', async () => {
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['https://example.com', 'invalid'], slackContext);
+      await command.handleExecution(['https://example.com', 'agentic', 'invalid'], slackContext);
 
       expect(slackContext.say.calledWith(':warning: Please provide a valid number of weeks (1-4).')).to.be.true;
+    });
+
+    it('rejects unsupported stream type', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution(['https://example.com', 'unsupported'], slackContext);
+
+      expect(slackContext.say.firstCall.args[0]).to.include(':warning: Unsupported stream type: unsupported. Supported types: agentic, referral');
     });
 
     it('logs errors when they occur', async () => {
       const error = new Error('Test Error');
       dataAccessStub.Site.findByBaseURL.rejects(error);
-      const command = RunAgenticTrafficBackfillCommand(context);
+      const command = BackfillLlmoCommand(context);
 
-      await command.handleExecution(['https://example.com'], slackContext);
+      await command.handleExecution(['https://example.com', 'agentic'], slackContext);
 
-      expect(context.log.error.calledWith('Error in agentic traffic backfill:', error)).to.be.true;
+      expect(context.log.error.calledWith('Error in LLMO backfill:', error)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Add slack command to backfill agentic traffic reports

example:
@spacecat run backfill-llmo adobe.com agentic 4