### PR TITLE
fix: adjust onboarding slack notification for clarity | LLMO-645

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -177,10 +177,9 @@ export async function validateSiteNotOnboarded(baseURL, imsOrgId, dataFolder, co
       await postLlmoAlert(
         ':warning: *Site is already onboarded* - Data folder already exists\n\n'
         + `• Site: \`${baseURL}\`\n`
-        + `• Requesting IMS Org: \`${imsOrgId}\`\n`
+        + `• Requested IMS Org: \`${imsOrgId}\`\n`
         + `• Current IMS Org: \`${currentImsOrgId}\`\n`
-        + `• Data Folder: \`${dataFolder}\`\n\n`
-        + 'The site has already been assigned to a different organization.',
+        + `• Data Folder: \`${dataFolder}`,
         context,
       );
 
@@ -225,11 +224,10 @@ export async function validateSiteNotOnboarded(baseURL, imsOrgId, dataFolder, co
         await postLlmoAlert(
           ':warning: *Site is already onboarded* - Assigned to a different organization\n\n'
           + `• Site: \`${baseURL}\`\n`
-          + `• Requesting IMS Org: \`${imsOrgId}\`\n`
+          + `• Requested IMS Org: \`${imsOrgId}\`\n`
           + `• Current IMS Org: \`${currentImsOrgId}\`\n`
-          + `• Current Org ID: \`${existingSite.getOrganizationId()}\`\n`
-          + `• Requested Org ID: \`${organization.getId()}\`\n\n`
-          + 'The site has already been assigned to a different organization.',
+          + `• Requested Org ID: \`${organization.getId()}\n`
+          + `• Current Org ID: \`${existingSite.getOrganizationId()}`,
           context,
         );
 
@@ -251,10 +249,9 @@ export async function validateSiteNotOnboarded(baseURL, imsOrgId, dataFolder, co
       await postLlmoAlert(
         ':warning: *Site is already onboarded* - Assigned to a different organization\n\n'
         + `• Site: \`${baseURL}\`\n`
-        + `• Requesting IMS Org: \`${imsOrgId}\`\n`
+        + `• Requested IMS Org: \`${imsOrgId}\`\n`
         + `• Current IMS Org: \`${currentImsOrgId}\`\n`
-        + `• Current Org ID: \`${existingSite.getOrganizationId()}\`\n\n`
-        + 'The site has already been assigned to a different organization.',
+        + `• Current Org ID: \`${existingSite.getOrganizationId()}`,
         context,
       );
 


### PR DESCRIPTION
## Description

Removes redundant/incorrect messages from the Slack message posted when customers get an error because the site is already onboarded. 
<img width="529" height="347" alt="image" src="https://github.com/user-attachments/assets/bb18a601-d32f-42a3-b72f-3712a1d3eb18" />


## Checks
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-645

Thanks for contributing!
