### PR TITLE
feat: LLMO-3956 write initial brand to normalized table during v2 onboarding

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1347,19 +1347,25 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       // Write initial brand to normalized brands table so DRS prompt sync can
       // find it via GET /v2/orgs/{orgId}/brands before the Brandalf job finishes.
       // Brandalf will upsert over this with LLM-identified sub-brands later.
-      const primaryUrl = siteConfig.getFetchConfig?.()?.overrideBaseURL || baseURL;
-      await upsertBrand({
-        organizationId: organization.getId(),
-        brand: {
-          name: brandName.trim(),
-          status: 'active',
-          urls: [{ value: primaryUrl, type: 'url' }],
-          brandAliases: [{ name: brandName.trim(), regions: ['gl'] }],
-        },
-        postgrestClient,
-        updatedBy: 'llmo-onboarding',
-      });
-      log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
+      // Use baseURL (matches sites.base_url) so syncBrandSites can link the brand
+      // to the site. overrideBaseURL may differ (e.g., www.blick.ch vs blick.ch)
+      // and would fail the exact-match lookup against the sites table.
+      try {
+        await upsertBrand({
+          organizationId: organization.getId(),
+          brand: {
+            name: brandName.trim(),
+            status: 'active',
+            urls: [{ value: baseURL, type: 'url' }],
+            brandAliases: [{ name: brandName.trim(), regions: ['gl'] }],
+          },
+          postgrestClient,
+          updatedBy: 'llmo-onboarding',
+        });
+        log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
+      } catch (brandError) {
+        log.warn(`Failed to create initial brand in normalized table: ${brandError.message}`);
+      }
 
       // Trigger Brandalf immediately after the v2 config exists so downstream
       // brand sync can attach results to the newly created organization.

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1316,6 +1316,7 @@ describe('LLMO Onboarding Functions', () => {
       const mockOctokit = createMockOctokit();
       const mockDrsClient = createMockDrsClient();
       const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+      const mockUpsertBrand = sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
 
       // Mock the Config import
       const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmock(
@@ -1329,6 +1330,7 @@ describe('LLMO Onboarding Functions', () => {
           mockOctokit,
           mockDrsClient,
           mockCustomerConfigV2Storage,
+          mockUpsertBrand,
         }),
       );
 
@@ -1426,7 +1428,20 @@ describe('LLMO Onboarding Functions', () => {
       });
       expect(mockLog.info).to.have.been.calledWith('Enabled brandalf feature flag for organization org123');
 
-      // Verify initial brand was written to normalized brands table
+      // Verify initial brand was written to normalized brands table with correct args
+      expect(mockUpsertBrand).to.have.been.calledOnce;
+      expect(mockUpsertBrand.firstCall.args[0]).to.deep.include({
+        organizationId: 'org123',
+        updatedBy: 'llmo-onboarding',
+      });
+      expect(mockUpsertBrand.firstCall.args[0].brand).to.deep.include({
+        name: 'Test Brand',
+        status: 'active',
+      });
+      // Must use baseURL (matches sites.base_url), not overrideBaseURL
+      expect(mockUpsertBrand.firstCall.args[0].brand.urls).to.deep.equal([
+        { value: 'https://example.com', type: 'url' },
+      ]);
       expect(mockLog.info).to.have.been.calledWith('Created initial brand "Test Brand" in normalized table for site site123');
 
       // Verify enableAudits was called
@@ -1455,6 +1470,110 @@ describe('LLMO Onboarding Functions', () => {
       // Verify logging
       expect(mockLog.info).to.have.been.calledWith('Starting LLMO onboarding for IMS org ABC123@AdobeOrg, baseURL https://example.com, brand Test Brand');
       expect(mockLog.info).to.have.been.calledWith('Created site site123 for https://example.com using LLMO onboarding mode v2');
+    });
+
+    it('should continue onboarding when upsertBrand fails', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns({
+          updateLlmoBrand: sinon.stub(),
+          updateLlmoDataFolder: sinon.stub(),
+          getImports: sinon.stub().returns([]),
+          enableImport: sinon.stub(),
+          getFetchConfig: sinon.stub().returns({}),
+          updateFetchConfig: sinon.stub(),
+          getBrandProfile: sinon.stub().returns(null),
+        }),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      // Feature flag postgrest mock
+      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const selectRead = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select: selectRead,
+        upsert: upsertStub,
+      });
+
+      // upsertBrand throws — should not block onboarding
+      const failingUpsertBrand = sinon.stub().rejects(new Error('PostgREST unavailable'));
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+
+      const { performLlmoOnboarding: onboardWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockUpsertBrand: failingUpsertBrand,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await onboardWithMocks(
+        {
+          domain: 'example.com',
+          imsOrgId: 'ABC123@AdobeOrg',
+          brandName: 'Test Brand',
+        },
+        context,
+      );
+
+      // Onboarding completes despite upsertBrand failure
+      expect(result.message).to.equal(
+        'LLMO onboarding completed successfully',
+      );
+      expect(failingUpsertBrand).to.have.been.calledOnce;
+      expect(mockLog.warn).to.have.been.calledWith(
+        'Failed to create initial brand in normalized table: '
+        + 'PostgREST unavailable',
+      );
+      // Brandalf job should still be submitted
+      expect(mockDrsClient.createFrom().submitJob)
+        .to.have.been.called;
     });
 
     it('should skip v2 initialization and Brandalf in v1 onboarding mode', async () => {


### PR DESCRIPTION
## Summary
- During v2 onboarding, writes the initial brand to the normalized `brands` + `brand_sites` tables (via `upsertBrand`) before submitting DRS jobs
- This ensures `GET /v2/orgs/{orgId}/brands` returns a brand with site linkage immediately, eliminating a race condition where the prompt generation job could finish before the Brandalf job creates the brand
- Brandalf will upsert over this minimal entry with LLM-identified sub-brands later

## Context
Companion to [adobe-rnd/llmo-data-retrieval-service#1153](https://github.com/adobe-rnd/llmo-data-retrieval-service/pull/1153) which switches DRS prompt sync from the non-existent `GET /v2/orgs/{id}/llmo-customer-config` endpoint to the working `GET /v2/orgs/{id}/brands` endpoint. This PR ensures a brand exists in the normalized table before DRS jobs run.

Related PRs:
- [#2066](https://github.com/adobe/spacecat-api-service/pull/2066) — enable brandalf feature flag during v2 onboarding (merged)
- [#2080](https://github.com/adobe/spacecat-api-service/pull/2080) — add new site as brand to existing v2 config (merged)
- [adobe-rnd/llmo-data-retrieval-service#1153](https://github.com/adobe-rnd/llmo-data-retrieval-service/pull/1153) — use brands API for v2 prompt sync

## Test plan
- [x] Full test suite: 6936 passing, 100% coverage
- [x] Lint clean
- [ ] E2E: onboard site, verify brand appears in `GET /v2/orgs/{orgId}/brands` before Brandalf completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)