### PR TITLE
fix: write to safe environment from spacecat dev

### DIFF
--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -449,7 +449,7 @@ async function updateIndexConfig(dataFolder, lambdaCtx, slackCtx) {
   await octokit.repos.createOrUpdateFileContents({
     owner,
     repo,
-    ref,
+    branch: ref,
     path,
     message: `Automation: Onboard ${dataFolder}`,
     content: Buffer.from(modifiedContent).toString('base64'),

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -349,7 +349,7 @@ describe('onboard-llmo-modal', () => {
       expect(octokitInstance.repos.createOrUpdateFileContents).to.have.been.calledWith({
         owner: 'adobe',
         repo: 'project-elmo-ui-data',
-        ref: 'main',
+        branch: 'main',
         path: 'helix-query.yaml',
         message: 'Automation: Onboard example-com',
         content: sinon.match.string,


### PR DESCRIPTION
When testing the onboard command on dev, we don't want to trigger an actual onboarding.