### PR TITLE
feat: add successRate parameter handling | LLMO-4000

### DIFF
--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -93,6 +93,7 @@ function parseAgenticTrafficParams(context) {
     agentType: q.agentType || q.agent_type || null,
     userAgent: q.userAgent || q.user_agent || null,
     contentType: q.contentType || q.content_type || null,
+    successRate: q.successRate || q.success_rate || null,
   };
 }
 
@@ -109,6 +110,7 @@ function buildRpcParams(siteId, parsed) {
     p_agent_type: parsed.agentType,
     p_user_agent: parsed.userAgent,
     p_content_type: parsed.contentType,
+    p_success_rate: parsed.successRate,
   };
 }
 

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -33,6 +33,7 @@ const ERR_NOT_FOUND = 'not found';
 
 const VALID_INTERVALS = new Set(['day', 'week', 'month']);
 const VALID_SORT_ORDERS = new Set(['asc', 'desc']);
+const VALID_SUCCESS_RATE_BUCKETS = new Set(['high', 'medium', 'low']);
 // Allowlists mirror the CASE whitelists in the DB RPCs — unknown values are already
 // rejected server-side, but we validate here too for defence-in-depth.
 const VALID_SORT_COLUMNS_BY_URL = new Set([
@@ -93,7 +94,11 @@ function parseAgenticTrafficParams(context) {
     agentType: q.agentType || q.agent_type || null,
     userAgent: q.userAgent || q.user_agent || null,
     contentType: q.contentType || q.content_type || null,
-    successRate: q.successRate || q.success_rate || null,
+    // Normalise to null for unknown buckets — mirrors how PLATFORM_CODE_TO_DB handles
+    // unknown platform codes, preventing a DB exception (500) for invalid input.
+    successRate: VALID_SUCCESS_RATE_BUCKETS.has(q.successRate || q.success_rate)
+      ? (q.successRate || q.success_rate)
+      : null,
   };
 }
 

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -251,6 +251,7 @@ describe('llmo-agentic-traffic', () => {
             agent_type: 'Chatbots',
             user_agent: 'GPTBot',
             content_type: 'html',
+            success_rate: 'high',
           },
         },
       });
@@ -263,6 +264,7 @@ describe('llmo-agentic-traffic', () => {
         p_agent_type: 'Chatbots',
         p_user_agent: 'GPTBot',
         p_content_type: 'html',
+        p_success_rate: 'high',
       });
     });
 
@@ -726,6 +728,19 @@ describe('llmo-agentic-traffic', () => {
         p_page_limit: 75,
         p_page_offset: 10,
         p_url_path_search: 'pricing',
+      });
+    });
+
+    it('forwards successRate filter as p_success_rate to the RPC', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
+      const ctx = makeContext({
+        client,
+        data: { startDate: '2026-01-01', endDate: '2026-01-28', successRate: 'low' },
+      });
+      const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_by_url', {
+        p_success_rate: 'low',
       });
     });
 

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -744,6 +744,32 @@ describe('llmo-agentic-traffic', () => {
       });
     });
 
+    it('accepts snake_case success_rate alias', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
+      const ctx = makeContext({
+        client,
+        data: { startDate: '2026-01-01', endDate: '2026-01-28', success_rate: 'medium' },
+      });
+      const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_by_url', {
+        p_success_rate: 'medium',
+      });
+    });
+
+    it('normalizes unknown successRate values to null instead of forwarding to the RPC', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
+      const ctx = makeContext({
+        client,
+        data: { startDate: '2026-01-01', endDate: '2026-01-28', successRate: 'invalid-bucket' },
+      });
+      const handler = createAgenticTrafficByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_by_url', {
+        p_success_rate: null,
+      });
+    });
+
     it('normalizes invalid page offsets to 0', async () => {
       const client = createMockClient({ rpc_agentic_traffic_by_url: { data: [], error: null } });
       const ctx = makeContext({


### PR DESCRIPTION
- Updated `parseAgenticTrafficParams` to include `successRate` from query parameters.
- Enhanced `buildRpcParams` to forward `successRate` as `p_success_rate` to the RPC.
- Added tests to ensure `successRate` is correctly processed and forwarded in the RPC call.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-4000
