### PR TITLE
fix: return full edgeOptimizeConfig in slim site DTO

### DIFF
--- a/src/dto/config.js
+++ b/src/dto/config.js
@@ -48,7 +48,7 @@ const toListJSON = (config) => {
     if (customerIntent) result.llmo.customerIntent = customerIntent;
   }
   if (isNonEmptyObject(json.edgeOptimizeConfig)) {
-    result.edgeOptimizeConfig = { enabled: json.edgeOptimizeConfig.enabled };
+    result.edgeOptimizeConfig = json.edgeOptimizeConfig;
   }
   if (isNonEmptyObject(json.slack)) {
     result.slack = json.slack;

--- a/test/dto/config.test.js
+++ b/test/dto/config.test.js
@@ -72,7 +72,7 @@ describe('ConfigDto', () => {
           customerIntent: [{ key: 'intent1' }],
           someInternalField: 'should-be-excluded',
         },
-        edgeOptimizeConfig: { enabled: true, stagingDomains: ['stage.example.com'] },
+        edgeOptimizeConfig: { enabled: true, opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
         slack: { channel: '#test', workspace: 'T123' },
         brandConfig: { brandId: 'brand-123' },
         fetchConfig: { overrideBaseURL: 'https://override.example.com' },
@@ -91,7 +91,7 @@ describe('ConfigDto', () => {
           tags: ['tag1'],
           customerIntent: [{ key: 'intent1' }],
         },
-        edgeOptimizeConfig: { enabled: true },
+        edgeOptimizeConfig: { enabled: true, opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
         slack: { channel: '#test', workspace: 'T123' },
         brandConfig: { brandId: 'brand-123' },
         fetchConfig: { overrideBaseURL: 'https://override.example.com' },
@@ -102,7 +102,7 @@ describe('ConfigDto', () => {
       expect(result).to.not.have.property('contentAiConfig');
       expect(result).to.not.have.property('cdnLogsConfig');
       expect(result.llmo).to.not.have.property('someInternalField');
-      expect(result.edgeOptimizeConfig).to.not.have.property('stagingDomains');
+      expect(result.edgeOptimizeConfig).to.have.property('stagingDomains');
     });
 
     it('handles partial config with only llmo', () => {
@@ -113,6 +113,19 @@ describe('ConfigDto', () => {
       const result = ConfigDto.toListJSON({ some: 'config' });
       expect(result).to.deep.equal({
         llmo: { dataFolder: '/data', brand: 'Test' },
+      });
+    });
+
+    it('includes full edgeOptimizeConfig when present', () => {
+      sinon.stub(Config, 'toDynamoItem').returns({
+        edgeOptimizeConfig: { opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
+        slack: { channel: '#test' },
+      });
+
+      const result = ConfigDto.toListJSON({ some: 'config' });
+      expect(result).to.deep.equal({
+        edgeOptimizeConfig: { opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
+        slack: { channel: '#test' },
       });
     });
   });


### PR DESCRIPTION
## fix: return full edgeOptimizeConfig in slim site DTO

### Summary
- The slim `ConfigDto.toListJSON` was cherry-picking only `enabled` from `edgeOptimizeConfig`, which produced empty objects `{}` for sites that had `opted` or `stagingDomains` configured but not `enabled`.
- Changed to return the full `edgeOptimizeConfig` object, preserving all properties (`enabled`, `opted`, `stagingDomains`).

### Changes
- **`src/dto/config.js`** — return `json.edgeOptimizeConfig` directly instead of `{ enabled: json.edgeOptimizeConfig.enabled }`
- **`test/dto/config.test.js`** — updated assertions to expect the full object; added test case covering `edgeOptimizeConfig` without `enabled`

### Test plan
- [x] Unit tests pass (`npx mocha test/dto/config.test.js`)
- [ ] Verify `GET /sites` no longer returns empty `edgeOptimizeConfig: {}` for sites without `enabled` set
- [ ] Verify sites with full `edgeOptimizeConfig` return all properties (`enabled`, `opted`, `stagingDomains`)