### PR TITLE
fix(deps): update @adobe/spacecat-shared-vault-secrets to 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@adobe/spacecat-shared-tier-client": "1.5.0",
         "@adobe/spacecat-shared-tokowaka-client": "1.13.4",
         "@adobe/spacecat-shared-utils": "^1.112.1",
-        "@adobe/spacecat-shared-vault-secrets": "1.3.3",
+        "@adobe/spacecat-shared-vault-secrets": "1.3.4",
         "@aws-sdk/client-s3": "3.1029.0",
         "@aws-sdk/client-secrets-manager": "3.1029.0",
         "@aws-sdk/client-sfn": "3.1029.0",
@@ -12076,12 +12076,12 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-vault-secrets": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.3.tgz",
-      "integrity": "sha512-fSnr/1e0JUByu1zMAKGyyxWEqyicHt1eL8cshbcmEsx8pdyL/18YmaHcP/n5tJG9N5830YGcAdbfdIDZfWYDTw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.4.tgz",
+      "integrity": "sha512-GWnAsaeComj6i55PE/S4SxVlaYqrgbtXtqNbXS/FIsLe01JQhBxaHHxgB6m6mhf58WGpobe5EDa44n6nDGvy7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/spacecat-shared-utils": "1.112.5",
+        "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@adobe/spacecat-shared-tier-client": "1.5.0",
     "@adobe/spacecat-shared-tokowaka-client": "1.13.4",
     "@adobe/spacecat-shared-utils": "^1.112.1",
-    "@adobe/spacecat-shared-vault-secrets": "1.3.3",
+    "@adobe/spacecat-shared-vault-secrets": "1.3.4",
     "@aws-sdk/client-s3": "3.1029.0",
     "@aws-sdk/client-secrets-manager": "3.1029.0",
     "@aws-sdk/client-sfn": "3.1029.0",


### PR DESCRIPTION
## Summary

Updates vault-secrets from 1.3.3 to 1.3.4 to fix Vault authentication failures caused by tracingFetch header injection.

## Problem

vault-secrets 1.3.3 switched Vault HTTP calls to `tracingFetch`, which injects `User-Agent` and `X-Amzn-Trace-Id` headers. These headers triggered intermittent 403s from the corporate WAF in front of `vault-amer.adobe.net`, spiking from ~10 failures/day to ~7,000 in 3 hours.

## Fix

vault-secrets 1.3.4 (adobe/spacecat-shared#1543) reverts to a dedicated `noCache()` fetch context from `@adobe/fetch` - isolated connection pool, no response caching, no header injection. Matches the original design.

## Test plan

- [ ] Monitor Vault 403 rate in Coralogix after deploy
- [ ] Verify cold starts succeed without `Failed to load secrets` errors