### PR TITLE
fix: dont cache empty result

### DIFF
--- a/src/controllers/paid/traffic.js
+++ b/src/controllers/paid/traffic.js
@@ -208,7 +208,7 @@ function TrafficController(context, log, env) {
 
     // add to cache
     let isCached = false;
-    if (response) {
+    if (response && response.length > 0) {
       isCached = await addResultJsonToCache(s3, cacheKey, response, log);
       log.info(`Athena result JSON to S3 cache (${cacheKey}) successful: ${isCached}`);
     }

--- a/test/controllers/paid/traffic.test.js
+++ b/test/controllers/paid/traffic.test.js
@@ -304,11 +304,13 @@ describe('Paid TrafficController', async () => {
       const controller = TrafficController(mockContext, mockLog, mockEnv);
       const res = await controller.getPaidTrafficByTypeChannel();
       expect(res.status).to.equal(200);
-      // Validate the object put to S3
-      expect(lastPutObject).to.exist;
-      const decompressed = await gunzipAsync(lastPutObject.input.Body);
-      const putBody = JSON.parse(decompressed.toString());
-      expect(putBody).to.deep.equal([]);
+      // Empty results should not be cached
+      expect(lastPutObject).to.not.exist;
+      // Validate the compressed response body directly
+      const gzippedBuffer = Buffer.from(await res.arrayBuffer());
+      const decompressed = await gunzipAsync(gzippedBuffer);
+      const body = JSON.parse(decompressed.toString());
+      expect(body).to.deep.equal([]);
     });
 
     it('getPaidTrafficByCampaignUrlDevice uses custom threshold config if provided', async () => {


### PR DESCRIPTION
its more common that empty result is result of missing import, caching this results in cleanup work 
so lets not cache it
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
