### PR TITLE
feat: Add support for ignored prompts in LLMO config

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -4530,6 +4530,98 @@ LlmoConfig:
           description: Array of competitor configurations
           items:
             $ref: '#/LlmoCompetitor'
+    deleted:
+      type: object
+      description: Deleted prompts configuration
+      properties:
+        prompts:
+          type: object
+          description: A record of deleted prompts keyed by UUID
+          additionalProperties:
+            $ref: '#/LlmoDeletedPrompt'
+    ignored:
+      type: object
+      description: Ignored prompts configuration
+      properties:
+        prompts:
+          type: object
+          description: A record of ignored prompts keyed by UUID
+          additionalProperties:
+            $ref: '#/LlmoIgnoredPrompt'
+  additionalProperties: true
+
+LlmoDeletedPrompt:
+  type: object
+  description: A deleted prompt entry in the LLMO configuration
+  required:
+    - prompt
+    - regions
+    - origin
+    - source
+    - topic
+    - category
+  properties:
+    prompt:
+      type: string
+      description: The prompt text
+      minLength: 1
+    regions:
+      type: array
+      description: Array of two-letter region codes
+      items:
+        type: string
+        pattern: '^[a-z][a-z]$'
+    origin:
+      type: string
+      description: The origin of the prompt (human, ai, or custom)
+    source:
+      type: string
+      description: The source of the prompt (config, api, or custom)
+    topic:
+      type: string
+      description: The topic name this prompt belonged to
+      minLength: 1
+    category:
+      type: string
+      description: The category name this prompt belonged to
+      minLength: 1
+    categoryId:
+      type: string
+      format: uuid
+      description: Optional UUID of the category
+    updatedBy:
+      type: string
+      description: The user who last updated this entry
+    updatedAt:
+      type: string
+      description: ISO timestamp of the last update
+  additionalProperties: true
+
+LlmoIgnoredPrompt:
+  type: object
+  description: An ignored prompt entry in the LLMO configuration
+  required:
+    - prompt
+    - region
+    - source
+  properties:
+    prompt:
+      type: string
+      description: The prompt text
+      minLength: 1
+    region:
+      type: string
+      pattern: '^[a-z][a-z]$'
+      description: Two-letter region code
+    source:
+      type: string
+      description: The source of the prompt (gsc or custom)
+    updatedBy:
+      type: string
+      description: The user who last updated this entry
+    updatedAt:
+      type: string
+      description: ISO timestamp of the last update
   additionalProperties: true
 
 LlmoEntity:

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@adobe/spacecat-shared-slack-client": "1.6.0",
         "@adobe/spacecat-shared-tier-client": "1.3.11",
         "@adobe/spacecat-shared-tokowaka-client": "1.7.6",
-        "@adobe/spacecat-shared-utils": "1.91.0",
+        "@adobe/spacecat-shared-utils": "1.93.0",
         "@aws-sdk/client-s3": "3.940.0",
         "@aws-sdk/client-secrets-manager": "3.940.0",
         "@aws-sdk/client-sfn": "3.940.0",
@@ -915,6 +915,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.0.tgz",
       "integrity": "sha512-3ZfFdjYtpv7RCgul9yyOBsRVsxLNapwt0YjASBhyzJGNjnPxrWDlqDtbpBdwAgA1Nuh9nmjzFDFu8CJWv6BMKw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.2.3",
         "aws4": "1.13.2"
@@ -1896,9 +1897,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.91.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.91.0.tgz",
-      "integrity": "sha512-nytJOD1Lh5yGPc0KTrb/6uljEiLAYrS9/KCgmsU4PtkqNpW+/HYGoggsJ9AL5qch92EhXuNriwwTQh+s0dyQBA==",
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.93.0.tgz",
+      "integrity": "sha512-V8FVfpL6+6TspETGbdrCDo38tMZNyG93Tpk619gTsV7TJG15825fERtve7iijJIvr4vRsv93rRYEZZIKSqePBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -3064,6 +3065,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -8157,6 +8159,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -8383,6 +8386,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -8589,6 +8593,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8752,6 +8757,7 @@
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -10671,6 +10677,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -10977,6 +10984,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11023,6 +11031,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11498,6 +11507,7 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -12148,6 +12158,7 @@
       "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14324,6 +14335,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -18306,6 +18318,7 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -19361,6 +19374,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -22507,6 +22521,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23176,6 +23191,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -24293,6 +24309,7 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24303,6 +24320,7 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -25012,6 +25030,7 @@
       "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -25898,6 +25917,7 @@
       "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.5",
@@ -26463,6 +26483,7 @@
       "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
@@ -27528,6 +27549,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -28261,6 +28283,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -28522,6 +28545,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -28531,6 +28555,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@adobe/spacecat-shared-slack-client": "1.6.0",
     "@adobe/spacecat-shared-tier-client": "1.3.11",
     "@adobe/spacecat-shared-tokowaka-client": "1.7.6",
-    "@adobe/spacecat-shared-utils": "1.91.0",
+    "@adobe/spacecat-shared-utils": "1.93.0",
     "@aws-sdk/client-s3": "3.940.0",
     "@aws-sdk/client-secrets-manager": "3.940.0",
     "@aws-sdk/client-sfn": "3.940.0",

--- a/src/controllers/llmo/llmo-config-metadata.js
+++ b/src/controllers/llmo/llmo-config-metadata.js
@@ -124,6 +124,7 @@ export const updateModifiedByDetails = (updates, oldConfig, userId) => {
   const oldBrandsAliases = oldConfig?.brands?.aliases || [];
   const oldCompetitors = oldConfig?.competitors?.competitors || [];
   const oldDeletedPrompts = oldConfig?.deleted?.prompts || {};
+  const oldIgnoredPrompts = oldConfig?.ignored?.prompts || {};
 
   const stats = {
     categories: { total: 0, modified: 0 },
@@ -133,6 +134,7 @@ export const updateModifiedByDetails = (updates, oldConfig, userId) => {
     brandAliases: { total: 0, modified: 0 },
     competitors: { total: 0, modified: 0 },
     deletedPrompts: { total: 0, modified: 0 },
+    ignoredPrompts: { total: 0, modified: 0 },
     categoryUrls: { total: 0 },
   };
 
@@ -288,6 +290,23 @@ export const updateModifiedByDetails = (updates, oldConfig, userId) => {
         prompt.updatedBy = userId;
         prompt.updatedAt = timestamp;
         stats.deletedPrompts.modified += 1;
+      }
+    });
+  }
+
+  // 6. Ignored Prompts
+  if (newConfig.ignored && newConfig.ignored.prompts) {
+    Object.entries(newConfig.ignored.prompts).forEach(([id, prompt]) => {
+      stats.ignoredPrompts.total += 1;
+      const oldPrompt = oldIgnoredPrompts[id];
+
+      if (oldPrompt) {
+        if (oldPrompt.updatedBy) prompt.updatedBy = oldPrompt.updatedBy;
+        if (oldPrompt.updatedAt) prompt.updatedAt = oldPrompt.updatedAt;
+      } else {
+        prompt.updatedBy = userId;
+        prompt.updatedAt = timestamp;
+        stats.ignoredPrompts.modified += 1;
       }
     });
   }

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -499,6 +499,7 @@ function LlmoController(ctx) {
         `${stats.brandAliases.total} brand aliases${stats.brandAliases.modified ? ` (${stats.brandAliases.modified} modified)` : ''}`,
         `${stats.competitors.total} competitors${stats.competitors.modified ? ` (${stats.competitors.modified} modified)` : ''}`,
         `${stats.deletedPrompts.total} deleted prompts${stats.deletedPrompts.modified ? ` (${stats.deletedPrompts.modified} modified)` : ''}`,
+        `${stats.ignoredPrompts.total} ignored prompts${stats.ignoredPrompts.modified ? ` (${stats.ignoredPrompts.modified} modified)` : ''}`,
         `${stats.categoryUrls.total} category URLs`,
       ];
       const configSummary = summaryParts.join(', ');

--- a/src/support/slack/commands/get-llmo-config-summary.js
+++ b/src/support/slack/commands/get-llmo-config-summary.js
@@ -92,6 +92,7 @@ function GetLlmoConfigSummaryCommand(context) {
     const brandAliases = config.brands?.aliases?.length || 0;
     const competitors = config.competitors?.competitors?.length || 0;
     const deletedPrompts = Object.keys(config.deleted?.prompts || {}).length;
+    const ignoredPrompts = Object.keys(config.ignored?.prompts || {}).length;
     const cdnProvider = config.cdnBucketConfig?.cdnProvider || 'N/A';
 
     return {
@@ -103,6 +104,7 @@ function GetLlmoConfigSummaryCommand(context) {
       brandAliases,
       competitors,
       deletedPrompts,
+      ignoredPrompts,
       cdnProvider,
     };
   };
@@ -198,6 +200,7 @@ function GetLlmoConfigSummaryCommand(context) {
           { id: 'brandAliases', title: 'Brand Aliases' },
           { id: 'competitors', title: 'Competitors' },
           { id: 'deletedPrompts', title: 'Deleted Prompts' },
+          { id: 'ignoredPrompts', title: 'Ignored Prompts' },
           { id: 'cdnProvider', title: 'CDN Provider' },
         ],
       });

--- a/test/controllers/llmo/llmo-config-metadata.test.js
+++ b/test/controllers/llmo/llmo-config-metadata.test.js
@@ -93,6 +93,7 @@ describe('LLMO Config Metadata Utils', () => {
         brandAliases: { total: 0, modified: 0 },
         competitors: { total: 0, modified: 0 },
         deletedPrompts: { total: 0, modified: 0 },
+        ignoredPrompts: { total: 0, modified: 0 },
         categoryUrls: { total: 0 },
       });
     });
@@ -369,6 +370,75 @@ describe('LLMO Config Metadata Utils', () => {
       expect(newConfig.deleted.prompts['del-1'].updatedAt).to.equal('2023');
       expect(newConfig.deleted.prompts['del-2'].updatedBy).to.equal(userId);
       expect(stats.deletedPrompts.modified).to.equal(1);
+    });
+
+    it('should handle ignored prompts', () => {
+      const inputConfig = {
+        ignored: {
+          prompts: {
+            'ign-1': { prompt: 'Ignored', region: 'us', source: 'gsc' },
+          },
+        },
+      };
+      const oldConfig = {};
+
+      const { newConfig, stats } = updateModifiedByDetails(inputConfig, oldConfig, userId);
+
+      expect(newConfig.ignored.prompts['ign-1'].updatedBy).to.equal(userId);
+      expect(stats.ignoredPrompts.modified).to.equal(1);
+    });
+
+    it('should handle ignored prompts when old config has no ignored section', () => {
+      const inputConfig = {
+        ignored: {
+          prompts: {
+            'ign-1': { prompt: 'Ignored', region: 'us', source: 'gsc' },
+          },
+        },
+      };
+      const oldConfig = { categories: {} }; // No ignored section
+
+      const { newConfig, stats } = updateModifiedByDetails(inputConfig, oldConfig, userId);
+
+      expect(newConfig.ignored.prompts['ign-1'].updatedBy).to.equal(userId);
+      expect(stats.ignoredPrompts.modified).to.equal(1);
+    });
+
+    it('should update metadata when adding a new ignored prompt', () => {
+      const oldConfig = {
+        ignored: {
+          prompts: {
+            'ign-1': {
+              prompt: 'Ignored',
+              region: 'us',
+              source: 'gsc',
+              updatedBy: 'old',
+              updatedAt: '2023',
+            },
+          },
+        },
+      };
+      const inputConfig = {
+        ignored: {
+          prompts: {
+            'ign-1': {
+              prompt: 'Ignored',
+              region: 'us',
+              source: 'gsc',
+              updatedBy: 'old',
+              updatedAt: '2023',
+            },
+            'ign-2': { prompt: 'New Ignored', region: 'gb', source: 'gsc' },
+          },
+        },
+      };
+
+      const { newConfig, stats } = updateModifiedByDetails(inputConfig, oldConfig, userId);
+
+      expect(newConfig.ignored.prompts['ign-1'].updatedBy).to.equal('old');
+      expect(newConfig.ignored.prompts['ign-1'].updatedAt).to.equal('2023');
+      expect(newConfig.ignored.prompts['ign-2'].updatedBy).to.equal(userId);
+      expect(stats.ignoredPrompts.modified).to.equal(1);
     });
 
     it('should handle brand aliases', () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -195,6 +195,7 @@ describe('LlmoController', () => {
         brandAliases: { total: 0, modified: 0 },
         competitors: { total: 0, modified: 0 },
         deletedPrompts: { total: 0, modified: 0 },
+        ignoredPrompts: { total: 0, modified: 0 },
         categoryUrls: { total: 0 },
       },
     }));
@@ -1444,6 +1445,7 @@ describe('LlmoController', () => {
           brandAliases: { total: 1, modified: 1 },
           competitors: { total: 1, modified: 1 },
           deletedPrompts: { total: 2, modified: 2 },
+          ignoredPrompts: { total: 1, modified: 1 },
           categoryUrls: { total: 2 },
         },
       }));
@@ -1539,6 +1541,7 @@ describe('LlmoController', () => {
           brandAliases: { total: 0, modified: 0 },
           competitors: { total: 0, modified: 0 },
           deletedPrompts: { total: 0, modified: 0 },
+          ignoredPrompts: { total: 0, modified: 0 },
           categoryUrls: { total: 4 },
         },
       }));
@@ -1576,6 +1579,7 @@ describe('LlmoController', () => {
           brandAliases: { total: 0, modified: 0 },
           competitors: { total: 0, modified: 0 },
           deletedPrompts: { total: 0, modified: 0 },
+          ignoredPrompts: { total: 0, modified: 0 },
           categoryUrls: { total: 0 },
         },
       }));
@@ -1617,6 +1621,7 @@ describe('LlmoController', () => {
           brandAliases: { total: 0, modified: 0 },
           competitors: { total: 0, modified: 0 },
           deletedPrompts: { total: 0, modified: 0 },
+          ignoredPrompts: { total: 0, modified: 0 },
           categoryUrls: { total: 0 },
         },
       }));

--- a/test/support/slack/commands/get-llmo-config-summary.test.js
+++ b/test/support/slack/commands/get-llmo-config-summary.test.js
@@ -133,6 +133,7 @@ describe('GetLlmoConfigSummaryCommand', () => {
       brands: { aliases: ['alias1'] },
       competitors: { competitors: ['comp1'] },
       deleted: { prompts: { deleted1: {} } },
+      ignored: { prompts: { ignored1: {} } },
       cdnBucketConfig: { cdnProvider: 'cloudflare' },
     };
 
@@ -153,6 +154,7 @@ describe('GetLlmoConfigSummaryCommand', () => {
     expect(lines[0]).to.include('Human Prompts');
     expect(lines[0]).to.include('AI Prompts');
     expect(lines[0]).to.include('Total Prompts');
+    expect(lines[0]).to.include('Ignored Prompts');
     // Data row should have 1 human prompt, 2 AI prompts, 3 total
     expect(lines[1]).to.include(',1,2,3,');
 


### PR DESCRIPTION
Adds handling for the new ignored field in the LLMO configuration schema, following the same pattern as the existing deleted prompts field.




Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
[LLMO-3005](https://jira.corp.adobe.com/browse/LLMO-3005)

Thanks for contributing!
