### PR TITLE
fix: use preview key instead of site api key in Edge Preview API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@adobe/spacecat-shared-scrape-client": "2.3.6",
         "@adobe/spacecat-shared-slack-client": "1.5.32",
         "@adobe/spacecat-shared-tier-client": "1.3.10",
-        "@adobe/spacecat-shared-tokowaka-client": "1.4.1",
+        "@adobe/spacecat-shared-tokowaka-client": "https://gist.github.com/dipratap/c893e5f937a62e34bee0a889b0b5287b/raw/1303df88bf212eb20c130a578cce9470baacd4f9/adobe-spacecat-shared-tokowaka-client-1.4.1.tgz",
         "@adobe/spacecat-shared-utils": "1.85.2",
         "@aws-sdk/client-s3": "3.940.0",
         "@aws-sdk/client-sfn": "3.940.0",
@@ -2414,8 +2414,8 @@
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.4.1.tgz",
-      "integrity": "sha512-4A0KDo4HbHWcOaXfNTGscLLdU/0t/AM2qsJzECaqn6filhxIqBsundlP2qwTHeJCbYsEFltQNRVFzn/ms3V7wQ==",
+      "resolved": "https://gist.github.com/dipratap/c893e5f937a62e34bee0a889b0b5287b/raw/1303df88bf212eb20c130a578cce9470baacd4f9/adobe-spacecat-shared-tokowaka-client-1.4.1.tgz",
+      "integrity": "sha512-MD83qivS+G7NCcJVeIDURsT5lhJnYdAXVCvGEyMMlPhn1T+STMvLV0F2vwM9T3M4tHU4TXpxR8z2OfYDGNGSag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@adobe/spacecat-shared-scrape-client": "2.3.6",
     "@adobe/spacecat-shared-slack-client": "1.5.32",
     "@adobe/spacecat-shared-tier-client": "1.3.10",
-    "@adobe/spacecat-shared-tokowaka-client": "1.4.1",
+    "@adobe/spacecat-shared-tokowaka-client": "https://gist.github.com/dipratap/c893e5f937a62e34bee0a889b0b5287b/raw/1303df88bf212eb20c130a578cce9470baacd4f9/adobe-spacecat-shared-tokowaka-client-1.4.1.tgz",
     "@adobe/spacecat-shared-utils": "1.85.2",
     "@aws-sdk/client-s3": "3.940.0",
     "@aws-sdk/client-sfn": "3.940.0",

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -3285,6 +3285,7 @@ describe('Suggestions Controller', () => {
         TOKOWAKA_PREVIEW_BUCKET: 'test-tokowaka-preview-bucket',
         TOKOWAKA_CDN_PROVIDER: 'test-cdn-provider',
         TOKOWAKA_EDGE_URL: 'https://edge-dev.tokowaka.now',
+        TOKOWAKA_PREVIEW_API_KEY: 'test-preview-api-key-123',
         TOKOWAKA_CDN_CONFIG: JSON.stringify({
           cloudfront: {
             distributionId: 'E123456',
@@ -3795,6 +3796,7 @@ describe('Suggestions Controller', () => {
           TOKOWAKA_PREVIEW_BUCKET: 'test-tokowaka-preview-bucket',
           TOKOWAKA_CDN_PROVIDER: 'test-cdn-provider',
           TOKOWAKA_EDGE_URL: 'https://edge-dev.tokowaka.now',
+          TOKOWAKA_PREVIEW_API_KEY: 'test-preview-api-key-123',
           TOKOWAKA_CDN_CONFIG: JSON.stringify({
             cloudfront: {
               distributionId: 'E123456',
@@ -4553,6 +4555,7 @@ describe('Suggestions Controller', () => {
         TOKOWAKA_PREVIEW_BUCKET: 'test-tokowaka-preview-bucket',
         TOKOWAKA_CDN_PROVIDER: 'test-cdn-provider',
         TOKOWAKA_EDGE_URL: 'https://edge-dev.tokowaka.now',
+        TOKOWAKA_PREVIEW_API_KEY: 'test-preview-api-key-123',
         TOKOWAKA_CDN_CONFIG: JSON.stringify({
           cloudfront: {
             distributionId: 'E123456',
@@ -4959,6 +4962,7 @@ describe('Suggestions Controller', () => {
         TOKOWAKA_PREVIEW_BUCKET: 'test-tokowaka-preview-bucket',
         TOKOWAKA_CDN_PROVIDER: 'test-cdn-provider',
         TOKOWAKA_EDGE_URL: 'https://edge-dev.tokowaka.now',
+        TOKOWAKA_PREVIEW_API_KEY: 'test-preview-api-key-123',
       };
 
       context.log = {
@@ -5244,6 +5248,7 @@ describe('Suggestions Controller', () => {
         TOKOWAKA_PREVIEW_BUCKET: 'test-tokowaka-preview-bucket',
         TOKOWAKA_CDN_PROVIDER: 'test-cdn-provider',
         TOKOWAKA_EDGE_URL: 'https://edge-dev.tokowaka.now',
+        TOKOWAKA_PREVIEW_API_KEY: 'test-preview-api-key-123',
         TOKOWAKA_CDN_CONFIG: JSON.stringify({
           cloudfront: {
             distributionId: 'E123456',


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
