### PR TITLE
feat: api-service checks 

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1607,6 +1607,13 @@ function SuggestionsController(ctx, sqs, env) {
     }
     const suggestionIds = [...new Set(rawSuggestionIds)];
 
+    const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const invalidIds = suggestionIds.filter((id) => !UUID_REGEX.test(id));
+    if (invalidIds.length > 0) {
+      context.log.warn(`[edge-deploy-failed] site: ${apexBaseUrl}, invalid suggestionIds: ${invalidIds.join(', ')}`);
+      return badRequest(`suggestionIds must be valid UUIDs. Invalid: ${invalidIds.join(', ')}`);
+    }
+
     // No productCode is passed to hasAccess(); the delegation block is not entered.
     // Org membership is the intended access gate for this endpoint.
     if (!await accessControlUtil.hasAccess(site)) {


### PR DESCRIPTION
## Summary
- Adds UUID format validation for all `suggestionIds` in the `deployToEdge` endpoint before any DB lookups
- Rejects non-UUID IDs (e.g. URLs accidentally passed as suggestion IDs) with HTTP 400 and a descriptive error
- Logs `[edge-deploy-failed]` with invalid IDs for observability

## Test plan
- [ ] All 379 existing unit tests pass
- [ ] `POST /sites/:siteId/suggestions/deploy-to-edge` with valid UUID array proceeds normally
- [ ] Request with `{ suggestionIds: ["not-a-uuid"] }` returns 400 with error message listing the invalid IDs
- [ ] Request with a mix of valid and invalid IDs returns 400

Fixes LLMO-3476

🤖 Generated with [Claude Code](https://claude.com/claude-code)