### PR TITLE
fix: shallow merge config patch (#2020)

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -632,7 +632,10 @@ function SitesController(ctx, log, env) {
     }
 
     if (isObject(requestBody.config)) {
-      const existingConfig = Config.toDynamoItem(site.getConfig()) || {};
+      const siteConfig = site.getConfig();
+      const existingConfig = isNonEmptyObject(siteConfig)
+        ? Config.toDynamoItem(siteConfig) || {}
+        : {};
       const merged = { ...existingConfig, ...requestBody.config };
       site.setConfig(merged);
       updates = true;

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -3360,6 +3360,51 @@ describe('Sites Controller', () => {
     expect(updatedSite.code).to.deep.equal(codeConfig);
   });
 
+  it('sets config when site has no existing config', async () => {
+    const site = sites[0];
+    site.getConfig = sandbox.stub().returns(null);
+    site.setConfig = sandbox.stub();
+    site.save = sandbox.stub().resolves(site);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: { slack: { channel: '#new' } },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(200);
+    expect(site.setConfig).to.have.been.calledOnce;
+
+    const mergedConfig = site.setConfig.firstCall.args[0];
+    expect(mergedConfig).to.deep.equal({ slack: { channel: '#new' } });
+  });
+
+  it('sets config when toDynamoItem returns null for existing config', async () => {
+    const site = sites[0];
+    site.getConfig = sandbox.stub().returns({ something: true });
+    site.setConfig = sandbox.stub();
+    site.save = sandbox.stub().resolves(site);
+
+    const toDynamoStub = sandbox.stub(Config, 'toDynamoItem').returns(null);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: { slack: { channel: '#new' } },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(200);
+    expect(toDynamoStub).to.have.been.called;
+    expect(site.setConfig).to.have.been.calledOnce;
+
+    const mergedConfig = site.setConfig.firstCall.args[0];
+    expect(mergedConfig).to.deep.equal({ slack: { channel: '#new' } });
+  });
+
   it('shallow-merges config so partial update preserves existing keys', async () => {
     const site = sites[0];
     const existingConfig = Config({


### PR DESCRIPTION
The `PATCH /sites/:siteId` endpoint was doing a full replacement of `config` via `site.setConfig()`. This risked accidental data loss if a client echoed back a trimmed config from a list endpoint response (e.g. from `GET /sites` which now returns a slim DTO).

- Changed config update in `updateSite` to **shallow-merge** incoming config with existing config using `{ ...existingConfig, ...requestBody.config }`
- Sending `{ config: { slack: { channel: "#new" } } }` now only replaces `slack`, leaving `llmo`, `handlers`, etc. untouched
- Clients can still intentionally remove a config key by explicitly setting it to `null`

- [x] `shallow-merges config so partial update preserves existing keys` — verifies untouched keys are preserved after partial config update
- [x] `allows removing a config key by explicitly setting it to null` — verifies explicit `null` deletion works as expected
- [x] All existing `updateSite` tests pass (6 tests)
- [x] All `updateCdnLogsConfig` tests pass
- [x] Lint clean

Made-with: Cursor

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
