### PR TITLE
fix: lower default limit for aem.live proxy requests from 10M to 5000

### DIFF
--- a/src/controllers/llmo/llmo-query-handler.js
+++ b/src/controllers/llmo/llmo-query-handler.js
@@ -15,7 +15,6 @@ import {
   applyFilters,
   applyInclusions,
   applySort,
-  DEFAULT_LLMO_GET_LIMIT,
   LLMO_SHEETDATA_SOURCE_URL,
 } from './llmo-utils.js';
 
@@ -82,7 +81,7 @@ const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryPar
   const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${llmoConfig.dataFolder}/${filePath}`);
 
   // Apply pagination parameters when calling the source URL
-  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : DEFAULT_LLMO_GET_LIMIT;
+  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : 10000000;
   const offset = queryParams.offset ? parseInt(queryParams.offset, 10) : 0;
 
   url.searchParams.set('limit', limit.toString());

--- a/src/controllers/llmo/llmo-utils.js
+++ b/src/controllers/llmo/llmo-utils.js
@@ -12,7 +12,6 @@
 
 // LLMO constants
 export const LLMO_SHEETDATA_SOURCE_URL = 'https://main--project-elmo-ui-data--adobe.aem.live';
-export const DEFAULT_LLMO_GET_LIMIT = 5000;
 
 // Supported CDN types. Aligned with auth-service (cdn-logs-infrastructure/common.js).
 export const CDN_TYPES = {

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -54,7 +54,6 @@ import {
   applyExclusions,
   applyGroups,
   applyMappings,
-  DEFAULT_LLMO_GET_LIMIT,
   LLMO_SHEETDATA_SOURCE_URL,
 } from './llmo-utils.js';
 import { LLMO_SHEET_MAPPINGS } from './llmo-mappings.js';
@@ -182,7 +181,9 @@ function LlmoController(ctx) {
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      url.searchParams.set('limit', limit || DEFAULT_LLMO_GET_LIMIT);
+      if (limit) {
+        url.searchParams.set('limit', limit);
+      }
       if (offset) {
         url.searchParams.set('offset', offset);
       }
@@ -230,7 +231,7 @@ function LlmoController(ctx) {
     // Start timing for the entire method
     const methodStartTime = Date.now();
 
-    const POST_DEFAULT_LIMIT = 1000000; // Default to 1M records to return all records
+    const FIXED_LLMO_LIMIT = 1000000;
 
     // Extract and validate request body structure
     const {
@@ -239,7 +240,7 @@ function LlmoController(ctx) {
       include = [],
       exclude = [],
       groupBy = [],
-      limit = POST_DEFAULT_LIMIT,
+      limit = FIXED_LLMO_LIMIT, // Default to 1M records to return all records
       offset = 0, // Default to 0 to return the first 1M records
     } = context.data || {};
 
@@ -408,7 +409,9 @@ function LlmoController(ctx) {
       // Add limit, offset and sheet query params to the url
       const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${sheetURL}`);
       const { limit, offset, sheet } = context.data;
-      url.searchParams.set('limit', limit || DEFAULT_LLMO_GET_LIMIT);
+      if (limit) {
+        url.searchParams.set('limit', limit);
+      }
       if (offset) {
         url.searchParams.set('offset', offset);
       }

--- a/test/controllers/llmo/llmo-query-handler.test.js
+++ b/test/controllers/llmo/llmo-query-handler.test.js
@@ -133,16 +133,6 @@ describe('llmo-query-handler', () => {
       expect(fetchUrl).to.include(TEST_DATA_SOURCE);
     });
 
-    it('should use default limit of 5000 when no limit is provided', async () => {
-      setupFetchTest(createSheetData([]));
-      mockContext.data = {};
-
-      await queryLlmoFiles(mockContext, mockLlmoConfig);
-
-      const fetchUrl = getFetchUrl();
-      expect(fetchUrl).to.include('limit=5000');
-    });
-
     it('should construct correct URL with sheetType and week', async () => {
       setupFetchTest(createSheetData([]));
 

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -34,7 +34,6 @@ const TEST_QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/123456789012/audit-j
 const CATEGORY_ID = '123e4567-e89b-12d3-a456-426614174000';
 const TOPIC_ID = '456e7890-e89b-12d3-a456-426614174001';
 const EXTERNAL_API_BASE_URL = 'https://main--project-elmo-ui-data--adobe.aem.live';
-const DEFAULT_LIMIT = 5000;
 
 const createMockResponse = (data, ok = true, status = 200) => ({
   ok,
@@ -691,7 +690,7 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({ data: 'test-data' });
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, {
+      expect(tracingFetchStub).to.have.been.calledWith(testUrl, {
         headers: {
           Authorization: `token ${TEST_API_KEY}`,
           'User-Agent': TEST_USER_AGENT,
@@ -700,17 +699,7 @@ describe('LlmoController', () => {
       });
     });
 
-    it('should add limit query parameter to URL when provided', async () => {
-      const mockResponse = createMockResponse({ data: 'test-data' });
-      tracingFetchStub.resolves(mockResponse);
-      mockContext.data.limit = '10';
-
-      await controller.getLlmoSheetData(mockContext);
-
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=10`, sinon.match.object);
-    });
-
-    ['offset', 'sheet'].forEach((param) => {
+    ['limit', 'offset', 'sheet'].forEach((param) => {
       it(`should add ${param} query parameter to URL when provided`, async () => {
         const mockResponse = createMockResponse({ data: 'test-data' });
         tracingFetchStub.resolves(mockResponse);
@@ -718,7 +707,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoSheetData(mockContext);
 
-        const expectedUrl = `${testUrl}?limit=${DEFAULT_LIMIT}&${param}=${mockContext.data[param]}`;
+        const expectedUrl = `${testUrl}?${param}=${mockContext.data[param]}`;
         expect(tracingFetchStub).to.have.been.calledWith(expectedUrl, sinon.match.object);
       });
     });
@@ -744,7 +733,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/test-data.json?limit=${DEFAULT_LIMIT}`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/test-data.json`,
         sinon.match.object,
       );
     });
@@ -757,7 +746,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoSheetData(mockContext);
 
-        expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, sinon.match.object);
+        expect(tracingFetchStub).to.have.been.calledWith(testUrl, sinon.match.object);
       });
     });
 
@@ -768,7 +757,7 @@ describe('LlmoController', () => {
 
       await controller.getLlmoSheetData(mockContext);
 
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, {
+      expect(tracingFetchStub).to.have.been.calledWith(testUrl, {
         headers: {
           Authorization: 'token hlx_api_key_missing',
           'User-Agent': TEST_USER_AGENT,
@@ -864,7 +853,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/w01/test-data.json?limit=${DEFAULT_LIMIT}`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/analytics/w01/test-data.json`,
         sinon.match.object,
       );
     });
@@ -893,7 +882,7 @@ describe('LlmoController', () => {
       await controller.getLlmoSheetData(mockContext);
 
       expect(tracingFetchStub).to.have.been.calledWith(
-        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/test-data.json?limit=${DEFAULT_LIMIT}`,
+        `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/test-data.json`,
         sinon.match.object,
       );
     });
@@ -917,20 +906,10 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({ data: 'test-data' });
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=${DEFAULT_LIMIT}`, sinon.match.object);
+      expect(tracingFetchStub).to.have.been.calledWith(testUrl, sinon.match.object);
     });
 
-    it('should add limit query parameter to URL when provided', async () => {
-      const mockResponse = createMockResponse({ data: 'test-data' });
-      tracingFetchStub.resolves(mockResponse);
-      mockContext.data.limit = '10';
-
-      await controller.getLlmoGlobalSheetData(mockContext);
-
-      expect(tracingFetchStub).to.have.been.calledWith(`${testUrl}?limit=10`, sinon.match.object);
-    });
-
-    ['offset', 'sheet'].forEach((param) => {
+    ['limit', 'offset', 'sheet'].forEach((param) => {
       it(`should add ${param} query parameter to URL when provided`, async () => {
         const mockResponse = createMockResponse({ data: 'test-data' });
         tracingFetchStub.resolves(mockResponse);
@@ -938,7 +917,7 @@ describe('LlmoController', () => {
 
         await controller.getLlmoGlobalSheetData(mockContext);
 
-        const expectedUrl = `${testUrl}?limit=${DEFAULT_LIMIT}&${param}=${mockContext.data[param]}`;
+        const expectedUrl = `${testUrl}?${param}=${mockContext.data[param]}`;
         expect(tracingFetchStub).to.have.been.calledWith(expectedUrl, sinon.match.object);
       });
     });


### PR DESCRIPTION
Reverts adobe/spacecat-api-service#2229