### PR TITLE
fix(slack/onboarding-llmo): allow rerun of onboarding command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@adobe/spacecat-shared-rum-api-client": "2.37.6",
         "@adobe/spacecat-shared-scrape-client": "2.1.4",
         "@adobe/spacecat-shared-slack-client": "1.5.26",
-        "@adobe/spacecat-shared-tier-client": "1.0.0",
+        "@adobe/spacecat-shared-tier-client": "1.0.1",
         "@adobe/spacecat-shared-utils": "1.50.6",
         "@aws-sdk/client-s3": "3.888.0",
         "@aws-sdk/client-sfn": "3.888.0",
@@ -29830,9 +29830,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tier-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.0.0.tgz",
-      "integrity": "sha512-lchZS3obst5rlX2uu4Eb6Gkqdkc/2UQ3C8XuZbiXe6hewWoLfs0iQBRGKqKor3Byg29g797so0ZitI44xWCICQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.0.1.tgz",
+      "integrity": "sha512-t/4k3CDLzzWkz+PDKkYw1ypLfrG8el03uaCFsIexAXKjlGu4T6cALTzJ1pTDMFrEf1kt2OEUMSXOCsJ41EBJrg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-data-access": "^2.61.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@adobe/spacecat-shared-rum-api-client": "2.37.6",
     "@adobe/spacecat-shared-scrape-client": "2.1.4",
     "@adobe/spacecat-shared-slack-client": "1.5.26",
-    "@adobe/spacecat-shared-tier-client": "1.0.0",
+    "@adobe/spacecat-shared-tier-client": "1.0.1",
     "@adobe/spacecat-shared-utils": "1.50.6",
     "@aws-sdk/client-s3": "3.888.0",
     "@aws-sdk/client-sfn": "3.888.0",

--- a/src/controllers/slack.js
+++ b/src/controllers/slack.js
@@ -80,6 +80,7 @@ export function initSlackBot(lambdaContext, App) {
   app.view('onboard_site_modal', actions.onboardSiteModal(lambdaContext));
   app.view('preflight_config_modal', actions.preflight_config_modal(lambdaContext));
   app.view('onboard_llmo_modal', actions.onboardLLMOModal(lambdaContext));
+  app.view('update_ims_org_modal', actions.updateIMSOrgModal(lambdaContext));
 
   return app;
 }

--- a/src/support/slack/actions/index.js
+++ b/src/support/slack/actions/index.js
@@ -15,7 +15,13 @@ import approveOrg from './approve-org.js';
 import approveSiteCandidate from './approve-site-candidate.js';
 import ignoreSiteCandidate from './ignore-site-candidate.js';
 import rejectOrg from './reject-org.js';
-import { startLLMOOnboarding, onboardLLMOModal } from './onboard-llmo-modal.js';
+import {
+  startLLMOOnboarding,
+  onboardLLMOModal,
+  addEntitlementsAction,
+  updateOrgAction,
+  updateIMSOrgModal,
+} from './onboard-llmo-modal.js';
 import { onboardSiteModal, startOnboarding } from './onboard-modal.js';
 import { preflightConfigModal } from './preflight-config-modal.js';
 import openPreflightConfig from './open-preflight-config.js';
@@ -28,10 +34,13 @@ const actions = {
   rejectOrg,
   onboardSiteModal,
   onboardLLMOModal,
+  updateIMSOrgModal,
   start_onboarding: startOnboarding,
   start_llmo_onboarding: startLLMOOnboarding,
   preflight_config_modal: preflightConfigModal,
   open_preflight_config: openPreflightConfig,
+  add_entitlements_action: addEntitlementsAction,
+  update_org_action: updateOrgAction,
 };
 
 export default actions;


### PR DESCRIPTION
- reuses the same command for onboarding
- if brand exists for given site, the users will be prompted with two buttons:
  - users can choose to only add/update entitlements and enrollments (this is done using the tier client)
  - they can also choose to update the IMS org, and subsequently update the entitlements and enrollments
- success and failure messages are posted in the same thread