### PR TITLE
fix: move llmo onboarding publish trigger off request path

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -39,6 +39,7 @@ export const BASIC_AUDITS = [
 export const ASO_DEMO_ORG = '66331367-70e6-4a49-8445-4f6d9c265af9';
 
 export const ASO_CRITICAL_SITES = [];
+const LLMO_ONBOARDING_PUBLISH_TRIGGER = 'trigger:llmo-onboarding-publish';
 
 /**
  * Generates the data folder name from a domain.
@@ -251,53 +252,6 @@ export async function validateSiteNotOnboarded(baseURL, imsOrgId, dataFolder, co
       isValid: false,
       error: `Unable to validate onboarding status: ${error.message}`,
     };
-  }
-}
-
-/**
- * Publishes a file to admin.hlx.page.
- * @param {string} filename - The filename to publish
- * @param {string} outputLocation - The output location
- * @param {object} log - Logger instance
- */
-async function publishToAdminHlx(filename, outputLocation, log) {
-  try {
-    const org = 'adobe';
-    const site = 'project-elmo-ui-data';
-    const ref = 'main';
-    const jsonFilename = `${filename.replace(/\.[^/.]+$/, '')}.json`;
-    const path = `${outputLocation}/${jsonFilename}`;
-    const headers = { Cookie: `auth_token=${process.env.HLX_ADMIN_TOKEN}` };
-
-    if (!process.env.HLX_ADMIN_TOKEN) {
-      log.warn('LLMO onboarding: HLX_ADMIN_TOKEN is not set');
-    }
-
-    const baseUrl = 'https://admin.hlx.page';
-    const endpoints = [
-      { name: 'preview', url: `${baseUrl}/preview/${org}/${site}/${ref}/${path}` },
-      { name: 'live', url: `${baseUrl}/live/${org}/${site}/${ref}/${path}` },
-    ];
-
-    for (const [index, endpoint] of endpoints.entries()) {
-      log.debug(`Publishing Excel report via admin API (${endpoint.name}): ${endpoint.url}`);
-
-      // eslint-disable-next-line no-await-in-loop
-      const response = await fetch(endpoint.url, { method: 'POST', headers });
-
-      if (!response.ok) {
-        throw new Error(`${endpoint.name} failed: ${response.status} ${response.statusText}`);
-      }
-
-      log.debug(`Excel report successfully published to ${endpoint.name}`);
-
-      if (index === 0) {
-        // eslint-disable-next-line no-await-in-loop,max-statements-per-line
-        await new Promise((resolve) => { setTimeout(resolve, 2000); });
-      }
-    }
-  } catch (publishError) {
-    log.error(`Failed to publish via admin.hlx.page: ${publishError.message}`);
   }
 }
 
@@ -545,9 +499,6 @@ export async function copyFilesToSharepoint(dataFolder, context, say = () => {})
     log.warn(`Warning: Query index at ${dataFolder} already exists. Skipping creation.`);
     await say(`Query index in ${dataFolder} already exists. Skipping creation.`);
   }
-
-  log.debug('Publishing query-index to admin.hlx.page');
-  await publishToAdminHlx('query-index', dataFolder, log);
 }
 
 /**
@@ -999,6 +950,22 @@ export async function triggerAudits(audits, context, site) {
   );
 }
 
+export async function enqueueLlmoOnboardingPublish(context, site, dataFolder) {
+  const { sqs, dataAccess, log } = context;
+  const { Configuration } = dataAccess;
+  const configuration = await Configuration.findLatest();
+
+  await sqs.sendMessage(configuration.getQueues().audits, {
+    type: LLMO_ONBOARDING_PUBLISH_TRIGGER,
+    siteId: site.getId(),
+    auditContext: {
+      dataFolder,
+    },
+  });
+
+  log.info(`Queued ${LLMO_ONBOARDING_PUBLISH_TRIGGER} for site ${site.getId()}`);
+}
+
 /**
  * Complete LLMO onboarding process.
  * @param {object} params - Onboarding parameters
@@ -1038,6 +1005,12 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
 
     // Copy files to SharePoint
     await copyFilesToSharepoint(dataFolder, context, say);
+
+    try {
+      await enqueueLlmoOnboardingPublish(context, site, dataFolder);
+    } catch (error) {
+      log.warn(`Failed to enqueue ${LLMO_ONBOARDING_PUBLISH_TRIGGER} for site ${site.getId()}: ${error.message}`);
+    }
 
     // Update index config
     await updateIndexConfig(dataFolder, context, say);

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1286,8 +1286,26 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('llmo-customer-analysis', mockSite);
       expect(mockConfiguration.save).to.have.been.called;
 
-      // Verify tracingFetch was called for publishing
-      expect(mockTracingFetch).to.have.been.called;
+      // Verify llmo-customer-analysis is triggered directly from onboarding
+      expect(context.sqs.sendMessage).to.have.been.calledWith(
+        'audit-queue',
+        sinon.match({ type: 'llmo-customer-analysis' }),
+      );
+      // Verify async publish trigger is enqueued
+      expect(context.sqs.sendMessage).to.have.been.calledWith(
+        'audit-queue',
+        sinon.match({
+          type: 'trigger:llmo-onboarding-publish',
+          siteId: 'site123',
+          auditContext: sinon.match({
+            dataFolder: 'dev/example-com',
+          }),
+        }),
+      );
+      expect(context.sqs.sendMessage).to.have.been.calledWith(
+        'audit-queue',
+        sinon.match({ type: 'wikipedia-analysis' }),
+      );
 
       // Verify logging
       expect(mockLog.info).to.have.been.calledWith('Starting LLMO onboarding for IMS org ABC123@AdobeOrg, baseURL https://example.com, brand Test Brand');
@@ -1394,6 +1412,87 @@ describe('LLMO Onboarding Functions', () => {
       restoreSetTimeout(originalSetTimeout);
     });
 
+    it('should swallow async publish enqueue failures and still complete onboarding', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns({
+          updateLlmoBrand: sinon.stub(),
+          updateLlmoDataFolder: sinon.stub(),
+          getImports: sinon.stub().returns([]),
+          enableImport: sinon.stub(),
+          getFetchConfig: sinon.stub().returns({}),
+          updateFetchConfig: sinon.stub(),
+        }),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      const originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+
+      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+        }),
+      );
+
+      const sendMessage = sinon.stub().callsFake(async (queue, message) => {
+        if (message.type === 'trigger:llmo-onboarding-publish') {
+          throw new Error('queue unavailable');
+        }
+        return Promise.resolve();
+      });
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage },
+      };
+
+      const result = await performLlmoOnboardingWithMocks({
+        domain: 'example.com',
+        brandName: 'Test Brand',
+        imsOrgId: 'ABC123@AdobeOrg',
+      }, context);
+
+      expect(result.siteId).to.equal('site123');
+      expect(mockLog.warn).to.have.been.calledWith(
+        sinon.match(/Failed to enqueue trigger:llmo-onboarding-publish/),
+      );
+
+      restoreSetTimeout(originalSetTimeout);
+    });
+
     it('should call cleanup functions when site.save() throws an error', async () => {
       // Mock organization
       const mockOrganization = {
@@ -1433,21 +1532,17 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
 
-      // Create mock fetch that handles both publish and bulk unpublish flows
+      // Create mock fetch that handles bulk unpublish flows
       const mockTracingFetch = sinon.stub();
-      // Publish preview
-      mockTracingFetch.onCall(0).resolves({ ok: true, status: 200, statusText: 'OK' });
-      // Publish live
-      mockTracingFetch.onCall(1).resolves({ ok: true, status: 200, statusText: 'OK' });
       // Bulk status job start
-      mockTracingFetch.onCall(2).resolves({
+      mockTracingFetch.onCall(0).resolves({
         ok: true,
         status: 200,
         statusText: 'OK',
         json: async () => ({ name: 'job-test-123' }),
       });
       // Job polling
-      mockTracingFetch.onCall(3).resolves({
+      mockTracingFetch.onCall(1).resolves({
         ok: true,
         status: 200,
         statusText: 'OK',
@@ -1460,14 +1555,14 @@ describe('LLMO Onboarding Functions', () => {
         }),
       });
       // Bulk unpublish (live)
-      mockTracingFetch.onCall(4).resolves({
+      mockTracingFetch.onCall(2).resolves({
         ok: true,
         status: 200,
         statusText: 'OK',
         json: async () => ({ name: 'unpublish-job-123' }),
       });
       // Bulk un-preview
-      mockTracingFetch.onCall(5).resolves({
+      mockTracingFetch.onCall(3).resolves({
         ok: true,
         status: 200,
         statusText: 'OK',
@@ -1524,7 +1619,7 @@ describe('LLMO Onboarding Functions', () => {
       // Verify deleteSharePointFolder was called (which deletes folder and unpublishes)
       expect(mockSharePointFolderLocal.exists).to.have.been.called;
       expect(mockSharePointFolderLocal.delete).to.have.been.called;
-      expect(mockTracingFetch).to.have.callCount(6);
+      expect(mockTracingFetch).to.have.callCount(4);
 
       // Verify revokeEnrollment was called
       const tierClient = mockTierClient.createForSite.returnValues[0];

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -184,43 +184,6 @@ describe('onboard-llmo-modal', () => {
     statusText: 'OK',
   });
 
-  // Helper function to create mocked modules with custom tracingFetch
-  const createMockedModulesWithTracingFetch = async (mockTracingFetch) => {
-    const updatedMockedLLMOOnboarding = await esmock('../../../../src/controllers/llmo/llmo-onboarding.js', {
-      '@adobe/spacecat-shared-data-access/src/models/site/config.js': sharedConfigMock,
-      '@adobe/spacecat-helix-content-sdk': sharedSharepointMock,
-      '@octokit/rest': {
-        Octokit: octokitMock,
-      },
-      '@adobe/spacecat-shared-tier-client': {
-        default: tierClientMock,
-      },
-      '../../../../src/utils/slack/base.js': sharedSlackMock,
-      '@adobe/spacecat-shared-utils': {
-        composeBaseURL: sinon.stub().callsFake((url) => url),
-        tracingFetch: mockTracingFetch,
-      },
-    });
-
-    const testMockedModule = await esmock('../../../../src/support/slack/actions/onboard-llmo-modal.js', {
-      '@adobe/spacecat-shared-data-access/src/models/site/config.js': sharedConfigMock,
-      '@adobe/spacecat-helix-content-sdk': sharedSharepointMock,
-      '@octokit/rest': {
-        Octokit: octokitMock,
-      },
-      '@adobe/spacecat-shared-tier-client': {
-        default: tierClientMock,
-      },
-      '../../../../src/utils/slack/base.js': sharedSlackMock,
-      '../../../../src/controllers/llmo/llmo-onboarding.js': updatedMockedLLMOOnboarding,
-      '../../../../src/support/brand-profile-trigger.js': {
-        triggerBrandProfileAgent: (...args) => triggerBrandProfileAgentStub(...args),
-      },
-    });
-
-    return testMockedModule;
-  };
-
   before(async () => {
     sandbox = sinon.createSandbox();
     // Create octokit mock
@@ -880,7 +843,7 @@ describe('onboard-llmo-modal', () => {
       expect(mockTierClient.createEntitlement).to.have.been.calledWith('FREE_TRIAL');
     });
 
-    it('should log warning when HLX_ADMIN_TOKEN is not set', async () => {
+    it('should enqueue async onboarding publish trigger', async () => {
       // Mock data
       const input = {
         baseURL: 'https://example.com',
@@ -893,55 +856,24 @@ describe('onboard-llmo-modal', () => {
       const mockSite = createDefaultMockSite(sandbox);
       const lambdaCtx = createDefaultMockLambdaCtx(sandbox, { mockSite });
       const slackCtx = createDefaultMockSlackCtx(sandbox);
-
-      // Mock fetch for admin.hlx.page calls
-      global.fetch = createDefaultMockFetch(sandbox);
-
-      // Store original env var
-      const originalToken = process.env.HLX_ADMIN_TOKEN;
-      // Remove the token
-      delete process.env.HLX_ADMIN_TOKEN;
-
-      try {
-        // Execute the function
-        await onboardSite(input, lambdaCtx, slackCtx);
-
-        // Verify that warning was logged
-        expect(lambdaCtx.log.warn).to.have.been.calledWith('LLMO onboarding: HLX_ADMIN_TOKEN is not set');
-      } finally {
-        // Restore original env var
-        if (originalToken !== undefined) {
-          process.env.HLX_ADMIN_TOKEN = originalToken;
-        }
-      }
-    });
-
-    it('should handle fetch error when publishing to admin.hlx.page fails', async () => {
-      // Mock data
-      const input = {
-        baseURL: 'https://example.com',
-        brandName: 'Test Brand',
-        imsOrgId: 'ABC123@AdobeOrg',
-        deliveryType: 'aem_edge',
-      };
-
-      // Use default mocks
-      const mockSite = createDefaultMockSite(sandbox);
-      const lambdaCtx = createDefaultMockLambdaCtx(sandbox, { mockSite });
-      const slackCtx = createDefaultMockSlackCtx(sandbox);
-
-      // Mock tracingFetch to throw an error
-      const mockTracingFetch = sandbox.stub().rejects(new Error('Network error'));
-      const testModule = await createMockedModulesWithTracingFetch(mockTracingFetch);
 
       // Execute the function
-      await testModule.onboardSite(input, lambdaCtx, slackCtx);
+      await onboardSite(input, lambdaCtx, slackCtx);
 
-      // Verify that error was logged
-      expect(lambdaCtx.log.error).to.have.been.calledWith(sinon.match('Failed to publish via admin.hlx.page: Network error'));
+      // Verify async publish trigger is enqueued
+      expect(lambdaCtx.sqs.sendMessage).to.have.been.calledWith(
+        'audit-queue',
+        sinon.match({
+          type: 'trigger:llmo-onboarding-publish',
+          siteId: 'site123',
+          auditContext: sinon.match({
+            dataFolder: 'example-com',
+          }),
+        }),
+      );
     });
 
-    it('should handle non-ok response when publishing to admin.hlx.page', async () => {
+    it('should handle async onboarding publish enqueue error gracefully', async () => {
       // Mock data
       const input = {
         baseURL: 'https://example.com',
@@ -955,19 +887,58 @@ describe('onboard-llmo-modal', () => {
       const lambdaCtx = createDefaultMockLambdaCtx(sandbox, { mockSite });
       const slackCtx = createDefaultMockSlackCtx(sandbox);
 
-      // Mock tracingFetch to return non-ok response
-      const mockTracingFetch = sandbox.stub().resolves({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
+      lambdaCtx.sqs.sendMessage.callsFake(async (_queue, message) => {
+        if (message.type === 'trigger:llmo-onboarding-publish') {
+          throw new Error('queue unavailable');
+        }
       });
 
-      // Re-mock modules with the failing tracingFetch
-      const testModule = await createMockedModulesWithTracingFetch(mockTracingFetch);
-      await testModule.onboardSite(input, lambdaCtx, slackCtx);
+      // Execute the function
+      await onboardSite(input, lambdaCtx, slackCtx);
 
-      // Verify that error was logged
-      expect(lambdaCtx.log.error).to.have.been.calledWith(sinon.match('Failed to publish via admin.hlx.page: preview failed: 500 Internal Server Error'));
+      // Verify enqueue warning is logged and onboarding continues
+      expect(lambdaCtx.log.warn).to.have.been.calledWith(
+        sinon.match('Failed to enqueue trigger:llmo-onboarding-publish for site site123: queue unavailable'),
+      );
+    });
+
+    it('should not require HLX_ADMIN_TOKEN for async publish enqueue path', async () => {
+      // Mock data
+      const input = {
+        baseURL: 'https://example.com',
+        brandName: 'Test Brand',
+        imsOrgId: 'ABC123@AdobeOrg',
+        deliveryType: 'aem_edge',
+      };
+
+      // Use default mocks
+      const mockSite = createDefaultMockSite(sandbox);
+      const lambdaCtx = createDefaultMockLambdaCtx(sandbox, { mockSite });
+      const slackCtx = createDefaultMockSlackCtx(sandbox);
+
+      // Store and clear token to verify onboarding still succeeds
+      const originalToken = process.env.HLX_ADMIN_TOKEN;
+      delete process.env.HLX_ADMIN_TOKEN;
+      try {
+        await onboardSite(input, lambdaCtx, slackCtx);
+
+        // Verify trigger still enqueued in tokenless mode
+        expect(lambdaCtx.sqs.sendMessage).to.have.been.calledWith(
+          'audit-queue',
+          sinon.match({
+            type: 'trigger:llmo-onboarding-publish',
+            auditContext: sinon.match({
+              dataFolder: 'example-com',
+            }),
+          }),
+        );
+      } finally {
+        if (originalToken !== undefined) {
+          process.env.HLX_ADMIN_TOKEN = originalToken;
+        } else {
+          delete process.env.HLX_ADMIN_TOKEN;
+        }
+      }
     });
 
     // In the new architecture, existing SharePoint data folder fails validation


### PR DESCRIPTION
## Summary
- remove synchronous Helix preview/live publish from the onboarding request path by deleting in-request `publishToAdminHlx` invocation
- enqueue `trigger:llmo-onboarding-publish` from onboarding after SharePoint copy completes
- enqueue payload includes `siteId` and `auditContext.dataFolder`
- keep `updateIndexConfig` (`helix-query.yaml` update) in onboarding and still executed synchronously in the request path
- keep direct `llmo-customer-analysis` audit triggering unchanged
- keep onboarding response contract unchanged and swallow publish-enqueue failures with warning logs

## Why this scope
- removes Helix publish latency from request handling while preserving onboarding setup steps in-request
- limits behavioral change to publish timing and introduces eventual consistency only for published `query-index.json` availability

## Behavior Impact
- onboarding still creates/copies `query-index.xlsx` and still updates `helix-query.yaml` in-request
- publish/preview happens asynchronously via audit queue trigger
- if enqueue fails, onboarding still completes and logs a warning

## Validation
- `npx mocha --spec=test/controllers/llmo/llmo-onboarding.test.js --spec=test/support/slack/actions/onboard-llmo-modal.test.js`
- result: 108 passing
