### PR TITLE
fix: edge-routing - consume promise token from header

### DIFF
--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -47,7 +47,7 @@ import {
   detectCdnForDomain,
 } from '../../support/edge-routing-utils.js';
 import { triggerBrandProfileAgent } from '../../support/brand-profile-trigger.js';
-import { getImsTokenFromCookie, authorizeEdgeCdnRouting } from '../../support/edge-routing-auth.js';
+import { getImsTokenFromPromiseToken, authorizeEdgeCdnRouting } from '../../support/edge-routing-auth.js';
 import {
   applyFilters,
   applyInclusions,
@@ -1319,7 +1319,7 @@ function LlmoController(ctx) {
         // Exchange promise token from cookie for an IMS user token
         let imsUserToken;
         try {
-          imsUserToken = await getImsTokenFromCookie(context);
+          imsUserToken = await getImsTokenFromPromiseToken(context);
           log.info(`[edge-optimize-routing] IMS user token obtained for site ${siteId}`);
         } catch (tokenError) {
           log.error(`[edge-optimize-routing-failed] ${baseURL} Failed to get IMS user token: ${tokenError.message}`);

--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,7 @@ async function run(request, context) {
   if (method === 'OPTIONS') {
     return noContent({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-promise-token',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
     });

--- a/src/support/edge-routing-auth.js
+++ b/src/support/edge-routing-auth.js
@@ -39,6 +39,7 @@ export async function getImsTokenFromPromiseToken(context) {
     err.status = 400;
     throw err;
   }
+  context.log?.info?.(`Promise token found in ${rawHeaderToken ? 'header' : 'cookie'}`);
 
   const promiseToken = decodeURIComponent(rawPromiseToken);
 

--- a/src/support/edge-routing-auth.js
+++ b/src/support/edge-routing-auth.js
@@ -22,16 +22,20 @@ export const LLMO_IMS_SERVICE_CODES = ['dx_llmo'];
 export const LLMO_ADMIN_GROUP_NAME = 'LLMO Admin';
 
 /**
- * Reads the promiseToken cookie from the request and exchanges it for an IMS user access token.
+ * Reads the promise token from the request (cookie first, then x-promise-token header)
+ * and exchanges it for an IMS user access token.
  *
  * @param {object} context - The request context.
  * @returns {Promise<string>} The IMS user access token.
  * @throws {Error} With a `status` property (400 or 401) on failure.
  */
-export async function getImsTokenFromCookie(context) {
-  const rawPromiseToken = getCookieValue(context, 'promiseToken');
+export async function getImsTokenFromPromiseToken(context) {
+  const rawCookieToken = getCookieValue(context, 'promiseToken');
+  const rawHeaderToken = context.pathInfo?.headers?.['x-promise-token'];
+  const rawPromiseToken = rawCookieToken || rawHeaderToken;
+
   if (!hasText(rawPromiseToken)) {
-    const err = new Error('promiseToken cookie is required for CDN routing');
+    const err = new Error('Authentication failed: mandatory token missing');
     err.status = 400;
     throw err;
   }

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -91,7 +91,7 @@ describe('LlmoController', () => {
   let getImsUserOrganizationsStub;
   let probeSiteAndResolveDomainStub;
   let callCdnRoutingApiStub;
-  let getImsTokenFromCookieStub;
+  let getImsTokenFromPromiseTokenStub;
   let edgeRoutingAuthReal;
   let detectCdnForDomainStub;
   let authorizeEdgeCdnRoutingStub;
@@ -191,7 +191,7 @@ describe('LlmoController', () => {
     });
 
     edgeRoutingAuthReal = await import('../../../src/support/edge-routing-auth.js');
-    getImsTokenFromCookieStub = sinon.stub().resolves('test-ims-user-token');
+    getImsTokenFromPromiseTokenStub = sinon.stub().resolves('test-ims-user-token');
     detectCdnForDomainStub = sinon.stub().resolves(LOG_SOURCES.AEM_CS_FASTLY);
     authorizeEdgeCdnRoutingStub = sinon.stub().callsFake((ctx, params, log) => (
       edgeRoutingAuthReal.authorizeEdgeCdnRouting(ctx, params, log)
@@ -232,7 +232,7 @@ describe('LlmoController', () => {
         fetchWithTimeout: (...args) => fetchWithTimeoutStub(...args),
       },
       '../../../src/support/edge-routing-auth.js': {
-        getImsTokenFromCookie: (...args) => getImsTokenFromCookieStub(...args),
+        getImsTokenFromPromiseToken: (...args) => getImsTokenFromPromiseTokenStub(...args),
         authorizeEdgeCdnRouting: (...args) => authorizeEdgeCdnRoutingStub(...args),
       },
       '@adobe/spacecat-shared-ims-client': {
@@ -648,8 +648,8 @@ describe('LlmoController', () => {
     getOrgGroupsStub = sinon.stub().resolves([{ groupName: 'LLMO Admin', ident: 99999 }]);
     getImsUserProfileStub = sinon.stub().resolves({ projectedProductContext: [{ prodCtx: { serviceCode: 'dx_llmo' } }] });
     getImsUserOrganizationsStub = sinon.stub().resolves([]);
-    getImsTokenFromCookieStub.reset();
-    getImsTokenFromCookieStub.resolves('test-ims-user-token');
+    getImsTokenFromPromiseTokenStub.reset();
+    getImsTokenFromPromiseTokenStub.resolves('test-ims-user-token');
     probeSiteAndResolveDomainStub = sinon.stub().resolves('www.example.com');
     detectCdnForDomainStub.reset();
     detectCdnForDomainStub.resolves(LOG_SOURCES.AEM_CS_FASTLY);
@@ -5250,7 +5250,7 @@ describe('LlmoController', () => {
         },
         '../../../src/utils/slack/base.js': { postSlackMessage: sinon.stub().resolves() },
         '../../../src/support/edge-routing-auth.js': {
-          getImsTokenFromCookie: sinon.stub().resolves('test-ims-user-token'),
+          getImsTokenFromPromiseToken: sinon.stub().resolves('test-ims-user-token'),
           authorizeEdgeCdnRouting: edgeRoutingAuthReal.authorizeEdgeCdnRouting,
         },
         '@adobe/spacecat-shared-ims-client': {
@@ -5320,7 +5320,7 @@ describe('LlmoController', () => {
         },
         '../../../src/utils/slack/base.js': { postSlackMessage: sinon.stub().resolves() },
         '../../../src/support/edge-routing-auth.js': {
-          getImsTokenFromCookie: sinon.stub().resolves('test-ims-user-token'),
+          getImsTokenFromPromiseToken: sinon.stub().resolves('test-ims-user-token'),
           authorizeEdgeCdnRouting: edgeRoutingAuthReal.authorizeEdgeCdnRouting,
         },
         '@adobe/spacecat-shared-ims-client': {
@@ -5387,7 +5387,7 @@ describe('LlmoController', () => {
         },
         '../../../src/utils/slack/base.js': { postSlackMessage: sinon.stub().resolves() },
         '../../../src/support/edge-routing-auth.js': {
-          getImsTokenFromCookie: sinon.stub().resolves('test-ims-user-token'),
+          getImsTokenFromPromiseToken: sinon.stub().resolves('test-ims-user-token'),
           authorizeEdgeCdnRouting: edgeRoutingAuthReal.authorizeEdgeCdnRouting,
         },
         '@adobe/spacecat-shared-ims-client': {
@@ -5585,14 +5585,14 @@ describe('LlmoController', () => {
       });
 
       it('returns 400 when promiseToken cookie is missing for CDN routing', async () => {
-        getImsTokenFromCookieStub.callsFake((ctx) => (
-          edgeRoutingAuthReal.getImsTokenFromCookie(ctx)
+        getImsTokenFromPromiseTokenStub.callsFake((ctx) => (
+          edgeRoutingAuthReal.getImsTokenFromPromiseToken(ctx)
         ));
         const result = await controller.createOrUpdateEdgeConfig(
           makeRoutingCtx({ pathInfo: { headers: { cookie: '' } } }),
         );
         expect(result.status).to.equal(400);
-        expect((await result.json()).message).to.include('promiseToken cookie is required');
+        expect((await result.json()).message).to.include('Authentication failed: mandatory token missing');
       });
 
       it('returns 200 with routing data when CDN routing succeeds', async () => {
@@ -5667,10 +5667,10 @@ describe('LlmoController', () => {
         );
       });
 
-      it('uses tokenError.status when getImsTokenFromCookie fails with a status', async () => {
+      it('uses tokenError.status when getImsTokenFromPromiseToken fails with a status', async () => {
         const tokenErr = new Error('IMS cookie exchange failed');
         tokenErr.status = 503;
-        getImsTokenFromCookieStub.rejects(tokenErr);
+        getImsTokenFromPromiseTokenStub.rejects(tokenErr);
         const result = await controller.createOrUpdateEdgeConfig(makeRoutingCtx());
         expect(result.status).to.equal(503);
         expect((await result.json()).message).to.equal('IMS cookie exchange failed');
@@ -5685,8 +5685,8 @@ describe('LlmoController', () => {
         expect((await result.json()).message).to.equal('Custom auth failure');
       });
 
-      it('returns 401 when getImsTokenFromCookie fails without a status', async () => {
-        getImsTokenFromCookieStub.rejects(new Error('token failure'));
+      it('returns 401 when getImsTokenFromPromiseToken fails without a status', async () => {
+        getImsTokenFromPromiseTokenStub.rejects(new Error('token failure'));
         const result = await controller.createOrUpdateEdgeConfig(makeRoutingCtx());
         expect(result.status).to.equal(401);
       });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -210,7 +210,7 @@ describe('Index Tests', () => {
     expect(resp.status).to.equal(204);
     expect(resp.headers.plain()).to.eql({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-promise-token',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
       'content-type': 'application/json; charset=utf-8',

--- a/test/support/edge-routing-auth.test.js
+++ b/test/support/edge-routing-auth.test.js
@@ -100,8 +100,13 @@ describe('edge-routing-auth', () => {
     it('returns access token when cookie is present', async () => {
       getCookieValueStub.returns('ptok');
       exchangePromiseTokenStub.resolves('user-token');
-      const token = await getImsTokenFromPromiseToken({});
+      const ctxLog = { info: sandbox.stub(), error: sandbox.stub() };
+      const token = await getImsTokenFromPromiseToken({
+        pathInfo: { headers: {} },
+        log: ctxLog,
+      });
       expect(token).to.equal('user-token');
+      expect(ctxLog.info).to.have.been.calledWith(sinon.match(/cookie/));
     });
 
     it('returns access token from x-promise-token header when cookie is absent', async () => {

--- a/test/support/edge-routing-auth.test.js
+++ b/test/support/edge-routing-auth.test.js
@@ -107,11 +107,14 @@ describe('edge-routing-auth', () => {
     it('returns access token from x-promise-token header when cookie is absent', async () => {
       getCookieValueStub.returns(null);
       exchangePromiseTokenStub.resolves('user-token-from-header');
+      const ctxLog = { info: sandbox.stub(), error: sandbox.stub() };
       const token = await getImsTokenFromPromiseToken({
         pathInfo: { headers: { 'x-promise-token': 'header-ptok' } },
+        log: ctxLog,
       });
       expect(token).to.equal('user-token-from-header');
       expect(exchangePromiseTokenStub).to.have.been.calledWith(sinon.match.any, 'header-ptok');
+      expect(ctxLog.info).to.have.been.calledWith(sinon.match(/header/));
     });
 
     it('prefers cookie over x-promise-token header when both are present', async () => {

--- a/test/support/edge-routing-auth.test.js
+++ b/test/support/edge-routing-auth.test.js
@@ -35,7 +35,7 @@ describe('edge-routing-auth', () => {
   let log;
   let getCookieValueStub;
   let exchangePromiseTokenStub;
-  let getImsTokenFromCookie;
+  let getImsTokenFromPromiseToken;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -58,22 +58,22 @@ describe('edge-routing-auth', () => {
         },
       },
     });
-    getImsTokenFromCookie = authMocked.getImsTokenFromCookie;
+    getImsTokenFromPromiseToken = authMocked.getImsTokenFromPromiseToken;
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  describe('getImsTokenFromCookie', () => {
-    it('throws 400 when promiseToken cookie is missing', async () => {
+  describe('getImsTokenFromPromiseToken', () => {
+    it('throws 400 when neither cookie nor x-promise-token header is present', async () => {
       getCookieValueStub.returns(null);
       try {
-        await getImsTokenFromCookie({ pathInfo: { headers: {} } });
+        await getImsTokenFromPromiseToken({ pathInfo: { headers: {} } });
         expect.fail('expected throw');
       } catch (e) {
         expect(e.status).to.equal(400);
-        expect(e.message).to.include('promiseToken cookie is required');
+        expect(e.message).to.include('Authentication failed: mandatory token missing');
       }
     });
 
@@ -82,7 +82,7 @@ describe('edge-routing-auth', () => {
       exchangePromiseTokenStub.rejects(new Error('ims down'));
       const ctxLog = { error: sandbox.stub() };
       try {
-        await getImsTokenFromCookie({
+        await getImsTokenFromPromiseToken({
           pathInfo: { headers: { cookie: 'promiseToken=ptok' } },
           log: ctxLog,
         });
@@ -97,11 +97,31 @@ describe('edge-routing-auth', () => {
       }
     });
 
-    it('returns access token when exchange succeeds', async () => {
+    it('returns access token when cookie is present', async () => {
       getCookieValueStub.returns('ptok');
       exchangePromiseTokenStub.resolves('user-token');
-      const token = await getImsTokenFromCookie({});
+      const token = await getImsTokenFromPromiseToken({});
       expect(token).to.equal('user-token');
+    });
+
+    it('returns access token from x-promise-token header when cookie is absent', async () => {
+      getCookieValueStub.returns(null);
+      exchangePromiseTokenStub.resolves('user-token-from-header');
+      const token = await getImsTokenFromPromiseToken({
+        pathInfo: { headers: { 'x-promise-token': 'header-ptok' } },
+      });
+      expect(token).to.equal('user-token-from-header');
+      expect(exchangePromiseTokenStub).to.have.been.calledWith(sinon.match.any, 'header-ptok');
+    });
+
+    it('prefers cookie over x-promise-token header when both are present', async () => {
+      getCookieValueStub.returns('cookie-ptok');
+      exchangePromiseTokenStub.resolves('user-token-from-cookie');
+      const token = await getImsTokenFromPromiseToken({
+        pathInfo: { headers: { 'x-promise-token': 'header-ptok' } },
+      });
+      expect(token).to.equal('user-token-from-cookie');
+      expect(exchangePromiseTokenStub).to.have.been.calledWith(sinon.match.any, 'cookie-ptok');
     });
   });
 


### PR DESCRIPTION
/edge-optimize-config API now accepts promise token from both header and cookie. Consuming from Cookie is kept to keep things backward compatible, and will be removed in a later iteration.