### PR TITLE
chore(ci): fix e2e workflow auth for private git dependency

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -15,9 +15,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: 'false'
 
       - name: Setup Node & NPM
         uses: ./.github/actions/setup-node-npm
+        env:
+          MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN: ${{ secrets.MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN }}
 
       - name: Run tests
         env:


### PR DESCRIPTION
## Summary
- Add `MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN` env var to the `setup-node-npm` step in the e2e-tests workflow
- Add `persist-credentials: 'false'` to the checkout step to prevent the `GITHUB_TOKEN` credential helper from overriding the git URL rewrite

The e2e workflow was failing on `npm ci` because it couldn't resolve the private `mysticat-data-service` git dependency. The CI workflow (`ci.yaml`) already has both of these configured correctly — this brings the e2e workflow in line.

## Test plan
- [ ] E2e workflow runs successfully (next scheduled run or manual trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)