### PR TITLE
fix(plg): waitlist non-AEM domains and enforce one onboarded domain per IMS org        

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -50,6 +50,7 @@ const ASO_TIER = EntitlementModel.TIERS.FREE_TRIAL;
 const PLG_PROFILE_KEY = 'aso_plg';
 
 const DOMAIN_ALREADY_ASSIGNED = 'already assigned to another organization';
+const DOMAIN_ALREADY_ONBOARDED_IN_ORG = 'another domain is already onboarded for this IMS org';
 
 // EDS host pattern: ref--repo--owner.aem.live (or hlx.live)
 const EDS_HOST_PATTERN = /^([\w-]+)--([\w-]+)--([\w-]+)\.(aem\.live|hlx\.live)$/i;
@@ -182,6 +183,18 @@ async function performAsoPlgOnboarding({ domain, imsOrgId }, context) {
       log.info(`Concurrent create detected, resuming PlgOnboarding record ${onboarding.getId()}`);
     }
   }
+  // Guard: only one domain per IMS org can be onboarded
+  const existingRecords = await PlgOnboarding.allByImsOrgId(imsOrgId);
+  const alreadyOnboarded = existingRecords
+    .find((r) => r.getDomain() !== domain && r.getStatus() === STATUSES.ONBOARDED);
+  if (alreadyOnboarded) {
+    log.info(`IMS org ${imsOrgId} already has onboarded domain ${alreadyOnboarded.getDomain()}, waitlisting ${domain}`);
+    onboarding.setStatus(STATUSES.WAITLISTED);
+    onboarding.setWaitlistReason(`Domain ${alreadyOnboarded.getDomain()} is ${DOMAIN_ALREADY_ONBOARDED_IN_ORG}`);
+    await onboarding.save();
+    return onboarding;
+  }
+
   // Fast path: preonboarded sites just need enrollment + ONBOARDED
   if (onboarding.getStatus() === STATUSES.PRE_ONBOARDING && onboarding.getSiteId()) {
     log.info(`Fast-tracking preonboarded record ${onboarding.getId()}`);

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -1329,6 +1329,66 @@ describe('PlgOnboardingController', () => {
     });
   });
 
+  // --- One domain per IMS org ---
+
+  describe('onboard - one domain per IMS org', () => {
+    let controller;
+
+    beforeEach(() => {
+      controller = PlgOnboardingController({ log: mockLog });
+    });
+
+    it('waitlists domain when another domain is already onboarded for the same IMS org', async () => {
+      const onboardedRecord = createMockOnboarding({
+        id: 'other-onboarding-id',
+        domain: 'other-domain.com',
+        status: 'ONBOARDED',
+      });
+      mockDataAccess.PlgOnboarding.allByImsOrgId.resolves([onboardedRecord]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(mockOnboarding.setWaitlistReason)
+        .to.have.been.calledWithMatch(/another domain is already onboarded for this IMS org/);
+      expect(mockOnboarding.save).to.have.been.called;
+      // Should NOT proceed to org resolution or site creation
+      expect(createOrFindOrganizationStub).to.not.have.been.called;
+      expect(mockDataAccess.Site.create).to.not.have.been.called;
+    });
+
+    it('allows onboarding when the same domain is already onboarded (re-onboard)', async () => {
+      const onboardedRecord = createMockOnboarding({
+        domain: TEST_DOMAIN,
+        status: 'ONBOARDED',
+      });
+      mockDataAccess.PlgOnboarding.allByImsOrgId.resolves([onboardedRecord]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+
+    it('allows onboarding when other domains exist but none are onboarded', async () => {
+      const waitlistedRecord = createMockOnboarding({
+        id: 'other-onboarding-id',
+        domain: 'other-domain.com',
+        status: 'WAITLISTED',
+      });
+      mockDataAccess.PlgOnboarding.allByImsOrgId.resolves([waitlistedRecord]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+  });
+
   // --- Entitlement ---
 
   describe('onboard - entitlement handling', () => {


### PR DESCRIPTION
 ## Summary                                                                             
  - Waitlist non-AEM domains during PLG onboarding using RUM domain key lookup with      
  delivery type fallback                                                                 
  - Enforce one onboarded domain per IMS org — if a different domain is already
  onboarded, new domains are waitlisted                                                  
                    

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
