### PR TITLE
fix: inline setup steps in e2e-tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -18,10 +18,19 @@ jobs:
         with:
           persist-credentials: 'false'
 
-      - name: Setup Node & NPM
-        uses: ./.github/actions/setup-node-npm
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Configure Git auth for private repos
+        run: |
+          git config --global url."https://x-access-token:${MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN}@github.com/".insteadOf "https://github.com/"
         env:
           MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN: ${{ secrets.MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         env:


### PR DESCRIPTION
The composite action .github/actions/setup-node-npm was removed during the mysticat-ci migration but e2e-tests.yaml still referenced it, causing the workflow to fail. Inline the steps directly instead.

## Related Issues

- E2E test failures reported via email notification, e.g. https://github.com/adobe/spacecat-api-service/actions/runs/23442223386/job/68196051158

