### PR TITLE
chore: disable major version updates for spacecat-shared-data-access

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,15 @@
         "zod"
       ],
       "allowedVersions": "<4.0.0"
+    },
+    {
+      "matchPackageNames": [
+        "@adobe/spacecat-shared-data-access"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule to disable major version update PRs for `@adobe/spacecat-shared-data-access`
- Minor and patch updates remain enabled

## Test plan
- [ ] Verify Renovate no longer creates PRs for major bumps of `@adobe/spacecat-shared-data-access`
- [ ] Confirm minor/patch update PRs are still created as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)