### PR TITLE
feat(edge-routing): verify UA routing is active before enabling CDN routing

### DIFF
--- a/src/support/edge-routing-utils.js
+++ b/src/support/edge-routing-utils.js
@@ -39,6 +39,7 @@ export const OPTIMIZE_AT_EDGE_ENABLED_MARKING_TYPE = 'optimize-at-edge-enabled-m
 export const EDGE_OPTIMIZE_MARKING_DELAY_SECONDS = 300;
 
 const EDGE_OPTIMIZE_USER_AGENT = 'AdobeEdgeOptimize-Test AdobeEdgeOptimize/1.0';
+const UA_ROUTING_HEADER = 'x-edgeoptimize-request-id';
 const PROBE_TIMEOUT_MS = 5000;
 const CDN_CALL_TIMEOUT_MS = 5000;
 
@@ -67,7 +68,9 @@ export function getHostnameWithoutWww(url, log) {
 /**
  * Probes the site URL and resolves the canonical domain for CDN API calls.
  *
- * - 2xx: returns the forwarded host derived from the probe URL.
+ * - 2xx with x-edgeoptimize-request-id header: returns the forwarded host derived from the probe
+ *   URL.
+ * - 2xx without x-edgeoptimize-request-id: throws (default UA routing not yet active).
  * - 301 to the same root domain: returns the forwarded host from the Location header.
  * - 301 to a different root domain: throws.
  * - Any other status: throws.
@@ -86,6 +89,12 @@ export async function probeSiteAndResolveDomain(siteUrl, log) {
   });
 
   if (probeResponse.ok) {
+    if (!probeResponse.headers.has(UA_ROUTING_HEADER)) {
+      throw new Error(
+        `Site ${siteUrl} returned ${probeResponse.status} but is missing the `
+        + `${UA_ROUTING_HEADER} response header — default UA routing is not yet active`,
+      );
+    }
     return calculateForwardedHost(siteUrl, log);
   }
 

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -5533,6 +5533,15 @@ describe('LlmoController', () => {
         expect((await result.json()).message).to.include('does not match');
       });
 
+      it('returns 400 when site probe succeeds but x-edgeoptimize-request-id header is absent', async () => {
+        probeSiteAndResolveDomainStub.rejects(new Error('missing the x-edgeoptimize-request-id response header'));
+        const result = await controller.createOrUpdateEdgeConfig(makeRoutingCtx());
+        expect(result.status).to.equal(400);
+        expect((await result.json()).message).to.include('x-edgeoptimize-request-id');
+        expect(getServicePrincipalTokenStub).to.not.have.been.called;
+        expect(callCdnRoutingApiStub).to.not.have.been.called;
+      });
+
       it('returns 401 when SP token request fails', async () => {
         getServicePrincipalTokenStub.rejects(new Error('IMS error'));
         const result = await controller.createOrUpdateEdgeConfig(makeRoutingCtx());

--- a/test/support/edge-routing-utils.test.js
+++ b/test/support/edge-routing-utils.test.js
@@ -87,14 +87,29 @@ describe('edge-routing-utils', () => {
   });
 
   describe('probeSiteAndResolveDomain', () => {
-    it('returns calculated domain on 2xx response', async () => {
-      fetchStub.resolves({ ok: true, status: 200 });
+    it('returns calculated domain on 2xx response with x-edgeoptimize-request-id header', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        headers: { has: (h) => h === 'x-edgeoptimize-request-id' },
+      });
       calculateForwardedHostStub.returns('example.com');
 
       const domain = await edgeUtils.probeSiteAndResolveDomain('https://example.com', log);
 
       expect(domain).to.equal('example.com');
       expect(calculateForwardedHostStub).to.have.been.calledWith('https://example.com', log);
+    });
+
+    it('throws when 2xx response is missing x-edgeoptimize-request-id header', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        headers: { has: () => false },
+      });
+
+      await expect(edgeUtils.probeSiteAndResolveDomain('https://example.com', log))
+        .to.be.rejectedWith('missing the x-edgeoptimize-request-id response header');
     });
 
     it('returns calculated domain from Location header on 301 to same root domain', async () => {


### PR DESCRIPTION
## Summary

- Adds `x-edgeoptimize-request-id` header check inside `probeSiteAndResolveDomain` so the existing `AdobeEdgeOptimize-Test` probe doubles as a UA routing precheck
- If the header is absent on a 2xx response, the probe throws and CDN routing is aborted with a 400 — the SP token is never fetched

## Test plan

- [x] `probeSiteAndResolveDomain` — existing 2xx test updated to include `x-edgeoptimize-request-id` header; new test asserts throw when header is absent
- [x] `createOrUpdateEdgeConfig` — new test asserts 400 is returned and SP token / CDN API are never called when probe fails due to missing header

🤖 Generated with [Claude Code](https://claude.com/claude-code)