### PR TITLE
feat: add url-brand-presence endpoint | LLMO-4000

### DIFF
--- a/docs/llmo-brandalf-apis/agentic-traffic-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-api.md
@@ -1,0 +1,232 @@
+# Agentic Traffic API
+
+Site-scoped endpoints that surface AI-crawler traffic metrics for a single site. Data is queried from the `agentic_traffic` table in mysticat-data-service via PostgREST RPC functions. All endpoints require LLMO organization access.
+
+---
+
+## API Paths
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/sites/:siteId/agentic-traffic/kpis` | Aggregate KPIs for the date range |
+| GET | `/sites/:siteId/agentic-traffic/kpis-trend` | KPIs broken down by time interval |
+| GET | `/sites/:siteId/agentic-traffic/by-region` | Total hits grouped by region |
+| GET | `/sites/:siteId/agentic-traffic/by-category` | Total hits grouped by content category |
+| GET | `/sites/:siteId/agentic-traffic/by-page-type` | Total hits grouped by page type |
+| GET | `/sites/:siteId/agentic-traffic/by-status` | Total hits grouped by HTTP status code |
+
+**Path parameters:**
+- `siteId` — Site UUID
+
+---
+
+## Common Query Parameters
+
+All endpoints in this file share these query parameters.
+
+| Parameter | Aliases | Type | Default | Description |
+|-----------|---------|------|---------|-------------|
+| `startDate` | `start_date` | string (YYYY-MM-DD) | 28 days ago | Start of date range |
+| `endDate` | `end_date` | string (YYYY-MM-DD) | today | End of date range |
+| `platform` | — | string | — | AI platform filter. Accepts UI codes — see platform mapping below. |
+| `categoryName` | `category_name` | string | — | Filter by content category name |
+| `agentType` | `agent_type` | string | — | Filter by agent type |
+| `userAgent` | `user_agent` | string | — | Filter by user agent string |
+| `contentType` | `content_type` | string | — | Filter by content type |
+
+### Platform Code Mapping
+
+The `platform` parameter accepts UI-friendly codes that are mapped to the values stored in the `agentic_traffic.platform` column before being sent to the database. Unknown codes and `all` resolve to `null` (no filter applied).
+
+| UI Code | DB Value |
+|---------|----------|
+| `openai` | `ChatGPT` |
+| `chatgpt` | `ChatGPT` |
+| `anthropic` | `Anthropic` |
+| `mistral` | `MistralAI` |
+| `perplexity` | `Perplexity` |
+| `gemini` | `Gemini` |
+| `google` | `Google` |
+| `amazon` | `Amazon` |
+
+> **Note:** Before this mapping was added, raw UI codes (e.g. `openai`) were forwarded to the DB verbatim and never matched any rows. Always pass a recognised UI code or omit the parameter entirely.
+
+---
+
+## Endpoint Details
+
+### GET `/sites/:siteId/agentic-traffic/kpis`
+
+Returns aggregate KPIs for the site over the requested date range.
+
+**RPC:** `rpc_agentic_traffic_kpis`
+
+**Response:**
+
+```json
+{
+  "totalHits": 48230,
+  "successRate": 0.94,
+  "avgTtfbMs": 312.5,
+  "avgCitabilityScore": 0.71
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalHits` | number | Total AI-crawler requests |
+| `successRate` | number \| null | Fraction of 2xx responses (0–1). `null` if no data. |
+| `avgTtfbMs` | number \| null | Average time-to-first-byte in milliseconds. `null` if no data. |
+| `avgCitabilityScore` | number \| null | Average citability score (0–1). `null` if no data. |
+
+---
+
+### GET `/sites/:siteId/agentic-traffic/kpis-trend`
+
+Returns KPIs grouped by time interval. Useful for sparklines and trend charts.
+
+**Additional parameter:**
+
+| Parameter | Type | Default | Valid values |
+|-----------|------|---------|-------------|
+| `interval` | string | `week` | `day`, `week`, `month` |
+
+**RPC:** `rpc_agentic_traffic_kpis_trend`
+
+**Response:**
+
+```json
+[
+  {
+    "periodStart": "2026-03-02",
+    "totalHits": 11200,
+    "successRate": 0.95,
+    "avgTtfbMs": 298.1,
+    "avgCitabilityScore": 0.73
+  },
+  {
+    "periodStart": "2026-02-23",
+    "totalHits": 10800,
+    "successRate": 0.93,
+    "avgTtfbMs": 315.4,
+    "avgCitabilityScore": 0.70
+  }
+]
+```
+
+Each item covers one `interval` period starting at `periodStart`.
+
+---
+
+### GET `/sites/:siteId/agentic-traffic/by-region`
+
+Returns total hits grouped by geographic region.
+
+**RPC:** `rpc_agentic_traffic_by_region`
+
+**Response:**
+
+```json
+[
+  { "region": "US", "totalHits": 24100 },
+  { "region": "DE", "totalHits": 8400 }
+]
+```
+
+---
+
+### GET `/sites/:siteId/agentic-traffic/by-category`
+
+Returns total hits grouped by content category.
+
+> **Note:** `categoryName` / `category_name` is not forwarded to this RPC — the function groups by category and filtering by a single category is not supported here. Use `by-url` with a `categoryName` filter for per-category URL breakdowns.
+
+**RPC:** `rpc_agentic_traffic_by_category`
+
+**Response:**
+
+```json
+[
+  { "categoryName": "Blog", "totalHits": 18900 },
+  { "categoryName": "Uncategorized", "totalHits": 5200 }
+]
+```
+
+---
+
+### GET `/sites/:siteId/agentic-traffic/by-page-type`
+
+Returns total hits grouped by page type.
+
+**RPC:** `rpc_agentic_traffic_by_page_type`
+
+**Response:**
+
+```json
+[
+  { "pageType": "article", "totalHits": 21300 },
+  { "pageType": "Other", "totalHits": 4100 }
+]
+```
+
+---
+
+### GET `/sites/:siteId/agentic-traffic/by-status`
+
+Returns total hits grouped by HTTP response status code.
+
+**RPC:** `rpc_agentic_traffic_by_status`
+
+**Response:**
+
+```json
+[
+  { "httpStatus": 200, "totalHits": 45300 },
+  { "httpStatus": 404, "totalHits": 2900 }
+]
+```
+
+---
+
+## RPC Parameter Mapping
+
+All site-scoped RPCs receive these parameters:
+
+| RPC Parameter | Source |
+|--------------|--------|
+| `p_site_id` | `:siteId` path param |
+| `p_start_date` | `startDate` / `start_date` |
+| `p_end_date` | `endDate` / `end_date` |
+| `p_platform` | `platform` after `PLATFORM_CODE_TO_DB` mapping |
+| `p_category_name` | `categoryName` / `category_name` |
+| `p_agent_type` | `agentType` / `agent_type` |
+| `p_user_agent` | `userAgent` / `user_agent` |
+| `p_content_type` | `contentType` / `content_type` |
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ `postgres`) |
+| 400 | Site or organization not found |
+| 400 | PostgREST/PostgreSQL RPC error |
+| 403 | User does not belong to the site's organization |
+
+---
+
+## Authentication & Access
+
+- Requires LLMO product access for the site's organization (`hasLlmoOrganizationAccess`)
+- Routes are listed in `REQUIRED_CAPABILITIES` (no capability token required beyond auth)
+
+---
+
+## Related APIs
+
+- [Agentic Traffic by URL API](./agentic-traffic-by-url-api.md) — Per-URL breakdown, user-agent breakdown, URL movers
+- [Agentic Traffic Filter Dimensions API](./agentic-traffic-filter-dimensions-api.md) — Available filter values for the UI
+- [Agentic Traffic Weeks API](./agentic-traffic-weeks-api.md) — ISO weeks with data, for the date picker
+- [Agentic Traffic URL Brand Presence API](./agentic-traffic-url-brand-presence-api.md) — Brand presence citation detail for a specific URL
+- [Agentic Traffic Global API](./agentic-traffic-global-api.md) — Cross-site global weekly hit totals

--- a/docs/llmo-brandalf-apis/agentic-traffic-by-url-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-by-url-api.md
@@ -1,0 +1,208 @@
+# Agentic Traffic by URL API
+
+URL-level and user-agent breakdown endpoints for agentic traffic data. These three endpoints expose per-URL performance, user-agent composition, and URL hit-count movers for a site.
+
+Data is queried from mysticat-data-service PostgreSQL via PostgREST RPC functions. All endpoints require LLMO organization access.
+
+---
+
+## API Paths
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/sites/:siteId/agentic-traffic/by-url` | Per-URL traffic breakdown with performance metrics |
+| GET | `/sites/:siteId/agentic-traffic/by-user-agent` | Traffic grouped by page type × agent type |
+| GET | `/sites/:siteId/agentic-traffic/movers` | Top and bottom URL movers by hit-count change |
+
+**Path parameters:**
+- `siteId` — Site UUID
+
+---
+
+## Common Query Parameters
+
+All three endpoints share the standard agentic traffic filters. See [Agentic Traffic API](./agentic-traffic-api.md#common-query-parameters) for the full parameter list and the platform code mapping.
+
+| Parameter | Aliases | Type | Default | Description |
+|-----------|---------|------|---------|-------------|
+| `startDate` | `start_date` | string (YYYY-MM-DD) | 28 days ago | Start of date range |
+| `endDate` | `end_date` | string (YYYY-MM-DD) | today | End of date range |
+| `platform` | — | string | — | AI platform UI code (mapped to DB value — see [platform mapping](./agentic-traffic-api.md#platform-code-mapping)) |
+| `categoryName` | `category_name` | string | — | Filter by content category name |
+| `agentType` | `agent_type` | string | — | Filter by agent type |
+| `userAgent` | `user_agent` | string | — | Filter by user agent string |
+| `contentType` | `content_type` | string | — | Filter by content type |
+
+---
+
+## Endpoint Details
+
+### GET `/sites/:siteId/agentic-traffic/by-url`
+
+Returns a per-URL breakdown with traffic volume, performance, and citability metrics. The default result set is the top 2000 URLs by total hits.
+
+**Additional parameters:**
+
+| Parameter | Aliases | Type | Default | Max | Description |
+|-----------|---------|------|---------|-----|-------------|
+| `sortBy` | `sort_by` | string | `total_hits` | — | Column to sort by |
+| `sortOrder` | `sort_order` | string | `desc` | — | `asc` or `desc` |
+| `limit` | — | integer | 2000 | 2000 | Maximum number of rows to return |
+
+**RPC:** `rpc_agentic_traffic_by_url`
+
+**Response:**
+
+```json
+[
+  {
+    "host": "www.example.com",
+    "urlPath": "/blog/ai-tools",
+    "totalHits": 4200,
+    "uniqueAgents": 8,
+    "topAgent": "GPTBot",
+    "topAgentType": "crawler",
+    "responseCodes": [200, 301],
+    "successRate": 0.97,
+    "avgTtfbMs": 280.5,
+    "categoryName": "Blog",
+    "avgCitabilityScore": 0.82,
+    "deployedAtEdge": true
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | Hostname (e.g. `www.example.com`) |
+| `urlPath` | string | URL path (e.g. `/blog/ai-tools`) |
+| `totalHits` | number | Total AI-crawler requests to this URL |
+| `uniqueAgents` | number | Number of distinct user-agent strings |
+| `topAgent` | string | Most frequent user-agent string |
+| `topAgentType` | string | Agent type of `topAgent` |
+| `responseCodes` | number[] | Distinct HTTP status codes seen for this URL |
+| `successRate` | number \| null | Fraction of 2xx responses (0–1) |
+| `avgTtfbMs` | number \| null | Average time-to-first-byte in milliseconds |
+| `categoryName` | string | Content category |
+| `avgCitabilityScore` | number \| null | Average citability score (0–1) |
+| `deployedAtEdge` | boolean | Whether the URL is deployed at the edge |
+
+---
+
+### GET `/sites/:siteId/agentic-traffic/by-user-agent`
+
+Returns traffic grouped by `(pageType, agentType)`. Useful for understanding which agent types target which page types.
+
+> **Note:** `userAgent` / `user_agent` is not forwarded to this RPC — it groups by agent and filtering by a single user agent is not supported here.
+
+**Additional parameters:**
+
+| Parameter | Aliases | Type | Default | Description |
+|-----------|---------|------|---------|-------------|
+| `sortBy` | `sort_by` | string | `total_hits` | Column to sort by |
+| `sortOrder` | `sort_order` | string | `desc` | `asc` or `desc` |
+
+**RPC:** `rpc_agentic_traffic_by_user_agent`
+
+**Response:**
+
+```json
+[
+  {
+    "pageType": "article",
+    "agentType": "crawler",
+    "uniqueAgents": 5,
+    "totalHits": 18400
+  },
+  {
+    "pageType": "product",
+    "agentType": "assistant",
+    "uniqueAgents": 2,
+    "totalHits": 6100
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pageType` | string | Page type (e.g. `article`, `product`) |
+| `agentType` | string | Agent type (e.g. `crawler`, `assistant`) |
+| `uniqueAgents` | number | Number of distinct user-agent strings in this group |
+| `totalHits` | number | Total hits for this `(pageType, agentType)` combination |
+
+---
+
+### GET `/sites/:siteId/agentic-traffic/movers`
+
+Returns the URLs with the largest absolute change in hit count between the oldest and newest date in the range. A single call returns both top movers (increased hits) and bottom movers (decreased hits) in one array, distinguished by `direction`.
+
+**Additional parameter:**
+
+| Parameter | Type | Default | Range | Description |
+|-----------|------|---------|-------|-------------|
+| `limit` | integer | 5 | 1–50 | Number of movers per direction |
+
+**RPC:** `rpc_agentic_traffic_movers`
+
+**Response:**
+
+```json
+[
+  {
+    "host": "www.example.com",
+    "urlPath": "/docs/getting-started",
+    "previousHits": 1200,
+    "currentHits": 3800,
+    "hitsChange": 2600,
+    "changePercent": 2.17,
+    "direction": "up"
+  },
+  {
+    "host": "www.example.com",
+    "urlPath": "/legacy/old-page",
+    "previousHits": 900,
+    "currentHits": 120,
+    "hitsChange": -780,
+    "changePercent": -0.87,
+    "direction": "down"
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | Hostname |
+| `urlPath` | string | URL path |
+| `previousHits` | number | Hit count at the oldest date in the range |
+| `currentHits` | number | Hit count at the newest date in the range |
+| `hitsChange` | number | `currentHits − previousHits` |
+| `changePercent` | number \| null | Fractional change (`hitsChange / previousHits`). `null` if `previousHits` is 0. |
+| `direction` | string | `"up"` (top mover) or `"down"` (bottom mover) |
+
+The response contains up to `2 × limit` items — `limit` entries with `direction: "up"` followed by `limit` entries with `direction: "down"`.
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ `postgres`) |
+| 400 | Site or organization not found |
+| 400 | PostgREST/PostgreSQL RPC error |
+| 403 | User does not belong to the site's organization |
+
+---
+
+## Authentication & Access
+
+- Requires LLMO product access for the site's organization (`hasLlmoOrganizationAccess`)
+- Routes are listed in `REQUIRED_CAPABILITIES`
+
+---
+
+## Related APIs
+
+- [Agentic Traffic API](./agentic-traffic-api.md) — KPIs, trend, and grouping by region/category/page-type/status
+- [Agentic Traffic Filter Dimensions API](./agentic-traffic-filter-dimensions-api.md) — Available filter values for the UI
+- [Agentic Traffic URL Brand Presence API](./agentic-traffic-url-brand-presence-api.md) — Brand presence citation detail for a specific URL

--- a/docs/llmo-brandalf-apis/agentic-traffic-filter-dimensions-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-filter-dimensions-api.md
@@ -1,0 +1,103 @@
+# Agentic Traffic Filter Dimensions API
+
+Returns the available filter values for the Agentic Traffic UI: categories, agent types, platforms, content types, and user agents. All five dimensions are returned in a single round-trip using a single RPC call with cascading behavior — each dimension list respects the other active filters but ignores its own filter.
+
+Data is queried from mysticat-data-service PostgreSQL via PostgREST. Requires LLMO organization access.
+
+---
+
+## API Path
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/sites/:siteId/agentic-traffic/filter-dimensions` | All filter dimensions for the site |
+
+**Path parameters:**
+- `siteId` — Site UUID
+
+---
+
+## Query Parameters
+
+Accepts the standard agentic traffic filters. The cascading behavior means each dimension list is computed with all other filters applied except its own.
+
+| Parameter | Aliases | Type | Default | Description |
+|-----------|---------|------|---------|-------------|
+| `startDate` | `start_date` | string (YYYY-MM-DD) | 28 days ago | Start of date range |
+| `endDate` | `end_date` | string (YYYY-MM-DD) | today | End of date range |
+| `platform` | — | string | — | AI platform UI code (mapped to DB value — see [platform mapping](./agentic-traffic-api.md#platform-code-mapping)) |
+| `categoryName` | `category_name` | string | — | Active category filter (cascades to other dimensions) |
+| `agentType` | `agent_type` | string | — | Active agent type filter |
+| `userAgent` | `user_agent` | string | — | Active user agent filter |
+| `contentType` | `content_type` | string | — | Active content type filter |
+
+---
+
+## RPC
+
+**Function:** `rpc_agentic_traffic_distinct_filters`
+
+All standard agentic traffic RPC parameters are forwarded. The function returns all five dimension arrays in one row as a JSONB result.
+
+---
+
+## Response Shape
+
+```json
+{
+  "categories": ["Blog", "Product", "Documentation"],
+  "agentTypes": ["crawler", "assistant", "api"],
+  "platforms": ["ChatGPT", "Gemini", "Perplexity"],
+  "contentTypes": ["text/html", "application/json"],
+  "userAgents": ["GPTBot", "Google-Extended", "ClaudeBot"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `categories` | string[] | Distinct content category names with data in the date range |
+| `agentTypes` | string[] | Distinct agent type values |
+| `platforms` | string[] | Distinct platform values **as stored in the DB** (e.g. `ChatGPT`, not `openai`) |
+| `contentTypes` | string[] | Distinct content type values |
+| `userAgents` | string[] | Distinct user agent strings |
+
+> **Note:** `platforms` in the response contains raw DB values (e.g. `ChatGPT`). When sending a `platform` filter back to any agentic traffic endpoint, use the corresponding UI code (e.g. `openai` or `chatgpt`) — the mapping is applied server-side.
+
+---
+
+## Sample URL
+
+```
+GET /sites/c2473d89-e997-458d-a86d-b4096649c12b/agentic-traffic/filter-dimensions
+```
+
+**With active filters (cascading):**
+```
+GET /sites/c2473d89-e997-458d-a86d-b4096649c12b/agentic-traffic/filter-dimensions?startDate=2026-03-01&endDate=2026-03-31&platform=chatgpt
+```
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ `postgres`) |
+| 400 | Site or organization not found |
+| 400 | PostgREST/PostgreSQL RPC error |
+| 403 | User does not belong to the site's organization |
+
+---
+
+## Authentication & Access
+
+- Requires LLMO product access for the site's organization (`hasLlmoOrganizationAccess`)
+- Route is listed in `REQUIRED_CAPABILITIES`
+
+---
+
+## Related APIs
+
+- [Agentic Traffic API](./agentic-traffic-api.md) — KPIs, trend, and grouping by region/category/page-type/status
+- [Agentic Traffic by URL API](./agentic-traffic-by-url-api.md) — Per-URL breakdown, user-agent breakdown, URL movers
+- [Agentic Traffic Weeks API](./agentic-traffic-weeks-api.md) — Available ISO weeks for the date picker

--- a/docs/llmo-brandalf-apis/agentic-traffic-global-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-global-api.md
@@ -1,0 +1,157 @@
+# Agentic Traffic Global API
+
+Cross-site weekly hit totals from the `agentic_traffic_global` table in mysticat-data-service. This is an admin/S2S endpoint — it is not site-scoped and does not apply per-org access filters.
+
+- **GET** — Read weekly totals (admin or LLMO org access required)
+- **POST** — Upsert a weekly total (admin or S2S consumer only)
+
+---
+
+## API Paths
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/llmo/agentic-traffic/global` | List global weekly agentic traffic totals |
+| POST | `/llmo/agentic-traffic/global` | Create or update a weekly total |
+
+---
+
+## GET `/llmo/agentic-traffic/global`
+
+### Query Parameters
+
+| Parameter | Type | Constraints | Default | Description |
+|-----------|------|------------|---------|-------------|
+| `year` | integer | 2000–9999 | — | Filter to a specific year |
+| `week` | integer | 1–53 | — | Filter to a specific ISO week number |
+| `limit` | integer | 1–520 | 52 | Maximum number of rows to return |
+
+Parameters are read from the raw query string. Non-integer values for `year`, `week`, or `limit` return 400.
+
+Results are ordered by `year DESC, week DESC` (most recent first).
+
+### Response
+
+```json
+[
+  {
+    "id": "019cb903-1184-7f92-8325-f9d1176af316",
+    "year": 2026,
+    "week": 11,
+    "hits": 4820000,
+    "createdAt": "2026-03-16T00:00:00.000Z",
+    "updatedAt": "2026-03-16T08:12:34.000Z",
+    "updatedBy": "spacecat-api-service"
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Row identifier |
+| `year` | number | Calendar year |
+| `week` | number | ISO week number (1–53) |
+| `hits` | number | Total agentic traffic hits across all sites for this week |
+| `createdAt` | string (ISO 8601) | Row creation timestamp |
+| `updatedAt` | string (ISO 8601) | Last update timestamp |
+| `updatedBy` | string \| null | IMS user ID or `spacecat-api-service` for automated upserts |
+
+### Access
+
+- Requires `report:read` capability
+- Valid for admins and users with LLMO organization access (`validateGlobalAgenticTrafficReadAccess`)
+
+### Sample URLs
+
+**Last 52 weeks (default):**
+```
+GET /llmo/agentic-traffic/global
+```
+
+**Specific year:**
+```
+GET /llmo/agentic-traffic/global?year=2026
+```
+
+**Specific week:**
+```
+GET /llmo/agentic-traffic/global?year=2026&week=11
+```
+
+---
+
+## POST `/llmo/agentic-traffic/global`
+
+Creates or updates the weekly total for a `(year, week)` pair. Uses an upsert with `ON CONFLICT (year, week)`.
+
+### Request Body
+
+```json
+{
+  "year": 2026,
+  "week": 11,
+  "hits": 4820000
+}
+```
+
+| Field | Type | Required | Constraints | Description |
+|-------|------|----------|------------|-------------|
+| `year` | integer | Yes | 2000–9999 | Calendar year |
+| `week` | integer | Yes | 1–53 | ISO week number |
+| `hits` | integer | Yes | ≥ 0 | Total hit count for the week |
+
+The request body must be a JSON object. Non-integer values or out-of-range values return 400.
+
+`updatedBy` is set server-side from the authenticated user's IMS profile (`user_id` or `sub`), falling back to `spacecat-api-service`.
+
+### Response
+
+Returns the upserted row in the same shape as the GET response:
+
+```json
+{
+  "id": "019cb903-1184-7f92-8325-f9d1176af316",
+  "year": 2026,
+  "week": 11,
+  "hits": 4820000,
+  "createdAt": "2026-03-16T00:00:00.000Z",
+  "updatedAt": "2026-03-16T08:12:34.000Z",
+  "updatedBy": "ABC1234@AdobeID"
+}
+```
+
+### Access
+
+- Requires `report:write` capability
+- Restricted to **admins** or **S2S consumers** (`accessControlUtil.hasAdminAccess() || context.s2sConsumer`)
+- Regular authenticated users receive 403
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | `year`, `week`, or `limit` is not a valid integer |
+| 400 | `year`, `week`, or `limit` is out of range |
+| 400 | Request body is missing or not a JSON object (POST) |
+| 400 | `year`, `week`, or `hits` missing or invalid (POST) |
+| 403 | Authenticated user is not an admin or S2S consumer (POST) |
+| 403 | User does not have LLMO org access (GET) |
+| 503 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ `postgres`) |
+
+---
+
+## Authentication & Access Summary
+
+| Endpoint | Required |
+|----------|----------|
+| `GET /llmo/agentic-traffic/global` | `report:read` + admin or LLMO org access |
+| `POST /llmo/agentic-traffic/global` | `report:write` + admin or S2S consumer |
+
+---
+
+## Related APIs
+
+- [Agentic Traffic API](./agentic-traffic-api.md) — Site-scoped KPIs and breakdowns
+- [Agentic Traffic by URL API](./agentic-traffic-by-url-api.md) — Per-URL breakdown, user-agent breakdown, URL movers

--- a/docs/llmo-brandalf-apis/agentic-traffic-url-brand-presence-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-url-brand-presence-api.md
@@ -1,0 +1,128 @@
+# Agentic Traffic URL Brand Presence API
+
+Returns brand presence citation detail for a specific URL within a site's agentic traffic context. Bridges the Agentic Traffic and Brand Presence features: given a URL (from the `by-url` breakdown), this endpoint shows how often that URL is cited in brand presence LLM executions, the weekly citation trends, and the specific prompts that cite it.
+
+The URL is resolved via `source_urls.url_hash` (MD5 fast-lookup) so the caller must pass the full URL. The `organisation_id` is derived from the site so the access model stays consistent with all other site-scoped agentic traffic endpoints.
+
+---
+
+## API Path
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/sites/:siteId/agentic-traffic/url-brand-presence` | Brand presence citation detail for a URL |
+
+**Path parameters:**
+- `siteId` — Site UUID
+
+---
+
+## Query Parameters
+
+| Parameter | Aliases | Type | Required | Description |
+|-----------|---------|------|----------|-------------|
+| `url` | — | string | **Yes** | Full URL to look up (e.g. `https://www.example.com/blog/ai-tools`) |
+| `startDate` | `start_date` | string (YYYY-MM-DD) | No | Start of date range. Default: 28 days ago |
+| `endDate` | `end_date` | string (YYYY-MM-DD) | No | End of date range. Default: today |
+| `platform` | — | string | No | AI platform UI code. Maps to the `model` RPC parameter via the platform mapping. Accepts same values as other agentic traffic endpoints (e.g. `chatgpt`, `gemini`) |
+
+> **Note:** `platform` is passed to the RPC as `p_model`, not `p_platform`. The same [platform code mapping](./agentic-traffic-api.md#platform-code-mapping) applies.
+
+---
+
+## RPC
+
+**Function:** `rpc_brand_presence_url_detail`
+
+| RPC Parameter | Source |
+|--------------|--------|
+| `p_organization_id` | `site.getOrganizationId()` — resolved from the site, not a caller-supplied value |
+| `p_url` | `url` query parameter |
+| `p_start_date` | `startDate` / `start_date` |
+| `p_end_date` | `endDate` / `end_date` |
+| `p_model` | `platform` after platform code mapping |
+| `p_site_id` | `:siteId` path param |
+
+The RPC returns a JSONB object (not an array). PostgREST delivers it directly.
+
+---
+
+## Response Shape
+
+```json
+{
+  "totalCitations": 312,
+  "totalMentions": 89,
+  "uniquePrompts": 14,
+  "weeklyTrends": [
+    {
+      "week": "2026-W11",
+      "citations": 42,
+      "mentions": 12
+    },
+    {
+      "week": "2026-W10",
+      "citations": 38,
+      "mentions": 9
+    }
+  ],
+  "prompts": [
+    {
+      "promptId": "019cb903-1184-7f92-8325-f9d1176af316",
+      "prompt": "best pdf tools for mac",
+      "citations": 28,
+      "mentions": 7
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalCitations` | number | Total times the URL was cited as a source |
+| `totalMentions` | number | Total times the brand was mentioned (with or without citation) |
+| `uniquePrompts` | number | Number of distinct prompts that cited this URL |
+| `weeklyTrends` | array | Weekly citation/mention counts. Shape depends on the RPC — forwarded as-is. |
+| `prompts` | array | Top prompts that cited the URL. Shape depends on the RPC — forwarded as-is. |
+
+---
+
+## Sample URLs
+
+**Citation detail for a specific URL:**
+```
+GET /sites/c2473d89-e997-458d-a86d-b4096649c12b/agentic-traffic/url-brand-presence?url=https%3A%2F%2Fwww.example.com%2Fblog%2Fai-tools
+```
+
+**With date range and platform:**
+```
+GET /sites/c2473d89-e997-458d-a86d-b4096649c12b/agentic-traffic/url-brand-presence?url=https%3A%2F%2Fwww.example.com%2Fblog%2Fai-tools&startDate=2026-03-01&endDate=2026-03-31&platform=chatgpt
+```
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | `url` parameter missing or empty |
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ `postgres`) |
+| 400 | Site or organization not found |
+| 400 | PostgREST/PostgreSQL RPC error |
+| 403 | User does not belong to the site's organization |
+
+---
+
+## Authentication & Access
+
+- Requires LLMO product access for the site's organization (`hasLlmoOrganizationAccess`)
+- `organisation_id` is always derived server-side from the site — callers cannot supply a different org
+- Route is listed in `REQUIRED_CAPABILITIES`
+
+---
+
+## Related APIs
+
+- [Agentic Traffic by URL API](./agentic-traffic-by-url-api.md) — Per-URL breakdown where URLs for this endpoint are discovered
+- [Agentic Traffic API](./agentic-traffic-api.md) — Site-level KPIs and grouping endpoints
+- [Brand Presence Stats API](./brand-presence-stats-api.md) — Org-level brand presence stats

--- a/docs/llmo-brandalf-apis/agentic-traffic-weeks-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-weeks-api.md
@@ -1,0 +1,110 @@
+# Agentic Traffic Weeks API
+
+Returns the list of ISO weeks for which a site has agentic traffic data. Powers the `ContinuousWeekPicker` custom-weeks time range option in the Agentic Traffic UI.
+
+The response is derived from the earliest and latest `traffic_date` in the `agentic_traffic` table for the site — two PostgREST queries in parallel — and then the full ISO week range between those dates is generated.
+
+---
+
+## API Path
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/sites/:siteId/agentic-traffic/weeks` | Available ISO weeks for the site |
+
+**Path parameters:**
+- `siteId` — Site UUID
+
+---
+
+## Query Parameters
+
+None. No date range or filter parameters are accepted — this endpoint always returns all weeks for which any data exists.
+
+---
+
+## Data Source
+
+Two parallel PostgREST queries against `agentic_traffic`:
+
+```javascript
+// Earliest date
+client.from('agentic_traffic').select('traffic_date')
+  .eq('site_id', siteId).order('traffic_date', { ascending: true }).limit(1)
+
+// Latest date
+client.from('agentic_traffic').select('traffic_date')
+  .eq('site_id', siteId).order('traffic_date', { ascending: false }).limit(1)
+```
+
+The ISO weeks between `minDate` and `maxDate` (inclusive) are then generated. Each week entry includes the start (Monday) and end (Sunday) dates.
+
+---
+
+## Response Shape
+
+```json
+{
+  "weeks": [
+    {
+      "week": "2026-W11",
+      "startDate": "2026-03-09",
+      "endDate": "2026-03-15"
+    },
+    {
+      "week": "2026-W10",
+      "startDate": "2026-03-02",
+      "endDate": "2026-03-08"
+    },
+    {
+      "week": "2026-W09",
+      "startDate": "2026-02-23",
+      "endDate": "2026-03-01"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `week` | string | ISO week identifier in `YYYY-Wnn` format |
+| `startDate` | string (YYYY-MM-DD) | Monday of the ISO week |
+| `endDate` | string (YYYY-MM-DD) | Sunday of the ISO week |
+
+Weeks are returned in **descending order** (most recent first). If the site has no traffic data, `weeks` is an empty array.
+
+---
+
+## Sample URLs
+
+**All weeks for a site:**
+```
+GET /sites/c2473d89-e997-458d-a86d-b4096649c12b/agentic-traffic/weeks
+```
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ `postgres`) |
+| 400 | Site or organization not found |
+| 400 | PostgREST query error fetching min/max dates |
+| 403 | User does not belong to the site's organization |
+| 200 | No data — `weeks` will be `[]` |
+
+---
+
+## Authentication & Access
+
+- Requires LLMO product access for the site's organization (`hasLlmoOrganizationAccess`)
+- Route is listed in `REQUIRED_CAPABILITIES`
+
+---
+
+## Related APIs
+
+- [Agentic Traffic API](./agentic-traffic-api.md) — KPIs, trend, and grouping by region/category/page-type/status
+- [Agentic Traffic Filter Dimensions API](./agentic-traffic-filter-dimensions-api.md) — Available filter values
+- [Brand Presence Weeks API](./brand-presence-weeks-api.md) — Equivalent weeks endpoint for Brand Presence

--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -462,6 +462,30 @@ paths:
     $ref: './llmo-api.yaml#/llmo-global-sheet-data'
   /llmo/agentic-traffic/global:
     $ref: './llmo-api.yaml#/llmo-agentic-traffic-global'
+  /sites/{siteId}/agentic-traffic/kpis:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-kpis'
+  /sites/{siteId}/agentic-traffic/kpis-trend:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-kpis-trend'
+  /sites/{siteId}/agentic-traffic/by-region:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-by-region'
+  /sites/{siteId}/agentic-traffic/by-category:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-by-category'
+  /sites/{siteId}/agentic-traffic/by-page-type:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-by-page-type'
+  /sites/{siteId}/agentic-traffic/by-status:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-by-status'
+  /sites/{siteId}/agentic-traffic/by-user-agent:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-by-user-agent'
+  /sites/{siteId}/agentic-traffic/by-url:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-by-url'
+  /sites/{siteId}/agentic-traffic/filter-dimensions:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-filter-dimensions'
+  /sites/{siteId}/agentic-traffic/weeks:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-weeks'
+  /sites/{siteId}/agentic-traffic/movers:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-movers'
+  /sites/{siteId}/agentic-traffic/url-brand-presence:
+    $ref: './llmo-api.yaml#/llmo-agentic-traffic-url-brand-presence'
   /sites/{siteId}/llmo/config:
     $ref: './llmo-api.yaml#/llmo-config'
   /sites/{siteId}/llmo/questions:

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -2048,3 +2048,520 @@ llmo-edge-optimize-status:
         $ref: './responses.yaml#/500'
     security:
       - api_key: [ ]
+
+llmo-agentic-traffic-url-brand-presence:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Brand presence citation detail for a URL
+    description: |
+      Returns brand presence citation data for a specific URL from the Postgres-backed
+      mysticat data service (`rpc_brand_presence_url_detail`). Used by the Agentic
+      Traffic PG dashboard URL details dialog.
+
+      Finds all brand presence LLM executions where the given URL was cited as a source,
+      then aggregates citation stats, a weekly trend, and the top 50 prompts that cited it.
+
+      URL matching tries four variants (with/without `https://`, with/without trailing slash)
+      so the caller can pass the URL exactly as it appears in the agentic traffic table.
+
+      Query parameters:
+      - `url` (**required**): full URL to look up, e.g. `https://www.adobe.com/express/page`
+      - `startDate`: date range start (`YYYY-MM-DD`); defaults to 28 days ago
+      - `endDate`: date range end (`YYYY-MM-DD`); defaults to today
+      - `platform`: UI platform code (e.g. `openai`, `perplexity`); omit for all models
+    operationId: getAgenticTrafficUrlBrandPresence
+    parameters:
+      - name: url
+        in: query
+        required: true
+        description: Full URL to look up brand presence citations for
+        schema:
+          type: string
+          example: 'https://www.adobe.com/express/create/poster'
+      - name: startDate
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date
+          example: '2026-01-01'
+      - name: endDate
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date
+          example: '2026-03-31'
+      - name: platform
+        in: query
+        required: false
+        description: UI platform code mapped to the DB model value
+        schema:
+          type: string
+          example: 'openai'
+    responses:
+      '200':
+        description: Brand presence citation detail for the URL
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficUrlBrandPresence'
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '403':
+        $ref: './responses.yaml#/403'
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: [ ]
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+
+# ── Common parameter fragment (referenced inline below) ───────────────────────
+# All site-scoped agentic traffic endpoints share these optional query filters.
+# siteId path param is declared at path level via parameters.yaml#/siteId.
+
+llmo-agentic-traffic-kpis:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Aggregated agentic traffic KPIs for a site
+    description: |
+      Returns a single row of aggregated KPI metrics for the site's agentic traffic
+      over the requested date range. Queries `rpc_agentic_traffic_kpis`.
+    operationId: getAgenticTrafficKpis
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+    responses:
+      '200':
+        description: Aggregated KPI metrics
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficKpis'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-kpis-trend:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Agentic traffic KPI time series for a site
+    description: |
+      Returns KPI metrics per time period (day / week / month) over the requested
+      date range. Queries `rpc_agentic_traffic_kpis_trend`.
+    operationId: getAgenticTrafficKpisTrend
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+      - name: interval
+        in: query
+        description: Bucketing interval; defaults to `week`
+        schema:
+          type: string
+          enum: [day, week, month]
+          default: week
+    responses:
+      '200':
+        description: KPI time series
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficKpisTrend'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-by-region:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Agentic traffic grouped by region
+    description: Queries `rpc_agentic_traffic_by_region`. Returns rows ordered by total hits descending.
+    operationId: getAgenticTrafficByRegion
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by region
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficByRegion'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-by-category:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Agentic traffic grouped by category
+    description: Queries `rpc_agentic_traffic_by_category`. Returns rows ordered by total hits descending.
+    operationId: getAgenticTrafficByCategory
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by category
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficByCategory'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-by-page-type:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Agentic traffic grouped by page type
+    description: Queries `rpc_agentic_traffic_by_page_type`. Returns rows ordered by total hits descending.
+    operationId: getAgenticTrafficByPageType
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by page type
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficByPageType'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-by-status:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Agentic traffic grouped by HTTP status code
+    description: Queries `rpc_agentic_traffic_by_status`. Returns rows ordered by total hits descending.
+    operationId: getAgenticTrafficByStatus
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by HTTP status code
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficByStatus'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-by-user-agent:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Agentic traffic grouped by page type and agent type
+    description: |
+      Queries `rpc_agentic_traffic_by_user_agent`. Powers the User Agent Analysis table.
+      Note: `userAgent` filter is not supported by this RPC.
+    operationId: getAgenticTrafficByUserAgent
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          enum: [page_type, agent_type, unique_agents, total_hits]
+          default: total_hits
+      - name: sortOrder
+        in: query
+        schema:
+          type: string
+          enum: [asc, desc]
+          default: desc
+    responses:
+      '200':
+        description: Traffic by page type and agent type
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficByUserAgent'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-by-url:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Per-URL agentic traffic performance analysis
+    description: |
+      Queries `rpc_agentic_traffic_by_url`. Powers the URL Performance table.
+      Returns up to `limit` URLs (default and max 2000) ordered by `sortBy`/`sortOrder`.
+    operationId: getAgenticTrafficByUrl
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 2000
+          default: 2000
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          enum: [host, url_path, unique_agents, success_rate, avg_ttfb_ms, category_name, total_hits]
+          default: total_hits
+      - name: sortOrder
+        in: query
+        schema:
+          type: string
+          enum: [asc, desc]
+          default: desc
+    responses:
+      '200':
+        description: Per-URL performance analysis
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficByUrl'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-filter-dimensions:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Distinct filter dimension values for agentic traffic
+    description: |
+      Returns cascading distinct filter values for the agentic traffic dashboard dropdowns.
+      Queries `rpc_agentic_traffic_distinct_filters` — each dimension list respects the
+      other active filters but ignores its own to avoid self-limiting dropdowns.
+    operationId: getAgenticTrafficFilterDimensions
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+    responses:
+      '200':
+        description: Distinct filter values
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficFilterDimensions'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-weeks:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Available ISO weeks for a site's agentic traffic data
+    description: |
+      Returns the list of ISO weeks for which the site has agentic traffic data,
+      derived from the min/max `traffic_date` in `agentic_traffic`. Used to populate
+      the Custom Weeks date picker in the dashboard.
+    operationId: getAgenticTrafficWeeks
+    responses:
+      '200':
+        description: Available ISO weeks
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficWeeks'
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-agentic-traffic-movers:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Top and bottom agentic traffic URL movers
+    description: |
+      Returns URLs with the largest hit changes between the oldest and newest traffic
+      dates in the selected range. Queries `rpc_agentic_traffic_movers`.
+      Returns up to `limit` rows each for `direction=up` (top movers) and
+      `direction=down` (bottom movers). Requires at least 2 distinct dates in the range.
+    operationId: getAgenticTrafficMovers
+    parameters:
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: categoryName, in: query, schema: { type: string } }
+      - { name: agentType, in: query, schema: { type: string } }
+      - { name: userAgent, in: query, schema: { type: string } }
+      - { name: contentType, in: query, schema: { type: string } }
+      - name: limit
+        in: query
+        description: Max rows per direction (default 5, max 50)
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 5
+    responses:
+      '200':
+        description: Top and bottom URL movers
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/AgenticTrafficMovers'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+      '503':
+        description: PostgREST / mysticat not configured for this deployment
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -7516,3 +7516,471 @@ PageRelationshipsSearchResponse:
       $ref: '#/PageRelationshipsMapping'
     errors:
       $ref: '#/PageRelationshipsErrorMapping'
+
+AgenticTrafficUrlBrandPresencePrompt:
+  type: object
+  description: A prompt that cited the URL as a source in a brand presence LLM execution
+  properties:
+    prompt:
+      type: string
+      description: The prompt text
+      example: 'best poster maker with templates'
+    topic:
+      oneOf:
+        - type: string
+        - type: 'null'
+      description: Topic the prompt belongs to
+      example: 'Poster Maker'
+    topicId:
+      oneOf:
+        - type: string
+        - type: 'null'
+      description: UUID of the topic
+      example: '019ce794-f3ab-7d3c-8f0a-46a0f08484d0'
+    regionCode:
+      oneOf:
+        - type: string
+        - type: 'null'
+      description: Region/market code
+      example: 'GB'
+    citations:
+      type: integer
+      description: Number of executions where the URL was cited
+      example: 13
+    mentions:
+      type: integer
+      description: Number of executions where the brand was mentioned
+      example: 13
+    avgSentiment:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Average sentiment score (-1 negative, 0 neutral, 1 positive)
+      example: 0.77
+    avgVisibilityScore:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Average visibility score (0-100)
+      example: 100.0
+    executionCount:
+      type: integer
+      description: Total number of LLM executions in this group
+      example: 13
+    categories:
+      type: array
+      items:
+        type: string
+      description: Distinct category names from the executions
+      example: ['Express']
+  required:
+    - prompt
+    - citations
+    - mentions
+    - executionCount
+    - categories
+
+AgenticTrafficUrlBrandPresenceWeeklyTrend:
+  type: object
+  description: Weekly citation counts for a URL
+  properties:
+    weekStr:
+      type: string
+      description: ISO week label (YYYY-WNN)
+      example: '2026-W06'
+    citationCount:
+      type: integer
+      description: Number of executions where the URL was cited that week
+      example: 314
+    mentionCount:
+      type: integer
+      description: Number of executions where the brand was mentioned that week
+      example: 295
+  required:
+    - weekStr
+    - citationCount
+    - mentionCount
+
+AgenticTrafficUrlBrandPresence:
+  type: object
+  description: Brand presence citation detail for a specific URL
+  properties:
+    totalCitations:
+      type: integer
+      description: Total number of LLM executions where this URL was cited
+      example: 314
+    totalMentions:
+      type: integer
+      description: Total number of LLM executions where the brand was mentioned
+      example: 295
+    uniquePrompts:
+      type: integer
+      description: Number of distinct prompts that cited this URL
+      example: 47
+    weeklyTrends:
+      type: array
+      items:
+        $ref: '#/AgenticTrafficUrlBrandPresenceWeeklyTrend'
+      description: Weekly citation trend, ordered oldest to newest
+    prompts:
+      type: array
+      items:
+        $ref: '#/AgenticTrafficUrlBrandPresencePrompt'
+      description: Top 50 prompts by execution count that cited this URL
+  required:
+    - totalCitations
+    - totalMentions
+    - uniquePrompts
+    - weeklyTrends
+    - prompts
+
+# ── Agentic Traffic PG (site-scoped) ─────────────────────────────────────────
+
+AgenticTrafficKpis:
+  type: object
+  description: Aggregated KPI metrics for a site's agentic traffic
+  properties:
+    totalHits:
+      type: integer
+      example: 4200
+    successRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Percentage of 2xx–3xx responses (0–100)
+      example: 94.5
+    avgTtfbMs:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Weighted average Time To First Byte in milliseconds
+      example: 182.3
+    avgCitabilityScore:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Average citability score (0–100); null when no data
+      example: 76.0
+  required:
+    - totalHits
+
+AgenticTrafficKpisTrendRow:
+  type: object
+  description: KPI metrics for a single time period
+  properties:
+    periodStart:
+      type: string
+      format: date
+      description: Start date of the period (ISO 8601)
+      example: '2026-03-02'
+    totalHits:
+      type: integer
+      example: 600
+    successRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 92.0
+    avgTtfbMs:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 175.0
+    avgCitabilityScore:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 75.0
+  required:
+    - periodStart
+    - totalHits
+
+AgenticTrafficKpisTrend:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficKpisTrendRow'
+  description: KPI time series ordered by period ascending
+
+AgenticTrafficByRegionRow:
+  type: object
+  properties:
+    region:
+      type: string
+      example: 'US'
+    totalHits:
+      type: integer
+      example: 800
+  required:
+    - region
+    - totalHits
+
+AgenticTrafficByRegion:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficByRegionRow'
+  description: Traffic grouped by region, ordered by total hits descending
+
+AgenticTrafficByCategoryRow:
+  type: object
+  properties:
+    categoryName:
+      type: string
+      example: 'Poster Maker'
+    totalHits:
+      type: integer
+      example: 400
+  required:
+    - categoryName
+    - totalHits
+
+AgenticTrafficByCategory:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficByCategoryRow'
+  description: Traffic grouped by category, ordered by total hits descending
+
+AgenticTrafficByPageTypeRow:
+  type: object
+  properties:
+    pageType:
+      type: string
+      example: 'article'
+    totalHits:
+      type: integer
+      example: 300
+  required:
+    - pageType
+    - totalHits
+
+AgenticTrafficByPageType:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficByPageTypeRow'
+  description: Traffic grouped by page type, ordered by total hits descending
+
+AgenticTrafficByStatusRow:
+  type: object
+  properties:
+    httpStatus:
+      type: integer
+      example: 200
+    totalHits:
+      type: integer
+      example: 3900
+  required:
+    - httpStatus
+    - totalHits
+
+AgenticTrafficByStatus:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficByStatusRow'
+  description: Traffic grouped by HTTP status code, ordered by total hits descending
+
+AgenticTrafficByUserAgentRow:
+  type: object
+  properties:
+    pageType:
+      type: string
+      example: 'article'
+    agentType:
+      type: string
+      example: 'Chatbots'
+    uniqueAgents:
+      type: integer
+      example: 5
+    totalHits:
+      type: integer
+      example: 200
+  required:
+    - pageType
+    - agentType
+    - uniqueAgents
+    - totalHits
+
+AgenticTrafficByUserAgent:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficByUserAgentRow'
+  description: Traffic grouped by page type and agent type
+
+AgenticTrafficByUrlRow:
+  type: object
+  properties:
+    host:
+      type: string
+      example: 'www.adobe.com'
+    urlPath:
+      type: string
+      example: '/express/create/poster'
+    totalHits:
+      type: integer
+      example: 150
+    uniqueAgents:
+      type: integer
+      example: 3
+    topAgent:
+      type: string
+      example: 'ChatGPT-User'
+    topAgentType:
+      type: string
+      example: 'Chatbots'
+    responseCodes:
+      type: array
+      items:
+        type: integer
+      example: [200, 301]
+    successRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 98.5
+    avgTtfbMs:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 120.5
+    categoryName:
+      type: string
+      example: 'Poster Maker'
+    avgCitabilityScore:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 65.0
+    deployedAtEdge:
+      type: boolean
+      example: true
+  required:
+    - host
+    - urlPath
+    - totalHits
+    - uniqueAgents
+    - topAgent
+    - topAgentType
+    - responseCodes
+    - deployedAtEdge
+
+AgenticTrafficByUrl:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficByUrlRow'
+  description: Per-URL performance analysis
+
+AgenticTrafficFilterDimensions:
+  type: object
+  description: Distinct filter values available for the selected site and date range
+  properties:
+    categories:
+      type: array
+      items:
+        type: string
+      example: ['Poster Maker', 'Electronics']
+    agentTypes:
+      type: array
+      items:
+        type: string
+      example: ['Chatbots', 'Research']
+    platforms:
+      type: array
+      items:
+        type: string
+      example: ['ChatGPT', 'Perplexity']
+    contentTypes:
+      type: array
+      items:
+        type: string
+      example: ['html', 'pdf']
+    userAgents:
+      type: array
+      items:
+        type: string
+      example: ['ChatGPT-User', 'GPTBot']
+  required:
+    - categories
+    - agentTypes
+    - platforms
+    - contentTypes
+    - userAgents
+
+AgenticTrafficWeekEntry:
+  type: object
+  description: An ISO week for which the site has agentic traffic data
+  properties:
+    week:
+      type: string
+      description: ISO week label (YYYY-WNN)
+      example: '2026-W10'
+    startDate:
+      oneOf:
+        - type: string
+          format: date
+        - type: 'null'
+      example: '2026-03-02'
+    endDate:
+      oneOf:
+        - type: string
+          format: date
+        - type: 'null'
+      example: '2026-03-08'
+  required:
+    - week
+
+AgenticTrafficWeeks:
+  type: object
+  description: Available ISO weeks for the site's agentic traffic data
+  properties:
+    weeks:
+      type: array
+      items:
+        $ref: '#/AgenticTrafficWeekEntry'
+  required:
+    - weeks
+
+AgenticTrafficMoverRow:
+  type: object
+  description: A URL with significant traffic change between the oldest and newest date in range
+  properties:
+    host:
+      type: string
+      example: 'www.adobe.com'
+    urlPath:
+      type: string
+      example: '/express/create/poster'
+    previousHits:
+      type: integer
+      description: Hits on the oldest date in the range
+      example: 100
+    currentHits:
+      type: integer
+      description: Hits on the newest date in the range
+      example: 200
+    hitsChange:
+      type: integer
+      description: Absolute change (positive = top mover, negative = bottom mover)
+      example: 100
+    changePercent:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Percentage change; null when previousHits is zero
+      example: 100.0
+    direction:
+      type: string
+      enum: ['up', 'down']
+      example: 'up'
+  required:
+    - host
+    - urlPath
+    - previousHits
+    - currentHits
+    - hitsChange
+    - direction
+
+AgenticTrafficMovers:
+  type: array
+  items:
+    $ref: '#/AgenticTrafficMoverRow'
+  description: |
+    Top and bottom URL movers ordered by `direction DESC, abs(hitsChange) DESC`.
+    Returns up to `limit` rows each for direction=up and direction=down.

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -13,6 +13,7 @@
 import {
   ok, badRequest, forbidden, internalServerError,
 } from '@adobe/spacecat-shared-http-utils';
+import { hasText } from '@adobe/spacecat-shared-utils';
 import { generateIsoWeekRange, getWeekDateRange } from './llmo-brand-presence.js';
 
 /**
@@ -35,6 +36,22 @@ const VALID_SORT_ORDERS = new Set(['asc', 'desc']);
 const DEFAULT_BY_URL_LIMIT = 2000;
 const MAX_BY_URL_LIMIT = 2000;
 
+/**
+ * Maps UI platform filter codes (PLATFORM_CODES) to the values stored in the
+ * agentic_traffic.platform column. Both ChatGPT paid/free codes map to the
+ * same DB value; 'all' and unknown codes resolve to null (no filter).
+ */
+const PLATFORM_CODE_TO_DB = {
+  openai: 'ChatGPT',
+  chatgpt: 'ChatGPT',
+  anthropic: 'Anthropic',
+  mistral: 'MistralAI',
+  perplexity: 'Perplexity',
+  gemini: 'Gemini',
+  google: 'Google',
+  amazon: 'Amazon',
+};
+
 function defaultDateRange() {
   const end = new Date();
   const start = new Date();
@@ -55,7 +72,7 @@ function parseAgenticTrafficParams(context) {
   return {
     startDate: q.startDate || q.start_date || defaults.startDate,
     endDate: q.endDate || q.end_date || defaults.endDate,
-    platform: q.platform || null,
+    platform: PLATFORM_CODE_TO_DB[q.platform] ?? null,
     categoryName: q.categoryName || q.category_name || null,
     agentType: q.agentType || q.agent_type || null,
     userAgent: q.userAgent || q.user_agent || null,
@@ -544,6 +561,76 @@ export function createAgenticTrafficWeeksHandler(getSiteAndValidateAccess) {
         });
 
         return ok({ weeks });
+      },
+    );
+  };
+}
+
+/**
+ * GET /sites/:siteId/agentic-traffic/url-brand-presence?url=&startDate=&endDate=&platform=
+ *
+ * Brand presence citation detail for a specific URL. Returns citation stats,
+ * weekly citation trends, and the top prompts that cite this URL as a source
+ * in brand presence LLM executions.
+ *
+ * The URL is resolved via source_urls.url_hash (md5 fast-lookup) so the caller
+ * must pass a full URL (e.g. "https://www.example.com/path").
+ * The organisation_id is derived from the site to keep auth consistent with all
+ * other site-scoped agentic traffic endpoints.
+ */
+export function createAgenticTrafficUrlBrandPresenceHandler(getSiteAndValidateAccess) {
+  return async function getAgenticTrafficUrlBrandPresence(context) {
+    return withAgenticTrafficAuth(
+      context,
+      getSiteAndValidateAccess,
+      'url-brand-presence',
+      async (ctx, client, siteId) => {
+        const parsed = parseAgenticTrafficParams(ctx);
+        const rawUrl = ctx.data?.url;
+
+        if (!hasText(rawUrl)) {
+          return badRequest('url parameter is required');
+        }
+
+        // Resolve organisationId directly from the site (no extra org lookup needed)
+        const { dataAccess } = ctx;
+        const { Site } = dataAccess;
+        const site = await Site.findById(siteId);
+        /* c8 ignore next 3 */
+        if (!site) {
+          return badRequest(`Site not found: ${siteId}`);
+        }
+        const organizationId = site.getOrganizationId();
+
+        const rpcParams = {
+          p_organization_id: organizationId,
+          p_url: rawUrl,
+          p_start_date: parsed.startDate,
+          p_end_date: parsed.endDate,
+          p_model: parsed.platform || null,
+          p_site_id: siteId,
+        };
+
+        const { data, error } = await client.rpc(
+          'rpc_brand_presence_url_detail',
+          rpcParams,
+        );
+
+        if (error) {
+          ctx.log.error(`Agentic traffic url-brand-presence PostgREST error: ${error.message}`);
+          return internalServerError('Failed to fetch brand presence data for URL');
+        }
+
+        // RPC returns a single JSONB row; data is an array with one element
+        // RETURNS JSONB → PostgREST delivers the object directly, not wrapped in an array
+        /* c8 ignore next */ const result = data ?? {};
+        return ok({
+          totalCitations: Number(result.totalCitations ?? 0),
+          totalMentions: Number(result.totalMentions ?? 0),
+          uniquePrompts: Number(result.uniquePrompts ?? 0),
+          weeklyTrends: Array.isArray(result.weeklyTrends) ? result.weeklyTrends : [],
+          prompts: Array.isArray(result.prompts) ? result.prompts : [],
+        });
       },
     );
   };

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -40,6 +40,13 @@ const MAX_BY_URL_LIMIT = 2000;
  * Maps UI platform filter codes (PLATFORM_CODES) to the values stored in the
  * agentic_traffic.platform column. Both ChatGPT paid/free codes map to the
  * same DB value; 'all' and unknown codes resolve to null (no filter).
+ *
+ * NOTE: This mapping is applied in parseAgenticTrafficParams and therefore
+ * affects ALL site-scoped agentic traffic endpoints (kpis, kpis-trend,
+ * by-region, by-category, by-page-type, by-status, by-user-agent, by-url,
+ * filter-dimensions, weeks, movers, url-brand-presence). Before this mapping
+ * existed, the raw UI code (e.g. "openai") was passed to the DB verbatim,
+ * which never matched any rows. This is the intentional behavioural fix.
  */
 const PLATFORM_CODE_TO_DB = {
   openai: 'ChatGPT',
@@ -101,7 +108,9 @@ function buildRpcParams(siteId, parsed) {
  * @param {Object} context - Request context
  * @param {Function} getSiteAndValidateAccess - Async (context) => { site, organization }
  * @param {string} handlerName - For error logging
- * @param {Function} handlerFn - Async (context, client, siteId) => response
+ * @param {Function} handlerFn - Async (context, client, siteId, siteContext) => response
+ *   siteContext = { site, organization } — forwarded from getSiteAndValidateAccess so
+ *   handlers that need org data (e.g. url-brand-presence) avoid a second DB lookup.
  * @returns {Promise<Response>}
  */
 async function withAgenticTrafficAuth(context, getSiteAndValidateAccess, handlerName, handlerFn) {
@@ -115,8 +124,9 @@ async function withAgenticTrafficAuth(context, getSiteAndValidateAccess, handler
 
   const { siteId } = context.params;
 
+  let siteContext;
   try {
-    await getSiteAndValidateAccess(context);
+    siteContext = await getSiteAndValidateAccess(context);
   } catch (error) {
     if (error.message?.includes(ERR_SITE_ACCESS)) {
       return forbidden('Only users belonging to the organization can view agentic traffic data');
@@ -128,7 +138,7 @@ async function withAgenticTrafficAuth(context, getSiteAndValidateAccess, handler
     return badRequest(error.message);
   }
 
-  return handlerFn(context, Site.postgrestService, siteId);
+  return handlerFn(context, Site.postgrestService, siteId, siteContext);
 }
 
 /**
@@ -584,7 +594,7 @@ export function createAgenticTrafficUrlBrandPresenceHandler(getSiteAndValidateAc
       context,
       getSiteAndValidateAccess,
       'url-brand-presence',
-      async (ctx, client, siteId) => {
+      async (ctx, client, siteId, siteContext) => {
         const parsed = parseAgenticTrafficParams(ctx);
         const rawUrl = ctx.data?.url;
 
@@ -592,15 +602,9 @@ export function createAgenticTrafficUrlBrandPresenceHandler(getSiteAndValidateAc
           return badRequest('url parameter is required');
         }
 
-        // Resolve organisationId directly from the site (no extra org lookup needed)
-        const { dataAccess } = ctx;
-        const { Site } = dataAccess;
-        const site = await Site.findById(siteId);
-        /* c8 ignore next 3 */
-        if (!site) {
-          return badRequest(`Site not found: ${siteId}`);
-        }
-        const organizationId = site.getOrganizationId();
+        // organisationId comes from siteContext forwarded by withAgenticTrafficAuth —
+        // getSiteAndValidateAccess already fetched the site, so no second DB roundtrip.
+        const organizationId = siteContext?.site?.getOrganizationId();
 
         const rpcParams = {
           p_organization_id: organizationId,
@@ -621,7 +625,6 @@ export function createAgenticTrafficUrlBrandPresenceHandler(getSiteAndValidateAc
           return internalServerError('Failed to fetch brand presence data for URL');
         }
 
-        // RPC returns a single JSONB row; data is an array with one element
         // RETURNS JSONB → PostgREST delivers the object directly, not wrapped in an array
         /* c8 ignore next */ const result = data ?? {};
         return ok({

--- a/src/controllers/llmo/llmo-mysticat-controller.js
+++ b/src/controllers/llmo/llmo-mysticat-controller.js
@@ -39,6 +39,7 @@ import {
   createAgenticTrafficFilterDimensionsHandler,
   createAgenticTrafficWeeksHandler,
   createAgenticTrafficMoversHandler,
+  createAgenticTrafficUrlBrandPresenceHandler,
 } from './llmo-agentic-traffic.js';
 
 /**
@@ -150,6 +151,9 @@ function LlmoMysticatController(ctx) {
   );
   const getAgenticTrafficWeeks = createAgenticTrafficWeeksHandler(getSiteAndValidateAccess);
   const getAgenticTrafficMovers = createAgenticTrafficMoversHandler(getSiteAndValidateAccess);
+  const getAgenticTrafficUrlBrandPresence = createAgenticTrafficUrlBrandPresenceHandler(
+    getSiteAndValidateAccess,
+  );
 
   return {
     getFilterDimensions,
@@ -178,6 +182,7 @@ function LlmoMysticatController(ctx) {
     getAgenticTrafficFilterDimensions,
     getAgenticTrafficWeeks,
     getAgenticTrafficMovers,
+    getAgenticTrafficUrlBrandPresence,
   };
 }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -440,6 +440,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/agentic-traffic/filter-dimensions': llmoMysticatController.getAgenticTrafficFilterDimensions,
     'GET /sites/:siteId/agentic-traffic/weeks': llmoMysticatController.getAgenticTrafficWeeks,
     'GET /sites/:siteId/agentic-traffic/movers': llmoMysticatController.getAgenticTrafficMovers,
+    'GET /sites/:siteId/agentic-traffic/url-brand-presence': llmoMysticatController.getAgenticTrafficUrlBrandPresence,
 
     // Brand Presence filter dimensions (PostgREST/mysticat-data-service)
     // spaceCatId = organization_id. brandId = 'all' for all brands, or UUID for single brand.

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -65,6 +65,7 @@ export const INTERNAL_ROUTES = [
   'GET /org/:spaceCatId/brands/:brandId/opportunities',
 
   // Agentic traffic PG dashboard endpoints (site-scoped) - UI only, not yet required by S2S
+  'GET /sites/:siteId/agentic-traffic/url-brand-presence',
   'GET /sites/:siteId/agentic-traffic/kpis',
   'GET /sites/:siteId/agentic-traffic/kpis-trend',
   'GET /sites/:siteId/agentic-traffic/by-region',

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -25,6 +25,7 @@ import {
   createAgenticTrafficByUrlHandler,
   createAgenticTrafficFilterDimensionsHandler,
   createAgenticTrafficWeeksHandler,
+  createAgenticTrafficUrlBrandPresenceHandler,
 } from '../../../src/controllers/llmo/llmo-agentic-traffic.js';
 
 use(sinonChai);
@@ -75,7 +76,7 @@ function makeContext(overrides = {}) {
       },
       ...overrides.dataAccess,
     },
-    log: { error: sinon.stub() },
+    log: { error: sinon.stub(), info: sinon.stub() },
     ...overrides.context,
   };
 }
@@ -128,6 +129,36 @@ describe('llmo-agentic-traffic', () => {
       const handler = createAgenticTrafficKpisHandler(denyAccess);
       const res = await handler(ctx);
       expect(res.status).to.equal(400);
+    });
+  });
+
+  // ── Platform code translation ──────────────────────────────────────────────
+
+  describe('platform code to DB value translation', () => {
+    const cases = [
+      ['openai', 'ChatGPT'],
+      ['chatgpt', 'ChatGPT'],
+      ['anthropic', 'Anthropic'],
+      ['mistral', 'MistralAI'],
+      ['perplexity', 'Perplexity'],
+      ['gemini', 'Gemini'],
+      ['google', 'Google'],
+      ['amazon', 'Amazon'],
+      ['all', null],
+      [undefined, null],
+      ['unknown-code', null],
+    ];
+
+    cases.forEach(([input, expected]) => {
+      it(`translates platform='${input}' → p_platform=${JSON.stringify(expected)}`, async () => {
+        const client = createMockClient({ rpc_agentic_traffic_kpis: { data: [], error: null } });
+        const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', platform: input } });
+        const handler = createAgenticTrafficKpisHandler(stubbedValidateAccess);
+        await handler(ctx);
+        expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_kpis', {
+          p_platform: expected,
+        });
+      });
     });
   });
 
@@ -906,6 +937,96 @@ describe('llmo-agentic-traffic', () => {
       const client = { rpc: sinon.stub(), from: sinon.stub().callsFake(() => makeChain()) };
       const ctx = makeContext({ client });
       const handler = createAgenticTrafficWeeksHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(500);
+    });
+  });
+
+  // ── URL Brand Presence ──────────────────────────────────────────────────────
+
+  describe('createAgenticTrafficUrlBrandPresenceHandler', () => {
+    const RPC = 'rpc_brand_presence_url_detail';
+
+    it('returns brand presence data for the URL on success', async () => {
+      const rpcPayload = {
+        totalCitations: 42,
+        totalMentions: 30,
+        uniquePrompts: 10,
+        weeklyTrends: [
+          { weekStr: '2026-W01', citationCount: 5, mentionCount: 3 },
+        ],
+        prompts: [
+          {
+            prompt: 'What is Adobe Express?',
+            topic: 'Product Features',
+            topicId: 'topic-uuid-1',
+            regionCode: 'US',
+            citations: 8,
+            mentions: 6,
+            avgSentiment: 0.75,
+            avgVisibilityScore: 85.0,
+            executionCount: 10,
+          },
+        ],
+      };
+      const client = createMockClient({
+        [RPC]: { data: rpcPayload, error: null }, // RETURNS JSONB → object directly, not array
+      });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', url: 'https://www.adobe.com/express' } });
+      const handler = createAgenticTrafficUrlBrandPresenceHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.totalCitations).to.equal(42);
+      expect(body.uniquePrompts).to.equal(10);
+      expect(body.weeklyTrends).to.have.length(1);
+      expect(body.prompts).to.have.length(1);
+      expect(body.prompts[0].prompt).to.equal('What is Adobe Express?');
+    });
+
+    it('returns 400 when url param is missing', async () => {
+      const client = createMockClient({ [RPC]: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28' } });
+      const handler = createAgenticTrafficUrlBrandPresenceHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(400);
+      expect(client.rpc).not.to.have.been.called;
+    });
+
+    it('passes organizationId from site to the RPC', async () => {
+      const client = createMockClient({
+        [RPC]: {
+          data: [{
+            totalCitations: 0, totalMentions: 0, uniquePrompts: 0, weeklyTrends: [], prompts: [],
+          }],
+          error: null,
+        },
+      });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', url: 'https://example.com/page' } });
+      const handler = createAgenticTrafficUrlBrandPresenceHandler(stubbedValidateAccess);
+      await handler(ctx);
+      const rpcArgs = client.rpc.firstCall.args[1];
+      expect(rpcArgs.p_organization_id).to.equal('org-1');
+      expect(rpcArgs.p_url).to.equal('https://example.com/page');
+      expect(rpcArgs.p_site_id).to.equal(SITE_ID);
+    });
+
+    it('returns empty arrays when RPC returns no data', async () => {
+      const client = createMockClient({ [RPC]: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', url: 'https://example.com' } });
+      const handler = createAgenticTrafficUrlBrandPresenceHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.totalCitations).to.equal(0);
+      expect(body.weeklyTrends).to.deep.equal([]);
+      expect(body.prompts).to.deep.equal([]);
+    });
+
+    it('returns 500 when RPC errors', async () => {
+      const client = createMockClient({ [RPC]: { data: null, error: { message: 'db error' } } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', url: 'https://example.com' } });
+      const handler = createAgenticTrafficUrlBrandPresenceHandler(stubbedValidateAccess);
       const res = await handler(ctx);
       expect(res.status).to.equal(500);
     });

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -81,14 +81,25 @@ function makeContext(overrides = {}) {
   };
 }
 
-const stubbedValidateAccess = sinon.stub().resolves();
+// Resolves with the same shape as the real getSiteAndValidateAccess so that
+// withAgenticTrafficAuth forwards { site, organization } to handlerFn as siteContext.
+const stubbedValidateAccess = sinon.stub().resolves({
+  site: { getOrganizationId: () => 'org-1' },
+  organization: { getId: () => 'org-1' },
+});
 
 describe('llmo-agentic-traffic', () => {
   const sandbox = sinon.createSandbox();
 
   afterEach(() => {
     sandbox.restore();
+    // reset() clears call history AND any per-test behaviour overrides;
+    // then re-apply the default so subsequent tests get the site context.
     stubbedValidateAccess.reset();
+    stubbedValidateAccess.resolves({
+      site: { getOrganizationId: () => 'org-1' },
+      organization: { getId: () => 'org-1' },
+    });
   });
 
   // ── Shared: PostgREST availability ──────────────────────────────────────────
@@ -996,9 +1007,9 @@ describe('llmo-agentic-traffic', () => {
     it('passes organizationId from site to the RPC', async () => {
       const client = createMockClient({
         [RPC]: {
-          data: [{
+          data: {
             totalCitations: 0, totalMentions: 0, uniquePrompts: 0, weeklyTrends: [], prompts: [],
-          }],
+          },
           error: null,
         },
       });

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -281,6 +281,7 @@ describe('getRouteHandlers', () => {
     getAgenticTrafficFilterDimensions: () => null,
     getAgenticTrafficWeeks: () => null,
     getAgenticTrafficMovers: () => null,
+    getAgenticTrafficUrlBrandPresence: () => null,
   };
 
   const mockLlmoOpportunitiesController = {
@@ -881,6 +882,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/agentic-traffic/filter-dimensions',
       'GET /sites/:siteId/agentic-traffic/weeks',
       'GET /sites/:siteId/agentic-traffic/movers',
+      'GET /sites/:siteId/agentic-traffic/url-brand-presence',
     ];
     expect(Object.keys(dynamicRoutes)).to.have.members(expectedDynamicRouteKeys);
 


### PR DESCRIPTION
## Description

  Adds a new endpoint that powers the URL details dialog in the Agentic Traffic PG dashboard. When a  user clicks "Details" on a URL in the URL Performance table, this endpoint returns brand presence citation data for that URL directly from the DB.

  - New handler createAgenticTrafficUrlBrandPresenceHandler in llmo-agentic-traffic.js — calls
  rpc_brand_presence_url_detail (mysticat-data-service), resolves organisation from site, returns
  citation stats, weekly trends, and top prompts that cited the URL as a source
  - New route GET /sites/:siteId/agentic-traffic/url-brand-presence registered in routes/index.js
  - Added to INTERNAL_ROUTES in required-capabilities.js (UI-only, not exposed to S2S consumers)
  - Unit tests — happy path, missing url param → 400, RPC error → 500, correct organizationId
  resolution from site

## Test plan
  - Call GET /sites/:siteId/agentic-traffic/url-brand-presence?url=https://www.adobe.com/express/pag
  e&startDate=2026-01-01&endDate=2026-03-31 with a valid site — expect 200 with ```{ totalCitations,
  totalMentions, uniquePrompts, weeklyTrends[], prompts[] }```
  - Confirm 400 when url param is missing
  - Confirm 403 for a site without LLMO org access

## Checks

Please ensure your pull request adheres to the following guidelines:
- [ x ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ x ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ x ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
[LLMO-4000](https://jira.corp.adobe.com/browse/LLMO-4000)