### PR TITLE
feat(llmo-3476): validate suggestion IDs are valid UUIDs in deployToEdge

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -797,11 +797,11 @@ function SuggestionsController(ctx, sqs, env) {
       const {
         id, status, skipReason, skipDetail,
       } = item;
-      if (!hasText(id)) {
+      if (!isValidUUID(id)) {
         return {
           index,
-          uuid: '',
-          message: 'suggestion id is required',
+          uuid: id || '',
+          message: 'suggestion id must be a valid UUID',
           statusCode: 400,
         };
       }
@@ -1093,6 +1093,10 @@ function SuggestionsController(ctx, sqs, env) {
     // suggestion-based flow (assess, fix, etc.)
     if (!isArray(suggestionIds)) {
       return badRequest('Request body must be an array of suggestionIds');
+    }
+    const invalidAutoFixIds = suggestionIds.filter((id) => !isValidUUID(id));
+    if (invalidAutoFixIds.length > 0) {
+      return badRequest(`suggestionIds must contain valid UUIDs. Invalid: ${invalidAutoFixIds.join(', ')}`);
     }
     if (variations && !isArray(variations)) {
       return badRequest('variations must be an array');
@@ -1404,6 +1408,11 @@ function SuggestionsController(ctx, sqs, env) {
     if (!isArray(suggestionIds) || suggestionIds.length === 0) {
       context.log.warn(`[edge-preview-failed] site: ${apexBaseUrl}, suggestionIds is not a non-empty array`);
       return badRequest('Request body must contain a non-empty array of suggestionIds');
+    }
+    const invalidPreviewIds = suggestionIds.filter((id) => !isValidUUID(id));
+    if (invalidPreviewIds.length > 0) {
+      context.log.warn(`[edge-preview-failed] site: ${apexBaseUrl}, invalid suggestionIds: ${invalidPreviewIds.join(', ')}`);
+      return badRequest(`suggestionIds must contain valid UUIDs. Invalid: ${invalidPreviewIds.join(', ')}`);
     }
 
     if (!await accessControlUtil.hasAccess(site)) {
@@ -2197,6 +2206,11 @@ function SuggestionsController(ctx, sqs, env) {
     if (!isArray(suggestionIds) || suggestionIds.length === 0) {
       context.log.warn('[edge-rollback-failed] site: n/a, suggestionIds is not a non-empty array');
       return badRequest('Request body must contain a non-empty array of suggestionIds');
+    }
+    const invalidRollbackIds = suggestionIds.filter((id) => !isValidUUID(id));
+    if (invalidRollbackIds.length > 0) {
+      context.log.warn(`[edge-rollback-failed] site: ${apexBaseUrl}, invalid suggestionIds: ${invalidRollbackIds.join(', ')}`);
+      return badRequest(`suggestionIds must contain valid UUIDs. Invalid: ${invalidRollbackIds.join(', ')}`);
     }
 
     // No productCode is passed to hasAccess(); the delegation block is not entered.

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1607,6 +1607,12 @@ function SuggestionsController(ctx, sqs, env) {
     }
     const suggestionIds = [...new Set(rawSuggestionIds)];
 
+    const invalidIds = suggestionIds.filter((id) => !isValidUUID(id));
+    if (invalidIds.length > 0) {
+      context.log.warn(`[edge-deploy-failed] site: ${apexBaseUrl}, invalid suggestionIds: ${invalidIds.join(', ')}`);
+      return badRequest(`suggestionIds must contain valid UUIDs. Invalid: ${invalidIds.join(', ')}`);
+    }
+
     // No productCode is passed to hasAccess(); the delegation block is not entered.
     // Org membership is the intended access gate for this endpoint.
     if (!await accessControlUtil.hasAccess(site)) {

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -5980,6 +5980,32 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('returns badRequest when suggestionIds contains non-UUID values', async () => {
+      const response = await suggestionsController.deploySuggestionToEdge({
+        ...context,
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: ['not-a-uuid', 'https://example.com/page'] },
+        env: {},
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.include('https://example.com/page');
+    });
+
+    it('returns badRequest when suggestionIds contains a mix of valid and invalid UUIDs', async () => {
+      const response = await suggestionsController.deploySuggestionToEdge({
+        ...context,
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0], 'not-a-uuid'] },
+        env: {},
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.not.include(SUGGESTION_IDS[0]);
+    });
+
     it('returns forbidden when user does not have access to site', async () => {
       sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
 

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -2926,6 +2926,25 @@ describe('Suggestions Controller', () => {
     expect(error).to.have.property('message', 'Request body must be an array of [{ id: <suggestion id>, status: <suggestion status> },...]');
   });
 
+  it('bulk patches suggestion status returns 400 per item when id is not a valid UUID', async () => {
+    const response = await suggestionsController.patchSuggestionsStatus({
+      params: {
+        siteId: SITE_ID,
+        opportunityId: OPPORTUNITY_ID,
+      },
+      data: [{ id: 'not-a-uuid', status: 'NEW' }, { id: SUGGESTION_IDS[0], status: 'NEW' }],
+      ...context,
+    });
+    expect(response.status).to.equal(207);
+    const body = await response.json();
+    expect(body.metadata).to.have.property('total', 2);
+    expect(body.metadata).to.have.property('success', 1);
+    expect(body.metadata).to.have.property('failed', 1);
+    expect(body.suggestions[0]).to.have.property('statusCode', 400);
+    expect(body.suggestions[0]).to.have.property('message', 'suggestion id must be a valid UUID');
+    expect(body.suggestions[1]).to.have.property('statusCode', 200);
+  });
+
   it('bulk patches suggestion status 1 fails passed data does not have id', async () => {
     const response = await suggestionsController.patchSuggestionsStatus({
       params: {
@@ -2950,7 +2969,7 @@ describe('Suggestions Controller', () => {
     expect(bulkPatchResponse.suggestions[0].suggestion).to.exist;
     expect(bulkPatchResponse.suggestions[1].suggestion).to.not.exist;
     expect(bulkPatchResponse.suggestions[0].message).to.not.exist;
-    expect(bulkPatchResponse.suggestions[1]).to.have.property('message', 'suggestion id is required');
+    expect(bulkPatchResponse.suggestions[1]).to.have.property('message', 'suggestion id must be a valid UUID');
   });
 
   it('bulk patches suggestion status fails if site ID does not match site id of the opportunity', async () => {
@@ -4268,6 +4287,36 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(400);
       const error = await response.json();
       expect(error).to.have.property('message', 'Request body must be an array of suggestionIds');
+    });
+
+    it('auto-fix suggestions returns 400 when suggestionIds contains non-UUID values', async () => {
+      const response = await suggestionsController.autofixSuggestions({
+        params: {
+          siteId: SITE_ID,
+          opportunityId: OPPORTUNITY_ID,
+        },
+        data: { suggestionIds: ['not-a-uuid', 'https://example.com/page'] },
+        ...context,
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.include('https://example.com/page');
+    });
+
+    it('auto-fix suggestions returns 400 when suggestionIds contains a mix of valid and invalid UUIDs', async () => {
+      const response = await suggestionsController.autofixSuggestions({
+        params: {
+          siteId: SITE_ID,
+          opportunityId: OPPORTUNITY_ID,
+        },
+        data: { suggestionIds: [SUGGESTION_IDS[0], 'not-a-uuid'] },
+        ...context,
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.not.include(SUGGESTION_IDS[0]);
     });
 
     it('auto-fix suggestions returns 404 if site not found', async () => {
@@ -8297,6 +8346,30 @@ describe('Suggestions Controller', () => {
       expect(error).to.have.property('message', 'Request body must contain a non-empty array of suggestionIds');
     });
 
+    it('should return 400 when suggestionIds contains non-UUID values', async () => {
+      const response = await suggestionsController.rollbackSuggestionFromEdge({
+        ...context,
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: ['not-a-uuid', 'https://example.com/page'] },
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.include('https://example.com/page');
+    });
+
+    it('should return 400 when suggestionIds contains a mix of valid and invalid UUIDs', async () => {
+      const response = await suggestionsController.rollbackSuggestionFromEdge({
+        ...context,
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0], 'not-a-uuid'] },
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.not.include(SUGGESTION_IDS[0]);
+    });
+
     it('uses base URL fallback when getHostName returns null (rollback)', async () => {
       site.getBaseURL = sandbox.stub().returns('');
       const response = await suggestionsController.rollbackSuggestionFromEdge({
@@ -9287,6 +9360,30 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(400);
       const body = await response.json();
       expect(body.message).to.include('non-empty array');
+    });
+
+    it('should return 400 if suggestionIds contains non-UUID values', async () => {
+      const response = await suggestionsController.previewSuggestions({
+        ...context,
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: ['not-a-uuid', 'https://example.com/page'] },
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.include('https://example.com/page');
+    });
+
+    it('should return 400 if suggestionIds contains a mix of valid and invalid UUIDs', async () => {
+      const response = await suggestionsController.previewSuggestions({
+        ...context,
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0], 'not-a-uuid'] },
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('not-a-uuid');
+      expect(body.message).to.not.include(SUGGESTION_IDS[0]);
     });
 
     it('should return 404 if site not found', async () => {


### PR DESCRIPTION
## Summary

The `POST /sites/:siteId/suggestions/deploy-to-edge` endpoint accepts a `suggestionIds` array but did not validate that each entry was a well-formed UUID before proceeding to DB lookups and downstream Tokowaka calls. This opened the door to unexpected behavior when non-UUID values (e.g. full page URLs accidentally passed as suggestion IDs) made it through to data-access layer queries.

Changes:
- Filters `suggestionIds` against the existing `isValidUUID` utility (already used throughout the controller for `siteId` / `opportunityId` validation)
- Returns HTTP 400 with a descriptive message listing the invalid IDs if any are found
- Logs `[edge-deploy-failed]` with the invalid IDs for observability, consistent with the existing warning pattern in this function

## Test plan
- [ ] All existing unit tests pass
- [ ] `POST /sites/:siteId/suggestions/deploy-to-edge` with a valid UUID array proceeds normally (no regression)
- [ ] Request with `{ suggestionIds: ["not-a-uuid", "https://example.com/page"] }` → 400, response body lists both invalid values
- [ ] Request with a mix of valid UUIDs and invalid values → 400, response body lists only the invalid entries

Fixes [LLMO-3476](https://jira.corp.adobe.com/browse/LLMO-3476)