### PR TITLE
fix: adding missing ip in edge routing utils.

### DIFF
--- a/src/support/edge-routing-utils.js
+++ b/src/support/edge-routing-utils.js
@@ -191,6 +191,7 @@ const AEM_CS_FASTLY_IPS = new Set([
   '151.101.67.10',
   '151.101.3.10',
   '151.101.107.10',
+  '151.101.131.10',
 ]);
 
 async function checkHost(host, log) {

--- a/test/support/edge-routing-utils.test.js
+++ b/test/support/edge-routing-utils.test.js
@@ -322,6 +322,13 @@ describe('edge-routing-utils', () => {
       expect(result).to.equal(CDN_TYPES.AEM_CS_FASTLY);
     });
 
+    it('returns aem-cs-fastly when A record matches 151.101.131.10', async () => {
+      dnsPromises.resolveCname.resolves([]);
+      dnsPromises.resolve4.withArgs('example.com').resolves(['151.101.131.10']);
+      const result = await edgeUtilsDns.detectCdnForDomain('example.com');
+      expect(result).to.equal(CDN_TYPES.AEM_CS_FASTLY);
+    });
+
     it('logs CNAME and A-record diagnostics when log is provided (covers log?.info branches)', async () => {
       const dnsLog = { info: sandbox.stub() };
       dnsPromises.resolveCname.withArgs('example.com').resolves(['unrelated-cname.example.com']);


### PR DESCRIPTION
Add 151.101.131.10 to AEM CS Fastly DNS IP allowlist

Extend the IPv4 set used for AEM Cloud Service (Fastly) CDN detection so apex/www lookups that resolve to 151.101.131.10 are classified as aem-cs-fastly, consistent with other known Fastly anycast addresses.