### PR TITLE
fix: return correct HTTP status codes for LLMO data fetch failures

### DIFF
--- a/src/controllers/llmo/llmo-query-handler.js
+++ b/src/controllers/llmo/llmo-query-handler.js
@@ -18,6 +18,25 @@ import {
   LLMO_SHEETDATA_SOURCE_URL,
 } from './llmo-utils.js';
 
+/**
+ * Error thrown when the upstream Helix/EDS API returns a non-OK response.
+ * Carries the upstream HTTP status so callers can map it to an appropriate response.
+ */
+export class UpstreamError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.name = 'UpstreamError';
+    this.upstreamStatus = status;
+  }
+}
+
+const RETRY_DELAY_MS = 1000;
+const MAX_RETRIES = 1;
+
+const delay = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
 const processData = (data, queryParams) => {
   let processedData = data;
 
@@ -74,14 +93,32 @@ const processData = (data, queryParams) => {
   return processedData;
 };
 
+const TIMEOUT_MS = 15000;
+const DEFAULT_LIMIT = 100000;
+
+/**
+ * Perform a single fetch attempt against the Helix/EDS backend.
+ * Returns the Response object (caller checks .ok).
+ */
+const fetchFromHelix = async (url, env, signal) => fetch(url.toString(), {
+  headers: {
+    Authorization: `token ${env.LLMO_HLX_API_KEY}`,
+    'User-Agent': SPACECAT_USER_AGENT,
+    'Accept-Encoding': 'br',
+  },
+  signal,
+});
+
 const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryParams) => {
   const { log, env } = context;
   const { sheet } = context.data;
 
   const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${llmoConfig.dataFolder}/${filePath}`);
 
-  // Apply pagination parameters when calling the source URL
-  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : 10000000;
+  // Apply pagination parameters when calling the source URL.
+  // Cap at DEFAULT_LIMIT to prevent oversized responses that overwhelm Helix.
+  const parsedLimit = queryParams.limit ? parseInt(queryParams.limit, 10) : DEFAULT_LIMIT;
+  const limit = Math.min(parsedLimit, DEFAULT_LIMIT);
   const offset = queryParams.offset ? parseInt(queryParams.offset, 10) : 0;
 
   url.searchParams.set('limit', limit.toString());
@@ -92,39 +129,42 @@ const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryPar
     url.searchParams.set('sheet', sheet);
   }
 
-  const urlAsString = url.toString();
-  log.info(`Fetching single file with path: ${urlAsString}`);
-
-  // Create an AbortController with a 15-second timeout
-  // to prevent large data fetches keeping the Lambda running for too long
-  const TIMEOUT_MS = 15000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS); // 15 seconds
+  log.info(`Fetching single file with path: ${url.toString()}`);
 
   // Validate API key exists before making the request
   if (!env.LLMO_HLX_API_KEY) {
-    clearTimeout(timeoutId);
     throw new Error('LLMO_HLX_API_KEY environment variable is not configured');
   }
+
+  // Each attempt gets its own AbortController with a fresh timeout
+  // so retries are not starved by time consumed by the first attempt.
+  let controller = new AbortController();
+  let timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   // Start timing the source fetch
   const sourceFetchStartTime = Date.now();
 
   try {
-    // Fetch data from the external endpoint using the dataFolder from config
-    const response = await fetch(url.toString(), {
-      headers: {
-        Authorization: `token ${env.LLMO_HLX_API_KEY}`,
-        'User-Agent': SPACECAT_USER_AGENT,
-        'Accept-Encoding': 'br',
-      },
-      signal: controller.signal,
-    });
+    let response = await fetchFromHelix(url, env, controller.signal);
+
+    // Retry once on 503 (Helix transiently overloaded)
+    if (response.status === 503 && MAX_RETRIES > 0) {
+      clearTimeout(timeoutId);
+      log.info(`Helix returned 503 for ${filePath}, retrying after ${RETRY_DELAY_MS}ms`);
+      await delay(RETRY_DELAY_MS);
+      controller = new AbortController();
+      timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+      response = await fetchFromHelix(url, env, controller.signal);
+    }
+
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
-      throw new Error(`External API returned ${response.status}: ${response.statusText}`);
+      log.warn(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
+      throw new UpstreamError(
+        response.status,
+        `External API returned ${response.status}: ${response.statusText}`,
+      );
     }
 
     // Get the raw response data
@@ -148,7 +188,7 @@ const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryPar
     clearTimeout(timeoutId);
     if (error.name === 'AbortError') {
       log.debug(`Request timeout after ${TIMEOUT_MS}ms for file: ${filePath}`);
-      throw new Error(`Request timeout after ${TIMEOUT_MS}ms`);
+      throw new UpstreamError(504, `Request timeout after ${TIMEOUT_MS}ms`);
     }
     throw error;
   }

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -66,7 +66,7 @@ import {
   appendRowsToQueryIndex,
   previewAndPublishQueryIndex,
 } from './llmo-onboarding.js';
-import { queryLlmoFiles } from './llmo-query-handler.js';
+import { queryLlmoFiles, UpstreamError } from './llmo-query-handler.js';
 import { updateModifiedByDetails } from './llmo-config-metadata.js';
 import { handleLlmoRationale } from './llmo-rationale.js';
 import { handleBrandClaims } from './brand-claims.js';
@@ -1092,8 +1092,19 @@ function LlmoController(ctx) {
       const { data, headers } = await queryLlmoFiles(context, llmoConfig);
       return ok(data, headers);
     } catch (error) {
+      const msg = cleanupHeaderValue(error.message);
+      if (error instanceof UpstreamError) {
+        const { upstreamStatus } = error;
+        log.error(`LLMO data fetch failed for site ${siteId} (upstream ${upstreamStatus}): ${error.message}`);
+        if (upstreamStatus === 404) {
+          return notFound(msg);
+        }
+        // 503/5xx from upstream → 502 Bad Gateway; timeout → 504
+        const status = upstreamStatus === 504 ? 504 : 502;
+        return createResponse({ message: msg }, status);
+      }
       log.error(`Error during LLMO cached query for site ${siteId}: ${error.message}`);
-      return badRequest(cleanupHeaderValue(error.message));
+      return badRequest(msg);
     }
   };
 

--- a/test/controllers/llmo/llmo-query-handler.test.js
+++ b/test/controllers/llmo/llmo-query-handler.test.js
@@ -21,6 +21,7 @@ use(chaiAsPromised);
 
 describe('llmo-query-handler', () => {
   let queryLlmoFiles;
+  let UpstreamError;
   let tracingFetchStub;
   let mockContext;
   let mockLlmoConfig;
@@ -95,6 +96,7 @@ describe('llmo-query-handler', () => {
     });
 
     queryLlmoFiles = module.queryLlmoFiles;
+    UpstreamError = module.UpstreamError;
   });
 
   afterEach(() => {
@@ -180,25 +182,76 @@ describe('llmo-query-handler', () => {
       ).to.be.rejectedWith('Network error');
     });
 
-    it('should handle non-OK HTTP responses', async () => {
+    it('should handle non-OK HTTP responses with UpstreamError', async () => {
       tracingFetchStub.resolves(createMockResponse({}, false, 500));
 
-      await expect(
-        queryLlmoFiles(mockContext, mockLlmoConfig),
-      ).to.be.rejectedWith('External API returned 500');
-      expect(mockLog.debug).to.have.been.calledWith(
+      try {
+        await queryLlmoFiles(mockContext, mockLlmoConfig);
+        expect.fail('should have thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(UpstreamError);
+        expect(error.upstreamStatus).to.equal(500);
+        expect(error.message).to.include('External API returned 500');
+      }
+      expect(mockLog.warn).to.have.been.calledWith(
         sinon.match(/Failed to fetch data from external endpoint/),
       );
     });
 
-    it('should handle timeout errors', async () => {
+    it('should handle 404 from upstream with correct status', async () => {
+      tracingFetchStub.resolves(createMockResponse({}, false, 404));
+
+      try {
+        await queryLlmoFiles(mockContext, mockLlmoConfig);
+        expect.fail('should have thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(UpstreamError);
+        expect(error.upstreamStatus).to.equal(404);
+      }
+    });
+
+    it('should retry once on 503 then succeed', async () => {
+      const successData = createSheetData([{ id: 1 }]);
+      tracingFetchStub
+        .onFirstCall().resolves(createMockResponse({}, false, 503))
+        .onSecondCall().resolves(createMockResponse(successData));
+
+      const result = await queryLlmoFiles(mockContext, mockLlmoConfig);
+
+      expect(tracingFetchStub).to.have.been.calledTwice;
+      expect(result.data).to.deep.equal(successData);
+      expect(mockLog.info).to.have.been.calledWith(
+        sinon.match(/Helix returned 503.*retrying/),
+      );
+    });
+
+    it('should throw UpstreamError after 503 retry exhausted', async () => {
+      tracingFetchStub.resolves(createMockResponse({}, false, 503));
+
+      try {
+        await queryLlmoFiles(mockContext, mockLlmoConfig);
+        expect.fail('should have thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(UpstreamError);
+        expect(error.upstreamStatus).to.equal(503);
+      }
+      // First attempt + 1 retry = 2 calls
+      expect(tracingFetchStub).to.have.been.calledTwice;
+    });
+
+    it('should handle timeout errors with UpstreamError', async () => {
       const abortError = new Error('The operation was aborted');
       abortError.name = 'AbortError';
       tracingFetchStub.rejects(abortError);
 
-      await expect(
-        queryLlmoFiles(mockContext, mockLlmoConfig),
-      ).to.be.rejectedWith('Request timeout after 15000ms');
+      try {
+        await queryLlmoFiles(mockContext, mockLlmoConfig);
+        expect.fail('should have thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(UpstreamError);
+        expect(error.upstreamStatus).to.equal(504);
+        expect(error.message).to.include('Request timeout after 15000ms');
+      }
       expect(mockLog.debug).to.have.been.calledWith(
         sinon.match(/Request timeout after 15000ms/),
       );
@@ -465,6 +518,26 @@ describe('llmo-query-handler', () => {
 
       const fetchUrl = getFetchUrl();
       expect(fetchUrl).to.include('limit=50');
+    });
+
+    it('should use default limit of 100000 when not specified', async () => {
+      setupFetchTest(createSheetData([]));
+
+      await queryLlmoFiles(mockContext, mockLlmoConfig);
+
+      const fetchUrl = getFetchUrl();
+      expect(fetchUrl).to.include('limit=100000');
+    });
+
+    it('should cap user-supplied limit at 100000', async () => {
+      setupFetchTest(createSheetData([]));
+      mockContext.data = { limit: '999999' };
+
+      await queryLlmoFiles(mockContext, mockLlmoConfig);
+
+      const fetchUrl = getFetchUrl();
+      expect(fetchUrl).to.include('limit=100000');
+      expect(fetchUrl).to.not.include('limit=999999');
     });
 
     it('should combine multiple query parameters', async () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -17,6 +17,7 @@ import esmock from 'esmock';
 import { S3Client } from '@aws-sdk/client-s3';
 import { llmoConfig } from '@adobe/spacecat-shared-utils';
 import { CDN_TYPES as LOG_SOURCES } from '../../../src/controllers/llmo/llmo-utils.js';
+import { UpstreamError } from '../../../src/controllers/llmo/llmo-query-handler.js';
 import { UnauthorizedProductError } from '../../../src/support/errors.js';
 
 use(sinonChai);
@@ -3380,6 +3381,7 @@ describe('LlmoController', () => {
       const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
         '../../../src/controllers/llmo/llmo-query-handler.js': {
           queryLlmoFiles: queryLlmoFilesStub,
+          UpstreamError,
         },
         '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
         ...getCommonMocks(),
@@ -3389,6 +3391,21 @@ describe('LlmoController', () => {
         controller: LlmoControllerWithCache(mockContext),
         stub: queryLlmoFilesStub,
       };
+    };
+
+    const createControllerWithError = async (error) => {
+      const queryLlmoFilesStub = sinon.stub().rejects(error);
+
+      const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-query-handler.js': {
+          queryLlmoFiles: queryLlmoFilesStub,
+          UpstreamError,
+        },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        ...getCommonMocks(),
+      });
+
+      return LlmoControllerWithCache(mockContext);
     };
 
     it('should successfully fetch and return files data', async () => {
@@ -3411,18 +3428,8 @@ describe('LlmoController', () => {
       expect(stub).to.have.been.calledWith(mockContext, mockLlmoConfig);
     });
 
-    it('should handle errors and return bad request', async () => {
-      const queryLlmoFilesStub = sinon.stub().rejects(new Error('Cache query failed'));
-
-      const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
-        '../../../src/controllers/llmo/llmo-query-handler.js': {
-          queryLlmoFiles: queryLlmoFilesStub,
-        },
-        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
-        ...getCommonMocks(),
-      });
-
-      const errorController = LlmoControllerWithCache(mockContext);
+    it('should handle non-upstream errors and return bad request', async () => {
+      const errorController = await createControllerWithError(new Error('Cache query failed'));
       const result = await errorController.queryFiles(mockContext);
 
       expect(result.status).to.equal(400);
@@ -3431,6 +3438,39 @@ describe('LlmoController', () => {
       expect(mockLog.error).to.have.been.calledWith(
         `Error during LLMO cached query for site ${TEST_SITE_ID}: Cache query failed`,
       );
+    });
+
+    it('should return 404 when upstream returns 404', async () => {
+      const errorController = await createControllerWithError(
+        new UpstreamError(404, 'External API returned 404: Not Found'),
+      );
+      const result = await errorController.queryFiles(mockContext);
+
+      expect(result.status).to.equal(404);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('404');
+    });
+
+    it('should return 502 when upstream returns 503', async () => {
+      const errorController = await createControllerWithError(
+        new UpstreamError(503, 'External API returned 503: Service Unavailable'),
+      );
+      const result = await errorController.queryFiles(mockContext);
+
+      expect(result.status).to.equal(502);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('503');
+    });
+
+    it('should return 504 on upstream timeout', async () => {
+      const errorController = await createControllerWithError(
+        new UpstreamError(504, 'Request timeout after 15000ms'),
+      );
+      const result = await errorController.queryFiles(mockContext);
+
+      expect(result.status).to.equal(504);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('timeout');
     });
 
     it('should return 404 when site is not found', async () => {


### PR DESCRIPTION
## Summary

The `queryFiles` endpoint (`GET /sites/:siteId/llmo/data/*`) was returning **400 Bad Request** for all upstream Helix/EDS failures, making it impossible for clients (DRS, UI, Fastly) to distinguish retryable errors from actual bad requests.

**Coralogix findings (prod, last 6h):** 46x 404s, 15x 503s, 2x timeouts — all returned as 400 to clients.

### Changes

- **UpstreamError class** — typed error carrying the upstream HTTP status, enabling callers to branch on machine-readable data
- **Correct status mapping** — upstream 404→404, 503/5xx→502 Bad Gateway, timeout→504 Gateway Timeout, actual client errors→400
- **503 retry with fresh timeout** — single retry after 1s with a new AbortController (not sharing the original timer budget)
- **Default limit capped at 100K** — was 10M (unbounded). User-supplied limits are also capped at 100K to prevent oversized Helix fetches. Aligns with UI's `DEFAULT_BATCH_SIZE = 100000`
- **Upstream failure log level** — bumped from `debug` to `warn` for better Coralogix visibility

### What this does NOT fix

- **Agentic-traffic PostgREST timeouts** — addressed by mysticat-data-service PR #324 (composite indexes)
- **Query-index update timeouts** — separate Helix publishing issue, out of scope
- **Distribution failures** — Helix backend capacity, requires infra-level fix

### Breaking change notice

Clients that previously handled `status === 400` for upstream failures will now see 404, 502, or 504 instead. This is a **semantic correction** — the previous 400 was wrong per HTTP standards. Clients implementing standard retry logic (retry on 5xx, don't retry on 4xx) will benefit immediately.

## Test plan

- [x] 37 query handler unit tests pass (including new: 503 retry, limit cap, UpstreamError classification)
- [x] 350 llmo controller unit tests pass (including new: 404/502/504 status mapping)
- [x] ESLint clean
- [x] Pre-commit hooks pass
- [ ] Monitor Coralogix after deploy — expect fewer 400s, new 404/502/504 distribution
- [ ] Verify DRS/UI clients handle new status codes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)