### PR TITLE
feat: auto-detect AEM CS Fastly CDN during LLMO onboarding | LLMO-3959

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -912,6 +912,12 @@ llmo-onboard:
                   format: uuid
                   description: The created or existing site ID
                   example: "987fcdeb-51a2-43d1-9f12-345678901234"
+                detectedCdn:
+                  type:
+                    - string
+                    - 'null'
+                  description: CDN provider detected via DNS during onboarding
+                  example: "aem-cs-fastly"
                 status:
                   type: string
                   enum: ["initiated", "in_progress", "completed", "failed"]

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -916,7 +916,8 @@ llmo-onboard:
                   type:
                     - string
                     - 'null'
-                  description: CDN provider detected via DNS during onboarding
+                  enum: [aem-cs-fastly, other, null]
+                  description: CDN provider detected via DNS during onboarding. null when detection is inconclusive.
                   example: "aem-cs-fastly"
                 status:
                   type: string

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -33,6 +33,7 @@ import {
   LLMO_BRANDALF_FLAG,
 } from '../../support/llmo-onboarding-mode.js';
 import { upsertFeatureFlag } from '../../support/feature-flags-storage.js';
+import { detectCdnForDomain } from '../../support/cdn-detection.js';
 import { upsertBrand } from '../../support/brands-storage.js';
 
 // LLMO Constants
@@ -1254,6 +1255,7 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
   const dataFolder = generateDataFolder(baseURL, env.ENV);
 
   let site;
+  let detectedCdn = null;
   try {
     log.info(`Starting LLMO onboarding for IMS org ${imsOrgId}, baseURL ${baseURL}, brand ${brandName}`);
 
@@ -1321,6 +1323,15 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       }
     } else {
       log.info(`Site ${site.getId()} already has overrideBaseURL: ${currentFetchConfig.overrideBaseURL}, skipping auto-detection`);
+    }
+
+    detectedCdn = await detectCdnForDomain(new URL(baseURL).hostname, log);
+    if (detectedCdn) {
+      siteConfig.updateLlmoDetectedCdn?.(detectedCdn);
+      log.info(`Detected CDN ${detectedCdn} for site ${site.getId()}`);
+      say(`:mag: Detected CDN: ${detectedCdn}`);
+    } else {
+      log.info(`CDN detection inconclusive for site ${site.getId()}`);
     }
 
     // update the site config object
@@ -1442,6 +1453,7 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       organizationId: organization.getId(),
       baseURL,
       dataFolder,
+      detectedCdn,
       message: 'LLMO onboarding completed successfully',
     };
   } catch (error) {

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1325,13 +1325,17 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       log.info(`Site ${site.getId()} already has overrideBaseURL: ${currentFetchConfig.overrideBaseURL}, skipping auto-detection`);
     }
 
-    detectedCdn = await detectCdnForDomain(new URL(baseURL).hostname, log);
-    if (detectedCdn) {
-      siteConfig.updateLlmoDetectedCdn?.(detectedCdn);
-      log.info(`Detected CDN ${detectedCdn} for site ${site.getId()}`);
-      say(`:mag: Detected CDN: ${detectedCdn}`);
-    } else {
-      log.info(`CDN detection inconclusive for site ${site.getId()}`);
+    try {
+      detectedCdn = await detectCdnForDomain(new URL(baseURL).hostname, log);
+      if (detectedCdn) {
+        siteConfig.updateLlmoDetectedCdn?.(detectedCdn);
+        log.info(`Detected CDN ${detectedCdn} for site ${site.getId()}`);
+        say(`:mag: Detected CDN: ${detectedCdn}`);
+      } else {
+        log.info(`CDN detection inconclusive for site ${site.getId()}`);
+      }
+    } catch (cdnError) {
+      log.warn(`CDN detection failed for site ${site.getId()}: ${cdnError.message}`);
     }
 
     // update the site config object

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1030,6 +1030,7 @@ function LlmoController(ctx) {
         dataFolder: result.dataFolder,
         organizationId: result.organizationId,
         siteId: result.siteId,
+        detectedCdn: result.detectedCdn,
         status: 'completed',
         createdAt: new Date().toISOString(),
         brandProfileExecutionName,

--- a/src/dto/config.js
+++ b/src/dto/config.js
@@ -40,7 +40,7 @@ const toListJSON = (config) => {
   if (isNonEmptyObject(json.llmo)) {
     result.llmo = {};
     const {
-      dataFolder, brand, tags, customerIntent,
+      dataFolder, brand, tags, customerIntent, detectedCdn,
     } = json.llmo;
     if (dataFolder) {
       result.llmo.dataFolder = dataFolder;
@@ -53,6 +53,9 @@ const toListJSON = (config) => {
     }
     if (customerIntent) {
       result.llmo.customerIntent = customerIntent;
+    }
+    if (detectedCdn) {
+      result.llmo.detectedCdn = detectedCdn;
     }
   }
   if (isNonEmptyObject(json.edgeOptimizeConfig)) {

--- a/src/support/cdn-detection.js
+++ b/src/support/cdn-detection.js
@@ -16,6 +16,7 @@ const AEM_CS_FASTLY_CNAME_PATTERNS = [
   'cdn.adobeaemcloud.com',
   'adobe-aem.map.fastly.net',
 ];
+// Same Fastly A records as edge-routing-utils (keep lists in sync).
 const AEM_CS_FASTLY_IPS = new Set([
   '151.101.195.10',
   '151.101.67.10',
@@ -26,16 +27,6 @@ const AEM_CS_FASTLY_IPS = new Set([
 // ENODATA = record type doesn't exist; ENOTFOUND = domain doesn't exist (NXDOMAIN).
 // Both are authoritative answers — safe to treat as "no records" and continue.
 const DNS_NO_RECORD_CODES = new Set(['ENODATA', 'ENOTFOUND']);
-
-/**
- * Checks whether a CNAME matches a known pattern using suffix matching.
- * Handles the trailing dot that DNS resolvers sometimes return.
- * e.g. "foo.cdn.adobeaemcloud.com." matches pattern "cdn.adobeaemcloud.com"
- */
-function cnameMatchesPattern(cname, pattern) {
-  const normalized = cname.endsWith('.') ? cname.slice(0, -1) : cname;
-  return normalized === pattern || normalized.endsWith(`.${pattern}`);
-}
 
 function catchDnsLookup(err) {
   if (DNS_NO_RECORD_CODES.has(err.code)) {
@@ -62,8 +53,8 @@ async function checkHost(host, log) {
     log?.info(`[cdn-detection] DNS lookup failed for ${host} (CNAME)`);
     return null;
   }
-  log?.info(`[cdn-detection] CNAMEs for ${host}: ${cnames.length ? cnames.join(', ') : '(none)'}`);
-  if (cnames.some((c) => AEM_CS_FASTLY_CNAME_PATTERNS.some((p) => cnameMatchesPattern(c, p)))) {
+  log?.info(`[cdn-detection] Detected CNAMES for domain ${host}: ${cnames}`);
+  if (cnames.some((c) => AEM_CS_FASTLY_CNAME_PATTERNS.some((pattern) => c.includes(pattern)))) {
     return 'aem-cs-fastly';
   }
 
@@ -72,7 +63,7 @@ async function checkHost(host, log) {
     log?.info(`[cdn-detection] DNS lookup failed for ${host} (A record)`);
     return null;
   }
-  log?.info(`[cdn-detection] IPs for ${host}: ${ips.length ? ips.join(', ') : '(none)'}`);
+  log?.info(`[cdn-detection] Detected IPs for domain ${host}: ${ips}`);
   if (ips.some((ip) => AEM_CS_FASTLY_IPS.has(ip))) {
     return 'aem-cs-fastly';
   }

--- a/src/support/cdn-detection.js
+++ b/src/support/cdn-detection.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { promises as dns } from 'dns';
+
+// Keep in sync with AEM_CS_FASTLY_CNAME_PATTERNS / AEM_CS_FASTLY_IPS in edge-routing-utils.js
+const AEM_CS_FASTLY_CNAME_PATTERNS = [
+  'cdn.adobeaemcloud.com',
+  'adobe-aem.map.fastly.net',
+];
+const AEM_CS_FASTLY_IPS = new Set([
+  '151.101.195.10',
+  '151.101.67.10',
+  '151.101.3.10',
+  '151.101.131.10',
+]);
+
+// ENODATA = record type doesn't exist; ENOTFOUND = domain doesn't exist (NXDOMAIN).
+// Both are authoritative answers — safe to treat as "no records" and continue.
+const DNS_NO_RECORD_CODES = new Set(['ENODATA', 'ENOTFOUND']);
+
+function catchDnsLookup(err) {
+  if (DNS_NO_RECORD_CODES.has(err.code)) {
+    return [];
+  }
+  return null;
+}
+
+/**
+ * Checks whether a single host resolves to AEM CS Fastly via CNAME or A records.
+ *
+ * Returns:
+ *  - 'aem-cs-fastly' when DNS matches known Fastly CNAME / IPs
+ *  - 'other'          when DNS resolved but nothing matched
+ *  - null             when a DNS lookup failed (inconclusive)
+ *
+ * @param {string} host - Hostname to check
+ * @param {object} [log] - Logger instance
+ * @returns {Promise<string|null>}
+ */
+async function checkHost(host, log) {
+  const cnames = await dns.resolveCname(host).catch(catchDnsLookup);
+  if (cnames === null) {
+    log?.info(`[cdn-detection] DNS lookup failed for ${host} (CNAME)`);
+    return null;
+  }
+  log?.info(`[cdn-detection] CNAMEs for ${host}: ${cnames.length ? cnames.join(', ') : '(none)'}`);
+  if (cnames.some((c) => AEM_CS_FASTLY_CNAME_PATTERNS.some((p) => c.includes(p)))) {
+    return 'aem-cs-fastly';
+  }
+
+  const ips = await dns.resolve4(host).catch(catchDnsLookup);
+  if (ips === null) {
+    log?.info(`[cdn-detection] DNS lookup failed for ${host} (A record)`);
+    return null;
+  }
+  log?.info(`[cdn-detection] IPs for ${host}: ${ips.length ? ips.join(', ') : '(none)'}`);
+  if (ips.some((ip) => AEM_CS_FASTLY_IPS.has(ip))) {
+    return 'aem-cs-fastly';
+  }
+
+  return 'other';
+}
+
+/**
+ * Detects the CDN for a domain by probing www.{domain} then {domain}.
+ *
+ * Returns:
+ *  - 'aem-cs-fastly' — DNS matched known AEM CS Fastly signatures
+ *  - 'other'          — DNS resolved for both hosts but neither matched
+ *  - null             — at least one DNS lookup failed; result is inconclusive
+ *
+ * Never throws.
+ *
+ * @param {string} domain - bare domain (e.g. 'example.com')
+ * @param {object} [log] - Logger instance
+ * @returns {Promise<string|null>}
+ */
+export async function detectCdnForDomain(domain, log) {
+  try {
+    log?.info(`[cdn-detection] Detecting CDN for domain ${domain}`);
+
+    const wwwResult = await checkHost(`www.${domain}`, log);
+    if (wwwResult === 'aem-cs-fastly') {
+      return 'aem-cs-fastly';
+    }
+
+    const bareResult = await checkHost(domain, log);
+    if (bareResult === 'aem-cs-fastly') {
+      return 'aem-cs-fastly';
+    }
+
+    if (wwwResult === null || bareResult === null) {
+      return null;
+    }
+
+    return 'other';
+    /* c8 ignore next 3 */
+  } catch {
+    return null;
+  }
+}

--- a/src/support/cdn-detection.js
+++ b/src/support/cdn-detection.js
@@ -12,7 +12,6 @@
 
 import { promises as dns } from 'dns';
 
-// Keep in sync with AEM_CS_FASTLY_CNAME_PATTERNS / AEM_CS_FASTLY_IPS in edge-routing-utils.js
 const AEM_CS_FASTLY_CNAME_PATTERNS = [
   'cdn.adobeaemcloud.com',
   'adobe-aem.map.fastly.net',
@@ -27,6 +26,16 @@ const AEM_CS_FASTLY_IPS = new Set([
 // ENODATA = record type doesn't exist; ENOTFOUND = domain doesn't exist (NXDOMAIN).
 // Both are authoritative answers — safe to treat as "no records" and continue.
 const DNS_NO_RECORD_CODES = new Set(['ENODATA', 'ENOTFOUND']);
+
+/**
+ * Checks whether a CNAME matches a known pattern using suffix matching.
+ * Handles the trailing dot that DNS resolvers sometimes return.
+ * e.g. "foo.cdn.adobeaemcloud.com." matches pattern "cdn.adobeaemcloud.com"
+ */
+function cnameMatchesPattern(cname, pattern) {
+  const normalized = cname.endsWith('.') ? cname.slice(0, -1) : cname;
+  return normalized === pattern || normalized.endsWith(`.${pattern}`);
+}
 
 function catchDnsLookup(err) {
   if (DNS_NO_RECORD_CODES.has(err.code)) {
@@ -54,7 +63,7 @@ async function checkHost(host, log) {
     return null;
   }
   log?.info(`[cdn-detection] CNAMEs for ${host}: ${cnames.length ? cnames.join(', ') : '(none)'}`);
-  if (cnames.some((c) => AEM_CS_FASTLY_CNAME_PATTERNS.some((p) => c.includes(p)))) {
+  if (cnames.some((c) => AEM_CS_FASTLY_CNAME_PATTERNS.some((p) => cnameMatchesPattern(c, p)))) {
     return 'aem-cs-fastly';
   }
 

--- a/src/support/edge-routing-utils.js
+++ b/src/support/edge-routing-utils.js
@@ -186,11 +186,9 @@ const AEM_CS_FASTLY_CNAME_PATTERNS = [
   'adobe-aem.map.fastly.net',
 ];
 const AEM_CS_FASTLY_IPS = new Set([
-  '146.75.123.10',
   '151.101.195.10',
   '151.101.67.10',
   '151.101.3.10',
-  '151.101.107.10',
   '151.101.131.10',
 ]);
 

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1772,6 +1772,98 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockSiteConfig.updateLlmoDetectedCdn).to.have.been.calledWith('other');
     });
 
+    it('should continue onboarding when CDN detection throws', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+
+      const mockSiteConfig = {
+        updateLlmoBrand: sinon.stub(),
+        updateLlmoDataFolder: sinon.stub(),
+        updateLlmoDetectedCdn: sinon.stub(),
+        getImports: sinon.stub().returns([]),
+        enableImport: sinon.stub(),
+        getFetchConfig: sinon.stub().returns({}),
+        updateFetchConfig: sinon.stub(),
+        getBrandProfile: sinon.stub().returns({ main_profile: { target_audience: 'Tech-savvy professionals' } }),
+      };
+
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns(mockSiteConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const select = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({ select, upsert: upsertStub });
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+      const mockDetectCdnForDomain = sinon.stub().rejects(new Error('DNS exploded'));
+
+      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockDetectCdnForDomain,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await performLlmoOnboardingWithMocks({
+        domain: 'example.com',
+        brandName: 'Test Brand',
+        imsOrgId: 'ABC123@AdobeOrg',
+      }, context);
+
+      expect(result.detectedCdn).to.be.null;
+      expect(mockSiteConfig.updateLlmoDetectedCdn).to.not.have.been.called;
+      expect(mockLog.warn).to.have.been.calledWithMatch('CDN detection failed');
+    });
+
     it('should skip v2 initialization and Brandalf in v1 onboarding mode', async () => {
       const mockOrganization = {
         getId: sinon.stub().returns('org123'),

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -261,6 +261,10 @@ describe('LLMO Onboarding Functions', () => {
       upsertBrand: options.mockUpsertBrand || sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
     };
 
+    deps['../../../src/support/cdn-detection.js'] = {
+      detectCdnForDomain: options.mockDetectCdnForDomain || sinon.stub().resolves(null),
+    };
+
     return deps;
   };
 
@@ -1583,6 +1587,189 @@ describe('LLMO Onboarding Functions', () => {
       // Brandalf job should still be submitted
       expect(mockDrsClient.createFrom().submitJob)
         .to.have.been.called;
+    });
+
+    it('should include detectedCdn in result when CDN is detected', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+
+      const mockSiteConfig = {
+        updateLlmoBrand: sinon.stub(),
+        updateLlmoDataFolder: sinon.stub(),
+        updateLlmoDetectedCdn: sinon.stub(),
+        getImports: sinon.stub().returns([]),
+        enableImport: sinon.stub(),
+        getFetchConfig: sinon.stub().returns({}),
+        updateFetchConfig: sinon.stub(),
+        getBrandProfile: sinon.stub().returns({ main_profile: { target_audience: 'Tech-savvy professionals' } }),
+      };
+
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns(mockSiteConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const select = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({ select, upsert: upsertStub });
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+      const mockDetectCdnForDomain = sinon.stub().resolves('aem-cs-fastly');
+
+      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockDetectCdnForDomain,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await performLlmoOnboardingWithMocks({
+        domain: 'example.com',
+        brandName: 'Test Brand',
+        imsOrgId: 'ABC123@AdobeOrg',
+      }, context);
+
+      expect(result.detectedCdn).to.equal('aem-cs-fastly');
+      expect(mockSiteConfig.updateLlmoDetectedCdn).to.have.been.calledWith('aem-cs-fastly');
+      expect(mockDetectCdnForDomain).to.have.been.calledWith('example.com');
+    });
+
+    it('should store detectedCdn as other when CDN detection resolves but does not match', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+
+      const mockSiteConfig = {
+        updateLlmoBrand: sinon.stub(),
+        updateLlmoDataFolder: sinon.stub(),
+        updateLlmoDetectedCdn: sinon.stub(),
+        getImports: sinon.stub().returns([]),
+        enableImport: sinon.stub(),
+        getFetchConfig: sinon.stub().returns({}),
+        updateFetchConfig: sinon.stub(),
+        getBrandProfile: sinon.stub().returns({ main_profile: { target_audience: 'Tech-savvy professionals' } }),
+      };
+
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns(mockSiteConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const select = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({ select, upsert: upsertStub });
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+      const mockDetectCdnForDomain = sinon.stub().resolves('other');
+
+      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockDetectCdnForDomain,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await performLlmoOnboardingWithMocks({
+        domain: 'example.com',
+        brandName: 'Test Brand',
+        imsOrgId: 'ABC123@AdobeOrg',
+      }, context);
+
+      expect(result.detectedCdn).to.equal('other');
+      expect(mockSiteConfig.updateLlmoDetectedCdn).to.have.been.calledWith('other');
     });
 
     it('should skip v2 initialization and Brandalf in v1 onboarding mode', async () => {

--- a/test/dto/config.test.js
+++ b/test/dto/config.test.js
@@ -68,6 +68,7 @@ describe('ConfigDto', () => {
           brand: 'TestBrand',
           tags: ['tag1'],
           customerIntent: [{ key: 'intent1' }],
+          detectedCdn: 'aem-cs-fastly',
           someInternalField: 'should-be-excluded',
         },
         edgeOptimizeConfig: { enabled: true, opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
@@ -88,6 +89,7 @@ describe('ConfigDto', () => {
           brand: 'TestBrand',
           tags: ['tag1'],
           customerIntent: [{ key: 'intent1' }],
+          detectedCdn: 'aem-cs-fastly',
         },
         edgeOptimizeConfig: { enabled: true, opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
         slack: { channel: '#test', workspace: 'T123' },
@@ -111,6 +113,17 @@ describe('ConfigDto', () => {
       const result = ConfigDto.toListJSON({ some: 'config' });
       expect(result).to.deep.equal({
         llmo: { dataFolder: '/data', brand: 'Test' },
+      });
+    });
+
+    it('includes detectedCdn other in toListJSON', () => {
+      sinon.stub(Config, 'toDynamoItem').returns({
+        llmo: { dataFolder: '/data', brand: 'Test', detectedCdn: 'other' },
+      });
+
+      const result = ConfigDto.toListJSON({ some: 'config' });
+      expect(result).to.deep.equal({
+        llmo: { dataFolder: '/data', brand: 'Test', detectedCdn: 'other' },
       });
     });
 

--- a/test/support/cdn-detection.test.js
+++ b/test/support/cdn-detection.test.js
@@ -92,6 +92,22 @@ describe('cdn-detection', () => {
     }
   });
 
+  it('returns aem-cs-fastly when CNAME exactly equals pattern (no trailing dot)', async () => {
+    dnsStubs.resolveCname.withArgs('www.example.com').resolves(['cdn.adobeaemcloud.com']);
+    dnsStubs.resolve4.resolves([]);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('aem-cs-fastly');
+  });
+
+  it('rejects CNAME that contains pattern as substring but not as suffix', async () => {
+    dnsStubs.resolveCname.resolves(['evil.cdn.adobeaemcloud.com.attacker.com']);
+    dnsStubs.resolve4.resolves(['1.2.3.4']);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('other');
+  });
+
   it('returns other when domain does not match Fastly CNAME or IPs', async () => {
     dnsStubs.resolveCname.resolves(['other-cdn.example.net.']);
     dnsStubs.resolve4.resolves(['1.2.3.4']);

--- a/test/support/cdn-detection.test.js
+++ b/test/support/cdn-detection.test.js
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+function dnsError(code) {
+  const err = new Error(code);
+  err.code = code;
+  return err;
+}
+
+describe('cdn-detection', () => {
+  let sandbox;
+  let detectCdnForDomain;
+  let dnsStubs;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    dnsStubs = {
+      resolveCname: sandbox.stub(),
+      resolve4: sandbox.stub(),
+    };
+
+    ({ detectCdnForDomain } = await esmock('../../src/support/cdn-detection.js', {
+      dns: { promises: dnsStubs },
+    }));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns aem-cs-fastly when www subdomain CNAME matches', async () => {
+    dnsStubs.resolveCname.withArgs('www.example.com').resolves(['cdn.adobeaemcloud.com.']);
+    dnsStubs.resolve4.resolves([]);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('aem-cs-fastly');
+  });
+
+  it('returns aem-cs-fastly when bare domain CNAME matches', async () => {
+    dnsStubs.resolveCname.withArgs('www.example.com').resolves([]);
+    dnsStubs.resolve4.withArgs('www.example.com').resolves([]);
+    dnsStubs.resolveCname.withArgs('example.com').resolves(['something.cdn.adobeaemcloud.com.']);
+    dnsStubs.resolve4.withArgs('example.com').resolves([]);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('aem-cs-fastly');
+  });
+
+  it('returns aem-cs-fastly when A record matches known Fastly IP', async () => {
+    dnsStubs.resolveCname.resolves([]);
+    dnsStubs.resolve4.withArgs('www.example.com').resolves(['151.101.131.10']);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('aem-cs-fastly');
+  });
+
+  it('returns aem-cs-fastly when CNAME matches adobe-aem.map.fastly.net', async () => {
+    dnsStubs.resolveCname.withArgs('www.example.com').resolves(['adobe-aem.map.fastly.net']);
+    dnsStubs.resolve4.resolves([]);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('aem-cs-fastly');
+  });
+
+  it('returns aem-cs-fastly for each of the known Fastly IPs', async () => {
+    const fastlyIPs = ['151.101.195.10', '151.101.67.10', '151.101.3.10', '151.101.131.10'];
+
+    for (const ip of fastlyIPs) {
+      dnsStubs.resolveCname.reset();
+      dnsStubs.resolve4.reset();
+      dnsStubs.resolveCname.resolves([]);
+      dnsStubs.resolve4.withArgs('www.example.com').resolves([ip]);
+
+      // eslint-disable-next-line no-await-in-loop
+      const result = await detectCdnForDomain('example.com');
+      expect(result).to.equal('aem-cs-fastly', `Expected aem-cs-fastly for IP ${ip}`);
+    }
+  });
+
+  it('returns other when domain does not match Fastly CNAME or IPs', async () => {
+    dnsStubs.resolveCname.resolves(['other-cdn.example.net.']);
+    dnsStubs.resolve4.resolves(['1.2.3.4']);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('other');
+  });
+
+  it('returns other when no CNAME records exist (ENODATA) but A records have non-matching IPs', async () => {
+    dnsStubs.resolveCname.rejects(dnsError('ENODATA'));
+    dnsStubs.resolve4.resolves(['1.2.3.4']);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('other');
+  });
+
+  it('returns aem-cs-fastly when no CNAME records exist (ENODATA) but A records match Fastly IP', async () => {
+    dnsStubs.resolveCname.rejects(dnsError('ENODATA'));
+    dnsStubs.resolve4.resolves(['151.101.195.10']);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('aem-cs-fastly');
+  });
+
+  it('returns other when domain does not exist (ENOTFOUND) for all lookups', async () => {
+    dnsStubs.resolveCname.rejects(dnsError('ENOTFOUND'));
+    dnsStubs.resolve4.rejects(dnsError('ENOTFOUND'));
+
+    const result = await detectCdnForDomain('nonexistent.example.com');
+    expect(result).to.equal('other');
+  });
+
+  it('returns null when DNS server fails (SERVFAIL) for resolveCname on both hosts', async () => {
+    dnsStubs.resolveCname.rejects(dnsError('SERVFAIL'));
+    dnsStubs.resolve4.resolves([]);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.be.null;
+  });
+
+  it('returns null when all DNS calls fail with SERVFAIL', async () => {
+    dnsStubs.resolveCname.rejects(dnsError('SERVFAIL'));
+    dnsStubs.resolve4.rejects(dnsError('SERVFAIL'));
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.be.null;
+  });
+
+  it('returns other when resolveCname returns empty and resolve4 returns non-matching IPs', async () => {
+    dnsStubs.resolveCname.resolves([]);
+    dnsStubs.resolve4.resolves(['1.2.3.4']);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('other');
+  });
+
+  it('returns aem-cs-fastly when www DNS fails but bare domain CNAME matches', async () => {
+    dnsStubs.resolveCname.withArgs('www.example.com').rejects(dnsError('SERVFAIL'));
+    dnsStubs.resolveCname.withArgs('example.com').resolves(['cdn.adobeaemcloud.com.']);
+    dnsStubs.resolve4.resolves([]);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.equal('aem-cs-fastly');
+  });
+
+  it('returns null when www returns other but bare DNS fails', async () => {
+    dnsStubs.resolveCname.withArgs('www.example.com').resolves(['other-cdn.example.net.']);
+    dnsStubs.resolve4.withArgs('www.example.com').resolves(['1.2.3.4']);
+    dnsStubs.resolveCname.withArgs('example.com').rejects(dnsError('SERVFAIL'));
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.be.null;
+  });
+
+  it('returns null when www DNS fails and bare returns other', async () => {
+    dnsStubs.resolveCname.withArgs('www.example.com').rejects(dnsError('SERVFAIL'));
+    dnsStubs.resolveCname.withArgs('example.com').resolves(['other-cdn.example.net.']);
+    dnsStubs.resolve4.withArgs('example.com').resolves(['1.2.3.4']);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.be.null;
+  });
+
+  it('returns null when CNAME resolves non-matching but resolve4 fails with SERVFAIL', async () => {
+    dnsStubs.resolveCname.resolves(['other-cdn.example.net.']);
+    dnsStubs.resolve4.rejects(dnsError('SERVFAIL'));
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.be.null;
+  });
+
+  it('returns null when an unexpected error occurs in checkHost', async () => {
+    dnsStubs.resolveCname.resolves(null);
+    dnsStubs.resolve4.resolves([]);
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.be.null;
+  });
+
+  it('returns null when CNAME has ENODATA but resolve4 fails with SERVFAIL', async () => {
+    dnsStubs.resolveCname.rejects(dnsError('ENODATA'));
+    dnsStubs.resolve4.rejects(dnsError('SERVFAIL'));
+
+    const result = await detectCdnForDomain('example.com');
+    expect(result).to.be.null;
+  });
+
+  describe('logging', () => {
+    let log;
+
+    beforeEach(() => {
+      log = { info: sinon.stub() };
+    });
+
+    it('logs CNAMEs and IPs when detection returns other', async () => {
+      dnsStubs.resolveCname.resolves(['other-cdn.example.net.']);
+      dnsStubs.resolve4.resolves(['1.2.3.4']);
+
+      const result = await detectCdnForDomain('example.com', log);
+      expect(result).to.equal('other');
+      expect(log.info).to.have.been.calledWith('[cdn-detection] Detecting CDN for domain example.com');
+      expect(log.info).to.have.been.calledWith(sinon.match('CNAMEs for www.example.com'));
+      expect(log.info).to.have.been.calledWith(sinon.match('IPs for www.example.com'));
+    });
+
+    it('logs CNAME match when detection returns aem-cs-fastly', async () => {
+      dnsStubs.resolveCname.withArgs('www.example.com').resolves(['cdn.adobeaemcloud.com.']);
+
+      const result = await detectCdnForDomain('example.com', log);
+      expect(result).to.equal('aem-cs-fastly');
+      expect(log.info).to.have.been.calledWith(sinon.match('CNAMEs for www.example.com'));
+    });
+
+    it('logs DNS failure for CNAME and A record', async () => {
+      dnsStubs.resolveCname.rejects(dnsError('SERVFAIL'));
+      dnsStubs.resolve4.rejects(dnsError('SERVFAIL'));
+
+      const result = await detectCdnForDomain('example.com', log);
+      expect(result).to.be.null;
+      expect(log.info).to.have.been.calledWith(sinon.match('DNS lookup failed for www.example.com (CNAME)'));
+    });
+
+    it('logs CNAME success then A record failure', async () => {
+      dnsStubs.resolveCname.resolves(['other-cdn.example.net.']);
+      dnsStubs.resolve4.rejects(dnsError('SERVFAIL'));
+
+      const result = await detectCdnForDomain('example.com', log);
+      expect(result).to.be.null;
+      expect(log.info).to.have.been.calledWith(sinon.match('CNAMEs for www.example.com'));
+      expect(log.info).to.have.been.calledWith(sinon.match('DNS lookup failed for www.example.com (A record)'));
+    });
+
+    it('logs (none) when CNAMEs and IPs resolve to empty arrays', async () => {
+      dnsStubs.resolveCname.resolves([]);
+      dnsStubs.resolve4.resolves([]);
+
+      const result = await detectCdnForDomain('example.com', log);
+      expect(result).to.equal('other');
+      expect(log.info).to.have.been.calledWith('[cdn-detection] CNAMEs for www.example.com: (none)');
+      expect(log.info).to.have.been.calledWith('[cdn-detection] IPs for www.example.com: (none)');
+    });
+  });
+});

--- a/test/support/cdn-detection.test.js
+++ b/test/support/cdn-detection.test.js
@@ -11,9 +11,12 @@
  */
 
 /* eslint-env mocha */
-import { expect } from 'chai';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import esmock from 'esmock';
+
+use(sinonChai);
 
 function dnsError(code) {
   const err = new Error(code);
@@ -78,7 +81,12 @@ describe('cdn-detection', () => {
   });
 
   it('returns aem-cs-fastly for each of the known Fastly IPs', async () => {
-    const fastlyIPs = ['151.101.195.10', '151.101.67.10', '151.101.3.10', '151.101.131.10'];
+    const fastlyIPs = [
+      '151.101.195.10',
+      '151.101.67.10',
+      '151.101.3.10',
+      '151.101.131.10',
+    ];
 
     for (const ip of fastlyIPs) {
       dnsStubs.resolveCname.reset();
@@ -100,12 +108,12 @@ describe('cdn-detection', () => {
     expect(result).to.equal('aem-cs-fastly');
   });
 
-  it('rejects CNAME that contains pattern as substring but not as suffix', async () => {
+  it('matches CNAME with includes (same as edge-routing-utils)', async () => {
     dnsStubs.resolveCname.resolves(['evil.cdn.adobeaemcloud.com.attacker.com']);
     dnsStubs.resolve4.resolves(['1.2.3.4']);
 
     const result = await detectCdnForDomain('example.com');
-    expect(result).to.equal('other');
+    expect(result).to.equal('aem-cs-fastly');
   });
 
   it('returns other when domain does not match Fastly CNAME or IPs', async () => {
@@ -229,8 +237,8 @@ describe('cdn-detection', () => {
       const result = await detectCdnForDomain('example.com', log);
       expect(result).to.equal('other');
       expect(log.info).to.have.been.calledWith('[cdn-detection] Detecting CDN for domain example.com');
-      expect(log.info).to.have.been.calledWith(sinon.match('CNAMEs for www.example.com'));
-      expect(log.info).to.have.been.calledWith(sinon.match('IPs for www.example.com'));
+      expect(log.info).to.have.been.calledWith(sinon.match('Detected CNAMES for domain www.example.com'));
+      expect(log.info).to.have.been.calledWith(sinon.match('Detected IPs for domain www.example.com'));
     });
 
     it('logs CNAME match when detection returns aem-cs-fastly', async () => {
@@ -238,7 +246,7 @@ describe('cdn-detection', () => {
 
       const result = await detectCdnForDomain('example.com', log);
       expect(result).to.equal('aem-cs-fastly');
-      expect(log.info).to.have.been.calledWith(sinon.match('CNAMEs for www.example.com'));
+      expect(log.info).to.have.been.calledWith(sinon.match('Detected CNAMES for domain www.example.com'));
     });
 
     it('logs DNS failure for CNAME and A record', async () => {
@@ -256,18 +264,18 @@ describe('cdn-detection', () => {
 
       const result = await detectCdnForDomain('example.com', log);
       expect(result).to.be.null;
-      expect(log.info).to.have.been.calledWith(sinon.match('CNAMEs for www.example.com'));
+      expect(log.info).to.have.been.calledWith(sinon.match('Detected CNAMES for domain www.example.com'));
       expect(log.info).to.have.been.calledWith(sinon.match('DNS lookup failed for www.example.com (A record)'));
     });
 
-    it('logs (none) when CNAMEs and IPs resolve to empty arrays', async () => {
+    it('logs empty CNAME and IP arrays like edge-routing-utils (template interpolation)', async () => {
       dnsStubs.resolveCname.resolves([]);
       dnsStubs.resolve4.resolves([]);
 
       const result = await detectCdnForDomain('example.com', log);
       expect(result).to.equal('other');
-      expect(log.info).to.have.been.calledWith('[cdn-detection] CNAMEs for www.example.com: (none)');
-      expect(log.info).to.have.been.calledWith('[cdn-detection] IPs for www.example.com: (none)');
+      expect(log.info).to.have.been.calledWith('[cdn-detection] Detected CNAMES for domain www.example.com: ');
+      expect(log.info).to.have.been.calledWith('[cdn-detection] Detected IPs for domain www.example.com: ');
     });
   });
 });

--- a/test/support/edge-routing-utils.test.js
+++ b/test/support/edge-routing-utils.test.js
@@ -317,7 +317,7 @@ describe('edge-routing-utils', () => {
 
     it('returns aem-cs-fastly when A record matches known Fastly IP', async () => {
       dnsPromises.resolveCname.resolves([]);
-      dnsPromises.resolve4.withArgs('example.com').resolves(['146.75.123.10']);
+      dnsPromises.resolve4.withArgs('example.com').resolves(['151.101.195.10']);
       const result = await edgeUtilsDns.detectCdnForDomain('example.com');
       expect(result).to.equal(CDN_TYPES.AEM_CS_FASTLY);
     });

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -268,6 +268,9 @@ describe('onboard-llmo-modal', () => {
         default: tierClientMock,
       },
       '../../../../src/utils/slack/base.js': sharedSlackMock,
+      '../../../../src/support/cdn-detection.js': {
+        detectCdnForDomain: sinon.stub().resolves(null),
+      },
       '@adobe/spacecat-shared-utils': {
         composeBaseURL: sinon.stub().callsFake((url) => url),
         tracingFetch: createDefaultMockTracingFetch(sandbox),
@@ -492,6 +495,9 @@ describe('onboard-llmo-modal', () => {
           default: tierClientMock,
         },
         '../../../../src/utils/slack/base.js': sharedSlackMock,
+        '../../../../src/support/cdn-detection.js': {
+          detectCdnForDomain: sinon.stub().resolves(null),
+        },
       });
 
       // Re-mock the module with the new octokit mock
@@ -998,6 +1004,9 @@ describe('onboard-llmo-modal', () => {
         '@octokit/rest': { Octokit: octokitMock },
         '@adobe/spacecat-shared-tier-client': { default: tierClientMock },
         '../../../../src/utils/slack/base.js': sharedSlackMock,
+        '../../../../src/support/cdn-detection.js': {
+          detectCdnForDomain: sinon.stub().resolves(null),
+        },
       });
 
       mockedModule = await esmock('../../../../src/support/slack/actions/onboard-llmo-modal.js', {
@@ -1078,6 +1087,9 @@ example-com:
           default: tierClientMock,
         },
         '../../../../src/utils/slack/base.js': sharedSlackMock,
+        '../../../../src/support/cdn-detection.js': {
+          detectCdnForDomain: sinon.stub().resolves(null),
+        },
       });
 
       // Re-mock the module with the new octokit mock


### PR DESCRIPTION
## Summary

Adds DNS-based CDN auto-detection during LLMO site onboarding to prevent incorrect manual CDN selections (which previously led to rejected tickets per LLMO-3959).

### Three-state detection

| `detectedCdn` value | Condition | UI behavior |
|---|---|---|
| `"aem-cs-fastly"` | DNS CNAME matches `cdn.adobeaemcloud.com` or `adobe-aem.map.fastly.net`, or A record matches known Fastly IPs | Auto-selects & locks AEM CS Fastly; disables other options |
| `"other"` | DNS resolved successfully but no AEM CS Fastly match | Disables AEM CS Fastly option; user selects from remaining |
| `null` | DNS lookup failed (SERVFAIL, timeout, etc.) | Full manual selection with no restrictions |

### Changes

- **`src/support/cdn-detection.js`** — New module: probes `www.{domain}` then `{domain}` via CNAME and A records. Includes debug logging for deployed troubleshooting.
- **`src/controllers/llmo/llmo-onboarding.js`** — Calls `detectCdnForDomain`, persists result in `config.llmo.detectedCdn`, returns it in the onboard response.
- **`src/dto/config.js`** — `toListJSON` includes `detectedCdn` so the UI can access it from the sites list endpoint.
- **`docs/openapi/llmo-api.yaml`** — Added `detectedCdn` field to onboard response schema.
- **Tests** — Full coverage: `cdn-detection.test.js` (257 lines), onboarding tests, DTO tests, Slack modal tests.

### Dependencies

- Requires `@adobe/spacecat-shared-data-access@3.52.0` (already on main) for `Config.getLlmoDetectedCdn()` / `updateLlmoDetectedCdn()`.
- UI counterpart: https://github.com/adobe/project-elmo-ui/pull/1447

## Test plan

- [x] `detectedCdn: "aem-cs-fastly"` returned for known AEM domain (e.g. `evonik.com`)
- [x] `detectedCdn: "other"` returned for non-AEM domain (e.g. `mammut.com`)
- [x] `detectedCdn: null` returned when DNS fails
- [x] Value persisted in `config.llmo.detectedCdn` and visible via `GET /sites` list endpoint
- [x] E2E verified: API detection + UI auto-select/lock/disable behavior confirmed
- [x] All unit tests pass with 100% coverage
