### PR TITLE
[SITES-40783] - fix: prefer specific routes over dynamic segments in matchPath

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -187,6 +187,15 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/audits/latest': auditsController.getAllLatestForSite,
     'GET /sites/:siteId/audits/:auditType': auditsController.getAllForSite,
     'GET /sites/:siteId/audits/:auditType/:auditedAt': sitesController.getAuditForSite,
+
+    // URL Store endpoints (defined before :auditType to ensure static segment match)
+    'GET /sites/:siteId/url-store': urlStoreController.listUrls,
+    'GET /sites/:siteId/url-store/by-audit/:auditType': urlStoreController.listUrlsByAuditType,
+    'GET /sites/:siteId/url-store/:base64Url': urlStoreController.getUrl,
+    'POST /sites/:siteId/url-store': urlStoreController.addUrls,
+    'PATCH /sites/:siteId/url-store': urlStoreController.updateUrls,
+    'DELETE /sites/:siteId/url-store': urlStoreController.deleteUrls,
+
     'PATCH /sites/:siteId/:auditType': auditsController.patchAuditForSite,
     'GET /sites/:siteId/latest-audit/:auditType': auditsController.getLatestForSite,
     'GET /sites/:siteId/experiments': experimentsController.getExperiments,
@@ -293,13 +302,6 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/top-pages/:source/:geo': sitesController.getTopPages,
     'POST /sites/:siteId/graph': sitesController.getGraph,
 
-    // URL Store endpoints
-    'GET /sites/:siteId/url-store': urlStoreController.listUrls,
-    'GET /sites/:siteId/url-store/by-audit/:auditType': urlStoreController.listUrlsByAuditType,
-    'GET /sites/:siteId/url-store/:base64Url': urlStoreController.getUrl,
-    'POST /sites/:siteId/url-store': urlStoreController.addUrls,
-    'PATCH /sites/:siteId/url-store': urlStoreController.updateUrls,
-    'DELETE /sites/:siteId/url-store': urlStoreController.deleteUrls,
     'GET /slack/events': slackController.handleEvent,
     'POST /slack/events': slackController.handleEvent,
     'POST /slack/channels/invite-by-user-id': slackController.inviteUserToChannel,


### PR DESCRIPTION
- Update matchPath to use specificity-based routing where routes with more static segments are preferred over routes with dynamic parameters
- Move PATCH /sites/:siteId/url-store above :auditType route
- Add tests for specificity-based route matching

Fixes SITES-40783

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
