### PR TITLE
fix: lower default limit for aem.live proxy requests from 10M to 5000

### DIFF
--- a/src/controllers/llmo/llmo-query-handler.js
+++ b/src/controllers/llmo/llmo-query-handler.js
@@ -80,6 +80,7 @@ const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryPar
 
   const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${llmoConfig.dataFolder}/${filePath}`);
 
+  // Apply pagination parameters when calling the source URL
   const DEFAULT_LIMIT = 5000;
   const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : DEFAULT_LIMIT;
   const offset = queryParams.offset ? parseInt(queryParams.offset, 10) : 0;

--- a/src/controllers/llmo/llmo-query-handler.js
+++ b/src/controllers/llmo/llmo-query-handler.js
@@ -15,6 +15,7 @@ import {
   applyFilters,
   applyInclusions,
   applySort,
+  DEFAULT_LLMO_GET_LIMIT,
   LLMO_SHEETDATA_SOURCE_URL,
 } from './llmo-utils.js';
 
@@ -81,8 +82,7 @@ const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryPar
   const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${llmoConfig.dataFolder}/${filePath}`);
 
   // Apply pagination parameters when calling the source URL
-  const DEFAULT_LIMIT = 5000;
-  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : DEFAULT_LIMIT;
+  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : DEFAULT_LLMO_GET_LIMIT;
   const offset = queryParams.offset ? parseInt(queryParams.offset, 10) : 0;
 
   url.searchParams.set('limit', limit.toString());

--- a/src/controllers/llmo/llmo-query-handler.js
+++ b/src/controllers/llmo/llmo-query-handler.js
@@ -80,8 +80,8 @@ const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryPar
 
   const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${llmoConfig.dataFolder}/${filePath}`);
 
-  // Apply pagination parameters when calling the source URL
-  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : 10000000;
+  const DEFAULT_LIMIT = 5000;
+  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : DEFAULT_LIMIT;
   const offset = queryParams.offset ? parseInt(queryParams.offset, 10) : 0;
 
   url.searchParams.set('limit', limit.toString());

--- a/src/controllers/llmo/llmo-utils.js
+++ b/src/controllers/llmo/llmo-utils.js
@@ -12,6 +12,7 @@
 
 // LLMO constants
 export const LLMO_SHEETDATA_SOURCE_URL = 'https://main--project-elmo-ui-data--adobe.aem.live';
+export const DEFAULT_LLMO_GET_LIMIT = 5000;
 
 // Supported CDN types. Aligned with auth-service (cdn-logs-infrastructure/common.js).
 export const CDN_TYPES = {

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -178,12 +178,12 @@ function LlmoController(ctx) {
         sheetURL = `${llmoConfig.dataFolder}/${dataSource}.json`;
       }
 
+      const DEFAULT_LIMIT = 5000;
+
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      if (limit) {
-        url.searchParams.set('limit', limit);
-      }
+      url.searchParams.set('limit', limit || DEFAULT_LIMIT);
       if (offset) {
         url.searchParams.set('offset', offset);
       }
@@ -231,7 +231,7 @@ function LlmoController(ctx) {
     // Start timing for the entire method
     const methodStartTime = Date.now();
 
-    const FIXED_LLMO_LIMIT = 1000000;
+    const DEFAULT_LIMIT = 5000;
 
     // Extract and validate request body structure
     const {
@@ -240,8 +240,8 @@ function LlmoController(ctx) {
       include = [],
       exclude = [],
       groupBy = [],
-      limit = FIXED_LLMO_LIMIT, // Default to 1M records to return all records
-      offset = 0, // Default to 0 to return the first 1M records
+      limit = DEFAULT_LIMIT,
+      offset = 0,
     } = context.data || {};
 
     // Validate request body structure
@@ -406,12 +406,12 @@ function LlmoController(ctx) {
       // Use 'llmo-global' folder
       const sheetURL = `llmo-global/${configName}.json`;
 
+      const GLOBAL_DEFAULT_LIMIT = 5000;
+
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      if (limit) {
-        url.searchParams.set('limit', limit);
-      }
+      url.searchParams.set('limit', limit || GLOBAL_DEFAULT_LIMIT);
       if (offset) {
         url.searchParams.set('offset', offset);
       }

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -54,6 +54,7 @@ import {
   applyExclusions,
   applyGroups,
   applyMappings,
+  DEFAULT_LLMO_GET_LIMIT,
   LLMO_SHEETDATA_SOURCE_URL,
 } from './llmo-utils.js';
 import { LLMO_SHEET_MAPPINGS } from './llmo-mappings.js';
@@ -178,12 +179,10 @@ function LlmoController(ctx) {
         sheetURL = `${llmoConfig.dataFolder}/${dataSource}.json`;
       }
 
-      const DEFAULT_LIMIT = 5000;
-
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      url.searchParams.set('limit', limit || DEFAULT_LIMIT);
+      url.searchParams.set('limit', limit ?? DEFAULT_LLMO_GET_LIMIT);
       if (offset) {
         url.searchParams.set('offset', offset);
       }
@@ -406,12 +405,10 @@ function LlmoController(ctx) {
       // Use 'llmo-global' folder
       const sheetURL = `llmo-global/${configName}.json`;
 
-      const GLOBAL_DEFAULT_LIMIT = 5000;
-
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      url.searchParams.set('limit', limit || GLOBAL_DEFAULT_LIMIT);
+      url.searchParams.set('limit', limit ?? DEFAULT_LLMO_GET_LIMIT);
       if (offset) {
         url.searchParams.set('offset', offset);
       }

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -231,7 +231,7 @@ function LlmoController(ctx) {
     // Start timing for the entire method
     const methodStartTime = Date.now();
 
-    const DEFAULT_LIMIT = 5000;
+    const POST_DEFAULT_LIMIT = 1000000;
 
     // Extract and validate request body structure
     const {
@@ -240,7 +240,7 @@ function LlmoController(ctx) {
       include = [],
       exclude = [],
       groupBy = [],
-      limit = DEFAULT_LIMIT,
+      limit = POST_DEFAULT_LIMIT,
       offset = 0,
     } = context.data || {};
 

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -230,7 +230,7 @@ function LlmoController(ctx) {
     // Start timing for the entire method
     const methodStartTime = Date.now();
 
-    const POST_DEFAULT_LIMIT = 1000000;
+    const POST_DEFAULT_LIMIT = 1000000; // Default to 1M records to return all records
 
     // Extract and validate request body structure
     const {
@@ -240,7 +240,7 @@ function LlmoController(ctx) {
       exclude = [],
       groupBy = [],
       limit = POST_DEFAULT_LIMIT,
-      offset = 0,
+      offset = 0, // Default to 0 to return the first 1M records
     } = context.data || {};
 
     // Validate request body structure

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -182,7 +182,7 @@ function LlmoController(ctx) {
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      url.searchParams.set('limit', limit ?? DEFAULT_LLMO_GET_LIMIT);
+      url.searchParams.set('limit', limit || DEFAULT_LLMO_GET_LIMIT);
       if (offset) {
         url.searchParams.set('offset', offset);
       }
@@ -408,7 +408,7 @@ function LlmoController(ctx) {
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      url.searchParams.set('limit', limit ?? DEFAULT_LLMO_GET_LIMIT);
+      url.searchParams.set('limit', limit || DEFAULT_LLMO_GET_LIMIT);
       if (offset) {
         url.searchParams.set('offset', offset);
       }

--- a/test/controllers/llmo/llmo-query-handler.test.js
+++ b/test/controllers/llmo/llmo-query-handler.test.js
@@ -133,6 +133,16 @@ describe('llmo-query-handler', () => {
       expect(fetchUrl).to.include(TEST_DATA_SOURCE);
     });
 
+    it('should use default limit of 5000 when no limit is provided', async () => {
+      setupFetchTest(createSheetData([]));
+      mockContext.data = {};
+
+      await queryLlmoFiles(mockContext, mockLlmoConfig);
+
+      const fetchUrl = getFetchUrl();
+      expect(fetchUrl).to.include('limit=5000');
+    });
+
     it('should construct correct URL with sheetType and week', async () => {
       setupFetchTest(createSheetData([]));
 

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -34,6 +34,7 @@ const TEST_QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/123456789012/audit-j
 const CATEGORY_ID = '123e4567-e89b-12d3-a456-426614174000';
 const TOPIC_ID = '456e7890-e89b-12d3-a456-426614174001';
 const EXTERNAL_API_BASE_URL = 'https://main--project-elmo-ui-data--adobe.aem.live';
+const DEFAULT_LIMIT = 5000;
 
 const createMockResponse = (data, ok = true, status = 200) => ({
   ok,
@@ -690,7 +691,7 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({ data: 'test-data' });
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, {
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, {
         headers: {
           Authorization: `token ${TEST_API_KEY}`,
           'User-Agent': TEST_USER_AGENT,
@@ -717,7 +718,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoSheetData(mockContext);
 
-        const expectedUrl = `${testUrl}?limit=5000&${param}=${mockContext.data[param]}`;
+        const expectedUrl = `${testUrl}?limit=${DEFAULT_LIMIT}&${param}=${mockContext.data[param]}`;
         expect(tracingFetchStub).to.have.been.calledWith(expectedUrl, sinon.match.object);
       });
     });
@@ -743,7 +744,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/test-data.json?limit=5000`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/test-data.json?limit=${DEFAULT_LIMIT}`,
         sinon.match.object,
       );
     });
@@ -756,7 +757,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoSheetData(mockContext);
 
-        expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, sinon.match.object);
+        expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, sinon.match.object);
       });
     });
 
@@ -767,7 +768,7 @@ describe('LlmoController', () => {
 
       await controller.getLlmoSheetData(mockContext);
 
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, {
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, {
         headers: {
           Authorization: 'token hlx_api_key_missing',
           'User-Agent': TEST_USER_AGENT,
@@ -863,7 +864,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/w01/test-data.json?limit=5000`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/w01/test-data.json?limit=${DEFAULT_LIMIT}`,
         sinon.match.object,
       );
     });
@@ -892,7 +893,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/test-data.json?limit=5000`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/test-data.json?limit=${DEFAULT_LIMIT}`,
         sinon.match.object,
       );
     });
@@ -916,7 +917,7 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({ data: 'test-data' });
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, sinon.match.object);
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, sinon.match.object);
     });
 
     it('should add limit query parameter to URL when provided', async () => {
@@ -937,7 +938,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoGlobalSheetData(mockContext);
 
-        const expectedUrl = `${testUrl}?limit=5000&${param}=${mockContext.data[param]}`;
+        const expectedUrl = `${testUrl}?limit=${DEFAULT_LIMIT}&${param}=${mockContext.data[param]}`;
         expect(tracingFetchStub).to.have.been.calledWith(expectedUrl, sinon.match.object);
       });
     });

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -690,7 +690,7 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({ data: 'test-data' });
-      expect(tracingFetchStub).to.have.been.calledWith(testUrl, {
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, {
         headers: {
           Authorization: `token ${TEST_API_KEY}`,
           'User-Agent': TEST_USER_AGENT,
@@ -699,7 +699,17 @@ describe('LlmoController', () => {
       });
     });
 
-    ['limit', 'offset', 'sheet'].forEach((param) => {
+    it('should add limit query parameter to URL when provided', async () => {
+      const mockResponse = createMockResponse({ data: 'test-data' });
+      tracingFetchStub.resolves(mockResponse);
+      mockContext.data.limit = '10';
+
+      await controller.getLlmoSheetData(mockContext);
+
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=10`, sinon.match.object);
+    });
+
+    ['offset', 'sheet'].forEach((param) => {
       it(`should add ${param} query parameter to URL when provided`, async () => {
         const mockResponse = createMockResponse({ data: 'test-data' });
         tracingFetchStub.resolves(mockResponse);
@@ -707,7 +717,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoSheetData(mockContext);
 
-        const expectedUrl = `${testUrl}?${param}=${mockContext.data[param]}`;
+        const expectedUrl = `${testUrl}?limit=5000&${param}=${mockContext.data[param]}`;
         expect(tracingFetchStub).to.have.been.calledWith(expectedUrl, sinon.match.object);
       });
     });
@@ -733,7 +743,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/test-data.json`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/test-data.json?limit=5000`,
         sinon.match.object,
       );
     });
@@ -746,7 +756,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoSheetData(mockContext);
 
-        expect(tracingFetchStub).to.have.been.calledWith(testUrl, sinon.match.object);
+        expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, sinon.match.object);
       });
     });
 
@@ -757,7 +767,7 @@ describe('LlmoController', () => {
 
       await controller.getLlmoSheetData(mockContext);
 
-      expect(tracingFetchStub).to.have.been.calledWith(testUrl, {
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, {
         headers: {
           Authorization: 'token hlx_api_key_missing',
           'User-Agent': TEST_USER_AGENT,
@@ -853,7 +863,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/w01/test-data.json`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/w01/test-data.json?limit=5000`,
         sinon.match.object,
       );
     });
@@ -882,7 +892,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/test-data.json`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/test-data.json?limit=5000`,
         sinon.match.object,
       );
     });
@@ -906,10 +916,20 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({ data: 'test-data' });
-      expect(tracingFetchStub).to.have.been.calledWith(testUrl, sinon.match.object);
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=5000`, sinon.match.object);
     });
 
-    ['limit', 'offset', 'sheet'].forEach((param) => {
+    it('should add limit query parameter to URL when provided', async () => {
+      const mockResponse = createMockResponse({ data: 'test-data' });
+      tracingFetchStub.resolves(mockResponse);
+      mockContext.data.limit = '10';
+
+      await controller.getLlmoGlobalSheetData(mockContext);
+
+      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=10`, sinon.match.object);
+    });
+
+    ['offset', 'sheet'].forEach((param) => {
       it(`should add ${param} query parameter to URL when provided`, async () => {
         const mockResponse = createMockResponse({ data: 'test-data' });
         tracingFetchStub.resolves(mockResponse);
@@ -917,7 +937,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoGlobalSheetData(mockContext);
 
-        const expectedUrl = `${testUrl}?${param}=${mockContext.data[param]}`;
+        const expectedUrl = `${testUrl}?limit=5000&${param}=${mockContext.data[param]}`;
         expect(tracingFetchStub).to.have.been.calledWith(expectedUrl, sinon.match.object);
       });
     });


### PR DESCRIPTION
- Uncached proxy endpoints were forwarding requests to aem.live with large default limits (10M for GET, 1M for POST) or no limit at all, causing resource exhaustion and 503 errors. 
- Callers that provide an explicit limit (audit workers with limit=80000) are not affected.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
