### PR TITLE
fix: remove stale llmo-customer-analysis trigger assertion and revert deploy-dev label

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l dzehnder --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "docs": "npm run docs:lint && npm run docs:build",
     "docs:build": "npx @redocly/cli build-docs -o ./docs/index.html --config docs/openapi/redocly-config.yaml",

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1313,11 +1313,6 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('llmo-customer-analysis', mockSite);
       expect(mockConfiguration.save).to.have.been.called;
 
-      // Verify llmo-customer-analysis is triggered directly from onboarding
-      expect(context.sqs.sendMessage).to.have.been.calledWith(
-        'audit-queue',
-        sinon.match({ type: 'llmo-customer-analysis' }),
-      );
       // Verify async publish trigger is enqueued
       expect(context.sqs.sendMessage).to.have.been.calledWith(
         'audit-queue',


### PR DESCRIPTION
## Summary

- Removes the stale test assertion that expected `llmo-customer-analysis` to be triggered via SQS `sendMessage`. PR #1781 moved this trigger to DRS, but the existing test (added by another PR while #1781 was in development) was preserved during the squash merge, causing the first test failure. That failure prevented `restoreSetTimeout()` from running, which cascaded into **69 total test failures**.
- Reverts the `deploy-dev` script label from `-l dzehnder` back to `-l latest` (accidentally merged from development).

## Test plan

- [x] Full test suite passes locally (3575 passing, 0 failing, 100% coverage)

Made with [Cursor](https://cursor.com)