### PR TITLE
feat: migrate secrets from AWS SM to Vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@adobe/fetch": "4.2.3",
         "@adobe/helix-shared-body-data": "2.2.3",
         "@adobe/helix-shared-bounce": "2.0.29",
-        "@adobe/helix-shared-secrets": "2.3.0",
         "@adobe/helix-shared-utils": "3.0.2",
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
@@ -32,6 +31,7 @@
         "@adobe/spacecat-shared-tier-client": "1.3.12",
         "@adobe/spacecat-shared-tokowaka-client": "1.9.0",
         "@adobe/spacecat-shared-utils": "1.96.1",
+        "@adobe/spacecat-shared-vault-secrets": "1.0.0",
         "@aws-sdk/client-s3": "3.996.0",
         "@aws-sdk/client-secrets-manager": "3.996.0",
         "@aws-sdk/client-sfn": "3.996.0",
@@ -762,26 +762,6 @@
         "@adobe/helix-shared-async": "2.0.2"
       }
     },
-    "node_modules/@adobe/helix-shared-secrets": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-secrets/-/helix-shared-secrets-2.3.0.tgz",
-      "integrity": "sha512-eSztnig3KWmyDBfMreaV8zTjWSu9MBVj3hhfIs+Ufs5isrXZag6om/uoB+DQArqADjbKtJHP8yXe8VWu34jvXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "^4.1.3",
-        "@adobe/helix-shared-wrap": "^1.0.5",
-        "aws4": "^1.12.0"
-      },
-      "optionalDependencies": {
-        "@adobe/helix-universal": "^5.0.0"
-      }
-    },
-    "node_modules/@adobe/helix-shared-secrets/node_modules/@adobe/helix-shared-wrap": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-wrap/-/helix-shared-wrap-1.0.5.tgz",
-      "integrity": "sha512-g8bap0KhWI6Y6USlf9Se4t+Og0A6udYkoQH2NBdj/HOLnLozwn+60wbVLJhHIW2Ldt81xmhBqjhW0j1BtCQ3uw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@adobe/helix-shared-utils": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@adobe/helix-shared-utils/-/helix-shared-utils-3.0.2.tgz",
@@ -811,6 +791,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.0.tgz",
       "integrity": "sha512-3ZfFdjYtpv7RCgul9yyOBsRVsxLNapwt0YjASBhyzJGNjnPxrWDlqDtbpBdwAgA1Nuh9nmjzFDFu8CJWv6BMKw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.2.3",
         "aws4": "1.13.2"
@@ -7929,6 +7910,19 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@adobe/spacecat-shared-vault-secrets": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.0.0.tgz",
+      "integrity": "sha512-53yXRwN/Rev/7d+Dgr3vQeB5l25b0phVfw0b9CbJ5y99w6bUzB6gmtGClVyzMDNKt5GDcKVzMTQwxzTJxyMeXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws4": "1.13.2"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
+      }
+    },
     "node_modules/@arr/every": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@arr/every/-/every-1.0.1.tgz",
@@ -9050,6 +9044,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -13500,6 +13495,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -13731,6 +13727,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -13937,6 +13934,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -14100,6 +14098,7 @@
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -16082,6 +16081,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -16388,6 +16388,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16434,6 +16435,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16909,6 +16911,7 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -17559,6 +17562,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19748,6 +19752,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -23731,6 +23736,7 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -24786,6 +24792,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -27971,6 +27978,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -28640,6 +28648,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -29744,6 +29753,7 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29754,6 +29764,7 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -30463,6 +30474,7 @@
       "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -31924,6 +31936,7 @@
       "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -32996,6 +33009,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -33720,6 +33734,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -33984,6 +33999,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -33993,6 +34009,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@adobe/fetch": "4.2.3",
     "@adobe/helix-shared-body-data": "2.2.3",
     "@adobe/helix-shared-bounce": "2.0.29",
-    "@adobe/helix-shared-secrets": "2.3.0",
+    "@adobe/spacecat-shared-vault-secrets": "1.0.0",
     "@adobe/helix-shared-utils": "3.0.2",
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@
 
 import wrap from '@adobe/helix-shared-wrap';
 import { helixStatus } from '@adobe/helix-status';
-import secrets from '@adobe/helix-shared-secrets';
+import vaultSecrets from '@adobe/spacecat-shared-vault-secrets';
 import bodyData from '@adobe/helix-shared-body-data';
 import {
   badRequest,
@@ -32,7 +32,7 @@ import {
   elevatedSlackClientWrapper,
   SLACK_TARGETS,
 } from '@adobe/spacecat-shared-slack-client';
-import { hasText, resolveSecretsName, logWrapper } from '@adobe/spacecat-shared-utils';
+import { hasText, logWrapper } from '@adobe/spacecat-shared-utils';
 
 import dataAccess from './support/data-access.js';
 import sqs from './support/sqs.js';
@@ -292,5 +292,5 @@ export const main = wrappedMain
   .with(s3ClientWrapper)
   .with(imsClientWrapper)
   .with(elevatedSlackClientWrapper, { slackTarget: WORKSPACE_EXTERNAL })
-  .with(secrets, { name: resolveSecretsName })
+  .with(vaultSecrets)
   .with(helixStatus);


### PR DESCRIPTION
## Summary

- Replaces `@adobe/helix-shared-secrets` with `@adobe/spacecat-shared-vault-secrets`
- Secrets are now loaded from HashiCorp Vault via per-service AppRole authentication
- Removes `resolveSecretsName` import (no longer needed - Vault wrapper auto-resolves from `ctx.func.name`)

## Changes

**src/index.js:**
- Import: `helix-shared-secrets` -> `spacecat-shared-vault-secrets`
- Wrapper: `.with(secrets, { name: resolveSecretsName })` -> `.with(vaultSecrets)`
- Removed unused `resolveSecretsName` import from `spacecat-shared-utils`

**package.json:**
- Removed: `@adobe/helix-shared-secrets: 2.3.0`
- Added: `@adobe/spacecat-shared-vault-secrets: 1.0.0`

## Context

Phase 4 of the Vault per-service AppRole migration (SITES-40735). Phases 1-3 set up the infrastructure: AppRole policies, bootstrap secrets, and synced all service secrets from SM to Vault. This PR switches api-service to read from Vault.

## Test plan

- [x] 3548 unit tests passing, 100% line coverage
- [x] Lint clean
- [x] CI passes
- [x] Deploy to dev, verify CloudWatch logs show "Vault client ready"
- [x] Verify no "error fetching secrets" or "Vault authentication failed" in logs
- [x] Smoke test key endpoints (/_status_check, /sites, /organizations)
- [ ] Deploy to stage, repeat checks
- [ ] Deploy to prod, repeat checks

## Rollback

Revert this commit. Old SM secrets remain intact and `helix-shared-secrets` can be restored.