### PR TITLE
feat: add SkipAuthHandler for local dev authentication bypass

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ import {
   s2sAuthWrapper,
 } from '@adobe/spacecat-shared-http-utils';
 import AuthInfo from '@adobe/spacecat-shared-http-utils/src/auth/auth-info.js';
+import AbstractHandler from '@adobe/spacecat-shared-http-utils/src/auth/handlers/abstract.js';
 import { imsClientWrapper } from '@adobe/spacecat-shared-ims-client';
 import {
   elevatedSlackClientWrapper,
@@ -133,6 +134,36 @@ function localCORSWrapper(fn) {
 
     return response;
   };
+}
+/* c8 ignore stop */
+
+/* c8 ignore start */
+/**
+ * Auth handler that bypasses authentication when SKIP_AUTH=true.
+ * For local development only — injects a mock admin identity.
+ */
+class SkipAuthHandler extends AbstractHandler {
+  constructor(log) {
+    super('skipAuth', log);
+  }
+
+  // eslint-disable-next-line no-unused-vars,class-methods-use-this
+  async checkAuth(request, context) {
+    if (context.env?.SKIP_AUTH !== 'true') {
+      return null;
+    }
+    this.log('SKIP_AUTH is true — injecting mock admin identity', 'info');
+    return new AuthInfo()
+      .withAuthenticated(true)
+      .withProfile({
+        user_id: 'local-dev-admin',
+        email: 'admin@localhost',
+        is_admin: true,
+        tenants: [],
+      })
+      .withType('api_key')
+      .withScopes([{ name: 'admin' }]);
+  }
 }
 /* c8 ignore stop */
 
@@ -329,7 +360,9 @@ const { WORKSPACE_EXTERNAL } = SLACK_TARGETS;
 // 2. authWrapper — handles JWT, IMS, scoped API key, legacy API key
 const wrappedMain = wrap(run)
   .with(authWrapper, {
-    authHandlers: [JwtHandler, AdobeImsHandler, ScopedApiKeyHandler, LegacyApiKeyHandler],
+    authHandlers: [
+      SkipAuthHandler, JwtHandler, AdobeImsHandler, ScopedApiKeyHandler, LegacyApiKeyHandler,
+    ],
   })
   .with(s2sAuthWrapper, { routeCapabilities: routeRequiredCapabilities });
 

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,12 @@ class SkipAuthHandler extends AbstractHandler {
     if (context.env?.SKIP_AUTH !== 'true') {
       return null;
     }
-    this.log('SKIP_AUTH is true — injecting mock admin identity', 'info');
+    // Defense-in-depth: refuse to skip auth in a deployed Lambda environment
+    if (context.func?.name || process.env.AWS_LAMBDA_FUNCTION_NAME) {
+      this.log('SKIP_AUTH is true but running in Lambda - ignoring', 'warn');
+      return null;
+    }
+    this.log('SKIP_AUTH is true - injecting mock admin identity', 'info');
     return new AuthInfo()
       .withAuthenticated(true)
       .withProfile({
@@ -174,29 +179,8 @@ class SkipAuthHandler extends AbstractHandler {
  * @returns {Response} a response
  */
 async function run(request, context) {
-  const { log, pathInfo, env } = context;
+  const { log, pathInfo } = context;
   const { route, suffix, method } = pathInfo;
-
-  // Add mock authInfo when authentication is skipped
-  /* c8 ignore start */
-  if (env.SKIP_AUTH === 'true' && !context.attributes?.authInfo) {
-    if (!context.attributes) {
-      context.attributes = {};
-    }
-    // Create a mock admin authInfo
-    context.attributes.authInfo = new AuthInfo()
-      .withAuthenticated(true)
-      .withProfile({
-        user_id: 'local-dev-admin',
-        email: 'admin@localhost',
-        is_admin: true,
-        // Empty tenants means hasOrganization will return false, but is_admin bypasses that
-        tenants: [],
-      })
-      .withType('api_key')
-      .withScopes([{ name: 'admin' }]);
-  }
-  /* c8 ignore stop */
 
   if (!hasText(route)) {
     log.info(`Unable to extract path info. Wrong format: ${suffix}`);


### PR DESCRIPTION
## Summary
- Adds `SkipAuthHandler` as the first handler in the auth middleware chain
- When `SKIP_AUTH=true` (local dev `.env`), injects a mock admin identity and short-circuits auth
- When `SKIP_AUTH` is absent or not `'true'` (all deployed environments), returns `null` and the chain falls through to the real handlers — zero production impact
- Fixes 401 errors when running the API service locally via `make run-api` in the mysticat-workspace local dev environment

## Context
The local dev environment sets `SKIP_AUTH=true` in `.env`, but previously no auth handler recognized this variable. All four real handlers (JWT, IMS, ScopedApiKey, LegacyApiKey) would fail and return 401 because the UI sends no credentials in local dev mode.

## Test plan
- [x] Unit tests pass (7791 passing, 1 pre-existing flaky timeout)
- [ ] `make run-api` in mysticat-workspace local dev → API responds 200 without auth headers
- [ ] Deployed environments unaffected (`SKIP_AUTH` is never set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)