### PR TITLE
fix: refactor LLMO overrideBaseURL resolution to canonical

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.28",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
-        "@adobe/spacecat-shared-ahrefs-client": "1.10.5",
         "@adobe/spacecat-shared-athena-client": "1.9.2",
         "@adobe/spacecat-shared-brand-client": "1.1.35",
         "@adobe/spacecat-shared-data-access": "2.104.0",
@@ -1090,54 +1089,6 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ahrefs-client": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ahrefs-client/-/spacecat-shared-ahrefs-client-1.10.5.tgz",
-      "integrity": "sha512-yqNyvMYdMEWbVbSkBqkHgGwOpFJMveLuXhU5keGDwZ0d1LfXWI6Fl6m57vvKMxF/meZis7OL+c5FTw5yNQCcgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.2.3",
-        "@adobe/helix-universal": "5.4.0",
-        "@adobe/spacecat-shared-utils": "1.81.1"
-      },
-      "engines": {
-        "node": ">=22.0.0 <25.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ahrefs-client/node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.81.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
-      "integrity": "sha512-GSQuLJsPsT6SDJNydhozgRNHl5qat4f+W7/IwyAvNfAqgPrF6Eb7+h4ZUz8Nb01Rm13Z18f6NY/u/wW12sdxtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.2.3",
-        "@aws-sdk/client-s3": "3.940.0",
-        "@aws-sdk/client-sqs": "3.940.0",
-        "@json2csv/plainjs": "7.0.6",
-        "aws-xray-sdk": "3.12.0",
-        "cheerio": "1.1.2",
-        "date-fns": "4.1.0",
-        "franc-min": "6.2.0",
-        "iso-639-3": "3.0.1",
-        "validator": "^13.15.15",
-        "world-countries": "5.1.0",
-        "zod": "^4.1.11"
-      },
-      "engines": {
-        "node": ">=22.0.0 <25.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ahrefs-client/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/spacecat-shared-athena-client": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal-logger": "3.0.28",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
-    "@adobe/spacecat-shared-ahrefs-client": "1.10.5",
     "@adobe/spacecat-shared-athena-client": "1.9.2",
     "@adobe/spacecat-shared-brand-client": "1.1.35",
     "@adobe/spacecat-shared-data-access": "2.104.0",


### PR DESCRIPTION
## Summary
- Replace Ahrefs-based `overrideBaseURL` detection in LLMO onboarding with canonical URL resolution.
- Keep override detection limited to `www` vs non-`www` hostname resolution.
- Preserve the original base URL path when setting override; never adopt a differing canonical path.
- Keep existing safety behavior: if `fetchConfig.overrideBaseURL` already exists, skip auto-detection.

## Why
AI prompt generation is moving away from Ahrefs, allowing us to remove the Ahrefs check from onboarding, making the onboarding a less error-prone user experience. While that simplifies the onboarding experience, we still need to indicate to the customer the overall health status of retrieving Ahrefs for the downstream services, like Onsite Opportunities, which is covered in [this PR](https://github.com/adobe/spacecat-audit-worker/pull/1959).

## Case Handling (Current Behavior)
1. Base URL has a non-`www` subdomain (e.g. `blog.example.com`): skip detection, no override.
2. Base canonical resolves to toggled hostname (`example.com` -> `www.example.com`): set override to toggled origin + original base path.
3. Base canonical resolves on same hostname (even if canonical path differs): no override.
4. Base canonical fails, alternate (`www` toggled) resolves to alternate hostname: set override to alternate origin + original base path.
5. Both base and alternate resolve but neither indicates toggled hostname is canonical: no override.
6. Base resolves, alternate fails: no override.
7. Both fail canonical resolution: warn and continue with no override.
8. Existing `fetchConfig.overrideBaseURL` present: skip detection and preserve existing value.

## Implementation Notes
- Removed Ahrefs dependency from LLMO onboarding override detection.
- Added canonical-based helper logic to derive override from hostname signal only.
- Updated LLMO onboarding and helper tests to canonical-driven scenarios.

## Validation
- `npx eslint src/controllers/llmo/llmo-onboarding.js test/controllers/llmo/llmo-onboarding.test.js test/controllers/llmo/test-helpers.js`
- `npx mocha --require test/setup-env.js --recursive --reporter dot test/controllers/llmo/llmo-onboarding.test.js`
  - Result: `60 passing`
