### PR TITLE
feat(llmo-3354): add PATCH endpoint to clear edge status on 404 pages

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -1303,6 +1303,32 @@ function SitesController(ctx, log, env) {
     }
   };
 
+  const patchPageCitabilityStatus = async (context) => {
+    const { siteId } = context.params;
+    const { url, httpStatus } = context.data || {};
+
+    if (!hasText(url)) {
+      return badRequest('url is required');
+    }
+
+    if (httpStatus !== 404) {
+      return ok({ url, httpStatus, updated: false });
+    }
+
+    const { PageCitability } = dataAccess;
+    const record = await PageCitability.findByUrl(url);
+    if (!record) {
+      return ok({ url, httpStatus, updated: false });
+    }
+
+    record.setIsDeployedAtEdge(false);
+    record.setCitabilityScore(0);
+    await record.save();
+
+    log.info(`Cleared edge deployment status for 404 page: ${url} (site: ${siteId})`);
+    return ok({ url, httpStatus, updated: true });
+  };
+
   return {
     createSite,
     getAll,
@@ -1317,6 +1343,7 @@ function SitesController(ctx, log, env) {
     updateSite,
     updateCdnLogsConfig,
     getPageCitabilityCounts,
+    patchPageCitabilityStatus,
     getTopPages,
     resolveSite,
     getBrandProfile,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -340,6 +340,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/brand-profile': sitesController.getBrandProfile,
     'POST /sites/:siteId/brand-profile': sitesController.triggerBrandProfile,
     'GET /sites/:siteId/page-citability/counts': sitesController.getPageCitabilityCounts,
+    'PATCH /sites/:siteId/page-citability/status': sitesController.patchPageCitabilityStatus,
     'GET /sites/:siteId/top-pages': sitesController.getTopPages,
     'GET /sites/:siteId/top-pages/:source': sitesController.getTopPages,
     'GET /sites/:siteId/top-pages/:source/:geo': sitesController.getTopPages,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -235,6 +235,7 @@ const routeRequiredCapabilities = {
   'GET /sites/:siteId': 'site:read',
   'PATCH /sites/:siteId': 'site:write',
   'PATCH /sites/:siteId/config/cdn-logs': 'site:write',
+  'PATCH /sites/:siteId/page-citability/status': 'site:write',
   'DELETE /sites/:siteId': 'site:write',
   'GET /sites/:siteId/bot-blocker': 'site:read',
   'GET /sites/:siteId/audits': 'audit:read',

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -133,6 +133,7 @@ describe('Sites Controller', () => {
     'updateSite',
     'updateCdnLogsConfig',
     'getPageCitabilityCounts',
+    'patchPageCitabilityStatus',
     'getTopPages',
     'getSiteMetricsBySource',
     'getPageMetricsBySource',


### PR DESCRIPTION
## Summary
- Adds `PATCH /sites/:siteId/page-citability/status` endpoint
- When called with a URL that returned HTTP 404, clears `isDeployedAtEdge = false` and resets `citabilityScore = 0` for the corresponding `PageCitability` record
- If the page isn't found in PageCitability (never tracked), returns `{ updated: false }` with no error
- If `httpStatus` is not 404, returns `{ updated: false }` (no-op for non-404 statuses)
- Route is protected by `site:write` capability

## Use Case
The edge worker observes when a previously-deployed page starts returning 404 (page deleted/moved). This endpoint lets the worker notify SpaceCat so the citability data remains accurate and the page is not shown as edge-deployed.

## Test plan
- [ ] All 233 unit tests pass
- [ ] `PATCH /sites/:siteId/page-citability/status` with `{ url: "...", httpStatus: 404 }` sets `isDeployedAtEdge=false` and `citabilityScore=0` on the record
- [ ] Same request for a URL not in PageCitability returns `{ updated: false }` with 200
- [ ] Request with `httpStatus: 200` returns `{ updated: false }` without touching the record

Fixes LLMO-3354

🤖 Generated with [Claude Code](https://claude.com/claude-code)