### PR TITLE
feat: broken backlinks id and update

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -47,6 +47,7 @@ import detectBotBlocker from './commands/detect-bot-blocker.js';
 import runPageCitability from './commands/run-page-citability.js';
 import runA11yCodefix from './commands/run-a11y-codefix.js';
 import identifyRedirects from './commands/identify-redirects.js';
+import identifyAndUpdateRedirects from './commands/identify-and-update-redirects.js';
 
 /**
  * Returns all commands.
@@ -92,4 +93,5 @@ export default (context) => [
   runPageCitability(context),
   runA11yCodefix(context),
   identifyRedirects(context),
+  identifyAndUpdateRedirects(context),
 ];

--- a/src/support/slack/commands/identify-and-update-redirects.js
+++ b/src/support/slack/commands/identify-and-update-redirects.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import BaseCommand from './base.js';
+import identifyRedirectsCommand from './identify-redirects.js';
+
+const PHRASES = ['update-redirects'];
+
+/*
+* Act as a wrapper around identify-redirects command to update the site's delivery config.
+*/
+export default function IdentifyAndUpdateRedirectsCommand(context) {
+  const innerContext = { ...context, updateRedirects: true };
+  const innerCommand = identifyRedirectsCommand(innerContext);
+
+  const baseCommand = BaseCommand({
+    id: 'identify-and-update-redirects',
+    name: 'Identify and Update Redirects',
+    description: 'Detects common redirect-manager patterns using Splunk logs (AEM CS/CW only) and updates the site\'s delivery config.',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {baseURL}`,
+  });
+
+  baseCommand.init(context);
+  return {
+    ...baseCommand,
+    handleExecution: innerCommand.handleExecution,
+  };
+}

--- a/src/support/slack/commands/identify-redirects.js
+++ b/src/support/slack/commands/identify-redirects.js
@@ -17,7 +17,7 @@ import BaseCommand from './base.js';
 import { extractURLFromSlackInput, postErrorMessage } from '../../../utils/slack/base.js';
 
 const PHRASES = ['identify-redirects'];
-const DEFAULT_MINUTES = 60;
+const DEFAULT_MINUTES = 3000; // 50 hours
 
 export default function IdentifyRedirectsCommand(context) {
   const baseCommand = BaseCommand({
@@ -33,6 +33,7 @@ export default function IdentifyRedirectsCommand(context) {
     env,
     log,
     sqs,
+    updateRedirects = false,
   } = context;
   const { Site } = dataAccess;
 
@@ -98,6 +99,7 @@ export default function IdentifyRedirectsCommand(context) {
         programId: String(programId),
         environmentId: String(environmentId),
         minutes,
+        updateRedirects,
         slackContext: {
           channelId,
           threadTs,

--- a/test/support/slack/commands/identify-redirects.test.js
+++ b/test/support/slack/commands/identify-redirects.test.js
@@ -223,7 +223,7 @@ describe('IdentifyRedirectsCommand', () => {
       baseURL: 'https://example.com',
       programId: 'p',
       environmentId: 'e',
-      minutes: 60,
+      minutes: 3000,
     });
     expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({
       slackContext: {


### PR DESCRIPTION
added a new "identify and update redirect" command to act as a wrapper around the pre-existing "identify redirect" command, to also update the deliveryConfig after identifying redirect source and redirect mode.

updated identify-redirect to 3000 minutes (50 hours) by default

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
