### PR TITLE
[SITES-40753] fix: await getOpportunity() in getAllSuggestionsForFix

### DIFF
--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -193,10 +193,11 @@ export class FixesController {
     if (res) return res;
 
     const suggestions = await fix.getSuggestions();
-    return ok(suggestions.map((s) => {
-      const opportunity = s.getOpportunity();
+    const results = await Promise.all(suggestions.map(async (s) => {
+      const opportunity = await s.getOpportunity();
       return SuggestionDto.toJSON(s, 'full', opportunity);
     }));
+    return ok(results);
   }
 
   /**


### PR DESCRIPTION
getOpportunity() returns a Promise; passing it unawaited to SuggestionDto.toJSON caused 'opportunity?.getType is not a function' when the DTO accessed opportunity type.


Local tetsing
<img width="1425" height="628" alt="image" src="https://github.com/user-attachments/assets/fd083294-6949-43c5-8fa4-cc6501680030" />

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
