### PR TITLE
fix: upsert topic_categories when creating a topic with categoryId

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -939,6 +939,7 @@ function BrandsController(ctx, log, env) {
         topic: topicData,
         postgrestClient,
         updatedBy,
+        log,
       });
 
       return createResponse(created, 201);

--- a/src/support/topics-storage.js
+++ b/src/support/topics-storage.js
@@ -73,13 +73,14 @@ export async function listTopics({
  *
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat organization UUID
- * @param {object} params.topic - Topic data { name, description?, brandId? }
+ * @param {object} params.topic - Topic data { name, description?, brandId?, categoryId? }
  * @param {object} params.postgrestClient - PostgREST client
  * @param {string} [params.updatedBy] - User performing the operation
+ * @param {object} [params.log] - Logger instance for warnings
  * @returns {Promise<object>} Created topic
  */
 export async function createTopic({
-  organizationId, topic, postgrestClient, updatedBy = 'system',
+  organizationId, topic, postgrestClient, updatedBy = 'system', log,
 }) {
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
@@ -114,7 +115,7 @@ export async function createTopic({
   // categoryId is a UUID FK to categories.id — resolve it from the payload.
   const categoryId = topic.categoryId || null;
   if (categoryId && data?.id) {
-    await postgrestClient
+    const { error: junctionError } = await postgrestClient
       .from('topic_categories')
       .upsert(
         { topic_id: data.id, category_id: categoryId },
@@ -123,6 +124,9 @@ export async function createTopic({
     // Upsert errors are intentionally not thrown — the topic was already
     // created successfully.  A missing or invalid categoryId should not
     // fail the entire operation.
+    if (junctionError) {
+      log?.warn(`Failed to link topic ${data.id} to category ${categoryId}: ${junctionError.message}`);
+    }
   }
 
   return mapDbTopicToV2(data);

--- a/src/support/topics-storage.js
+++ b/src/support/topics-storage.js
@@ -109,6 +109,22 @@ export async function createTopic({
   if (error) {
     throw new Error(`Failed to create topic: ${error.message}`);
   }
+
+  // Link topic to category via the topic_categories junction table.
+  // categoryId is a UUID FK to categories.id — resolve it from the payload.
+  const categoryId = topic.categoryId || null;
+  if (categoryId && data?.id) {
+    await postgrestClient
+      .from('topic_categories')
+      .upsert(
+        { topic_id: data.id, category_id: categoryId },
+        { onConflict: 'topic_id,category_id' },
+      );
+    // Upsert errors are intentionally not thrown — the topic was already
+    // created successfully.  A missing or invalid categoryId should not
+    // fail the entire operation.
+  }
+
   return mapDbTopicToV2(data);
 }
 

--- a/test/it/postgres/topics.test.js
+++ b/test/it/postgres/topics.test.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ctx } from './harness.js';
+import { resetPostgres } from './seed.js';
+import topicTests from '../shared/tests/topics.js';
+
+topicTests(() => ctx.httpClient, resetPostgres);

--- a/test/it/shared/tests/topics.js
+++ b/test/it/shared/tests/topics.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ORG_1_ID } from '../seed-ids.js';
+
+const POSTGREST_PORT = process.env.IT_POSTGREST_PORT || '3300';
+const POSTGREST_URL = `http://localhost:${POSTGREST_PORT}`;
+
+/**
+ * Query PostgREST directly to inspect topic_categories junction rows.
+ * The SpaceCat API does not expose this table via its own routes.
+ */
+async function getTopicCategories(topicUuid) {
+  const res = await fetch(
+    `${POSTGREST_URL}/topic_categories?topic_id=eq.${topicUuid}`,
+    { headers: { Accept: 'application/json' } },
+  );
+  return res.json();
+}
+
+/**
+ * Integration tests for topic creation with topic_categories junction.
+ *
+ * Validates that createTopic upserts a topic_categories row when categoryId
+ * is provided in the topic payload, and skips when it is absent.
+ */
+export default function topicTests(getHttpClient, resetData) {
+  describe('Topics — topic_categories junction', () => {
+    describe('POST /v2/orgs/:orgId/topics with categoryId', () => {
+      before(() => resetData());
+
+      it('creates a topic_categories junction row linking topic to category', async () => {
+        const http = getHttpClient();
+
+        // 1. Create a category
+        const catRes = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/categories`,
+          { id: 'baseurl-discovery-research', name: 'Discovery & Research', origin: 'human' },
+        );
+        expect(catRes.status).to.equal(201);
+        const categoryUuid = catRes.body.uuid;
+
+        // 2. Create a topic WITH categoryId
+        const topicRes = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/topics`,
+          { name: 'Adobe Firefly', categoryId: categoryUuid },
+        );
+        expect(topicRes.status).to.equal(201);
+        const topicUuid = topicRes.body.uuid;
+
+        // 3. Verify topic_categories junction via PostgREST
+        const junctionRows = await getTopicCategories(topicUuid);
+        expect(junctionRows).to.have.lengthOf(1);
+        expect(junctionRows[0].topic_id).to.equal(topicUuid);
+        expect(junctionRows[0].category_id).to.equal(categoryUuid);
+      });
+    });
+
+    describe('POST /v2/orgs/:orgId/topics without categoryId', () => {
+      before(() => resetData());
+
+      it('does not create a topic_categories junction row', async () => {
+        const http = getHttpClient();
+
+        // Create a topic WITHOUT categoryId
+        const topicRes = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/topics`,
+          { name: 'Standalone Topic' },
+        );
+        expect(topicRes.status).to.equal(201);
+        const topicUuid = topicRes.body.uuid;
+
+        // Verify no topic_categories junction row
+        const junctionRows = await getTopicCategories(topicUuid);
+        expect(junctionRows).to.have.lengthOf(0);
+      });
+    });
+
+    describe('Idempotency: duplicate topic with same categoryId', () => {
+      before(() => resetData());
+
+      it('upserts topic and junction without duplicating either', async () => {
+        const http = getHttpClient();
+
+        // Create a category
+        const catRes = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/categories`,
+          { id: 'baseurl-comparison', name: 'Comparison & Decision', origin: 'human' },
+        );
+        expect(catRes.status).to.equal(201);
+        const categoryUuid = catRes.body.uuid;
+
+        const topicPayload = { name: 'Content Management', categoryId: categoryUuid };
+
+        // First POST
+        const res1 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/topics`, topicPayload);
+        expect(res1.status).to.equal(201);
+        const topicUuid = res1.body.uuid;
+
+        // Second POST (upsert)
+        const res2 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/topics`, topicPayload);
+        expect(res2.status).to.equal(201);
+        expect(res2.body.uuid).to.equal(topicUuid); // same row
+
+        // Only one junction row
+        const junctionRows = await getTopicCategories(topicUuid);
+        expect(junctionRows).to.have.lengthOf(1);
+      });
+    });
+  });
+}

--- a/test/support/topics-storage.test.js
+++ b/test/support/topics-storage.test.js
@@ -185,6 +185,42 @@ describe('topics-storage', () => {
       expect(fromStub).to.have.been.calledWith('topic_categories');
     });
 
+    it('warns via log when topic_categories upsert fails', async () => {
+      const dbRow = {
+        id: 'uuid-warn',
+        topic_id: 'warn-topic',
+        name: 'Warn Topic',
+        description: null,
+        status: 'active',
+        brand_id: null,
+        created_at: '2026-04-01T00:00:00Z',
+        created_by: 'system',
+        updated_at: '2026-04-01',
+        updated_by: 'system',
+      };
+
+      const topicsQuery = createChainableQuery({ data: dbRow, error: null });
+      const tcQuery = createChainableQuery({ data: null, error: { message: 'FK violation' } });
+      const fromStub = sinon.stub();
+      fromStub.withArgs('topics').returns(topicsQuery);
+      fromStub.withArgs('topic_categories').returns(tcQuery);
+      const postgrestClient = { from: fromStub };
+      const log = { warn: sinon.stub() };
+
+      const result = await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'Warn Topic', categoryId: 'bad-category-uuid' },
+        postgrestClient,
+        log,
+      });
+
+      // Topic creation still succeeds
+      expect(result.id).to.equal('warn-topic');
+      // Warning was emitted
+      expect(log.warn).to.have.been.calledOnce;
+      expect(log.warn.firstCall.args[0]).to.include('FK violation');
+    });
+
     it('skips topic_categories when categoryId is not provided', async () => {
       const dbRow = {
         id: 'uuid-no-cat',

--- a/test/support/topics-storage.test.js
+++ b/test/support/topics-storage.test.js
@@ -155,6 +155,63 @@ describe('topics-storage', () => {
       expect(result.createdBy).to.equal('user@test.com');
     });
 
+    it('upserts topic_categories when categoryId is provided', async () => {
+      const dbRow = {
+        id: 'uuid-tc',
+        topic_id: 'cat-linked-topic',
+        name: 'Category Linked',
+        description: null,
+        status: 'active',
+        brand_id: null,
+        created_at: '2026-04-01T00:00:00Z',
+        created_by: 'system',
+        updated_at: '2026-04-01',
+        updated_by: 'system',
+      };
+
+      const topicsQuery = createChainableQuery({ data: dbRow, error: null });
+      const tcQuery = createChainableQuery({ data: null, error: null });
+      const fromStub = sinon.stub();
+      fromStub.withArgs('topics').returns(topicsQuery);
+      fromStub.withArgs('topic_categories').returns(tcQuery);
+      const postgrestClient = { from: fromStub };
+
+      await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'Category Linked', categoryId: 'cat-uuid-123' },
+        postgrestClient,
+      });
+
+      expect(fromStub).to.have.been.calledWith('topic_categories');
+    });
+
+    it('skips topic_categories when categoryId is not provided', async () => {
+      const dbRow = {
+        id: 'uuid-no-cat',
+        topic_id: 'no-cat-topic',
+        name: 'No Category',
+        description: null,
+        status: 'active',
+        brand_id: null,
+        created_at: '2026-04-01T00:00:00Z',
+        created_by: 'system',
+        updated_at: '2026-04-01',
+        updated_by: 'system',
+      };
+
+      const query = createChainableQuery({ data: dbRow, error: null });
+      const fromStub = sinon.stub().returns(query);
+      const postgrestClient = { from: fromStub };
+
+      await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'No Category' },
+        postgrestClient,
+      });
+
+      expect(fromStub).to.not.have.been.calledWith('topic_categories');
+    });
+
     it('throws on database error during create', async () => {
       const query = createChainableQuery({ data: null, error: { message: 'unique violation' } });
       const postgrestClient = { from: sinon.stub().returns(query) };


### PR DESCRIPTION
## Summary

- `createTopic` in `topics-storage.js` now inserts a `topic_categories` junction row when the topic payload includes a `categoryId` field
- Uses PostgREST upsert with `onConflict: 'topic_id,category_id'` for idempotency
- Junction row errors are silently swallowed — topic creation succeeds even if the category FK is invalid

## Context

The SpaceCat API was silently ignoring `categoryId` when creating topics via `POST /v2/orgs/:orgId/topics`. This meant the `topic_categories` junction table was never populated, leaving all topics without category associations.

Discovered while investigating LLMO-4160 — the DRS scheduler and seed scripts both include `categoryId` in topic payloads, expecting the API to create the M2M link.

Related PRs:
- adobe-rnd/llmo-data-retrieval-service#1294 (LLMO-4160 fix script — creates topic_categories directly)
- adobe-rnd/llmo-data-retrieval-service#1303 (seed script — sends categoryId via API)
- adobe-rnd/llmo-data-retrieval-service#1304 (scheduler forward fix — sends categoryId via API)
- adobe/mysticat-data-service#345 (backfill migration for existing data)

## Test plan

- [x] Unit tests pass: `npx mocha test/support/topics-storage.test.js` (22 passing)
- [x] New test: verifies `topic_categories` upsert when `categoryId` provided
- [x] New test: verifies skip when `categoryId` absent
- [ ] Integration test coverage via existing `test/it/postgres/` suite

🤖 Generated with [Claude Code](https://claude.ai/code)