### PR TITLE
docs: add Fastly service reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Fastly
 
-This service runs behind Fastly CDN service `DlxppS2VoAizEqJ9bPasq6` (AEM Sites Optimizer [SpaceCat] Prod) at `spacecat.experiencecloud.live`. VCL snippets handle routing, CORS, HSTS, and API gateway auth. See `mysticat-architecture/platform/reference/fastly-services.md` for full reference.
+This service runs behind Fastly CDN service `DlxppS2VoAizEqJ9bPasq6` (AEM Sites Optimizer [SpaceCat] Prod) at `spacecat.experiencecloud.live`. VCL snippets handle routing, CORS, HSTS, and API gateway auth. See [mysticat-architecture Fastly services reference](https://github.com/adobe/mysticat-architecture/blob/main/platform/reference/fastly-services.md) for full reference.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Adds a Fastly section to CLAUDE.md documenting the CDN service ID (`DlxppS2VoAizEqJ9bPasq6`), the production domain (`spacecat.experiencecloud.live`), and what VCL snippets handle (routing, CORS, HSTS, API gateway auth)
- Points to `mysticat-architecture/platform/reference/fastly-services.md` for the full reference

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm the Fastly section appears between the intro paragraph and the Commands section