### PR TITLE
fix: filter out forms opp not shown on ui

### DIFF
--- a/src/controllers/paid/opportunity-matcher.js
+++ b/src/controllers/paid/opportunity-matcher.js
@@ -57,9 +57,9 @@ function isValidOpportunity(opportunityData) {
   const hasValue = projectedTrafficValue > 0 || projectedConversionValue > 0;
   if (!hasValue) return false;
 
-  // Exclude forms opportunities with null brief fields in guidance recommendations
-  // This happens when scrapedStatus is false (form wasn't successfully scraped)
-  // These cause UI rendering issues
+  // Exclude forms opportunities with scrapedStatus = false
+  // When forms aren't successfully scraped, they have incomplete data (null formDetails)
+  // which causes UI rendering issues
   const formTypes = [
     'high-form-views-low-conversions',
     'high-page-views-low-form-nav',
@@ -67,6 +67,10 @@ function isValidOpportunity(opportunityData) {
     'form-accessibility',
   ];
   if (formTypes.includes(type)) {
+    // Filter out opportunities where scrapedStatus is false
+    if (data?.scrapedStatus === false) return false;
+
+    // Also check for null brief fields in guidance recommendations as a fallback
     const recommendations = original.getGuidance?.()?.recommendations;
     const hasInvalidBrief = recommendations?.some(
       (rec) => rec?.brief === null || rec?.brief === undefined,
@@ -90,7 +94,9 @@ const OPPORTUNITY_TYPE_CONFIGS = [
     requiresUrlMatching: false,
     matcher: (oppData) => {
       const { tags, type, data } = oppData;
-      return tags?.some((tag) => tag?.toLowerCase() === 'paid media')
+      const lowerTags = tags?.map((tag) => tag?.toLowerCase());
+      return lowerTags?.includes('paid media')
+        || lowerTags?.includes('paid traffic')
         || type === 'consent-banner'
         || data?.opportunityType === 'no-cta-above-the-fold';
     },

--- a/test/controllers/paid/top-paid-opportunities.test.js
+++ b/test/controllers/paid/top-paid-opportunities.test.js
@@ -202,6 +202,17 @@ describe('TopPaidOpportunitiesController', () => {
       expect(opportunities).to.have.lengthOf(1);
     });
 
+    it('returns paid media opportunities (with paid traffic tag)', async () => {
+      const paidOppty = createOpportunity({ id: 'oppty-1', tags: ['paid traffic'] });
+      setupOpportunityMocks(mockContext.dataAccess.Opportunity, [paidOppty]);
+
+      const response = await controller.getTopPaidOpportunities({
+        params: { siteId: SITE_ID }, data: {},
+      });
+      const opportunities = await response.json();
+      expect(opportunities).to.have.lengthOf(1);
+    });
+
     it('returns consent-banner opportunities in top paid opportunities', async () => {
       const consentOppty = createOpportunity({ id: 'consent-1', type: 'consent-banner' });
       setupOpportunityMocks(mockContext.dataAccess.Opportunity, [consentOppty]);
@@ -664,6 +675,50 @@ describe('TopPaidOpportunitiesController', () => {
       setupOpportunityMocks(
         mockContext.dataAccess.Opportunity,
         [validFormsOppty, missingBriefFormsOppty],
+      );
+      mockContext.dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
+      mockAthenaClient.query.resolves([
+        createTrafficData({ url: 'https://example.com/form1', pageviews: '3000' }),
+        createTrafficData({ url: 'https://example.com/form2', pageviews: '5000' }),
+      ]);
+
+      const response = await controller.getTopPaidOpportunities({
+        params: { siteId: SITE_ID }, data: { year: 2025, week: 1 },
+      });
+      const opportunities = await response.json();
+      expect(opportunities).to.have.lengthOf(1);
+      expect(opportunities[0].opportunityId).to.equal('forms-1');
+    });
+
+    it('filters out forms opportunities with scrapedStatus = false', async () => {
+      const validFormsOppty = createOpportunity({
+        id: 'forms-1',
+        type: 'high-page-views-low-form-views',
+        data: {
+          projectedConversionValue: 3000,
+          form: 'https://example.com/form1',
+          scrapedStatus: true,
+        },
+      });
+      const unscrapedFormsOppty = createOpportunity({
+        id: 'forms-2',
+        type: 'high-page-views-low-form-views',
+        data: {
+          projectedConversionValue: 5000,
+          form: 'https://example.com/form2',
+          scrapedStatus: false,
+          formDetails: {
+            is_lead_gen: null,
+            industry: null,
+            form_type: null,
+            form_category: null,
+            cpl: null,
+          },
+        },
+      });
+      setupOpportunityMocks(
+        mockContext.dataAccess.Opportunity,
+        [validFormsOppty, unscrapedFormsOppty],
       );
       mockContext.dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
       mockAthenaClient.query.resolves([


### PR DESCRIPTION
fiter out forms opp with scrape = false
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
