### PR TITLE
fix(slack): re-enablement path uses numbered brand-presence-free splits

### DIFF
--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -965,12 +965,16 @@ export function reEnableDefaultsAction(lambdaContext) {
         GEO_BRAND_PRESENCE_DAILY,
         site,
       );
+      const hasFreeSplitEnabled = isAnyFreeSplitEnabled(configuration, site);
       const hasExistingGeoBrandPresence = isWeeklyFreeEnabled
         || isWeeklyPaidEnabled
-        || isDailyEnabled;
+        || isDailyEnabled
+        || hasFreeSplitEnabled;
 
+      let targetSplit;
       if (!hasExistingGeoBrandPresence) {
-        configuration.enableHandlerForSite(GEO_BRAND_PRESENCE_WEEKLY_FREE, site);
+        targetSplit = findBestFreeSplit(configuration);
+        configuration.enableHandlerForSite(targetSplit, site);
         await configuration.save();
       }
 
@@ -982,7 +986,7 @@ export function reEnableDefaultsAction(lambdaContext) {
 
       const geoBrandPresenceStatus = hasExistingGeoBrandPresence
         ? 'geo-brand-presence (existing configuration preserved)'
-        : 'geo-brand-presence-free';
+        : targetSplit;
 
       await client.chat.postMessage({
         channel: originalChannel,

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -1968,9 +1968,9 @@ example-com:
       const handler = mockedModule.reEnableDefaultsAction(lambdaCtx);
       await handler({ ack: mockAck, body: mockBody, client: mockClient });
 
-      expect(mockConfig.enableHandlerForSite).to.have.been.calledWith('geo-brand-presence-free', mockSite);
+      expect(mockConfig.enableHandlerForSite).to.have.been.calledWith('geo-brand-presence-free-1', mockSite);
       expect(mockClient.chat.postMessage).to.have.been.calledWith(
-        sinon.match({ text: sinon.match('geo-brand-presence-free') }),
+        sinon.match({ text: sinon.match('geo-brand-presence-free-1') }),
       );
     });
 


### PR DESCRIPTION
## Summary
- The `reEnableDefaultsAction` was assigning sites to the base `geo-brand-presence-free` handler instead of a numbered split (e.g., `geo-brand-presence-free-1`), causing duplicate site assignments across slots
- Now checks `isAnyFreeSplitEnabled()` to detect if the site is already in any numbered split
- Uses `findBestFreeSplit()` to assign to the slot with the fewest sites, consistent with the onboarding path
- Slack status message now shows the actual split name instead of the generic `geo-brand-presence-free`

## Test plan
- [x] Existing test updated to expect numbered split (`geo-brand-presence-free-1`)
- [x] All 3277 tests passing
- [ ] Verify re-enablement in Slack assigns to correct numbered slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)