### PR TITLE
fix: normalize case for status and deliveryType path params

### DIFF
--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -141,7 +141,8 @@ export class FixesController {
    * @returns {Promise<Response>} Array of suggestions response.
    */
   async getByStatus(context) {
-    const { siteId, opportunityId, status } = context.params;
+    const { siteId, opportunityId, status: rawStatus } = context.params;
+    const status = rawStatus?.toUpperCase();
     let res = checkRequestParams(siteId, opportunityId) ?? await this.#checkAccess(siteId);
     if (res) return res;
 

--- a/src/controllers/opportunities.js
+++ b/src/controllers/opportunities.js
@@ -104,7 +104,8 @@ function OpportunitiesController(ctx) {
    */
   const getByStatus = async (context) => {
     const siteId = context.params?.siteId;
-    const status = context.params?.status;
+
+    const status = context.params?.status?.toUpperCase();
 
     if (!isValidUUID(siteId)) {
       return badRequest('Site ID required');

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -333,7 +333,7 @@ function SitesController(ctx, log, env) {
     if (!accessControlUtil.hasAdminAccess()) {
       return forbidden('Only admins can view all sites');
     }
-    const deliveryType = context.params?.deliveryType;
+    const deliveryType = context.params?.deliveryType?.toLowerCase();
 
     if (!hasText(deliveryType)) {
       return badRequest('Delivery type required');

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -278,7 +278,7 @@ function SuggestionsController(ctx, sqs, env) {
   const getByStatus = async (context) => {
     const siteId = context.params?.siteId;
     const opptyId = context.params?.opportunityId;
-    const status = context.params?.status || undefined;
+    const status = context.params?.status?.toUpperCase() || undefined;
     const viewParam = context.data?.view;
 
     if (!isValidUUID(siteId)) {
@@ -326,7 +326,7 @@ function SuggestionsController(ctx, sqs, env) {
   const getByStatusPaged = async (context) => {
     const siteId = context.params?.siteId;
     const opptyId = context.params?.opportunityId;
-    const status = context.params?.status || undefined;
+    const status = context.params?.status?.toUpperCase() || undefined;
     const limit = parseInt(context.params?.limit, 10) || DEFAULT_PAGE_SIZE;
     const cursor = context.params?.cursor || null;
     const viewParam = context.data?.view;

--- a/test/it/shared/tests/fixes.js
+++ b/test/it/shared/tests/fixes.js
@@ -123,6 +123,23 @@ export default function fixTests(getHttpClient, resetData) {
         expect(res.body[0].status).to.equal('PENDING');
       });
 
+      it('user: matches status case-insensitively (lowercase)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`${BASE}/by-status/pending`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(1);
+        expectFixDto(res.body[0]);
+        expect(res.body[0].status).to.equal('PENDING');
+      });
+
+      it('user: matches status case-insensitively (mixed case)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`${BASE}/by-status/Pending`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(1);
+        expect(res.body[0].status).to.equal('PENDING');
+      });
+
       it('user: returns empty for status with no matches', async () => {
         const http = getHttpClient();
         const res = await http.user.get(`${BASE}/by-status/FAILED`);

--- a/test/it/shared/tests/opportunities.js
+++ b/test/it/shared/tests/opportunities.js
@@ -94,6 +94,24 @@ export default function opportunityTests(getHttpClient, resetData) {
         expect(res.body[0].status).to.equal('NEW');
       });
 
+      it('user: matches status case-insensitively (lowercase)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`/sites/${SITE_1_ID}/opportunities/by-status/new`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(1);
+        expect(res.body[0].id).to.equal(OPPTY_1_ID);
+        expect(res.body[0].status).to.equal('NEW');
+      });
+
+      it('user: matches status case-insensitively (mixed case)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`/sites/${SITE_1_ID}/opportunities/by-status/New`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(1);
+        expect(res.body[0].id).to.equal(OPPTY_1_ID);
+        expect(res.body[0].status).to.equal('NEW');
+      });
+
       it('user: returns empty array for status with no matches', async () => {
         const http = getHttpClient();
         const res = await http.user.get(`/sites/${SITE_1_ID}/opportunities/by-status/IGNORED`);

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -175,6 +175,26 @@ export default function siteTests(getHttpClient, resetData) {
         });
       });
 
+      it('admin: matches delivery type case-insensitively (uppercase)', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites/by-delivery-type/AEM_EDGE');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(2);
+        res.body.forEach((site) => {
+          expect(site.deliveryType).to.equal('aem_edge');
+        });
+      });
+
+      it('admin: matches delivery type case-insensitively (mixed case)', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites/by-delivery-type/Aem_Edge');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(2);
+        res.body.forEach((site) => {
+          expect(site.deliveryType).to.equal('aem_edge');
+        });
+      });
+
       it('admin: returns empty array for unmatched delivery type', async () => {
         const http = getHttpClient();
         const res = await http.admin.get('/sites/by-delivery-type/other');

--- a/test/it/shared/tests/suggestions.js
+++ b/test/it/shared/tests/suggestions.js
@@ -130,6 +130,27 @@ export default function suggestionTests(getHttpClient, resetData) {
         });
       });
 
+      it('user: matches status case-insensitively (lowercase)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`${BASE}/by-status/new`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(2);
+        res.body.forEach((s) => {
+          expectSuggestionDto(s);
+          expect(s.status).to.equal('NEW');
+        });
+      });
+
+      it('user: matches status case-insensitively (mixed case)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`${BASE}/by-status/New`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(2);
+        res.body.forEach((s) => {
+          expect(s.status).to.equal('NEW');
+        });
+      });
+
       it('user: returns empty for status with no matches', async () => {
         const http = getHttpClient();
         const res = await http.user.get(`${BASE}/by-status/SKIPPED`);


### PR DESCRIPTION
## Summary
- Normalize `status` path params to uppercase in opportunities, suggestions, and fixes `by-status` endpoints
- Normalize `deliveryType` path param to lowercase in sites `by-delivery-type` endpoint
- PostgreSQL uses case-sensitive equality (unlike DynamoDB), so URLs like `/by-status/new` or `/by-delivery-type/AEM_EDGE` would return empty results without normalization

## Test plan
- [x] Unit tests pass (3586 passing, 100% line/branch/statement coverage)
- [x] PostgreSQL IT tests pass (285 passing, includes 8 new case-insensitivity tests)
- [ ] DynamoDB IT tests (pre-existing infra issue — data-access routes to CloudFront instead of DynamoDB Local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)