### PR TITLE
fix: switch auto-fix URL grouping to whitelist approach

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -51,16 +51,21 @@ function SuggestionsController(ctx, sqs, env) {
     throw new Error('Data access required');
   }
 
-  const AUTOFIX_UNGROUPED_OPPTY_TYPES = [
-    'broken-backlinks',
-    'form-accessibility',
-    'product-metatags',
-    'security-permissions-redundant',
+  /**
+   * Opportunity types that use URL-based suggestion grouping for auto-fix.
+   * Suggestions are grouped by URL and sent as separate auto-fix messages per URL.
+   * Add here only when URL grouping is needed.
+   */
+  const URL_GROUPED_OPPORTUNITY_TYPES = [
+    'alt-text',
+    'broken-internal-links',
+    'high-organic-low-ctr',
+    'meta-tags',
   ];
 
   const DEFAULT_PAGE_SIZE = 100;
 
-  const shouldGroupSuggestionsForAutofix = (type) => !AUTOFIX_UNGROUPED_OPPTY_TYPES.includes(type);
+  const shouldGroupSuggestionsForAutofix = (type) => URL_GROUPED_OPPORTUNITY_TYPES.includes(type);
 
   /**
    * Checks if a suggestion is a domain-wide auto generated suggestion


### PR DESCRIPTION
Previously, new opportunity types defaulted to URL-grouped behavior, which silently dropped suggestions without URL data. Now types must explicitly opt-in to URL grouping, making ungrouped the safe default.

---

Please ensure your pull request adheres to the following guidelines:

- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:

- [x] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [x] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:

- [x] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:

- [x] make sure you update the API specification with the type, schema of the audit result and an example
