### PR TITLE
feat(delegation): restrict add-delegate Slack command via env allowlist

### DIFF
--- a/src/support/slack/commands/add-delegate.js
+++ b/src/support/slack/commands/add-delegate.js
@@ -48,20 +48,25 @@ function AddDelegateCommand(context) {
     const { say, user: userId } = slackContext;
 
     try {
-      const [siteArg, imsOrgId, productCode] = args;
-
-      if (!siteArg || !imsOrgId || !productCode) {
-        await say(baseCommand.usage());
-        return;
-      }
-
-      // Allowlist check: only permitted Slack user IDs may run this command.
+      // Allowlist check first — unauthorized users should not see usage hints or
+      // learn anything about command arguments.
+      // Fail-open when env var is unset: intentional backwards-compatible default
+      // so existing deployments are not broken on upgrade. Flip to deny-by-default
+      // once the env var is confirmed deployed everywhere.
       const allowedUsers = (env?.DELEGATE_ALLOWED_SLACK_USER_IDS || '')
         .split(',')
         .map((id) => id.trim())
         .filter(Boolean);
       if (allowedUsers.length > 0 && !allowedUsers.includes(userId)) {
+        log.warn(`[AddDelegate] Unauthorized attempt by slack user ${userId}`);
         await say(':x: You are not authorized to use this command.');
+        return;
+      }
+
+      const [siteArg, imsOrgId, productCode] = args;
+
+      if (!siteArg || !imsOrgId || !productCode) {
+        await say(baseCommand.usage());
         return;
       }
 

--- a/test/support/slack/commands/add-delegate.test.js
+++ b/test/support/slack/commands/add-delegate.test.js
@@ -135,6 +135,7 @@ describe('AddDelegateCommand', () => {
       await command.handleExecution(['https://example.com', IMS_ORG_ID, 'LLMO'], slackContext);
       expect(slackContext.say.firstCall.args[0]).to.include(':x:');
       expect(slackContext.say.firstCall.args[0]).to.include('not authorized');
+      expect(context.log.warn).to.have.been.calledWith(sinon.match(/Unauthorized attempt/));
       expect(context.dataAccess.SiteImsOrgAccess.create).not.to.have.been.called;
     });
 


### PR DESCRIPTION
## Summary

- Adds `DELEGATE_ALLOWED_SLACK_USER_IDS` env variable (comma-separated Slack user IDs) to gate who can invoke the `add delegate` Slack command
- When the variable is set, callers not in the list receive `:x: You are not authorized to use this command.` and execution stops before any DB access
- When unset or blank, the command remains open to all users — no behavior change for existing deployments

## How to enable

Set the env variable in the Lambda/deployment config:
```
DELEGATE_ALLOWED_SLACK_USER_IDS=U12345ABC,U67890DEF
```
Slack user IDs can be found via a user's Slack profile → *Copy member ID*.

## Test plan

- [ ] `rejects non-allowlisted user when DELEGATE_ALLOWED_SLACK_USER_IDS is set` ✅
- [ ] `allows allowlisted user when DELEGATE_ALLOWED_SLACK_USER_IDS is set` ✅
- [ ] `allows any user when DELEGATE_ALLOWED_SLACK_USER_IDS is not set` ✅
- [ ] `allows any user when DELEGATE_ALLOWED_SLACK_USER_IDS is empty string` ✅
- [ ] Full unit test suite passes at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)