### PR TITLE
fix: add money-pages to Slack run-audit allowed audits list

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -49,6 +49,7 @@ const ALL_AUDITS = [
   'summarization',
   'faqs',
   'related-urls',
+  'money-pages',
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Adds `money-pages` to the `ALL_AUDITS` array in the Slack `run audit` command so the audit can be triggered via Slack

## Test plan
- [ ] Verify `run audit money-pages` works in Slack after the DB configuration record is registered via the API