### PR TITLE
feat(plg): PLG tier, ASO enrollment revocation, FF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@adobe/spacecat-shared-gpt-client": "1.6.22",
         "@adobe/spacecat-shared-http-utils": "1.25.2",
         "@adobe/spacecat-shared-ims-client": "1.12.5",
+        "@adobe/spacecat-shared-launchdarkly-client": "^1.1.0",
         "@adobe/spacecat-shared-rum-api-client": "2.40.12",
         "@adobe/spacecat-shared-scrape-client": "2.6.2",
         "@adobe/spacecat-shared-slack-client": "1.6.6",
@@ -699,6 +700,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -6421,6 +6423,600 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-launchdarkly-client/-/spacecat-shared-launchdarkly-client-1.1.1.tgz",
+      "integrity": "sha512-4jFAsTs69d7WXABjbxoe4mEAjNr8qnsuPtoqSbtpRE+xlk/dVsj7LAj/lQtJuPq7RmtLv/5RdmiKx3V7RgqBmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/helix-universal": "5.4.1",
+        "@adobe/spacecat-shared-utils": "1.81.1",
+        "@launchdarkly/node-server-sdk": "^9.9.7"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@adobe/spacecat-shared-utils": {
+      "version": "1.81.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
+      "integrity": "sha512-GSQuLJsPsT6SDJNydhozgRNHl5qat4f+W7/IwyAvNfAqgPrF6Eb7+h4ZUz8Nb01Rm13Z18f6NY/u/wW12sdxtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/fetch": "4.2.3",
+        "@aws-sdk/client-s3": "3.940.0",
+        "@aws-sdk/client-sqs": "3.940.0",
+        "@json2csv/plainjs": "7.0.6",
+        "aws-xray-sdk": "3.12.0",
+        "cheerio": "1.1.2",
+        "date-fns": "4.1.0",
+        "franc-min": "6.2.0",
+        "iso-639-3": "3.0.1",
+        "validator": "^13.15.15",
+        "world-countries": "5.1.0",
+        "zod": "^4.1.11"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/client-s3": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.940.0.tgz",
+      "integrity": "sha512-Wi4qnBT6shRRMXuuTgjMFTU5mu2KFWisgcigEMPptjPGUtJvBVi4PTGgS64qsLoUk/obqDAyOBOfEtRZ2ddC2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.936.0",
+        "@aws-sdk/middleware-expect-continue": "3.936.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-location-constraint": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-s3": "3.940.0",
+        "@aws-sdk/middleware-ssec": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/signature-v4-multi-region": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-blob-browser": "^4.2.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/hash-stream-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/client-sqs": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.940.0.tgz",
+      "integrity": "sha512-tXPi9OlELbiewGDb9maXDMhdYW617I9osGo/C1GAR6eLYwj40/TfOBeOQf3tX9EcH8NpDBuMksxoAvkpvqYIKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/core": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
+      "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.940.0.tgz",
+      "integrity": "sha512-/G3l5/wbZYP2XEQiOoIkRJmlv15f1P3MSd1a0gz27lHEMrOJOGq66rF1Ca4OJLzapWt3Fy9BPrZAepoAX11kMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.940.0.tgz",
+      "integrity": "sha512-dOrc03DHElNBD6N9Okt4U0zhrG4Wix5QUBSZPr5VN8SvmjD9dkrrxOkkJaMCl/bzrW7kbQEp7LuBdbxArMmOZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.940.0.tgz",
+      "integrity": "sha512-gn7PJQEzb/cnInNFTOaDoCN/hOKqMejNmLof1W5VW95Qk0TPO52lH8R4RmJPnRrwFMswOWswTOpR1roKNLIrcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-env": "3.940.0",
+        "@aws-sdk/credential-provider-http": "3.940.0",
+        "@aws-sdk/credential-provider-login": "3.940.0",
+        "@aws-sdk/credential-provider-process": "3.940.0",
+        "@aws-sdk/credential-provider-sso": "3.940.0",
+        "@aws-sdk/credential-provider-web-identity": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.940.0.tgz",
+      "integrity": "sha512-M8NFAvgvO6xZjiti5kztFiAYmSmSlG3eUfr4ZHSfXYZUA/KUdZU/D6xJyaLnU8cYRWBludb6K9XPKKVwKfqm4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.940.0",
+        "@aws-sdk/credential-provider-http": "3.940.0",
+        "@aws-sdk/credential-provider-ini": "3.940.0",
+        "@aws-sdk/credential-provider-process": "3.940.0",
+        "@aws-sdk/credential-provider-sso": "3.940.0",
+        "@aws-sdk/credential-provider-web-identity": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.940.0.tgz",
+      "integrity": "sha512-pILBzt5/TYCqRsJb7vZlxmRIe0/T+FZPeml417EK75060ajDGnVJjHcuVdLVIeKoTKm9gmJc9l45gon6PbHyUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.940.0.tgz",
+      "integrity": "sha512-q6JMHIkBlDCOMnA3RAzf8cGfup+8ukhhb50fNpghMs1SNBGhanmaMbZSgLigBRsPQW7fOk2l8jnzdVLS+BB9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.940.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/token-providers": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.940.0.tgz",
+      "integrity": "sha512-9QLTIkDJHHaYL0nyymO41H8g3ui1yz6Y3GmAN1gYQa6plXisuFBnGAbmKVj7zNvjWaOKdF0dV3dd3AFKEDoJ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.936.0.tgz",
+      "integrity": "sha512-XLSVVfAorUxZh6dzF+HTOp4R1B5EQcdpGcPliWr0KUj2jukgjZEcqbBmjyMF/p9bmyQsONX80iURF1HLAlW0qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.936.0.tgz",
+      "integrity": "sha512-Eb4ELAC23bEQLJmUMYnPWcjD3FZIsmz2svDiXEcxRkQU9r7NRID7pM7C5NPH94wOfiCk0b2Y8rVyFXW0lGQwbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.940.0.tgz",
+      "integrity": "sha512-WdsxDAVj5qaa5ApAP+JbpCOMHFGSmzjs2Y2OBSbWPeR9Ew7t/Okj+kUub94QJPsgzhvU1/cqNejhsw5VxeFKSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.936.0.tgz",
+      "integrity": "sha512-SCMPenDtQMd9o5da9JzkHz838w3327iqXk3cbNnXWqnNRx6unyW8FL0DZ84gIY12kAyVHz5WEqlWuekc15ehfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.940.0.tgz",
+      "integrity": "sha512-JYkLjgS1wLoKHJ40G63+afM1ehmsPsjcmrHirKh8+kSCx4ip7+nL1e/twV4Zicxr8RJi9Y0Ahq5mDvneilDDKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.936.0.tgz",
+      "integrity": "sha512-39WohFCCPeD6LV8zLQq7CyYbIieetEDDNLsEPeGJSh2Uv9qpY9r6zJRSTjb8hTuQbHDSEOGntHMYKpLoHdoxdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.936.0.tgz",
+      "integrity": "sha512-/GLC9lZdVp05ozRik5KsuODR/N7j+W+2TbfdFL3iS+7un+gnP6hC8RDOZd6WhpZp7drXQ9guKiTAxkZQwzS8DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.940.0.tgz",
+      "integrity": "sha512-nJbLrUj6fY+l2W2rIB9P4Qvpiy0tnTdg/dmixRxrU1z3e8wBdspJlyE+AZN4fuVbeL6rrRrO/zxQC1bB3cw5IA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.940.0.tgz",
+      "integrity": "sha512-x0mdv6DkjXqXEcQj3URbCltEzW6hoy/1uIL+i8gExP6YKrnhiZ7SzuB4gPls2UOpK5UqLiqXjhRLfBb1C9i4Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.940.0.tgz",
+      "integrity": "sha512-ugHZEoktD/bG6mdgmhzLDjMP2VrYRAUPRPF1DpCyiZexkH7DCU7XrSJyXMvkcf0DHV+URk0q2sLf/oqn1D2uYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/token-providers": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.940.0.tgz",
+      "integrity": "sha512-k5qbRe/ZFjW9oWEdzLIa2twRVIEx7p/9rutofyrRysrtEnYh3HAWCngAnwbgKMoiwa806UzcTRx0TjyEpnKcCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.940.0.tgz",
+      "integrity": "sha512-dlD/F+L/jN26I8Zg5x0oDGJiA+/WEQmnSE27fi5ydvYnpfQLwThtQo9SsNS47XSR/SOULaaoC9qx929rZuo74A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-launchdarkly-client/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@adobe/spacecat-shared-rum-api-client": {
       "version": "2.40.12",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.40.12.tgz",
@@ -10221,6 +10817,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -14345,6 +14942,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -14499,6 +15097,60 @@
         "@langchain/core": ">=0.3.68 <0.4.0"
       }
     },
+    "node_modules/@launchdarkly/js-sdk-common": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.0.tgz",
+      "integrity": "sha512-f/xRD8gl/bSOVljat79nAzX0V0QjJ76R54aAbB6PJDWL+7BWBSFMxduaeokzbX53cs3oOVajL8ej/ps7+ojMeQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@launchdarkly/js-server-sdk-common": {
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.3.tgz",
+      "integrity": "sha512-9lf1IRLJSghtDZlUT04KmmJOwRnAUuqXUcn7C2S9jNPDvrsmFJeD9Dpn7PoCUOR5rZgqAEveWdlBw9qjWeY6jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@launchdarkly/js-sdk-common": "2.24.0",
+        "semver": "7.5.4"
+      }
+    },
+    "node_modules/@launchdarkly/js-server-sdk-common/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@launchdarkly/js-server-sdk-common/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@launchdarkly/node-server-sdk": {
+      "version": "9.10.10",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.10.tgz",
+      "integrity": "sha512-qJNVrHbX+FKUhVUl7FWK9ICsL4lJmHBE7vOCkvERFFODRxYrrf8HdiyYDf79aI8JMSOLCKZgcJJKNXAvRJXThg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@launchdarkly/js-server-sdk-common": "2.18.3",
+        "https-proxy-agent": "^7.0.6",
+        "launchdarkly-eventsource": "2.2.0"
+      }
+    },
     "node_modules/@microsoft/microsoft-graph-client": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-3.0.7.tgz",
@@ -14576,6 +15228,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -14782,6 +15435,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -14945,6 +15599,7 @@
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -16938,6 +17593,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -17253,6 +17909,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -17300,6 +17957,7 @@
       "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17775,6 +18433,7 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -18437,6 +19096,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20649,6 +21309,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -24331,6 +24992,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/launchdarkly-eventsource": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-2.2.0.tgz",
+      "integrity": "sha512-u38fYlLSq/m6oFz0MS1/76Sj2xzlYhTKZ+sf/vju6PA86PMc6fPlY5k8CdU79edLXjNwsvIQTDvDNy3llDqB8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -24913,6 +25583,7 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -25967,6 +26638,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -28548,6 +29220,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -29084,6 +29757,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -30329,6 +31003,7 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30339,6 +31014,7 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -31108,6 +31784,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -32515,6 +33192,7 @@
       "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -33612,6 +34290,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -34364,6 +35043,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -34434,6 +35114,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",
@@ -34628,6 +35314,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -34637,6 +35324,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@adobe/spacecat-shared-gpt-client": "1.6.22",
     "@adobe/spacecat-shared-http-utils": "1.25.2",
     "@adobe/spacecat-shared-ims-client": "1.12.5",
+    "@adobe/spacecat-shared-launchdarkly-client": "^1.1.0",
     "@adobe/spacecat-shared-rum-api-client": "2.40.12",
     "@adobe/spacecat-shared-scrape-client": "2.6.2",
     "@adobe/spacecat-shared-slack-client": "1.6.6",

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -54,7 +54,13 @@ const ASO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.ASO;
 const ASO_TIER = EntitlementModel.TIERS.PLG;
 const PLG_PROFILE_KEY = 'aso_plg';
 const LD_FF_PROJECT_NAME = 'experience-success-studio';
-const LD_AUTO_FIX_META_TAGS_FLAG = 'auto-fix-meta-tags';
+const LD_API_TOKEN_ENV_VAR = 'LD_EXPERIENCE_SUCCESS_API_TOKEN';
+const LD_AUTO_FIX_FLAGS = [
+  'auto-fix-meta-tags',
+  'cwv-auto-fix',
+  'alt-text-auto-fix',
+  'broken-backlinks-auto-fix',
+];
 
 const REVIEW_REASONS = {
   DOMAIN_ALREADY_ONBOARDED_IN_ORG: 'DOMAIN_ALREADY_ONBOARDED_IN_ORG',
@@ -182,22 +188,63 @@ async function revokePreOnboardedSiteEnrollment(site, entitlement, context) {
 }
 
 /**
- * TODO: Update LaunchDarkly feature flags for the PLG tier transition.
- * Called after a site is successfully enrolled in the PLG tier.
- * Flag names and API details to be provided by the team.
- * @param {object} site - The onboarded site.
- * @param {object} context - Request context.
+ * Upserts a single LaunchDarkly flag's variation 0 to include the org + site.
+ * Variation 0 value is a JSON object: { [imsOrgId]: [siteBaseURLs] }.
+ * @param {object} ldClient - LaunchDarklyClient instance.
+ * @param {string} flagKey - Flag key.
+ * @param {string} imsOrgId - IMS org ID.
+ * @param {string} siteBaseURL - Site base URL.
+ * @param {object} log - Logger.
  */
+async function upsertLdFlag(ldClient, flagKey, imsOrgId, siteBaseURL, log) {
+  const flag = await ldClient.getFeatureFlag(LD_FF_PROJECT_NAME, flagKey);
+  const rawValue = flag.variations?.[0]?.value;
+
+  if (rawValue === undefined) {
+    log.warn(`LaunchDarkly flag ${flagKey} has no variations`);
+    return;
+  }
+
+  const isStringWrapped = typeof rawValue === 'string';
+  const parsed = isStringWrapped ? JSON.parse(rawValue) : rawValue;
+
+  const existingSites = parsed[imsOrgId] ?? [];
+  if (existingSites.includes(siteBaseURL)) {
+    log.info(`LaunchDarkly: ${siteBaseURL} already in ${flagKey} for org ${imsOrgId}`);
+    return;
+  }
+
+  const merged = { ...parsed, [imsOrgId]: [...existingSites, siteBaseURL] };
+  const newValue = isStringWrapped ? JSON.stringify(merged) : merged;
+
+  await ldClient.updateVariationValue(
+    LD_FF_PROJECT_NAME,
+    flagKey,
+    0,
+    newValue,
+    `plg-onboarding: enable ${flagKey} for ${imsOrgId} / ${siteBaseURL}`,
+  );
+
+  log.info(`LaunchDarkly: enabled ${flagKey} for org ${imsOrgId}, site ${siteBaseURL}`);
+}
+
 /**
- * Enables the `auto-fix-meta-tags` LaunchDarkly feature flag for the given site's org.
- * Variation 0 of the flag holds a JSON object mapping IMS org IDs to site base URL arrays.
- * This function adds the org + site URL to that variation (upsert semantics).
+ * Enables all PLG auto-fix LaunchDarkly feature flags for the given site's org.
+ * Uses the experience-success-studio project token (LD_EXPERIENCE_SUCCESS_API_TOKEN).
+ * Each flag update is non-fatal — onboarding continues even if one fails.
  * @param {object} site - The onboarded site.
  * @param {object} context - Request context.
  */
 async function updateLaunchDarklyFlags(site, context) {
-  const { log } = context;
-  const ldClient = LaunchDarklyClient.createFrom(context);
+  const { log, env } = context;
+
+  const apiToken = env[LD_API_TOKEN_ENV_VAR];
+  if (!apiToken) {
+    log.warn(`Cannot update LaunchDarkly flags: ${LD_API_TOKEN_ENV_VAR} is not set`);
+    return;
+  }
+
+  const ldClient = new LaunchDarklyClient({ apiToken }, log);
 
   const imsOrgId = (await context.dataAccess.Organization.findById(
     await site.getOrganizationId(),
@@ -210,39 +257,15 @@ async function updateLaunchDarklyFlags(site, context) {
 
   const siteBaseURL = site.getBaseURL();
 
-  try {
-    const flag = await ldClient.getFeatureFlag(LD_FF_PROJECT_NAME, LD_AUTO_FIX_META_TAGS_FLAG);
-    const rawValue = flag.variations?.[0]?.value;
+  const results = await Promise.allSettled(
+    LD_AUTO_FIX_FLAGS.map((flagKey) => upsertLdFlag(ldClient, flagKey, imsOrgId, siteBaseURL, log)),
+  );
 
-    if (rawValue === undefined) {
-      log.warn(`LaunchDarkly flag ${LD_AUTO_FIX_META_TAGS_FLAG} has no variations`);
-      return;
+  results.forEach((result, i) => {
+    if (result.status === 'rejected') {
+      log.error(`Failed to update LaunchDarkly flag ${LD_AUTO_FIX_FLAGS[i]}: ${result.reason?.message}`);
     }
-
-    const isStringWrapped = typeof rawValue === 'string';
-    const parsed = isStringWrapped ? JSON.parse(rawValue) : rawValue;
-
-    const existingSites = parsed[imsOrgId] ?? [];
-    if (existingSites.includes(siteBaseURL)) {
-      log.info(`LaunchDarkly: ${siteBaseURL} already in ${LD_AUTO_FIX_META_TAGS_FLAG} for org ${imsOrgId}`);
-      return;
-    }
-
-    const merged = { ...parsed, [imsOrgId]: [...existingSites, siteBaseURL] };
-    const newValue = isStringWrapped ? JSON.stringify(merged) : merged;
-
-    await ldClient.updateVariationValue(
-      LD_FF_PROJECT_NAME,
-      LD_AUTO_FIX_META_TAGS_FLAG,
-      0,
-      newValue,
-      `plg-onboarding: enable auto-fix-meta-tags for ${imsOrgId} / ${siteBaseURL}`,
-    );
-
-    log.info(`LaunchDarkly: enabled ${LD_AUTO_FIX_META_TAGS_FLAG} for org ${imsOrgId}, site ${siteBaseURL}`);
-  } catch (error) {
-    log.error(`Failed to update LaunchDarkly flag ${LD_AUTO_FIX_META_TAGS_FLAG}: ${error.message}`);
-  }
+  });
 }
 
 async function createOrFindProject(baseURL, organizationId, context) {
@@ -656,6 +679,7 @@ async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHos
     const { entitlement } = await ensureAsoEntitlement(site, context);
     await revokePreOnboardedSiteEnrollment(site, entitlement, context);
     await updateLaunchDarklyFlags(site, context);
+
     steps.entitlementCreated = true;
 
     // Step 10: Trigger audit runs

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -35,7 +35,6 @@ import {
   enableAudits,
   enableImports,
   triggerAudits,
-  ASO_DEMO_ORG,
 } from '../llmo/llmo-onboarding.js';
 import {
   autoResolveAuthorUrl,
@@ -144,10 +143,6 @@ function isSafeDomain(domain) {
     /\.private\./i,
   ];
   return !blocked.some((pattern) => pattern.test(domain));
-}
-
-function isInternalOrg(orgId, env) {
-  return orgId === env.DEFAULT_ORGANIZATION_ID || orgId === ASO_DEMO_ORG;
 }
 
 async function ensureAsoEntitlement(site, context) {
@@ -300,7 +295,7 @@ async function createOrFindProject(baseURL, organizationId, context) {
  * @returns {Promise<object>} PlgOnboarding record
  */
 async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHost }, context) {
-  const { dataAccess, log, env } = context;
+  const { dataAccess, log } = context;
   const { Site, PlgOnboarding, Organization } = dataAccess;
 
   if (!isValidHostname(domain)) {
@@ -422,8 +417,7 @@ async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHos
     if (site) {
       const existingOrgId = site.getOrganizationId();
 
-      if (existingOrgId !== organizationId
-        && !isInternalOrg(existingOrgId, env)) {
+      if (existingOrgId !== organizationId) {
         const existingOrg = await Organization.findById(existingOrgId);
         /* c8 ignore next */
         const existingImsOrgId = existingOrg?.getImsOrgId?.() || existingOrgId;
@@ -435,12 +429,6 @@ async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHos
         onboarding.setSteps(steps);
         await onboarding.save();
         return onboarding;
-      }
-
-      // Move from internal org to customer's org if needed
-      if (existingOrgId !== organizationId) {
-        site.setOrganizationId(organizationId);
-        log.info(`Reassigning site ${site.getId()} from org ${existingOrgId} to ${organizationId}`);
       }
     }
 

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -39,7 +39,6 @@ import {
 import {
   autoResolveAuthorUrl,
   findDeliveryType,
-  deriveProjectName,
   updateCodeConfig,
   queueDeliveryConfigWriter,
 } from '../../support/utils.js';
@@ -50,8 +49,9 @@ import AccessControlUtil from '../../support/access-control-util.js';
 
 const { STATUSES, REVIEW_DECISIONS } = PlgOnboardingModel;
 const ASO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.ASO;
-const ASO_TIER = EntitlementModel.TIERS.FREE_TRIAL;
+const ASO_TIER = EntitlementModel.TIERS.PLG;
 const PLG_PROFILE_KEY = 'aso_plg';
+const PLG_PROJECT_NAME = 'experience-success-studio';
 
 const REVIEW_REASONS = {
   DOMAIN_ALREADY_ONBOARDED_IN_ORG: 'DOMAIN_ALREADY_ONBOARDED_IN_ORG',
@@ -144,30 +144,60 @@ function isInternalOrg(orgId, env) {
 
 async function ensureAsoEntitlement(site, context) {
   const { log } = context;
+  const tierClient = await TierClient.createForSite(context, site, ASO_PRODUCT_CODE);
   try {
-    const tierClient = await TierClient.createForSite(context, site, ASO_PRODUCT_CODE);
-    const { entitlement, siteEnrollment } = await tierClient
-      .createEntitlement(ASO_TIER);
-    log.info(`Created ASO entitlement ${entitlement.getId()} and enrollment ${siteEnrollment.getId()} for site ${site.getId()}`);
-    return { entitlement, siteEnrollment };
+    const result = await tierClient.createEntitlement(ASO_TIER);
+    log.info(`ASO entitlement ${result.entitlement.getId()} and enrollment ${result.siteEnrollment?.getId()} ensured for site ${site.getId()}`);
+    return result;
   } catch (error) {
-    if (error.message?.includes('already exists')
-      || error.message?.includes('Already enrolled')) {
-      log.info(`ASO entitlement already exists for site ${site.getId()}`);
-      return null;
+    if (error.message?.includes('already exists') || error.message?.includes('Already enrolled')) {
+      log.info(`ASO entitlement already exists for site ${site.getId()}, fetching existing`);
+      return tierClient.checkValidEntitlement();
     }
     throw error;
   }
 }
 
-async function createOrFindProject(baseURL, organizationId, context) {
+/**
+ * Revokes the ASO site enrollment for any other site under the same entitlement.
+ * Used to enforce one active PLG enrollment per org when upgrading from PRE_ONBOARD.
+ * @param {object} site - The newly enrolled site.
+ * @param {object} entitlement - The ASO entitlement for the org.
+ * @param {object} context - Request context.
+ */
+async function revokePreOnboardedSiteEnrollment(site, entitlement, context) {
+  const { dataAccess, log } = context;
+  const { SiteEnrollment } = dataAccess;
+
+  const enrollments = await SiteEnrollment.allByEntitlementId(entitlement.getId());
+  const toRevoke = enrollments.find((e) => e.getSiteId() !== site.getId());
+
+  if (toRevoke) {
+    log.info(`Revoking ASO enrollment ${toRevoke.getId()} for previously enrolled site ${toRevoke.getSiteId()}`);
+    await toRevoke.remove();
+  }
+}
+
+/**
+ * TODO: Update LaunchDarkly feature flags for the PLG tier transition.
+ * Called after a site is successfully enrolled in the PLG tier.
+ * Flag names and API details to be provided by the team.
+ * @param {object} site - The onboarded site.
+ * @param {object} context - Request context.
+ */
+// eslint-disable-next-line no-unused-vars
+async function updateLaunchDarklyFlags(site, context) {
+  // TODO: implement once flag names and LD API details are confirmed
+  context.log.info(`[TODO] LaunchDarkly FF update placeholder for site ${site.getId()}`);
+}
+
+async function createOrFindProject(organizationId, context) {
   const { dataAccess, log } = context;
   const { Project } = dataAccess;
-  const projectName = deriveProjectName(baseURL);
 
   const existingProject = (
     await Project.allByOrganizationId(organizationId)
-  ).find((p) => p.getProjectName() === projectName);
+  ).find((p) => p.getProjectName() === PLG_PROJECT_NAME);
 
   if (existingProject) {
     log.debug(`Found existing project ${existingProject.getId()}`);
@@ -175,9 +205,9 @@ async function createOrFindProject(baseURL, organizationId, context) {
   }
 
   const newProject = await Project.create({
-    projectName, organizationId,
+    projectName: PLG_PROJECT_NAME, organizationId,
   });
-  log.info(`Created project ${newProject.getId()} for ${baseURL}`);
+  log.info(`Created project ${newProject.getId()} for org ${organizationId}`);
   return newProject;
 }
 
@@ -260,7 +290,9 @@ async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHos
     log.info(`Fast-tracking preonboarded record ${onboarding.getId()}`);
     const site = await Site.findById(onboarding.getSiteId());
     if (site) {
-      await ensureAsoEntitlement(site, context);
+      const { entitlement } = await ensureAsoEntitlement(site, context);
+      await revokePreOnboardedSiteEnrollment(site, entitlement, context);
+      await updateLaunchDarklyFlags(site, context);
       const steps = { ...(onboarding.getSteps() || {}), entitlementCreated: true };
       onboarding.setStatus(STATUSES.ONBOARDED);
       onboarding.setSteps(steps);
@@ -506,7 +538,7 @@ async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHos
     }
 
     // Create/assign project
-    const project = await createOrFindProject(baseURL, organizationId, context);
+    const project = await createOrFindProject(organizationId, context);
     if (!site.getProjectId()) {
       site.setProjectId(project.getId());
     }
@@ -565,8 +597,10 @@ async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHos
       log.warn(`Failed to enroll site in config handlers: ${error.message}`);
     }
 
-    // Step 9: Add ASO entitlement
-    await ensureAsoEntitlement(site, context);
+    // Step 9: Add ASO entitlement, revoke any pre-onboarded site's enrollment, update FF
+    const { entitlement } = await ensureAsoEntitlement(site, context);
+    await revokePreOnboardedSiteEnrollment(site, entitlement, context);
+    await updateLaunchDarklyFlags(site, context);
     steps.entitlementCreated = true;
 
     // Step 10: Trigger audit runs

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -56,10 +56,9 @@ const PLG_PROFILE_KEY = 'aso_plg';
 const LD_FF_PROJECT_NAME = 'experience-success-studio';
 const LD_API_TOKEN_ENV_VAR = 'LD_EXPERIENCE_SUCCESS_API_TOKEN';
 const LD_AUTO_FIX_FLAGS = [
-  'auto-fix-meta-tags',
-  'cwv-auto-fix',
-  'alt-text-auto-fix',
-  'broken-backlinks-auto-fix',
+  'FF_cwv-auto-fix',
+  'FF_alt-text-auto-fix',
+  'FF_broken-backlinks-auto-fix',
 ];
 
 const REVIEW_REASONS = {
@@ -196,7 +195,7 @@ async function revokePreOnboardedSiteEnrollment(site, entitlement, context) {
  * @param {string} siteBaseURL - Site base URL.
  * @param {object} log - Logger.
  */
-async function upsertLdFlag(ldClient, flagKey, imsOrgId, siteBaseURL, log) {
+async function upsertLdFlag(ldClient, flagKey, imsOrgId, siteId, log) {
   const flag = await ldClient.getFeatureFlag(LD_FF_PROJECT_NAME, flagKey);
   const rawValue = flag.variations?.[0]?.value;
 
@@ -209,12 +208,12 @@ async function upsertLdFlag(ldClient, flagKey, imsOrgId, siteBaseURL, log) {
   const parsed = isStringWrapped ? JSON.parse(rawValue) : rawValue;
 
   const existingSites = parsed[imsOrgId] ?? [];
-  if (existingSites.includes(siteBaseURL)) {
-    log.info(`LaunchDarkly: ${siteBaseURL} already in ${flagKey} for org ${imsOrgId}`);
+  if (existingSites.includes(siteId)) {
+    log.info(`LaunchDarkly: site ${siteId} already in ${flagKey} for org ${imsOrgId}`);
     return;
   }
 
-  const merged = { ...parsed, [imsOrgId]: [...existingSites, siteBaseURL] };
+  const merged = { ...parsed, [imsOrgId]: [...existingSites, siteId] };
   const newValue = isStringWrapped ? JSON.stringify(merged) : merged;
 
   await ldClient.updateVariationValue(
@@ -222,10 +221,10 @@ async function upsertLdFlag(ldClient, flagKey, imsOrgId, siteBaseURL, log) {
     flagKey,
     0,
     newValue,
-    `plg-onboarding: enable ${flagKey} for ${imsOrgId} / ${siteBaseURL}`,
+    `plg-onboarding: enable ${flagKey} for ${imsOrgId} / ${siteId}`,
   );
 
-  log.info(`LaunchDarkly: enabled ${flagKey} for org ${imsOrgId}, site ${siteBaseURL}`);
+  log.info(`LaunchDarkly: enabled ${flagKey} for org ${imsOrgId}, site ${siteId}`);
 }
 
 /**
@@ -255,10 +254,10 @@ async function updateLaunchDarklyFlags(site, context) {
     return;
   }
 
-  const siteBaseURL = site.getBaseURL();
+  const siteId = site.getId();
 
   const results = await Promise.allSettled(
-    LD_AUTO_FIX_FLAGS.map((flagKey) => upsertLdFlag(ldClient, flagKey, imsOrgId, siteBaseURL, log)),
+    LD_AUTO_FIX_FLAGS.map((flagKey) => upsertLdFlag(ldClient, flagKey, imsOrgId, siteId, log)),
   );
 
   results.forEach((result, i) => {

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -15,6 +15,7 @@ import { Site as SiteModel } from '@adobe/spacecat-shared-data-access';
 import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
 import { Entitlement as EntitlementModel } from '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js';
 import PlgOnboardingModel from '@adobe/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.model.js';
+import LaunchDarklyClient from '@adobe/spacecat-shared-launchdarkly-client';
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import TierClient from '@adobe/spacecat-shared-tier-client';
 import {
@@ -53,6 +54,7 @@ const ASO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.ASO;
 const ASO_TIER = EntitlementModel.TIERS.PLG;
 const PLG_PROFILE_KEY = 'aso_plg';
 const LD_FF_PROJECT_NAME = 'experience-success-studio';
+const LD_AUTO_FIX_META_TAGS_FLAG = 'auto-fix-meta-tags';
 
 const REVIEW_REASONS = {
   DOMAIN_ALREADY_ONBOARDED_IN_ORG: 'DOMAIN_ALREADY_ONBOARDED_IN_ORG',
@@ -186,11 +188,61 @@ async function revokePreOnboardedSiteEnrollment(site, entitlement, context) {
  * @param {object} site - The onboarded site.
  * @param {object} context - Request context.
  */
-// eslint-disable-next-line no-unused-vars
+/**
+ * Enables the `auto-fix-meta-tags` LaunchDarkly feature flag for the given site's org.
+ * Variation 0 of the flag holds a JSON object mapping IMS org IDs to site base URL arrays.
+ * This function adds the org + site URL to that variation (upsert semantics).
+ * @param {object} site - The onboarded site.
+ * @param {object} context - Request context.
+ */
 async function updateLaunchDarklyFlags(site, context) {
-  // TODO: implement once flag names and LD API details are confirmed
-  // LD FF project: experience-success-studio (LD_FF_PROJECT_NAME)
-  context.log.info(`[TODO] LaunchDarkly FF update placeholder for site ${site.getId()} (LD project: ${LD_FF_PROJECT_NAME})`);
+  const { log } = context;
+  const ldClient = LaunchDarklyClient.createFrom(context);
+
+  const imsOrgId = (await context.dataAccess.Organization.findById(
+    await site.getOrganizationId(),
+  ))?.getImsOrgId();
+
+  if (!imsOrgId) {
+    log.warn(`Cannot update LaunchDarkly flags: no IMS org ID for site ${site.getId()}`);
+    return;
+  }
+
+  const siteBaseURL = site.getBaseURL();
+
+  try {
+    const flag = await ldClient.getFeatureFlag(LD_FF_PROJECT_NAME, LD_AUTO_FIX_META_TAGS_FLAG);
+    const rawValue = flag.variations?.[0]?.value;
+
+    if (rawValue === undefined) {
+      log.warn(`LaunchDarkly flag ${LD_AUTO_FIX_META_TAGS_FLAG} has no variations`);
+      return;
+    }
+
+    const isStringWrapped = typeof rawValue === 'string';
+    const parsed = isStringWrapped ? JSON.parse(rawValue) : rawValue;
+
+    const existingSites = parsed[imsOrgId] ?? [];
+    if (existingSites.includes(siteBaseURL)) {
+      log.info(`LaunchDarkly: ${siteBaseURL} already in ${LD_AUTO_FIX_META_TAGS_FLAG} for org ${imsOrgId}`);
+      return;
+    }
+
+    const merged = { ...parsed, [imsOrgId]: [...existingSites, siteBaseURL] };
+    const newValue = isStringWrapped ? JSON.stringify(merged) : merged;
+
+    await ldClient.updateVariationValue(
+      LD_FF_PROJECT_NAME,
+      LD_AUTO_FIX_META_TAGS_FLAG,
+      0,
+      newValue,
+      `plg-onboarding: enable auto-fix-meta-tags for ${imsOrgId} / ${siteBaseURL}`,
+    );
+
+    log.info(`LaunchDarkly: enabled ${LD_AUTO_FIX_META_TAGS_FLAG} for org ${imsOrgId}, site ${siteBaseURL}`);
+  } catch (error) {
+    log.error(`Failed to update LaunchDarkly flag ${LD_AUTO_FIX_META_TAGS_FLAG}: ${error.message}`);
+  }
 }
 
 async function createOrFindProject(baseURL, organizationId, context) {

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -173,21 +173,26 @@ async function revokePreOnboardedSiteEnrollment(site, entitlement, context) {
   const { SiteEnrollment } = dataAccess;
 
   const enrollments = await SiteEnrollment.allByEntitlementId(entitlement.getId());
-  const toRevoke = enrollments.find((e) => e.getSiteId() !== site.getId());
+  const toRevoke = enrollments.filter((e) => e.getSiteId() !== site.getId());
 
-  if (toRevoke) {
-    log.info(`Revoking ASO enrollment ${toRevoke.getId()} for previously enrolled site ${toRevoke.getSiteId()}`);
-    await toRevoke.remove();
-  }
+  await Promise.all(toRevoke.map((e) => {
+    log.info(`Revoking ASO enrollment ${e.getId()} for previously enrolled site ${e.getSiteId()}`);
+    return e.remove();
+  }));
 }
 
 /**
  * Upserts a single LaunchDarkly flag's variation 0 to include the org + site.
- * Variation 0 value is a JSON object: { [imsOrgId]: [siteBaseURLs] }.
+ * Variation 0 value is a JSON object: { [imsOrgId]: [siteIds] }.
+ *
+ * NOTE: This function performs a read-modify-write on the flag variation without
+ * locking. Two concurrent onboardings could overwrite each other's addition. The
+ * idempotent check makes this self-healing on retry (re-running onboarding will
+ * re-add a lost entry), but a missed write will not be detected automatically.
  * @param {object} ldClient - LaunchDarklyClient instance.
  * @param {string} flagKey - Flag key.
  * @param {string} imsOrgId - IMS org ID.
- * @param {string} siteBaseURL - Site base URL.
+ * @param {string} siteId - Site ID.
  * @param {object} log - Logger.
  */
 async function upsertLdFlag(ldClient, flagKey, imsOrgId, siteId, log) {
@@ -200,7 +205,13 @@ async function upsertLdFlag(ldClient, flagKey, imsOrgId, siteId, log) {
   }
 
   const isStringWrapped = typeof rawValue === 'string';
-  const parsed = isStringWrapped ? JSON.parse(rawValue) : rawValue;
+  let parsed;
+  try {
+    parsed = isStringWrapped ? JSON.parse(rawValue) : rawValue;
+  } catch (e) {
+    log.warn(`LaunchDarkly flag ${flagKey} has malformed JSON in variation 0, skipping: ${e.message}`);
+    return;
+  }
 
   const existingSites = parsed[imsOrgId] ?? [];
   if (existingSites.includes(siteId)) {
@@ -241,7 +252,7 @@ async function updateLaunchDarklyFlags(site, context) {
   const ldClient = new LaunchDarklyClient({ apiToken }, log);
 
   const imsOrgId = (await context.dataAccess.Organization.findById(
-    await site.getOrganizationId(),
+    site.getOrganizationId(),
   ))?.getImsOrgId();
 
   if (!imsOrgId) {
@@ -739,8 +750,8 @@ function PlgOnboardingController(ctx) {
     // Admins can onboard on behalf of any IMS org — imsOrgId must be explicitly provided
     let imsOrgId;
     if (isAdmin) {
-      if (!hasText(requestedImsOrgId)) {
-        return badRequest('imsOrgId is required when onboarding as admin');
+      if (!hasText(requestedImsOrgId) || !isValidIMSOrgId(requestedImsOrgId)) {
+        return badRequest('Valid imsOrgId is required when onboarding as admin');
       }
       imsOrgId = requestedImsOrgId;
     } else {

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -39,6 +39,7 @@ import {
 import {
   autoResolveAuthorUrl,
   findDeliveryType,
+  deriveProjectName,
   updateCodeConfig,
   queueDeliveryConfigWriter,
 } from '../../support/utils.js';
@@ -51,7 +52,7 @@ const { STATUSES, REVIEW_DECISIONS } = PlgOnboardingModel;
 const ASO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.ASO;
 const ASO_TIER = EntitlementModel.TIERS.PLG;
 const PLG_PROFILE_KEY = 'aso_plg';
-const PLG_PROJECT_NAME = 'experience-success-studio';
+const LD_FF_PROJECT_NAME = 'experience-success-studio';
 
 const REVIEW_REASONS = {
   DOMAIN_ALREADY_ONBOARDED_IN_ORG: 'DOMAIN_ALREADY_ONBOARDED_IN_ORG',
@@ -188,16 +189,18 @@ async function revokePreOnboardedSiteEnrollment(site, entitlement, context) {
 // eslint-disable-next-line no-unused-vars
 async function updateLaunchDarklyFlags(site, context) {
   // TODO: implement once flag names and LD API details are confirmed
-  context.log.info(`[TODO] LaunchDarkly FF update placeholder for site ${site.getId()}`);
+  // LD FF project: experience-success-studio (LD_FF_PROJECT_NAME)
+  context.log.info(`[TODO] LaunchDarkly FF update placeholder for site ${site.getId()} (LD project: ${LD_FF_PROJECT_NAME})`);
 }
 
-async function createOrFindProject(organizationId, context) {
+async function createOrFindProject(baseURL, organizationId, context) {
   const { dataAccess, log } = context;
   const { Project } = dataAccess;
+  const projectName = deriveProjectName(baseURL);
 
   const existingProject = (
     await Project.allByOrganizationId(organizationId)
-  ).find((p) => p.getProjectName() === PLG_PROJECT_NAME);
+  ).find((p) => p.getProjectName() === projectName);
 
   if (existingProject) {
     log.debug(`Found existing project ${existingProject.getId()}`);
@@ -205,9 +208,9 @@ async function createOrFindProject(organizationId, context) {
   }
 
   const newProject = await Project.create({
-    projectName: PLG_PROJECT_NAME, organizationId,
+    projectName, organizationId,
   });
-  log.info(`Created project ${newProject.getId()} for org ${organizationId}`);
+  log.info(`Created project ${newProject.getId()} for ${baseURL}`);
   return newProject;
 }
 
@@ -538,7 +541,7 @@ async function performAsoPlgOnboarding({ domain, imsOrgId, rumHost: presetRumHos
     }
 
     // Create/assign project
-    const project = await createOrFindProject(organizationId, context);
+    const project = await createOrFindProject(baseURL, organizationId, context);
     if (!site.getProjectId()) {
       site.setProjectId(project.getId());
     }

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -1301,8 +1301,8 @@ describe('PlgOnboardingController', () => {
       expect(mockDataAccess.Site.create).to.not.have.been.called;
     });
 
-    it('returns WAITING_FOR_IP_ALLOWLISTING for existing site and saves org change', async () => {
-      const existingSite = createMockSite({ orgId: DEFAULT_ORG_ID });
+    it('returns WAITING_FOR_IP_ALLOWLISTING for existing site in same org', async () => {
+      const existingSite = createMockSite({ orgId: TEST_ORG_ID });
       mockDataAccess.Site.findByBaseURL.resolves(existingSite);
 
       detectBotBlockerStub.resolves({
@@ -1318,8 +1318,6 @@ describe('PlgOnboardingController', () => {
       expect(res.status).to.equal(200);
       expect(mockOnboarding.setStatus)
         .to.have.been.calledWith('WAITING_FOR_IP_ALLOWLISTING');
-      expect(existingSite.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
-      expect(existingSite.save).to.have.been.called;
     });
 
     it('uses ipsToWhitelist fallback for bot blocker', async () => {
@@ -1406,7 +1404,7 @@ describe('PlgOnboardingController', () => {
       controller = PlgOnboardingController({ log: mockLog });
     });
 
-    it('reassigns site from DEFAULT_ORGANIZATION_ID to customer org', async () => {
+    it('waitlists when site belongs to DEFAULT_ORGANIZATION_ID', async () => {
       const existingSite = createMockSite({ orgId: DEFAULT_ORG_ID });
       mockDataAccess.Site.findByBaseURL.resolves(existingSite);
 
@@ -1415,11 +1413,13 @@ describe('PlgOnboardingController', () => {
       const res = await controller.onboard(context);
 
       expect(res.status).to.equal(200);
-      expect(existingSite.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
-      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+      expect(existingSite.setOrganizationId).to.not.have.been.called;
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(mockOnboarding.setWaitlistReason)
+        .to.have.been.calledWithMatch(/already assigned to another organization/);
     });
 
-    it('reassigns site from ASO_DEMO_ORG to customer org', async () => {
+    it('waitlists when site belongs to ASO_DEMO_ORG', async () => {
       const existingSite = createMockSite({ orgId: DEMO_ORG_ID });
       mockDataAccess.Site.findByBaseURL.resolves(existingSite);
 
@@ -1428,7 +1428,10 @@ describe('PlgOnboardingController', () => {
       const res = await controller.onboard(context);
 
       expect(res.status).to.equal(200);
-      expect(existingSite.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(existingSite.setOrganizationId).to.not.have.been.called;
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(mockOnboarding.setWaitlistReason)
+        .to.have.been.calledWithMatch(/already assigned to another organization/);
     });
   });
 

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -593,14 +593,14 @@ describe('PlgOnboardingController', () => {
       const context = buildContext({ domain: TEST_DOMAIN });
       const res = await adminController.onboard(context);
       expect(res.status).to.equal(400);
-      expect(res.value).to.equal('imsOrgId is required when onboarding as admin');
+      expect(res.value).to.equal('Valid imsOrgId is required when onboarding as admin');
     });
 
     it('returns 400 when imsOrgId is empty string in admin onboard call', async () => {
       const context = buildContext({ domain: TEST_DOMAIN, imsOrgId: '' });
       const res = await adminController.onboard(context);
       expect(res.status).to.equal(400);
-      expect(res.value).to.equal('imsOrgId is required when onboarding as admin');
+      expect(res.value).to.equal('Valid imsOrgId is required when onboarding as admin');
     });
 
     it('onboards successfully when admin provides imsOrgId', async () => {
@@ -1666,6 +1666,27 @@ describe('PlgOnboardingController', () => {
       expect(mockEnrollment.remove).to.have.been.calledOnce;
     });
 
+    it('revokes all other enrollments when multiple exist under same entitlement', async () => {
+      const mockEnrollment1 = {
+        getId: sandbox.stub().returns('enroll-old-1'),
+        getSiteId: sandbox.stub().returns('other-site-1'),
+        remove: sandbox.stub().resolves(),
+      };
+      const mockEnrollment2 = {
+        getId: sandbox.stub().returns('enroll-old-2'),
+        getSiteId: sandbox.stub().returns('other-site-2'),
+        remove: sandbox.stub().resolves(),
+      };
+      mockDataAccess.SiteEnrollment.allByEntitlementId.resolves([mockEnrollment1, mockEnrollment2]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockEnrollment1.remove).to.have.been.calledOnce;
+      expect(mockEnrollment2.remove).to.have.been.calledOnce;
+    });
+
     it('does not revoke when no other enrollment exists', async () => {
       mockDataAccess.SiteEnrollment.allByEntitlementId.resolves([]);
 
@@ -1673,6 +1694,21 @@ describe('PlgOnboardingController', () => {
       const res = await controller.onboard(context);
 
       expect(res.status).to.equal(200);
+    });
+
+    it('returns error status when enrollment removal fails', async () => {
+      const mockEnrollment = {
+        getId: sandbox.stub().returns('enroll-old'),
+        getSiteId: sandbox.stub().returns('other-site-uuid'),
+        remove: sandbox.stub().rejects(new Error('DB remove failed')),
+      };
+      mockDataAccess.SiteEnrollment.allByEntitlementId.resolves([mockEnrollment]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(500);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ERROR');
     });
   });
 
@@ -1988,6 +2024,9 @@ describe('PlgOnboardingController', () => {
           entitlementCreated: true,
         }),
       );
+      // Revocation and LD flag steps must run in the fast path
+      expect(mockDataAccess.SiteEnrollment.allByEntitlementId).to.have.been.called;
+      expect(ldGetFeatureFlagStub).to.have.been.called;
       // Should NOT run full onboarding steps
       expect(createOrFindOrganizationStub).to.not.have.been.called;
       expect(detectBotBlockerStub).to.not.have.been.called;

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -1638,6 +1638,40 @@ describe('PlgOnboardingController', () => {
     });
   });
 
+  // --- ASO enrollment revocation ---
+
+  describe('onboard - ASO enrollment revocation', () => {
+    let controller;
+    beforeEach(() => {
+      controller = PlgOnboardingController({ log: mockLog });
+    });
+
+    it('revokes pre-onboarded site enrollment when another site exists under same entitlement', async () => {
+      const OTHER_SITE_ID = 'other-site-uuid';
+      const mockEnrollment = {
+        getId: sandbox.stub().returns('enroll-old'),
+        getSiteId: sandbox.stub().returns(OTHER_SITE_ID),
+        remove: sandbox.stub().resolves(),
+      };
+      mockDataAccess.SiteEnrollment.allByEntitlementId.resolves([mockEnrollment]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockEnrollment.remove).to.have.been.calledOnce;
+    });
+
+    it('does not revoke when no other enrollment exists', async () => {
+      mockDataAccess.SiteEnrollment.allByEntitlementId.resolves([]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+    });
+  });
+
   // --- LaunchDarkly feature flag update ---
 
   describe('onboard - LaunchDarkly flag update', () => {
@@ -1683,6 +1717,40 @@ describe('PlgOnboardingController', () => {
 
       expect(res.status).to.equal(200);
       expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+
+    it('skips LD update when org has no IMS org ID', async () => {
+      mockDataAccess.Organization.findById.resolves(null);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(ldUpdateVariationValueStub).to.not.have.been.called;
+    });
+
+    it('skips LD update when flag has no variations', async () => {
+      ldGetFeatureFlagStub.resolves({ variations: [] });
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(ldUpdateVariationValueStub).to.not.have.been.called;
+    });
+
+    it('handles string-wrapped variation 0 value', async () => {
+      ldGetFeatureFlagStub.resolves({
+        variations: [{ value: JSON.stringify({}) }],
+      });
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      await controller.onboard(context);
+
+      expect(ldUpdateVariationValueStub).to.have.been.calledOnce;
+      const newValue = ldUpdateVariationValueStub.firstCall.args[3];
+      expect(typeof newValue).to.equal('string');
+      expect(JSON.parse(newValue)).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
     });
   });
 

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -219,7 +219,7 @@ describe('PlgOnboardingController', () => {
     // Project
     mockProject = {
       getId: sandbox.stub().returns(TEST_PROJECT_ID),
-      getProjectName: sandbox.stub().returns('experience-success-studio'),
+      getProjectName: sandbox.stub().returns('example.com'),
     };
 
     // PlgOnboarding mock
@@ -967,7 +967,7 @@ describe('PlgOnboardingController', () => {
       await controller.onboard(context);
 
       expect(mockDataAccess.Project.create).to.have.been.calledWith({
-        projectName: 'experience-success-studio',
+        projectName: 'example.com',
         organizationId: TEST_ORG_ID,
       });
       expect(mockSite.setProjectId).to.have.been.calledWith(TEST_PROJECT_ID);

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -52,6 +52,9 @@ describe('PlgOnboardingController', () => {
   let triggerBrandProfileAgentStub;
   let tierClientCreateForSiteStub;
   let tierClientCreateEntitlementStub;
+  let ldGetFeatureFlagStub;
+  let ldUpdateVariationValueStub;
+  let ldCreateFromStub;
   let configToDynamoItemStub;
 
   // Mock objects
@@ -189,6 +192,16 @@ describe('PlgOnboardingController', () => {
     // Brand profile
     triggerBrandProfileAgentStub = sandbox.stub().resolves('exec-123');
 
+    // LaunchDarkly
+    ldGetFeatureFlagStub = sandbox.stub().resolves({
+      variations: [{ value: {} }],
+    });
+    ldUpdateVariationValueStub = sandbox.stub().resolves({});
+    ldCreateFromStub = sandbox.stub().returns({
+      getFeatureFlag: ldGetFeatureFlagStub,
+      updateVariationValue: ldUpdateVariationValueStub,
+    });
+
     // TierClient
     tierClientCreateEntitlementStub = sandbox.stub().resolves({
       entitlement: { getId: () => 'ent-1' },
@@ -288,6 +301,9 @@ describe('PlgOnboardingController', () => {
           internalServerError: (msg) => ({ status: 500, value: msg }),
           notFound: (msg) => ({ status: 404, value: msg }),
           ok: (data) => ({ status: 200, value: data }),
+        },
+        '@adobe/spacecat-shared-launchdarkly-client': {
+          default: { createFrom: ldCreateFromStub },
         },
         '@adobe/spacecat-shared-rum-api-client': {
           default: {
@@ -503,6 +519,9 @@ describe('PlgOnboardingController', () => {
               }),
             },
           },
+          '@adobe/spacecat-shared-launchdarkly-client': {
+            default: { createFrom: ldCreateFromStub },
+          },
           '@adobe/spacecat-shared-tier-client': {
             default: { createForSite: tierClientCreateForSiteStub },
           },
@@ -512,7 +531,7 @@ describe('PlgOnboardingController', () => {
           '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js': {
             Entitlement: {
               PRODUCT_CODES: { ASO: 'aso_optimizer' },
-              TIERS: { FREE_TRIAL: 'FREE_TRIAL' },
+              TIERS: { FREE_TRIAL: 'FREE_TRIAL', PLG: 'PLG', PRE_ONBOARD: 'PRE_ONBOARD' },
             },
           },
           '@adobe/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.model.js': {
@@ -1619,6 +1638,54 @@ describe('PlgOnboardingController', () => {
     });
   });
 
+  // --- LaunchDarkly feature flag update ---
+
+  describe('onboard - LaunchDarkly flag update', () => {
+    let controller;
+    beforeEach(() => {
+      controller = PlgOnboardingController({ log: mockLog });
+    });
+
+    it('adds org and site to auto-fix-meta-tags flag variation 0', async () => {
+      ldGetFeatureFlagStub.resolves({ variations: [{ value: {} }] });
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      await controller.onboard(context);
+
+      expect(ldGetFeatureFlagStub).to.have.been.calledWith(
+        'experience-success-studio',
+        'auto-fix-meta-tags',
+      );
+      expect(ldUpdateVariationValueStub).to.have.been.calledOnce;
+      const [projectKey, flagKey, varIndex, newValue] = ldUpdateVariationValueStub.firstCall.args;
+      expect(projectKey).to.equal('experience-success-studio');
+      expect(flagKey).to.equal('auto-fix-meta-tags');
+      expect(varIndex).to.equal(0);
+      expect(newValue).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
+    });
+
+    it('skips duplicate site already present in variation 0', async () => {
+      ldGetFeatureFlagStub.resolves({
+        variations: [{ value: { [TEST_IMS_ORG_ID]: [TEST_BASE_URL] } }],
+      });
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      await controller.onboard(context);
+
+      expect(ldUpdateVariationValueStub).to.not.have.been.called;
+    });
+
+    it('continues onboarding when LD flag update fails', async () => {
+      ldGetFeatureFlagStub.rejects(new Error('LD service unavailable'));
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+  });
+
   // --- Delivery config writer (CDN + optional redirect params) ---
 
   describe('onboard - delivery config writer', () => {
@@ -2050,6 +2117,9 @@ describe('PlgOnboardingController', () => {
               }),
             },
           },
+          '@adobe/spacecat-shared-launchdarkly-client': {
+            default: { createFrom: ldCreateFromStub },
+          },
           '@adobe/spacecat-shared-tier-client': {
             default: { createForSite: tierClientCreateForSiteStub },
           },
@@ -2059,7 +2129,7 @@ describe('PlgOnboardingController', () => {
           '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js': {
             Entitlement: {
               PRODUCT_CODES: { ASO: 'aso_optimizer' },
-              TIERS: { FREE_TRIAL: 'FREE_TRIAL' },
+              TIERS: { FREE_TRIAL: 'FREE_TRIAL', PLG: 'PLG', PRE_ONBOARD: 'PRE_ONBOARD' },
             },
           },
           '@adobe/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.model.js': {
@@ -2425,6 +2495,9 @@ describe('PlgOnboardingController', () => {
               }),
             },
           },
+          '@adobe/spacecat-shared-launchdarkly-client': {
+            default: { createFrom: ldCreateFromStub },
+          },
           '@adobe/spacecat-shared-tier-client': {
             default: { createForSite: tierClientCreateForSiteStub },
           },
@@ -2434,7 +2507,7 @@ describe('PlgOnboardingController', () => {
           '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js': {
             Entitlement: {
               PRODUCT_CODES: { ASO: 'aso_optimizer' },
-              TIERS: { FREE_TRIAL: 'FREE_TRIAL' },
+              TIERS: { FREE_TRIAL: 'FREE_TRIAL', PLG: 'PLG', PRE_ONBOARD: 'PRE_ONBOARD' },
             },
           },
           '@adobe/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.model.js': {
@@ -2516,6 +2589,9 @@ describe('PlgOnboardingController', () => {
                 }),
               },
             },
+            '@adobe/spacecat-shared-launchdarkly-client': {
+              default: { createFrom: ldCreateFromStub },
+            },
             '@adobe/spacecat-shared-tier-client': {
               default: { createForSite: sandbox.stub() },
             },
@@ -2523,7 +2599,7 @@ describe('PlgOnboardingController', () => {
               Config: { toDynamoItem: sandbox.stub() },
             },
             '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js': {
-              Entitlement: { PRODUCT_CODES: { ASO: 'aso_optimizer' }, TIERS: { FREE_TRIAL: 'FREE_TRIAL' } },
+              Entitlement: { PRODUCT_CODES: { ASO: 'aso_optimizer' }, TIERS: { FREE_TRIAL: 'FREE_TRIAL', PLG: 'PLG', PRE_ONBOARD: 'PRE_ONBOARD' } },
             },
             '@adobe/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.model.js': {
               default: {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -1681,27 +1681,27 @@ describe('PlgOnboardingController', () => {
       controller = PlgOnboardingController({ log: mockLog });
     });
 
-    it('adds org and site to all 4 auto-fix flags in variation 0', async () => {
+    it('adds org and site to all 3 auto-fix flags in variation 0', async () => {
       ldGetFeatureFlagStub.resolves({ variations: [{ value: {} }] });
 
       const context = buildContext({ domain: TEST_DOMAIN });
       await controller.onboard(context);
 
-      const expectedFlags = ['auto-fix-meta-tags', 'cwv-auto-fix', 'alt-text-auto-fix', 'broken-backlinks-auto-fix'];
+      const expectedFlags = ['FF_cwv-auto-fix', 'FF_alt-text-auto-fix', 'FF_broken-backlinks-auto-fix'];
       expectedFlags.forEach((flagKey) => {
         expect(ldGetFeatureFlagStub).to.have.been.calledWith('experience-success-studio', flagKey);
       });
-      expect(ldUpdateVariationValueStub.callCount).to.equal(4);
-      const metaTagsCall = ldUpdateVariationValueStub.getCalls().find((c) => c.args[1] === 'auto-fix-meta-tags');
-      expect(metaTagsCall).to.exist;
-      expect(metaTagsCall.args[0]).to.equal('experience-success-studio');
-      expect(metaTagsCall.args[2]).to.equal(0);
-      expect(metaTagsCall.args[3]).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
+      expect(ldUpdateVariationValueStub.callCount).to.equal(3);
+      const cwvCall = ldUpdateVariationValueStub.getCalls().find((c) => c.args[1] === 'FF_cwv-auto-fix');
+      expect(cwvCall).to.exist;
+      expect(cwvCall.args[0]).to.equal('experience-success-studio');
+      expect(cwvCall.args[2]).to.equal(0);
+      expect(cwvCall.args[3]).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_SITE_ID] });
     });
 
     it('skips duplicate site already present in variation 0', async () => {
       ldGetFeatureFlagStub.resolves({
-        variations: [{ value: { [TEST_IMS_ORG_ID]: [TEST_BASE_URL] } }],
+        variations: [{ value: { [TEST_IMS_ORG_ID]: [TEST_SITE_ID] } }],
       });
 
       const context = buildContext({ domain: TEST_DOMAIN });
@@ -1760,11 +1760,11 @@ describe('PlgOnboardingController', () => {
       const context = buildContext({ domain: TEST_DOMAIN });
       await controller.onboard(context);
 
-      expect(ldUpdateVariationValueStub.callCount).to.equal(4);
+      expect(ldUpdateVariationValueStub.callCount).to.equal(3);
       ldUpdateVariationValueStub.getCalls().forEach((call) => {
         const newValue = call.args[3];
         expect(typeof newValue).to.equal('string');
-        expect(JSON.parse(newValue)).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
+        expect(JSON.parse(newValue)).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_SITE_ID] });
       });
     });
   });

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -1806,6 +1806,19 @@ describe('PlgOnboardingController', () => {
         expect(JSON.parse(newValue)).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_SITE_ID] });
       });
     });
+
+    it('skips flag and warns when variation 0 contains malformed JSON string', async () => {
+      ldGetFeatureFlagStub.resolves({
+        variations: [{ value: 'not-valid-json{{{' }],
+      });
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(ldUpdateVariationValueStub).to.not.have.been.called;
+      expect(mockLog.warn).to.have.been.calledWithMatch(/malformed JSON/);
+    });
   });
 
   // --- Delivery config writer (CDN + optional redirect params) ---

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -196,6 +196,10 @@ describe('PlgOnboardingController', () => {
     });
     tierClientCreateForSiteStub = sandbox.stub().resolves({
       createEntitlement: tierClientCreateEntitlementStub,
+      checkValidEntitlement: sandbox.stub().resolves({
+        entitlement: { getId: () => 'ent-1' },
+        siteEnrollment: { getId: () => 'enroll-1' },
+      }),
     });
 
     // Config
@@ -215,7 +219,7 @@ describe('PlgOnboardingController', () => {
     // Project
     mockProject = {
       getId: sandbox.stub().returns(TEST_PROJECT_ID),
-      getProjectName: sandbox.stub().returns('example.com'),
+      getProjectName: sandbox.stub().returns('experience-success-studio'),
     };
 
     // PlgOnboarding mock
@@ -249,6 +253,9 @@ describe('PlgOnboardingController', () => {
         create: sandbox.stub().resolves(mockOnboarding),
         allByImsOrgId: sandbox.stub().resolves([]),
         all: sandbox.stub().resolves([]),
+      },
+      SiteEnrollment: {
+        allByEntitlementId: sandbox.stub().resolves([]),
       },
     };
 
@@ -298,7 +305,7 @@ describe('PlgOnboardingController', () => {
         '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js': {
           Entitlement: {
             PRODUCT_CODES: { ASO: 'aso_optimizer' },
-            TIERS: { FREE_TRIAL: 'FREE_TRIAL' },
+            TIERS: { FREE_TRIAL: 'FREE_TRIAL', PLG: 'PLG', PRE_ONBOARD: 'PRE_ONBOARD' },
           },
         },
         '@adobe/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.model.js': {
@@ -960,7 +967,7 @@ describe('PlgOnboardingController', () => {
       await controller.onboard(context);
 
       expect(mockDataAccess.Project.create).to.have.been.calledWith({
-        projectName: 'example.com',
+        projectName: 'experience-success-studio',
         organizationId: TEST_ORG_ID,
       });
       expect(mockSite.setProjectId).to.have.been.calledWith(TEST_PROJECT_ID);

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -281,6 +281,7 @@ describe('PlgOnboardingController', () => {
 
     mockEnv = {
       DEFAULT_ORGANIZATION_ID: DEFAULT_ORG_ID,
+      LD_EXPERIENCE_SUCCESS_API_TOKEN: 'test-ld-token',
     };
 
     PlgOnboardingController = (await esmock(
@@ -303,7 +304,7 @@ describe('PlgOnboardingController', () => {
           ok: (data) => ({ status: 200, value: data }),
         },
         '@adobe/spacecat-shared-launchdarkly-client': {
-          default: { createFrom: ldCreateFromStub },
+          default: ldCreateFromStub,
         },
         '@adobe/spacecat-shared-rum-api-client': {
           default: {
@@ -520,7 +521,7 @@ describe('PlgOnboardingController', () => {
             },
           },
           '@adobe/spacecat-shared-launchdarkly-client': {
-            default: { createFrom: ldCreateFromStub },
+            default: ldCreateFromStub,
           },
           '@adobe/spacecat-shared-tier-client': {
             default: { createForSite: tierClientCreateForSiteStub },
@@ -1680,22 +1681,22 @@ describe('PlgOnboardingController', () => {
       controller = PlgOnboardingController({ log: mockLog });
     });
 
-    it('adds org and site to auto-fix-meta-tags flag variation 0', async () => {
+    it('adds org and site to all 4 auto-fix flags in variation 0', async () => {
       ldGetFeatureFlagStub.resolves({ variations: [{ value: {} }] });
 
       const context = buildContext({ domain: TEST_DOMAIN });
       await controller.onboard(context);
 
-      expect(ldGetFeatureFlagStub).to.have.been.calledWith(
-        'experience-success-studio',
-        'auto-fix-meta-tags',
-      );
-      expect(ldUpdateVariationValueStub).to.have.been.calledOnce;
-      const [projectKey, flagKey, varIndex, newValue] = ldUpdateVariationValueStub.firstCall.args;
-      expect(projectKey).to.equal('experience-success-studio');
-      expect(flagKey).to.equal('auto-fix-meta-tags');
-      expect(varIndex).to.equal(0);
-      expect(newValue).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
+      const expectedFlags = ['auto-fix-meta-tags', 'cwv-auto-fix', 'alt-text-auto-fix', 'broken-backlinks-auto-fix'];
+      expectedFlags.forEach((flagKey) => {
+        expect(ldGetFeatureFlagStub).to.have.been.calledWith('experience-success-studio', flagKey);
+      });
+      expect(ldUpdateVariationValueStub.callCount).to.equal(4);
+      const metaTagsCall = ldUpdateVariationValueStub.getCalls().find((c) => c.args[1] === 'auto-fix-meta-tags');
+      expect(metaTagsCall).to.exist;
+      expect(metaTagsCall.args[0]).to.equal('experience-success-studio');
+      expect(metaTagsCall.args[2]).to.equal(0);
+      expect(metaTagsCall.args[3]).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
     });
 
     it('skips duplicate site already present in variation 0', async () => {
@@ -1717,6 +1718,18 @@ describe('PlgOnboardingController', () => {
 
       expect(res.status).to.equal(200);
       expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+
+    it('skips LD update when LD_EXPERIENCE_SUCCESS_API_TOKEN is not set', async () => {
+      const context = {
+        ...buildContext({ domain: TEST_DOMAIN }),
+        env: { DEFAULT_ORGANIZATION_ID: DEFAULT_ORG_ID },
+      };
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(ldGetFeatureFlagStub).to.not.have.been.called;
+      expect(mockLog.warn).to.have.been.calledWithMatch(/LD_EXPERIENCE_SUCCESS_API_TOKEN/);
     });
 
     it('skips LD update when org has no IMS org ID', async () => {
@@ -1747,10 +1760,12 @@ describe('PlgOnboardingController', () => {
       const context = buildContext({ domain: TEST_DOMAIN });
       await controller.onboard(context);
 
-      expect(ldUpdateVariationValueStub).to.have.been.calledOnce;
-      const newValue = ldUpdateVariationValueStub.firstCall.args[3];
-      expect(typeof newValue).to.equal('string');
-      expect(JSON.parse(newValue)).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
+      expect(ldUpdateVariationValueStub.callCount).to.equal(4);
+      ldUpdateVariationValueStub.getCalls().forEach((call) => {
+        const newValue = call.args[3];
+        expect(typeof newValue).to.equal('string');
+        expect(JSON.parse(newValue)).to.deep.equal({ [TEST_IMS_ORG_ID]: [TEST_BASE_URL] });
+      });
     });
   });
 
@@ -2186,7 +2201,7 @@ describe('PlgOnboardingController', () => {
             },
           },
           '@adobe/spacecat-shared-launchdarkly-client': {
-            default: { createFrom: ldCreateFromStub },
+            default: ldCreateFromStub,
           },
           '@adobe/spacecat-shared-tier-client': {
             default: { createForSite: tierClientCreateForSiteStub },
@@ -2564,7 +2579,7 @@ describe('PlgOnboardingController', () => {
             },
           },
           '@adobe/spacecat-shared-launchdarkly-client': {
-            default: { createFrom: ldCreateFromStub },
+            default: ldCreateFromStub,
           },
           '@adobe/spacecat-shared-tier-client': {
             default: { createForSite: tierClientCreateForSiteStub },
@@ -2658,7 +2673,7 @@ describe('PlgOnboardingController', () => {
               },
             },
             '@adobe/spacecat-shared-launchdarkly-client': {
-              default: { createFrom: ldCreateFromStub },
+              default: ldCreateFromStub,
             },
             '@adobe/spacecat-shared-tier-client': {
               default: { createForSite: sandbox.stub() },


### PR DESCRIPTION


- Change ASO_TIER from FREE_TRIAL to PLG; TierClient auto-upgrades PRE_ONBOARD -> PLG
- Fix project name to 'experience-success-studio' for all PLG onboardings
- Revoke pre-onboarded site's ASO enrollment when new site enrolls under same entitlement
- Add updateLaunchDarklyFlags placeholder stub (flag details TBD)
- ensureAsoEntitlement falls back to checkValidEntitlement on race-condition 'already exists'

Resolves: SITES-42938

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
