### PR TITLE
fix: correct DRS client parameter name and prompt count (LLMO-1819)

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1075,7 +1075,7 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
           brandName: brandName.trim(),
           audience,
           region: 'US',
-          numPrompts: 42,
+          numPrompts: 50,
           siteId: site.getId(),
           imsOrgId,
         });

--- a/src/support/drs-client.js
+++ b/src/support/drs-client.js
@@ -40,7 +40,7 @@ export default function DrsClient(context) {
    * @param {string} params.brandName - The brand name
    * @param {string} params.audience - Target audience description
    * @param {string} [params.region='US'] - Geographic region for prompts
-   * @param {number} [params.numPrompts=42] - Number of prompts to generate
+   * @param {number} [params.numPrompts=50] - Number of prompts to generate
    * @param {string} params.siteId - The SpaceCat site ID
    * @param {string} params.imsOrgId - The Adobe IMS organization ID
    * @returns {Promise<object>} Job submission result with job_id
@@ -51,7 +51,7 @@ export default function DrsClient(context) {
     brandName,
     audience,
     region = 'US',
-    numPrompts = 42,
+    numPrompts = 50,
     siteId,
     imsOrgId,
   }) {
@@ -64,7 +64,7 @@ export default function DrsClient(context) {
       source: 'onboarding',
       parameters: {
         base_url: baseUrl,
-        brand_name: brandName,
+        brand: brandName,
         audience,
         region,
         num_prompts: numPrompts,

--- a/test/support/drs-client.test.js
+++ b/test/support/drs-client.test.js
@@ -85,7 +85,7 @@ describe('DRS Client', () => {
       brandName: 'TestBrand',
       audience: 'general audience',
       region: 'US',
-      numPrompts: 42,
+      numPrompts: 50,
       siteId: 'site-uuid-123',
       imsOrgId: 'org@AdobeOrg',
     };
@@ -113,10 +113,10 @@ describe('DRS Client', () => {
       expect(body.provider_id).to.equal('prompt_generation_base_url');
       expect(body.source).to.equal('onboarding');
       expect(body.parameters.base_url).to.equal('https://example.com');
-      expect(body.parameters.brand_name).to.equal('TestBrand');
+      expect(body.parameters.brand).to.equal('TestBrand');
       expect(body.parameters.audience).to.equal('general audience');
       expect(body.parameters.region).to.equal('US');
-      expect(body.parameters.num_prompts).to.equal(42);
+      expect(body.parameters.num_prompts).to.equal(50);
       expect(body.webhook_url).to.be.undefined;
       expect(body.parameters.metadata.site_id).to.equal('site-uuid-123');
       expect(body.parameters.metadata.imsOrgId).to.equal('org@AdobeOrg');
@@ -141,7 +141,7 @@ describe('DRS Client', () => {
 
       const body = JSON.parse(mockFetch.firstCall.args[1].body);
       expect(body.parameters.region).to.equal('US');
-      expect(body.parameters.num_prompts).to.equal(42);
+      expect(body.parameters.num_prompts).to.equal(50);
     });
 
     it('throws error when DRS is not configured', async () => {


### PR DESCRIPTION
## Summary

- DRS expects `brand` but we sent `brand_name` → "brand is required" validation error
- Default `numPrompts` was 42 instead of 50 (in both `drs-client.js` and `llmo-onboarding.js`)

## Test plan

- [x] drs-client tests updated: assert `brand` instead of `brand_name` in payload
- [x] drs-client tests updated: assert default `num_prompts` is 50
- [x] Verify onboarding controller passes `numPrompts: 50`
- [ ] E2E: submit DRS job via onboarding, verify no "brand is required" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of LLMO-1819 bug fix rollout (see also: spacecat-audit-worker, llmo-data-retrieval-service PRs)