### PR TITLE
feat: prompt details add mentions and competitors data

### DIFF
--- a/docs/llmo-brandalf-apis/prompt-detail-api.md
+++ b/docs/llmo-brandalf-apis/prompt-detail-api.md
@@ -14,7 +14,7 @@ Returns all execution rows, weekly aggregated statistics, and citation sources f
 **Path parameters:**
 - `spaceCatId` — Organization ID (UUID)
 - `brandId` — `all` (all brands) or a specific brand UUID
-- `topicId` — URL-encoded topic name (e.g. `PDF%20Editing`)
+- `topicId` — URL-encoded topic **name** (e.g. `PDF%20Editing`) or a **topic UUID**; when a UUID, the API filters executions by `topic_id` and still returns a human-readable `topic` label when row data includes `topics`
 
 ---
 
@@ -45,6 +45,7 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
 ```json
 {
   "topic": "PDF Editing",
+  "topicId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "prompt": "best pdf editor for mac",
   "region": "US",
   "stats": {
@@ -77,6 +78,8 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
   "executions": [
     {
       "prompt": "best pdf editor for mac",
+      "promptId": "019cb903-1184-7f92-8325-f9d1176af316",
+      "executionId": "019cb903-1184-7f92-8325-f9d1176af317",
       "region": "US",
       "executionDate": "2026-03-08",
       "week": "2026-W10",
@@ -90,7 +93,9 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
       "origin": "human",
       "category": "Acrobat",
       "sources": "https://example.com/pdf-editor",
-      "errorCode": ""
+      "errorCode": "",
+      "businessCompetitors": "Competitor A;Competitor B",
+      "detectedBrandMentions": "Acme Corp, OtherBrand"
     }
   ],
   "sources": [
@@ -111,6 +116,15 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
 ---
 
 ## Response Field Reference
+
+### Top-level fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `topic` | string | Display label for the topic (from `topics` on the first execution row when present, otherwise the decoded `:topicId` path value) |
+| `topicId` | string \| null | Stable topic UUID: prefers `topic_id` from the first execution row; if missing, uses `:topicId` when the path is a valid UUID; `null` when the path is a topic name and rows have no `topic_id` |
+| `prompt` | string | Prompt text from the required `prompt` query parameter |
+| `region` | string | Region filter applied for this response (from `promptRegion` / `prompt_region`, or empty when not scoped) |
 
 ### `stats` Object
 
@@ -143,6 +157,8 @@ All execution rows for this prompt+region within the date range. Sorted newest-f
 | Field | Type | Description |
 |-------|------|-------------|
 | `prompt` | string | The prompt text |
+| `promptId` | string | Prompt UUID from `brand_presence_executions.prompt_id` (stringified); empty string when null |
+| `executionId` | string | Execution row UUID from `brand_presence_executions.id` (stringified); empty string when null |
 | `region` | string | Region code |
 | `executionDate` | string | Execution date (YYYY-MM-DD) |
 | `week` | string | ISO week string derived from `executionDate` |
@@ -157,6 +173,8 @@ All execution rows for this prompt+region within the date range. Sorted newest-f
 | `category` | string | Category name |
 | `sources` | string | URL from the execution |
 | `errorCode` | string | Error code if the execution failed, empty otherwise |
+| `businessCompetitors` | string | Value of `business_competitors` (competitor names; DB pipelines typically use `;` as delimiter); empty string when null |
+| `detectedBrandMentions` | string | Value of `detected_brand_mentions` as stored for the execution; empty string when null |
 
 ### `sources[]` Array
 
@@ -175,7 +193,7 @@ Aggregated citation sources for this prompt. Deduplicated by URL. Same structure
 
 ## Aggregation Logic
 
-1. Query all `brand_presence_executions` rows matching the topic, prompt text, and (optionally) region code
+1. Query all `brand_presence_executions` rows matching the topic, prompt text, and (optionally) region code (selected columns include `id`, `topic_id`, `prompt_id`, `business_competitors`, `detected_brand_mentions`, and fields used for stats and display)
 2. Compute prompt-level stats inline:
    - Average `visibility_score` (excluding null/NaN)
    - Average `position` (excluding "Not Mentioned" and non-numeric)

--- a/docs/llmo-brandalf-apis/topics-api.md
+++ b/docs/llmo-brandalf-apis/topics-api.md
@@ -108,6 +108,8 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
 
 ```json
 {
+  "topic": "PDF Editing",
+  "topicId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "items": [
     {
       "topic": "PDF Editing",
@@ -131,6 +133,8 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
   "totalCount": 47
 }
 ```
+
+Root **`topic`** and **`topicId`** mirror the [Topic Detail API](topic-detail-api.md) conventions: same resolution from execution rows and the `:topicId` path (UUID path filters by `topic_id` but still returns a display label and stable id when the query returns rows). `topicId` is `null` when the path is a topic name and rows have no `topic_id`.
 
 ### Prompt Object Fields
 

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -161,6 +161,53 @@ function parseTopicIds(q) {
   return arr.filter((id) => id != null && isValidUUID(String(id)));
 }
 
+/**
+ * PostgREST filter for URL path `:topicId` (after decodeURIComponent):
+ * trimmed value is a UUID → topic_id; otherwise topics (display name).
+ * @param {Object} query - PostgREST builder chain (from/select/org/date/model already applied)
+ * @param {string} decodedTopicParam - decoded path segment
+ * @returns {Object} query with .eq('topic_id' | 'topics', ...) applied
+ */
+export function applyTopicPathFilter(query, decodedTopicParam) {
+  const trimmed = String(decodedTopicParam).trim();
+  if (isValidUUID(trimmed)) {
+    return query.eq('topic_id', trimmed);
+  }
+  return query.eq('topics', decodedTopicParam);
+}
+
+/**
+ * Response topic label: use row topics when present, else the path param
+ * (e.g. UUID when no rows or null topics).
+ * @param {Array<Object>} rows - execution rows
+ * @param {string} decodedTopicParam - decoded :topicId
+ */
+function topicLabelForDetailResponse(rows, decodedTopicParam) {
+  if (!rows || rows.length === 0) {
+    return decodedTopicParam;
+  }
+  const label = rows[0].topics;
+  return hasText(label) ? label : decodedTopicParam;
+}
+
+/**
+ * Stable topic id for JSON: prefer DB topic_id on first row, else UUID path param if valid.
+ * @param {Array<Object>} rows - execution rows (may be empty)
+ * @param {string} decodedTopicParam - decoded :topicId
+ * @returns {string|null}
+ */
+export function topicIdForDetailResponse(rows, decodedTopicParam) {
+  const trimmedParam = String(decodedTopicParam).trim();
+  const rowId = rows?.[0]?.topic_id;
+  if (hasText(rowId)) {
+    return String(rowId).trim();
+  }
+  if (isValidUUID(trimmedParam)) {
+    return trimmedParam;
+  }
+  return null;
+}
+
 function parseFilterDimensionsParams(context) {
   const q = context.data || {};
   return {
@@ -1615,10 +1662,10 @@ export function createTopicPromptsHandler(getOrgAndValidateAccess) {
         .from('brand_presence_executions')
         .select(PROMPTS_SELECT)
         .eq('organization_id', organizationId)
-        .eq('topics', topicName)
         .gte('execution_date', startDate)
         .lte('execution_date', endDate)
         .eq('model', model);
+      q = applyTopicPathFilter(q, topicName);
 
       if (shouldApplyFilter(params.siteId)) {
         q = q.eq('site_id', params.siteId);
@@ -1824,7 +1871,7 @@ export function createSearchHandler(getOrgAndValidateAccess) {
 // ── Topic Detail / Prompt Detail ─────────────────────────────────────────────
 
 // eslint-disable-next-line max-len
-const DETAIL_SELECT = 'id, topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, answer, url, error_code, business_competitors, detected_brand_mentions';
+const DETAIL_SELECT = 'id, topic_id, topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, answer, url, error_code, business_competitors, detected_brand_mentions';
 
 /**
  * Derives the ISO week string from an execution_date using the shared toISOWeek helper.
@@ -2076,8 +2123,8 @@ export function createTopicDetailHandler(getOrgAndValidateAccess) {
         }
       }
 
-      const q = buildDetailExecQuery(client, organizationId, params, defaults, filterByBrandId)
-        .eq('topics', topicName);
+      let q = buildDetailExecQuery(client, organizationId, params, defaults, filterByBrandId);
+      q = applyTopicPathFilter(q, topicName);
 
       const { data: execRows, error: execError } = await q.limit(WEEKS_QUERY_LIMIT);
 
@@ -2087,9 +2134,12 @@ export function createTopicDetailHandler(getOrgAndValidateAccess) {
       }
 
       const rows = execRows || [];
+      const topicResponseLabel = topicLabelForDetailResponse(rows, topicName);
+      const topicIdResponse = topicIdForDetailResponse(rows, topicName);
       if (rows.length === 0) {
         return ok({
-          topic: topicName,
+          topic: topicResponseLabel,
+          topicId: topicIdResponse,
           stats: {
             averageVisibilityScore: 0,
             averagePosition: 0,
@@ -2153,7 +2203,8 @@ export function createTopicDetailHandler(getOrgAndValidateAccess) {
       const sources = aggregateDetailSources(flatSources);
 
       return ok({
-        topic: topicName,
+        topic: topicResponseLabel,
+        topicId: topicIdResponse,
         /* c8 ignore start */
         stats: {
           averageVisibilityScore: topicStats.averageVisibilityScore || 0,
@@ -2218,8 +2269,8 @@ export function createPromptDetailHandler(getOrgAndValidateAccess) {
         }
       }
 
-      let q = buildDetailExecQuery(client, organizationId, params, defaults, filterByBrandId)
-        .eq('topics', topicName)
+      let q = buildDetailExecQuery(client, organizationId, params, defaults, filterByBrandId);
+      q = applyTopicPathFilter(q, topicName)
         .eq('prompt', promptText);
 
       if (shouldApplyFilter(regionCode)) {
@@ -2234,9 +2285,12 @@ export function createPromptDetailHandler(getOrgAndValidateAccess) {
       }
 
       const rows = execRows || [];
+      const topicResponseLabel = topicLabelForDetailResponse(rows, topicName);
+      const topicIdResponse = topicIdForDetailResponse(rows, topicName);
       if (rows.length === 0) {
         return ok({
-          topic: topicName,
+          topic: topicResponseLabel,
+          topicId: topicIdResponse,
           prompt: promptText,
           region: regionCode || '',
           stats: {
@@ -2339,7 +2393,8 @@ export function createPromptDetailHandler(getOrgAndValidateAccess) {
       const sources = aggregateDetailSources(flatSources);
 
       return ok({
-        topic: topicName,
+        topic: topicResponseLabel,
+        topicId: topicIdResponse,
         prompt: promptText,
         region: regionCode || '',
         stats: {

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -1871,7 +1871,7 @@ export function createSearchHandler(getOrgAndValidateAccess) {
 // ── Topic Detail / Prompt Detail ─────────────────────────────────────────────
 
 // eslint-disable-next-line max-len
-const DETAIL_SELECT = 'id, topic_id, topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, answer, url, error_code, business_competitors, detected_brand_mentions';
+const DETAIL_SELECT = 'id, topic_id, topics, prompt, prompt_id, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, answer, url, error_code, business_competitors, detected_brand_mentions';
 
 /**
  * Derives the ISO week string from an execution_date using the shared toISOWeek helper.
@@ -2172,6 +2172,8 @@ export function createTopicDetailHandler(getOrgAndValidateAccess) {
           const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
           return {
             prompt: r.prompt || '',
+            promptId: r.prompt_id != null ? String(r.prompt_id) : '',
+            executionId: r.id != null ? String(r.id) : '',
             region: r.region_code || '',
             executionDate: r.execution_date || '',
             week: weekFromExecDate(r.execution_date),
@@ -2362,6 +2364,8 @@ export function createPromptDetailHandler(getOrgAndValidateAccess) {
           const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
           return {
             prompt: r.prompt || '',
+            promptId: r.prompt_id != null ? String(r.prompt_id) : '',
+            executionId: r.id != null ? String(r.id) : '',
             region: r.region_code || '',
             executionDate: r.execution_date || '',
             week: weekFromExecDate(r.execution_date),

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -1824,7 +1824,7 @@ export function createSearchHandler(getOrgAndValidateAccess) {
 // ── Topic Detail / Prompt Detail ─────────────────────────────────────────────
 
 // eslint-disable-next-line max-len
-const DETAIL_SELECT = 'id, topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, answer, url, error_code';
+const DETAIL_SELECT = 'id, topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, answer, url, error_code, business_competitors, detected_brand_mentions';
 
 /**
  * Derives the ISO week string from an execution_date using the shared toISOWeek helper.
@@ -2136,6 +2136,8 @@ export function createTopicDetailHandler(getOrgAndValidateAccess) {
             category: r.category_name || '',
             sources: r.url || '',
             errorCode: r.error_code || '',
+            businessCompetitors: r.business_competitors || '',
+            detectedBrandMentions: r.detected_brand_mentions || '',
           };
         });
 
@@ -2320,6 +2322,8 @@ export function createPromptDetailHandler(getOrgAndValidateAccess) {
             category: r.category_name || '',
             sources: r.url || '',
             errorCode: r.error_code || '',
+            businessCompetitors: r.business_competitors || '',
+            detectedBrandMentions: r.detected_brand_mentions || '',
           };
         });
 

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -182,7 +182,7 @@ export function applyTopicPathFilter(query, decodedTopicParam) {
  * @param {Array<Object>} rows - execution rows
  * @param {string} decodedTopicParam - decoded :topicId
  */
-function topicLabelForDetailResponse(rows, decodedTopicParam) {
+export function topicLabelForDetailResponse(rows, decodedTopicParam) {
   if (!rows || rows.length === 0) {
     return decodedTopicParam;
   }
@@ -1645,7 +1645,7 @@ export function createTopicsHandler(getOrgAndValidateAccess) {
 }
 
 // eslint-disable-next-line max-len
-const PROMPTS_SELECT = 'topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, url, error_code';
+const PROMPTS_SELECT = 'topic_id, topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, url, error_code';
 
 /**
  * Creates the getTopicPrompts handler.
@@ -1716,7 +1716,10 @@ export function createTopicPromptsHandler(getOrgAndValidateAccess) {
         }
       }
 
-      let items = buildPromptDetails(data || []);
+      const rawRows = data || [];
+      const topicResponseLabel = topicLabelForDetailResponse(rawRows, topicName);
+      const topicIdResponse = topicIdForDetailResponse(rawRows, topicName);
+      let items = buildPromptDetails(rawRows);
 
       // When a search query is provided, filter to only prompts whose text
       // matches — mirroring the original brand presence client-side behaviour
@@ -1733,7 +1736,12 @@ export function createTopicPromptsHandler(getOrgAndValidateAccess) {
       const start = pagination.page * pagination.pageSize;
       const paged = items.slice(start, start + pagination.pageSize);
 
-      return ok({ items: paged, totalCount });
+      return ok({
+        items: paged,
+        totalCount,
+        topic: topicResponseLabel,
+        topicId: topicIdResponse,
+      });
     },
   );
 }
@@ -1896,6 +1904,39 @@ const DETAIL_SELECT = 'id, topic_id, topics, prompt, prompt_id, region_code, men
  */
 function weekFromExecDate(execDate) {
   return toISOWeek(execDate).week;
+}
+
+/**
+ * Maps a `brand_presence_executions` detail row (`DETAIL_SELECT`) to one `executions[]` entry.
+ * Shared by topic-detail and prompt-detail handlers.
+ * @param {Object} r - Raw PostgREST row
+ * @returns {Object}
+ */
+function mapBrandPresenceDetailExecutionRow(r) {
+  const mentioned = r.mentions === true || r.mentions === 'true';
+  const cited = r.citations === true || r.citations === 'true';
+  const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
+  return {
+    prompt: r.prompt || '',
+    promptId: r.prompt_id != null ? String(r.prompt_id) : '',
+    executionId: r.id != null ? String(r.id) : '',
+    region: r.region_code || '',
+    executionDate: r.execution_date || '',
+    week: weekFromExecDate(r.execution_date),
+    answer: r.answer || '',
+    mentions: mentioned,
+    citations: cited,
+    visibilityScore: Number.isNaN(vs) ? 0 : vs,
+    position: r.position ? String(r.position) : '',
+    sentiment: r.sentiment || '',
+    volume: r.volume != null ? String(r.volume) : '',
+    origin: r.origin || '',
+    category: r.category_name || '',
+    sources: r.url || '',
+    errorCode: r.error_code || '',
+    businessCompetitors: r.business_competitors || '',
+    detectedBrandMentions: r.detected_brand_mentions || '',
+  };
 }
 
 /**
@@ -2184,32 +2225,7 @@ export function createTopicDetailHandler(getOrgAndValidateAccess) {
       // Build execution entries (all rows, newest first)
       const executions = rows
         .sort((a, b) => (b.execution_date || '').localeCompare(a.execution_date || ''))
-        .map((r) => {
-          const mentioned = r.mentions === true || r.mentions === 'true';
-          const cited = r.citations === true || r.citations === 'true';
-          const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
-          return {
-            prompt: r.prompt || '',
-            promptId: r.prompt_id != null ? String(r.prompt_id) : '',
-            executionId: r.id != null ? String(r.id) : '',
-            region: r.region_code || '',
-            executionDate: r.execution_date || '',
-            week: weekFromExecDate(r.execution_date),
-            answer: r.answer || '',
-            mentions: mentioned,
-            citations: cited,
-            visibilityScore: Number.isNaN(vs) ? 0 : vs,
-            position: r.position ? String(r.position) : '',
-            sentiment: r.sentiment || '',
-            volume: r.volume != null ? String(r.volume) : '',
-            origin: r.origin || '',
-            category: r.category_name || '',
-            sources: r.url || '',
-            errorCode: r.error_code || '',
-            businessCompetitors: r.business_competitors || '',
-            detectedBrandMentions: r.detected_brand_mentions || '',
-          };
-        });
+        .map(mapBrandPresenceDetailExecutionRow);
 
       // Fetch sources
       const execIdMap = new Map(rows.map((r) => [r.id, r]));
@@ -2376,32 +2392,7 @@ export function createPromptDetailHandler(getOrgAndValidateAccess) {
 
       const executions = rows
         .sort((a, b) => (b.execution_date || '').localeCompare(a.execution_date || ''))
-        .map((r) => {
-          const mentioned = r.mentions === true || r.mentions === 'true';
-          const cited = r.citations === true || r.citations === 'true';
-          const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
-          return {
-            prompt: r.prompt || '',
-            promptId: r.prompt_id != null ? String(r.prompt_id) : '',
-            executionId: r.id != null ? String(r.id) : '',
-            region: r.region_code || '',
-            executionDate: r.execution_date || '',
-            week: weekFromExecDate(r.execution_date),
-            answer: r.answer || '',
-            mentions: mentioned,
-            citations: cited,
-            visibilityScore: Number.isNaN(vs) ? 0 : vs,
-            position: r.position ? String(r.position) : '',
-            sentiment: r.sentiment || '',
-            volume: r.volume != null ? String(r.volume) : '',
-            origin: r.origin || '',
-            category: r.category_name || '',
-            sources: r.url || '',
-            errorCode: r.error_code || '',
-            businessCompetitors: r.business_competitors || '',
-            detectedBrandMentions: r.detected_brand_mentions || '',
-          };
-        });
+        .map(mapBrandPresenceDetailExecutionRow);
 
       // Fetch sources
       const execIdMap = new Map(rows.map((r) => [r.id, r]));

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -6312,6 +6312,7 @@ describe('llmo-brand-presence', () => {
           topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'q1',
+          prompt_id: 'p1-id',
           region_code: 'US',
           mentions: true,
           citations: false,
@@ -6334,6 +6335,7 @@ describe('llmo-brand-presence', () => {
           topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'q2',
+          prompt_id: 'p2-id',
           region_code: 'US',
           mentions: false,
           citations: true,
@@ -6367,6 +6369,10 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[0].executionDate).to.equal('2026-03-08');
       expect(body.executions[1].executionDate).to.equal('2026-03-01');
       expect(body.executions[0].prompt).to.equal('q2');
+      expect(body.executions[0].promptId).to.equal('p2-id');
+      expect(body.executions[0].executionId).to.equal('exec-2');
+      expect(body.executions[1].promptId).to.equal('p1-id');
+      expect(body.executions[1].executionId).to.equal('exec-1');
       expect(body.executions[0].mentions).to.equal(false);
       expect(body.executions[0].citations).to.equal(true);
       expect(body.executions[0].errorCode).to.equal('E01');
@@ -6544,6 +6550,8 @@ describe('llmo-brand-presence', () => {
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body.executions[0].prompt).to.equal('');
+      expect(body.executions[0].promptId).to.equal('');
+      expect(body.executions[0].executionId).to.equal('');
       expect(body.executions[0].region).to.equal('');
       expect(body.executions[0].executionDate).to.equal('');
       expect(body.executions[0].businessCompetitors).to.equal('');
@@ -6794,6 +6802,7 @@ describe('llmo-brand-presence', () => {
           topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'What is AI?',
+          prompt_id: 'pd-older',
           region_code: 'US',
           mentions: true,
           citations: true,
@@ -6815,6 +6824,7 @@ describe('llmo-brand-presence', () => {
           topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'What is AI?',
+          prompt_id: 'pd-newer',
           region_code: 'US',
           mentions: false,
           citations: false,
@@ -6853,6 +6863,10 @@ describe('llmo-brand-presence', () => {
       // Sorted newest first
       expect(body.executions[0].executionDate).to.equal('2026-03-08');
       expect(body.executions[1].executionDate).to.equal('2026-03-01');
+      expect(body.executions[0].promptId).to.equal('pd-newer');
+      expect(body.executions[1].promptId).to.equal('pd-older');
+      expect(body.executions[0].executionId).to.equal('e2');
+      expect(body.executions[1].executionId).to.equal('e1');
       expect(body.executions[0].businessCompetitors).to.equal('Rival;OtherCo');
       expect(body.executions[0].detectedBrandMentions).to.equal('Acme');
       expect(body.executions[1].businessCompetitors).to.equal('');
@@ -7029,10 +7043,13 @@ describe('llmo-brand-presence', () => {
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body.executions[0].prompt).to.equal('');
+      expect(body.executions[0].promptId).to.equal('');
+      expect(body.executions[0].executionId).to.equal('e1');
       expect(body.executions[0].region).to.equal('');
       expect(body.executions[0].executionDate).to.equal('');
       expect(body.executions[0].businessCompetitors).to.equal('');
       expect(body.executions[0].detectedBrandMentions).to.equal('');
+      expect(body.executions[1].executionId).to.equal('e2');
     });
 
     it('includes sources aggregated from fetchSourcesForExecutions', async () => {

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -6111,6 +6111,8 @@ describe('llmo-brand-presence', () => {
           answer: 'Some answer',
           url: 'https://a.com',
           error_code: null,
+          business_competitors: null,
+          detected_brand_mentions: null,
         },
         {
           id: 'exec-2',
@@ -6129,6 +6131,8 @@ describe('llmo-brand-presence', () => {
           answer: 'Another answer',
           url: 'https://b.com',
           error_code: 'E01',
+          business_competitors: 'CompA;CompB',
+          detected_brand_mentions: 'Our Brand, Other',
         },
       ];
       const client = createTableAwareMock({
@@ -6154,6 +6158,10 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[1].position).to.equal('');
       expect(body.executions[1].sentiment).to.equal('');
       expect(body.executions[1].category).to.equal('');
+      expect(body.executions[0].businessCompetitors).to.equal('CompA;CompB');
+      expect(body.executions[0].detectedBrandMentions).to.equal('Our Brand, Other');
+      expect(body.executions[1].businessCompetitors).to.equal('');
+      expect(body.executions[1].detectedBrandMentions).to.equal('');
       expect(body.weeklyStats.length).to.be.greaterThan(0);
     });
 
@@ -6321,6 +6329,8 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[0].prompt).to.equal('');
       expect(body.executions[0].region).to.equal('');
       expect(body.executions[0].executionDate).to.equal('');
+      expect(body.executions[0].businessCompetitors).to.equal('');
+      expect(body.executions[0].detectedBrandMentions).to.equal('');
     });
   });
 
@@ -6500,6 +6510,8 @@ describe('llmo-brand-presence', () => {
           answer: 'Answer A',
           url: 'https://a.com',
           error_code: null,
+          business_competitors: null,
+          detected_brand_mentions: null,
         },
         {
           id: 'e2',
@@ -6518,6 +6530,8 @@ describe('llmo-brand-presence', () => {
           answer: 'Answer B',
           url: '',
           error_code: null,
+          business_competitors: 'Rival;OtherCo',
+          detected_brand_mentions: 'Acme',
         },
       ];
       const client = createTableAwareMock({
@@ -6541,6 +6555,10 @@ describe('llmo-brand-presence', () => {
       // Sorted newest first
       expect(body.executions[0].executionDate).to.equal('2026-03-08');
       expect(body.executions[1].executionDate).to.equal('2026-03-01');
+      expect(body.executions[0].businessCompetitors).to.equal('Rival;OtherCo');
+      expect(body.executions[0].detectedBrandMentions).to.equal('Acme');
+      expect(body.executions[1].businessCompetitors).to.equal('');
+      expect(body.executions[1].detectedBrandMentions).to.equal('');
     });
 
     it('counts negative sentiment rows but scores them at 0', async () => {
@@ -6714,6 +6732,8 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[0].prompt).to.equal('');
       expect(body.executions[0].region).to.equal('');
       expect(body.executions[0].executionDate).to.equal('');
+      expect(body.executions[0].businessCompetitors).to.equal('');
+      expect(body.executions[0].detectedBrandMentions).to.equal('');
     });
 
     it('includes sources aggregated from fetchSourcesForExecutions', async () => {

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -15,6 +15,8 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
   addDaysToDate,
+  applyTopicPathFilter,
+  topicIdForDetailResponse,
   aggregateDetailSources,
   aggregateSentimentByWeek,
   aggregateTopicData,
@@ -300,6 +302,50 @@ describe('llmo-brand-presence', () => {
     it('compares truthy strings normally', () => {
       expect(strCompare('a', 'b')).to.be.lessThan(0);
       expect(strCompare('b', 'a')).to.be.greaterThan(0);
+    });
+  });
+
+  describe('applyTopicPathFilter', () => {
+    it('uses topic_id for valid UUID strings', () => {
+      const id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const q = { eq: sinon.stub().returnsThis() };
+      applyTopicPathFilter(q, id);
+      expect(q.eq).to.have.been.calledOnceWith('topic_id', id);
+    });
+
+    it('uses topics for non-UUID values', () => {
+      const q = { eq: sinon.stub().returnsThis() };
+      applyTopicPathFilter(q, 'My Topic');
+      expect(q.eq).to.have.been.calledOnceWith('topics', 'My Topic');
+    });
+
+    it('trims whitespace for UUID detection', () => {
+      const id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const q = { eq: sinon.stub().returnsThis() };
+      applyTopicPathFilter(q, `  ${id}  `);
+      expect(q.eq).to.have.been.calledOnceWith('topic_id', id);
+    });
+  });
+
+  describe('topicIdForDetailResponse', () => {
+    it('returns topic_id from first row when present', () => {
+      const id = 'f6a7b8c9-d0e1-2345-f678-901234567890';
+      expect(topicIdForDetailResponse([{ topic_id: id }], 'Any Topic')).to.equal(id);
+    });
+
+    it('returns trimmed UUID path when rows lack topic_id', () => {
+      const id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      expect(topicIdForDetailResponse([], id)).to.equal(id);
+      expect(topicIdForDetailResponse([], `  ${id}  `)).to.equal(id);
+    });
+
+    it('returns null for name path when rows lack topic_id', () => {
+      expect(topicIdForDetailResponse([], 'My Topic')).to.be.null;
+    });
+
+    it('returns UUID path when first row topic_id is empty string', () => {
+      const id = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+      expect(topicIdForDetailResponse([{ topic_id: '' }], id)).to.equal(id);
     });
   });
 
@@ -4924,6 +4970,18 @@ describe('llmo-brand-presence', () => {
       expect(client.eq).to.have.been.calledWith('topics', 'AI Art');
     });
 
+    it('filters by topic_id when topicId param is a UUID', async () => {
+      const client = createChainableMock();
+      const topicUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      mockContext.params.topicId = topicUuid;
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createTopicPromptsHandler(getOrgAndValidateAccess);
+      await handler(mockContext);
+
+      expect(client.eq).to.have.been.calledWith('topic_id', topicUuid);
+    });
+
     it('applies pagination to prompt results', async () => {
       const rows = [];
       for (let i = 0; i < 5; i += 1) {
@@ -6032,10 +6090,28 @@ describe('llmo-brand-presence', () => {
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body.topic).to.equal('AI Overview');
+      expect(body.topicId).to.be.null;
       expect(body.weeklyStats).to.deep.equal([]);
       expect(body.executions).to.deep.equal([]);
       expect(body.sources).to.deep.equal([]);
       expect(body.stats.averageVisibilityScore).to.equal(0);
+    });
+
+    it('returns topicId when path is UUID and no execution rows', async () => {
+      const topicUuid = 'd4e5f6a7-b8c9-0123-def0-123456789012';
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: [], error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.params.topicId = topicUuid;
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createTopicDetailHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      const body = await result.json();
+      expect(body.topic).to.equal(topicUuid);
+      expect(body.topicId).to.equal(topicUuid);
     });
 
     it('returns ok with zeroed stats when data is null', async () => {
@@ -6076,6 +6152,103 @@ describe('llmo-brand-presence', () => {
       expect(client.eq).to.have.been.calledWith('topics', 'AI Overview');
     });
 
+    it('filters by topic_id when topicId path is a UUID', async () => {
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: [], error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      const topicUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      mockContext.params.topicId = topicUuid;
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createTopicDetailHandler(getOrgAndValidateAccess);
+      await handler(mockContext);
+
+      expect(client.eq).to.have.been.calledWith('topic_id', topicUuid);
+    });
+
+    it('returns topics display name in body.topic when path used a UUID', async () => {
+      const topicUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const rows = [
+        {
+          id: 'exec-1',
+          topics: 'Resolved Topic Title',
+          topic_id: topicUuid,
+          prompt: 'q',
+          region_code: 'US',
+          mentions: true,
+          citations: false,
+          visibility_score: 10,
+          position: '1',
+          sentiment: 'Positive',
+          volume: '1',
+          origin: 'o',
+          category_name: 'C',
+          execution_date: '2026-03-01',
+          answer: 'a',
+          url: '',
+          error_code: null,
+          business_competitors: '',
+          detected_brand_mentions: '',
+        },
+      ];
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: rows, error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.params.topicId = topicUuid;
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createTopicDetailHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.topic).to.equal('Resolved Topic Title');
+      expect(body.topicId).to.equal(topicUuid);
+    });
+
+    it('uses path param for body.topic when rows have null topics', async () => {
+      const topicUuid = 'c3d4e5f6-a7b8-9012-cdef-123456789012';
+      const rows = [
+        {
+          id: 'exec-1',
+          topics: null,
+          topic_id: topicUuid,
+          prompt: 'q',
+          region_code: 'US',
+          mentions: false,
+          citations: false,
+          visibility_score: 10,
+          position: '1',
+          sentiment: 'Neutral',
+          volume: '1',
+          origin: 'o',
+          category_name: 'C',
+          execution_date: '2026-03-01',
+          answer: 'a',
+          url: '',
+          error_code: null,
+          business_competitors: '',
+          detected_brand_mentions: '',
+        },
+      ];
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: rows, error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.params.topicId = topicUuid;
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createTopicDetailHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.topic).to.equal(topicUuid);
+      expect(body.topicId).to.equal(topicUuid);
+    });
+
     it('filters by brand_id when brandId is a UUID', async () => {
       const client = createTableAwareMock({
         brand_presence_executions: { data: [], error: null },
@@ -6091,10 +6264,52 @@ describe('llmo-brand-presence', () => {
       expect(client.eq).to.have.been.calledWith('brand_id', '0178a3f0-1234-7000-8000-000000000001');
     });
 
-    it('returns executions sorted newest first and includes all mapped fields', async () => {
+    it('returns topicId from row when path is topic name', async () => {
+      const topicDbId = 'e5f6a7b8-c9d0-1234-e789-012345678901';
       const rows = [
         {
           id: 'exec-1',
+          topics: 'AI Overview',
+          topic_id: topicDbId,
+          prompt: 'q1',
+          region_code: 'US',
+          mentions: true,
+          citations: false,
+          visibility_score: 10,
+          position: '1',
+          sentiment: 'Positive',
+          volume: '1',
+          origin: 'o',
+          category_name: 'C',
+          execution_date: '2026-03-01',
+          answer: 'a',
+          url: '',
+          error_code: null,
+          business_competitors: '',
+          detected_brand_mentions: '',
+        },
+      ];
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: rows, error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.params.topicId = 'AI%20Overview';
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createTopicDetailHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      const body = await result.json();
+      expect(body.topic).to.equal('AI Overview');
+      expect(body.topicId).to.equal(topicDbId);
+    });
+
+    it('returns executions sorted newest first and includes all mapped fields', async () => {
+      const topicRowId = 'a0b1c2d3-e4f5-6789-a012-3456789abcde';
+      const rows = [
+        {
+          id: 'exec-1',
+          topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'q1',
           region_code: 'US',
@@ -6116,6 +6331,7 @@ describe('llmo-brand-presence', () => {
         },
         {
           id: 'exec-2',
+          topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'q2',
           region_code: 'US',
@@ -6162,6 +6378,7 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[0].detectedBrandMentions).to.equal('Our Brand, Other');
       expect(body.executions[1].businessCompetitors).to.equal('');
       expect(body.executions[1].detectedBrandMentions).to.equal('');
+      expect(body.topicId).to.equal(topicRowId);
       expect(body.weeklyStats.length).to.be.greaterThan(0);
     });
 
@@ -6401,12 +6618,31 @@ describe('llmo-brand-presence', () => {
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body.topic).to.equal('AI Overview');
+      expect(body.topicId).to.be.null;
       expect(body.prompt).to.equal('What is AI?');
       expect(body.weeklyStats).to.deep.equal([]);
       expect(body.executions).to.deep.equal([]);
       expect(body.sources).to.deep.equal([]);
       expect(body.stats.visibilityScore).to.equal(0);
       expect(body.stats.mentions).to.equal(0);
+    });
+
+    it('returns topicId when path is UUID and no execution rows (prompt-detail)', async () => {
+      const topicUuid = 'e5f6a7b8-c9d0-1234-e789-012345678902';
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: [], error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.params.topicId = topicUuid;
+      mockContext.data = { prompt: 'What is AI?' };
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createPromptDetailHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      const body = await result.json();
+      expect(body.topic).to.equal(topicUuid);
+      expect(body.topicId).to.equal(topicUuid);
     });
 
     it('returns ok with zeroed stats when data is null', async () => {
@@ -6446,6 +6682,65 @@ describe('llmo-brand-presence', () => {
 
       expect(client.eq).to.have.been.calledWith('topics', 'AI Overview');
       expect(client.eq).to.have.been.calledWith('prompt', 'What is AI?');
+    });
+
+    it('filters by topic_id when topicId path is a UUID', async () => {
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: [], error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      const topicUuid = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+      mockContext.params.topicId = topicUuid;
+      mockContext.data = { prompt: 'What is AI?' };
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createPromptDetailHandler(getOrgAndValidateAccess);
+      await handler(mockContext);
+
+      expect(client.eq).to.have.been.calledWith('topic_id', topicUuid);
+      expect(client.eq).to.have.been.calledWith('prompt', 'What is AI?');
+    });
+
+    it('returns topics display name in body.topic when path used a UUID (prompt-detail)', async () => {
+      const topicUuid = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+      const rows = [
+        {
+          id: 'e1',
+          topics: 'Shown Topic Name',
+          topic_id: topicUuid,
+          prompt: 'What is AI?',
+          region_code: 'US',
+          mentions: true,
+          citations: true,
+          visibility_score: 80,
+          position: '2',
+          sentiment: 'Positive',
+          volume: '100',
+          origin: 'organic',
+          category_name: 'Search',
+          execution_date: '2026-03-01',
+          answer: 'Answer A',
+          url: 'https://a.com',
+          error_code: null,
+          business_competitors: '',
+          detected_brand_mentions: '',
+        },
+      ];
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: rows, error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.params.topicId = topicUuid;
+      mockContext.data = { prompt: 'What is AI?' };
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createPromptDetailHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.topic).to.equal('Shown Topic Name');
+      expect(body.topicId).to.equal(topicUuid);
     });
 
     it('applies region_code filter when promptRegion is provided', async () => {
@@ -6492,9 +6787,11 @@ describe('llmo-brand-presence', () => {
     });
 
     it('computes averaged stats and returns executions sorted newest first', async () => {
+      const topicRowId = 'f1a2b3c4-d5e6-7890-abcd-ef1234567890';
       const rows = [
         {
           id: 'e1',
+          topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'What is AI?',
           region_code: 'US',
@@ -6515,6 +6812,7 @@ describe('llmo-brand-presence', () => {
         },
         {
           id: 'e2',
+          topic_id: topicRowId,
           topics: 'AI Overview',
           prompt: 'What is AI?',
           region_code: 'US',
@@ -6559,6 +6857,7 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[0].detectedBrandMentions).to.equal('Acme');
       expect(body.executions[1].businessCompetitors).to.equal('');
       expect(body.executions[1].detectedBrandMentions).to.equal('');
+      expect(body.topicId).to.equal(topicRowId);
     });
 
     it('counts negative sentiment rows but scores them at 0', async () => {

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -17,6 +17,7 @@ import {
   addDaysToDate,
   applyTopicPathFilter,
   topicIdForDetailResponse,
+  topicLabelForDetailResponse,
   aggregateDetailSources,
   aggregateSentimentByWeek,
   aggregateTopicData,
@@ -348,6 +349,26 @@ describe('llmo-brand-presence', () => {
     it('returns UUID path when first row topic_id is empty string', () => {
       const id = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
       expect(topicIdForDetailResponse([{ topic_id: '' }], id)).to.equal(id);
+    });
+  });
+
+  describe('topicLabelForDetailResponse', () => {
+    it('returns decoded path when there are no rows', () => {
+      expect(topicLabelForDetailResponse([], 'My Topic')).to.equal('My Topic');
+    });
+
+    it('returns first row topics when present', () => {
+      expect(topicLabelForDetailResponse([{ topics: 'AI Overview' }], 'ignored')).to.equal('AI Overview');
+    });
+
+    it('returns path when first row topics is null', () => {
+      const path = 'c3d4e5f6-a7b8-9012-cdef-123456789012';
+      expect(topicLabelForDetailResponse([{ topics: null, topic_id: path }], path)).to.equal(path);
+    });
+
+    it('returns path when first row topics is empty string', () => {
+      const path = 'Named Topic';
+      expect(topicLabelForDetailResponse([{ topics: '' }], path)).to.equal(path);
     });
   });
 
@@ -4927,6 +4948,44 @@ describe('llmo-brand-presence', () => {
       expect(body.items).to.have.lengthOf(1);
       expect(body.items[0].prompt).to.equal('q1');
       expect(body.totalCount).to.equal(1);
+      expect(body.topic).to.equal('PDF');
+      expect(body.topicId).to.be.null;
+    });
+
+    it('returns topic and topicId when path is a topic UUID', async () => {
+      const topicUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const rows = [
+        {
+          topic_id: topicUuid,
+          topics: 'Resolved Label',
+          prompt: 'q1',
+          region_code: 'US',
+          mentions: true,
+          citations: false,
+          visibility_score: 80,
+          position: '2',
+          sentiment: 'Positive',
+          execution_date: '2026-03-01',
+          url: 'https://x.com',
+          error_code: null,
+          origin: 'human',
+          category_name: 'Docs',
+        },
+      ];
+      mockContext.params.topicId = topicUuid;
+      mockContext.dataAccess.Site.postgrestService = createChainableMock({
+        data: rows,
+        error: null,
+      });
+
+      const handler = createTopicPromptsHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.topic).to.equal('Resolved Label');
+      expect(body.topicId).to.equal(topicUuid);
+      expect(body.totalCount).to.equal(1);
     });
 
     it('returns empty items when no data', async () => {
@@ -4943,6 +5002,8 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.items).to.deep.equal([]);
       expect(body.totalCount).to.equal(0);
+      expect(body.topic).to.equal('None');
+      expect(body.topicId).to.be.null;
     });
 
     it('returns empty items when data is null', async () => {
@@ -4959,6 +5020,8 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.items).to.deep.equal([]);
       expect(body.totalCount).to.equal(0);
+      expect(body.topic).to.equal('None');
+      expect(body.topicId).to.be.null;
     });
 
     it('filters by topics column using topicId param', async () => {
@@ -6750,6 +6813,49 @@ describe('llmo-brand-presence', () => {
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body.topic).to.equal('Shown Topic Name');
+      expect(body.topicId).to.equal(topicUuid);
+    });
+
+    it('uses path param for body.topic when rows have null topics (prompt-detail)', async () => {
+      const topicUuid = 'd4e5f6a7-b8c9-0123-def4-567890abcdef';
+      const rows = [
+        {
+          id: 'e1',
+          topics: null,
+          topic_id: topicUuid,
+          prompt: 'What is AI?',
+          prompt_id: 'p1',
+          region_code: 'US',
+          mentions: true,
+          citations: true,
+          visibility_score: 80,
+          position: '2',
+          sentiment: 'Positive',
+          volume: '100',
+          origin: 'organic',
+          category_name: 'Search',
+          execution_date: '2026-03-01',
+          answer: 'Answer A',
+          url: 'https://a.com',
+          error_code: null,
+          business_competitors: '',
+          detected_brand_mentions: '',
+        },
+      ];
+      const client = createTableAwareMock({
+        brand_presence_executions: { data: rows, error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.params.topicId = topicUuid;
+      mockContext.data = { prompt: 'What is AI?' };
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createPromptDetailHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.topic).to.equal(topicUuid);
       expect(body.topicId).to.equal(topicUuid);
     });
 


### PR DESCRIPTION
## Brand Presence detail API — PR summary

### Summary

Improves **Brand Presence topic detail**, **prompt detail**, and **topic prompts** so they support **topic UUID paths**, return a stable **`topicId`**, surface **competitor and mention strings** on each execution, and expose **`promptId`** and **`executionId`** on each execution row. **`prompt-detail-api.md`** is updated to match.

---

### API / behavior

#### `:topicId` path

- After `decodeURIComponent`, if the segment is a **UUID**, filters use **`topic_id`**; otherwise **`topics`** (display name).
- Applies to **topic prompts**, **topic detail**, and **prompt detail**.

#### Topic & prompt detail JSON

- **`topic`**: Human-readable label when `topics` exists on rows; otherwise the path value (e.g. UUID when there is no label).
- **`topicId`**: Prefer first row’s **`topic_id`**; else the path when it is a valid UUID; else **`null`**.

#### `executions[]` (topic + prompt detail)

| Field | Source (`brand_presence_executions`) | Notes |
|--------|--------------------------------------|--------|
| `promptId` | `prompt_id` | String; `''` if null |
| `executionId` | `id` | String; `''` if null |
| `businessCompetitors` | `business_competitors` | `''` if null |
| `detectedBrandMentions` | `detected_brand_mentions` | `''` if null |

#### PostgREST

- **`DETAIL_SELECT`** includes `id`, `topic_id`, `prompt_id`, `business_competitors`, `detected_brand_mentions`, and existing detail columns so the API can populate the fields above.

---

### Code changes

**`src/controllers/llmo/llmo-brand-presence.js`**

- **`applyTopicPathFilter(query, decodedTopicParam)`** (exported): UUID → `eq('topic_id', …)`, else `eq('topics', …)`.
- **`topicIdForDetailResponse(rows, decodedTopicParam)`** (exported): stable topic UUID for JSON.
- **`topicLabelForDetailResponse(rows, decodedTopicParam)`**: display `topic` string.
- **`createTopicPromptsHandler`**: uses `applyTopicPathFilter` instead of always `eq('topics', topicName)`.
- **`createTopicDetailHandler` / `createPromptDetailHandler`**: path filter; `topic` + `topicId` on responses; execution objects include `promptId`, `executionId`, `businessCompetitors`, `detectedBrandMentions`.

---

### Tests

**`test/controllers/llmo/llmo-brand-presence.test.js`**

- UUID vs name path behavior.
- `topicId` / label helpers.
- Execution fields: `promptId`, `executionId`, competitors, mentions, and empty fallbacks.

---

### Docs

**`docs/llmo-brandalf-apis/prompt-detail-api.md`**

- Path parameter semantics (name vs UUID).
- Sample JSON: `topicId`, `promptId`, `executionId`, `businessCompetitors`, `detectedBrandMentions`.
- Top-level field reference and expanded **`executions[]`** table.
- Aggregation step notes aligned with `DETAIL_SELECT`.

---

### Related commits (branch history)

- `feat: prompt details add mentions and competitors data`
- `fix: allow passing topicIds in the prompt details api`

---

### Suggested conventional commit / PR title

`feat(llmo): brand presence detail — topic UUID path, topicId, execution ids, competitors/mentions`