### PR TITLE
feat: revoke ASO enrollments from all other sites during PLG onboarding

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -276,6 +276,65 @@ async function revokePreOnboardedSiteEnrollment(site, entitlement, context) {
 }
 
 /**
+ * Revokes ASO enrollments from all other sites in the organization to ensure only
+ * the newly onboarded PLG site has an active ASO enrollment. This enforces the
+ * "one PLG site per org" policy by removing ASO access from any other sites that
+ * may have been created outside the PLG onboarding flow.
+ * @param {object} site - The newly onboarded PLG site (keep this site's enrollment).
+ * @param {string} organizationId - The organization ID.
+ * @param {object} context - Request context.
+ */
+async function revokeAsoEnrollmentsFromOtherSites(site, organizationId, context) {
+  const { dataAccess, log } = context;
+  const { Site, Entitlement, SiteEnrollment } = dataAccess;
+
+  try {
+    // Get all sites in the organization
+    const allSites = await Site.allByOrganizationId(organizationId);
+    const otherSites = allSites.filter((s) => s.getId() !== site.getId());
+
+    if (otherSites.length === 0) {
+      log.info(`No other sites found in org ${organizationId}, skipping ASO enrollment revocation`);
+      return;
+    }
+
+    log.info(`Found ${otherSites.length} other site(s) in org ${organizationId}, checking for ASO enrollments to revoke`);
+
+    // Get ASO entitlement for the organization
+    const entitlements = await Entitlement.allByOrganizationId(organizationId);
+    const asoEntitlement = entitlements.find((e) => e.getProductCode() === ASO_PRODUCT_CODE);
+
+    if (!asoEntitlement) {
+      log.info(`No ASO entitlement found for org ${organizationId}, nothing to revoke`);
+      return;
+    }
+
+    // Get all ASO enrollments
+    const asoEnrollments = await SiteEnrollment.allByEntitlementId(asoEntitlement.getId());
+    const enrollmentsToRevoke = asoEnrollments.filter(
+      (e) => otherSites.some((s) => s.getId() === e.getSiteId()),
+    );
+
+    if (enrollmentsToRevoke.length === 0) {
+      log.info(`No ASO enrollments to revoke for other sites in org ${organizationId}`);
+      return;
+    }
+
+    // Revoke enrollments from other sites
+    await Promise.all(enrollmentsToRevoke.map(async (enrollment) => {
+      const siteId = enrollment.getSiteId();
+      log.info(`Revoking ASO enrollment ${enrollment.getId()} from site ${siteId} to ensure only the newly onboarded PLG site has ASO access`);
+      await enrollment.remove();
+    }));
+
+    log.info(`Successfully revoked ${enrollmentsToRevoke.length} ASO enrollment(s) from other sites in org ${organizationId}`);
+  } catch (error) {
+    // Non-fatal: log the error but don't block onboarding
+    log.error(`Failed to revoke ASO enrollments from other sites in org ${organizationId}: ${error.message}`);
+  }
+}
+
+/**
  * Disables the summit-plg config handler for a given site. Non-fatal.
  * @param {object} site - The site to disable the handler for.
  * @param {object} context - Request context.
@@ -659,8 +718,10 @@ async function performAsoPlgOnboarding({
     log.info(`Fast-tracking preonboarded record ${onboarding.getId()}`);
     const site = await Site.findById(onboarding.getSiteId());
     if (site) {
+      const siteOrganizationId = site.getOrganizationId();
       const { entitlement } = await ensureAsoEntitlement(site, context);
       await revokePreOnboardedSiteEnrollment(site, entitlement, context);
+      await revokeAsoEnrollmentsFromOtherSites(site, siteOrganizationId, context);
       await updateLaunchDarklyFlags(site, context);
       const steps = { ...(onboarding.getSteps() || {}), entitlementCreated: true };
       onboarding.setStatus(STATUSES.ONBOARDED);
@@ -1043,6 +1104,11 @@ async function performAsoPlgOnboarding({
     // Step 9: Add ASO entitlement, revoke any pre-onboarded site's enrollment, update FF
     const { entitlement } = await ensureAsoEntitlement(site, context);
     await revokePreOnboardedSiteEnrollment(site, entitlement, context);
+
+    // Step 9b: Revoke ASO enrollments from all other sites in the organization
+    // This ensures only the newly onboarded PLG site has ASO access
+    await revokeAsoEnrollmentsFromOtherSites(site, organizationId, context);
+
     await updateLaunchDarklyFlags(site, context);
 
     steps.entitlementCreated = true;

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -249,6 +249,7 @@ describe('PlgOnboardingController', () => {
         findByBaseURL: sandbox.stub().resolves(null),
         findById: sandbox.stub().resolves(null),
         create: sandbox.stub().resolves(mockSite),
+        allByOrganizationId: sandbox.stub().resolves([]),
       },
       Organization: {
         findByImsOrgId: sandbox.stub().resolves(mockOrganization),
@@ -2855,6 +2856,161 @@ describe('PlgOnboardingController', () => {
     });
   });
 
+  // --- Global ASO enrollment revocation from all other sites in org ---
+
+  describe('onboard - global ASO enrollment revocation from other sites', () => {
+    let controller;
+    beforeEach(() => {
+      controller = PlgOnboardingController({ log: mockLog });
+    });
+
+    it('revokes ASO enrollments from all other sites in the organization', async () => {
+      const OTHER_SITE_ID_1 = 'other-site-1';
+      const OTHER_SITE_ID_2 = 'other-site-2';
+      const ASO_ENTITLEMENT_ID = 'aso-entitlement-id';
+
+      // Mock other sites in the organization
+      const otherSite1 = createMockSite({ id: OTHER_SITE_ID_1 });
+      const otherSite2 = createMockSite({ id: OTHER_SITE_ID_2 });
+      mockDataAccess.Site.allByOrganizationId.resolves([
+        mockSite, // the newly onboarded site
+        otherSite1,
+        otherSite2,
+      ]);
+
+      // Mock ASO entitlement
+      const mockAsoEntitlement = {
+        getId: sandbox.stub().returns(ASO_ENTITLEMENT_ID),
+        getProductCode: sandbox.stub().returns('aso_optimizer'),
+      };
+      mockDataAccess.Entitlement.allByOrganizationId.resolves([mockAsoEntitlement]);
+
+      // Mock enrollments for other sites
+      const enrollment1 = {
+        getId: sandbox.stub().returns('enrollment-1'),
+        getSiteId: sandbox.stub().returns(OTHER_SITE_ID_1),
+        remove: sandbox.stub().resolves(),
+      };
+      const enrollment2 = {
+        getId: sandbox.stub().returns('enrollment-2'),
+        getSiteId: sandbox.stub().returns(OTHER_SITE_ID_2),
+        remove: sandbox.stub().resolves(),
+      };
+
+      // First call for revokePreOnboardedSiteEnrollment, second for
+      // revokeAsoEnrollmentsFromOtherSites
+      mockDataAccess.SiteEnrollment.allByEntitlementId
+        .onFirstCall().resolves([]) // No preonboarded enrollments to revoke
+        .onSecondCall().resolves([enrollment1, enrollment2]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockDataAccess.Site.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(mockDataAccess.Entitlement.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(enrollment1.remove).to.have.been.calledOnce;
+      expect(enrollment2.remove).to.have.been.calledOnce;
+    });
+
+    it('does not revoke when only the newly onboarded site exists in org', async () => {
+      // Only one site in the org
+      mockDataAccess.Site.allByOrganizationId.resolves([mockSite]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockDataAccess.Site.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      // Should not check for entitlements when no other sites exist
+      expect(mockDataAccess.Entitlement.allByOrganizationId).to.not.have.been.called;
+    });
+
+    it('does not revoke when no ASO entitlement exists for the org', async () => {
+      const OTHER_SITE_ID = 'other-site-1';
+      const otherSite = createMockSite({ id: OTHER_SITE_ID });
+      mockDataAccess.Site.allByOrganizationId.resolves([mockSite, otherSite]);
+
+      // No ASO entitlement exists
+      mockDataAccess.Entitlement.allByOrganizationId.resolves([]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockDataAccess.Entitlement.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+    });
+
+    it('does not revoke when other sites have no ASO enrollments', async () => {
+      const OTHER_SITE_ID = 'other-site-1';
+      const ASO_ENTITLEMENT_ID = 'aso-entitlement-id';
+
+      const otherSite = createMockSite({ id: OTHER_SITE_ID });
+      mockDataAccess.Site.allByOrganizationId.resolves([mockSite, otherSite]);
+
+      const mockAsoEntitlement = {
+        getId: sandbox.stub().returns(ASO_ENTITLEMENT_ID),
+        getProductCode: sandbox.stub().returns('aso_optimizer'),
+      };
+      mockDataAccess.Entitlement.allByOrganizationId.resolves([mockAsoEntitlement]);
+
+      // First call for revokePreOnboardedSiteEnrollment, second for
+      // revokeAsoEnrollmentsFromOtherSites
+      mockDataAccess.SiteEnrollment.allByEntitlementId
+        .onFirstCall().resolves([])
+        .onSecondCall().resolves([]); // No enrollments exist for other sites
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockDataAccess.SiteEnrollment.allByEntitlementId)
+        .to.have.been.calledWith(ASO_ENTITLEMENT_ID);
+    });
+
+    it('continues onboarding when global revocation fails (non-fatal)', async () => {
+      const OTHER_SITE_ID = 'other-site-1';
+      const ASO_ENTITLEMENT_ID = 'aso-entitlement-id';
+
+      const otherSite = createMockSite({ id: OTHER_SITE_ID });
+      mockDataAccess.Site.allByOrganizationId.resolves([mockSite, otherSite]);
+
+      const mockAsoEntitlement = {
+        getId: sandbox.stub().returns(ASO_ENTITLEMENT_ID),
+        getProductCode: sandbox.stub().returns('aso_optimizer'),
+      };
+      mockDataAccess.Entitlement.allByOrganizationId.resolves([mockAsoEntitlement]);
+
+      const failingEnrollment = {
+        getId: sandbox.stub().returns('enrollment-1'),
+        getSiteId: sandbox.stub().returns(OTHER_SITE_ID),
+        remove: sandbox.stub().rejects(new Error('Removal failed')),
+      };
+
+      mockDataAccess.SiteEnrollment.allByEntitlementId
+        .onFirstCall().resolves([])
+        .onSecondCall().resolves([failingEnrollment]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      // Should still succeed despite revocation failure (non-fatal)
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+
+    it('handles Site.allByOrganizationId failure gracefully', async () => {
+      mockDataAccess.Site.allByOrganizationId.rejects(new Error('DB query failed'));
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      // Should still succeed despite lookup failure (non-fatal)
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+  });
+
   // --- LaunchDarkly feature flag update ---
 
   describe('onboard - LaunchDarkly flag update', () => {
@@ -3237,6 +3393,145 @@ describe('PlgOnboardingController', () => {
       // Falls through to full onboarding
       expect(response.status).to.equal(200);
       expect(createOrFindOrganizationStub).to.have.been.called;
+    });
+
+    it('revokes ASO enrollments from other sites in org during preonboarding fast path', async () => {
+      const OTHER_SITE_ID_1 = 'other-site-1';
+      const OTHER_SITE_ID_2 = 'other-site-2';
+      const ASO_ENTITLEMENT_ID = 'aso-entitlement-1';
+
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(mockSite);
+
+      // Mock other sites in the organization
+      const otherSite1 = createMockSite({ id: OTHER_SITE_ID_1 });
+      const otherSite2 = createMockSite({ id: OTHER_SITE_ID_2 });
+      mockDataAccess.Site.allByOrganizationId.resolves([
+        mockSite, // the newly onboarded site
+        otherSite1,
+        otherSite2,
+      ]);
+
+      // Mock ASO entitlement for the org
+      const mockAsoEntitlement = {
+        getId: sandbox.stub().returns(ASO_ENTITLEMENT_ID),
+        getProductCode: sandbox.stub().returns('aso_optimizer'),
+      };
+      mockDataAccess.Entitlement.allByOrganizationId.resolves([mockAsoEntitlement]);
+
+      // Mock ASO enrollments for other sites
+      const enrollment1 = {
+        getId: sandbox.stub().returns('enrollment-1'),
+        getSiteId: sandbox.stub().returns(OTHER_SITE_ID_1),
+        remove: sandbox.stub().resolves(),
+      };
+      const enrollment2 = {
+        getId: sandbox.stub().returns('enrollment-2'),
+        getSiteId: sandbox.stub().returns(OTHER_SITE_ID_2),
+        remove: sandbox.stub().resolves(),
+      };
+      // First call is for revokePreOnboardedSiteEnrollment, second is for
+      // revokeAsoEnrollmentsFromOtherSites
+      mockDataAccess.SiteEnrollment.allByEntitlementId
+        .onFirstCall().resolves([]) // No preonboarded enrollments
+        .onSecondCall().resolves([enrollment1, enrollment2]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(mockDataAccess.Site.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(enrollment1.remove).to.have.been.called;
+      expect(enrollment2.remove).to.have.been.called;
+    });
+
+    it('handles case when no other sites exist in org during preonboarding fast path', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(mockSite);
+
+      // Only the newly onboarded site exists
+      mockDataAccess.Site.allByOrganizationId.resolves([mockSite]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(mockDataAccess.Site.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      // Should not attempt to revoke anything
+      expect(mockDataAccess.Entitlement.allByOrganizationId).to.not.have.been.called;
+    });
+
+    it('handles case when no ASO entitlement exists during preonboarding fast path', async () => {
+      const OTHER_SITE_ID = 'other-site-1';
+
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(mockSite);
+
+      const otherSite = createMockSite({ id: OTHER_SITE_ID });
+      mockDataAccess.Site.allByOrganizationId.resolves([mockSite, otherSite]);
+
+      // No ASO entitlement in org
+      mockDataAccess.Entitlement.allByOrganizationId.resolves([]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(mockDataAccess.Site.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(mockDataAccess.Entitlement.allByOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+    });
+
+    it('continues onboarding when ASO enrollment revocation fails during preonboarding fast path', async () => {
+      const OTHER_SITE_ID = 'other-site-1';
+      const ASO_ENTITLEMENT_ID = 'aso-entitlement-1';
+
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(mockSite);
+
+      const otherSite = createMockSite({ id: OTHER_SITE_ID });
+      mockDataAccess.Site.allByOrganizationId.resolves([mockSite, otherSite]);
+
+      const mockAsoEntitlement = {
+        getId: sandbox.stub().returns(ASO_ENTITLEMENT_ID),
+        getProductCode: sandbox.stub().returns('aso_optimizer'),
+      };
+      mockDataAccess.Entitlement.allByOrganizationId.resolves([mockAsoEntitlement]);
+
+      const failingEnrollment = {
+        getId: sandbox.stub().returns('enrollment-1'),
+        getSiteId: sandbox.stub().returns(OTHER_SITE_ID),
+        remove: sandbox.stub().rejects(new Error('Failed to revoke')),
+      };
+      mockDataAccess.SiteEnrollment.allByEntitlementId
+        .onFirstCall().resolves([])
+        .onSecondCall().resolves([failingEnrollment]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      // Should still succeed despite revocation failure
+      expect(response.status).to.equal(200);
+      expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
     });
   });
 


### PR DESCRIPTION
Ensures only the newly onboarded PLG site has ASO access by revoking ASO enrollments from all other sites in the organization. This enforces the "one PLG site per org" policy globally, not just for sites created through PLG onboarding.

- Add revokeAsoEnrollmentsFromOtherSites() function to revoke ASO enrollments from other sites in the organization
- Call this function in both regular onboarding and preonboarding fast-track paths
- Add comprehensive test coverage for all scenarios:
  - Multiple sites with ASO enrollments get revoked
  - No other sites in org (skip revocation)
  - No ASO entitlement exists (skip revocation)
  - No enrollments exist for other sites (skip revocation)
  - Revocation failures are non-fatal (continue onboarding)
  - Database query failures are handled gracefully

The revocation is non-fatal - if it fails, onboarding continues successfully. This ensures customers only see the newly onboarded site in their PLG experience.

Made-with: Cursor

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
