### PR TITLE
fix: make brand profile exec names unique

### DIFF
--- a/src/support/brand-profile-trigger.js
+++ b/src/support/brand-profile-trigger.js
@@ -77,8 +77,11 @@ export const triggerBrandProfileAgent = async ({
     return null;
   }
 
-  const idempotencyKey = `${AGENT_ID}-${resolvedSiteId}-${reason}-${Date.now()}`;
-  const executionName = `${AGENT_ID}-${resolvedSiteId}-${reason}`.slice(0, 80);
+  const uniqueSuffix = Date.now().toString(36);
+  const idempotencyKey = `${AGENT_ID}-${resolvedSiteId}-${reason}-${uniqueSuffix}`;
+  // Step Functions execution names must be unique for a long retention window (~90 days),
+  // so include a short suffix to avoid ExecutionAlreadyExists when triggered repeatedly.
+  const executionName = `${AGENT_ID}-${resolvedSiteId}-${reason}-${uniqueSuffix}`.slice(0, 80);
 
   try {
     const payload = {

--- a/test/support/brand-profile-trigger.test.js
+++ b/test/support/brand-profile-trigger.test.js
@@ -115,8 +115,9 @@ describe('brand-profile-trigger helper', () => {
     });
     expect(payload.context).to.deep.equal({ baseURL: 'https://example.com' });
     expect(payload.slackContext).to.deep.equal(slackContext);
-    expect(payload.idempotencyKey).to.match(/^brand-profile-site-123-test-reason-\d+/);
-    expect(options.executionName).to.match(/^brand-profile-site-123-test-reason/);
+    // Suffix is a short base36 timestamp to ensure uniqueness across repeated triggers.
+    expect(payload.idempotencyKey).to.match(/^brand-profile-site-123-test-reason-[0-9a-z]+$/);
+    expect(options.executionName).to.match(/^brand-profile-site-123-test-reason-[0-9a-z]+$/);
   });
 
   it('defaults slack context to empty object when not provided', async () => {


### PR DESCRIPTION
### Summary
Make `brand-profile` Step Functions executions use a **unique execution name** per trigger to prevent `ExecutionAlreadyExists` errors when the same site/reason is triggered repeatedly within the Step Functions name-retention window.

### Changes
- Updated `triggerBrandProfileAgent` to append a short unique suffix to `executionName` (and `idempotencyKey`) while keeping the readable prefix `brand-profile-<siteId>-<reason>`.
- Adjusted `brand-profile-trigger` unit test expectations to account for the new suffix format.

### Why
Step Functions execution names cannot be reused for an extended retention period (e.g., ~90 days). The previous deterministic name (`brand-profile-<siteId>-<reason>`) could collide on subsequent runs for the same site/reason after the prior execution completed.

### Testing
- `npm test` (spacecat-api-service)