### PR TITLE
fix: support backfill cdn-analysis and current week for report

### DIFF
--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -18,124 +18,173 @@ import {
 
 import BaseCommand from './base.js';
 
-const SUPPORTED_STREAMS = {
-  agentic: 'cdn-logs-report',
-  referral: null, // no-op for now
-};
-
 const PHRASES = ['backfill-llmo'];
 
-async function triggerBackfill(context, configuration, siteId, streamType, weeks = 4) {
+const AUDIT_TYPES = {
+  CDN_ANALYSIS: 'cdn-analysis',
+  CDN_LOGS_REPORT: 'cdn-logs-report',
+};
+
+function parseArgs(args) {
+  const parsed = {};
+
+  for (const arg of args) {
+    if (arg.includes('=')) {
+      const [key, value] = arg.split('=');
+      parsed[key] = value;
+    }
+  }
+
+  return parsed;
+}
+
+async function triggerBackfill(context, configuration, siteId, auditType, timeValue) {
   const { sqs } = context;
-  const auditType = SUPPORTED_STREAMS[streamType];
 
-  /* c8 ignore next 3 */
-  if (!auditType) {
-    throw new Error(`Unsupported stream type: ${streamType}`);
-  }
+  switch (auditType) {
+    case AUDIT_TYPES.CDN_ANALYSIS: {
+      const days = timeValue;
+      const now = new Date();
 
-  const weekOffsets = [];
-  for (let i = 1; i <= weeks; i += 1) {
-    weekOffsets.push(-i);
-  }
+      for (let dayOffset = 1; dayOffset <= days; dayOffset += 1) {
+        const targetDate = new Date(now);
+        targetDate.setDate(now.getDate() - dayOffset);
 
-  for (const week of weekOffsets) {
-    const message = {
-      type: auditType,
-      siteId,
-      auditContext: {
-        weekOffset: week,
-      },
-    };
-    // eslint-disable-next-line no-await-in-loop
-    await sqs.sendMessage(configuration.getQueues().audits, message);
+        for (let hour = 0; hour < 24; hour += 1) {
+          const message = {
+            type: auditType,
+            siteId,
+            auditContext: {
+              year: targetDate.getFullYear(),
+              month: targetDate.getMonth() + 1,
+              day: targetDate.getDate(),
+              hour,
+            },
+          };
+          // eslint-disable-next-line no-await-in-loop
+          await sqs.sendMessage(configuration.getQueues().audits, message);
+        }
+      }
+      break;
+    }
+
+    case AUDIT_TYPES.CDN_LOGS_REPORT: {
+      const weeks = timeValue;
+
+      // Determine weekOffset values: [0] for current week, [-1, -2, -3, -4] for previous weeks
+      const weekOffsets = weeks === 0 ? [0] : Array.from({ length: weeks }, (_, i) => -(i + 1));
+
+      for (const weekOffset of weekOffsets) {
+        const message = {
+          type: auditType,
+          siteId,
+          auditContext: {
+            weekOffset,
+          },
+        };
+        // eslint-disable-next-line no-await-in-loop
+        await sqs.sendMessage(configuration.getQueues().audits, message);
+      }
+      break;
+    }
+    /* c8 ignore start */
+    default:
+      throw new Error(`Unsupported audit type: ${auditType}`);
+    /* c8 ignore end */
   }
 }
 
-/**
- * Creates the BackfillLlmoCommand object.
- *
- * @param {Object} context - The context object.
- * @returns {BackfillLlmoCommand} - The BackfillLlmoCommand object.
- * @constructor
- */
 function BackfillLlmoCommand(context) {
   const baseCommand = BaseCommand({
     id: 'backfill-llmo',
     name: 'Backfill LLMO',
-    description: 'Backfills LLMO streams for the last given number of weeks (max: 4 weeks).',
+    description: 'Backfills LLMO audits.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {baseURL} {streamType} [weeks]`,
+    usageText: `${PHRASES[0]} baseurl={baseURL} audit={auditType} [days={days}|weeks={weeks}]`,
   });
 
-  const {
-    dataAccess, log,
-  } = context;
+  const { dataAccess, log } = context;
   const { Site, Configuration } = dataAccess;
 
-  /**
-   * Handles LLMO stream backfill for a single site.
-   *
-   * @param {string[]} args - The args provided to the command ([baseURL, streamType, weeks]).
-   * @param {Object} slackContext - The Slack context object.
-   * @param {Function} slackContext.say - The Slack say function.
-   * @returns {Promise} A promise that resolves when the operation is complete.
-   */
   const handleExecution = async (args, slackContext) => {
     const { say } = slackContext;
 
     try {
-      if (args.length < 2) {
-        await say(':warning: Missing required arguments. Please provide: `baseURL` and `streamType`.');
-        await say(`Usage: _${baseCommand.usage().replace('Usage: _', '').replace('_', '')}_`);
-        await say(`Supported stream types: ${Object.keys(SUPPORTED_STREAMS).join(', ')}`);
+      const parsed = parseArgs(args);
+
+      if (!parsed.baseurl || !parsed.audit) {
+        await say(':warning: Required: baseurl={baseURL} audit={auditType}');
+        await say('Examples:');
+        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_ANALYSIS} days=3\``);
+        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} weeks=2\``);
+        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} weeks=0\` (current week)`);
         return;
       }
 
-      const [baseURLInput, streamType, weeksInput] = args;
-      const weeks = weeksInput ? parseInt(weeksInput, 10) : 4;
-
-      const baseURL = extractURLFromSlackInput(baseURLInput);
+      const baseURL = extractURLFromSlackInput(parsed.baseurl);
+      const auditType = parsed.audit;
 
       if (!isValidUrl(baseURL)) {
-        await say(':warning: Please provide a valid site base URL.');
+        await say(':warning: Invalid URL provided');
         return;
       }
 
-      if (!SUPPORTED_STREAMS[streamType]) {
-        await say(`:warning: Unsupported stream type: ${streamType}. Supported types: ${Object.keys(SUPPORTED_STREAMS).join(', ')}`);
-        return;
+      let timeValue;
+      let timeDesc;
+
+      switch (auditType) {
+        case AUDIT_TYPES.CDN_ANALYSIS:
+          timeValue = parseInt(parsed.days, 10) || 1;
+          timeDesc = `${timeValue} days (${timeValue * 24} hours)`;
+          break;
+
+        case AUDIT_TYPES.CDN_LOGS_REPORT:
+          timeValue = parseInt(parsed.weeks, 10);
+          if (Number.isNaN(timeValue)) timeValue = 4;
+
+          if (timeValue > 4) {
+            await say(`:warning: Max 4 weeks for ${AUDIT_TYPES.CDN_LOGS_REPORT}`);
+            return;
+          }
+
+          if (timeValue === 0) {
+            timeDesc = 'current week only';
+          } else {
+            timeDesc = `${timeValue} previous weeks`;
+          }
+          break;
+
+        default:
+          await say(`:warning: Supported audits: ${AUDIT_TYPES.CDN_ANALYSIS}, ${AUDIT_TYPES.CDN_LOGS_REPORT}`);
+          return;
       }
 
-      if (weeksInput && (Number.isNaN(weeks) || weeks < 1 || weeks > 4)) {
-        await say(':warning: Please provide a valid number of weeks (1-4).');
-        return;
-      }
-
-      await say(`:gear: Starting ${streamType} backfill for site ${baseURL} (${weeks} weeks)...`);
+      await say(`:gear: Starting ${auditType} backfill for ${baseURL} (${timeDesc})...`);
 
       const site = await Site.findByBaseURL(baseURL);
       if (!site) {
-        await say(`:x: Site '${baseURL}' not found.`);
+        await say(`:x: Site '${baseURL}' not found`);
         return;
       }
 
-      const siteId = site.getId();
-
       const configuration = await Configuration.findLatest();
+      await triggerBackfill(context, configuration, site.getId(), auditType, timeValue);
 
-      await triggerBackfill(context, configuration, siteId, streamType, weeks);
-
-      const message = `:white_check_mark: *${streamType.charAt(0).toUpperCase() + streamType.slice(1)} backfill triggered successfully!*
-        
-:link: *Site:* ${baseURL}
-:identification_card: *Site ID:* ${siteId}
-:calendar: *Weeks:* ${weeks}
-:ocean: *Stream:* ${streamType}
-
-The ${streamType} backfill for the last ${weeks} week${weeks === 1 ? '' : 's'} has been triggered.`;
-
-      await say(message);
+      let totalMessages;
+      switch (auditType) {
+        case AUDIT_TYPES.CDN_ANALYSIS:
+          totalMessages = timeValue * 24;
+          break;
+        case AUDIT_TYPES.CDN_LOGS_REPORT:
+          totalMessages = timeValue === 0 ? 1 : timeValue;
+          break;
+        /* c8 ignore start */
+        default:
+          totalMessages = 1;
+          break;
+        /* c8 ignore end */
+      }
+      await say(`:white_check_mark: ${auditType} backfill triggered! ${totalMessages} messages queued.`);
     } catch (error) {
       log.error('Error in LLMO backfill:', error);
       await postErrorMessage(say, error);


### PR DESCRIPTION
• CDN Analysis backfill - backfills hourly audits for specified days
• CDN Logs Report backfill - backfills weekly reports (1-4 weeks or current week)