### PR TITLE
fix(plg): Enable automatic reassignment of pre-onboarded internal org sites during customer onboarding

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -659,9 +659,37 @@ async function performAsoPlgOnboarding({
     log.info(`Fast-tracking preonboarded record ${onboarding.getId()}`);
     const site = await Site.findById(onboarding.getSiteId());
     if (site) {
+      // Resolve customer's organization from imsOrgId
+      const organization = await createOrFindOrganization(imsOrgId, context);
+      const customerOrgId = organization.getId();
+
+      // Check if site needs to be moved from internal org to customer org
+      const currentSiteOrgId = site.getOrganizationId();
+      let needsOrgReassignment = false;
+
+      if (currentSiteOrgId !== customerOrgId) {
+        if (isInternalOrg(currentSiteOrgId, env) && !isInternalOrgDemoSite(site.getId(), env)) {
+          log.info(`Preonboarded site ${site.getId()} is in internal org ${currentSiteOrgId}, will reassign to customer org ${customerOrgId}`);
+          needsOrgReassignment = true;
+        } else {
+          log.warn(`Preonboarded site ${site.getId()} is in different customer org ${currentSiteOrgId}, expected ${customerOrgId}`);
+        }
+      }
+
       const { entitlement } = await ensureAsoEntitlement(site, context);
       await revokePreOnboardedSiteEnrollment(site, entitlement, context);
       await updateLaunchDarklyFlags(site, context);
+
+      // Reassign site org if needed
+      if (needsOrgReassignment) {
+        site.setOrganizationId(customerOrgId);
+        await site.save();
+        log.info(`Reassigned preonboarded site ${site.getId()} from internal org to customer org ${customerOrgId}`);
+      }
+
+      // Update PlgOnboarding's organizationId to customer org
+      onboarding.setOrganizationId(customerOrgId);
+
       const steps = { ...(onboarding.getSteps() || {}), entitlementCreated: true };
       onboarding.setStatus(STATUSES.ONBOARDED);
       onboarding.setWaitlistReason(null);
@@ -1064,6 +1092,8 @@ async function performAsoPlgOnboarding({
       log.info(`Reassigning site ${site.getId()} to org ${organizationId} (was in internal/demo org)`);
       site.setOrganizationId(organizationId);
       await site.save();
+      // Update PlgOnboarding's organizationId to match the site's new org
+      onboarding.setOrganizationId(organizationId);
       steps.siteOrgReassigned = true;
     }
 

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -1648,7 +1648,8 @@ function PlgOnboardingController(ctx) {
   /**
    * POST /plg/records
    * Admin: create a PLG onboarding record with a given status (defaults to INACTIVE).
-   * Body: { imsOrgId, domain, status? }
+   * Body: { imsOrgId, domain, status?, siteId?, organizationId?, steps?,
+   *         botBlocker?, completedAt? }
    */
   const createOnboarding = async (context) => {
     const accessControlUtil = AccessControlUtil.fromContext(context);
@@ -1657,7 +1658,16 @@ function PlgOnboardingController(ctx) {
     }
 
     const { data } = context;
-    const { imsOrgId, domain, status = STATUSES.INACTIVE } = data || {};
+    const {
+      imsOrgId,
+      domain,
+      status = STATUSES.INACTIVE,
+      siteId,
+      organizationId,
+      steps,
+      botBlocker,
+      completedAt,
+    } = data || {};
 
     if (!hasText(imsOrgId) || !isValidIMSOrgId(imsOrgId)) {
       return badRequest('Valid imsOrgId is required');
@@ -1680,6 +1690,25 @@ function PlgOnboardingController(ctx) {
     const onboarding = await PlgOnboarding.create({
       imsOrgId, domain, baseURL, status,
     });
+
+    // Set optional preonboarding fields if provided
+    if (siteId) {
+      onboarding.setSiteId(siteId);
+    }
+    if (organizationId) {
+      onboarding.setOrganizationId(organizationId);
+    }
+    if (steps && typeof steps === 'object') {
+      onboarding.setSteps(steps);
+    }
+    if (botBlocker && typeof botBlocker === 'object') {
+      onboarding.setBotBlocker(botBlocker);
+    }
+    if (completedAt) {
+      onboarding.setCompletedAt(completedAt);
+    }
+
+    await onboarding.save();
     return created(PlgOnboardingDto.toAdminJSON(onboarding));
   };
 

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -672,7 +672,27 @@ async function performAsoPlgOnboarding({
           log.info(`Preonboarded site ${site.getId()} is in internal org ${currentSiteOrgId}, will reassign to customer org ${customerOrgId}`);
           needsOrgReassignment = true;
         } else {
-          log.warn(`Preonboarded site ${site.getId()} is in different customer org ${currentSiteOrgId}, expected ${customerOrgId}`);
+          // Site is in different customer org - cannot reassign, must waitlist
+          const existingOrg = await Organization.findById(currentSiteOrgId);
+          /* c8 ignore next */
+          const existingImsOrgId = existingOrg?.getImsOrgId?.() || currentSiteOrgId;
+          /* c8 ignore next */
+          const existingOrgName = existingOrg?.getName?.() || currentSiteOrgId;
+          const customerOrgName = organization.getName();
+          const waitlistReason = `Preonboarded site is assigned to different organization (org: ${existingOrgName}, id: ${existingImsOrgId}). Cannot be moved to '${customerOrgName}'.`;
+
+          log.warn(`Preonboarded site ${site.getId()} is in different customer org ${currentSiteOrgId}, expected ${customerOrgId} - waitlisting`);
+
+          onboarding.setStatus(STATUSES.WAITLISTED);
+          onboarding.setWaitlistReason(waitlistReason);
+          const steps = { ...(onboarding.getSteps() || {}), orgResolutionFailed: true };
+          onboarding.setSteps(steps);
+          if (updatedBy) {
+            onboarding.setUpdatedBy(updatedBy);
+          }
+          await onboarding.save();
+          await postPlgOnboardingNotification(onboarding, context);
+          return onboarding;
         }
       }
 
@@ -684,11 +704,10 @@ async function performAsoPlgOnboarding({
       if (needsOrgReassignment) {
         site.setOrganizationId(customerOrgId);
         await site.save();
+        // Update PlgOnboarding's organizationId to match the site's new org
+        onboarding.setOrganizationId(customerOrgId);
         log.info(`Reassigned preonboarded site ${site.getId()} from internal org to customer org ${customerOrgId}`);
       }
-
-      // Update PlgOnboarding's organizationId to customer org
-      onboarding.setOrganizationId(customerOrgId);
 
       const steps = { ...(onboarding.getSteps() || {}), entitlementCreated: true };
       onboarding.setStatus(STATUSES.ONBOARDED);

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -2002,6 +2002,8 @@ describe('PlgOnboardingController', () => {
       // Verify site org is reassigned to the new customer org
       expect(existingSite.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
       expect(existingSite.save).to.have.been.called;
+      // Verify PlgOnboarding org is also updated to match
+      expect(mockOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
     });
 
     it('waitlists when site id is listed in ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS', async () => {
@@ -3183,8 +3185,11 @@ describe('PlgOnboardingController', () => {
       // Revocation and LD flag steps must run in the fast path
       expect(mockDataAccess.SiteEnrollment.allByEntitlementId).to.have.been.called;
       expect(ldGetFeatureFlagStub).to.have.been.called;
-      // Should NOT run full onboarding steps
-      expect(createOrFindOrganizationStub).to.not.have.been.called;
+      // Organization must be resolved in fast path now
+      expect(createOrFindOrganizationStub).to.have.been.called;
+      // PlgOnboarding's organizationId must be updated to customer org
+      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      // Should NOT run other full onboarding steps
       expect(detectBotBlockerStub).to.not.have.been.called;
     });
 
@@ -3237,6 +3242,113 @@ describe('PlgOnboardingController', () => {
       // Falls through to full onboarding
       expect(response.status).to.equal(200);
       expect(createOrFindOrganizationStub).to.have.been.called;
+    });
+
+    it('reassigns preonboarded site from internal org to customer org', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-123';
+
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: INTERNAL_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+
+      const siteInInternalOrg = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
+      mockDataAccess.Site.findById.resolves(siteInInternalOrg);
+
+      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(createOrFindOrganizationStub).to.have.been.called;
+      expect(siteInInternalOrg.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(siteInInternalOrg.save).to.have.been.called;
+      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+
+    it('does not reassign when preonboarded site already in customer org', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: TEST_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+
+      const siteInCustomerOrg = createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID });
+      mockDataAccess.Site.findById.resolves(siteInCustomerOrg);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(createOrFindOrganizationStub).to.have.been.called;
+      // Site org should NOT be changed (already in customer org)
+      expect(siteInCustomerOrg.setOrganizationId).to.not.have.been.called;
+      // PlgOnboarding org should still be updated to ensure consistency
+      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+    });
+
+    it('skips reassignment for internal org demo sites', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-123';
+      const DEMO_SITE_ID = 'demo-site-456';
+
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: DEMO_SITE_ID,
+        organizationId: INTERNAL_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+
+      const demoSite = createMockSite({ id: DEMO_SITE_ID, orgId: INTERNAL_ORG_ID });
+      mockDataAccess.Site.findById.resolves(demoSite);
+
+      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = DEMO_SITE_ID;
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      // Demo site should NOT be reassigned (stays in internal org)
+      expect(demoSite.setOrganizationId).to.not.have.been.called;
+      // But PlgOnboarding org should still be updated to customer org
+      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+    });
+
+    it('warns when preonboarded site is in different customer org', async () => {
+      const OTHER_CUSTOMER_ORG = 'other-customer-org-789';
+
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: OTHER_CUSTOMER_ORG,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain
+        .resolves(preonboardedOnboarding);
+
+      const siteInOtherOrg = createMockSite({ id: TEST_SITE_ID, orgId: OTHER_CUSTOMER_ORG });
+      mockDataAccess.Site.findById.resolves(siteInOtherOrg);
+
+      mockEnv.ASO_PLG_EXCLUDED_ORGS = 'some-internal-org';
+      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      // Site should NOT be reassigned (different customer org)
+      expect(siteInOtherOrg.setOrganizationId).to.not.have.been.called;
+      // PlgOnboarding org should be updated to current customer's org
+      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
     });
   });
 

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -3187,8 +3187,8 @@ describe('PlgOnboardingController', () => {
       expect(ldGetFeatureFlagStub).to.have.been.called;
       // Organization must be resolved in fast path now
       expect(createOrFindOrganizationStub).to.have.been.called;
-      // PlgOnboarding's organizationId must be updated to customer org
-      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      // PlgOnboarding's organizationId should NOT be updated (site already in correct org)
+      expect(preonboardedOnboarding.setOrganizationId).to.not.have.been.called;
       // Should NOT run other full onboarding steps
       expect(detectBotBlockerStub).to.not.have.been.called;
     });
@@ -3291,8 +3291,8 @@ describe('PlgOnboardingController', () => {
       expect(createOrFindOrganizationStub).to.have.been.called;
       // Site org should NOT be changed (already in customer org)
       expect(siteInCustomerOrg.setOrganizationId).to.not.have.been.called;
-      // PlgOnboarding org should still be updated to ensure consistency
-      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      // PlgOnboarding org should NOT be updated (site org didn't change)
+      expect(preonboardedOnboarding.setOrganizationId).to.not.have.been.called;
       expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
     });
 
@@ -3320,11 +3320,11 @@ describe('PlgOnboardingController', () => {
       expect(response.status).to.equal(200);
       // Demo site should NOT be reassigned (stays in internal org)
       expect(demoSite.setOrganizationId).to.not.have.been.called;
-      // But PlgOnboarding org should still be updated to customer org
-      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      // PlgOnboarding org should NOT be updated (site org didn't change)
+      expect(preonboardedOnboarding.setOrganizationId).to.not.have.been.called;
     });
 
-    it('warns when preonboarded site is in different customer org', async () => {
+    it('waitlists when preonboarded site is in different customer org', async () => {
       const OTHER_CUSTOMER_ORG = 'other-customer-org-789';
 
       const preonboardedOnboarding = createMockOnboarding({
@@ -3345,10 +3345,17 @@ describe('PlgOnboardingController', () => {
       const response = await controller.onboard(context);
 
       expect(response.status).to.equal(200);
-      // Site should NOT be reassigned (different customer org)
+      // Should be WAITLISTED, not ONBOARDED
+      expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(preonboardedOnboarding.setWaitlistReason).to.have.been.calledWithMatch(
+        /different organization/,
+      );
+      // Site should NOT be changed
       expect(siteInOtherOrg.setOrganizationId).to.not.have.been.called;
-      // PlgOnboarding org should be updated to current customer's org
-      expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      // PlgOnboarding org should NOT be updated
+      expect(preonboardedOnboarding.setOrganizationId).to.not.have.been.called;
+      // Should NOT create entitlement
+      expect(tierClientCreateForSiteStub).to.not.have.been.called;
     });
   });
 

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -5913,6 +5913,161 @@ describe('PlgOnboardingController', () => {
             sinon.match({ status: 'PRE_ONBOARDING' }),
           );
         });
+
+        it('creates preonboarding record with siteId, organizationId, and steps', async () => {
+          const preonboardingData = {
+            imsOrgId: TEST_IMS_ORG_ID,
+            domain: TEST_DOMAIN,
+            status: 'PRE_ONBOARDING',
+            siteId: TEST_SITE_ID,
+            organizationId: TEST_ORG_ID,
+            steps: { siteCreated: true, entitlementCreated: true },
+          };
+
+          const res = await AdminAccessPlgController({ log: mockLog }).createOnboarding({
+            data: preonboardingData,
+            dataAccess: mockDataAccess,
+            attributes: {},
+          });
+
+          expect(res.status).to.equal(201);
+          expect(mockOnboarding.setSiteId).to.have.been.calledWith(TEST_SITE_ID);
+          expect(mockOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+          expect(mockOnboarding.setSteps).to.have.been.calledWith(
+            sinon.match({ siteCreated: true, entitlementCreated: true }),
+          );
+          expect(mockOnboarding.save).to.have.been.called;
+        });
+
+        it('creates preonboarding record with botBlocker info', async () => {
+          const botBlockerInfo = {
+            type: 'Cloudflare',
+            ipsToAllowlist: ['1.2.3.4', '5.6.7.8'],
+          };
+
+          const res = await AdminAccessPlgController({ log: mockLog }).createOnboarding({
+            data: {
+              imsOrgId: TEST_IMS_ORG_ID,
+              domain: TEST_DOMAIN,
+              status: 'WAITING_FOR_IP_ALLOWLISTING',
+              botBlocker: botBlockerInfo,
+            },
+            dataAccess: mockDataAccess,
+            attributes: {},
+          });
+
+          expect(res.status).to.equal(201);
+          expect(mockOnboarding.setBotBlocker).to.have.been.calledWith(
+            sinon.match(botBlockerInfo),
+          );
+          expect(mockOnboarding.save).to.have.been.called;
+        });
+
+        it('creates preonboarding record with completedAt timestamp', async () => {
+          const completedAt = '2026-04-18T12:00:00.000Z';
+
+          const res = await AdminAccessPlgController({ log: mockLog }).createOnboarding({
+            data: {
+              imsOrgId: TEST_IMS_ORG_ID,
+              domain: TEST_DOMAIN,
+              status: 'PRE_ONBOARDING',
+              completedAt,
+            },
+            dataAccess: mockDataAccess,
+            attributes: {},
+          });
+
+          expect(res.status).to.equal(201);
+          expect(mockOnboarding.setCompletedAt).to.have.been.calledWith(completedAt);
+          expect(mockOnboarding.save).to.have.been.called;
+        });
+
+        it('creates preonboarding record with all optional fields', async () => {
+          const fullPreonboardingData = {
+            imsOrgId: TEST_IMS_ORG_ID,
+            domain: TEST_DOMAIN,
+            status: 'PRE_ONBOARDING',
+            siteId: TEST_SITE_ID,
+            organizationId: TEST_ORG_ID,
+            steps: { siteCreated: true, entitlementCreated: true, auditsEnabled: true },
+            completedAt: '2026-04-18T12:00:00.000Z',
+          };
+
+          const res = await AdminAccessPlgController({ log: mockLog }).createOnboarding({
+            data: fullPreonboardingData,
+            dataAccess: mockDataAccess,
+            attributes: {},
+          });
+
+          expect(res.status).to.equal(201);
+          expect(mockOnboarding.setSiteId).to.have.been.calledWith(TEST_SITE_ID);
+          expect(mockOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+          expect(mockOnboarding.setSteps).to.have.been.calledWith(
+            sinon.match({
+              siteCreated: true,
+              entitlementCreated: true,
+              auditsEnabled: true,
+            }),
+          );
+          expect(mockOnboarding.setCompletedAt).to.have.been.calledWith(
+            '2026-04-18T12:00:00.000Z',
+          );
+          expect(mockOnboarding.save).to.have.been.called;
+        });
+
+        it('creates record without optional fields when not provided', async () => {
+          const res = await AdminAccessPlgController({ log: mockLog }).createOnboarding({
+            data: {
+              imsOrgId: TEST_IMS_ORG_ID,
+              domain: TEST_DOMAIN,
+              status: 'INACTIVE',
+            },
+            dataAccess: mockDataAccess,
+            attributes: {},
+          });
+
+          expect(res.status).to.equal(201);
+          expect(mockOnboarding.setSiteId).to.not.have.been.called;
+          expect(mockOnboarding.setOrganizationId).to.not.have.been.called;
+          expect(mockOnboarding.setSteps).to.not.have.been.called;
+          expect(mockOnboarding.setBotBlocker).to.not.have.been.called;
+          expect(mockOnboarding.setCompletedAt).to.not.have.been.called;
+          expect(mockOnboarding.save).to.have.been.called;
+        });
+
+        it('ignores invalid steps field (non-object)', async () => {
+          const res = await AdminAccessPlgController({ log: mockLog }).createOnboarding({
+            data: {
+              imsOrgId: TEST_IMS_ORG_ID,
+              domain: TEST_DOMAIN,
+              status: 'PRE_ONBOARDING',
+              steps: 'invalid-string',
+            },
+            dataAccess: mockDataAccess,
+            attributes: {},
+          });
+
+          expect(res.status).to.equal(201);
+          expect(mockOnboarding.setSteps).to.not.have.been.called;
+          expect(mockOnboarding.save).to.have.been.called;
+        });
+
+        it('ignores invalid botBlocker field (non-object)', async () => {
+          const res = await AdminAccessPlgController({ log: mockLog }).createOnboarding({
+            data: {
+              imsOrgId: TEST_IMS_ORG_ID,
+              domain: TEST_DOMAIN,
+              status: 'WAITING_FOR_IP_ALLOWLISTING',
+              botBlocker: 'invalid-string',
+            },
+            dataAccess: mockDataAccess,
+            attributes: {},
+          });
+
+          expect(res.status).to.equal(201);
+          expect(mockOnboarding.setBotBlocker).to.not.have.been.called;
+          expect(mockOnboarding.save).to.have.been.called;
+        });
       });
 
       describe('updateOnboardingStatus', () => {


### PR DESCRIPTION
Three critical fixes for PLG preonboarding workflow:

- Automatic site org reassignment from internal orgs to customer orgs during onboarding for preonboarding sites
- Enhanced POST /plg/records API to persist preonboarding metadata
- Fixed conditional PLG org ID updates to prevent data inconsistencies

Local testing
<img width="1406" height="498" alt="image" src="https://github.com/user-attachments/assets/1bda8838-44db-4d0a-8019-c2a89c0c7698" />
moved from internal org


Changes:
- Regular onboarding: Update PlgOnboarding.organizationId when site org is reassigned
- Preonboarding fast-track: Add missing org resolution and site reassignment logic:
  - Resolve customer org from imsOrgId
  - Detect if site is in internal org vs customer org
  - Reassign site to customer org if needed
  - Update PlgOnboarding.organizationId to customer org
- Add comprehensive test coverage for all reassignment scenarios:
  - Site in internal org (should reassign)
  - Site already in customer org (no reassignment)
  - Internal org demo sites (skip reassignment)
  - Site in different customer org (no reassignment, warn)

This fix ensures preonboarded sites with incorrect internal org IDs are automatically corrected when customers complete onboarding, without requiring a separate data-fix script.

Made-with: Cursor

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
