### PR TITLE
chore: remove unnecessary logs to reduce Coralogix usage

### DIFF
--- a/src/agents/org-detector/agent.js
+++ b/src/agents/org-detector/agent.js
@@ -244,7 +244,7 @@ export default class OrgDetectorAgent {
       return 'tools';
     }
 
-    this.log.info('Agent reached to conclusion. Finishing the process');
+    this.log.info('Agent reached to conclusion. Finishing the process'); //
     return END;
   }
 

--- a/src/agents/org-detector/tools/main-content-retriever.js
+++ b/src/agents/org-detector/tools/main-content-retriever.js
@@ -39,14 +39,14 @@ export async function retrieveMainContent(url, apiKey, apiUrl, log) {
 
   const content = responseData.results?.[0]?.content || '';
   if (!content) {
-    log.info(`Could not retrieve the main content of URL: ${url}`);
+    log.info(`Could not retrieve the main content of URL: ${url}`); //
     return null;
   }
 
   const dom = new JSDOM(content);
   const mainContent = dom.window.document.querySelector('main');
   if (!mainContent) {
-    log.info('No `<main>` element found in the parsed content.');
+    log.info('No `<main>` element found in the parsed content.'); //
     return null;
   }
 

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -66,7 +66,6 @@ function BrandsController(ctx, log, env) {
   const getBrandsForOrganization = async (context) => {
     const organizationId = context.params?.organizationId;
     try {
-      log.info(`Getting brands for organization: ${organizationId}`);
       if (!isValidUUID(organizationId)) {
         return badRequest('Organization ID required');
       }
@@ -84,7 +83,6 @@ function BrandsController(ctx, log, env) {
       const imsUserToken = getImsUserToken(context);
       const brandClient = BrandClient.createFrom(context);
       const brands = await brandClient.getBrandsForOrganization(imsOrgId, `Bearer ${imsUserToken}`);
-      log.info(`Found ${brands.length} brands for organization: ${organizationId}`);
       return ok(brands);
     } catch (error) {
       log.error(`Error getting brands for organization: ${organizationId}`, error);
@@ -123,7 +121,6 @@ function BrandsController(ctx, log, env) {
   const getBrandGuidelinesForSite = async (context) => {
     const siteId = context.params?.siteId;
     try {
-      log.info(`Getting brand guidelines for site: ${siteId}`);
       if (!isValidUUID(siteId)) {
         return badRequest('Site ID required');
       }
@@ -142,14 +139,12 @@ function BrandsController(ctx, log, env) {
         brandId,
         userId,
       };
-      log.info(`Brand ID mapping for site: ${siteId} is ${brandId}`);
       if (!hasText(brandId) || !hasText(userId)) {
         return notFound(`Brand config is missing, brandId or userId for site ID: ${siteId}`);
       }
       const organizationId = site.getOrganizationId();
       const organization = await Organization.findById(organizationId);
       const imsOrgId = organization?.getImsOrgId();
-      log.info(`IMS Org ID for site: ${siteId} is ${imsOrgId}`);
       const imsConfig = getImsConfig();
       const brandClient = BrandClient.createFrom(context);
       const brandGuidelines = await brandClient.getBrandGuidelines(
@@ -157,7 +152,6 @@ function BrandsController(ctx, log, env) {
         imsOrgId,
         imsConfig,
       );
-      log.info(`Found brand guidelines for site: ${siteId}`);
       return ok(brandGuidelines);
     } catch (error) {
       log.error(`Error getting brand guidelines for site: ${siteId}`, error);

--- a/src/controllers/event/fulfillment.js
+++ b/src/controllers/event/fulfillment.js
@@ -110,8 +110,6 @@ function FulfillmentController(context) {
       const eventType = requestContext.params?.eventType
         || FULFILLMENT_EVENT_TYPES.EDGE_DELIVERY_SERVICES;
 
-      log.info(`Processing fulfillment events for event type: ${eventType}`);
-
       // Validate eventType
       if (!Object.values(FULFILLMENT_EVENT_TYPES).includes(eventType)) {
         log.error(`Invalid event type: ${eventType}`);

--- a/src/controllers/hooks.js
+++ b/src/controllers/hooks.js
@@ -148,14 +148,12 @@ async function fetchHlxConfig(hlxConfig, hlxAdminToken, log) {
   const { hlxVersion, rso } = hlxConfig;
 
   if (hlxVersion < 5) {
-    log.info(`HLX version is ${hlxVersion}. Skipping fetching hlx config`);
+    log.info(`HLX version is ${hlxVersion}. Skipping fetching hlx config`); // unsure
     return null;
   }
 
   const { owner, site } = rso;
   const url = `https://admin.hlx.page/config/${owner}/aggregated/${site}.json`;
-
-  log.info(`Fetching hlx config for ${owner}/${site} with url: ${url}`);
 
   try {
     const response = await fetch(url, {
@@ -163,7 +161,7 @@ async function fetchHlxConfig(hlxConfig, hlxAdminToken, log) {
     });
 
     if (response.status === 200) {
-      log.info(`HLX config found for ${owner}/${site}`);
+      log.info(`HLX config found for ${owner}/${site}`); // remove?
       return response.json();
     }
 
@@ -186,7 +184,7 @@ async function getContentSource(hlxConfig, log) {
   const fstabResponse = await fetch(`https://raw.githubusercontent.com/${owner}/${repo}/${ref}/fstab.yaml`);
 
   if (fstabResponse.status !== 200) {
-    log.info(`Error fetching fstab.yaml for ${owner}/${repo}. Status: ${fstabResponse.status}`);
+    log.info(`Error fetching fstab.yaml for ${owner}/${repo}. Status: ${fstabResponse.status}`); // log as error?
     return null;
   }
 
@@ -198,7 +196,7 @@ async function getContentSource(hlxConfig, log) {
     : null;
 
   if (!isValidUrl(url)) {
-    log.info(`No content source found for ${owner}/${repo} in fstab.yaml`);
+    log.info(`No content source found for ${owner}/${repo} in fstab.yaml`); // log as error?
     return null;
   }
 
@@ -224,7 +222,6 @@ async function extractHlxConfig(domains, hlxVersion, hlxAdminToken, log) {
     const rso = parseHlxRSO(domain);
     if (isObject(rso)) {
       hlxConfig.rso = rso;
-      log.info(`Parsed RSO: ${JSON.stringify(rso)} for domain: ${domain}`);
       // eslint-disable-next-line no-await-in-loop
       const config = await fetchHlxConfig(hlxConfig, hlxAdminToken, log);
       if (isObject(config)) {
@@ -239,7 +236,7 @@ async function extractHlxConfig(domains, hlxVersion, hlxAdminToken, log) {
           hlxConfig.content = content;
         }
         hlxConfig.hlxVersion = 5;
-        log.info(`HLX config found for ${rso.owner}/${rso.site}: ${JSON.stringify(config)}`);
+        log.info(`HLX config found for ${rso.owner}/${rso.site}: ${JSON.stringify(config)}`); // unsure
       } else {
         try {
           // eslint-disable-next-line no-await-in-loop
@@ -374,7 +371,6 @@ function HooksController(lambdaContext) {
           if (!deepEqual(siteHlxConfig[key], candidateHlxConfig[key])) {
             updatedHlxConfig[key] = candidateHlxConfig[key];
             hlxConfigChanged = true;
-            log.info(`HLX config key "${key}" updated for site: ${baseURL}`);
           }
         });
 
@@ -383,7 +379,7 @@ function HooksController(lambdaContext) {
           await site.save();
 
           const action = siteHasHlxConfig && hlxConfigChanged ? 'updated' : 'added';
-          log.info(`HLX config ${action} for existing site: *<${baseURL}|${baseURL}>*${getHlxConfigMessagePart(hlxConfig)}`);
+          log.info(`HLX config ${action} for existing site: *<${baseURL}|${baseURL}>*${getHlxConfigMessagePart(hlxConfig)}`); // unsure
         }
       }
       throw new InvalidSiteCandidate('Site candidate already exists in sites db', baseURL);
@@ -407,8 +403,6 @@ function HooksController(lambdaContext) {
 
   async function processCDNHook(context) {
     const { log } = context;
-
-    log.info(`Processing CDN site candidate. Input: ${JSON.stringify(context.data)}`);
 
     const {
       // eslint-disable-next-line camelcase,no-unused-vars

--- a/src/controllers/import.js
+++ b/src/controllers/import.js
@@ -136,8 +136,6 @@ function ImportController(context) {
    * @return {object} the user profile.
    */
   function validateAccessScopes(scopes) {
-    log.debug(`validating scopes: ${scopes}`);
-
     try {
       auth.checkScopes(scopes);
     } catch (error) {
@@ -236,8 +234,6 @@ function ImportController(context) {
         isUrlInBaseDomains(urls, allowedDomains);
       }
 
-      log.info(`Creating a new import job with ${urls.length} URLs.`);
-
       // Merge the import configuration options with the request options allowing the user options
       // to override the defaults
       const mergedOptions = {
@@ -282,7 +278,7 @@ function ImportController(context) {
    */
   async function getImportJobsByDateRange(requestContext) {
     const { startDate, endDate } = parseRequestContext(requestContext);
-    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}.`);
+    log.debug(`Fetching import jobs between startDate: ${startDate} and endDate: ${endDate}.`); // unsure
 
     try {
       validateAccessScopes([SCOPE.READ_ALL]);

--- a/src/controllers/llmo.js
+++ b/src/controllers/llmo.js
@@ -81,7 +81,6 @@ function LlmoController(ctx) {
     const { siteId, dataSource, sheetType } = context.params;
     const { env } = context;
     try {
-      log.info(`validating LLMO sheet data for siteId: ${siteId}, dataSource: ${dataSource}, sheetType: ${sheetType}`);
       const { llmoConfig } = await getSiteAndValidateLlmo(context);
       const sheetURL = sheetType ? `${llmoConfig.dataFolder}/${sheetType}/${dataSource}.json` : `${llmoConfig.dataFolder}/${dataSource}.json`;
 
@@ -116,7 +115,6 @@ function LlmoController(ctx) {
       // Get the response data
       const data = await response.json();
 
-      log.info(`Successfully proxied data for siteId: ${siteId}, sheetURL: ${sheetURL}`);
       // Return the data and let the framework handle the compression
       return ok(data, {
         ...(response.headers ? Object.fromEntries(response.headers.entries()) : {}),

--- a/src/controllers/paid/caching-helper.js
+++ b/src/controllers/paid/caching-helper.js
@@ -62,7 +62,6 @@ async function fileExists(s3, key, log, maxAttempts = 3, delayMs = 200) {
 
 async function getS3CachedResult(s3, key, log, ignoreNotFound = true) {
   try {
-    log.info(`Fetching cached result key: ${key}`);
     const { bucket, prefix } = parseS3Uri(key);
 
     const getCachedFile = new GetObjectCommand({ Bucket: bucket, Key: prefix });
@@ -78,7 +77,7 @@ async function getS3CachedResult(s3, key, log, ignoreNotFound = true) {
     if (err.name === 'NoSuchKey' && ignoreNotFound) {
       return null;
     }
-    log.error(`Unepected exception when trying to fetch cached results on key: ${key}. Ignoring error and continuing with normal query. Exception was ${err}`);
+    log.error(`Unexpected exception when trying to fetch cached results on key: ${key}. Ignoring error and continuing with normal query. Exception was ${err}`);
     return null;
   }
 }

--- a/src/controllers/paid/traffic.js
+++ b/src/controllers/paid/traffic.js
@@ -100,12 +100,10 @@ function TrafficController(context, log, env) {
   async function tryGetCacheResult(siteId, query, noCache) {
     const { cacheKey, outPrefix } = getCacheKey(siteId, query, CACHE_LOCATION);
     if (isTrue(noCache)) {
-      log.info(`Skipping cache check for file: ${cacheKey} because param noCache is: ${noCache}`);
       return { cachedResultUrl: null, cacheKey, outPrefix };
     }
     const maxAttempts = 1;
     if (await fileExists(s3, cacheKey, log, maxAttempts)) {
-      log.info(`Found cached result. Fetching signed URL for Athena result from S3: ${cacheKey}`);
       const ignoreNotFound = true;
       const cachedUrl = await getS3CachedResult(s3, cacheKey, log, ignoreNotFound);
       return { cachedResultUrl: cachedUrl, cacheKey, outPrefix };
@@ -117,8 +115,6 @@ function TrafficController(context, log, env) {
   async function fetchPaidTrafficData(dimensions, mapper) {
     /* c8 ignore next 1 */
     const requestId = context.invocation?.requestId;
-    log.info(`Fetching paid traffic data for the request: ${requestId}`);
-
     const siteId = context.params?.siteId;
     const site = await Site.findById(siteId);
     if (!site) {
@@ -175,10 +171,8 @@ function TrafficController(context, log, env) {
 
     const description = `fetch paid channel data db: ${rumMetricsDatabase}| siteKey: ${siteId} | year: ${year} | month: ${month} | week: ${week} } | temporalCondition: ${quereyParams.temporalCondition} | groupBy: [${dimensions.join(', ')}] `;
 
-    log.info(`Processing query: ${description}`);
     // build query
     const query = getTrafficAnalysisQuery(quereyParams);
-    log.debug(`Fetching paid data with query: ${query}`);
 
     // first try to get from cache
     const { cachedResultUrl, cacheKey, outPrefix } = await tryGetCacheResult(
@@ -209,10 +203,8 @@ function TrafficController(context, log, env) {
     const resultLocation = `${ATHENA_TEMP_FOLDER}/${outPrefix}`;
     const athenaClient = AWSAthenaClient.fromContext(context, resultLocation);
 
-    log.info(`Fetching paid data directly from Athena table: ${tableName}`);
     const results = await athenaClient.query(query, rumMetricsDatabase, description);
     const response = results.map((row) => mapper.toJSON(row, thresholdConfig, baseURL));
-    log.info(`Successfully fetched results of length ${response?.length}`);
 
     // add to cache
     let isCached = false;
@@ -226,7 +218,7 @@ function TrafficController(context, log, env) {
       // verifying file is reachable before returning
       const verifiedSignedUrl = await getSignedUrlWithRetries(s3, cacheKey, log, 5);
       if (verifiedSignedUrl != null) {
-        log.info(`Succesfully verified file existance, returning signedUrl from key: ${isCached}.  Request ID: ${requestId}`);
+        log.info(`Successfully verified file existence, returning signedUrl from key: ${isCached}.  Request ID: ${requestId}`); // keep?
         return found(
           verifiedSignedUrl,
         );

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -136,8 +136,6 @@ function PreflightController(ctx, log, env) {
       const isDev = env.AWS_ENV === 'dev';
       const step = data.step.toLowerCase();
 
-      log.info(`Creating preflight job for ${data.urls.length} URLs with step: ${step}`);
-
       const url = new URL(data.urls[0]);
       const previewBaseURL = `${url.protocol}//${url.hostname}`;
       const site = await dataAccess.Site.findByPreviewURL(previewBaseURL);
@@ -161,7 +159,6 @@ function PreflightController(ctx, log, env) {
       if (CS_TYPES.includes(site.getAuthoringType())) {
         try {
           promiseTokenResponse = await getCSPromiseToken(context);
-          log.info('Successfully got promise token');
         } catch (e) {
           log.error(`Failed to get promise token: ${e.message}`);
           if (e instanceof ErrorWithStatusCode) {
@@ -226,8 +223,6 @@ function PreflightController(ctx, log, env) {
    */
   const getPreflightJobStatusAndResult = async (context) => {
     const jobId = context.params?.jobId;
-
-    log.info(`Getting preflight job status for jobId: ${jobId}`);
 
     if (!isValidUUID(jobId)) {
       log.error(`Invalid jobId: ${jobId}`);

--- a/src/controllers/reports.js
+++ b/src/controllers/reports.js
@@ -292,7 +292,6 @@ function ReportsController(ctx, log, env) {
       });
 
       if (existingReport) {
-        log.info(`Report already exists for site ${siteId} with the same parameters`);
         const existingStatus = existingReport.getStatus();
         return createResponse({
           message: `Report already exists for site ${siteId} with the same parameters`,
@@ -323,8 +322,6 @@ function ReportsController(ctx, log, env) {
 
       // Send message to the report-jobs queue
       await sendReportTriggerMessage(sqs, reportsQueueUrl, reportMessage, reportType);
-
-      log.info(`Report job queued successfully for site ${siteId}, report type: ${reportType}, reportId: ${reportId}`);
 
       // Return response with current structure plus new fields
       return ok({
@@ -400,8 +397,6 @@ function ReportsController(ctx, log, env) {
         }
         return ReportDto.toJSON(report);
       }));
-
-      log.info(`Retrieved ${reports.length} reports for site ${siteId}`);
 
       return ok({
         siteId,
@@ -479,8 +474,6 @@ function ReportsController(ctx, log, env) {
       // Convert report to JSON using the DTO
       const reportJSON = ReportDto.toJSON(report, presignedUrlObject);
 
-      log.info(`Retrieved report ${reportId} for site ${siteId}`);
-
       return ok(reportJSON);
     } catch (error) {
       log.error(`Failed to get report ${reportId} for site ${siteId}: ${error.message}`);
@@ -542,7 +535,7 @@ function ReportsController(ctx, log, env) {
             deleteS3Object(s3, s3ReportBucket, rawReportKey),
             deleteS3Object(s3, s3MystiqueBucket, mystiqueReportKey),
           ]);
-          log.info(`S3 files deleted for report ${reportId}: ${rawReportKey}, ${mystiqueReportKey}`);
+          log.info(`S3 files deleted for report ${reportId}: ${rawReportKey}, ${mystiqueReportKey}`); // keep?
         } catch (s3Error) {
           // Log S3 deletion error but continue with database deletion
           log.warn(`Failed to delete S3 files for report ${reportId}: ${s3Error.message}`);
@@ -552,7 +545,7 @@ function ReportsController(ctx, log, env) {
       // Delete the report from database
       await report.remove();
 
-      log.info(`Report ${reportId} deleted successfully for site ${siteId}`);
+      log.info(`Report ${reportId} deleted successfully for site ${siteId}`); // keep?
 
       return ok({
         message: 'Report deleted successfully',
@@ -631,7 +624,7 @@ function ReportsController(ctx, log, env) {
 
       try {
         await uploadS3Object(s3, s3MystiqueBucket, mystiqueReportKey, data);
-        log.info(`Enhanced report updated successfully for report ${reportId} at key: ${mystiqueReportKey}`);
+        log.info(`Enhanced report updated successfully for report ${reportId} at key: ${mystiqueReportKey}`); // keep?
       } catch (s3Error) {
         log.error(`Failed to upload enhanced report to S3 for report ${reportId}: ${s3Error.message}`);
         return internalServerError(`Failed to update report in S3: ${s3Error.message}`);
@@ -639,8 +632,6 @@ function ReportsController(ctx, log, env) {
 
       // Update the report's lastModified timestamp
       await report.save();
-
-      log.info(`Report ${reportId} enhanced data updated successfully for site ${siteId}`);
 
       return ok({
         message: 'Enhanced report updated successfully',

--- a/src/controllers/sandbox-audit.js
+++ b/src/controllers/sandbox-audit.js
@@ -71,7 +71,6 @@ function SandboxAuditController(ctx) {
       }
 
       const configuration = await Configuration.findLatest();
-      log.info(`SandboxAudit: Triggering audit(s) for siteId ${siteId}, types: ${allowed.join(', ')}`);
 
       return triggerAudits(site, configuration, allowed, ctx, skipped);
     } catch (error) {

--- a/src/controllers/scrapeJob.js
+++ b/src/controllers/scrapeJob.js
@@ -91,7 +91,7 @@ function ScrapeJobController(context) {
    */
   async function getScrapeJobsByDateRange(requestContext) {
     const { startDate, endDate } = parseRequestContext(requestContext);
-    log.debug(`Fetching scrape jobs between startDate: ${startDate} and endDate: ${endDate}.`);
+    log.debug(`Fetching scrape jobs between startDate: ${startDate} and endDate: ${endDate}.`); // unsure
 
     try {
       const jobs = await scrapeClient.getScrapeJobsByDateRange(startDate, endDate);
@@ -166,8 +166,6 @@ function ScrapeJobController(context) {
     if (!hasText(encodedBaseURL)) {
       return badRequest('Base URL required');
     }
-
-    log.debug(`Fetching scrape jobs by baseURL: ${encodedBaseURL} and processingType: ${processingType}.`);
 
     let decodedBaseURL = null;
     try {

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -589,8 +589,6 @@ function SitesController(ctx, log, env) {
 
       const projectedTrafficValue = pageViewsChange * cpc;
 
-      log.info(`Got RUM metrics for site ${siteId} current: ${current.length}`);
-
       return ok({
         pageViewsChange,
         ctrChange,

--- a/src/controllers/slack.js
+++ b/src/controllers/slack.js
@@ -122,7 +122,7 @@ function SlackController(SlackApp) {
 
     // Suppress retry events due to HTTP timeout (usually caused by cold starts)
     if (headers['x-slack-retry-reason'] === 'http_timeout') {
-      log.info(`Ignoring retry event: ${payload.event_id}`);
+      log.info(`Ignoring retry event: ${payload.event_id}`); // probably keep?
       return new Response('', { headers: { 'x-error': 'ignored-event' } });
     }
 
@@ -186,7 +186,7 @@ function SlackController(SlackApp) {
       return notFound('Slack channel not found for this organization.');
     }
 
-    log.info(`Inviting userId: ${userProfile.userId} to the Slack channel for IMS org ID: ${imsOrgId} (organizationId ${spaceCatOrg.getId()}).`);
+    log.info(`Inviting userId: ${userProfile.userId} to the Slack channel for IMS org ID: ${imsOrgId} (organizationId ${spaceCatOrg.getId()}).`); // unsure
 
     try {
       await elevatedClient.inviteUsersByEmail(orgSlackChannelId, [userProfile]);

--- a/src/index.js
+++ b/src/index.js
@@ -201,7 +201,7 @@ async function run(request, context) {
       return await handler(context);
     } else {
       const notFoundMessage = `no such route /${route}`;
-      log.info(notFoundMessage);
+      log.info(notFoundMessage); // keep? we already return notfound with the message
       return notFound(notFoundMessage);
     }
   } catch (e) {

--- a/src/support/access-control-util.js
+++ b/src/support/access-control-util.js
@@ -45,7 +45,7 @@ export default class AccessControlUtil {
 
     const endpoint = `${pathInfo?.method?.toUpperCase()} ${pathInfo?.suffix}`;
     if (isAnonymous(endpoint)) {
-      log.info(`Anonymous endpoint, skipping authorization: ${sanitizePath(endpoint)}`);
+      log.info(`Anonymous endpoint, skipping authorization: ${sanitizePath(endpoint)}`); // keep?
       const profile = { user_id: 'anonymous' };
       this.authInfo = new AuthInfo()
         .withAuthenticated(true)

--- a/src/support/import-supervisor.js
+++ b/src/support/import-supervisor.js
@@ -242,7 +242,6 @@ function ImportSupervisor(services, config) {
 
     // if the job type is 'xwalk', then we need to write the 3 files to S3
     if (options?.type === ImportJobModel.ImportOptionTypes.XWALK) {
-      log.info('Writing component models, filters, and definitions to S3 for jobId: ', newImportJob.getId());
       await writeFileToS3('component-models.json', newImportJob.getId(), models);
       await writeFileToS3('component-filters.json', newImportJob.getId(), filters);
       await writeFileToS3('component-definition.json', newImportJob.getId(), definitions);
@@ -386,13 +385,9 @@ function ImportSupervisor(services, config) {
     job.setStatus(ImportJobModel.ImportJobStatus.STOPPED);
     await job.save();
 
-    log.info(`Stopping import job with jobId: ${jobId} invoked by hashed API key: ${hashWithSHA256(importApiKey)}`);
-
-    log.info(`Purging the queue ${importQueueUrlPrefix}${job.getImportQueueId()} for the import job with jobId: ${jobId}`);
-
     await sqs.purgeQueue(`${importQueueUrlPrefix}${job.getImportQueueId()}`);
 
-    log.info(`Import job with jobId: ${jobId} has been stopped successfully`);
+    log.info(`Import job with jobId: ${jobId} invoked by hashed API key: ${hashWithSHA256(importApiKey)} has been stopped successfully`); // keep?
   }
 
   return {

--- a/src/support/sandbox-audit-service.js
+++ b/src/support/sandbox-audit-service.js
@@ -157,7 +157,7 @@ export async function enforceRateLimit(site, auditTypes, ctx, log) {
 
   // Rate limiting disabled - allow all
   if (!Number.isFinite(rateLimitHours) || rateLimitHours <= 0) {
-    log.info('Rate limiting disabled (rateLimitHours is 0 or invalid), allowing all audits');
+    log.info('Rate limiting disabled (rateLimitHours is 0 or invalid), allowing all audits'); // keep? or not needed
     return { allowed: auditTypes, skipped: [] };
   }
 

--- a/src/support/slack/actions/approve-org.js
+++ b/src/support/slack/actions/approve-org.js
@@ -36,8 +36,6 @@ export default function approveOrg(lambdaContext) {
       const { message = {}, user } = body;
       const { blocks } = message;
 
-      log.info(JSON.stringify(body));
-
       await ack(); // slack expects acknowledgement within 3s
 
       const messageText = blocks[0]?.text?.text;
@@ -66,8 +64,6 @@ export default function approveOrg(lambdaContext) {
         ...replyText,
         replace_original: true,
       };
-
-      log.info(`Responding org approval with: ${JSON.stringify(reply)}`);
 
       await respond(reply);
     } catch (e) {

--- a/src/support/slack/actions/approve-site-candidate.js
+++ b/src/support/slack/actions/approve-site-candidate.js
@@ -50,15 +50,11 @@ export default function approveSiteCandidate(lambdaContext) {
       } = body;
       const { blocks, ts: threadTs } = message;
 
-      log.info(JSON.stringify(body));
-
       await ack(); // slack expects acknowledgement within 3s
 
       const baseURL = extractURLFromSlackMessage(blocks[0]?.text?.text);
 
       const siteCandidate = await SiteCandidate.findByBaseURL(baseURL);
-
-      log.info(`Creating a new site: ${baseURL}`);
 
       const isFnF = actions[0]?.text?.text === BUTTON_LABELS.APPROVE_FRIENDS_FAMILY;
 
@@ -105,8 +101,6 @@ export default function approveSiteCandidate(lambdaContext) {
         approved: true,
       });
 
-      log.info(`Responding site candidate approval with: ${JSON.stringify(reply)}`);
-
       await respond(reply);
 
       await announceSiteDiscovery(
@@ -122,8 +116,6 @@ export default function approveSiteCandidate(lambdaContext) {
           siteCandidate.getBaseURL().replace('https://', ''),
           siteCandidate.getHlxConfig()?.rso?.owner,
         );
-
-        log.info(`Detected org: ${JSON.stringify(org)}`);
 
         if (hasText(org?.name) && hasText(org?.imsOrgId)) {
           const { name, imsOrgId } = org;

--- a/src/support/slack/actions/ignore-site-candidate.js
+++ b/src/support/slack/actions/ignore-site-candidate.js
@@ -22,13 +22,9 @@ export default function ignoreSiteCandidate(lambdaContext) {
       const { message = {}, user } = body;
       const { blocks } = message;
 
-      log.info(JSON.stringify(body));
-
       await ack(); // slack expects acknowledgement within 3s
 
       const baseURL = extractURLFromSlackMessage(blocks[0]?.text?.text);
-
-      log.info(`Site is ignored: ${baseURL}`);
 
       const siteCandidate = await SiteCandidate.findByBaseURL(baseURL);
 
@@ -42,8 +38,6 @@ export default function ignoreSiteCandidate(lambdaContext) {
         username: user.username,
         approved: false,
       });
-
-      log.info(`Responding site candidate ignore with: ${JSON.stringify(reply)}`);
 
       await respond(reply);
     } catch (e) {

--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -240,7 +240,6 @@ async function createOrg(imsOrgId, lambdaCtx, slackCtx) {
   let imsOrgDetails;
   try {
     imsOrgDetails = await imsClient.getImsOrganizationDetails(imsOrgId);
-    log.info(`IMS Org Details: ${imsOrgDetails}`);
   } catch (error) {
     log.error(`Error retrieving IMS Org details: ${error.message}`);
     await say(`:x: Could not find an IMS org with the ID *${imsOrgId}*.`);
@@ -309,7 +308,7 @@ export function startLLMOOnboarding(lambdaContext) {
 
       if (!site) {
         await fullOnboardingModal(body, client, respond, brandURL);
-        log.info(`User ${user.id} started full onboarding process for ${brandURL}.`);
+        log.info(`User ${user.id} started full onboarding process for ${brandURL}.`); // unsure
         return;
       }
 
@@ -321,13 +320,13 @@ export function startLLMOOnboarding(lambdaContext) {
           text: `:cdbot-error: It looks like ${brandURL} is already configured for LLMO with brand ${brand}`,
           replace_original: true,
         });
-        log.info(`Aborted ${brandURL} onboarding: Already onboarded with brand ${brand}`);
+        log.info(`Aborted ${brandURL} onboarding: Already onboarded with brand ${brand}`); // necessary?
         return;
       }
 
       await elmoOnboardingModal(body, client, respond, brandURL);
 
-      log.info(`User ${user.id} started LLMO onboarding process for ${brandURL} with existing site ${site.getId()}.`);
+      log.info(`User ${user.id} started LLMO onboarding process for ${brandURL} with existing site ${site.getId()}.`); // keep?
     } catch (e) {
       log.error('Error handling start onboarding:', e);
       await respond({
@@ -358,7 +357,7 @@ async function publishToAdminHlx(filename, outputLocation, log) {
     ];
 
     for (const [index, endpoint] of endpoints.entries()) {
-      log.info(`Publishing Excel report via admin API (${endpoint.name}): ${endpoint.url}`);
+      log.info(`Publishing Excel report via admin API (${endpoint.name}): ${endpoint.url}`); // necessary?
 
       // eslint-disable-next-line no-await-in-loop
       const response = await fetch(endpoint.url, { method: 'POST', headers });
@@ -367,10 +366,9 @@ async function publishToAdminHlx(filename, outputLocation, log) {
         throw new Error(`${endpoint.name} failed: ${response.status} ${response.statusText}`);
       }
 
-      log.info(`Excel report successfully published to ${endpoint.name}`);
+      log.info(`Excel report successfully published to ${endpoint.name}`); // necessary?
 
       if (index === 0) {
-        log.info('Waiting 2 seconds before publishing to live...');
         // eslint-disable-next-line no-await-in-loop,max-statements-per-line
         await new Promise((resolve) => { setTimeout(resolve, 2000); });
       }
@@ -392,14 +390,14 @@ async function copyFilesToSharepoint(dataFolder, lambdaCtx) {
     domainId: process.env.SHAREPOINT_DOMAIN_ID,
   }, { url: SHAREPOINT_URL, type: 'onedrive' });
 
-  log.info(`Copying query-index to ${dataFolder}`);
+  log.info(`Copying query-index to ${dataFolder}`); //
   const folder = sharepointClient.getDocument(`/sites/elmo-ui-data/${dataFolder}/`);
   const queryIndex = sharepointClient.getDocument('/sites/elmo-ui-data/template/query-index.xlsx');
 
   await folder.createFolder(dataFolder, '/');
   await queryIndex.copy(`/${dataFolder}/query-index.xlsx`);
 
-  log.info('Publishing query-index to admin.hlx.page');
+  log.info('Publishing query-index to admin.hlx.page'); // necessary?
   await publishToAdminHlx('query-index', dataFolder, log);
 }
 
@@ -407,7 +405,7 @@ async function copyFilesToSharepoint(dataFolder, lambdaCtx) {
 async function updateIndexConfig(dataFolder, lambdaCtx) {
   const { log } = lambdaCtx;
 
-  log.info('Starting Git modification of helix query config');
+  log.info('Starting Git modification of helix query config'); // necessary?
 
   const octokit = new Octokit({
     auth: process.env.LLMO_ONBOARDING_GITHUB_TOKEN,
@@ -442,7 +440,7 @@ async function updateIndexConfig(dataFolder, lambdaCtx) {
     sha: file.sha,
   });
 
-  log.info('Done with Git modification of helix query config');
+  log.info('Done with Git modification of helix query config'); //
 }
 
 async function createSiteAndOrganization(input, lambda, slackContext) {
@@ -502,7 +500,6 @@ export async function onboardSite(input, lambdaCtx, slackCtx) {
     await updateIndexConfig(dataFolder, lambdaCtx);
 
     const siteId = site.getId();
-    log.info(`Found site ${baseURL} with ID: ${siteId}`);
 
     // Get current site config
     const siteConfig = site.getConfig();
@@ -534,10 +531,10 @@ export async function onboardSite(input, lambdaCtx, slackCtx) {
     );
 
     if (!hasAgenticTrafficEnabled) {
-      log.info(`Enabling agentic traffic audits for organization ${orgId} (first site in org)`);
+      log.info(`Enabling agentic traffic audits for organization ${orgId} (first site in org)`); //
       configuration.enableHandlerForSite(AGENTIC_TRAFFIC_ANALYSIS_AUDIT, site);
     } else {
-      log.info(`Agentic traffic audits already enabled for organization ${orgId}, skipping`);
+      log.info(`Agentic traffic audits already enabled for organization ${orgId}, skipping`); // necessary ?
     }
 
     // enable the cdn-logs-report audits for agentic traffic
@@ -549,7 +546,7 @@ export async function onboardSite(input, lambdaCtx, slackCtx) {
     try {
       await configuration.save();
       await site.save();
-      log.info(`Successfully updated LLMO config for site ${siteId}`);
+      log.info(`Successfully updated LLMO config for site ${siteId}`); //
 
       // trigger the llmo-customer-analysis handler
       const sqsTriggerMesasage = {
@@ -588,7 +585,7 @@ export function onboardLLMOModal(lambdaContext) {
 
   return async ({ ack, body, client }) => {
     try {
-      log.info('Starting onboarding process...');
+      log.info('Starting onboarding process...'); //
 
       const { view, user } = body;
       const { values } = view.state;
@@ -656,7 +653,7 @@ export function onboardLLMOModal(lambdaContext) {
         brandName, baseURL: brandURL, imsOrgId, deliveryType,
       }, lambdaContext, slackContext);
 
-      log.info(`Onboard LLMO modal processed for user ${user.id}, site ${brandURL}`);
+      log.info(`Onboard LLMO modal processed for user ${user.id}, site ${brandURL}`); // keep?
     } catch (e) {
       log.error('Error handling onboard site modal:', e);
       await ack({

--- a/src/support/slack/actions/onboard-modal.js
+++ b/src/support/slack/actions/onboard-modal.js
@@ -369,7 +369,7 @@ export function startOnboarding(lambdaContext) {
         },
       });
 
-      log.info(`User ${user.id} started onboarding process`);
+      log.info(`User ${user.id} started onboarding process`); // keep?
     } catch (error) {
       log.error('Error handling start onboarding:', error);
       await respond({
@@ -542,7 +542,7 @@ ${deliveryConfigInfo}${previewConfigInfo}
         });
       }
 
-      log.info(`Onboard site modal processed for user ${user.id}, site ${siteUrl}`);
+      log.info(`Onboard site modal processed for user ${user.id}, site ${siteUrl}`); // keep?
     } catch (error) {
       log.error('Error handling onboard site modal:', error);
       await ack({

--- a/src/support/slack/actions/preflight-config-modal.js
+++ b/src/support/slack/actions/preflight-config-modal.js
@@ -142,7 +142,7 @@ export function preflightConfigModal(lambdaContext) {
         configDetails = `:gear: *Delivery Config:* Program ${deliveryConfigFromPreview.programId}, Environment ${deliveryConfigFromPreview.environmentId}\n`
                        + `:link: *Preview URL:* ${previewUrl}`;
 
-        log.info(`Preflight audit enabled for site ${siteId} with delivery config:`, {
+        log.info(`Preflight audit enabled for site ${siteId} with delivery config:`, { // keep?
           authoringType,
           deliveryConfig: deliveryConfigFromPreview,
         });
@@ -151,7 +151,7 @@ export function preflightConfigModal(lambdaContext) {
         configDetails = `:gear: *Helix Config:* ${helixConfigFromPreview.rso.ref}--${helixConfigFromPreview.rso.site}--${helixConfigFromPreview.rso.owner}.${helixConfigFromPreview.rso.tld}\n`
                        + `:link: *Preview URL:* ${previewUrl}`;
 
-        log.info(`Preflight audit enabled for site ${siteId} with helix config:`, {
+        log.info(`Preflight audit enabled for site ${siteId} with helix config:`, { // keep?
           authoringType,
           helixConfig: helixConfigFromPreview,
         });

--- a/src/support/slack/actions/reject-org.js
+++ b/src/support/slack/actions/reject-org.js
@@ -21,8 +21,6 @@ export default function rejectOrg(lambdaContext) {
       const { channel, message = {}, user } = body;
       const { blocks, ts: threadTs } = message;
 
-      log.info(JSON.stringify(body));
-
       await ack(); // slack expects acknowledgement within 3s
 
       const messageText = blocks[0]?.text?.text;
@@ -40,8 +38,6 @@ export default function rejectOrg(lambdaContext) {
         ...replyText,
         replace_original: true,
       };
-
-      log.info(`Responding org rejection with: ${JSON.stringify(reply)}`);
 
       await respond(reply);
 

--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -49,7 +49,7 @@ async function triggerBackfill(context, configuration, siteId, streamType, weeks
     };
     // eslint-disable-next-line no-await-in-loop
     await sqs.sendMessage(configuration.getQueues().audits, message);
-    log.info(`Successfully triggered ${streamType} backfill ${auditType} with message: ${JSON.stringify(message)}`);
+    log.info(`Successfully triggered ${streamType} backfill ${auditType} with message: ${JSON.stringify(message)}`); // keep?
   }
 }
 
@@ -122,7 +122,6 @@ function BackfillLlmoCommand(context) {
       }
 
       const siteId = site.getId();
-      log.info(`Found site ${baseURL} with ID: ${siteId}`);
 
       const configuration = await Configuration.findLatest();
 

--- a/src/support/slack/commands/onboard.js
+++ b/src/support/slack/commands/onboard.js
@@ -197,13 +197,11 @@ function OnboardCommand(context) {
           fileStream.write(csvStringifier.stringifyRecords([reportLine]));
         }
 
-        log.info('All sites were processed and onboarded.');
-
         fileStream.end();
 
         fileStream.on('finish', async () => {
           try {
-            const uploadResponse = client.files.upload({
+            client.files.upload({ // this should work without the constant no?
               channels: channelId,
               file: fs.createReadStream(tempFilePath),
               filename: 'spacecat_onboarding_report.csv',
@@ -211,7 +209,6 @@ function OnboardCommand(context) {
               initial_comment: ':spacecat: *Batch onboarding in progress!* :satellite:\nHere you can find the *execution report*. :memo:',
               thread_ts: threadTs,
             });
-            log.info(uploadResponse);
           } catch (error) {
             await say(`:warning: Failed to upload the report to Slack: ${error.message}`);
           }

--- a/src/support/slack/commands/run-import.js
+++ b/src/support/slack/commands/run-import.js
@@ -367,7 +367,7 @@ function RunImportCommand(context) {
         const pageURL = extractedPageURL && supportsPageURLs && isValidUrl(extractedPageURL)
           ? extractedPageURL
           : undefined;
-        log.info(`Import run of type ${importType} for site ${baseURL} with input: `, { pageURL, startDate, endDate });
+
         await runImportForSite(
           importType,
           baseURL,

--- a/src/support/slack/commands/run-scrape.js
+++ b/src/support/slack/commands/run-scrape.js
@@ -63,7 +63,6 @@ function RunScrapeCommand(context) {
     }
 
     const urls = topPages.map((page) => ({ url: page.getUrl() }));
-    log.info(`Found top pages for site \`${baseURL}\`, total ${topPages.length} pages.`);
 
     const batches = [];
     for (let i = 0; i < urls.length; i += batchSize) {

--- a/src/support/slack/commands/run-traffic-analysis-backfill.js
+++ b/src/support/slack/commands/run-traffic-analysis-backfill.js
@@ -65,8 +65,6 @@ function RunTrafficAnalysisBackfillCommand(context) {
     const { sqs } = context;
     const importQueueUrl = config.getQueues().imports;
 
-    log.info(`Import run of type ${TRAFFIC_ANALYSIS_IMPORT_TYPE} for site ${site.getBaseURL()} with input: `, { week, year });
-
     await sqs.sendMessage(importQueueUrl, {
       type: TRAFFIC_ANALYSIS_IMPORT_TYPE,
       trigger: 'backfill',

--- a/src/support/slack/commands/set-ims-org.js
+++ b/src/support/slack/commands/set-ims-org.js
@@ -82,7 +82,6 @@ function SetSiteOrganizationCommand(context) {
         let imsOrgDetails;
         try {
           imsOrgDetails = await imsClient.getImsOrganizationDetails(userImsOrgId);
-          log.info(`IMS Org Details: ${imsOrgDetails}`);
         } catch (error) {
           log.error(`Error retrieving IMS Org details: ${error.message}`);
           await say(`:x: Could not find an IMS org with the ID *${userImsOrgId}*.`);

--- a/src/support/slack/slack-handler.js
+++ b/src/support/slack/slack-handler.js
@@ -23,7 +23,7 @@ import {
  * @return {SlackHandler} The slack handler.
  * @constructor
  */
-function SlackHandler(commands, log) {
+function SlackHandler(commands) {
   /**
    * Handles app_mention event.
    *
@@ -49,8 +49,6 @@ function SlackHandler(commands, log) {
       botToken: context.botToken || process.env.SLACK_BOT_TOKEN,
       files: event?.files || [],
     };
-
-    log.info(`App_mention event received: ${JSON.stringify(event)} in thread ${threadTs} with context ${JSON.stringify(context)}`);
 
     const command = commands.find((cmd) => cmd.accepts(message));
     if (command) {

--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -50,7 +50,7 @@ export class SQS {
 
     try {
       const data = await this.sqsClient.send(msgCommand);
-      this.log.info(`Success, message sent. MessageID:  ${data.MessageId}`);
+      this.log.info(`Success, message sent. MessageID:  ${data.MessageId}`); // keep right? - sends a lot of messages
     } catch (e) {
       const { type, code, message: msg } = e;
       this.log.error(`Message sent failed. Type: ${type}, Code: ${code}, Message: ${msg}`);
@@ -88,7 +88,7 @@ export class SQS {
 
     try {
       await this.sqsClient.send(purgeQueueCommand);
-      this.log.info(`Success, queue purged. QueueUrl: ${queueUrl}`);
+      this.log.info(`Success, queue purged. QueueUrl: ${queueUrl}`); // keep?
     } catch (e) {
       const { type, code, message: msg } = e;
       this.log.error(`Queue purge failed. Type: ${type}, Code: ${code}, Message: ${msg}`);


### PR DESCRIPTION
This PR removes unnecessary logs that were cluttering the output and causing us to hit the limit in Coralogix. Only essential logs are kept to ensure clearer debugging and reduced noise.

EPIC: [SITES-34661](https://jira.corp.adobe.com/browse/SITES-34661)