### PR TITLE
feat: add optimize-at-edge-enabled-marking to global import slack command

### DIFF
--- a/src/support/slack/commands/run-global-import.js
+++ b/src/support/slack/commands/run-global-import.js
@@ -20,6 +20,7 @@ const PHRASES = ['run global import'];
 
 const GLOBAL_IMPORTS = [
   'stale-suggestions-cleanup',
+  'optimize-at-edge-enabled-marking',
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Adds `optimize-at-edge-enabled-marking` to the list of valid global import types in the Slack `run global import` command
- Allows triggering the edge go-live check job via Slack: `run global import optimize-at-edge-enabled-marking`

## Test plan
- [ ] Verify `run global import optimize-at-edge-enabled-marking` is accepted by the Slack command
- [ ] Verify `run global import` (no args) shows updated usage with the new type listed
- [ ] Verify invalid import type still shows warning message

🤖 Generated with [Claude Code](https://claude.com/claude-code)