### PR TITLE
feat: update brandalf api docs with latest schema

### DIFF
--- a/docs/llmo-brandalf-apis/brand-presence-apis-overview.md
+++ b/docs/llmo-brandalf-apis/brand-presence-apis-overview.md
@@ -1,0 +1,372 @@
+# Brand Presence APIs — consolidated reference
+
+Single entry point for all org-scoped Brand Presence HTTP APIs backed by mysticat-data-service (PostgREST). Each route exists in two variants: `brands/all` (organization-wide) and `brands/:brandId` (single brand UUID).
+
+**Path pattern:** `GET /org/:spaceCatId/brands/{all|:brandId}/brand-presence/...`
+
+- `:spaceCatId` — organization UUID (same as SpaceCat org id).
+- `all` — aggregate across brands; `:brandId` — filter to one brand.
+
+Parameters are typically supplied as **query string** fields (merged into request `data` by the API gateway). Aliases such as `start_date` / `startDate` are noted per endpoint.
+
+Deep-dive docs: [filter-dimensions](filter-dimensions-api.md), [weeks](brand-presence-weeks-api.md), [sentiment-overview](sentiment-overview-api.md), [market-tracking-trends](market-tracking-trends-api.md), [topics & prompts](topics-api.md), [search](search-api.md), [topic detail](topic-detail-api.md), [prompt detail](prompt-detail-api.md), [sentiment-movers](sentiment-movers-api.md), [share-of-voice](share-of-voice-api.md), [stats](brand-presence-stats-api.md).
+
+---
+
+## Master table
+
+Each **Query parameters** cell lists one parameter per line as `name : sample (optional)` or `(required)`. Lists use HTML (`<ul><li>`) so they render on separate lines in GitHub, many IDEs, and doc tools; if your viewer strips HTML, use the **Detail doc** link for the same parameters in Markdown.
+
+| # | Method | API path | Purpose | Query parameters | Example response | Detail doc |
+|---|--------|----------|---------|------------------|------------------|------------|
+| 1 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/filter-dimensions` | Returns distinct filter values for dropdowns: brands, categories, topics, origins, regions, page_intents. | <ul><li><code>startDate</code> : <code>2025-09-27</code> (optional)</li><li><code>endDate</code> : <code>2025-09-30</code> (optional)</li><li><code>model</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : <code>c2473d89-e997-458d-a86d-b4096649c12b</code> (optional)</li><li><code>categoryId</code> : <code>Acrobat</code> or category UUID (optional)</li><li><code>topicIds</code> : <code>0178a3f0-1234-7000-8000-0000000000aa,0178a3f0-1234-7000-8000-0000000000bb</code> (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li><li><code>origin</code> : <code>ai</code> (optional)</li></ul> | [§1](#1-filter-dimensions) | [filter-dimensions-api.md](filter-dimensions-api.md) |
+| 2 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/weeks` | Returns ISO weeks (`YYYY-Wnn`) with calendar start/end for week pickers from `brand_metrics_weekly`. | <ul><li><code>model</code> : <code>gemini</code> (optional)</li><li><code>siteId</code> : <code>c2473d89-e997-458d-a86d-b4096649c12b</code> (optional)</li></ul> | [§2](#2-weeks) | [brand-presence-weeks-api.md](brand-presence-weeks-api.md) |
+| 3 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/sentiment-overview` | Weekly positive/neutral/negative **percentages** and prompt counts (deduped per week) for sentiment charts. | <ul><li><code>startDate</code> : <code>2025-09-01</code> (optional)</li><li><code>endDate</code> : <code>2025-09-30</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : <code>c2473d89-e997-458d-a86d-b4096649c12b</code> (optional)</li><li><code>categoryId</code> : <code>Acrobat</code> or UUID (optional)</li><li><code>topicIds</code> : comma-separated UUIDs (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li><li><code>origin</code> : <code>human</code> (optional)</li></ul> | [§3](#3-sentiment-overview) | [sentiment-overview-api.md](sentiment-overview-api.md) |
+| 4 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/market-tracking-trends` | Weekly brand mentions/citations (deduped) plus competitor mention/citation totals per week. | <ul><li><code>startDate</code> : <code>2025-09-01</code> (optional)</li><li><code>endDate</code> : <code>2025-09-30</code> (optional)</li><li><code>model</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : <code>c2473d89-e997-458d-a86d-b4096649c12b</code> (optional)</li><li><code>categoryId</code> : <code>0178a3f0-1234-7000-8000-000000000099</code> (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li></ul> <em>Not supported:</em> <code>topicIds</code>, <code>origin</code>. | [§4](#4-market-tracking-trends) | [market-tracking-trends-api.md](market-tracking-trends-api.md) |
+| 5 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/topics` | Paginated **topic summaries** for the Data Insights table (aggregates per topic). | <ul><li><code>startDate</code> : <code>2026-02-09</code> (optional)</li><li><code>endDate</code> : <code>2026-03-09</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>categoryId</code> : UUID or name (optional)</li><li><code>topicIds</code> : comma-separated UUIDs (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>DE</code> (optional)</li><li><code>origin</code> : <code>ai</code> (optional)</li><li><code>page</code> : <code>0</code> (optional)</li><li><code>pageSize</code> : <code>20</code> (optional)</li><li><code>sortBy</code> : <code>mentions</code> (optional; <code>name</code>, <code>visibility</code>, <code>citations</code>, <code>sentiment</code>, <code>popularity</code>, <code>position</code>)</li><li><code>sortOrder</code> : <code>desc</code> (optional; <code>asc</code>)</li></ul> | [§5](#5-topics) | [topics-api.md — Topics](topics-api.md#1-topics-endpoint) |
+| 6 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/topics/:topicId/prompts` | Prompt-level rows for one topic (`:topicId` = URL-encoded topic name). Same filters/pagination as topics. | <ul><li><code>:topicId</code> (path) : <code>PDF%20Editing</code> (required)</li><li><code>startDate</code> : <code>2026-02-09</code> (optional)</li><li><code>endDate</code> : <code>2026-03-09</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>categoryId</code> : UUID or name (optional)</li><li><code>topicIds</code> : comma-separated UUIDs (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li><li><code>origin</code> : <code>ai</code> (optional)</li><li><code>page</code> : <code>0</code> (optional)</li><li><code>pageSize</code> : <code>20</code> (optional)</li><li><code>query</code> : <code>merge</code> (optional; prompt text substring)</li></ul> | [§6](#6-topic-prompts) | [topics-api.md — Topic prompts](topics-api.md#2-topic-prompts-endpoint) |
+| 7 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/search` | Search topics/prompts; returns topic summaries with `matchType` (`topic` vs `prompt`). | <ul><li><code>query</code> : <code>pdf</code> (required; 2–500 chars)</li><li><code>startDate</code> : <code>2026-02-09</code> (optional)</li><li><code>endDate</code> : <code>2026-03-09</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>categoryId</code> : UUID or name (optional)</li><li><code>topicIds</code> : comma-separated UUIDs (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>JP</code> (optional)</li><li><code>origin</code> : <code>human</code> (optional)</li><li><code>page</code> : <code>0</code> (optional)</li><li><code>pageSize</code> : <code>20</code> (optional)</li><li><code>sortBy</code> : <code>mentions</code> (optional)</li><li><code>sortOrder</code> : <code>desc</code> (optional)</li></ul> | [§7](#7-search) | [search-api.md](search-api.md) |
+| 8 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/topics/:topicId/detail` | Full **topic** drill-down: stats, weekly mini-stats, all executions, citation sources. | <ul><li><code>:topicId</code> (path) : <code>PDF%20Editing</code> (required)</li><li><code>startDate</code> : <code>2026-02-09</code> (optional)</li><li><code>endDate</code> : <code>2026-03-09</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li><li><code>origin</code> : <code>human</code> (optional)</li></ul> <em>Note:</em> detail query does not apply <code>categoryId</code> / <code>topicIds</code>. | [§8](#8-topic-detail) | [topic-detail-api.md](topic-detail-api.md) |
+| 9 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/topics/:topicId/prompt-detail` | Drill-down for one **prompt** (+ optional region) inside a topic. | <ul><li><code>:topicId</code> (path) : <code>PDF%20Editing</code> (required)</li><li><code>prompt</code> : <code>best pdf editor for mac</code> (required)</li><li><code>promptRegion</code> / <code>prompt_region</code> : <code>US</code> (optional)</li><li><code>startDate</code> : <code>2026-02-09</code> (optional)</li><li><code>endDate</code> : <code>2026-03-09</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>chatgpt</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>origin</code> : <code>human</code> (optional)</li></ul> | [§9](#9-prompt-detail) | [prompt-detail-api.md](prompt-detail-api.md) |
+| 10 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/sentiment-movers` | Top/bottom prompts by sentiment change (RPC `rpc_sentiment_movers`). | <ul><li><code>type</code> : <code>top</code> or <code>bottom</code> (optional)</li><li><code>startDate</code> : <code>2026-02-09</code> (optional)</li><li><code>endDate</code> : <code>2026-03-09</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>google-ai-mode</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>categoryId</code> : category UUID (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li><li><code>origin</code> : <code>human</code> (optional)</li><li><code>topicIds</code> : comma-separated UUIDs (optional)</li></ul> | [§10](#10-sentiment-movers) | [sentiment-movers-api.md](sentiment-movers-api.md) |
+| 11 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/share-of-voice` | Per-topic share of voice, competitors, rankings (`rpc_share_of_voice`). | <ul><li><code>startDate</code> : <code>2025-09-27</code> (optional)</li><li><code>endDate</code> : <code>2025-09-30</code> (optional)</li><li><code>model</code> : <code>gemini</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>categoryId</code> : <code>0178a3f0-1234-7000-8000-000000000099</code> (optional)</li><li><code>topicIds</code> : comma-separated UUIDs (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li><li><code>origin</code> : <code>ai</code> (optional)</li><li><code>maxCompetitors</code> / <code>max_competitors</code> : <code>5</code> (optional)</li></ul> | [§11](#11-share-of-voice) | [share-of-voice-api.md](share-of-voice-api.md) |
+| 12 | GET | `/org/:spaceCatId/brands/{all\|:brandId}/brand-presence/stats` | Org/brand execution totals and averages via `rpc_brand_presence_stats`; optional weekly slices. | <ul><li><code>startDate</code> : <code>2025-01-01</code> (optional)</li><li><code>endDate</code> : <code>2025-01-31</code> (optional)</li><li><code>model</code> / <code>platform</code> : <code>gemini</code> (optional)</li><li><code>showTrends</code> / <code>show_trends</code> : <code>true</code> (optional)</li><li><code>siteId</code> : site UUID (optional)</li><li><code>categoryId</code> : category UUID (optional)</li><li><code>topicIds</code> : comma-separated UUIDs (optional)</li><li><code>regionCode</code> / <code>region</code> : <code>US</code> (optional)</li><li><code>origin</code> : <code>ai</code> (optional)</li></ul> | [§12](#12-stats) | [brand-presence-stats-api.md](brand-presence-stats-api.md) |
+
+---
+
+## Example responses (backend shape)
+
+Illustrative JSON; real data varies by org and filters.
+
+### 1. Filter dimensions
+
+```json
+{
+  "brands": [{ "id": "019cb903-1184-7f92-8325-f9d1176af316", "label": "Acrobat" }],
+  "categories": [{ "id": "Acrobat", "label": "Acrobat" }],
+  "topics": [{ "id": "0178a3f0-1234-7000-8000-0000000000aa", "label": "combine pdf" }],
+  "origins": [{ "id": "ai", "label": "ai" }],
+  "regions": [{ "id": "US", "label": "US" }],
+  "page_intents": [{ "id": "TRANSACTIONAL", "label": "TRANSACTIONAL" }]
+}
+```
+
+### 2. Weeks
+
+```json
+{
+  "weeks": [
+    { "week": "2026-W11", "startDate": "2026-03-09", "endDate": "2026-03-15" },
+    { "week": "2026-W10", "startDate": "2026-03-02", "endDate": "2026-03-08" }
+  ]
+}
+```
+
+### 3. Sentiment overview
+
+```json
+{
+  "weeklyTrends": [
+    {
+      "week": "2026-W11",
+      "weekNumber": 11,
+      "year": 2026,
+      "sentiment": [
+        { "name": "Positive", "value": 45, "color": "#047857" },
+        { "name": "Neutral", "value": 30, "color": "#4B5563" },
+        { "name": "Negative", "value": 25, "color": "#B91C1C" }
+      ],
+      "totalPrompts": 120,
+      "promptsWithSentiment": 100,
+      "mentions": 0,
+      "citations": 0,
+      "visibilityScore": 0,
+      "competitors": []
+    }
+  ]
+}
+```
+
+### 4. Market tracking trends
+
+```json
+{
+  "weeklyTrends": [
+    {
+      "week": "2026-W10",
+      "weekNumber": 10,
+      "year": 2026,
+      "mentions": 42,
+      "citations": 18,
+      "competitors": [
+        { "name": "competitor_a", "mentions": 30, "citations": 10 },
+        { "name": "competitor_b", "mentions": 12, "citations": 5 }
+      ]
+    }
+  ],
+  "weeklyTrendsForComparison": []
+}
+```
+
+*(Production: `weeklyTrendsForComparison` duplicates `weeklyTrends`.)*
+
+### 5. Topics
+
+```json
+{
+  "topicDetails": [
+    {
+      "topic": "PDF Editing",
+      "promptCount": 47,
+      "brandMentions": 312,
+      "brandCitations": 198,
+      "sourceCount": 85,
+      "popularityVolume": "High",
+      "averageVisibilityScore": 72.5,
+      "averagePosition": 3.2,
+      "averageSentiment": 75
+    }
+  ],
+  "totalCount": 142
+}
+```
+
+### 6. Topic prompts
+
+```json
+{
+  "items": [
+    {
+      "topic": "PDF Editing",
+      "prompt": "best pdf editor for mac",
+      "region": "US",
+      "category": "Acrobat",
+      "executionDate": "2026-03-08",
+      "answer": "",
+      "sources": "",
+      "relatedURL": "https://example.com/pdf-editor",
+      "citationsCount": 1,
+      "mentionsCount": 1,
+      "isAnswered": true,
+      "visibilityScore": 85,
+      "position": "2",
+      "sentiment": "Positive",
+      "errorCode": "",
+      "origin": "human"
+    }
+  ],
+  "totalCount": 47
+}
+```
+
+### 7. Search
+
+```json
+{
+  "topicDetails": [
+    {
+      "topic": "PDF Editing",
+      "matchType": "topic",
+      "promptCount": 47,
+      "brandMentions": 312,
+      "brandCitations": 198,
+      "sourceCount": 85,
+      "popularityVolume": "High",
+      "averageVisibilityScore": 72.5,
+      "averagePosition": 3.2,
+      "averageSentiment": 75
+    }
+  ],
+  "totalCount": 1
+}
+```
+
+### 8. Topic detail
+
+```json
+{
+  "topic": "PDF Editing",
+  "stats": {
+    "averageVisibilityScore": 72.5,
+    "averagePosition": 3.2,
+    "averageSentiment": 75,
+    "popularityVolume": "High",
+    "brandMentions": 312,
+    "brandCitations": 198,
+    "promptCount": 47,
+    "sourceCount": 85
+  },
+  "weeklyStats": [
+    {
+      "week": "2026-W10",
+      "visibilityScore": 70,
+      "position": 3.5,
+      "mentions": 78,
+      "citations": 50,
+      "volume": "High",
+      "sentiment": 72
+    }
+  ],
+  "executions": [
+    {
+      "prompt": "best pdf editor for mac",
+      "region": "US",
+      "executionDate": "2026-03-08",
+      "week": "2026-W10",
+      "answer": "Based on current reviews…",
+      "mentions": true,
+      "citations": true,
+      "visibilityScore": 85,
+      "position": "2",
+      "sentiment": "Positive",
+      "volume": "-30",
+      "origin": "human",
+      "category": "Acrobat",
+      "sources": "https://example.com/pdf-editor",
+      "errorCode": ""
+    }
+  ],
+  "sources": [
+    {
+      "url": "https://example.com/pdf-editor-review",
+      "hostname": "example.com",
+      "contentType": "earned",
+      "citationCount": 3,
+      "weeks": ["2026-W10"],
+      "prompts": [{ "prompt": "best pdf editor for mac", "count": 2 }]
+    }
+  ]
+}
+```
+
+### 9. Prompt detail
+
+```json
+{
+  "topic": "PDF Editing",
+  "prompt": "best pdf editor for mac",
+  "region": "US",
+  "stats": {
+    "visibilityScore": 82.5,
+    "position": "2.3",
+    "sentiment": 83,
+    "mentions": 4,
+    "citations": 3
+  },
+  "weeklyStats": [
+    {
+      "week": "2026-W10",
+      "visibilityScore": 80,
+      "position": 2.5,
+      "mentions": 1,
+      "citations": 1,
+      "volume": "High",
+      "sentiment": 75
+    }
+  ],
+  "executions": [],
+  "sources": []
+}
+```
+
+### 10. Sentiment movers
+
+```json
+{
+  "movers": [
+    {
+      "promptId": "019cb903-1184-7f92-8325-f9d1176af316",
+      "prompt": "best pdf merge tool for mac",
+      "topicId": "019cb903-2295-7f92-8325-a8c2045bf427",
+      "topic": "Merge PDF",
+      "categoryId": "019cb903-3306-7f92-8325-b7d3156cg538",
+      "category": "Acrobat",
+      "region": "GB",
+      "origin": "HUMAN",
+      "popularity": "High",
+      "fromSentiment": "neutral",
+      "toSentiment": "positive",
+      "fromDate": "2026-02-23",
+      "toDate": "2026-03-09",
+      "executionCount": 48
+    }
+  ]
+}
+```
+
+### 11. Share of voice
+
+```json
+{
+  "shareOfVoiceData": [
+    {
+      "id": "EVs-15-5",
+      "topic": "EVs",
+      "popularity": "High",
+      "brandMentions": 5,
+      "totalMentions": 15,
+      "shareOfVoice": 33.33,
+      "ranking": 2,
+      "topCompetitors": [
+        { "name": "tesla", "mentions": 6, "shareOfVoice": 40.0, "source": "configured" }
+      ],
+      "allCompetitors": [
+        { "name": "tesla", "mentions": 6, "shareOfVoice": 40.0, "source": "configured" },
+        { "name": "ford", "mentions": 4, "shareOfVoice": 26.67, "source": "detected" }
+      ],
+      "brandShareOfVoice": { "name": "Our Brand", "mentions": 5, "shareOfVoice": 33.33 }
+    }
+  ]
+}
+```
+
+### 12. Stats
+
+**Without** `showTrends`:
+
+```json
+{
+  "stats": {
+    "total_executions": 1250,
+    "average_visibility_score": 4.2,
+    "total_mentions": 89,
+    "total_citations": 312
+  }
+}
+```
+
+**With** `showTrends=true` (excerpt):
+
+```json
+{
+  "stats": {
+    "total_executions": 1250,
+    "average_visibility_score": 4.2,
+    "total_mentions": 89,
+    "total_citations": 312
+  },
+  "trends": [
+    {
+      "startDate": "2025-01-15",
+      "endDate": "2025-01-21",
+      "data": {
+        "stats": {
+          "total_executions": 180,
+          "average_visibility_score": 4.5,
+          "total_mentions": 12,
+          "total_citations": 45
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Authentication and errors
+
+- All endpoints: authenticated user/API key with access to the organization; Brand Presence uses PostgREST (`DATA_SERVICE_PROVIDER=postgres`).
+- Common errors: **400** (misconfiguration, bad request, PostgREST error, bad `topicId` encoding); **403** (not in org, or invalid `siteId` for org).
+
+See per-topic docs for RPC parameters, row limits, and edge cases.

--- a/docs/llmo-brandalf-apis/brand-presence-stats-api.md
+++ b/docs/llmo-brandalf-apis/brand-presence-stats-api.md
@@ -193,3 +193,5 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/019cb903-1184-7f92-8325-f9d
 
 - [Filter Dimensions API](./filter-dimensions-api.md) — Filter options for Brand Presence
 - [Brand Presence Weeks API](./brand-presence-weeks-api.md) — Available weeks for date picker
+- [Brand Presence Sentiment Overview API](./sentiment-overview-api.md) — Weekly sentiment distribution
+- [Brand Presence Market Tracking Trends API](./market-tracking-trends-api.md) — Weekly mentions, citations, and competitors

--- a/docs/llmo-brandalf-apis/brand-presence-weeks-api.md
+++ b/docs/llmo-brandalf-apis/brand-presence-weeks-api.md
@@ -141,6 +141,8 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/weeks?mo
 ## Related APIs
 
 - [Brand Presence Filter Dimensions API](filter-dimensions-api.md) — Returns available filter options (brands, categories, topics, origins, regions, page_intents) for the Brand Presence feature.
+- [Brand Presence Sentiment Overview API](sentiment-overview-api.md) — Weekly sentiment distribution
+- [Brand Presence Market Tracking Trends API](market-tracking-trends-api.md) — Weekly mentions, citations, and competitor breakdown
 
 ---
 

--- a/docs/llmo-brandalf-apis/filter-dimensions-api.md
+++ b/docs/llmo-brandalf-apis/filter-dimensions-api.md
@@ -180,6 +180,8 @@ client.from('page_intents').select('page_intent').eq('site_id', siteId).limit(50
 ## Related APIs
 
 - [Brand Presence Weeks API](brand-presence-weeks-api.md) — Returns applicable weeks for a given model, optionally filtered by brand or site.
+- [Brand Presence Sentiment Overview API](sentiment-overview-api.md) — Weekly sentiment percentages
+- [Brand Presence Market Tracking Trends API](market-tracking-trends-api.md) — Weekly mentions, citations, and competitor breakdown
 
 ---
 

--- a/docs/llmo-brandalf-apis/market-tracking-trends-api.md
+++ b/docs/llmo-brandalf-apis/market-tracking-trends-api.md
@@ -1,0 +1,147 @@
+# Brand Presence Market Tracking Trends API
+
+Returns weekly **brand** mention/citation counts (after prompt-level deduplication) plus per-competitor mention/citation totals per week for market-tracking charts. Data comes from `brand_presence_executions` and `executions_competitor_data` via PostgREST (mysticat-data-service).
+
+---
+
+## API Paths
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/org/:spaceCatId/brands/all/brand-presence/market-tracking-trends` | Trends for all brands in the organization |
+| GET | `/org/:spaceCatId/brands/:brandId/brand-presence/market-tracking-trends` | Trends for a specific brand |
+
+**Path parameters:**
+- `spaceCatId` — Organization ID (UUID)
+- `brandId` — `all` (all brands) or a specific brand UUID
+
+---
+
+## Query Parameters
+
+| Parameter | Aliases | Type | Default | Description |
+|-----------|---------|------|---------|-------------|
+| `startDate` | `start_date` | string (YYYY-MM-DD) | 28 days ago | Start of date range |
+| `endDate` | `end_date` | string (YYYY-MM-DD) | today | End of date range |
+| `model` | — | string | `chatgpt` | LLM model |
+| `siteId` | `site_id` | string (UUID) | — | Filter by site |
+| `categoryId` | `category_id` | string (UUID or name) | — | Filter by category UUID or category name |
+| `regionCode` | `region_code`, `region` | string | — | Filter by region code |
+
+**Not supported on this endpoint (unlike filter-dimensions / sentiment-overview):** `topicIds`, `origin`.
+
+---
+
+## Default Values
+
+| Parameter | Default |
+|-----------|---------|
+| `startDate` | 28 days before today |
+| `endDate` | Today |
+| `model` | `chatgpt` |
+
+---
+
+## Sample URLs
+
+**All brands:**
+```
+GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/market-tracking-trends?model=chatgpt
+```
+
+**Single brand with site and category:**
+```
+GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/019cb903-1184-7f92-8325-f9d1176af316/brand-presence/market-tracking-trends?startDate=2025-09-01&endDate=2025-09-30&siteId=c2473d89-e997-458d-a86d-b4096649c12b&categoryId=0178a3f0-1234-7000-8000-000000000099&regionCode=US
+```
+
+---
+
+## Internal Queries (PostgREST)
+
+Two queries run in parallel.
+
+### 1. Brand executions (`brand_presence_executions`)
+
+- **Columns:** `execution_date`, `prompt`, `topics`, `region_code`, `site_id`, `mentions`, `citations`
+- **Filters:** `organization_id`, `model`, date range, optional `site_id`, `brand_id`, `category_id` / `category_name`, `region_code`
+
+### 2. Competitor aggregates (`executions_competitor_data`)
+
+- **Columns:** `execution_date`, `competitor`, `mentions`, `citations`
+- **Same dimension filters** as the brand query
+
+There is no RPC; aggregation is done in the API service (`aggregateWeeklyTrends`).
+
+---
+
+## Aggregation (`aggregateWeeklyTrends`)
+
+**Brand side:** For each ISO week (derived from `execution_date` via `dateToIsoWeek`), rows are deduplicated by `prompt|topics|region_code|site_id`. Unique keys with `mentions === true` increment the week’s mention count; unique keys with `citations === true` increment the citation count.
+
+**Competitor side:** Rows are grouped by week and competitor name; `mentions` and `citations` from `executions_competitor_data` are summed (no prompt-level deduplication on this table).
+
+**Ordering:** Weeks ascending. Competitors within a week are sorted by `mentions + citations` descending.
+
+---
+
+## Response Shape
+
+The JSON body includes `weeklyTrends` and `weeklyTrendsForComparison`. Both properties hold the **same** week objects (duplicate arrays for clients that bind two chart series).
+
+```json
+{
+  "weeklyTrends": [
+    {
+      "week": "2026-W10",
+      "weekNumber": 10,
+      "year": 2026,
+      "mentions": 42,
+      "citations": 18,
+      "competitors": [
+        { "name": "competitor_a", "mentions": 30, "citations": 10 },
+        { "name": "competitor_b", "mentions": 12, "citations": 5 }
+      ]
+    }
+  ]
+}
+```
+
+`weeklyTrendsForComparison` repeats the `weeklyTrends` array (same length and entries).
+
+**Per-week fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `week` | string | ISO week `YYYY-Wnn` |
+| `weekNumber` | number | Week of year |
+| `year` | number | ISO week year |
+| `mentions` | number | Deduped brand mention count for the week |
+| `citations` | number | Deduped brand citation count for the week |
+| `competitors` | array | `{ name, mentions, citations }` per competitor, sorted by total activity |
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ postgres) |
+| 400 | Organization not found |
+| 400 | PostgREST/PostgreSQL query error on either query |
+| 403 | User does not belong to the organization |
+| 403 | Site does not belong to the organization (when `siteId` provided; validated before queries) |
+
+---
+
+## Related APIs
+
+- [Brand Presence Sentiment Overview API](sentiment-overview-api.md) — Weekly sentiment percentages
+- [Share of Voice API](share-of-voice-api.md) — Topic-level SOV (RPC-backed)
+- [Brand Presence Filter Dimensions API](filter-dimensions-api.md) — Filter dropdown values
+- [Brand Presence Weeks API](brand-presence-weeks-api.md) — Applicable ISO weeks
+
+---
+
+## Authentication
+
+Requires valid authentication (JWT, IMS, or API key) with access to the organization.

--- a/docs/llmo-brandalf-apis/sentiment-movers-api.md
+++ b/docs/llmo-brandalf-apis/sentiment-movers-api.md
@@ -174,6 +174,8 @@ Content-Type: application/json
 
 ## Related APIs
 
+- [Brand Presence Sentiment Overview API](sentiment-overview-api.md) — Weekly sentiment distribution
+- [Brand Presence Market Tracking Trends API](market-tracking-trends-api.md) — Weekly mentions, citations, and competitors
 - [Brand Presence Filter Dimensions API](filter-dimensions-api.md) — Returns available filter options
 - [Brand Presence Weeks API](brand-presence-weeks-api.md) — Returns applicable weeks
 

--- a/docs/llmo-brandalf-apis/sentiment-overview-api.md
+++ b/docs/llmo-brandalf-apis/sentiment-overview-api.md
@@ -1,0 +1,159 @@
+# Brand Presence Sentiment Overview API
+
+Returns per-week sentiment distribution (positive, neutral, negative) for charting the Brand Presence sentiment overview. Data is read from `brand_presence_executions` via PostgREST (mysticat-data-service). Prompts are deduplicated per ISO week using the key `prompt|region_code|topics` so counts align with the legacy Brand Presence UI (unique prompts, not raw execution rows).
+
+---
+
+## API Paths
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/org/:spaceCatId/brands/all/brand-presence/sentiment-overview` | Sentiment trends for all brands in the organization |
+| GET | `/org/:spaceCatId/brands/:brandId/brand-presence/sentiment-overview` | Sentiment trends for a specific brand |
+
+**Path parameters:**
+- `spaceCatId` — Organization ID (UUID)
+- `brandId` — `all` (all brands) or a specific brand UUID
+
+---
+
+## Query Parameters
+
+Parameters are read from the request the same way as other Brand Presence org routes (typically query string fields merged into `context.data`).
+
+| Parameter | Aliases | Type | Default | Description |
+|-----------|---------|------|---------|-------------|
+| `startDate` | `start_date` | string (YYYY-MM-DD) | 28 days ago | Start of date range |
+| `endDate` | `end_date` | string (YYYY-MM-DD) | today | End of date range |
+| `model` | `platform` | string | `chatgpt` | LLM model |
+| `siteId` | `site_id` | string (UUID) | — | Filter by site |
+| `categoryId` | `category_id` | string (UUID or name) | — | Filter by category UUID or category name |
+| `topicIds` | — | string or array | — | Filter by topic UUID(s). Comma-separated, array, or single UUID; non-UUID values ignored |
+| `regionCode` | `region_code`, `region` | string | — | Filter by region code (e.g. US, DE, WW) |
+| `origin` | — | string | — | Filter by origin (case-insensitive `ILIKE` match) |
+
+---
+
+## Default Values
+
+| Parameter | Default |
+|-----------|---------|
+| `startDate` | 28 days before today |
+| `endDate` | Today |
+| `model` | `chatgpt` |
+
+---
+
+## Sample URLs
+
+**All brands, default range:**
+```
+GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/sentiment-overview
+```
+
+**Single brand with filters:**
+```
+GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/019cb903-1184-7f92-8325-f9d1176af316/brand-presence/sentiment-overview?startDate=2025-09-01&endDate=2025-09-30&model=gemini&regionCode=US
+```
+
+---
+
+## Internal Query (PostgREST)
+
+The handler selects from `brand_presence_executions`:
+
+- **Columns:** `execution_date`, `sentiment`, `prompt`, `region_code`, `topics`
+- **Filters:** `organization_id`, `execution_date` range, `model`, optional `site_id`, `brand_id` (when path is not `all`), `category_id` / `category_name`, `topic_id IN (...)`, `region_code`, `origin`
+- **Row limit:** 200,000 rows (`WEEKS_QUERY_LIMIT`)
+
+```javascript
+client
+  .from('brand_presence_executions')
+  .select('execution_date, sentiment, prompt, region_code, topics')
+  .eq('organization_id', organizationId)
+  .gte('execution_date', startDate)
+  .lte('execution_date', endDate)
+  .eq('model', model)
+  // + optional filters: site_id, brand_id, category_id/category_name, topic_id in, region_code, origin ilike
+  .limit(200000)
+```
+
+---
+
+## Aggregation (`aggregateSentimentByWeek`)
+
+1. **Bucket by ISO week** — Each `execution_date` is mapped to a week string `YYYY-Wnn` (UTC).
+2. **Deduplicate per week** — One row per `prompt|region_code|topics` per week; duplicates are skipped.
+3. **Count sentiment** — `positive`, `neutral`, and `negative` are counted case-insensitively; empty or other values do not increment sentiment buckets but still count toward `totalPrompts`.
+4. **Percentages** — `positivePct` and `negativePct` are rounded to integers; `neutralPct` = `100 - positivePct - negativePct` (so the three segments sum to 100 for display).
+
+When `brands/all` is used and the same prompt appears for multiple brands, only the first-seen row per dedup key in iteration order is used (avoids double-counting across brands).
+
+---
+
+## Response Shape
+
+```json
+{
+  "weeklyTrends": [
+    {
+      "week": "2026-W11",
+      "weekNumber": 11,
+      "year": 2026,
+      "sentiment": [
+        { "name": "Positive", "value": 45, "color": "#047857" },
+        { "name": "Neutral", "value": 30, "color": "#4B5563" },
+        { "name": "Negative", "value": 25, "color": "#B91C1C" }
+      ],
+      "totalPrompts": 120,
+      "promptsWithSentiment": 100,
+      "mentions": 0,
+      "citations": 0,
+      "visibilityScore": 0,
+      "competitors": []
+    }
+  ]
+}
+```
+
+**Field descriptions (per week object):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `week` | string | ISO week `YYYY-Wnn` |
+| `weekNumber` | number | Week of year |
+| `year` | number | ISO week year |
+| `sentiment` | array | Three slices for charts: Positive, Neutral, Negative with `value` = percentage (0–100) and fixed `color` |
+| `totalPrompts` | number | Unique prompts in the week (after dedup) |
+| `promptsWithSentiment` | number | Subset of those with a recognized positive/neutral/negative sentiment |
+| `mentions` | number | Always `0` in current implementation (reserved for chart compatibility) |
+| `citations` | number | Always `0` |
+| `visibilityScore` | number | Always `0` |
+| `competitors` | array | Always `[]` for this endpoint |
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ postgres) |
+| 400 | Organization not found |
+| 400 | PostgREST/PostgreSQL query error |
+| 403 | User does not belong to the organization |
+| 403 | Site does not belong to the organization (when `siteId` provided) |
+
+---
+
+## Related APIs
+
+- [Brand Presence Market Tracking Trends API](market-tracking-trends-api.md) — Weekly mentions, citations, and competitor breakdown
+- [Brand Presence Sentiment Movers API](sentiment-movers-api.md) — Top/bottom sentiment movers between dates
+- [Brand Presence Filter Dimensions API](filter-dimensions-api.md) — Filter dropdown values
+- [Brand Presence Weeks API](brand-presence-weeks-api.md) — Applicable ISO weeks for selectors
+
+---
+
+## Authentication
+
+Requires valid authentication (JWT, IMS, or API key) with access to the organization.

--- a/docs/llmo-brandalf-apis/share-of-voice-api.md
+++ b/docs/llmo-brandalf-apis/share-of-voice-api.md
@@ -237,3 +237,4 @@ The handler reshapes the flat RPC rows into `ShareOfVoiceData[]`:
 
 - [Brand Presence Filter Dimensions API](filter-dimensions-api.md) — Returns available filter options for the Brand Presence feature.
 - [Brand Presence Weeks API](brand-presence-weeks-api.md) — Returns applicable weeks for a given model.
+- [Brand Presence Market Tracking Trends API](market-tracking-trends-api.md) — Weekly trends from executions + competitor data (non-RPC)

--- a/docs/llmo-brandalf-apis/topics-api.md
+++ b/docs/llmo-brandalf-apis/topics-api.md
@@ -182,6 +182,8 @@ Prompts are deduplicated by `prompt|region_code` — when multiple executions ex
 
 - [Brand Presence Filter Dimensions API](filter-dimensions-api.md) — Returns available filter options
 - [Brand Presence Weeks API](brand-presence-weeks-api.md) — Returns applicable weeks
+- [Brand Presence Sentiment Overview API](sentiment-overview-api.md) — Weekly sentiment distribution for charts
+- [Brand Presence Market Tracking Trends API](market-tracking-trends-api.md) — Weekly mentions, citations, and competitors
 - [Brand Presence Sentiment Movers API](sentiment-movers-api.md) — Top/bottom sentiment movers
 
 ---


### PR DESCRIPTION
# Brand Presence API documentation — change summary

## New endpoint docs

- Added **`sentiment-overview-api.md`** and **`market-tracking-trends-api.md`** for routes that were previously undocumented (aligned with `llmo-brand-presence.js`).

## Cross-links

- Updated **Related APIs** (or equivalent) in: `topics-api.md`, `filter-dimensions-api.md`, `brand-presence-weeks-api.md`, `sentiment-movers-api.md`, `share-of-voice-api.md`, `brand-presence-stats-api.md` so readers can reach the new specs.

## Parent overview

- Added **`brand-presence-apis-overview.md`** — single index for all **12** org-scoped Brand Presence routes:
  - Master table: method, path, purpose, query/path parameters, link to example JSON below, link to the detailed doc.
  - **Detail doc** column points at the right `.md` file (and `topics-api.md` section anchors for Topics vs topic prompts).

## Table formatting (overview)

- **Query parameters** column: one parameter per line, pattern `name : sample (optional|required)`, implemented with HTML `<ul>/<li>` so lists render on separate lines in common Markdown viewers.
- Short note under the table explains the pattern
