### PR TITLE
feat: add CI-level OpenAPI documentation validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ admin-idp-p*.json
 .prettierrc
 .vscode/settings.json
 
+# Generated OpenAPI bundle (test artifact)
+docs/openapi/.bundled-api.json
+
 # Cursor
 .cursor/*
 !.cursor/rules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,8 @@
         "@semantic-release/git": "10.0.1",
         "@semantic-release/npm": "12.0.2",
         "@xmldom/xmldom": "0.9.9",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "c8": "10.1.3",
         "chai": "6.2.2",
         "chai-as-promised": "8.0.2",
@@ -17157,10 +17159,9 @@
       }
     },
     "node_modules/ajv": {
-      "name": "@redocly/ajv",
       "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,8 @@
     "@semantic-release/git": "10.0.1",
     "@semantic-release/npm": "12.0.2",
     "@xmldom/xmldom": "0.9.9",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "c8": "10.1.3",
     "chai": "6.2.2",
     "chai-as-promised": "8.0.2",

--- a/src/routes/undocumented-routes.js
+++ b/src/routes/undocumented-routes.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Routes that exist in code but are not yet documented in the OpenAPI spec.
+ * Each entry must have a comment explaining why it is undocumented.
+ *
+ * This list is enforced by test/routes/openapi-coverage.test.js with a ratchet:
+ * the count cannot grow without updating the ceiling in the test.
+ * As routes are documented in OpenAPI, remove them from this list.
+ *
+ * Format: 'METHOD /path/:param' (same as routeDefinitions in routes/index.js)
+ *
+ * @type {string[]}
+ */
+export const UNDOCUMENTED_ROUTES = [
+  // --- Categories (v2) ---
+  'GET /v2/orgs/:spaceCatId/categories',
+  'POST /v2/orgs/:spaceCatId/categories',
+  'PATCH /v2/orgs/:spaceCatId/categories/:categoryId',
+  'DELETE /v2/orgs/:spaceCatId/categories/:categoryId',
+
+  // --- Config sync ---
+  'POST /v2/orgs/:spaceCatId/sites/:siteId/sync-config',
+
+  // --- Sites: export formats ---
+  'GET /sites.csv',
+  'GET /sites.xlsx',
+
+  // --- Sites: metadata ---
+  'GET /sites/:siteId/metadata',
+
+  // --- Sites: URL store (bulk operations without URL in path) ---
+  'POST /sites/:siteId/url-store',
+  'PATCH /sites/:siteId/url-store',
+
+  // --- Sites: opportunities ---
+  'GET /sites/:siteId/opportunities/top-paid',
+
+  // --- Sites: page citability ---
+  'GET /sites/:siteId/page-citability/counts',
+
+  // --- Sites: LLMO ---
+  'PATCH /sites/:siteId/llmo/config',
+  'GET /sites/:siteId/llmo/rationale',
+
+  // --- Sites: site enrollments ---
+  'POST /sites/:siteId/site-enrollments',
+
+  // --- Sites: IMS org access delegation ---
+  'POST /sites/:siteId/ims-org-access',
+  'GET /sites/:siteId/ims-org-access',
+  'GET /sites/:siteId/ims-org-access/:accessId',
+  'DELETE /sites/:siteId/ims-org-access/:accessId',
+
+  // --- Slack ---
+  'GET /slack/events',
+  'POST /slack/events',
+
+  // --- Tools: import ---
+  'GET /tools/import/jobs/by-date-range/:startDate/:endDate/all-jobs',
+
+  // --- Tools: scrape ---
+  'GET /tools/scrape/jobs/by-url/:url',
+
+  // --- Organizations: user details ---
+  'GET /organizations/:organizationId/userDetails/:externalUserId',
+  'POST /organizations/:organizationId/userDetails',
+
+  // --- Organizations: entitlements ---
+  'POST /organizations/:organizationId/entitlements',
+
+  // --- Trial users ---
+  'GET /trial-users/email-preferences',
+  'PATCH /trial-users/email-preferences',
+
+  // --- Consumers ---
+  'GET /consumers',
+  'GET /consumers/by-client-id/:clientId',
+  'GET /consumers/:consumerId',
+  'POST /consumers/register',
+  'PATCH /consumers/:consumerId',
+  'POST /consumers/:consumerId/revoke',
+
+  // --- Brand presence analytics (org-level) ---
+  'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions',
+  'GET /org/:spaceCatId/brands/all/brand-presence/weeks',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/weeks',
+  'GET /org/:spaceCatId/brands/all/brand-presence/sentiment-overview',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/sentiment-overview',
+  'GET /org/:spaceCatId/brands/all/brand-presence/market-tracking-trends',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/market-tracking-trends',
+  'GET /org/:spaceCatId/brands/all/brand-presence/topics',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics',
+  'GET /org/:spaceCatId/brands/all/brand-presence/topics/:topicId/prompts',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/prompts',
+  'GET /org/:spaceCatId/brands/all/brand-presence/search',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/search',
+  'GET /org/:spaceCatId/brands/all/brand-presence/topics/:topicId/detail',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/detail',
+  'GET /org/:spaceCatId/brands/all/brand-presence/topics/:topicId/prompt-detail',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/prompt-detail',
+  'GET /org/:spaceCatId/brands/all/brand-presence/sentiment-movers',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/sentiment-movers',
+  'GET /org/:spaceCatId/brands/all/brand-presence/share-of-voice',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/share-of-voice',
+  'GET /org/:spaceCatId/brands/all/brand-presence/stats',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/stats',
+  'GET /org/:spaceCatId/opportunities/count',
+  'GET /org/:spaceCatId/brands/all/opportunities',
+  'GET /org/:spaceCatId/brands/:brandId/opportunities',
+];
+
+/**
+ * OpenAPI paths documented in the spec but with no corresponding code route.
+ * These are tracked here so the coverage test can account for them.
+ * Each entry should be investigated: remove from OpenAPI if dead, or add code route if planned.
+ *
+ * Format: 'METHOD /openapi/path/{param}' (OpenAPI format)
+ *
+ * @type {string[]}
+ */
+export const PHANTOM_OPENAPI_ROUTES = [
+  // Auth routes — documented but not implemented in routes/index.js
+  'GET /auth/google/{siteId}',
+  'GET /auth/google/{siteId}/status',
+  'POST /auth/login',
+
+  // Hook — documented but not in routes
+  'POST /hooks/site-integration/analytics/{hookSecret}',
+
+  // LLMO customer config (v2) — documented but not in routes
+  'GET /v2/orgs/{spaceCatId}/llmo-customer-config',
+  'POST /v2/orgs/{spaceCatId}/llmo-customer-config',
+  'PATCH /v2/orgs/{spaceCatId}/llmo-customer-config',
+  'GET /v2/orgs/{spaceCatId}/llmo-customer-config-lean',
+  'GET /v2/orgs/{spaceCatId}/llmo-topics',
+  'GET /v2/orgs/{spaceCatId}/llmo-prompts',
+
+  // URL store — OpenAPI uses {base64Url} in path, code uses bulk endpoint without URL param
+  'POST /sites/{siteId}/url-store/{base64Url}',
+  'PATCH /sites/{siteId}/url-store/{base64Url}',
+];

--- a/test/it/shared/helpers/assertions.js
+++ b/test/it/shared/helpers/assertions.js
@@ -11,7 +11,7 @@
  */
 
 import { expect } from 'chai';
-import { validateResponseSchema } from './schema-validator.js';
+import { validateResponseSchema, validateRequestSchema } from './schema-validator.js';
 
 const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
 
@@ -146,10 +146,52 @@ export function expectSchemaValid(res, method, openApiPath) {
   if (res.status >= 400 || res.body == null) return;
 
   const statusCode = String(res.status);
-  const { errors } = validateResponseSchema(method, openApiPath, statusCode, res.body);
+  const result = validateResponseSchema(method, openApiPath, statusCode, res.body);
+
+  expect(
+    result.errors,
+    `OpenAPI schema mismatch [${method} ${openApiPath} ${statusCode}]:\n${result.errors.join('\n')}`,
+  ).to.have.lengthOf(0);
+}
+
+/**
+ * Strict variant of expectSchemaValid that also rejects undocumented fields.
+ * Injects `additionalProperties: false` into every object schema that doesn't
+ * explicitly set it, catching fields returned by DTOs but missing from the spec.
+ *
+ * @param {object} res - HTTP response { status, body }
+ * @param {string} method - HTTP method
+ * @param {string} openApiPath - OpenAPI path template
+ */
+export function expectSchemaValidStrict(res, method, openApiPath) {
+  if (res.status >= 400 || res.body == null) return;
+
+  const statusCode = String(res.status);
+  const opts = { strict: true };
+  const result = validateResponseSchema(method, openApiPath, statusCode, res.body, opts);
+
+  expect(
+    result.errors,
+    `OpenAPI strict schema mismatch [${method} ${openApiPath} ${statusCode}]:\n${result.errors.join('\n')}`,
+  ).to.have.lengthOf(0);
+}
+
+/**
+ * Validates that a request body conforms to the declared OpenAPI requestBody
+ * schema. Proves that input parameter types and required fields are
+ * documented correctly.
+ *
+ * @param {*} body - The request body that will be / was sent
+ * @param {string} method - HTTP method (POST, PATCH, etc.)
+ * @param {string} openApiPath - OpenAPI path template
+ */
+export function expectRequestSchemaValid(body, method, openApiPath) {
+  if (body == null) return;
+
+  const { errors } = validateRequestSchema(method, openApiPath, body);
 
   expect(
     errors,
-    `OpenAPI schema mismatch [${method} ${openApiPath} ${statusCode}]:\n${errors.join('\n')}`,
+    `OpenAPI request schema mismatch [${method} ${openApiPath}]:\n${errors.join('\n')}`,
   ).to.have.lengthOf(0);
 }

--- a/test/it/shared/helpers/assertions.js
+++ b/test/it/shared/helpers/assertions.js
@@ -11,6 +11,7 @@
  */
 
 import { expect } from 'chai';
+import { validateResponseSchema } from './schema-validator.js';
 
 const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
 
@@ -131,4 +132,24 @@ export function expectBatch201(res, expectedTotal) {
 export function expectNonEmptyString(value, label = 'field') {
   expect(value, `${label} should be a string`).to.be.a('string');
   expect(value, `${label} should not be empty`).to.have.length.greaterThan(0);
+}
+
+/**
+ * Validates that an API response body conforms to the declared OpenAPI schema.
+ * Skips validation for error responses (4xx/5xx) and empty bodies.
+ *
+ * @param {object} res - HTTP response { status, body }
+ * @param {string} method - HTTP method (GET, POST, etc.)
+ * @param {string} openApiPath - OpenAPI path template (e.g., '/sites/{siteId}')
+ */
+export function expectSchemaValid(res, method, openApiPath) {
+  if (res.status >= 400 || res.body == null) return;
+
+  const statusCode = String(res.status);
+  const { errors } = validateResponseSchema(method, openApiPath, statusCode, res.body);
+
+  expect(
+    errors,
+    `OpenAPI schema mismatch [${method} ${openApiPath} ${statusCode}]:\n${errors.join('\n')}`,
+  ).to.have.lengthOf(0);
 }

--- a/test/it/shared/helpers/schema-validator.js
+++ b/test/it/shared/helpers/schema-validator.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(testDir, '../../../..');
+
+/**
+ * OpenAPI-specific keywords that are not part of JSON Schema and must be stripped
+ * before AJV compilation to keep strict mode enabled.
+ */
+const OPENAPI_KEYWORDS = [
+  'example', 'examples', 'externalDocs', 'discriminator',
+  'xml', 'deprecated', 'readOnly', 'writeOnly',
+];
+
+let bundledSpec = null;
+let ajv = null;
+const validatorCache = new Map();
+
+/**
+ * Bundles and caches the OpenAPI spec using @redocly/cli.
+ * Called lazily on first use. Takes ~3s.
+ */
+function getBundledSpec() {
+  if (bundledSpec) return bundledSpec;
+
+  const apiYamlPath = join(rootDir, 'docs/openapi/api.yaml');
+  const output = execSync(
+    `npx @redocly/cli bundle "${apiYamlPath}" --format json`,
+    { cwd: rootDir, encoding: 'utf8', timeout: 30000 },
+  );
+  bundledSpec = JSON.parse(output);
+  return bundledSpec;
+}
+
+/**
+ * Returns a configured AJV instance with format validators.
+ */
+function getAjv() {
+  if (ajv) return ajv;
+  ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv;
+}
+
+/**
+ * Recursively strips OpenAPI-specific keywords from a schema object.
+ * Returns a new object — does not mutate the input.
+ */
+function stripOpenApiKeywords(schema) {
+  if (schema == null || typeof schema !== 'object') return schema;
+  if (Array.isArray(schema)) return schema.map(stripOpenApiKeywords);
+
+  return Object.fromEntries(
+    Object.entries(schema)
+      .filter(([key]) => !OPENAPI_KEYWORDS.includes(key) && !key.startsWith('x-'))
+      .map(([key, value]) => [key, stripOpenApiKeywords(value)]),
+  );
+}
+
+/**
+ * Retrieves the response schema for a given method, path, and status code.
+ *
+ * @param {string} method - HTTP method (GET, POST, etc.)
+ * @param {string} openApiPath - OpenAPI path template (e.g., '/sites/{siteId}')
+ * @param {string} statusCode - HTTP status code (e.g., '200')
+ * @returns {object|null} The JSON Schema for the response body, or null if not defined
+ */
+export function getSchemaForResponse(method, openApiPath, statusCode) {
+  const spec = getBundledSpec();
+  const pathDef = spec.paths?.[openApiPath];
+  if (!pathDef) return null;
+
+  const operation = pathDef[method.toLowerCase()];
+  if (!operation) return null;
+
+  const response = operation.responses?.[statusCode];
+  if (!response) return null;
+
+  return response.content?.['application/json']?.schema ?? null;
+}
+
+/**
+ * Validates a response body against the declared OpenAPI schema.
+ *
+ * @param {string} method - HTTP method
+ * @param {string} openApiPath - OpenAPI path template
+ * @param {string} statusCode - HTTP status code as string
+ * @param {*} body - The response body to validate
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateResponseSchema(method, openApiPath, statusCode, body) {
+  // Skip validation for empty bodies
+  if (body == null) return { valid: true, errors: [] };
+
+  const schema = getSchemaForResponse(method, openApiPath, statusCode);
+  if (!schema) {
+    // No schema defined for this response — nothing to validate
+    return { valid: true, errors: [] };
+  }
+
+  const cacheKey = `${method}:${openApiPath}:${statusCode}`;
+  let validate = validatorCache.get(cacheKey);
+
+  if (!validate) {
+    const cleaned = stripOpenApiKeywords(schema);
+    const ajvInstance = getAjv();
+    try {
+      validate = ajvInstance.compile(cleaned);
+    } catch (err) {
+      return {
+        valid: false,
+        errors: [`Schema compilation failed for ${cacheKey}: ${err.message}`],
+      };
+    }
+    validatorCache.set(cacheKey, validate);
+  }
+
+  // For array responses, validate the body directly
+  // For object responses, validate the body directly
+  const valid = validate(body);
+
+  if (valid) return { valid: true, errors: [] };
+
+  const errors = validate.errors.map((err) => {
+    const path = err.instancePath || '(root)';
+    return `${path}: ${err.message} (${JSON.stringify(err.params)})`;
+  });
+
+  return { valid: false, errors };
+}

--- a/test/it/shared/helpers/schema-validator.js
+++ b/test/it/shared/helpers/schema-validator.js
@@ -11,6 +11,7 @@
  */
 
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import Ajv2020 from 'ajv/dist/2020.js';
@@ -40,11 +41,13 @@ function getBundledSpec() {
   if (bundledSpec) return bundledSpec;
 
   const apiYamlPath = join(rootDir, 'docs/openapi/api.yaml');
-  const output = execSync(
-    `npx @redocly/cli bundle "${apiYamlPath}" --format json`,
+  const outPath = join(rootDir, 'docs/openapi/.bundled-api.json');
+  execSync(
+    `npx @redocly/cli bundle "${apiYamlPath}" --ext json -o "${outPath}"`,
     { cwd: rootDir, encoding: 'utf8', timeout: 30000 },
   );
-  bundledSpec = JSON.parse(output);
+  const content = readFileSync(outPath, 'utf8');
+  bundledSpec = JSON.parse(content);
   return bundledSpec;
 }
 

--- a/test/it/shared/helpers/schema-validator.js
+++ b/test/it/shared/helpers/schema-validator.js
@@ -43,7 +43,7 @@ function getBundledSpec() {
   const apiYamlPath = join(rootDir, 'docs/openapi/api.yaml');
   const outPath = join(rootDir, 'docs/openapi/.bundled-api.json');
   execSync(
-    `npx @redocly/cli bundle "${apiYamlPath}" --ext json -o "${outPath}"`,
+    `npx @redocly/cli bundle "${apiYamlPath}" --dereferenced --ext json -o "${outPath}"`,
     { cwd: rootDir, encoding: 'utf8', timeout: 30000 },
   );
   const content = readFileSync(outPath, 'utf8');

--- a/test/it/shared/helpers/schema-validator.js
+++ b/test/it/shared/helpers/schema-validator.js
@@ -21,7 +21,7 @@ const rootDir = join(testDir, '../../../..');
 
 /**
  * OpenAPI-specific keywords that are not part of JSON Schema and must be stripped
- * before AJV compilation to keep strict mode enabled.
+ * before AJV compilation.
  */
 const OPENAPI_KEYWORDS = [
   'example', 'examples', 'externalDocs', 'discriminator',
@@ -74,12 +74,80 @@ function stripOpenApiKeywords(schema) {
 }
 
 /**
- * Retrieves the response schema for a given method, path, and status code.
+ * Recursively injects `additionalProperties: false` into every object schema
+ * that has `properties` defined but no explicit `additionalProperties` setting.
+ * This enables strict validation that catches undocumented fields in responses.
  *
- * @param {string} method - HTTP method (GET, POST, etc.)
- * @param {string} openApiPath - OpenAPI path template (e.g., '/sites/{siteId}')
- * @param {string} statusCode - HTTP status code (e.g., '200')
- * @returns {object|null} The JSON Schema for the response body, or null if not defined
+ * Skips schemas that already set `additionalProperties` (true, false, or schema),
+ * and schemas without `properties` (e.g., free-form objects, maps).
+ */
+function injectStrictAdditionalProperties(schema) {
+  if (schema == null || typeof schema !== 'object') return schema;
+  if (Array.isArray(schema)) return schema.map(injectStrictAdditionalProperties);
+
+  const result = {};
+  for (const [key, value] of Object.entries(schema)) {
+    result[key] = injectStrictAdditionalProperties(value);
+  }
+
+  if (
+    result.type === 'object'
+    && result.properties
+    && !('additionalProperties' in result)
+  ) {
+    result.additionalProperties = false;
+  }
+
+  return result;
+}
+
+/**
+ * Compiles and caches an AJV validator for a given schema.
+ */
+function compileValidator(cacheKey, schema, { strict = false } = {}) {
+  const fullKey = strict ? `strict:${cacheKey}` : cacheKey;
+  let validate = validatorCache.get(fullKey);
+
+  if (!validate) {
+    let cleaned = stripOpenApiKeywords(schema);
+    if (strict) {
+      cleaned = injectStrictAdditionalProperties(cleaned);
+    }
+    const ajvInstance = getAjv();
+    try {
+      validate = ajvInstance.compile(cleaned);
+    } catch (err) {
+      return {
+        valid: false,
+        errors: [`Schema compilation failed for ${fullKey}: ${err.message}`],
+      };
+    }
+    validatorCache.set(fullKey, validate);
+  }
+
+  return validate;
+}
+
+/**
+ * Runs an AJV validator against a body and formats errors.
+ */
+function runValidation(validate, body) {
+  // compileValidator may return an error object instead of a function
+  if (validate.valid === false) return validate;
+
+  const valid = validate(body);
+  if (valid) return { valid: true, errors: [] };
+
+  const errors = validate.errors.map((err) => {
+    const path = err.instancePath || '(root)';
+    return `${path}: ${err.message} (${JSON.stringify(err.params)})`;
+  });
+
+  return { valid: false, errors };
+}
+
+/**
+ * Retrieves the response schema for a given method, path, and status code.
  */
 export function getSchemaForResponse(method, openApiPath, statusCode) {
   const spec = getBundledSpec();
@@ -96,51 +164,66 @@ export function getSchemaForResponse(method, openApiPath, statusCode) {
 }
 
 /**
+ * Retrieves the request body schema for a given method and path.
+ */
+export function getSchemaForRequest(method, openApiPath) {
+  const spec = getBundledSpec();
+  const pathDef = spec.paths?.[openApiPath];
+  if (!pathDef) return null;
+
+  const operation = pathDef[method.toLowerCase()];
+  if (!operation) return null;
+
+  return operation.requestBody?.content?.['application/json']?.schema ?? null;
+}
+
+/**
  * Validates a response body against the declared OpenAPI schema.
  *
  * @param {string} method - HTTP method
  * @param {string} openApiPath - OpenAPI path template
  * @param {string} statusCode - HTTP status code as string
  * @param {*} body - The response body to validate
+ * @param {object} [options]
+ * @param {boolean} [options.strict=false] - When true, injects
+ *   additionalProperties: false into all object schemas that don't
+ *   explicitly set it. This catches undocumented fields in responses.
  * @returns {{ valid: boolean, errors: string[] }}
  */
-export function validateResponseSchema(method, openApiPath, statusCode, body) {
-  // Skip validation for empty bodies
+export function validateResponseSchema(
+  method,
+  openApiPath,
+  statusCode,
+  body,
+  { strict = false } = {},
+) {
   if (body == null) return { valid: true, errors: [] };
 
   const schema = getSchemaForResponse(method, openApiPath, statusCode);
-  if (!schema) {
-    // No schema defined for this response — nothing to validate
-    return { valid: true, errors: [] };
-  }
+  if (!schema) return { valid: true, errors: [] };
 
-  const cacheKey = `${method}:${openApiPath}:${statusCode}`;
-  let validate = validatorCache.get(cacheKey);
+  const cacheKey = `res:${method}:${openApiPath}:${statusCode}`;
+  const validate = compileValidator(cacheKey, schema, { strict });
 
-  if (!validate) {
-    const cleaned = stripOpenApiKeywords(schema);
-    const ajvInstance = getAjv();
-    try {
-      validate = ajvInstance.compile(cleaned);
-    } catch (err) {
-      return {
-        valid: false,
-        errors: [`Schema compilation failed for ${cacheKey}: ${err.message}`],
-      };
-    }
-    validatorCache.set(cacheKey, validate);
-  }
+  return runValidation(validate, body);
+}
 
-  // For array responses, validate the body directly
-  // For object responses, validate the body directly
-  const valid = validate(body);
+/**
+ * Validates a request body against the declared OpenAPI requestBody schema.
+ *
+ * @param {string} method - HTTP method
+ * @param {string} openApiPath - OpenAPI path template
+ * @param {*} body - The request body to validate
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateRequestSchema(method, openApiPath, body) {
+  if (body == null) return { valid: true, errors: [] };
 
-  if (valid) return { valid: true, errors: [] };
+  const schema = getSchemaForRequest(method, openApiPath);
+  if (!schema) return { valid: true, errors: [] };
 
-  const errors = validate.errors.map((err) => {
-    const path = err.instancePath || '(root)';
-    return `${path}: ${err.message} (${JSON.stringify(err.params)})`;
-  });
+  const cacheKey = `req:${method}:${openApiPath}`;
+  const validate = compileValidator(cacheKey, schema);
 
-  return { valid: false, errors };
+  return runValidation(validate, body);
 }

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -11,7 +11,12 @@
  */
 
 import { expect } from 'chai';
-import { expectISOTimestamp, expectSchemaValid } from '../helpers/assertions.js';
+import {
+  expectISOTimestamp,
+  expectSchemaValid,
+  expectSchemaValidStrict,
+  expectRequestSchemaValid,
+} from '../helpers/assertions.js';
 import {
   ORG_1_ID,
   ORG_2_ID,
@@ -83,6 +88,7 @@ export default function siteTests(getHttpClient, resetData) {
         const res = await http.admin.get('/sites');
         expect(res.status).to.equal(200);
         expectSchemaValid(res, 'GET', '/sites');
+        expectSchemaValidStrict(res, 'GET', '/sites');
         // getAll excludes DEFAULT_ORGANIZATION_ID (ORG_1) sites (SITE_1, SITE_2)
         // Returns SITE_3 (ORG_2) + SITE_4 (ORG_3)
         expect(res.body).to.be.an('array').with.lengthOf(2);
@@ -105,6 +111,7 @@ export default function siteTests(getHttpClient, resetData) {
         const res = await http.admin.get(`/sites/${SITE_1_ID}`);
         expect(res.status).to.equal(200);
         expectSchemaValid(res, 'GET', '/sites/{siteId}');
+        expectSchemaValidStrict(res, 'GET', '/sites/{siteId}');
         expectSiteDto(res.body);
         expect(res.body.id).to.equal(SITE_1_ID);
         expect(res.body.baseURL).to.equal(SITE_1_BASE_URL);
@@ -264,11 +271,12 @@ export default function siteTests(getHttpClient, resetData) {
 
       it('admin: creates a new site', async () => {
         const http = getHttpClient();
-        const res = await http.admin.post('/sites', {
-          baseURL: 'https://new-it-site.example.com',
-        });
+        const body = { baseURL: 'https://new-it-site.example.com' };
+        expectRequestSchemaValid(body, 'POST', '/sites');
+        const res = await http.admin.post('/sites', body);
         expect(res.status).to.equal(201);
         expectSchemaValid(res, 'POST', '/sites');
+        expectSchemaValidStrict(res, 'POST', '/sites');
         expectSiteDto(res.body);
         expect(res.body.baseURL).to.equal('https://new-it-site.example.com');
         expect(res.body.organizationId).to.equal(ORG_1_ID);
@@ -309,11 +317,12 @@ export default function siteTests(getHttpClient, resetData) {
 
       it('user: updates accessible site name', async () => {
         const http = getHttpClient();
-        const res = await http.user.patch(`/sites/${testSiteId}`, {
-          name: 'Updated Site Name',
-        });
+        const body = { name: 'Updated Site Name' };
+        expectRequestSchemaValid(body, 'PATCH', '/sites/{siteId}');
+        const res = await http.user.patch(`/sites/${testSiteId}`, body);
         expect(res.status).to.equal(200);
         expectSchemaValid(res, 'PATCH', '/sites/{siteId}');
+        expectSchemaValidStrict(res, 'PATCH', '/sites/{siteId}');
         expectSiteDto(res.body);
         expect(res.body.id).to.equal(testSiteId);
         expect(res.body.name).to.equal('Updated Site Name');

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -11,7 +11,7 @@
  */
 
 import { expect } from 'chai';
-import { expectISOTimestamp } from '../helpers/assertions.js';
+import { expectISOTimestamp, expectSchemaValid } from '../helpers/assertions.js';
 import {
   ORG_1_ID,
   ORG_2_ID,
@@ -82,6 +82,7 @@ export default function siteTests(getHttpClient, resetData) {
         const http = getHttpClient();
         const res = await http.admin.get('/sites');
         expect(res.status).to.equal(200);
+        expectSchemaValid(res, 'GET', '/sites');
         // getAll excludes DEFAULT_ORGANIZATION_ID (ORG_1) sites (SITE_1, SITE_2)
         // Returns SITE_3 (ORG_2) + SITE_4 (ORG_3)
         expect(res.body).to.be.an('array').with.lengthOf(2);
@@ -103,6 +104,7 @@ export default function siteTests(getHttpClient, resetData) {
         const http = getHttpClient();
         const res = await http.admin.get(`/sites/${SITE_1_ID}`);
         expect(res.status).to.equal(200);
+        expectSchemaValid(res, 'GET', '/sites/{siteId}');
         expectSiteDto(res.body);
         expect(res.body.id).to.equal(SITE_1_ID);
         expect(res.body.baseURL).to.equal(SITE_1_BASE_URL);
@@ -180,6 +182,7 @@ export default function siteTests(getHttpClient, resetData) {
         const http = getHttpClient();
         const res = await http.admin.get(`/sites/by-base-url/${base64url(SITE_1_BASE_URL)}`);
         expect(res.status).to.equal(200);
+        expectSchemaValid(res, 'GET', '/sites/by-base-url/{base64BaseUrl}');
         expectSiteDto(res.body);
         expect(res.body.id).to.equal(SITE_1_ID);
         expect(res.body.baseURL).to.equal(SITE_1_BASE_URL);
@@ -212,6 +215,7 @@ export default function siteTests(getHttpClient, resetData) {
         const http = getHttpClient();
         const res = await http.admin.get('/sites/by-delivery-type/aem_edge');
         expect(res.status).to.equal(200);
+        expectSchemaValid(res, 'GET', '/sites/by-delivery-type/{deliveryType}');
         // SITE_1, SITE_3, and SITE_4 are aem_edge; SITE_2 is aem_cs
         expect(res.body).to.be.an('array').with.lengthOf(3);
         res.body.forEach((site) => {
@@ -264,6 +268,7 @@ export default function siteTests(getHttpClient, resetData) {
           baseURL: 'https://new-it-site.example.com',
         });
         expect(res.status).to.equal(201);
+        expectSchemaValid(res, 'POST', '/sites');
         expectSiteDto(res.body);
         expect(res.body.baseURL).to.equal('https://new-it-site.example.com');
         expect(res.body.organizationId).to.equal(ORG_1_ID);
@@ -308,6 +313,7 @@ export default function siteTests(getHttpClient, resetData) {
           name: 'Updated Site Name',
         });
         expect(res.status).to.equal(200);
+        expectSchemaValid(res, 'PATCH', '/sites/{siteId}');
         expectSiteDto(res.body);
         expect(res.body.id).to.equal(testSiteId);
         expect(res.body.name).to.equal('Updated Site Name');

--- a/test/routes/openapi-coverage.test.js
+++ b/test/routes/openapi-coverage.test.js
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { expect } from 'chai';
+import YAML from 'yaml';
+import { INTERNAL_ROUTES } from '../../src/routes/required-capabilities.js';
+import { UNDOCUMENTED_ROUTES, PHANTOM_OPENAPI_ROUTES } from '../../src/routes/undocumented-routes.js';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(testDir, '../..');
+const openApiDir = join(rootDir, 'docs/openapi');
+
+/**
+ * Known parameter name differences between Express routes and OpenAPI paths.
+ * Key: Express param name (without colon), Value: OpenAPI param name (without braces).
+ */
+const PARAM_NAME_MAP = {
+  baseURL: 'base64BaseUrl',
+  url: 'base64Url',
+  id: 'apiKeyId',
+};
+
+/**
+ * Converts an Express-style route to OpenAPI format.
+ * 'GET /sites/:siteId' -> 'GET /sites/{siteId}'
+ * Also applies known parameter name normalizations.
+ */
+function toOpenApiFormat(route) {
+  return route.replace(/:([^/]+)/g, (_, paramName) => {
+    const mapped = PARAM_NAME_MAP[paramName] || paramName;
+    return `{${mapped}}`;
+  });
+}
+
+/**
+ * Normalizes all path parameters to {_} for structural comparison.
+ * 'GET /sites/{siteId}' -> 'GET /sites/{_}'
+ */
+function normalizeParams(route) {
+  return route.replace(/\{[^}]+\}/g, '{_}');
+}
+
+/**
+ * Extracts route keys from src/routes/index.js using regex.
+ * Same approach proven in required-capabilities.test.js.
+ */
+function extractCodeRoutes() {
+  const routesPath = join(rootDir, 'src/routes/index.js');
+  const content = readFileSync(routesPath, 'utf8');
+  const routeDefMatch = content.match(/const routeDefinitions = \{([\s\S]*?)\};/);
+  if (!routeDefMatch) {
+    throw new Error('Could not find routeDefinitions in routes/index.js');
+  }
+  const routeKeys = [...routeDefMatch[1].matchAll(/'([A-Z]+\s[^']+)'/g)].map((m) => m[1]);
+  if (routeKeys.length <= 100) {
+    throw new Error('Regex failed to extract routes from routes/index.js - format may have changed');
+  }
+  return routeKeys;
+}
+
+/**
+ * Decodes a JSON Pointer fragment (used in $ref anchors).
+ * ~1 -> /, ~0 -> ~
+ */
+function decodeJsonPointer(fragment) {
+  return fragment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+/**
+ * Resolves a nested YAML value by following a slash-separated key path.
+ * Handles both direct keys and JSON Pointer encoded keys.
+ */
+function resolveAnchor(parsed, anchor) {
+  // First try direct key lookup (most common case)
+  if (parsed[anchor]) return parsed[anchor];
+
+  // Try JSON Pointer path traversal for nested anchors like 'paths/~1sites~1{siteId}'
+  const parts = anchor.split('/');
+  let current = parsed;
+  for (const part of parts) {
+    const decoded = decodeJsonPointer(part);
+    if (current == null || typeof current !== 'object') return null;
+    current = current[decoded];
+  }
+  return current;
+}
+
+/**
+ * Extracts all METHOD + path combinations from the OpenAPI spec.
+ * Reads api.yaml, follows $ref pointers to domain files, and extracts HTTP methods.
+ */
+function extractOpenApiRoutes() {
+  const apiYaml = readFileSync(join(openApiDir, 'api.yaml'), 'utf8');
+  const spec = YAML.parse(apiYaml);
+  const routes = [];
+  const httpMethods = ['get', 'post', 'put', 'patch', 'delete'];
+
+  for (const [pathTemplate, ref] of Object.entries(spec.paths)) {
+    const refStr = ref.$ref;
+    if (!refStr) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const [file, anchor] = refStr.split('#/');
+    const filePath = join(openApiDir, file);
+
+    let fileContent;
+    try {
+      fileContent = readFileSync(filePath, 'utf8');
+    } catch {
+      throw new Error(
+        `OpenAPI $ref file not found: ${filePath} (path ${pathTemplate})`,
+      );
+    }
+
+    const parsed = YAML.parse(fileContent);
+    const pathDef = resolveAnchor(parsed, anchor);
+    if (!pathDef) {
+      throw new Error(
+        `Missing anchor '${anchor}' in ${file} (path ${pathTemplate})`,
+      );
+    }
+
+    const methods = httpMethods.filter((m) => pathDef[m]);
+    for (const method of methods) {
+      routes.push(`${method.toUpperCase()} ${pathTemplate}`);
+    }
+  }
+
+  return routes;
+}
+
+// Pre-compute at module load time (outside mocha timeout)
+const codeRoutes = extractCodeRoutes();
+const openApiRoutes = extractOpenApiRoutes();
+
+describe('OpenAPI coverage', () => {
+  it('every code route must be documented in OpenAPI or listed as undocumented/internal', () => {
+    const openApiSet = new Set(openApiRoutes.map(normalizeParams));
+    const internalSet = new Set(
+      INTERNAL_ROUTES.map((r) => normalizeParams(toOpenApiFormat(r))),
+    );
+    const undocumentedSet = new Set(
+      UNDOCUMENTED_ROUTES.map((r) => normalizeParams(toOpenApiFormat(r))),
+    );
+
+    const missing = codeRoutes
+      .map(toOpenApiFormat)
+      .map(normalizeParams)
+      .filter((r) => !openApiSet.has(r) && !internalSet.has(r) && !undocumentedSet.has(r));
+
+    expect(
+      missing,
+      `Code route(s) not documented in OpenAPI and not in UNDOCUMENTED_ROUTES or INTERNAL_ROUTES:\n${missing.join('\n')}`,
+    ).to.have.lengthOf(0);
+  });
+
+  it('every OpenAPI path must have a corresponding code route or be listed as phantom', () => {
+    const codeSet = new Set(codeRoutes.map((r) => normalizeParams(toOpenApiFormat(r))));
+    const phantomSet = new Set(PHANTOM_OPENAPI_ROUTES.map(normalizeParams));
+
+    const orphaned = openApiRoutes
+      .map(normalizeParams)
+      .filter((r) => !codeSet.has(r) && !phantomSet.has(r));
+
+    expect(
+      orphaned,
+      `OpenAPI path(s) with no corresponding code route and not in PHANTOM_OPENAPI_ROUTES:\n${orphaned.join('\n')}`,
+    ).to.have.lengthOf(0);
+  });
+
+  it('UNDOCUMENTED_ROUTES entries must all correspond to actual code routes', () => {
+    const codeSet = new Set(codeRoutes.map((r) => normalizeParams(toOpenApiFormat(r))));
+
+    const stale = UNDOCUMENTED_ROUTES
+      .map((r) => normalizeParams(toOpenApiFormat(r)))
+      .filter((r) => !codeSet.has(r));
+
+    expect(
+      stale,
+      `UNDOCUMENTED_ROUTES entries with no matching code route (remove stale entries):\n${stale.join('\n')}`,
+    ).to.have.lengthOf(0);
+  });
+
+  it('UNDOCUMENTED_ROUTES entries must not already be documented in OpenAPI', () => {
+    const openApiSet = new Set(openApiRoutes.map(normalizeParams));
+
+    const alreadyDocumented = UNDOCUMENTED_ROUTES
+      .map((r) => normalizeParams(toOpenApiFormat(r)))
+      .filter((r) => openApiSet.has(r));
+
+    expect(
+      alreadyDocumented,
+      `UNDOCUMENTED_ROUTES entries that are already in OpenAPI (remove from allowlist):\n${alreadyDocumented.join('\n')}`,
+    ).to.have.lengthOf(0);
+  });
+
+  it('PHANTOM_OPENAPI_ROUTES entries must all exist in the OpenAPI spec', () => {
+    const openApiSet = new Set(openApiRoutes.map(normalizeParams));
+
+    const stale = PHANTOM_OPENAPI_ROUTES
+      .map(normalizeParams)
+      .filter((r) => !openApiSet.has(r));
+
+    expect(
+      stale,
+      `PHANTOM_OPENAPI_ROUTES entries not found in OpenAPI spec (remove stale entries):\n${stale.join('\n')}`,
+    ).to.have.lengthOf(0);
+  });
+
+  describe('ratchet', () => {
+    // This ceiling must only decrease over time as routes get documented.
+    // Increase it only if intentionally adding new undocumented routes.
+    const UNDOCUMENTED_CEILING = 61;
+    const PHANTOM_CEILING = 12;
+
+    it(`UNDOCUMENTED_ROUTES count must not exceed ${UNDOCUMENTED_CEILING}`, () => {
+      expect(
+        UNDOCUMENTED_ROUTES.length,
+        `UNDOCUMENTED_ROUTES has ${UNDOCUMENTED_ROUTES.length} entries (ceiling: ${UNDOCUMENTED_CEILING}). `
+        + 'If you added new routes, document them in OpenAPI instead of adding to this list. '
+        + 'If you documented existing routes, lower the ceiling.',
+      ).to.be.at.most(UNDOCUMENTED_CEILING);
+    });
+
+    it(`PHANTOM_OPENAPI_ROUTES count must not exceed ${PHANTOM_CEILING}`, () => {
+      expect(
+        PHANTOM_OPENAPI_ROUTES.length,
+        `PHANTOM_OPENAPI_ROUTES has ${PHANTOM_OPENAPI_ROUTES.length} entries (ceiling: ${PHANTOM_CEILING}). `
+        + 'If you added new OpenAPI paths, ensure they have a code route. '
+        + 'If you removed phantom paths, lower the ceiling.',
+      ).to.be.at.most(PHANTOM_CEILING);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Layer 1 — Route coverage** (unit tests): Fails CI when code routes lack OpenAPI documentation or vice versa. Explicit allowlist for 61 currently undocumented routes with a ratchet mechanism that prevents the count from growing.
- **Layer 2 — Response schema validation** (IT tests): Validates actual API response bodies against declared OpenAPI schemas using AJV, proving output types and required fields are correct.
- **Layer 2 — Request schema validation** (IT tests): Validates request bodies against declared OpenAPI `requestBody` schemas, proving input types and required fields are documented correctly.
- **Layer 2 — Strict response mode** (IT tests): Injects `additionalProperties: false` into object schemas to catch undocumented fields leaking through DTOs that are missing from the spec.
- Both layers run within existing CI pipeline (`npm test` and `it-postgres`) — no workflow changes needed

## New assertion helpers for IT tests
| Helper | Purpose |
|--------|---------|
| `expectSchemaValid(res, method, path)` | Validates response body matches declared schema (types, required fields) |
| `expectSchemaValidStrict(res, method, path)` | Same + rejects undocumented fields not in the schema |
| `expectRequestSchemaValid(body, method, path)` | Validates request body matches declared requestBody schema |

## Test plan
- [x] `npm test` passes (7182 tests, including 7 new OpenAPI coverage tests)
- [x] `npm run lint` passes
- [ ] IT tests (`npx mocha --require test/it/postgres/harness.js --timeout 30000 'test/it/postgres/sites.test.js'`) validate schema assertions
- [ ] Verify removing an OpenAPI path causes the coverage test to fail
- [ ] Verify adding a new route without OpenAPI docs causes the coverage test to fail
- [ ] Verify `expectSchemaValidStrict` catches undocumented response fields
- [ ] Verify `expectRequestSchemaValid` catches request body type mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)