### PR TITLE
fix: clean up stale prompts references and enable urls for PostgreSQL

### DIFF
--- a/docs/decisions/001-bulk-delete-via-post.md
+++ b/docs/decisions/001-bulk-delete-via-post.md
@@ -18,7 +18,6 @@ are unaffected because they identify the target resource via path parameters.
 ## Decision
 Bulk deletion endpoints that require a request body use POST with an action suffix:
 - `POST /sites/:siteId/url-store/delete`
-- `POST /sites/:siteId/sentiment/topics/:topicId/prompts/remove`
 - `POST /sites/:siteId/sentiment/guidelines/:guidelineId/audits/unlink`
 
 ## Consequences

--- a/docs/openapi/guidelines-api.yaml
+++ b/docs/openapi/guidelines-api.yaml
@@ -148,7 +148,7 @@ topic-by-id:
     summary: Update a topic
     description: |
       Updates a sentiment topic. Only provided fields are updated.
-      Note: subPrompts array is replaced entirely, not merged.
+      Note: urls array is replaced entirely, not merged.
     operationId: updateSentimentTopic
     requestBody:
       required: true

--- a/docs/sentiment-guidelines-spec.md
+++ b/docs/sentiment-guidelines-spec.md
@@ -12,15 +12,22 @@ The Brand Sentiment Guidelines Store allows customers to define and configure to
 
 ### SentimentTopic
 
-Represents a subject/topic for sentiment analysis with optional sub-prompts.
+Represents a subject/topic for sentiment analysis with associated URLs.
 
 ```typescript
+interface SentimentTopicUrl {
+  url: string;              // URL being tracked
+  timesCited: number;       // Number of times this URL was cited
+  category?: string;        // Optional category for the URL
+  subPrompts?: string[];    // Optional sub-prompts scoped to this URL
+}
+
 interface SentimentTopic {
   siteId: string;           // Parent site identifier (partition key)
   topicId: string;          // Unique topic identifier (sort key, auto-generated UUID)
   name: string;             // Topic name/subject to analyze (required, e.g., "2026 Corvette Stingray")
   description?: string;     // Optional description for context
-  subPrompts: string[];     // Additional prompts/questions for deeper analysis
+  urls: SentimentTopicUrl[];// URLs with citation data and per-URL sub-prompts
   enabled: boolean;         // Whether topic is active (default: true)
   createdAt: string;        // ISO 8601 timestamp
   updatedAt: string;        // ISO 8601 timestamp
@@ -36,10 +43,22 @@ interface SentimentTopic {
   "topicId": "topic-001",
   "name": "2026 Corvette Stingray",
   "description": "Track sentiment about the latest Corvette model",
-  "subPrompts": [
-    "What do people say about performance?",
-    "How is the design being received?",
-    "Price sentiment?"
+  "urls": [
+    {
+      "url": "https://en.wikipedia.org/wiki/Corvette_Stingray",
+      "timesCited": 12,
+      "category": "automotive",
+      "subPrompts": [
+        "What do people say about performance?",
+        "How is the design being received?"
+      ]
+    },
+    {
+      "url": "https://www.reddit.com/r/corvette",
+      "timesCited": 8,
+      "category": "forums",
+      "subPrompts": ["Price sentiment?"]
+    }
   ],
   "enabled": true,
   "createdAt": "2026-01-15T10:00:00Z",
@@ -94,7 +113,7 @@ interface SentimentGuideline {
 
 ## API Endpoints
 
-### Topics (7 endpoints)
+### Topics (5 endpoints)
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
@@ -103,8 +122,6 @@ interface SentimentGuideline {
 | `POST` | `/sites/:siteId/sentiment/topics` | Create topics (bulk) |
 | `PATCH` | `/sites/:siteId/sentiment/topics/:topicId` | Update a topic |
 | `DELETE` | `/sites/:siteId/sentiment/topics/:topicId` | Delete a topic |
-| `POST` | `/sites/:siteId/sentiment/topics/:topicId/prompts` | Add sub-prompts to a topic |
-| `DELETE` | `/sites/:siteId/sentiment/topics/:topicId/prompts` | Remove sub-prompts from a topic |
 
 ### Guidelines (7 endpoints)
 
@@ -149,7 +166,14 @@ POST /sites/:siteId/sentiment/topics
   {
     "name": "BMW XM 2026",
     "description": "Track sentiment about the latest BMW XM luxury SUV",
-    "subPrompts": ["Performance feedback?", "Interior quality?", "Price perception?"],
+    "urls": [
+      {
+        "url": "https://en.wikipedia.org/wiki/BMW_XM",
+        "timesCited": 0,
+        "category": "automotive",
+        "subPrompts": ["Performance feedback?", "Interior quality?"]
+      }
+    ],
     "enabled": true
   }
 ]
@@ -278,7 +302,7 @@ This provides:
 1. **Setup Topics:**
    ```
    POST /sites/:siteId/sentiment/topics
-   Body: [{ name: "2026 Corvette Stingray", subPrompts: ["Performance?", "Price?"] }]
+   Body: [{ name: "2026 Corvette Stingray", urls: [{ url: "https://example.com", timesCited: 0, subPrompts: ["Performance?", "Price?"] }] }]
    ```
 
 2. **Setup Guidelines with Audit Associations:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@adobe/spacecat-shared-ahrefs-client": "1.10.7",
         "@adobe/spacecat-shared-athena-client": "1.9.6",
         "@adobe/spacecat-shared-brand-client": "1.1.38",
-        "@adobe/spacecat-shared-data-access": "3.14.0",
+        "@adobe/spacecat-shared-data-access": "3.15.0",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
         "@adobe/spacecat-shared-drs-client": "1.2.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.19",
@@ -2350,9 +2350,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.14.0.tgz",
-      "integrity": "sha512-94bF4cA55BYfBAMCmHFVPbCCCmqDIMB27Ha21AHe8dz9Yyb3ZxvcTRotxbhupzYkZuhNLZMUPIqkNfeiV+guXw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.15.0.tgz",
+      "integrity": "sha512-xX2meO+WfkHWnGpDEkZi6mdltbsrp4mGMR3Wob5Y9xfmVj41N8QULVfYdZjB48eTVSG3ykSAlMQR3ie4NqTiYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@adobe/spacecat-shared-ahrefs-client": "1.10.7",
     "@adobe/spacecat-shared-athena-client": "1.9.6",
     "@adobe/spacecat-shared-brand-client": "1.1.38",
-    "@adobe/spacecat-shared-data-access": "3.14.0",
+    "@adobe/spacecat-shared-data-access": "3.15.0",
     "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
     "@adobe/spacecat-shared-drs-client": "1.2.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.19",

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -369,8 +369,6 @@ const routeRequiredCapabilities = {
   'POST /sites/:siteId/sentiment/topics': 'sentimentTopic:write',
   'PATCH /sites/:siteId/sentiment/topics/:topicId': 'sentimentTopic:write',
   'DELETE /sites/:siteId/sentiment/topics/:topicId': 'sentimentTopic:write',
-  'POST /sites/:siteId/sentiment/topics/:topicId/prompts': 'sentimentTopic:write',
-  'POST /sites/:siteId/sentiment/topics/:topicId/prompts/remove': 'sentimentTopic:write',
 
   // Sentiment - Guidelines
   'GET /sites/:siteId/sentiment/guidelines': 'sentimentGuideline:read',

--- a/test/e2e/guidelines.http
+++ b/test/e2e/guidelines.http
@@ -41,10 +41,16 @@ Content-Type: application/json
   {
     "name": "2026 Corvette Stingray",
     "description": "Track sentiment about the latest Corvette model",
-    "subPrompts": [
-      "What do people say about performance?",
-      "How is the design being received?",
-      "Price sentiment?"
+    "urls": [
+      {
+        "url": "https://en.wikipedia.org/wiki/Corvette_Stingray",
+        "timesCited": 0,
+        "category": "automotive",
+        "subPrompts": [
+          "What do people say about performance?",
+          "How is the design being received?"
+        ]
+      }
     ],
     "enabled": true
   }
@@ -59,13 +65,19 @@ Content-Type: application/json
   {
     "name": "BMW XM 2026",
     "description": "Track sentiment about BMW XM luxury SUV",
-    "subPrompts": ["Performance feedback?", "Interior quality?"],
+    "urls": [
+      {
+        "url": "https://en.wikipedia.org/wiki/BMW_XM",
+        "timesCited": 0,
+        "subPrompts": ["Performance feedback?", "Interior quality?"]
+      }
+    ],
     "enabled": true
   },
   {
     "name": "Mediterranean Cruises",
     "description": "Monitor cruise line sentiment",
-    "subPrompts": ["Service quality?", "Value for money?"],
+    "urls": [],
     "enabled": true
   },
   {
@@ -117,33 +129,6 @@ Content-Type: application/json
 ### Delete a topic
 DELETE {{baseUrl}}/sites/{{siteId}}/sentiment/topics/{{topicId}}
 x-api-key: {{apiKey}}
-
-# =============================================================================
-# TOPICS - Sub-Prompts Management
-# =============================================================================
-
-### Add sub-prompts to a topic
-POST {{baseUrl}}/sites/{{siteId}}/sentiment/topics/{{topicId}}/prompts
-x-api-key: {{apiKey}}
-Content-Type: application/json
-
-{
-  "prompts": [
-    "What are users saying about reliability?",
-    "How does it compare to competitors?"
-  ]
-}
-
-### Remove sub-prompts from a topic
-POST {{baseUrl}}/sites/{{siteId}}/sentiment/topics/{{topicId}}/prompts/remove
-x-api-key: {{apiKey}}
-Content-Type: application/json
-
-{
-  "prompts": [
-    "What are users saying about reliability?"
-  ]
-}
 
 # =============================================================================
 # GUIDELINES - List & Create
@@ -348,15 +333,14 @@ Content-Type: application/json
 # 2. Create topics (create test data)
 # 3. List topics (verify added)
 # 4. Get specific topic (verify details)
-# 5. Add sub-prompts to topic
-# 6. Update topic (modify)
-# 7. List guidelines (should be empty or show existing)
-# 8. Create guidelines with audit associations
-# 9. Get specific guideline (verify details)
-# 10. Link/unlink audits
-# 11. Get config (verify combined response)
-# 12. Get config with audit filter (verify filtering)
-# 13. Delete topics and guidelines (cleanup)
+# 5. Update topic (modify name, urls, etc.)
+# 6. List guidelines (should be empty or show existing)
+# 7. Create guidelines with audit associations
+# 8. Get specific guideline (verify details)
+# 9. Link/unlink audits
+# 10. Get config (verify combined response)
+# 11. Get config with audit filter (verify filtering)
+# 12. Delete topics and guidelines (cleanup)
 
 # =============================================================================
 # VALID AUDIT TYPES

--- a/test/it/postgres/docker-compose.yml
+++ b/test/it/postgres/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       retries: 30
 
   data-service:
-    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v1.18.0
+    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v1.19.0
     container_name: spacecat-it-data-service
     depends_on:
       db:

--- a/test/it/postgres/seed-data/sentiment-topics.js
+++ b/test/it/postgres/seed-data/sentiment-topics.js
@@ -18,8 +18,6 @@
  * - TOPIC_2: enabled, 0 urls
  * - TOPIC_3: disabled
  *
- * Note: urls field is postgrestIgnore so not included here.
- *
  * Format: snake_case (v3 / PostgreSQL / PostgREST)
  */
 export const sentimentTopics = [
@@ -28,6 +26,20 @@ export const sentimentTopics = [
     topic_id: 'a1111111-1111-4111-b111-111111111111',
     name: 'Product Quality',
     description: 'Tracks sentiment about product quality',
+    urls: [
+      {
+        url: 'https://en.wikipedia.org/wiki/Product_Quality',
+        times_cited: 10,
+        category: 'manufacturing',
+        sub_prompts: ['How is build quality?'],
+      },
+      {
+        url: 'https://www.reddit.com/r/quality',
+        times_cited: 5,
+        category: 'reviews',
+        sub_prompts: ['Is the product reliable?'],
+      },
+    ],
     enabled: true,
     created_by: 'seed@test.com',
   },
@@ -36,6 +48,7 @@ export const sentimentTopics = [
     topic_id: 'a2222222-2222-4222-a222-222222222222',
     name: 'Customer Service',
     description: 'Tracks sentiment about customer service',
+    urls: [],
     enabled: true,
     created_by: 'seed@test.com',
   },
@@ -44,6 +57,12 @@ export const sentimentTopics = [
     topic_id: 'a3333333-3333-4333-b333-333333333333',
     name: 'Pricing',
     description: 'Tracks sentiment about pricing',
+    urls: [{
+      url: 'https://en.wikipedia.org/wiki/Pricing',
+      times_cited: 3,
+      category: 'pricing',
+      sub_prompts: ['Is it affordable?'],
+    }],
     enabled: false,
     created_by: 'seed@test.com',
   },

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -329,8 +329,6 @@ describe('getRouteHandlers', () => {
     createTopics: sinon.stub(),
     updateTopic: sinon.stub(),
     deleteTopic: sinon.stub(),
-    addSubPrompts: sinon.stub(),
-    removeSubPrompts: sinon.stub(),
     linkAudits: sinon.stub(),
     unlinkAudits: sinon.stub(),
     listGuidelines: sinon.stub(),


### PR DESCRIPTION
- Bump @adobe/spacecat-shared-data-access to 3.15.0 (postgrestIgnore removed)
- Bump mysticat-data-service image to v1.19.0 (urls column migration)
- Add urls to Postgres seed data to match Dynamo seed
- Remove orphan capability entries for deleted prompts routes
- Remove addSubPrompts/removeSubPrompts from route test mock
- Fix OpenAPI PATCH description: subPrompts -> urls
- Update spec, e2e tests, and ADR to reflect urls model

Made-with: Cursor

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
