### PR TITLE
fix: filter-dimensions should return category's id column instead of category_id

### DIFF
--- a/docs/llmo-brandalf-apis/filter-dimensions-api.md
+++ b/docs/llmo-brandalf-apis/filter-dimensions-api.md
@@ -56,7 +56,7 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/filter-d
     { "id": "uuid", "label": "Brand Name" }
   ],
   "categories": [
-    { "id": "books", "label": "Books" }
+    { "id": "0178a3f0-1234-7000-8000-0000000000aa", "label": "Books" }
   ],
   "topics": [
     { "id": "0178a3f0-1234-7000-8000-0000000000aa", "label": "Topic A" }
@@ -82,7 +82,7 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/filter-d
 | Field | Source |
 |--------|--------|
 | `brands` | Org-wide: `brands` (active/pending). With `siteId`: **`brand_sites`** rows for that org + site, with embedded `brands` (id, name) |
-| `categories` | `categories` (org, active/pending) |
+| `categories` | `categories` (org, active/pending); each `id` is **`categories.id`** (UUID) for use as `categoryId` on other Brand Presence APIs |
 | `topics` | `topics` filtered by org and optional brand scope |
 | `origins` | Fixed: `human`, `ai` |
 | `regions` | `regions` reference table |

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -454,20 +454,20 @@ export async function fetchBrandsForConfig(client, organizationId, siteFilter, f
 }
 
 /**
- * Org-scoped categories (active / pending).
+ * Org-scoped categories (active / pending). Option `id` is `categories.id` (UUID) for filtering.
  * @internal Exported for tests
  */
 export async function fetchCategoriesForConfig(client, organizationId) {
   const { data, error } = await client
     .from('categories')
-    .select('category_id, name')
+    .select('id, name')
     .eq('organization_id', organizationId)
     .in('status', ['pending', 'active'])
     .limit(QUERY_LIMIT);
   if (error || !data?.length) {
     return [];
   }
-  const opts = data.map((c) => toFilterOption(c.category_id, c.name));
+  const opts = data.map((c) => toFilterOption(String(c.id), c.name));
   opts.sort((a, b) => strCompare(a.label, b.label));
   return opts;
 }

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -573,7 +573,7 @@ describe('llmo-brand-presence', () => {
         sites: { data: [{ id: '0178a3f0-1234-7000-8000-0000000000aa' }], error: null },
         brands: { data: [{ id: '0178a3f0-1234-7000-8000-0000000000bb', name: 'Acme' }], error: null },
         prompts: { data: null, count: 12, error: null },
-        categories: { data: [{ category_id: 'books', name: 'Books' }], error: null },
+        categories: { data: [{ id: '0178a3f0-1234-7000-8000-0000000000ee', name: 'Books' }], error: null },
         topics: {
           data: [{
             id: '0178a3f0-1234-7000-8000-0000000000cc',
@@ -602,7 +602,7 @@ describe('llmo-brand-presence', () => {
       ]);
       expect(body.regions).to.deep.equal([{ id: 'US', label: 'United States' }]);
       expect(body.brands).to.deep.equal([{ id: '0178a3f0-1234-7000-8000-0000000000bb', label: 'Acme' }]);
-      expect(body.categories).to.deep.equal([{ id: 'books', label: 'Books' }]);
+      expect(body.categories).to.deep.equal([{ id: '0178a3f0-1234-7000-8000-0000000000ee', label: 'Books' }]);
       expect(body.topics).to.deep.equal([{ id: '0178a3f0-1234-7000-8000-0000000000cc', label: 'Topic A' }]);
       expect(body.page_intents).to.deep.equal([{ id: 'informational', label: 'informational' }]);
       expect(tableMock.rpc).not.to.have.been.called;
@@ -656,7 +656,7 @@ describe('llmo-brand-presence', () => {
           error: null,
         },
         prompts: { data: null, count: 3, error: null },
-        categories: { data: [{ category_id: 'books', name: 'Books' }], error: null },
+        categories: { data: [{ id: '0178a3f0-1234-7000-8000-0000000000ee', name: 'Books' }], error: null },
         topics: {
           data: [{
             id: '0178a3f0-1234-7000-8000-0000000000cc',
@@ -698,7 +698,7 @@ describe('llmo-brand-presence', () => {
           error: null,
         },
         prompts: { data: null, count: 7, error: null },
-        categories: { data: [{ category_id: 'books', name: 'Books' }], error: null },
+        categories: { data: [{ id: '0178a3f0-1234-7000-8000-0000000000ee', name: 'Books' }], error: null },
         topics: {
           data: [{
             id: '0178a3f0-1234-7000-8000-0000000000cc',
@@ -737,7 +737,7 @@ describe('llmo-brand-presence', () => {
           error: null,
         },
         prompts: { data: null, count: 1, error: null },
-        categories: { data: [{ category_id: 'books', name: 'Books' }], error: null },
+        categories: { data: [{ id: '0178a3f0-1234-7000-8000-0000000000ee', name: 'Books' }], error: null },
         topics: {
           data: [{
             id: '0178a3f0-1234-7000-8000-0000000000cc',


### PR DESCRIPTION
# Summary of changes (`fix/category-id` vs `main`)

## Goal

Brand Presence **filter-dimensions** should expose each category’s **`categories.id` (UUID)** as the option `id`, not **`category_id`**, so clients can use that value consistently (e.g. as `categoryId` on other APIs).

## Files changed

| File | Change |
|------|--------|
| `src/controllers/llmo/llmo-brand-presence.js` | `fetchCategoriesForConfig` selects **`id, name`** (was `category_id, name`) and maps with **`toFilterOption(String(c.id), c.name)`**. JSDoc notes option `id` is `categories.id` for filtering. |
| `test/controllers/llmo/llmo-brand-presence.test.js` | Mocks and expectations: category rows use **`id` + `name`**; expected filter option `id` is a **UUID** (not a slug like `"books"`). |
| `docs/llmo-brandalf-apis/filter-dimensions-api.md` | Example `categories[].id` is a **UUID**; field table states **`id` = `categories.id`** and use as **`categoryId`** elsewhere. |

## Scope

- About **20 lines** changed (**10 insertions / 10 deletions**).
- **No** `docs/openapi/schemas.yaml` updates in this change set (docs under `docs/llmo-brandalf-apis/` only).

## Commit (on branch)

`fix: filter-dimensions should return category's id column instead of category_id`