### PR TITLE
feat(plg): allow admin callers to bypass tenant check in get status call

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -41,6 +41,7 @@ import {
 import { loadProfileConfig } from '../../utils/slack/base.js';
 import { triggerBrandProfileAgent } from '../../support/brand-profile-trigger.js';
 import { PlgOnboardingDto } from '../../dto/plg-onboarding.js';
+import AccessControlUtil from '../../support/access-control-util.js';
 
 const { STATUSES } = PlgOnboardingModel;
 const ASO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.ASO;
@@ -398,15 +399,28 @@ async function performAsoPlgOnboarding({ domain, imsOrgId }, context) {
     await enableAudits(site, context, auditTypes);
     steps.auditsEnabled = true;
 
-    // Step 7b: Enroll site in summit-plg config handler
+    // Step 7b: Enroll site in config handlers (summit-plg + auto-suggest/auto-fix)
     try {
       const { Configuration } = dataAccess;
       const configuration = await Configuration.findLatest();
-      configuration.enableHandlerForSite('summit-plg', site);
+      const configHandlers = [
+        'summit-plg',
+        'broken-backlinks-auto-suggest',
+        'broken-backlinks-auto-fix',
+        'alt-text-auto-fix',
+        'alt-text-auto-suggest-mystique',
+        'alt-text',
+        'cwv-auto-fix',
+        'cwv-auto-suggest',
+        'cwv',
+      ];
+      configHandlers.forEach((handler) => {
+        configuration.enableHandlerForSite(handler, site);
+      });
       await configuration.save();
-      log.info(`Enrolled site ${site.getId()} in summit-plg config`);
+      log.info(`Enrolled site ${site.getId()} in config handlers: ${configHandlers.join(', ')}`);
     } catch (error) {
-      log.warn(`Failed to enroll site in summit-plg config: ${error.message}`);
+      log.warn(`Failed to enroll site in config handlers: ${error.message}`);
     }
 
     // Step 8: Add ASO entitlement
@@ -526,16 +540,21 @@ function PlgOnboardingController(ctx) {
       return badRequest('Authentication information is required');
     }
 
-    const profile = authInfo.getProfile();
+    // Admin/API key holders can access any org's status
+    const accessControlUtil = AccessControlUtil.fromContext(context);
+    if (!accessControlUtil.hasAdminAccess()) {
+      // Non-admin: validate caller's IMS tenant matches requested imsOrgId
+      const profile = authInfo.getProfile();
 
-    if (!profile?.tenants?.[0]?.id) {
-      return badRequest('User profile or organization ID not found in authentication token');
-    }
+      if (!profile?.tenants?.[0]?.id) {
+        return badRequest('User profile or organization ID not found in authentication token');
+      }
 
-    const matchedTenant = profile.tenants
-      .find((t) => `${t.id}@AdobeOrg` === requestedImsOrgId);
-    if (!matchedTenant) {
-      return forbidden('Not authorized for this IMS org');
+      const matchedTenant = profile.tenants
+        .find((t) => `${t.id}@AdobeOrg` === requestedImsOrgId);
+      if (!matchedTenant) {
+        return forbidden('Not authorized for this IMS org');
+      }
     }
 
     const { PlgOnboarding } = da;

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -319,6 +319,11 @@ describe('PlgOnboardingController', () => {
         '../../../src/support/brand-profile-trigger.js': {
           triggerBrandProfileAgent: triggerBrandProfileAgentStub,
         },
+        '../../../src/support/access-control-util.js': {
+          default: {
+            fromContext: () => ({ hasAdminAccess: () => false }),
+          },
+        },
       },
     )).default;
   });
@@ -1354,7 +1359,7 @@ describe('PlgOnboardingController', () => {
 
       expect(res.status).to.equal(200);
       expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
-      expect(mockLog.warn).to.have.been.calledWithMatch(/Failed to enroll site in summit-plg/);
+      expect(mockLog.warn).to.have.been.calledWithMatch(/Failed to enroll site in config handlers/);
     });
   });
 
@@ -1612,6 +1617,137 @@ describe('PlgOnboardingController', () => {
       expect(res.value[0].domain).to.equal('example1.com');
       expect(res.value[1].id).to.equal('rec-2');
       expect(res.value[1].domain).to.equal('example2.com');
+    });
+  });
+
+  // --- getStatus: admin / API key bypass ---
+
+  describe('getStatus - admin bypass', () => {
+    let AdminPlgOnboardingController;
+
+    beforeEach(async () => {
+      AdminPlgOnboardingController = (await esmock(
+        '../../../src/controllers/plg/plg-onboarding.js',
+        {
+          '@adobe/spacecat-shared-utils': {
+            composeBaseURL: composeBaseURLStub,
+            detectBotBlocker: detectBotBlockerStub,
+            detectLocale: detectLocaleStub,
+            hasText: (val) => typeof val === 'string' && val.trim().length > 0,
+            isValidIMSOrgId: (val) => typeof val === 'string' && val.endsWith('@AdobeOrg'),
+            resolveCanonicalUrl: resolveCanonicalUrlStub,
+          },
+          '@adobe/spacecat-shared-http-utils': {
+            badRequest: (msg) => ({ status: 400, value: msg }),
+            createResponse: (body, status) => ({ status, value: body }),
+            forbidden: (msg) => ({ status: 403, value: msg }),
+            internalServerError: (msg) => ({ status: 500, value: msg }),
+            notFound: (msg) => ({ status: 404, value: msg }),
+            ok: (data) => ({ status: 200, value: data }),
+          },
+          '@adobe/spacecat-shared-rum-api-client': {
+            default: {
+              createFrom: sandbox.stub().returns({
+                retrieveDomainkey: rumRetrieveDomainkeyStub,
+              }),
+            },
+          },
+          '@adobe/spacecat-shared-tier-client': {
+            default: { createForSite: tierClientCreateForSiteStub },
+          },
+          '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
+            Config: { toDynamoItem: configToDynamoItemStub },
+          },
+          '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js': {
+            Entitlement: {
+              PRODUCT_CODES: { ASO: 'aso_optimizer' },
+              TIERS: { FREE_TRIAL: 'FREE_TRIAL' },
+            },
+          },
+          '@adobe/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.model.js': {
+            default: {
+              STATUSES: {
+                IN_PROGRESS: 'IN_PROGRESS',
+                ONBOARDED: 'ONBOARDED',
+                PRE_ONBOARDING: 'PRE_ONBOARDING',
+                ERROR: 'ERROR',
+                WAITING_FOR_IP_ALLOWLISTING: 'WAITING_FOR_IP_ALLOWLISTING',
+                WAITLISTED: 'WAITLISTED',
+              },
+            },
+          },
+          '../../../src/controllers/llmo/llmo-onboarding.js': {
+            createOrFindOrganization: createOrFindOrganizationStub,
+            enableAudits: enableAuditsStub,
+            enableImports: enableImportsStub,
+            triggerAudits: triggerAuditsStub,
+            ASO_DEMO_ORG: DEMO_ORG_ID,
+          },
+          '../../../src/support/utils.js': {
+            autoResolveAuthorUrl: autoResolveAuthorUrlStub,
+            updateCodeConfig: updateCodeConfigStub,
+            findDeliveryType: findDeliveryTypeStub,
+            deriveProjectName: deriveProjectNameStub,
+          },
+          '../../../src/utils/slack/base.js': {
+            loadProfileConfig: loadProfileConfigStub,
+          },
+          '../../../src/support/brand-profile-trigger.js': {
+            triggerBrandProfileAgent: triggerBrandProfileAgentStub,
+          },
+          '../../../src/support/access-control-util.js': {
+            default: {
+              fromContext: () => ({ hasAdminAccess: () => true }),
+            },
+          },
+        },
+      )).default;
+    });
+
+    it('allows admin to access any org without tenant match', async () => {
+      const record = createMockOnboarding({ status: 'ONBOARDED' });
+      mockDataAccess.PlgOnboarding.allByImsOrgId.resolves([record]);
+
+      const res = await AdminPlgOnboardingController({ log: mockLog }).getStatus({
+        dataAccess: mockDataAccess,
+        params: { imsOrgId: 'COMPLETELY_DIFFERENT@AdobeOrg' },
+        attributes: {
+          authInfo: {
+            getProfile: sandbox.stub().returns({ tenants: [{ id: 'ADMIN_TENANT' }] }),
+          },
+        },
+      });
+
+      expect(res.status).to.equal(200);
+      expect(res.value).to.be.an('array').with.length(1);
+    });
+
+    it('allows admin even when authInfo has no profile tenants', async () => {
+      const record = createMockOnboarding({ status: 'ONBOARDED' });
+      mockDataAccess.PlgOnboarding.allByImsOrgId.resolves([record]);
+
+      const res = await AdminPlgOnboardingController({ log: mockLog }).getStatus({
+        dataAccess: mockDataAccess,
+        params: { imsOrgId: TEST_IMS_ORG_ID },
+        attributes: {
+          authInfo: {
+            getProfile: sandbox.stub().returns(null),
+          },
+        },
+      });
+
+      expect(res.status).to.equal(200);
+    });
+
+    it('still returns 400 for missing authInfo even as admin path', async () => {
+      const res = await AdminPlgOnboardingController({ log: mockLog }).getStatus({
+        dataAccess: mockDataAccess,
+        params: { imsOrgId: TEST_IMS_ORG_ID },
+        attributes: {},
+      });
+
+      expect(res.status).to.equal(400);
+      expect(res.value).to.equal('Authentication information is required');
     });
   });
 });


### PR DESCRIPTION
Admin users and API key callers (hasAdminAccess) can now query PLG onboarding status for any IMS org without needing a matching tenant in their token. IMS/JWT callers still require tenant ownership validation.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
