### PR TITLE
feat(llmo-3954): add IMS service principal token for CDN routing API calls

### DIFF
--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -34,7 +34,7 @@ import { Entitlement as EntitlementModel } from '@adobe/spacecat-shared-data-acc
 import TokowakaClient, { calculateForwardedHost } from '@adobe/spacecat-shared-tokowaka-client';
 import AccessControlUtil from '../../support/access-control-util.js';
 import { UnauthorizedProductError } from '../../support/errors.js';
-import { exchangePromiseToken } from '../../support/utils.js';
+import { exchangePromiseToken, getServicePrincipalToken } from '../../support/utils.js';
 import { triggerBrandProfileAgent } from '../../support/brand-profile-trigger.js';
 import {
   applyFilters,
@@ -1614,12 +1614,19 @@ function LlmoController(ctx) {
 
     let imsUserToken;
     try {
-      log.debug(`Getting IMS user token for site ${siteId}`);
-      imsUserToken = await exchangePromiseToken(context, promiseToken);
-      log.info('IMS user token obtained successfully');
-    } catch (tokenError) {
-      log.warn(`Fetching IMS user token for site ${siteId} failed: ${tokenError.status} ${tokenError.message}`);
-      return createResponse({ message: 'Authentication failed with upstream IMS service' }, 401);
+      log.debug(`Getting IMS service principal token for site ${siteId}`);
+      imsUserToken = await getServicePrincipalToken(context);
+      log.info('IMS service principal token obtained successfully');
+    } catch (spTokenError) {
+      log.warn(`Service principal token unavailable for site ${siteId}: ${spTokenError.message}; falling back to promise token`);
+      try {
+        log.debug(`Getting IMS user token for site ${siteId}`);
+        imsUserToken = await exchangePromiseToken(context, promiseToken);
+        log.info('IMS user token obtained successfully (fallback)');
+      } catch (tokenError) {
+        log.warn(`Fetching IMS user token for site ${siteId} failed: ${tokenError.status} ${tokenError.message}`);
+        return createResponse({ message: 'Authentication failed with upstream IMS service' }, 401);
+      }
     }
 
     try {

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -12,7 +12,7 @@
 import { Site as SiteModel } from '@adobe/spacecat-shared-data-access';
 import { Entitlement as EntitlementModel } from '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js';
 import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
-import { ImsPromiseClient } from '@adobe/spacecat-shared-ims-client';
+import { ImsPromiseClient, ImsClient } from '@adobe/spacecat-shared-ims-client';
 import URI from 'urijs';
 import {
   hasText,
@@ -706,6 +706,22 @@ export async function exchangePromiseToken(context, promiseToken) {
     promiseToken,
     !!context.env?.AUTOFIX_CRYPT_SECRET && !!context.env?.AUTOFIX_CRYPT_SALT,
   )).access_token;
+  return accessToken;
+}
+
+/**
+ * Obtains an IMS Service Principal (client_credentials) access token for the
+ * LLMO backend service. Uses the IMS v3 token endpoint.
+ *
+ * Required env vars: IMS_HOST, IMS_CLIENT_ID, IMS_CLIENT_CODE, IMS_CLIENT_SECRET
+ *
+ * @param {Object} context - The request context (provides env + log).
+ * @returns {Promise<string>} The IMS access token string.
+ * @throws {Error} If env vars are missing or the IMS call fails.
+ */
+export async function getServicePrincipalToken(context) {
+  const imsClient = ImsClient.createFrom(context);
+  const { access_token: accessToken } = await imsClient.getServiceAccessTokenV3();
   return accessToken;
 }
 


### PR DESCRIPTION
## Summary
- Adds `getServicePrincipalToken(context)` to `support/utils.js` using `ImsClient.getServiceAccessTokenV3()` (client_credentials grant)
- `updateEdgeOptimizeCDNRouting` now tries the SP token first; falls back to the user promise token if `IMS_CLIENT_ID`/`IMS_CLIENT_SECRET` env vars are not configured
- This enables the LLMO backend to call the Internal CDN API on behalf of customers using its own service identity, without needing to pass a user token through the UI

## Required env vars
`IMS_HOST`, `IMS_CLIENT_ID`, `IMS_CLIENT_CODE`, `IMS_CLIENT_SECRET` (already available via Vault)

## Test plan
- [ ] All 346 llmo controller tests pass
- [ ] All 98 utils tests pass
- [ ] When SP env vars are configured: CDN routing call uses SP token (no `x-promise-token` header needed)
- [ ] When SP env vars are absent: falls back to promise token (existing behavior)

Fixes LLMO-3954

🤖 Generated with [Claude Code](https://claude.com/claude-code)