### PR TITLE
Llmo onboarding hotfix

### DIFF
--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -608,15 +608,14 @@ export function onboardLLMOModal(lambdaContext) {
 
       const brandName = values.brand_name_input.brand_name.value;
       const imsOrgId = values.ims_org_input.ims_org_id.value;
-      const deliveryType = values.delivery_type_input.delivery_type.selected_option?.value;
+      const deliveryType = values.delivery_type_input?.delivery_type?.selected_option?.value;
 
-      if (!brandName || !imsOrgId || !deliveryType) {
+      if (!brandName || !imsOrgId) {
         await ack({
           response_action: 'errors',
           errors: {
             brand_name_input: !brandName ? 'Brand name is required' : undefined,
             ims_org_input: !imsOrgId ? 'IMS Org ID is required' : undefined,
-            delivery_type_input: !deliveryType ? 'Delivery type is required' : undefined,
           },
         });
         return;
@@ -625,7 +624,7 @@ export function onboardLLMOModal(lambdaContext) {
       log.info('Onboarding request with parameters:', {
         brandName,
         imsOrgId,
-        deliveryType,
+        deliveryType: deliveryType ?? 'not set',
         brandURL,
         originalChannel,
         originalThreadTs,

--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -455,14 +455,14 @@ async function createSiteAndOrganization(input, lambda, slackContext) {
   const org = await Organization.findByImsOrgId(imsOrgId);
   let orgId = org?.getId();
   if (!orgId) {
-    const newOrg = createOrg(imsOrgId, lambda, slackContext);
+    const newOrg = await createOrg(imsOrgId, lambda, slackContext);
     orgId = newOrg.getId();
   }
 
   const site = await Site.create({
     baseURL, deliveryType, organizationId: orgId,
   });
-  site.save();
+  await site.save();
   return site.getId();
 }
 


### PR DESCRIPTION
Remove delivery type required (since if it's already onboarded to spacecat, the value can be left away)