### PR TITLE
fix(plg): move org reassignment before entitlement operations

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -667,6 +667,8 @@ async function performAsoPlgOnboarding({
       const currentSiteOrgId = site.getOrganizationId();
       let needsOrgReassignment = false;
 
+      // Note: On retry, currentSiteOrgId may already equal customerOrgId if a previous
+      // attempt successfully saved the org reassignment but failed during entitlement creation
       if (currentSiteOrgId !== customerOrgId) {
         if (isInternalOrg(currentSiteOrgId, env) && !isInternalOrgDemoSite(site.getId(), env)) {
           log.info(`Preonboarded site ${site.getId()} is in internal org ${currentSiteOrgId}, will reassign to customer org ${customerOrgId}`);
@@ -710,7 +712,13 @@ async function performAsoPlgOnboarding({
       await revokePreOnboardedSiteEnrollment(site, entitlement, context);
       await updateLaunchDarklyFlags(site, context);
 
-      const steps = { ...(onboarding.getSteps() || {}), entitlementCreated: true };
+      const steps = {
+        ...(onboarding.getSteps() || {}),
+        entitlementCreated: true,
+      };
+      if (needsOrgReassignment) {
+        steps.siteOrgReassigned = true;
+      }
       onboarding.setStatus(STATUSES.ONBOARDED);
       onboarding.setWaitlistReason(null);
       onboarding.setBotBlocker(null);
@@ -780,8 +788,8 @@ async function performAsoPlgOnboarding({
 
       if (existingOrgId !== organizationId) {
         if (isInternalOrg(existingOrgId, env) && !isInternalOrgDemoSite(site.getId(), env)) {
-          log.info(`Site ${site.getId()} org ${existingOrgId} is internal/demo — will reassign to new org ${organizationId} after successful onboarding`);
-          // Don't save yet - we'll reassign the org just before marking ONBOARDED
+          log.info(`Site ${site.getId()} org ${existingOrgId} is internal/demo — will reassign to new org ${organizationId} before entitlement operations`);
+          // Will reassign at Step 9, before creating entitlements
           needsOrgReassignment = true;
         } else {
           const existingOrg = await Organization.findById(existingOrgId);

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -696,11 +696,8 @@ async function performAsoPlgOnboarding({
         }
       }
 
-      const { entitlement } = await ensureAsoEntitlement(site, context);
-      await revokePreOnboardedSiteEnrollment(site, entitlement, context);
-      await updateLaunchDarklyFlags(site, context);
-
-      // Reassign site org if needed
+      // Reassign site org if needed BEFORE entitlement operations
+      // This ensures ensureAsoEntitlement gets the correct customer org's entitlement
       if (needsOrgReassignment) {
         site.setOrganizationId(customerOrgId);
         await site.save();
@@ -708,6 +705,10 @@ async function performAsoPlgOnboarding({
         onboarding.setOrganizationId(customerOrgId);
         log.info(`Reassigned preonboarded site ${site.getId()} from internal org to customer org ${customerOrgId}`);
       }
+
+      const { entitlement } = await ensureAsoEntitlement(site, context);
+      await revokePreOnboardedSiteEnrollment(site, entitlement, context);
+      await updateLaunchDarklyFlags(site, context);
 
       const steps = { ...(onboarding.getSteps() || {}), entitlementCreated: true };
       onboarding.setStatus(STATUSES.ONBOARDED);
@@ -1087,26 +1088,8 @@ async function performAsoPlgOnboarding({
       log.warn(`Failed to enroll site in config handlers: ${error.message}`);
     }
 
-    // Step 9: Add ASO entitlement, revoke any pre-onboarded site's enrollment, update FF
-    const { entitlement } = await ensureAsoEntitlement(site, context);
-    await revokePreOnboardedSiteEnrollment(site, entitlement, context);
-    await updateLaunchDarklyFlags(site, context);
-
-    steps.entitlementCreated = true;
-
-    // Step 10: Trigger audit runs
-    await triggerAudits(auditTypes, context, site);
-
-    // Step 11: Trigger brand profile (non-blocking)
-    try {
-      await triggerBrandProfileAgent({
-        context, site, reason: 'plg-onboarding',
-      });
-    } catch (error) {
-      log.warn(`Failed to trigger brand-profile for site ${site.getId()}: ${error.message}`);
-    }
-
-    // Reassign site org if it was previously in an internal/demo org
+    // Step 9: Reassign site org if it was previously in an internal/demo org
+    // This must happen BEFORE entitlement operations to ensure we get the correct org's entitlement
     if (needsOrgReassignment) {
       log.info(`Reassigning site ${site.getId()} to org ${organizationId} (was in internal/demo org)`);
       site.setOrganizationId(organizationId);
@@ -1114,6 +1097,25 @@ async function performAsoPlgOnboarding({
       // Update PlgOnboarding's organizationId to match the site's new org
       onboarding.setOrganizationId(organizationId);
       steps.siteOrgReassigned = true;
+    }
+
+    // Step 10: Add ASO entitlement, revoke any pre-onboarded site's enrollment, update FF
+    const { entitlement } = await ensureAsoEntitlement(site, context);
+    await revokePreOnboardedSiteEnrollment(site, entitlement, context);
+    await updateLaunchDarklyFlags(site, context);
+
+    steps.entitlementCreated = true;
+
+    // Step 11: Trigger audit runs
+    await triggerAudits(auditTypes, context, site);
+
+    // Step 12: Trigger brand profile (non-blocking)
+    try {
+      await triggerBrandProfileAgent({
+        context, site, reason: 'plg-onboarding',
+      });
+    } catch (error) {
+      log.warn(`Failed to trigger brand-profile for site ${site.getId()}: ${error.message}`);
     }
 
     // Mark as completed

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -3270,6 +3270,8 @@ describe('PlgOnboardingController', () => {
       expect(siteInInternalOrg.save).to.have.been.called;
       expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
       expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+      // Verify order: site org reassignment happens BEFORE entitlement operations
+      expect(siteInInternalOrg.save).to.have.been.calledBefore(tierClientCreateForSiteStub);
     });
 
     it('does not reassign when preonboarded site already in customer org', async () => {
@@ -3356,6 +3358,30 @@ describe('PlgOnboardingController', () => {
       expect(preonboardedOnboarding.setOrganizationId).to.not.have.been.called;
       // Should NOT create entitlement
       expect(tierClientCreateForSiteStub).to.not.have.been.called;
+    });
+
+    it('reassigns site from internal org before entitlement in full onboarding path', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-999';
+
+      // Simulate full onboarding (not PRE_ONBOARDING)
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(null);
+
+      // Existing site in internal org
+      const existingSite = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
+      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
+
+      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      // Verify site was reassigned
+      expect(existingSite.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(existingSite.save).to.have.been.called;
+      // Verify order: site org reassignment happens BEFORE entitlement operations
+      expect(existingSite.save).to.have.been.calledBefore(tierClientCreateForSiteStub);
     });
   });
 


### PR DESCRIPTION
Fix critical bug where site org reassignment happened AFTER entitlement operations, causing enrollments to be revoked from the wrong organization.

**The Problem:**
When a site in Sites Internal org was onboarded to a customer org:
1. ensureAsoEntitlement() got the Sites Internal org's entitlement
2. revokePreOnboardedSiteEnrollment() revoked ALL other Sites Internal sites' enrollments
3. Then the site was moved to customer org (too late)

This caused Sites Internal sites to lose their enrollments when other sites were being onboarded.

**The Fix:**
Move site org reassignment to happen BEFORE entitlement operations in both code paths:
1. Fast-track preonboarding path (PRE_ONBOARDING status)
2. Full onboarding path (new sites from internal orgs)

Now the flow correctly:
- Reassigns site to customer org FIRST
- Gets the customer org's entitlement
- Revokes enrollments only within that customer org
- Sites Internal org remains untouched

This ensures data integrity and prevents accidental removal of enrollments from internal org sites during customer onboarding.

Made-with: Cursor

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
