### PR TITLE
fix: enhance llmo end point to accept imsOrgId from payload as well

### DIFF
--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -64,7 +64,7 @@ const { readConfig, writeConfig } = llmo;
 const { readStrategy, writeStrategy } = llmoStrategy;
 const { llmoConfig: llmoConfigSchema } = schemas;
 
-const IMS_ORG_ID_REGEX = /[a-z0-9]{24}@AdobeOrg/i;
+const IMS_ORG_ID_REGEX = /^[a-z0-9]{24}@AdobeOrg$/i;
 
 function LlmoController(ctx) {
   const accessControlUtil = AccessControlUtil.fromContext(ctx);
@@ -840,11 +840,11 @@ function LlmoController(ctx) {
    * Onboards a new customer to LLMO.
    * This endpoint handles the complete onboarding process for net new customers
    * including organization validation, site creation, and LLMO configuration.
+   * Requires LLMO administrator access.
    *
    * The IMS org ID is resolved in the following order of precedence:
-   * 1. `imsOrgId` field in the request payload — must match {@link IMS_ORG_ID_REGEX}
-   *    (`<24-char alphanumeric>@AdobeOrg`). Useful when an LLMO administrator is
-   *    onboarding on behalf of another org.
+   * 1. `imsOrgId` field in the request payload — must match `/^[a-z0-9]{24}@AdobeOrg$/i`.
+   *    Useful when an LLMO administrator is onboarding on behalf of another org.
    * 2. JWT token fallback — derived from `profile.tenants[0].id` appended with
    *    `@AdobeOrg`. This is the original behaviour and is preserved for backward
    *    compatibility with all existing callers that do not supply `imsOrgId`.
@@ -854,7 +854,7 @@ function LlmoController(ctx) {
    * @param {string} context.data.domain - Customer domain to onboard.
    * @param {string} context.data.brandName - Brand name for the customer.
    * @param {string} [context.data.imsOrgId] - Optional IMS org ID override
-   *   (must match `<24-char alphanumeric>@AdobeOrg`). When omitted the org ID
+   *   (must match `/^[a-z0-9]{24}@AdobeOrg$/i`). When omitted the org ID
    *   is read from the authenticated user's JWT token.
    * @returns {Promise<Response>} The onboarding response.
    */
@@ -883,8 +883,10 @@ function LlmoController(ctx) {
       if (payloadImsOrgId) {
         // Payload takes precedence — validate format before use
         if (!IMS_ORG_ID_REGEX.test(payloadImsOrgId)) {
+          log.warn(`LLMO onboarding rejected invalid imsOrgId for domain ${domain}, brand ${brandName}`);
           return badRequest('Invalid imsOrgId');
         }
+        log.info(`LLMO onboarding using payload-supplied imsOrgId for domain ${domain}, brand ${brandName}`);
         imsOrgId = payloadImsOrgId;
       } else {
         // Backward-compatible fallback: derive org ID from the JWT token

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -2840,17 +2840,13 @@ describe('LlmoController', () => {
       expect(responseBody.message).to.equal('Only LLMO administrators can onboard');
     });
 
-    it('should use imsOrgId from payload when provided and valid', async () => {
+    it('should use imsOrgId from payload when provided and valid, even with no authInfo', async () => {
       const payloadImsOrgId = 'abcdef123456789012345678@AdobeOrg';
       const contextWithPayloadOrg = {
         ...onboardingContext,
         data: { ...onboardingContext.data, imsOrgId: payloadImsOrgId },
-        // No tenants in profile — proves JWT fallback is not used
-        attributes: {
-          authInfo: {
-            getProfile: sinon.stub().returns({ email: 'admin@example.com' }),
-          },
-        },
+        // No authInfo at all — proves JWT fallback path is never reached
+        attributes: {},
       };
 
       const LlmoControllerOnboard = await esmock('../../../src/controllers/llmo/llmo.js', {
@@ -2918,7 +2914,15 @@ describe('LlmoController', () => {
       });
       const testController = LlmoControllerOnboard(mockContext);
 
-      for (const invalid of ['not-valid', 'tooshort@AdobeOrg', 'abcdef123456789012345678', 'abcdef123456789012345678@WrongSuffix']) {
+      for (const invalid of [
+        'not-valid',
+        'tooshort@AdobeOrg',
+        'abcdef123456789012345678',
+        'abcdef123456789012345678@WrongSuffix',
+        'PREFIXabcdef123456789012345678@AdobeOrg', // missing ^ anchor
+        'abcdef123456789012345678@AdobeOrg_SUFFIX', // missing $ anchor
+        'abcdef1234567890123456789@AdobeOrg', // 25 chars (off-by-one)
+      ]) {
         const contextWithBadOrg = {
           ...onboardingContext,
           data: { ...onboardingContext.data, imsOrgId: invalid },
@@ -2975,6 +2979,51 @@ describe('LlmoController', () => {
         sinon.match({ imsOrgId: 'test-tenant-id@AdobeOrg' }),
         sinon.match.any,
       );
+    });
+
+    it('should accept payload imsOrgId with uppercase letters (/i flag)', async () => {
+      const upperCaseImsOrgId = 'ABCDEF123456789012345678@ADOBEORG';
+      const contextWithUpperOrg = {
+        ...onboardingContext,
+        data: { ...onboardingContext.data, imsOrgId: upperCaseImsOrgId },
+        attributes: {},
+      };
+
+      const LlmoControllerOnboard = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-onboarding.js': {
+          validateSiteNotOnboarded: validateSiteNotOnboardedStub,
+          performLlmoOnboarding: performLlmoOnboardingStub,
+          generateDataFolder: (baseURL, env) => {
+            const url = new URL(baseURL);
+            const dataFolderName = url.hostname.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+            return env === 'prod' ? dataFolderName : `dev/${dataFolderName}`;
+          },
+        },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
+          Config: { toDynamoItem: sinon.stub().returnsArg(0) },
+        },
+        '@adobe/spacecat-shared-utils': {
+          SPACECAT_USER_AGENT: TEST_USER_AGENT,
+          tracingFetch: tracingFetchStub,
+          hasText: (text) => text && text.trim().length > 0,
+          isObject: (obj) => obj !== null && typeof obj === 'object',
+          llmoConfig,
+          schemas: {},
+          composeBaseURL: (domain) => (domain.startsWith('http') ? domain : `https://${domain}`),
+        },
+        '../../../src/support/brand-profile-trigger.js': {
+          triggerBrandProfileAgent: (...args) => triggerBrandProfileAgentStub(...args),
+        },
+        ...getCommonMocks(),
+      });
+      const testController = LlmoControllerOnboard(mockContext);
+
+      const result = await testController.onboardCustomer(contextWithUpperOrg);
+
+      expect(result.status).to.equal(200);
+      const responseBody = await result.json();
+      expect(responseBody.imsOrgId).to.equal(upperCaseImsOrgId);
     });
   });
 


### PR DESCRIPTION
## Summary

The `onboardCustomer` endpoint now accepts an optional `imsOrgId` field in
the request payload. When provided, it is validated against the IMS org ID
format and used directly, allowing LLMO administrators to onboard on behalf
of another org. When omitted, the existing JWT-derived org ID path is used
unchanged, preserving full backward compatibility.

## Changes

- Add `IMS_ORG_ID_REGEX` constant for format validation
- Resolve `imsOrgId` from payload first, fall back to JWT token
- Return `400 "Invalid imsOrgId"` without exposing the expected format
- Update JSDoc to document the two-path resolution

## Tests

- Payload `imsOrgId` is used and passed through to `performLlmoOnboarding`
- Invalid payload `imsOrgId` formats return `400` without calling `performLlmoOnboarding`
- No `imsOrgId` in payload falls back to JWT-derived org ID (backward compat)
