### PR TITLE
feat: add edge-fetch API endpoint for Tokowaka URL fetching

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -220,6 +220,8 @@ paths:
     $ref: './site-opportunities.yaml#/site-opportunity-suggestions-status'
   /sites/{siteId}/opportunities/{opportunityId}/suggestions/auto-fix:
     $ref: './site-opportunities.yaml#/site-opportunity-suggestions-auto-fix'
+  /sites/{siteId}/opportunities/{opportunityId}/suggestions/edge-live-preview:
+    $ref: './site-opportunities.yaml#/site-opportunity-suggestions-edge-live-preview'
   /sites/{siteId}/site-enrollments:
     $ref: './site-enrollments-api.yaml#/site-enrollments-by-site'
   /sites/{siteId}/user-activities:

--- a/docs/openapi/site-opportunities.yaml
+++ b/docs/openapi/site-opportunities.yaml
@@ -610,6 +610,83 @@ site-opportunity-suggestion:
     security:
       - ims_key: [ ]
 
+site-opportunity-suggestions-edge-live-preview:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+    - $ref: './parameters.yaml#/opportunityId'
+  post:
+    operationId: edgeLivePreview
+    summary: |
+      Fetch live content from a URL using Tokowaka-AI User-Agent
+    description: |
+      Fetches live content from a given URL using the Tokowaka-AI User-Agent.
+      This is useful for previewing what content is currently deployed or accessible
+      from a specific URL.
+    tags:
+      - opportunity-suggestions
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - url
+            properties:
+              url:
+                type: string
+                format: uri
+                description: The URL to fetch content from
+                example: https://www.lovesac.com/sactionals
+    responses:
+      '200':
+        description: Successfully fetched content from the URL
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [success, error]
+                  description: Fetch status
+                statusCode:
+                  type: integer
+                  description: HTTP status code from the URL
+                message:
+                  type: string
+                  description: Error message if fetch failed
+                html:
+                  type: object
+                  description: HTML content object (similar to edge-preview response)
+                  properties:
+                    url:
+                      type: string
+                      description: The requested URL
+                    content:
+                      type: string
+                      description: The fetched HTML content (null if fetch failed)
+              example:
+                status: success
+                statusCode: 200
+                html:
+                  url: https://www.lovesac.com/sactionals
+                  content: "<html>...</html>"
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '404':
+        $ref: './responses.yaml#/404'
+      '429':
+        $ref: './responses.yaml#/429'
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        $ref: './responses.yaml#/503'
+    security:
+      - ims_key: [ ]
+
 site-opportunity-suggestion-fixes:
   parameters:
     - $ref: './parameters.yaml#/siteId'

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -195,6 +195,7 @@ export default function getRouteHandlers(
     'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-deploy': suggestionsController.deploySuggestionToEdge,
     'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-rollback': suggestionsController.rollbackSuggestionFromEdge,
     'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-preview': suggestionsController.previewSuggestions,
+    'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-live-preview': suggestionsController.fetchFromEdge,
     'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status': suggestionsController.getByStatus,
     'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit/:cursor': suggestionsController.getByStatusPaged,
     'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit': suggestionsController.getByStatusPaged,

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -439,6 +439,7 @@ describe('getRouteHandlers', () => {
       'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-deploy',
       'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-rollback',
       'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-preview',
+      'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-live-preview',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit/:cursor',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit',


### PR DESCRIPTION
- Add fetchFromEdge method in suggestions controller
- Implement site and opportunity validation
- Add URL format validation (HTTP/HTTPS only)
- Custom User-Agent: Tokowaka-AI Tokowaka/1.0
- Add unit tests (13 test cases)
- Update OpenAPI documentation

## Related Issues
https://github.com/adobe-rnd/tokowaka-worker/issues/386

