### PR TITLE
fix: align llmo agentic by-url RPC params

### DIFF
--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -32,8 +32,8 @@ const ERR_NOT_FOUND = 'not found';
 
 const VALID_INTERVALS = new Set(['day', 'week', 'month']);
 const VALID_SORT_ORDERS = new Set(['asc', 'desc']);
-const DEFAULT_BY_URL_LIMIT = 2000;
-const MAX_BY_URL_LIMIT = 2000;
+const DEFAULT_BY_URL_LIMIT = 50;
+const MAX_BY_URL_LIMIT = 500;
 
 function defaultDateRange() {
   const end = new Date();
@@ -365,14 +365,21 @@ export function createAgenticTrafficByUrlHandler(getSiteAndValidateAccess) {
         const rawSortOrder = (ctx.data?.sortOrder || ctx.data?.sort_order || 'desc').toLowerCase();
         const sortOrder = VALID_SORT_ORDERS.has(rawSortOrder) ? rawSortOrder : 'desc';
         const rawLimit = ctx.data?.limit;
+        const rawPageOffset = ctx.data?.pageOffset || ctx.data?.page_offset;
+        const urlPathSearch = ctx.data?.urlPathSearch || ctx.data?.url_path_search || null;
         const parsedLimit = Number.parseInt(String(rawLimit), 10) || DEFAULT_BY_URL_LIMIT;
         const limit = rawLimit != null
           ? Math.min(parsedLimit, MAX_BY_URL_LIMIT)
           : DEFAULT_BY_URL_LIMIT;
+        const pageOffset = rawPageOffset != null
+          ? Math.max(Number.parseInt(String(rawPageOffset), 10) || 0, 0)
+          : 0;
 
         const rpcParams = {
           ...buildRpcParams(siteId, parsed),
-          p_limit: limit,
+          p_page_limit: limit,
+          p_page_offset: pageOffset,
+          p_url_path_search: urlPathSearch,
           p_sort_by: rawSortBy,
           p_sort_order: sortOrder,
         };

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -565,21 +565,21 @@ describe('llmo-agentic-traffic', () => {
       expect(body[0].deployedAtEdge).to.equal(true);
     });
 
-    it('caps limit at 2000', async () => {
+    it('caps limit at 500', async () => {
       const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
       const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', limit: 99999 } });
       const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
       await handler(ctx);
       const rpcCallArgs = client.rpc.firstCall.args[1];
-      expect(rpcCallArgs.p_limit).to.equal(2000);
+      expect(rpcCallArgs.p_page_limit).to.equal(500);
     });
 
-    it('uses default limit of 2000 when not specified', async () => {
+    it('uses default limit of 50 when not specified', async () => {
       const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
       const ctx = makeContext({ client });
       const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
       await handler(ctx);
-      expect(client.rpc.firstCall.args[1].p_limit).to.equal(2000);
+      expect(client.rpc.firstCall.args[1].p_page_limit).to.equal(50);
     });
 
     it('falls back to desc for an invalid sort order', async () => {
@@ -588,6 +588,27 @@ describe('llmo-agentic-traffic', () => {
       const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
       await handler(ctx);
       expect(client.rpc.firstCall.args[1].p_sort_order).to.equal('desc');
+    });
+
+    it('forwards pagination and path search params to the new RPC signature', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
+      const ctx = makeContext({
+        client,
+        data: {
+          startDate: '2026-01-01',
+          endDate: '2026-01-28',
+          limit: 75,
+          pageOffset: 10,
+          urlPathSearch: 'pricing',
+        },
+      });
+      const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_by_url', {
+        p_page_limit: 75,
+        p_page_offset: 10,
+        p_url_path_search: 'pricing',
+      });
     });
 
     it('handles null optional fields in URL rows', async () => {

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -194,6 +194,54 @@ describe('llmo-agentic-traffic', () => {
       const res = await handler(ctx);
       expect(res.status).to.equal(500);
     });
+
+    it('accepts snake_case query parameter aliases', async () => {
+      const client = createMockClient({
+        rpc_agentic_traffic_kpis: { data: [], error: null },
+      });
+      const ctx = makeContext({
+        client,
+        context: {
+          data: {
+            start_date: '2026-01-01',
+            end_date: '2026-01-28',
+            category_name: 'Products',
+            agent_type: 'Chatbots',
+            user_agent: 'GPTBot',
+            content_type: 'html',
+          },
+        },
+      });
+      const handler = createAgenticTrafficKpisHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_kpis', {
+        p_start_date: '2026-01-01',
+        p_end_date: '2026-01-28',
+        p_category_name: 'Products',
+        p_agent_type: 'Chatbots',
+        p_user_agent: 'GPTBot',
+        p_content_type: 'html',
+      });
+    });
+
+    it('uses the default date range when dates are omitted', async () => {
+      sandbox.useFakeTimers(new Date('2026-02-01T12:00:00.000Z'));
+      const client = createMockClient({
+        rpc_agentic_traffic_kpis: { data: [], error: null },
+      });
+      const ctx = makeContext({
+        client,
+        context: {
+          data: undefined,
+        },
+      });
+      const handler = createAgenticTrafficKpisHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_kpis', {
+        p_start_date: '2026-01-04',
+        p_end_date: '2026-02-01',
+      });
+    });
   });
 
   // ── KPIs Trend ─────────────────────────────────────────────────────────────
@@ -608,6 +656,23 @@ describe('llmo-agentic-traffic', () => {
         p_page_limit: 75,
         p_page_offset: 10,
         p_url_path_search: 'pricing',
+      });
+    });
+
+    it('normalizes invalid page offsets to 0', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
+      const ctx = makeContext({
+        client,
+        data: {
+          startDate: '2026-01-01',
+          endDate: '2026-01-28',
+          pageOffset: 'not-a-number',
+        },
+      });
+      const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_by_url', {
+        p_page_offset: 0,
       });
     });
 


### PR DESCRIPTION
## Summary
- align the LLMO agentic by-url controller with the new data-service RPC signature
- switch the API request from `p_limit` to `p_page_limit`
- forward `pageOffset` and `urlPathSearch` to the paginated/searchable RPC contract
- match the API-side by-url limit defaults to the new database cap (`50` default, `500` max)

## Testing
- `/Users/amagapu/workspace/mysticat-workspace/spacecat-api-service/node_modules/.bin/mocha -i -g 'Post-Deploy' --spec=test/controllers/llmo/llmo-agentic-traffic.test.js '--ignore=test/it/**'`

## Why
Without this change, merging the latest mysticat-data-service agentic RPC migration would break the API-service `by-url` endpoint because the database now expects `p_page_limit` / `p_page_offset` / `p_url_path_search` instead of the legacy `p_limit` shape.
