### PR TITLE
fix: scope trial-user-invite duplicate check to current organization

### DIFF
--- a/src/controllers/trial-users.js
+++ b/src/controllers/trial-users.js
@@ -127,8 +127,10 @@ function TrialUsersController(ctx) {
         return forbidden('Access denied to this organization');
       }
 
-      // Check if trial user already exists with this email
-      const existingTrialUser = await TrialUser.findByEmailId(emailId);
+      // Check if trial user already exists with this email in this organization
+      const existingTrialUsers = await TrialUser.allByEmailId(emailId);
+      const existingTrialUser = existingTrialUsers
+        .find((user) => user.getOrganizationId() === organizationId);
       if (existingTrialUser) {
         return createResponse({ message: `Trial user with this email already exists ${existingTrialUser.getId()}` }, 409);
       }

--- a/test/controllers/trial-users.test.js
+++ b/test/controllers/trial-users.test.js
@@ -91,6 +91,7 @@ describe('Trial User Controller', () => {
       findById: sandbox.stub().resolves(mockTrialUser),
       allByOrganizationId: sandbox.stub().resolves(mockTrialUsers),
       findByEmailId: sandbox.stub().resolves(null),
+      allByEmailId: sandbox.stub().resolves([]),
       create: sandbox.stub().resolves(mockTrialUser),
       STATUSES: {
         INVITED: 'INVITED',
@@ -166,6 +167,7 @@ describe('Trial User Controller', () => {
     mockDataAccess.TrialUser.findByOrganizationId = sandbox
       .stub()
       .resolves(mockTrialUsers);
+    mockDataAccess.TrialUser.allByEmailId = sandbox.stub().resolves([]);
     mockDataAccess.Organization.findById = sandbox.stub().resolves(mockOrganization);
 
     // Store reference to the mock instance for test manipulation
@@ -629,8 +631,8 @@ describe('Trial User Controller', () => {
       expect(body.message).to.equal('Access denied to this organization');
     });
 
-    it('should return conflict when trial user already exists', async () => {
-      mockDataAccess.TrialUser.findByEmailId.resolves(mockTrialUser);
+    it('should return conflict when trial user already exists in same organization', async () => {
+      mockDataAccess.TrialUser.allByEmailId.resolves([mockTrialUser]);
 
       const context = {
         params: { organizationId },
@@ -653,11 +655,49 @@ describe('Trial User Controller', () => {
       expect(body.message).to.equal(`Trial user with this email already exists ${mockTrialUser.getId()}`);
     });
 
+    it('should not return conflict when trial user exists in different organization', async () => {
+      const trialUserInDifferentOrg = {
+        getId: () => 'trial-user-other-org',
+        getOrganizationId: () => '999e4567-e89b-12d3-a456-426614174999',
+        getExternalUserId: () => 'ext-user-other',
+        getStatus: () => 'INVITED',
+        getProvider: () => 'GOOGLE',
+        getLastSeenAt: () => '2023-01-01T00:00:00Z',
+        getEmailId: () => 'existing@example.com',
+        getFirstName: () => 'Other',
+        getLastName: () => 'User',
+        getMetadata: () => ({ origin: 'INVITED' }),
+        getCreatedAt: () => '2023-01-01T00:00:00Z',
+        getUpdatedAt: () => '2023-01-01T00:00:00Z',
+        getUpdatedBy: () => 'existing@example.com',
+      };
+
+      mockDataAccess.TrialUser.allByEmailId.resolves([trialUserInDifferentOrg]);
+
+      const context = {
+        params: { organizationId },
+        data: { emailId: 'existing@example.com' },
+        dataAccess: mockDataAccess,
+        log: mockLogger,
+        env: {},
+        attributes: {
+          authInfo: new AuthInfo()
+            .withType('jwt')
+            .withProfile({ is_admin: true })
+            .withAuthenticated(true),
+        },
+      };
+
+      const result = await trialUserController.createTrialUserForEmailInvite(context);
+
+      expect(result.status).to.equal(201);
+    });
+
     it('should return internal server error when database operation fails', async () => {
       const dbError = new Error('Database connection failed');
       mockDataAccess.TrialUser.create.rejects(dbError);
-      // Ensure findByEmailId returns null for this test
-      mockDataAccess.TrialUser.findByEmailId.resolves(null);
+      // Ensure allByEmailId returns empty for this test
+      mockDataAccess.TrialUser.allByEmailId.resolves([]);
 
       const context = {
         params: { organizationId },


### PR DESCRIPTION
## Summary
- The `POST /organizations/:orgId/trial-user-invite` endpoint was returning 409 Conflict when a trial user with the same email existed in **any** organization, not just the target one
- The collaboration page only displays users for the current org, so users would see "already exists" errors for emails not visible on their page
- Changed the duplicate check from `findByEmailId` (global, single result) to `allByEmailId` + `.find()` filtered by `organizationId`, so the 409 only triggers when the email already exists **within the same organization**

## Test plan
- [x] Updated existing 409 test to use org-scoped check
- [x] Added new test: email exists in different org → proceeds to 201 (no conflict)
- [x] Updated DB error test mock to use `allByEmailId`
- [x] All 43 tests passing
- [x] 100% code coverage on `trial-users.js` controller
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)