### PR TITLE
fix: aggregate prompt-level mentions and citations across executions | LLMO-3605

### DIFF
--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -1017,14 +1017,21 @@ export function buildPromptDetails(rows) {
   rows.forEach((row) => {
     const key = buildTopicPromptKey(row);
     const existing = promptMap.get(key);
-    if (!existing || (row.execution_date > existing.execution_date)) {
-      promptMap.set(key, row);
+    if (!existing) {
+      promptMap.set(key, {
+        latestRow: row,
+        totalMentions: 0,
+        totalCitations: 0,
+      });
+    } else if (row.execution_date > existing.latestRow.execution_date) {
+      existing.latestRow = row;
     }
+    const entry = promptMap.get(key);
+    if (row.mentions === true || row.mentions === 'true') entry.totalMentions += 1;
+    if (row.citations === true || row.citations === 'true') entry.totalCitations += 1;
   });
 
-  return [...promptMap.values()].map((r) => {
-    const mentioned = r.mentions === true || r.mentions === 'true';
-    const cited = r.citations === true || r.citations === 'true';
+  return [...promptMap.values()].map(({ latestRow: r, totalMentions, totalCitations }) => {
     const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
 
     return {
@@ -1036,8 +1043,8 @@ export function buildPromptDetails(rows) {
       answer: '',
       sources: '',
       relatedURL: r.url || '',
-      citationsCount: cited ? 1 : 0,
-      mentionsCount: mentioned ? 1 : 0,
+      citationsCount: totalCitations,
+      mentionsCount: totalMentions,
       isAnswered: !(r.error_code),
       visibilityScore: Number.isNaN(vs) ? 0 : vs,
       position: r.position ? String(r.position) : '',

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -3872,6 +3872,45 @@ describe('llmo-brand-presence', () => {
       expect(result[0].origin).to.equal('');
     });
 
+    it('aggregates mentions and citations across all execution rows per prompt', () => {
+      const rows = [
+        {
+          topics: 'PDF',
+          prompt: 'best pdf editor',
+          region_code: 'US',
+          mentions: true,
+          citations: true,
+          visibility_score: 80,
+          execution_date: '2026-03-01',
+        },
+        {
+          topics: 'PDF',
+          prompt: 'best pdf editor',
+          region_code: 'US',
+          mentions: true,
+          citations: false,
+          visibility_score: 70,
+          execution_date: '2026-03-08',
+        },
+        {
+          topics: 'PDF',
+          prompt: 'best pdf editor',
+          region_code: 'US',
+          mentions: false,
+          citations: true,
+          visibility_score: 90,
+          execution_date: '2026-03-15',
+        },
+      ];
+      const result = buildPromptDetails(rows);
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].mentionsCount).to.equal(2);
+      expect(result[0].citationsCount).to.equal(2);
+      // Latest execution's metadata is used
+      expect(result[0].executionDate).to.equal('2026-03-15');
+      expect(result[0].visibilityScore).to.equal(90);
+    });
+
     it('uses "Unknown" for null topics and counts citations correctly', () => {
       const rows = [
         {


### PR DESCRIPTION
## Summary

Fixes a bug where prompt-level mentions and citations in the Data Insights table always showed 0 (or at most 1), while topic-level counts were correct.

### Root Cause

`buildPromptDetails` deduplicated rows by `prompt|region_code` and kept only the latest execution row, then read `mentions`/`citations` as a boolean from that single row (`cited ? 1 : 0`). Topic-level aggregation (`aggregateTopicData`) correctly counted across all execution rows.

### Fix

`buildPromptDetails` now accumulates `totalMentions` and `totalCitations` across all execution rows for each unique prompt, while still using the latest execution row for other metadata (visibility, position, sentiment, etc.). This matches the topic-level aggregation strategy.

## Test Plan

- [x] New test: verifies mentions/citations are summed across 3 execution rows for the same prompt
- [x] All existing tests pass (single-row cases produce identical results)
- [x] 100% code coverage maintained

Made with [Cursor](https://cursor.com)