### PR TITLE
fix: make POST /v2/orgs/:id/categories idempotent by name | LLMO-4370

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -121,6 +121,10 @@ paths:
     $ref: './brands-v2-api.yaml#/v2-brands-for-org'
   /v2/orgs/{spaceCatId}/brands/{brandId}:
     $ref: './brands-v2-api.yaml#/v2-brand-for-org'
+  /v2/orgs/{spaceCatId}/categories:
+    $ref: './categories-v2-api.yaml#/v2-categories-for-org'
+  /v2/orgs/{spaceCatId}/categories/{categoryId}:
+    $ref: './categories-v2-api.yaml#/v2-category-for-org'
   /v2/orgs/{spaceCatId}/topics:
     $ref: './topics-v2-api.yaml#/v2-topics-for-org'
   /v2/orgs/{spaceCatId}/topics/{topicId}:

--- a/docs/openapi/categories-v2-api.yaml
+++ b/docs/openapi/categories-v2-api.yaml
@@ -1,0 +1,192 @@
+v2-categories-for-org:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+        example: 'a1b2c3d4-5678-90ab-cdef-1234567890ab'
+    - name: status
+      in: query
+      required: false
+      description: Filter by category status. Default excludes deleted categories.
+      schema:
+        type: string
+        enum: [active, pending, deleted, ignored]
+        example: 'active'
+  get:
+    tags:
+      - customer-config
+    summary: List categories for an organization (v2)
+    description: |
+      Returns all categories for the given organization, backed by
+      PostgREST/Aurora. By default, deleted categories are excluded. Use the
+      `status` query parameter to filter by specific status or include deleted
+      categories.
+    operationId: listCategoriesForOrgV2
+    security:
+      - ims_key: []
+      - api_key: []
+    responses:
+      '200':
+        description: Categories retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/V2CategoryListResponse'
+      '400':
+        $ref: './responses.yaml#/400'
+      '403':
+        description: User does not have access to this organization
+      '404':
+        $ref: './responses.yaml#/404-organization-not-found-with-id'
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        description: PostgREST unavailable (DATA_SERVICE_PROVIDER=postgres required)
+  post:
+    tags:
+      - customer-config
+    summary: Create a category (idempotent by name) (v2)
+    description: |
+      Creates a new category for the organization, idempotent by name.
+
+      Name matching is case-insensitive and whitespace-normalized (NFC),
+      so `"Discovery & Research"`, `"  discovery  &  research  "`, and
+      `"DISCOVERY & RESEARCH"` resolve to the same category.
+
+      Behavior by outcome:
+      - **New row inserted** — returns `201 Created` with the new row.
+      - **Existing row matched with identical fields** — no-op; returns
+        `200 OK` with the existing row. Audit trail (`updatedAt`,
+        `updatedBy`) is preserved.
+      - **Existing row matched with differing fields** — patch applied to
+        `origin` / `status` (with provenance guard: `origin` is never
+        downgraded from `human` to `ai`), returns `200 OK` with the
+        updated row.
+      - **Soft-deleted row matched** — resurrected: status flipped to
+        `active`, stable `id` (slug) preserved, returns `201 Created`.
+
+      Clients discriminating creation from idempotent update should inspect
+      the HTTP status, not the response body (identical in both cases).
+
+      Never returns `409`: duplicate-name reposts are absorbed by design.
+    operationId: createCategoryForOrgV2
+    security:
+      - ims_key: []
+      - api_key: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: './schemas.yaml#/V2CategoryInput'
+    responses:
+      '200':
+        description: |
+          Existing category returned (idempotent update or no-op).
+          The `id` (slug) of the returned row is authoritative — it may
+          differ from a client-supplied `id` if the stored row was created
+          with a different slug.
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/V2Category'
+      '201':
+        description: |
+          New category created, or a soft-deleted category with the same
+          name was resurrected (status flipped back to `active`).
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/V2Category'
+      '400':
+        $ref: './responses.yaml#/400'
+      '403':
+        description: User does not have access to this organization
+      '404':
+        $ref: './responses.yaml#/404-organization-not-found-with-id'
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        description: PostgREST unavailable (DATA_SERVICE_PROVIDER=postgres required)
+
+v2-category-for-org:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+        example: 'a1b2c3d4-5678-90ab-cdef-1234567890ab'
+    - name: categoryId
+      in: path
+      required: true
+      description: Category business key (category_id slug)
+      schema:
+        type: string
+        example: 'baseurl-discovery-research'
+  patch:
+    tags:
+      - customer-config
+    summary: Update a category (v2)
+    description: |
+      Updates an existing category. Only provided fields are updated. The
+      `name` field is canonicalized (trim + whitespace-collapse + NFC) on
+      write.
+    operationId: updateCategoryForOrgV2
+    security:
+      - ims_key: []
+      - api_key: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: './schemas.yaml#/V2CategoryUpdateInput'
+    responses:
+      '200':
+        description: Category updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/V2Category'
+      '400':
+        $ref: './responses.yaml#/400'
+      '403':
+        description: User does not have access to this organization
+      '404':
+        description: Organization or category not found
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        description: PostgREST unavailable (DATA_SERVICE_PROVIDER=postgres required)
+  delete:
+    tags:
+      - customer-config
+    summary: Delete a category (v2)
+    description: |
+      Soft-deletes a category by setting its status to `deleted`. The
+      category remains queryable with `?status=deleted` and can be
+      resurrected by POSTing a category with the same name.
+    operationId: deleteCategoryForOrgV2
+    security:
+      - ims_key: []
+      - api_key: []
+    responses:
+      '204':
+        description: Category deleted successfully
+      '400':
+        $ref: './responses.yaml#/400'
+      '403':
+        description: User does not have access to this organization
+      '404':
+        description: Organization or category not found
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        description: PostgREST unavailable (DATA_SERVICE_PROVIDER=postgres required)

--- a/docs/openapi/categories-v2-api.yaml
+++ b/docs/openapi/categories-v2-api.yaml
@@ -72,7 +72,9 @@ v2-categories-for-org:
       Clients discriminating creation from idempotent update should inspect
       the HTTP status, not the response body (identical in both cases).
 
-      Never returns `409`: duplicate-name reposts are absorbed by design.
+      Duplicate-name reposts (the common DRS re-sync case) are absorbed by
+      design and do NOT produce `409`. `409` is reserved for the two
+      orthogonal race conditions documented under the `409` response below.
     operationId: createCategoryForOrgV2
     security:
       - ims_key: []
@@ -108,6 +110,19 @@ v2-categories-for-org:
         description: User does not have access to this organization
       '404':
         $ref: './responses.yaml#/404-organization-not-found-with-id'
+      '409':
+        description: |
+          Rare race condition — caller should retry the full POST. Fires in
+          two scenarios:
+          1. The existing row matched by name was hard-deleted (not soft-
+             deleted) between our lookup and our update — message
+             `Category was concurrently modified; please retry`.
+          2. A unique-constraint other than `uq_category_name_per_org` was
+             tripped on insert (e.g. `uq_category_id_per_org` when the
+             client-supplied slug collides with an unrelated existing
+             row). Message echoes the actual constraint name.
+          Treated as an idempotent retry signal by DRS-class clients;
+          logged at WARN (not ERROR) server-side.
       '500':
         $ref: './responses.yaml#/500'
       '503':
@@ -161,6 +176,11 @@ v2-category-for-org:
         description: User does not have access to this organization
       '404':
         description: Organization or category not found
+      '409':
+        description: |
+          Updated `name` collides with another active or soft-deleted
+          category in the same organization (`uq_category_name_per_org`).
+          Message echoes the actual constraint name.
       '500':
         $ref: './responses.yaml#/500'
       '503':

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -7144,6 +7144,112 @@ V2BrandListResponse:
       items:
         $ref: '#/V2Brand'
 
+V2Category:
+  type: object
+  description: A category in the normalized categories table
+  required:
+    - id
+    - uuid
+    - name
+    - status
+    - origin
+  properties:
+    id:
+      type: string
+      description: Category business key (category_id slug). Stable once assigned.
+      example: 'baseurl-discovery-research'
+    uuid:
+      type: string
+      format: uuid
+      description: UUID primary key (categories.id)
+    name:
+      type: string
+      description: |
+        Human-readable category name. Stored canonicalized (trim +
+        whitespace-collapse + NFC). Matching on POST is case-insensitive.
+      example: 'Discovery & Research'
+    status:
+      type: string
+      enum: [active, pending, deleted, ignored]
+      description: Category status
+      example: 'active'
+    origin:
+      type: string
+      enum: [human, ai]
+      description: |
+        Provenance of this category. `human` is sticky — idempotent reposts
+        with `origin: ai` do NOT downgrade a human-curated category.
+      example: 'human'
+    createdAt:
+      type: string
+      format: date-time
+      description: Creation timestamp
+    createdBy:
+      type: string
+      description: User or system that created the category
+    updatedAt:
+      type: string
+      format: date-time
+      description: Last update timestamp
+    updatedBy:
+      type: string
+      description: User or system that last updated the category
+
+V2CategoryInput:
+  type: object
+  description: |
+    Request body for creating a category. POST is idempotent by name — see
+    `categories-v2-api.yaml` for the 200/201 semantics and the provenance
+    guard on `origin`.
+  required:
+    - name
+  properties:
+    id:
+      type: string
+      description: |
+        Client-supplied slug. Used only when inserting a brand-new row; for
+        existing rows the stored `id` is preserved (FK stability).
+      example: 'discovery-research'
+    name:
+      type: string
+      description: Human-readable category name. Canonicalized on write.
+      example: 'Discovery & Research'
+    origin:
+      type: string
+      enum: [human, ai]
+      default: 'human'
+      description: |
+        Provenance. Subject to the human→ai downgrade guard on existing rows.
+    status:
+      type: string
+      enum: [active, pending, ignored]
+      default: 'active'
+
+V2CategoryUpdateInput:
+  type: object
+  description: Request body for updating a category (partial update).
+  properties:
+    name:
+      type: string
+      description: Human-readable category name. Canonicalized on write.
+    origin:
+      type: string
+      enum: [human, ai]
+    status:
+      type: string
+      enum: [active, pending, deleted, ignored]
+
+V2CategoryListResponse:
+  type: object
+  description: Response envelope for listing categories
+  required:
+    - categories
+  properties:
+    categories:
+      type: array
+      items:
+        $ref: '#/V2Category'
+
 V2Topic:
   type: object
   description: A topic in the normalized topics table

--- a/docs/openapi/topics-v2-api.yaml
+++ b/docs/openapi/topics-v2-api.yaml
@@ -83,6 +83,14 @@ v2-topics-for-org:
         description: User does not have access to this organization
       '404':
         $ref: './responses.yaml#/404-organization-not-found-with-id'
+      '409':
+        description: |
+          A unique-constraint violation escaped the `organization_id,
+          topic_id` upsert target. The response `message` echoes the actual
+          constraint name that fired (e.g. `uq_topic_per_org`) so callers
+          can discriminate between constraint classes without parsing 500
+          bodies. Treated as an idempotent retry signal by DRS-class
+          clients; logged at WARN (not ERROR) server-side.
       '500':
         $ref: './responses.yaml#/500'
       '503':

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -752,21 +752,38 @@ function BrandsController(ctx, log, env) {
       const { postgrestClient } = context.dataAccess.services;
       const updatedBy = context.attributes?.authInfo?.profile?.email || 'system';
 
-      const { category, created } = await createCategory({
+      const { category, created, outcome } = await createCategory({
         organizationId: spaceCatId,
         category: categoryData,
         postgrestClient,
         updatedBy,
+        log,
+      });
+
+      // Log-storm quantification tag: lets Coralogix aggregate
+      // category_post_result by outcome so the LLMO-4370 cleanup can be
+      // quantified post-deploy (insert/resurrect/update/noop/race_retry*)
+      // without grepping messages. LLMO-4370 #15.
+      log.info(`Category POST resolved for organization ${spaceCatId}`, {
+        organization_id: spaceCatId,
+        category_id: category.id,
+        outcome,
       });
 
       // 201 on insert, 200 on idempotent update — lets callers (UI toast,
       // DRS audit log) distinguish "created new" from "ensured existing".
       return createResponse(category, created ? 201 : 200);
     } catch (error) {
-      // Storage is idempotent by name: matching rows return via the normal
-      // path, so we never see a 409 here. Anything caught here is a real
-      // failure.
-      log.error(`Error creating category for organization ${spaceCatId}:`, error);
+      // Storage is idempotent by name on the happy path, but still raises
+      // a typed 409 on the concurrent hard-delete race (row vanishes
+      // between lookup and update) and on non-name uniqueness collisions
+      // (slug drift). Those are retry signals, not server faults — warn,
+      // don't error, to keep Coralogix ERROR severity clean. LLMO-4370 #2.
+      if (error?.status === 409) {
+        log.warn(`Category conflict for organization ${spaceCatId}: ${error.message}`);
+      } else {
+        log.error(`Error creating category for organization ${spaceCatId}:`, error);
+      }
       return createErrorResponse(error);
     }
   };
@@ -815,7 +832,14 @@ function BrandsController(ctx, log, env) {
       }
       return ok(updated);
     } catch (error) {
-      log.error(`Error updating category ${categoryId} for organization ${spaceCatId}:`, error);
+      // PATCH to a name colliding with a sibling row in the same org
+      // surfaces from storage as a typed 409. Mirror the POST handler so
+      // legitimate name-conflict retries don't pollute ERROR severity.
+      if (error?.status === 409) {
+        log.warn(`Category update conflict for organization ${spaceCatId}: ${error.message}`);
+      } else {
+        log.error(`Error updating category ${categoryId} for organization ${spaceCatId}:`, error);
+      }
       return createErrorResponse(error);
     }
   };

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -752,18 +752,20 @@ function BrandsController(ctx, log, env) {
       const { postgrestClient } = context.dataAccess.services;
       const updatedBy = context.attributes?.authInfo?.profile?.email || 'system';
 
-      const created = await createCategory({
+      const { category, created } = await createCategory({
         organizationId: spaceCatId,
         category: categoryData,
         postgrestClient,
         updatedBy,
       });
 
-      return createResponse(created, 201);
+      // 201 on insert, 200 on idempotent update — lets callers (UI toast,
+      // DRS audit log) distinguish "created new" from "ensured existing".
+      return createResponse(category, created ? 201 : 200);
     } catch (error) {
-      // Storage is idempotent by name: matching rows return 201 with the
-      // existing row, so we never see a 409 here. Anything caught here is a
-      // real failure.
+      // Storage is idempotent by name: matching rows return via the normal
+      // path, so we never see a 409 here. Anything caught here is a real
+      // failure.
       log.error(`Error creating category for organization ${spaceCatId}:`, error);
       return createErrorResponse(error);
     }
@@ -948,7 +950,10 @@ function BrandsController(ctx, log, env) {
       return createResponse(created, 201);
     } catch (error) {
       if (error?.status === 409) {
-        log.info(`Topic already exists for organization ${spaceCatId}: ${error.message}`);
+        // Warn (not error) — DRS-style idempotent retries stop polluting
+        // ERROR severity, but legitimate duplicate-submit bugs (UI double-
+        // click, malformed payload) remain visible at WARN for triage.
+        log.warn(`Topic conflict for organization ${spaceCatId}: ${error.message}`);
       } else {
         log.error(`Error creating topic for organization ${spaceCatId}:`, error);
       }

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -761,6 +761,9 @@ function BrandsController(ctx, log, env) {
 
       return createResponse(created, 201);
     } catch (error) {
+      // Storage is idempotent by name: matching rows return 201 with the
+      // existing row, so we never see a 409 here. Anything caught here is a
+      // real failure.
       log.error(`Error creating category for organization ${spaceCatId}:`, error);
       return createErrorResponse(error);
     }
@@ -944,7 +947,11 @@ function BrandsController(ctx, log, env) {
 
       return createResponse(created, 201);
     } catch (error) {
-      log.error(`Error creating topic for organization ${spaceCatId}:`, error);
+      if (error?.status === 409) {
+        log.info(`Topic already exists for organization ${spaceCatId}: ${error.message}`);
+      } else {
+        log.error(`Error creating topic for organization ${spaceCatId}:`, error);
+      }
       return createErrorResponse(error);
     }
   };

--- a/src/support/categories-storage.js
+++ b/src/support/categories-storage.js
@@ -62,15 +62,61 @@ export async function listCategories({
   return (data || []).map(mapDbCategoryToV2);
 }
 
+async function findCategoryByName(postgrestClient, organizationId, name) {
+  const { data, error } = await postgrestClient
+    .from('categories')
+    .select('*')
+    .eq('organization_id', organizationId)
+    .eq('name', name)
+    .neq('status', 'deleted')
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Failed to lookup category by name: ${error.message}`);
+  }
+  return data || null;
+}
+
+async function updateExistingCategory(postgrestClient, existing, category, updatedBy) {
+  const patch = { updated_by: updatedBy };
+  if (category.origin && category.origin !== existing.origin) {
+    patch.origin = category.origin;
+  }
+  if (category.status && category.status !== existing.status) {
+    patch.status = category.status;
+  }
+
+  const { data, error } = await postgrestClient
+    .from('categories')
+    .update(patch)
+    .eq('id', existing.id)
+    .select()
+    .single();
+  if (error) {
+    throw new Error(`Failed to update existing category: ${error.message}`);
+  }
+  return mapDbCategoryToV2(data);
+}
+
 /**
- * Creates a category in the categories table.
+ * Creates a category in the categories table, idempotent by name.
+ *
+ * If a non-deleted category with the same name already exists for the
+ * organization, its non-key fields are refreshed (origin/status/updated_by)
+ * and the existing row is returned — the stable `category_id` slug is
+ * preserved so foreign-key references remain valid.
+ *
+ * Rationale: clients (notably DRS) re-post the same canonical categories
+ * on every sync run with a potentially drifted slug. Without name-level
+ * idempotency, every such re-post trips `uq_category_name_per_org` and
+ * surfaces as a 409 — thousands per day of false-positive ERROR logs.
+ * See LLMO-4370.
  *
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat organization UUID
- * @param {object} params.category - Category data { name, origin? }
+ * @param {object} params.category - Category data { name, id?, origin?, status? }
  * @param {object} params.postgrestClient - PostgREST client
  * @param {string} [params.updatedBy] - User performing the operation
- * @returns {Promise<object>} Created category
+ * @returns {Promise<object>} Created or updated category
  */
 export async function createCategory({
   organizationId, category, postgrestClient, updatedBy = 'system',
@@ -82,8 +128,12 @@ export async function createCategory({
     throw new Error('Category name is required');
   }
 
-  const categoryId = category.id || category.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const existing = await findCategoryByName(postgrestClient, organizationId, category.name);
+  if (existing) {
+    return updateExistingCategory(postgrestClient, existing, category, updatedBy);
+  }
 
+  const categoryId = category.id || category.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
   const row = {
     organization_id: organizationId,
     category_id: categoryId,
@@ -95,15 +145,18 @@ export async function createCategory({
 
   const { data, error } = await postgrestClient
     .from('categories')
-    .upsert(row, { onConflict: 'organization_id,category_id' })
+    .insert(row)
     .select()
     .single();
 
   if (error) {
     if (error.code === '23505' && /uq_category_name_per_org/.test(error.message || '')) {
-      const conflict = new Error(`Category with name '${category.name}' already exists for this organization`);
-      conflict.status = 409;
-      throw conflict;
+      // Race: another writer inserted the same name between our lookup and
+      // insert. Retry the lookup once and fold into the normal update path.
+      const raced = await findCategoryByName(postgrestClient, organizationId, category.name);
+      if (raced) {
+        return updateExistingCategory(postgrestClient, raced, category, updatedBy);
+      }
     }
     throw new Error(`Failed to create category: ${error.message}`);
   }

--- a/src/support/categories-storage.js
+++ b/src/support/categories-storage.js
@@ -12,6 +12,11 @@
 
 import { hasText } from '@adobe/spacecat-shared-utils';
 
+// Zero-width / BOM characters that pass `trim()` but render invisible. Strip
+// in canonicalization so a name like "Foo\u200B" cannot produce a row that
+// looks identical to "Foo" in the UI yet bypasses idempotent matching.
+const ZERO_WIDTH_RE = /[\u200B-\u200D\uFEFF]/g;
+
 // Canonicalize a display name for storage and comparison. Non-lossy:
 // preserves the client's casing and punctuation, but folds whitespace and
 // unicode-composition variants so that "  Taxonomy " and "Taxonomy" — or an
@@ -19,13 +24,24 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 // "A & B" vs "A and B" are intentionally NOT folded here; that requires a
 // business rule, not a canonical form.
 function canonicalizeName(name) {
-  return name.normalize('NFC').trim().replace(/\s+/g, ' ');
+  return name.normalize('NFC').replace(ZERO_WIDTH_RE, '').trim().replace(/\s+/g, ' ');
 }
 
 // PostgREST-pattern-safe escape of literal `%` and `_` so ilike() matches
 // an exact canonical string rather than a wildcard pattern.
-function escapeIlike(s) {
+export function escapeIlike(s) {
   return s.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+function extractConstraintName(error) {
+  const match = /unique constraint "([^"]+)"/.exec(error?.message || '');
+  return match ? match[1] : 'unique constraint';
+}
+
+function conflictError(message, cause) {
+  const err = new Error(message, { cause });
+  err.status = 409;
+  return err;
 }
 
 function mapDbCategoryToV2(row) {
@@ -99,16 +115,19 @@ async function findCategoryByName(postgrestClient, organizationId, name) {
 }
 
 // Builds the patch an idempotent re-POST should apply on top of an existing
-// row. Returns null when nothing meaningful changes — callers use that as a
-// signal to short-circuit without writing (and without bumping updated_by /
-// updated_at), so a no-op DRS heartbeat preserves the last human edit's
-// audit trail.
+// row. Returns { patch, downgradeBlocked } — patch is null when nothing
+// meaningful changes (no-op short-circuit: no write, no bumped
+// updated_by/updated_at, so a DRS heartbeat preserves the last human edit's
+// audit trail). downgradeBlocked is true when the caller attempted to
+// change origin from 'human' to 'ai' — callers surface that as an operator
+// signal.
 //
 // Provenance rule: never downgrade `origin: 'human'` to `'ai'`. A scheduler
 // asserting `ai` must not erase a human curator's explicit labeling.
 // Resurrection from soft-deleted is always a write regardless of field diff.
 function buildCategoryPatch(existing, category, { resurrect }) {
   const patch = {};
+  let downgradeBlocked = false;
 
   if (resurrect) {
     patch.status = 'active';
@@ -118,12 +137,17 @@ function buildCategoryPatch(existing, category, { resurrect }) {
 
   if (category.origin && category.origin !== existing.origin) {
     const downgrade = existing.origin === 'human' && category.origin === 'ai';
-    if (!downgrade) {
+    if (downgrade) {
+      downgradeBlocked = true;
+    } else {
       patch.origin = category.origin;
     }
   }
 
-  return Object.keys(patch).length === 0 ? null : patch;
+  return {
+    patch: Object.keys(patch).length === 0 ? null : patch,
+    downgradeBlocked,
+  };
 }
 
 async function updateExistingCategory(postgrestClient, existing, patch, updatedBy) {
@@ -140,26 +164,58 @@ async function updateExistingCategory(postgrestClient, existing, patch, updatedB
     // Row was hard-deleted between lookup and update. Surface as a typed
     // 409 so callers can retry the full POST — which will then take the
     // insert path against a now-absent row.
-    const conflict = new Error('Category was concurrently modified; please retry');
-    conflict.status = 409;
-    throw conflict;
+    throw conflictError('Category was concurrently modified; please retry');
   }
   return mapDbCategoryToV2(data);
 }
 
 // Resolves an existing row against an incoming idempotent POST: either
 // short-circuits (no write, no audit-trail churn) or applies a patch —
-// including resurrecting soft-deleted rows. Returns { category, created }:
-// `created: true` when the row was resurrected (client-visible: the
-// resource reappears), otherwise false.
-async function resolveExistingCategory(postgrestClient, existing, category, updatedBy) {
+// including resurrecting soft-deleted rows. Returns
+// { category, created, outcome } where `outcome` is one of
+// 'noop' | 'update' | 'resurrect' (possibly prefixed 'race_retry_' when
+// invoked from the 23505 race-recovery path). `created: true` when the row
+// was resurrected (client-visible: the resource reappears).
+async function resolveExistingCategory(
+  postgrestClient,
+  existing,
+  category,
+  updatedBy,
+  { raceRecovery = false, log, organizationId } = {},
+) {
   const resurrect = existing.status === 'deleted';
-  const patch = buildCategoryPatch(existing, category, { resurrect });
+  const { patch, downgradeBlocked } = buildCategoryPatch(existing, category, { resurrect });
+
+  if (downgradeBlocked) {
+    // Operator signal: a scheduler/AI caller tried to stamp 'ai' over a
+    // human-curated row. Preserved silently in the patch math; logged here
+    // so misconfigured DRS taxonomies can be found in Coralogix without
+    // reading individual rows. LLMO-4370 #13.
+    log?.warn?.('Blocked origin downgrade human->ai on category', {
+      organization_id: organizationId,
+      category_id: existing.category_id,
+      attempted_origin: category.origin,
+      current_origin: existing.origin,
+    });
+  }
+
   if (!patch) {
-    return { category: mapDbCategoryToV2(existing), created: false };
+    return {
+      category: mapDbCategoryToV2(existing),
+      created: false,
+      outcome: raceRecovery ? 'race_retry_noop' : 'noop',
+    };
   }
   const updated = await updateExistingCategory(postgrestClient, existing, patch, updatedBy);
-  return { category: updated, created: resurrect };
+  let outcome;
+  if (raceRecovery) {
+    outcome = 'race_retry';
+  } else if (resurrect) {
+    outcome = 'resurrect';
+  } else {
+    outcome = 'update';
+  }
+  return { category: updated, created: resurrect, outcome };
 }
 
 /**
@@ -181,13 +237,16 @@ async function resolveExistingCategory(postgrestClient, existing, category, upda
  * @param {object} params.category - Category data { name, id?, origin?, status? }
  * @param {object} params.postgrestClient - PostgREST client
  * @param {string} [params.updatedBy] - User performing the operation
- * @returns {Promise<{category: object, created: boolean}>}
+ * @param {object} [params.log] - Logger for operator signals (downgrade blocks)
+ * @returns {Promise<{category: object, created: boolean, outcome: string}>}
  *   `category` is the resulting row (mapped); `created` is true when a new
- *   row was inserted and false when an existing row was updated. Callers
- *   map this to HTTP 201 vs 200.
+ *   row was inserted/resurrected and false when an existing row was
+ *   updated. Callers map `created` to HTTP 201 vs 200. `outcome` is one of
+ *   'insert' | 'resurrect' | 'update' | 'noop' | 'race_retry' |
+ *   'race_retry_noop', for post-deploy log-storm quantification.
  */
 export async function createCategory({
-  organizationId, category, postgrestClient, updatedBy = 'system',
+  organizationId, category, postgrestClient, updatedBy = 'system', log,
 }) {
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
@@ -203,13 +262,37 @@ export async function createCategory({
 
   const existing = await findCategoryByName(postgrestClient, organizationId, canonicalName);
   if (existing) {
-    return resolveExistingCategory(postgrestClient, existing, category, updatedBy);
+    return resolveExistingCategory(
+      postgrestClient,
+      existing,
+      category,
+      updatedBy,
+      { log, organizationId },
+    );
   }
 
-  const categoryId = category.id || canonicalName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  // Derive a slug from the canonical name when none supplied, trimming
+  // leading/trailing dashes so "   !!  " and Unicode-only names don't
+  // produce a degenerate bare '-'. The client-supplied slug is trusted
+  // verbatim (FK-stability).
+  let derivedSlug;
+  if (category.id) {
+    derivedSlug = category.id;
+  } else {
+    derivedSlug = canonicalName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (!derivedSlug) {
+      throw new Error(
+        'Category name produces an empty slug after normalization; supply an explicit `id`',
+      );
+    }
+  }
+
   const row = {
     organization_id: organizationId,
-    category_id: categoryId,
+    category_id: derivedSlug,
     name: canonicalName,
     origin: category.origin || 'human',
     status: category.status || 'active',
@@ -223,24 +306,44 @@ export async function createCategory({
     .single();
 
   if (error) {
-    if (error.code === '23505' && /uq_category_name_per_org/.test(error.message || '')) {
-      // Race: another writer inserted the same name between our lookup and
-      // insert. Retry the lookup once and fold into the normal resolve path.
-      // If the retry lookup itself fails, preserve the original 23505 as
-      // the primary cause — it's the more diagnostic error for this path.
-      let raced = null;
-      try {
-        raced = await findCategoryByName(postgrestClient, organizationId, canonicalName);
-      } catch (_lookupErr) {
-        // Intentionally swallow — fall through to the original-error throw.
-      }
-      if (raced) {
-        return resolveExistingCategory(postgrestClient, raced, category, updatedBy);
+    if (error.code === '23505') {
+      const constraint = extractConstraintName(error);
+      if (constraint === 'uq_category_name_per_org') {
+        // Race: another writer inserted the same name between our lookup
+        // and insert. Retry the lookup once and fold into the normal
+        // resolve path. If the retry lookup itself fails, preserve the
+        // original 23505 as the primary cause — it's the more diagnostic
+        // error for this path.
+        let raced = null;
+        try {
+          raced = await findCategoryByName(postgrestClient, organizationId, canonicalName);
+        } catch (_lookupErr) {
+          // Intentionally swallow — fall through to the original-error throw.
+        }
+        if (raced) {
+          return resolveExistingCategory(
+            postgrestClient,
+            raced,
+            category,
+            updatedBy,
+            { raceRecovery: true, log, organizationId },
+          );
+        }
+      } else {
+        // Any other unique-constraint violation (e.g. slug collision via
+        // uq_category_id_per_org when the client ships a drifted `id` that
+        // maps to a different name already occupying that slug) surfaces as
+        // a typed 409 echoing the actual constraint — mirrors the topics
+        // pattern so callers don't have to mine 500 bodies. LLMO-4370 #5/#6.
+        throw conflictError(
+          `Category conflicts with ${constraint} for this organization`,
+          error,
+        );
       }
     }
     throw new Error(`Failed to create category: ${error.message}`, { cause: error });
   }
-  return { category: mapDbCategoryToV2(data), created: true };
+  return { category: mapDbCategoryToV2(data), created: true, outcome: 'insert' };
 }
 
 /**
@@ -281,6 +384,16 @@ export async function updateCategory({
     .maybeSingle();
 
   if (error) {
+    // A PATCH to a name that collides with another row in the same org
+    // trips `uq_category_name_per_org`. Surface as a typed 409 echoing the
+    // constraint — symmetric with POST, so clients don't see a random 500
+    // on what is really a duplicate-name conflict. LLMO-4370 #9.
+    if (error.code === '23505') {
+      throw conflictError(
+        `Category conflicts with ${extractConstraintName(error)} for this organization`,
+        error,
+      );
+    }
     throw new Error(`Failed to update category: ${error.message}`, { cause: error });
   }
   if (!data) {

--- a/src/support/categories-storage.js
+++ b/src/support/categories-storage.js
@@ -12,6 +12,22 @@
 
 import { hasText } from '@adobe/spacecat-shared-utils';
 
+// Canonicalize a display name for storage and comparison. Non-lossy:
+// preserves the client's casing and punctuation, but folds whitespace and
+// unicode-composition variants so that "  Taxonomy " and "Taxonomy" — or an
+// NFD vs NFC é — collapse to the same stored form. Semantic variants like
+// "A & B" vs "A and B" are intentionally NOT folded here; that requires a
+// business rule, not a canonical form.
+function canonicalizeName(name) {
+  return name.normalize('NFC').trim().replace(/\s+/g, ' ');
+}
+
+// PostgREST-pattern-safe escape of literal `%` and `_` so ilike() matches
+// an exact canonical string rather than a wildcard pattern.
+function escapeIlike(s) {
+  return s.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
 function mapDbCategoryToV2(row) {
   return {
     id: row.category_id,
@@ -56,45 +72,94 @@ export async function listCategories({
 
   const { data, error } = await query;
   if (error) {
-    throw new Error(`Failed to list categories: ${error.message}`);
+    throw new Error(`Failed to list categories: ${error.message}`, { cause: error });
   }
 
   return (data || []).map(mapDbCategoryToV2);
 }
 
+// Finds ANY row for the org whose canonical name matches (case-insensitive,
+// whitespace-folded, NFC). Includes soft-deleted rows so callers can choose
+// between idempotent update and resurrection. Note: DB unique constraint
+// `uq_category_name_per_org` is case-sensitive, so two concurrent inserts
+// with different cases can still both succeed — a full schema-level fix
+// requires a partial-index or generated-column migration (out of scope).
 async function findCategoryByName(postgrestClient, organizationId, name) {
+  const canonical = canonicalizeName(name);
   const { data, error } = await postgrestClient
     .from('categories')
     .select('*')
     .eq('organization_id', organizationId)
-    .eq('name', name)
-    .neq('status', 'deleted')
+    .ilike('name', escapeIlike(canonical))
     .maybeSingle();
   if (error) {
-    throw new Error(`Failed to lookup category by name: ${error.message}`);
+    throw new Error(`Failed to lookup category by name: ${error.message}`, { cause: error });
   }
-  return data || null;
+  return data;
 }
 
-async function updateExistingCategory(postgrestClient, existing, category, updatedBy) {
-  const patch = { updated_by: updatedBy };
-  if (category.origin && category.origin !== existing.origin) {
-    patch.origin = category.origin;
-  }
-  if (category.status && category.status !== existing.status) {
+// Builds the patch an idempotent re-POST should apply on top of an existing
+// row. Returns null when nothing meaningful changes — callers use that as a
+// signal to short-circuit without writing (and without bumping updated_by /
+// updated_at), so a no-op DRS heartbeat preserves the last human edit's
+// audit trail.
+//
+// Provenance rule: never downgrade `origin: 'human'` to `'ai'`. A scheduler
+// asserting `ai` must not erase a human curator's explicit labeling.
+// Resurrection from soft-deleted is always a write regardless of field diff.
+function buildCategoryPatch(existing, category, { resurrect }) {
+  const patch = {};
+
+  if (resurrect) {
+    patch.status = 'active';
+  } else if (category.status && category.status !== existing.status) {
     patch.status = category.status;
   }
 
+  if (category.origin && category.origin !== existing.origin) {
+    const downgrade = existing.origin === 'human' && category.origin === 'ai';
+    if (!downgrade) {
+      patch.origin = category.origin;
+    }
+  }
+
+  return Object.keys(patch).length === 0 ? null : patch;
+}
+
+async function updateExistingCategory(postgrestClient, existing, patch, updatedBy) {
   const { data, error } = await postgrestClient
     .from('categories')
-    .update(patch)
+    .update({ ...patch, updated_by: updatedBy })
     .eq('id', existing.id)
     .select()
-    .single();
+    .maybeSingle();
   if (error) {
-    throw new Error(`Failed to update existing category: ${error.message}`);
+    throw new Error(`Failed to update existing category: ${error.message}`, { cause: error });
+  }
+  if (!data) {
+    // Row was hard-deleted between lookup and update. Surface as a typed
+    // 409 so callers can retry the full POST — which will then take the
+    // insert path against a now-absent row.
+    const conflict = new Error('Category was concurrently modified; please retry');
+    conflict.status = 409;
+    throw conflict;
   }
   return mapDbCategoryToV2(data);
+}
+
+// Resolves an existing row against an incoming idempotent POST: either
+// short-circuits (no write, no audit-trail churn) or applies a patch —
+// including resurrecting soft-deleted rows. Returns { category, created }:
+// `created: true` when the row was resurrected (client-visible: the
+// resource reappears), otherwise false.
+async function resolveExistingCategory(postgrestClient, existing, category, updatedBy) {
+  const resurrect = existing.status === 'deleted';
+  const patch = buildCategoryPatch(existing, category, { resurrect });
+  if (!patch) {
+    return { category: mapDbCategoryToV2(existing), created: false };
+  }
+  const updated = await updateExistingCategory(postgrestClient, existing, patch, updatedBy);
+  return { category: updated, created: resurrect };
 }
 
 /**
@@ -116,7 +181,10 @@ async function updateExistingCategory(postgrestClient, existing, category, updat
  * @param {object} params.category - Category data { name, id?, origin?, status? }
  * @param {object} params.postgrestClient - PostgREST client
  * @param {string} [params.updatedBy] - User performing the operation
- * @returns {Promise<object>} Created or updated category
+ * @returns {Promise<{category: object, created: boolean}>}
+ *   `category` is the resulting row (mapped); `created` is true when a new
+ *   row was inserted and false when an existing row was updated. Callers
+ *   map this to HTTP 201 vs 200.
  */
 export async function createCategory({
   organizationId, category, postgrestClient, updatedBy = 'system',
@@ -128,16 +196,21 @@ export async function createCategory({
     throw new Error('Category name is required');
   }
 
-  const existing = await findCategoryByName(postgrestClient, organizationId, category.name);
-  if (existing) {
-    return updateExistingCategory(postgrestClient, existing, category, updatedBy);
+  const canonicalName = canonicalizeName(category.name);
+  if (!hasText(canonicalName)) {
+    throw new Error('Category name is required');
   }
 
-  const categoryId = category.id || category.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const existing = await findCategoryByName(postgrestClient, organizationId, canonicalName);
+  if (existing) {
+    return resolveExistingCategory(postgrestClient, existing, category, updatedBy);
+  }
+
+  const categoryId = category.id || canonicalName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
   const row = {
     organization_id: organizationId,
     category_id: categoryId,
-    name: category.name,
+    name: canonicalName,
     origin: category.origin || 'human',
     status: category.status || 'active',
     updated_by: updatedBy,
@@ -152,15 +225,22 @@ export async function createCategory({
   if (error) {
     if (error.code === '23505' && /uq_category_name_per_org/.test(error.message || '')) {
       // Race: another writer inserted the same name between our lookup and
-      // insert. Retry the lookup once and fold into the normal update path.
-      const raced = await findCategoryByName(postgrestClient, organizationId, category.name);
+      // insert. Retry the lookup once and fold into the normal resolve path.
+      // If the retry lookup itself fails, preserve the original 23505 as
+      // the primary cause — it's the more diagnostic error for this path.
+      let raced = null;
+      try {
+        raced = await findCategoryByName(postgrestClient, organizationId, canonicalName);
+      } catch (_lookupErr) {
+        // Intentionally swallow — fall through to the original-error throw.
+      }
       if (raced) {
-        return updateExistingCategory(postgrestClient, raced, category, updatedBy);
+        return resolveExistingCategory(postgrestClient, raced, category, updatedBy);
       }
     }
-    throw new Error(`Failed to create category: ${error.message}`);
+    throw new Error(`Failed to create category: ${error.message}`, { cause: error });
   }
-  return mapDbCategoryToV2(data);
+  return { category: mapDbCategoryToV2(data), created: true };
 }
 
 /**
@@ -183,7 +263,7 @@ export async function updateCategory({
 
   const patch = { updated_by: updatedBy };
   if (updates.name !== undefined) {
-    patch.name = updates.name;
+    patch.name = canonicalizeName(updates.name);
   }
   if (updates.origin !== undefined) {
     patch.origin = updates.origin;
@@ -201,7 +281,7 @@ export async function updateCategory({
     .maybeSingle();
 
   if (error) {
-    throw new Error(`Failed to update category: ${error.message}`);
+    throw new Error(`Failed to update category: ${error.message}`, { cause: error });
   }
   if (!data) {
     return null;
@@ -235,7 +315,7 @@ export async function deleteCategory({
     .maybeSingle();
 
   if (error) {
-    throw new Error(`Failed to delete category: ${error.message}`);
+    throw new Error(`Failed to delete category: ${error.message}`, { cause: error });
   }
   return !!data;
 }

--- a/src/support/topics-storage.js
+++ b/src/support/topics-storage.js
@@ -62,7 +62,7 @@ export async function listTopics({
 
   const { data, error } = await query;
   if (error) {
-    throw new Error(`Failed to list topics: ${error.message}`);
+    throw new Error(`Failed to list topics: ${error.message}`, { cause: error });
   }
 
   return (data || []).map(mapDbTopicToV2);
@@ -108,15 +108,19 @@ export async function createTopic({
     .single();
 
   if (error) {
-    // Symmetry with categories: surface unique-constraint violations as 409
-    // so callers can handle conflicts idempotently without relying on 500
-    // bodies. LLMO-4370.
+    // Any unique-constraint violation that escapes the `organization_id,
+    // topic_id` upsert target is surfaced as a typed 409 so callers can
+    // handle it without mining 500 bodies. The message echoes the actual
+    // constraint name rather than hard-coding a field (the colliding
+    // column may not be `name`). LLMO-4370.
     if (error.code === '23505') {
-      const conflict = new Error(`Topic with name '${topic.name}' already exists for this organization`);
+      const match = /unique constraint "([^"]+)"/.exec(error.message || '');
+      const constraint = match ? match[1] : 'unique constraint';
+      const conflict = new Error(`Topic conflicts with ${constraint} for this organization`);
       conflict.status = 409;
       throw conflict;
     }
-    throw new Error(`Failed to create topic: ${error.message}`);
+    throw new Error(`Failed to create topic: ${error.message}`, { cause: error });
   }
 
   // Link topic to category via the topic_categories junction table.
@@ -181,7 +185,7 @@ export async function updateTopic({
     .maybeSingle();
 
   if (error) {
-    throw new Error(`Failed to update topic: ${error.message}`);
+    throw new Error(`Failed to update topic: ${error.message}`, { cause: error });
   }
   if (!data) {
     return null;
@@ -215,7 +219,7 @@ export async function deleteTopic({
     .maybeSingle();
 
   if (error) {
-    throw new Error(`Failed to delete topic: ${error.message}`);
+    throw new Error(`Failed to delete topic: ${error.message}`, { cause: error });
   }
   return !!data;
 }

--- a/src/support/topics-storage.js
+++ b/src/support/topics-storage.js
@@ -108,6 +108,14 @@ export async function createTopic({
     .single();
 
   if (error) {
+    // Symmetry with categories: surface unique-constraint violations as 409
+    // so callers can handle conflicts idempotently without relying on 500
+    // bodies. LLMO-4370.
+    if (error.code === '23505') {
+      const conflict = new Error(`Topic with name '${topic.name}' already exists for this organization`);
+      conflict.status = 409;
+      throw conflict;
+    }
     throw new Error(`Failed to create topic: ${error.message}`);
   }
 

--- a/src/support/topics-storage.js
+++ b/src/support/topics-storage.js
@@ -116,7 +116,13 @@ export async function createTopic({
     if (error.code === '23505') {
       const match = /unique constraint "([^"]+)"/.exec(error.message || '');
       const constraint = match ? match[1] : 'unique constraint';
-      const conflict = new Error(`Topic conflicts with ${constraint} for this organization`);
+      // Chain the original PostgREST error as `cause` so operators reading
+      // WARN-level conflict logs can still reach the raw DB error during
+      // triage — symmetric with categories-storage. LLMO-4370 #14.
+      const conflict = new Error(
+        `Topic conflicts with ${constraint} for this organization`,
+        { cause: error },
+      );
       conflict.status = 409;
       throw conflict;
     }

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -2393,6 +2393,76 @@ describe('Brands Controller', () => {
       const body = await response.json();
       expect(body.message).to.match(/Failed to lookup category by name/);
     });
+
+    it('returns 409 and logs at warn (not error) when storage raises concurrent-hard-delete 409', async () => {
+      // Storage surfaces the race as a typed 409. The controller must
+      // mirror the topics pattern and demote these to WARN to avoid
+      // re-polluting Coralogix ERROR severity — the explicit goal of
+      // LLMO-4370.
+      const existingRow = {
+        id: 'uuid-vanishing',
+        category_id: 'vanishing',
+        name: 'Vanishing',
+        status: 'active',
+        origin: 'human',
+        updated_at: '2026-01-01T00:00:00Z',
+        updated_by: 'system',
+      };
+      // Shared across every .from() call, so the first maybeSingle() (the
+      // lookup) finds the row and the second (post-update) returns null —
+      // simulating the row being hard-deleted between the two round-trips.
+      const sharedMaybeSingle = sandbox.stub();
+      sharedMaybeSingle.onCall(0).resolves({ data: existingRow, error: null });
+      sharedMaybeSingle.onCall(1).resolves({ data: null, error: null });
+      mockDataAccess.services.postgrestClient = {
+        from: sandbox.stub().callsFake(() => ({
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          neq: sandbox.stub().returnsThis(),
+          ilike: sandbox.stub().returnsThis(),
+          order: sandbox.stub().returnsThis(),
+          update: sandbox.stub().returnsThis(),
+          maybeSingle: sharedMaybeSingle,
+        })),
+      };
+      loggerStub.warn.resetHistory();
+      loggerStub.error.resetHistory();
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+
+      const response = await brandsController.createCategoryForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        // Force the update path (differing status) so the race path is hit.
+        data: { name: 'Vanishing', status: 'pending' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { profile: { email: 'tester@adobe.com' } } },
+      });
+
+      expect(response.status).to.equal(409);
+      expect(loggerStub.warn).to.have.been.called;
+      expect(loggerStub.error).to.not.have.been.called;
+    });
+
+    it('logs the outcome tag for post-deploy Coralogix quantification', async () => {
+      loggerStub.info.resetHistory();
+      await brandsController.createCategoryForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'My Category' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+      });
+
+      // info call includes {organization_id, category_id, outcome} for
+      // aggregatable log-storm metrics — see LLMO-4370 #15.
+      expect(loggerStub.info).to.have.been.called;
+      const infoCall = loggerStub.info.getCalls().find(
+        (c) => /Category POST resolved/.test(c.args[0] || ''),
+      );
+      expect(infoCall).to.exist;
+      expect(infoCall.args[1]).to.have.property('outcome', 'insert');
+      expect(infoCall.args[1]).to.have.property('organization_id', ORGANIZATION_ID);
+    });
   });
 
   describe('updateCategoryForOrg', () => {
@@ -2549,6 +2619,43 @@ describe('Brands Controller', () => {
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(500);
+    });
+
+    it('returns 409 and logs at warn when PATCH name collides with a sibling in the same org', async () => {
+      // Storage layer maps 23505 on `uq_category_name_per_org` to a typed
+      // 409. The controller must surface that at WARN to keep the PATCH
+      // path symmetric with POST's no-storm contract. LLMO-4370 #9.
+      mockDataAccess.services.postgrestClient = {
+        from: sandbox.stub().callsFake(() => ({
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          neq: sandbox.stub().returnsThis(),
+          order: sandbox.stub().returnsThis(),
+          update: sandbox.stub().returnsThis(),
+          maybeSingle: sandbox.stub().resolves({
+            data: null,
+            error: {
+              code: '23505',
+              message: 'duplicate key value violates unique constraint "uq_category_name_per_org"',
+            },
+          }),
+        })),
+      };
+      loggerStub.warn.resetHistory();
+      loggerStub.error.resetHistory();
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+
+      const response = await brandsController.updateCategoryForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        data: { name: 'Collides With Sibling' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { profile: { email: 'tester@adobe.com' } } },
+      });
+
+      expect(response.status).to.equal(409);
+      expect(loggerStub.warn).to.have.been.called;
+      expect(loggerStub.error).to.not.have.been.called;
     });
   });
 

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -2166,24 +2166,32 @@ describe('Brands Controller', () => {
   });
 
   describe('createCategoryForOrg', () => {
+    const CATEGORY_ROW = {
+      id: 'cat-uuid',
+      category_id: 'my-category',
+      name: 'My Category',
+      status: 'active',
+      origin: 'human',
+      updated_at: '2026-01-01T00:00:00Z',
+      updated_by: 'user@test.com',
+    };
+
     beforeEach(() => {
+      // Lookup returns null (not found) on first .maybeSingle(), and .single()
+      // (from insert path) resolves the happy-path row. Tests that want the
+      // "existing row" path override maybeSingle to return CATEGORY_ROW.
       mockDataAccess.services.postgrestClient = {
         from: sandbox.stub().callsFake(() => ({
           select: sandbox.stub().returnsThis(),
           eq: sandbox.stub().returnsThis(),
           neq: sandbox.stub().returnsThis(),
           order: sandbox.stub().returnsThis(),
+          insert: sandbox.stub().returnsThis(),
+          update: sandbox.stub().returnsThis(),
           upsert: sandbox.stub().returnsThis(),
+          maybeSingle: sandbox.stub().resolves({ data: null, error: null }),
           single: sandbox.stub().resolves({
-            data: {
-              id: 'cat-uuid',
-              category_id: 'my-category',
-              name: 'My Category',
-              status: 'active',
-              origin: 'human',
-              updated_at: '2026-01-01T00:00:00Z',
-              updated_by: 'user@test.com',
-            },
+            data: CATEGORY_ROW,
             error: null,
           }),
         })),
@@ -2308,23 +2316,27 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(500);
     });
 
-    it('returns 409 when the storage layer throws a duplicate-name error', async () => {
+    it('returns 201 with the existing row when a category with the same name already exists (idempotent)', async () => {
+      const existingRow = {
+        id: 'uuid-existing',
+        category_id: 'baseurl-discovery-research',
+        name: 'Discovery & Research',
+        status: 'active',
+        origin: 'human',
+        updated_at: '2026-03-15T00:00:00Z',
+        updated_by: 'tester@adobe.com',
+      };
       mockDataAccess.services.postgrestClient = {
         from: sandbox.stub().callsFake(() => ({
           select: sandbox.stub().returnsThis(),
           eq: sandbox.stub().returnsThis(),
           neq: sandbox.stub().returnsThis(),
           order: sandbox.stub().returnsThis(),
+          insert: sandbox.stub().returnsThis(),
+          update: sandbox.stub().returnsThis(),
           upsert: sandbox.stub().returnsThis(),
-          single: sandbox.stub().resolves({
-            data: null,
-            error: {
-              code: '23505',
-              message: 'duplicate key value violates unique constraint "uq_category_name_per_org"',
-              details: 'Key (organization_id, name)=(..., DupTest) already exists.',
-              hint: '',
-            },
-          }),
+          maybeSingle: sandbox.stub().resolves({ data: existingRow, error: null }),
+          single: sandbox.stub().resolves({ data: existingRow, error: null }),
         })),
       };
       brandsController = BrandsController(context, loggerStub, mockEnv);
@@ -2332,33 +2344,36 @@ describe('Brands Controller', () => {
       const response = await brandsController.createCategoryForOrg({
         ...context,
         params: { spaceCatId: ORGANIZATION_ID },
-        data: { name: 'DupTest' },
+        // Client posts a drifted slug; the stable `category_id` must be preserved.
+        data: { id: 'discovery-research', name: 'Discovery & Research' },
         dataAccess: mockDataAccess,
         attributes: { authInfo: { profile: { email: 'tester@adobe.com' } } },
       });
 
-      expect(response.status).to.equal(409);
+      expect(response.status).to.equal(201);
       const body = await response.json();
-      expect(body.message).to.match(/already exists/i);
+      expect(body.id).to.equal('baseurl-discovery-research');
+      expect(body.uuid).to.equal('uuid-existing');
     });
 
-    it('returns 500 when the storage layer returns a non-23505 PostgREST error', async () => {
+    it('returns 500 when the lookup-by-name query fails with a non-23505 PostgREST error', async () => {
       mockDataAccess.services.postgrestClient = {
         from: sandbox.stub().callsFake(() => ({
           select: sandbox.stub().returnsThis(),
           eq: sandbox.stub().returnsThis(),
           neq: sandbox.stub().returnsThis(),
           order: sandbox.stub().returnsThis(),
+          insert: sandbox.stub().returnsThis(),
+          update: sandbox.stub().returnsThis(),
           upsert: sandbox.stub().returnsThis(),
-          single: sandbox.stub().resolves({
+          maybeSingle: sandbox.stub().resolves({
             data: null,
             error: {
               code: '23503',
               message: 'insert or update on table "categories" violates foreign key constraint "categories_org_fk"',
-              details: '',
-              hint: '',
             },
           }),
+          single: sandbox.stub().resolves({ data: null, error: null }),
         })),
       };
       brandsController = BrandsController(context, loggerStub, mockEnv);
@@ -2373,7 +2388,7 @@ describe('Brands Controller', () => {
 
       expect(response.status).to.equal(500);
       const body = await response.json();
-      expect(body.message).to.match(/Failed to create category/);
+      expect(body.message).to.match(/Failed to lookup category by name/);
     });
   });
 
@@ -2928,6 +2943,44 @@ describe('Brands Controller', () => {
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(500);
+    });
+
+    it('returns 409 and logs at info (not error) when the storage layer raises a 23505 unique violation', async () => {
+      mockDataAccess.services.postgrestClient = {
+        from: sandbox.stub().callsFake(() => ({
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          neq: sandbox.stub().returnsThis(),
+          order: sandbox.stub().returnsThis(),
+          upsert: sandbox.stub().returnsThis(),
+          single: sandbox.stub().resolves({
+            data: null,
+            error: {
+              code: '23505',
+              message: 'duplicate key value violates unique constraint "uq_topic_per_org"',
+              details: '',
+              hint: '',
+            },
+          }),
+        })),
+      };
+      loggerStub.info.resetHistory();
+      loggerStub.error.resetHistory();
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+
+      const response = await brandsController.createTopicForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'DupTopic' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { profile: { email: 'tester@adobe.com' } } },
+      });
+
+      expect(response.status).to.equal(409);
+      const body = await response.json();
+      expect(body.message).to.match(/already exists/i);
+      expect(loggerStub.info).to.have.been.called;
+      expect(loggerStub.error).to.not.have.been.called;
     });
   });
 

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -2185,6 +2185,7 @@ describe('Brands Controller', () => {
           select: sandbox.stub().returnsThis(),
           eq: sandbox.stub().returnsThis(),
           neq: sandbox.stub().returnsThis(),
+          ilike: sandbox.stub().returnsThis(),
           order: sandbox.stub().returnsThis(),
           insert: sandbox.stub().returnsThis(),
           update: sandbox.stub().returnsThis(),
@@ -2316,7 +2317,7 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(500);
     });
 
-    it('returns 201 with the existing row when a category with the same name already exists (idempotent)', async () => {
+    it('returns 200 with the existing row when a category with the same name already exists (idempotent update)', async () => {
       const existingRow = {
         id: 'uuid-existing',
         category_id: 'baseurl-discovery-research',
@@ -2331,6 +2332,7 @@ describe('Brands Controller', () => {
           select: sandbox.stub().returnsThis(),
           eq: sandbox.stub().returnsThis(),
           neq: sandbox.stub().returnsThis(),
+          ilike: sandbox.stub().returnsThis(),
           order: sandbox.stub().returnsThis(),
           insert: sandbox.stub().returnsThis(),
           update: sandbox.stub().returnsThis(),
@@ -2350,7 +2352,7 @@ describe('Brands Controller', () => {
         attributes: { authInfo: { profile: { email: 'tester@adobe.com' } } },
       });
 
-      expect(response.status).to.equal(201);
+      expect(response.status).to.equal(200);
       const body = await response.json();
       expect(body.id).to.equal('baseurl-discovery-research');
       expect(body.uuid).to.equal('uuid-existing');
@@ -2362,6 +2364,7 @@ describe('Brands Controller', () => {
           select: sandbox.stub().returnsThis(),
           eq: sandbox.stub().returnsThis(),
           neq: sandbox.stub().returnsThis(),
+          ilike: sandbox.stub().returnsThis(),
           order: sandbox.stub().returnsThis(),
           insert: sandbox.stub().returnsThis(),
           update: sandbox.stub().returnsThis(),
@@ -2945,7 +2948,7 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(500);
     });
 
-    it('returns 409 and logs at info (not error) when the storage layer raises a 23505 unique violation', async () => {
+    it('returns 409 and logs at warn (not error) when the storage layer raises a 23505 unique violation', async () => {
       mockDataAccess.services.postgrestClient = {
         from: sandbox.stub().callsFake(() => ({
           select: sandbox.stub().returnsThis(),
@@ -2964,7 +2967,7 @@ describe('Brands Controller', () => {
           }),
         })),
       };
-      loggerStub.info.resetHistory();
+      loggerStub.warn.resetHistory();
       loggerStub.error.resetHistory();
       brandsController = BrandsController(context, loggerStub, mockEnv);
 
@@ -2978,8 +2981,8 @@ describe('Brands Controller', () => {
 
       expect(response.status).to.equal(409);
       const body = await response.json();
-      expect(body.message).to.match(/already exists/i);
-      expect(loggerStub.info).to.have.been.called;
+      expect(body.message).to.include('uq_topic_per_org');
+      expect(loggerStub.warn).to.have.been.called;
       expect(loggerStub.error).to.not.have.been.called;
     });
   });

--- a/test/it/shared/tests/categories-prompts.js
+++ b/test/it/shared/tests/categories-prompts.js
@@ -20,7 +20,10 @@ import { ORG_1_ID, BRAND_1_ID } from '../seed-ids.js';
  * 1. Fallback path: category exists with unprefixed slug, prompt references prefixed slug
  *    — the fallback strips the DRS prefix and resolves to the existing category
  * 2. Fix verification: POST categories with explicit id preserves name, no duplicates
- * 3. Idempotency: duplicate category creation upserts (201), not conflicts (409)
+ * 3. Idempotency: duplicate category creation returns 200 (idempotent update),
+ *    not 201 (insert). See LLMO-4370 — the status-code contract flipped from
+ *    `201|409` (old upsert) to `200|201` (idempotent-by-name), so callers can
+ *    discriminate a fresh row from a re-post without parsing the body.
  *
  * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
  * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
@@ -117,10 +120,10 @@ export default function categoriesPromptsTests(getHttpClient, resetData) {
 
     // ── Idempotency ──
 
-    describe('Category creation with id is idempotent (upsert)', () => {
+    describe('Category creation is idempotent by name (200 on re-post)', () => {
       before(() => resetData());
 
-      it('second POST with same id upserts without error', async () => {
+      it('second POST with the same name returns 200 (idempotent update)', async () => {
         const http = getHttpClient();
 
         const payload = { id: 'baseurl-test', name: 'Test', origin: 'ai' };
@@ -128,11 +131,14 @@ export default function categoriesPromptsTests(getHttpClient, resetData) {
         const res1 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/categories`, payload);
         expect(res1.status).to.equal(201);
 
-        // Second call — the API uses upsert, so same id should succeed
+        // Second call — idempotent by name: the existing row is matched,
+        // no-op short-circuits (identical fields), response is 200. This
+        // lets DRS-class clients discriminate "created new" from "ensured
+        // existing" without parsing the body. LLMO-4370.
         const res2 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/categories`, payload);
-        expect(res2.status).to.equal(201);
+        expect(res2.status).to.equal(200);
 
-        // Verify only one category exists with that id
+        // Only one category exists — no duplicate.
         const listRes = await http.admin.get(`/v2/orgs/${ORG_1_ID}/categories`);
         expect(listRes.status).to.equal(200);
 

--- a/test/support/categories-storage.test.js
+++ b/test/support/categories-storage.test.js
@@ -155,6 +155,89 @@ describe('categories-storage', () => {
       })).to.be.rejectedWith('Category name is required');
     });
 
+    it('rejects names that are only whitespace / zero-width after NFC canonicalization', async () => {
+      const postgrestClient = { from: () => { } };
+      await expect(createCategory({
+        organizationId: ORG_ID, category: { name: '   ' }, postgrestClient,
+      })).to.be.rejectedWith('Category name is required');
+    });
+
+    it('canonicalizes the stored name (trim, whitespace-collapse, NFC) and finds case-variants as existing', async () => {
+      // Existing row uses the canonical form; client POSTs a messy variant
+      // with leading/trailing whitespace, internal double-spaces, and a
+      // different case. Storage must match it as the same category.
+      const existingRow = {
+        id: 'uuid-canon',
+        category_id: 'discovery-research',
+        name: 'Discovery & Research',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-02-01',
+        created_by: 'first@test.com',
+        updated_at: '2026-02-01',
+        updated_by: 'first@test.com',
+      };
+
+      const postgrestClient = createSequentialClient([
+        { data: existingRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { name: '  discovery  &  research  ' },
+        postgrestClient,
+        updatedBy: 'repost@test.com',
+      });
+
+      // Matched existing row (case-insensitive ilike lookup); no-op
+      // short-circuit preserves audit trail.
+      expect(result.created).to.be.false;
+      expect(result.category.uuid).to.equal('uuid-canon');
+    });
+
+    it('stores the canonical form on insert (not the client-posted whitespace)', async () => {
+      const capturedInsert = { row: null };
+      const postgrestClient = {
+        from: sinon.stub().callsFake(() => ({
+          select: sinon.stub().returnsThis(),
+          eq: sinon.stub().returnsThis(),
+          ilike: sinon.stub().returnsThis(),
+          maybeSingle: sinon.stub().resolves({ data: null, error: null }),
+          insert: sinon.stub().callsFake((row) => {
+            capturedInsert.row = row;
+            return {
+              select: () => ({
+                single: () => Promise.resolve({
+                  data: {
+                    id: 'uuid-new',
+                    category_id: row.category_id,
+                    name: row.name,
+                    status: row.status,
+                    origin: row.origin,
+                    created_at: '2026-04-20',
+                    created_by: 'user@test.com',
+                    updated_at: '2026-04-20',
+                    updated_by: row.updated_by,
+                  },
+                  error: null,
+                }),
+              }),
+            };
+          }),
+        })),
+      };
+
+      await createCategory({
+        organizationId: ORG_ID,
+        category: { name: '  Edge   Case  ' },
+        postgrestClient,
+      });
+
+      expect(capturedInsert.row.name).to.equal('Edge Case');
+      // Slug is derived from the canonical name too.
+      expect(capturedInsert.row.category_id).to.equal('edge-case');
+    });
+
     it('inserts a new category when no row matches by name', async () => {
       const insertedRow = {
         id: 'uuid-new',
@@ -182,12 +265,13 @@ describe('categories-storage', () => {
         updatedBy: 'user@test.com',
       });
 
-      expect(result.id).to.equal('my-new-category');
-      expect(result.name).to.equal('My New Category');
-      expect(result.createdAt).to.equal('2026-03-01T00:00:00Z');
+      expect(result.created).to.be.true;
+      expect(result.category.id).to.equal('my-new-category');
+      expect(result.category.name).to.equal('My New Category');
+      expect(result.category.createdAt).to.equal('2026-03-01T00:00:00Z');
     });
 
-    it('returns the existing row (idempotent) when a category with the same name exists', async () => {
+    it('short-circuits (no write) when an existing row already matches — preserves audit trail', async () => {
       const existingRow = {
         id: 'uuid-existing',
         category_id: 'baseurl-discovery-research',
@@ -199,30 +283,29 @@ describe('categories-storage', () => {
         updated_at: '2026-02-01T00:00:00Z',
         updated_by: 'first@test.com',
       };
-      const updatedRow = {
-        ...existingRow,
-        updated_at: '2026-03-15T00:00:00Z',
-        updated_by: 'second@test.com',
-      };
 
       const postgrestClient = createSequentialClient([
         // lookup — existing row found
         { data: existingRow, error: null },
-        // update — success, stable category_id preserved
-        { data: updatedRow, error: null },
+        // NO second round-trip expected; if createCategory tries one this
+        // will resolve the same stub and the test would still pass, but the
+        // from-call count assertion below guards against that.
       ]);
 
       const result = await createCategory({
         organizationId: ORG_ID,
-        // client ships a drifted slug; storage must NOT overwrite category_id
+        // client ships a drifted slug with no field diffs; should be a no-op
         category: { id: 'discovery-research', name: 'Discovery & Research' },
         postgrestClient,
         updatedBy: 'second@test.com',
       });
 
-      expect(result.uuid).to.equal('uuid-existing');
-      expect(result.id).to.equal('baseurl-discovery-research');
-      expect(result.updatedBy).to.equal('second@test.com');
+      expect(result.created).to.be.false;
+      expect(result.category.uuid).to.equal('uuid-existing');
+      expect(result.category.id).to.equal('baseurl-discovery-research');
+      // Audit fields preserved — no UPDATE fired.
+      expect(result.category.updatedBy).to.equal('first@test.com');
+      expect(postgrestClient.from).to.have.been.calledOnce;
     });
 
     it('updates non-key fields (origin, status) when client supplies new values', async () => {
@@ -257,9 +340,10 @@ describe('categories-storage', () => {
         updatedBy: 'editor@test.com',
       });
 
-      expect(result.status).to.equal('active');
-      expect(result.origin).to.equal('human');
-      expect(result.updatedBy).to.equal('editor@test.com');
+      expect(result.created).to.be.false;
+      expect(result.category.status).to.equal('active');
+      expect(result.category.origin).to.equal('human');
+      expect(result.category.updatedBy).to.equal('editor@test.com');
     });
 
     it('rethrows when the lookup-by-name query fails', async () => {
@@ -334,8 +418,9 @@ describe('categories-storage', () => {
         updatedBy: 'loser@test.com',
       });
 
-      expect(result.uuid).to.equal('uuid-raced');
-      expect(result.id).to.equal('concurrent');
+      expect(result.created).to.be.false;
+      expect(result.category.uuid).to.equal('uuid-raced');
+      expect(result.category.id).to.equal('concurrent');
     });
 
     it('throws the original create error when a 23505 fires without matching the name-unique constraint', async () => {
@@ -406,16 +491,189 @@ describe('categories-storage', () => {
         updated_by: 'system',
       };
 
+      const dbError = { message: 'update blew up' };
       const postgrestClient = createSequentialClient([
         { data: existingRow, error: null },
-        { data: null, error: { message: 'update blew up' } },
+        { data: null, error: dbError },
       ]);
 
-      await expect(createCategory({
+      const err = await createCategory({
         organizationId: ORG_ID,
-        category: { name: 'ErrTest' },
+        // supply a differing status to force the update path (not no-op)
+        category: { name: 'ErrTest', status: 'pending' },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to update existing category: update blew up');
+      }).catch((e) => e);
+
+      expect(err.message).to.equal('Failed to update existing category: update blew up');
+      // Error.cause preserves the original PostgREST error for diagnostics.
+      expect(err.cause).to.equal(dbError);
+    });
+
+    it('throws a typed 409 when the row is hard-deleted between lookup and update', async () => {
+      const existingRow = {
+        id: 'uuid-vanishing',
+        category_id: 'vanishing',
+        name: 'Vanishing',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-01-01',
+        created_by: 'system',
+        updated_at: '2026-01-01',
+        updated_by: 'system',
+      };
+
+      const postgrestClient = createSequentialClient([
+        // lookup finds the row
+        { data: existingRow, error: null },
+        // update returns zero rows — row was hard-deleted concurrently
+        { data: null, error: null },
+      ]);
+
+      const err = await createCategory({
+        organizationId: ORG_ID,
+        // differing status forces the update path
+        category: { name: 'Vanishing', status: 'pending' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err).to.be.instanceOf(Error);
+      expect(err.status).to.equal(409);
+      expect(err.message).to.match(/concurrently modified/i);
+    });
+
+    it('preserves the original 23505 error when the retry lookup itself fails', async () => {
+      const insertError = {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint "uq_category_name_per_org"',
+      };
+      const postgrestClient = createSequentialClient([
+        // first lookup — nothing yet
+        { data: null, error: null },
+        // insert — 23505 race
+        { data: null, error: insertError },
+        // retry lookup — itself fails (transient connection issue)
+        { data: null, error: { message: 'connection reset' } },
+      ]);
+
+      const err = await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'FlakyRace' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      // Original 23505 surfaces as the primary cause, not the secondary
+      // lookup failure — the 23505 is the more diagnostic signal.
+      expect(err.message).to.include('uq_category_name_per_org');
+      expect(err.cause).to.equal(insertError);
+    });
+
+    it('resurrects a soft-deleted row with the same name (created=true)', async () => {
+      const deletedRow = {
+        id: 'uuid-deleted',
+        category_id: 'legacy-slug',
+        name: 'Taxonomy',
+        status: 'deleted',
+        origin: 'human',
+        created_at: '2026-01-01',
+        created_by: 'curator@test.com',
+        updated_at: '2026-02-01',
+        updated_by: 'curator@test.com',
+      };
+      const resurrectedRow = {
+        ...deletedRow,
+        status: 'active',
+        updated_at: '2026-04-20T00:00:00Z',
+        updated_by: 'recreator@test.com',
+      };
+
+      const postgrestClient = createSequentialClient([
+        { data: deletedRow, error: null },
+        { data: resurrectedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Taxonomy' },
+        postgrestClient,
+        updatedBy: 'recreator@test.com',
+      });
+
+      // Client-visible: the resource reappears -> created:true -> 201.
+      expect(result.created).to.be.true;
+      expect(result.category.uuid).to.equal('uuid-deleted');
+      expect(result.category.status).to.equal('active');
+      expect(result.category.id).to.equal('legacy-slug');
+    });
+
+    it('does NOT downgrade origin from human to ai on an idempotent re-POST', async () => {
+      const humanRow = {
+        id: 'uuid-human',
+        category_id: 'curated',
+        name: 'Curated',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-01-01',
+        created_by: 'curator@test.com',
+        updated_at: '2026-02-01',
+        updated_by: 'curator@test.com',
+      };
+
+      const postgrestClient = createSequentialClient([
+        { data: humanRow, error: null },
+        // If storage erroneously tries to update, this stub resolves with an
+        // origin='ai' row — the assertion below would then fail.
+        { data: { ...humanRow, origin: 'ai', updated_by: 'drs' }, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        // DRS asserts origin:'ai' on a category a human already curated
+        category: { name: 'Curated', origin: 'ai' },
+        postgrestClient,
+        updatedBy: 'drs',
+      });
+
+      expect(result.created).to.be.false;
+      expect(result.category.origin).to.equal('human');
+      expect(result.category.updatedBy).to.equal('curator@test.com');
+      // No update round-trip fires for a pure provenance-downgrade attempt.
+      expect(postgrestClient.from).to.have.been.calledOnce;
+    });
+
+    it('does allow origin upgrade from ai to human', async () => {
+      const aiRow = {
+        id: 'uuid-ai',
+        category_id: 'auto-discovered',
+        name: 'Auto-Discovered',
+        status: 'active',
+        origin: 'ai',
+        created_at: '2026-01-01',
+        created_by: 'system',
+        updated_at: '2026-01-01',
+        updated_by: 'system',
+      };
+      const upgradedRow = {
+        ...aiRow,
+        origin: 'human',
+        updated_by: 'curator@test.com',
+        updated_at: '2026-04-20',
+      };
+
+      const postgrestClient = createSequentialClient([
+        { data: aiRow, error: null },
+        { data: upgradedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Auto-Discovered', origin: 'human' },
+        postgrestClient,
+        updatedBy: 'curator@test.com',
+      });
+
+      expect(result.created).to.be.false;
+      expect(result.category.origin).to.equal('human');
+      expect(result.category.updatedBy).to.equal('curator@test.com');
     });
   });
 

--- a/test/support/categories-storage.test.js
+++ b/test/support/categories-storage.test.js
@@ -34,6 +34,19 @@ function createChainableQuery(resolveWith = { data: [], error: null }) {
   return new Proxy({}, handler);
 }
 
+// Sequential client: each call to `.from()` returns the next chainable
+// query with its own resolved response, so a test can simulate distinct
+// lookup / insert / update round-trips.
+function createSequentialClient(responses) {
+  let i = 0;
+  const from = sinon.stub().callsFake(() => {
+    const resp = responses[i] || responses[responses.length - 1];
+    i += 1;
+    return createChainableQuery(resp);
+  });
+  return { from };
+}
+
 describe('categories-storage', () => {
   const ORG_ID = '11111111-1111-4111-8111-111111111111';
 
@@ -142,8 +155,8 @@ describe('categories-storage', () => {
       })).to.be.rejectedWith('Category name is required');
     });
 
-    it('creates a category and returns mapped result', async () => {
-      const dbRow = {
+    it('inserts a new category when no row matches by name', async () => {
+      const insertedRow = {
         id: 'uuid-new',
         category_id: 'my-new-category',
         name: 'My New Category',
@@ -155,8 +168,12 @@ describe('categories-storage', () => {
         updated_by: 'user@test.com',
       };
 
-      const query = createChainableQuery({ data: dbRow, error: null });
-      const postgrestClient = { from: sinon.stub().returns(query) };
+      const postgrestClient = createSequentialClient([
+        // lookup — not found
+        { data: null, error: null },
+        // insert — success
+        { data: insertedRow, error: null },
+      ]);
 
       const result = await createCategory({
         organizationId: ORG_ID,
@@ -168,71 +185,237 @@ describe('categories-storage', () => {
       expect(result.id).to.equal('my-new-category');
       expect(result.name).to.equal('My New Category');
       expect(result.createdAt).to.equal('2026-03-01T00:00:00Z');
-      expect(result.createdBy).to.equal('user@test.com');
     });
 
-    it('throws on database error during create', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'unique violation' } });
-      const postgrestClient = { from: sinon.stub().returns(query) };
+    it('returns the existing row (idempotent) when a category with the same name exists', async () => {
+      const existingRow = {
+        id: 'uuid-existing',
+        category_id: 'baseurl-discovery-research',
+        name: 'Discovery & Research',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-02-01T00:00:00Z',
+        created_by: 'first@test.com',
+        updated_at: '2026-02-01T00:00:00Z',
+        updated_by: 'first@test.com',
+      };
+      const updatedRow = {
+        ...existingRow,
+        updated_at: '2026-03-15T00:00:00Z',
+        updated_by: 'second@test.com',
+      };
+
+      const postgrestClient = createSequentialClient([
+        // lookup — existing row found
+        { data: existingRow, error: null },
+        // update — success, stable category_id preserved
+        { data: updatedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        // client ships a drifted slug; storage must NOT overwrite category_id
+        category: { id: 'discovery-research', name: 'Discovery & Research' },
+        postgrestClient,
+        updatedBy: 'second@test.com',
+      });
+
+      expect(result.uuid).to.equal('uuid-existing');
+      expect(result.id).to.equal('baseurl-discovery-research');
+      expect(result.updatedBy).to.equal('second@test.com');
+    });
+
+    it('updates non-key fields (origin, status) when client supplies new values', async () => {
+      const existingRow = {
+        id: 'uuid-upd',
+        category_id: 'taxonomy',
+        name: 'Taxonomy',
+        status: 'pending',
+        origin: 'ai',
+        created_at: '2026-02-01',
+        created_by: 'system',
+        updated_at: '2026-02-01',
+        updated_by: 'system',
+      };
+      const updatedRow = {
+        ...existingRow,
+        status: 'active',
+        origin: 'human',
+        updated_at: '2026-03-20',
+        updated_by: 'editor@test.com',
+      };
+
+      const postgrestClient = createSequentialClient([
+        { data: existingRow, error: null },
+        { data: updatedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Taxonomy', origin: 'human', status: 'active' },
+        postgrestClient,
+        updatedBy: 'editor@test.com',
+      });
+
+      expect(result.status).to.equal('active');
+      expect(result.origin).to.equal('human');
+      expect(result.updatedBy).to.equal('editor@test.com');
+    });
+
+    it('rethrows when the lookup-by-name query fails', async () => {
+      const postgrestClient = createSequentialClient([
+        { data: null, error: { message: 'connection refused' } },
+      ]);
 
       await expect(createCategory({
         organizationId: ORG_ID,
-        category: { name: 'Duplicate Category' },
+        category: { name: 'Lookup Fail' },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to create category: unique violation');
+      })).to.be.rejectedWith('Failed to lookup category by name: connection refused');
     });
 
-    it('throws a 409-typed error when the DB returns uq_category_name_per_org violation', async () => {
-      const postgrestClient = {
-        from: sinon.stub().returns(createChainableQuery({
+    it('rethrows when the insert hits a non-uniqueness database error', async () => {
+      const postgrestClient = createSequentialClient([
+        // lookup — not found
+        { data: null, error: null },
+        // insert — unrelated FK violation
+        {
+          data: null,
+          error: { code: '23503', message: 'foreign key violation' },
+        },
+      ]);
+
+      await expect(createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Bad Insert' },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to create category: foreign key violation');
+    });
+
+    it('recovers idempotently when a concurrent insert wins the 23505 race', async () => {
+      const racedRow = {
+        id: 'uuid-raced',
+        category_id: 'concurrent',
+        name: 'Concurrent',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-04-01',
+        created_by: 'racer@test.com',
+        updated_at: '2026-04-01',
+        updated_by: 'racer@test.com',
+      };
+      const updatedRow = {
+        ...racedRow,
+        updated_by: 'loser@test.com',
+        updated_at: '2026-04-01T00:00:01Z',
+      };
+
+      const postgrestClient = createSequentialClient([
+        // first lookup — nothing yet
+        { data: null, error: null },
+        // insert — loses race, uq_category_name_per_org fires
+        {
           data: null,
           error: {
             code: '23505',
             message: 'duplicate key value violates unique constraint "uq_category_name_per_org"',
-            details: 'Key (organization_id, name)=(00000000-..., DupTest) already exists.',
-            hint: '',
           },
-        })),
-      };
+        },
+        // second lookup — finds the winning row
+        { data: racedRow, error: null },
+        // update — applies our non-key fields
+        { data: updatedRow, error: null },
+      ]);
 
-      const err = await createCategory({
+      const result = await createCategory({
         organizationId: ORG_ID,
-        category: { name: 'DupTest' },
+        category: { name: 'Concurrent' },
         postgrestClient,
-        updatedBy: 'test',
-      }).catch((e) => e);
+        updatedBy: 'loser@test.com',
+      });
 
-      expect(err).to.be.instanceOf(Error);
-      expect(err.status).to.equal(409);
-      expect(err.message).to.match(/already exists/i);
-      expect(err.message).to.include('DupTest');
+      expect(result.uuid).to.equal('uuid-raced');
+      expect(result.id).to.equal('concurrent');
     });
 
-    it('throws a generic error when 23505 is raised without a matching constraint message', async () => {
-      const postgrestClient = {
-        from: sinon.stub().returns(createChainableQuery({
+    it('throws the original create error when a 23505 fires without matching the name-unique constraint', async () => {
+      const postgrestClient = createSequentialClient([
+        { data: null, error: null },
+        {
           data: null,
           error: {
             code: '23505',
-            // message intentionally omitted to cover the `error.message || ''` fallback
-            // while keeping the regex match path false
-            details: '',
-            hint: '',
+            message: 'duplicate key value violates unique constraint "some_other_constraint"',
           },
-        })),
+        },
+      ]);
+
+      await expect(createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Weird' },
+        postgrestClient,
+      })).to.be.rejectedWith(/Failed to create category/);
+    });
+
+    it('falls back to the empty-string regex test when a 23505 error has no message', async () => {
+      const postgrestClient = createSequentialClient([
+        { data: null, error: null },
+        {
+          data: null,
+          error: { code: '23505' }, // message intentionally omitted
+        },
+      ]);
+
+      await expect(createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'NoMsg' },
+        postgrestClient,
+      })).to.be.rejectedWith(/Failed to create category/);
+    });
+
+    it('throws when the retry lookup after a 23505 race still finds nothing', async () => {
+      const postgrestClient = createSequentialClient([
+        { data: null, error: null },
+        {
+          data: null,
+          error: {
+            code: '23505',
+            message: 'duplicate key value violates unique constraint "uq_category_name_per_org"',
+          },
+        },
+        { data: null, error: null },
+      ]);
+
+      await expect(createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Lost Race' },
+        postgrestClient,
+      })).to.be.rejectedWith(/Failed to create category/);
+    });
+
+    it('rethrows when the update path hits a database error', async () => {
+      const existingRow = {
+        id: 'uuid-err',
+        category_id: 'errtest',
+        name: 'ErrTest',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-01-01',
+        created_by: 'system',
+        updated_at: '2026-01-01',
+        updated_by: 'system',
       };
 
-      const err = await createCategory({
-        organizationId: ORG_ID,
-        category: { name: 'OtherDup' },
-        postgrestClient,
-        updatedBy: 'test',
-      }).catch((e) => e);
+      const postgrestClient = createSequentialClient([
+        { data: existingRow, error: null },
+        { data: null, error: { message: 'update blew up' } },
+      ]);
 
-      expect(err).to.be.instanceOf(Error);
-      expect(err.status).to.be.undefined;
-      expect(err.message).to.match(/^Failed to create category:/);
-      expect(err.message).to.not.match(/already exists/i);
+      await expect(createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'ErrTest' },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to update existing category: update blew up');
     });
   });
 

--- a/test/support/categories-storage.test.js
+++ b/test/support/categories-storage.test.js
@@ -16,7 +16,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import {
-  listCategories, createCategory, updateCategory, deleteCategory,
+  listCategories, createCategory, updateCategory, deleteCategory, escapeIlike,
 } from '../../src/support/categories-storage.js';
 
 use(sinonChai);
@@ -134,11 +134,32 @@ describe('categories-storage', () => {
     });
 
     it('throws on database error', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'DB error' } });
+      const dbError = { message: 'DB error' };
+      const query = createChainableQuery({ data: null, error: dbError });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
-      await expect(listCategories({ organizationId: ORG_ID, postgrestClient }))
-        .to.be.rejectedWith('Failed to list categories');
+      const err = await listCategories({ organizationId: ORG_ID, postgrestClient }).catch((e) => e);
+      expect(err.message).to.include('Failed to list categories');
+      // Error.cause preserves the original PostgREST error for diagnostics.
+      expect(err.cause).to.equal(dbError);
+    });
+  });
+
+  describe('escapeIlike', () => {
+    // Regression guard: a future refactor that drops the `.replace` would
+    // otherwise silently re-enable PostgREST ILIKE pattern injection —
+    // `%` and `_` would become wildcards and match rows they shouldn't.
+    it('escapes percent, underscore, and backslash literals', () => {
+      expect(escapeIlike('50% Off')).to.equal('50\\% Off');
+      expect(escapeIlike('foo_bar')).to.equal('foo\\_bar');
+      expect(escapeIlike('with\\backslash')).to.equal('with\\\\backslash');
+      // Compound: all three literals in one string.
+      expect(escapeIlike('a%b_c\\d')).to.equal('a\\%b\\_c\\\\d');
+    });
+
+    it('leaves regular strings untouched', () => {
+      expect(escapeIlike('Discovery & Research')).to.equal('Discovery & Research');
+      expect(escapeIlike('')).to.equal('');
     });
   });
 
@@ -155,11 +176,64 @@ describe('categories-storage', () => {
       })).to.be.rejectedWith('Category name is required');
     });
 
-    it('rejects names that are only whitespace / zero-width after NFC canonicalization', async () => {
+    it('rejects names that are only whitespace after canonicalization', async () => {
       const postgrestClient = { from: () => { } };
       await expect(createCategory({
         organizationId: ORG_ID, category: { name: '   ' }, postgrestClient,
       })).to.be.rejectedWith('Category name is required');
+    });
+
+    it('strips zero-width / BOM characters before validation (U+200B/C/D and U+FEFF)', async () => {
+      const postgrestClient = { from: () => { } };
+      // trim() does NOT remove these — without the explicit strip they
+      // would slip past hasText() and produce an invisible row.
+      await expect(createCategory({
+        organizationId: ORG_ID, category: { name: '\u200B\u200C\u200D\uFEFF' }, postgrestClient,
+      })).to.be.rejectedWith('Category name is required');
+    });
+
+    it('rejects names that canonicalize to a degenerate slug when no id is supplied', async () => {
+      // Non-ASCII-only names collapse to a bare "-" via the slug derivation
+      // `replace(/[^a-z0-9]+/g, '-')`. Rejecting at the API boundary keeps
+      // such rows from landing with meaningless FKs. Caller can opt out
+      // by supplying an explicit `id`.
+      const postgrestClient = createSequentialClient([
+        { data: null, error: null },
+      ]);
+      await expect(createCategory({
+        organizationId: ORG_ID,
+        category: { name: '日本語' },
+        postgrestClient,
+      })).to.be.rejectedWith(/empty slug/);
+    });
+
+    it('accepts non-ASCII names when the client supplies an explicit slug', async () => {
+      const insertedRow = {
+        id: 'uuid-jp',
+        category_id: 'japanese-cat',
+        name: '日本語',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-04-20',
+        created_by: 'user@test.com',
+        updated_at: '2026-04-20',
+        updated_by: 'user@test.com',
+      };
+      const postgrestClient = createSequentialClient([
+        { data: null, error: null },
+        { data: insertedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { id: 'japanese-cat', name: '日本語' },
+        postgrestClient,
+        updatedBy: 'user@test.com',
+      });
+
+      expect(result.created).to.be.true;
+      expect(result.outcome).to.equal('insert');
+      expect(result.category.id).to.equal('japanese-cat');
     });
 
     it('canonicalizes the stored name (trim, whitespace-collapse, NFC) and finds case-variants as existing', async () => {
@@ -266,6 +340,7 @@ describe('categories-storage', () => {
       });
 
       expect(result.created).to.be.true;
+      expect(result.outcome).to.equal('insert');
       expect(result.category.id).to.equal('my-new-category');
       expect(result.category.name).to.equal('My New Category');
       expect(result.category.createdAt).to.equal('2026-03-01T00:00:00Z');
@@ -301,6 +376,7 @@ describe('categories-storage', () => {
       });
 
       expect(result.created).to.be.false;
+      expect(result.outcome).to.equal('noop');
       expect(result.category.uuid).to.equal('uuid-existing');
       expect(result.category.id).to.equal('baseurl-discovery-research');
       // Audit fields preserved — no UPDATE fired.
@@ -341,39 +417,100 @@ describe('categories-storage', () => {
       });
 
       expect(result.created).to.be.false;
+      expect(result.outcome).to.equal('update');
       expect(result.category.status).to.equal('active');
       expect(result.category.origin).to.equal('human');
       expect(result.category.updatedBy).to.equal('editor@test.com');
     });
 
+    it('captures the exact patch sent to .update() on an idempotent update', async () => {
+      // Regression guard: if buildCategoryPatch ever leaks an unintended
+      // field (e.g. `name`) into the update path, this capture-and-assert
+      // pattern catches it. LLMO-4370 #12.
+      const existingRow = {
+        id: 'uuid-patch',
+        category_id: 'patchable',
+        name: 'Patchable',
+        status: 'pending',
+        origin: 'ai',
+        created_at: '2026-01-01',
+        created_by: 'system',
+        updated_at: '2026-01-01',
+        updated_by: 'system',
+      };
+      const capturedUpdate = { row: null };
+      const postgrestClient = {
+        from: sinon.stub().callsFake(() => ({
+          select: sinon.stub().returnsThis(),
+          eq: sinon.stub().returnsThis(),
+          ilike: sinon.stub().returnsThis(),
+          neq: sinon.stub().returnsThis(),
+          order: sinon.stub().returnsThis(),
+          maybeSingle: sinon.stub().resolves({ data: existingRow, error: null }),
+          update: sinon.stub().callsFake((row) => {
+            capturedUpdate.row = row;
+            return {
+              eq: sinon.stub().returnsThis(),
+              select: () => ({
+                maybeSingle: () => Promise.resolve({
+                  data: {
+                    ...existingRow, status: 'active', origin: 'human', updated_by: 'editor@test.com',
+                  },
+                  error: null,
+                }),
+              }),
+            };
+          }),
+        })),
+      };
+
+      await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Patchable', origin: 'human', status: 'active' },
+        postgrestClient,
+        updatedBy: 'editor@test.com',
+      });
+
+      // Only non-key fields flow into the update; `name` is never patched
+      // (lookup canonicalized match guarantees identity).
+      expect(capturedUpdate.row).to.have.property('status', 'active');
+      expect(capturedUpdate.row).to.have.property('origin', 'human');
+      expect(capturedUpdate.row).to.have.property('updated_by', 'editor@test.com');
+      expect(capturedUpdate.row).to.not.have.property('name');
+      expect(capturedUpdate.row).to.not.have.property('category_id');
+    });
+
     it('rethrows when the lookup-by-name query fails', async () => {
+      const lookupError = { message: 'connection refused' };
       const postgrestClient = createSequentialClient([
-        { data: null, error: { message: 'connection refused' } },
+        { data: null, error: lookupError },
       ]);
 
-      await expect(createCategory({
+      const err = await createCategory({
         organizationId: ORG_ID,
         category: { name: 'Lookup Fail' },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to lookup category by name: connection refused');
+      }).catch((e) => e);
+      expect(err.message).to.include('Failed to lookup category by name: connection refused');
+      expect(err.cause).to.equal(lookupError);
     });
 
     it('rethrows when the insert hits a non-uniqueness database error', async () => {
+      const fkError = { code: '23503', message: 'foreign key violation' };
       const postgrestClient = createSequentialClient([
         // lookup — not found
         { data: null, error: null },
         // insert — unrelated FK violation
-        {
-          data: null,
-          error: { code: '23503', message: 'foreign key violation' },
-        },
+        { data: null, error: fkError },
       ]);
 
-      await expect(createCategory({
+      const err = await createCategory({
         organizationId: ORG_ID,
         category: { name: 'Bad Insert' },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to create category: foreign key violation');
+      }).catch((e) => e);
+      expect(err.message).to.include('Failed to create category: foreign key violation');
+      expect(err.cause).to.equal(fkError);
     });
 
     it('recovers idempotently when a concurrent insert wins the 23505 race', async () => {
@@ -419,43 +556,94 @@ describe('categories-storage', () => {
       });
 
       expect(result.created).to.be.false;
+      expect(result.outcome).to.equal('race_retry_noop');
       expect(result.category.uuid).to.equal('uuid-raced');
       expect(result.category.id).to.equal('concurrent');
     });
 
-    it('throws the original create error when a 23505 fires without matching the name-unique constraint', async () => {
+    it('marks the race-recovery path outcome as race_retry when a patch actually applies', async () => {
+      // Same 23505 race, but this time the losing writer has fresh
+      // non-key fields to apply (status change), so the race-recovery
+      // resolve path takes the update branch, not the no-op.
+      const racedRow = {
+        id: 'uuid-raced-patch',
+        category_id: 'rpatch',
+        name: 'RacePatch',
+        status: 'pending',
+        origin: 'human',
+        created_at: '2026-04-01',
+        created_by: 'racer@test.com',
+        updated_at: '2026-04-01',
+        updated_by: 'racer@test.com',
+      };
+      const updatedRow = {
+        ...racedRow, status: 'active', updated_at: '2026-04-01T00:00:01Z', updated_by: 'loser@test.com',
+      };
       const postgrestClient = createSequentialClient([
         { data: null, error: null },
         {
           data: null,
           error: {
             code: '23505',
-            message: 'duplicate key value violates unique constraint "some_other_constraint"',
+            message: 'duplicate key value violates unique constraint "uq_category_name_per_org"',
           },
         },
+        { data: racedRow, error: null },
+        { data: updatedRow, error: null },
       ]);
 
-      await expect(createCategory({
+      const result = await createCategory({
         organizationId: ORG_ID,
-        category: { name: 'Weird' },
+        category: { name: 'RacePatch', status: 'active' },
         postgrestClient,
-      })).to.be.rejectedWith(/Failed to create category/);
+        updatedBy: 'loser@test.com',
+      });
+
+      expect(result.outcome).to.equal('race_retry');
+      expect(result.category.status).to.equal('active');
     });
 
-    it('falls back to the empty-string regex test when a 23505 error has no message', async () => {
+    it('surfaces a typed 409 when a 23505 fires against a non-name constraint (slug collision)', async () => {
+      // Scenario: client POSTs {id: 'foo', name: 'NewName'}. Lookup by
+      // 'NewName' finds nothing. INSERT trips `uq_category_id_per_org`
+      // because slug `foo` is already occupied by a different row with a
+      // different name. Mirror the topics pattern — surface as a typed
+      // 409 with constraint echo so callers don't see a generic 500 on
+      // what is really a constraint conflict. LLMO-4370 #5/#6.
+      const insertError = {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint "uq_category_id_per_org"',
+      };
       const postgrestClient = createSequentialClient([
         { data: null, error: null },
-        {
-          data: null,
-          error: { code: '23505' }, // message intentionally omitted
-        },
+        { data: null, error: insertError },
       ]);
 
-      await expect(createCategory({
+      const err = await createCategory({
+        organizationId: ORG_ID,
+        category: { id: 'foo', name: 'NewName' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.message).to.include('uq_category_id_per_org');
+      expect(err.cause).to.equal(insertError);
+    });
+
+    it('surfaces a generic-constraint 409 when a 23505 has no quoted constraint name', async () => {
+      const postgrestClient = createSequentialClient([
+        { data: null, error: null },
+        { data: null, error: { code: '23505' } }, // no message — generic fallback
+      ]);
+
+      const err = await createCategory({
         organizationId: ORG_ID,
         category: { name: 'NoMsg' },
         postgrestClient,
-      })).to.be.rejectedWith(/Failed to create category/);
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.message).to.match(/unique constraint/i);
     });
 
     it('throws when the retry lookup after a 23505 race still finds nothing', async () => {
@@ -600,9 +788,115 @@ describe('categories-storage', () => {
 
       // Client-visible: the resource reappears -> created:true -> 201.
       expect(result.created).to.be.true;
+      expect(result.outcome).to.equal('resurrect');
       expect(result.category.uuid).to.equal('uuid-deleted');
       expect(result.category.status).to.equal('active');
       expect(result.category.id).to.equal('legacy-slug');
+    });
+
+    // Resurrection × provenance matrix — LLMO-4370 #10.
+    it('resurrects a soft-deleted human-origin row on ai POST WITHOUT downgrading origin', async () => {
+      const deletedHuman = {
+        id: 'uuid-dh',
+        category_id: 'curated-legacy',
+        name: 'Curated',
+        status: 'deleted',
+        origin: 'human',
+        created_at: '2026-01-01',
+        created_by: 'curator@test.com',
+        updated_at: '2026-02-01',
+        updated_by: 'curator@test.com',
+      };
+      const resurrectedRow = {
+        ...deletedHuman, status: 'active', updated_by: 'drs', updated_at: '2026-04-20',
+      };
+      const postgrestClient = createSequentialClient([
+        { data: deletedHuman, error: null },
+        { data: resurrectedRow, error: null },
+      ]);
+      const log = { warn: sinon.stub() };
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Curated', origin: 'ai' },
+        postgrestClient,
+        updatedBy: 'drs',
+        log,
+      });
+
+      expect(result.created).to.be.true;
+      expect(result.outcome).to.equal('resurrect');
+      expect(result.category.origin).to.equal('human');
+      // Downgrade attempt is surfaced to operators so misconfigured DRS
+      // taxonomies are findable in Coralogix.
+      expect(log.warn).to.have.been.calledOnce;
+      expect(log.warn.firstCall.args[0]).to.match(/downgrade/i);
+    });
+
+    it('resurrects a soft-deleted ai-origin row on human POST AND upgrades origin', async () => {
+      const deletedAi = {
+        id: 'uuid-da',
+        category_id: 'auto-legacy',
+        name: 'Auto-Legacy',
+        status: 'deleted',
+        origin: 'ai',
+        created_at: '2026-01-01',
+        created_by: 'system',
+        updated_at: '2026-01-01',
+        updated_by: 'system',
+      };
+      const resurrectedRow = {
+        ...deletedAi, status: 'active', origin: 'human', updated_by: 'curator@test.com', updated_at: '2026-04-20',
+      };
+      const postgrestClient = createSequentialClient([
+        { data: deletedAi, error: null },
+        { data: resurrectedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'Auto-Legacy', origin: 'human' },
+        postgrestClient,
+        updatedBy: 'curator@test.com',
+      });
+
+      expect(result.created).to.be.true;
+      expect(result.outcome).to.equal('resurrect');
+      expect(result.category.origin).to.equal('human');
+    });
+
+    it('resurrects a soft-deleted row on a POST without an origin field — preserves existing origin', async () => {
+      const deletedHuman = {
+        id: 'uuid-dnone',
+        category_id: 'noorigin',
+        name: 'NoOrigin',
+        status: 'deleted',
+        origin: 'human',
+        created_at: '2026-01-01',
+        created_by: 'curator@test.com',
+        updated_at: '2026-02-01',
+        updated_by: 'curator@test.com',
+      };
+      const resurrectedRow = {
+        ...deletedHuman, status: 'active', updated_by: 'recreator@test.com', updated_at: '2026-04-20',
+      };
+      const postgrestClient = createSequentialClient([
+        { data: deletedHuman, error: null },
+        { data: resurrectedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        // No `origin` field — client didn't assert a provenance opinion.
+        category: { name: 'NoOrigin' },
+        postgrestClient,
+        updatedBy: 'recreator@test.com',
+      });
+
+      expect(result.created).to.be.true;
+      expect(result.outcome).to.equal('resurrect');
+      // Existing origin preserved unchanged.
+      expect(result.category.origin).to.equal('human');
     });
 
     it('does NOT downgrade origin from human to ai on an idempotent re-POST', async () => {
@@ -634,10 +928,48 @@ describe('categories-storage', () => {
       });
 
       expect(result.created).to.be.false;
+      expect(result.outcome).to.equal('noop');
       expect(result.category.origin).to.equal('human');
       expect(result.category.updatedBy).to.equal('curator@test.com');
       // No update round-trip fires for a pure provenance-downgrade attempt.
       expect(postgrestClient.from).to.have.been.calledOnce;
+    });
+
+    it('logs a WARN when a human->ai downgrade is blocked (active row, no other diffs)', async () => {
+      const humanRow = {
+        id: 'uuid-warn',
+        category_id: 'curated-warn',
+        name: 'CuratedWarn',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-01-01',
+        created_by: 'curator@test.com',
+        updated_at: '2026-02-01',
+        updated_by: 'curator@test.com',
+      };
+      const postgrestClient = createSequentialClient([
+        { data: humanRow, error: null },
+      ]);
+      const log = { warn: sinon.stub() };
+
+      await createCategory({
+        organizationId: ORG_ID,
+        category: { name: 'CuratedWarn', origin: 'ai' },
+        postgrestClient,
+        updatedBy: 'drs',
+        log,
+      });
+
+      expect(log.warn).to.have.been.calledOnce;
+      // Structured fields are passed as a second arg so operators can
+      // filter by organization_id / category_id in Coralogix.
+      const [, fields] = log.warn.firstCall.args;
+      expect(fields).to.include({
+        organization_id: ORG_ID,
+        category_id: 'curated-warn',
+        attempted_origin: 'ai',
+        current_origin: 'human',
+      });
     });
 
     it('does allow origin upgrade from ai to human', async () => {
@@ -672,6 +1004,7 @@ describe('categories-storage', () => {
       });
 
       expect(result.created).to.be.false;
+      expect(result.outcome).to.equal('update');
       expect(result.category.origin).to.equal('human');
       expect(result.category.updatedBy).to.equal('curator@test.com');
     });
@@ -728,15 +1061,42 @@ describe('categories-storage', () => {
     });
 
     it('throws on database error during update', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'update failed' } });
+      const dbError = { message: 'update failed' };
+      const query = createChainableQuery({ data: null, error: dbError });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
-      await expect(updateCategory({
+      const err = await updateCategory({
         organizationId: ORG_ID,
         categoryId: 'test',
         updates: { name: 'Will Fail' },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to update category: update failed');
+      }).catch((e) => e);
+      expect(err.message).to.include('Failed to update category: update failed');
+      expect(err.cause).to.equal(dbError);
+    });
+
+    it('surfaces a typed 409 when PATCH name collides with a sibling in the same org', async () => {
+      // PATCH was previously unguarded: a rename to a name already taken
+      // by another row in the same org tripped `uq_category_name_per_org`
+      // and surfaced as a 500. Symmetric with POST now — 409 with
+      // constraint echo. LLMO-4370 #9.
+      const collisionError = {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint "uq_category_name_per_org"',
+      };
+      const query = createChainableQuery({ data: null, error: collisionError });
+      const postgrestClient = { from: sinon.stub().returns(query) };
+
+      const err = await updateCategory({
+        organizationId: ORG_ID,
+        categoryId: 'test',
+        updates: { name: 'Taken Name' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.message).to.include('uq_category_name_per_org');
+      expect(err.cause).to.equal(collisionError);
     });
   });
 
@@ -775,14 +1135,17 @@ describe('categories-storage', () => {
     });
 
     it('throws on database error during delete', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'delete failed' } });
+      const dbError = { message: 'delete failed' };
+      const query = createChainableQuery({ data: null, error: dbError });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
-      await expect(deleteCategory({
+      const err = await deleteCategory({
         organizationId: ORG_ID,
         categoryId: 'test',
         postgrestClient,
-      })).to.be.rejectedWith('Failed to delete category: delete failed');
+      }).catch((e) => e);
+      expect(err.message).to.include('Failed to delete category: delete failed');
+      expect(err.cause).to.equal(dbError);
     });
   });
 });

--- a/test/support/topics-storage.test.js
+++ b/test/support/topics-storage.test.js
@@ -100,11 +100,13 @@ describe('topics-storage', () => {
     });
 
     it('throws on database error', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'DB error' } });
+      const dbError = { message: 'DB error' };
+      const query = createChainableQuery({ data: null, error: dbError });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
-      await expect(listTopics({ organizationId: ORG_ID, postgrestClient }))
-        .to.be.rejectedWith('Failed to list topics');
+      const err = await listTopics({ organizationId: ORG_ID, postgrestClient }).catch((e) => e);
+      expect(err.message).to.include('Failed to list topics');
+      expect(err.cause).to.equal(dbError);
     });
   });
 
@@ -249,27 +251,28 @@ describe('topics-storage', () => {
     });
 
     it('throws on database error during create', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'unique violation' } });
+      const dbError = { message: 'unique violation' };
+      const query = createChainableQuery({ data: null, error: dbError });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
-      await expect(createTopic({
+      const err = await createTopic({
         organizationId: ORG_ID,
         topic: { name: 'Duplicate Topic' },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to create topic');
+      }).catch((e) => e);
+      expect(err.message).to.include('Failed to create topic');
+      expect(err.cause).to.equal(dbError);
     });
 
     it('throws a 409-typed error echoing the constraint name on a 23505 unique violation', async () => {
+      const raw = {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint "uq_topic_per_org"',
+        details: '',
+        hint: '',
+      };
       const postgrestClient = {
-        from: sinon.stub().returns(createChainableQuery({
-          data: null,
-          error: {
-            code: '23505',
-            message: 'duplicate key value violates unique constraint "uq_topic_per_org"',
-            details: '',
-            hint: '',
-          },
-        })),
+        from: sinon.stub().returns(createChainableQuery({ data: null, error: raw })),
       };
 
       const err = await createTopic({
@@ -282,6 +285,10 @@ describe('topics-storage', () => {
       expect(err).to.be.instanceOf(Error);
       expect(err.status).to.equal(409);
       expect(err.message).to.include('uq_topic_per_org');
+      // Original PostgREST error preserved as `cause` so operators reading
+      // the WARN-level conflict log can still reach the raw DB payload
+      // during triage. LLMO-4370 #14.
+      expect(err.cause).to.equal(raw);
     });
 
     it('still surfaces 409 with a generic message when the 23505 error lacks a constraint clause', async () => {
@@ -387,15 +394,18 @@ describe('topics-storage', () => {
     });
 
     it('throws on database error during update', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'connection timeout' } });
+      const dbError = { message: 'connection timeout' };
+      const query = createChainableQuery({ data: null, error: dbError });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
-      await expect(updateTopic({
+      const err = await updateTopic({
         organizationId: ORG_ID,
         topicId: 'test',
         updates: { name: 'Will Fail' },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to update topic');
+      }).catch((e) => e);
+      expect(err.message).to.include('Failed to update topic');
+      expect(err.cause).to.equal(dbError);
     });
   });
 
@@ -434,14 +444,17 @@ describe('topics-storage', () => {
     });
 
     it('throws on database error during delete', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'permission denied' } });
+      const dbError = { message: 'permission denied' };
+      const query = createChainableQuery({ data: null, error: dbError });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
-      await expect(deleteTopic({
+      const err = await deleteTopic({
         organizationId: ORG_ID,
         topicId: 'test',
         postgrestClient,
-      })).to.be.rejectedWith('Failed to delete topic');
+      }).catch((e) => e);
+      expect(err.message).to.include('Failed to delete topic');
+      expect(err.cause).to.equal(dbError);
     });
   });
 

--- a/test/support/topics-storage.test.js
+++ b/test/support/topics-storage.test.js
@@ -258,6 +258,32 @@ describe('topics-storage', () => {
         postgrestClient,
       })).to.be.rejectedWith('Failed to create topic');
     });
+
+    it('throws a 409-typed error when the DB returns a 23505 unique violation', async () => {
+      const postgrestClient = {
+        from: sinon.stub().returns(createChainableQuery({
+          data: null,
+          error: {
+            code: '23505',
+            message: 'duplicate key value violates unique constraint "uq_topic_per_org"',
+            details: '',
+            hint: '',
+          },
+        })),
+      };
+
+      const err = await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'DupTopic' },
+        postgrestClient,
+        updatedBy: 'test',
+      }).catch((e) => e);
+
+      expect(err).to.be.instanceOf(Error);
+      expect(err.status).to.equal(409);
+      expect(err.message).to.match(/already exists/i);
+      expect(err.message).to.include('DupTopic');
+    });
   });
 
   describe('updateTopic', () => {

--- a/test/support/topics-storage.test.js
+++ b/test/support/topics-storage.test.js
@@ -259,7 +259,7 @@ describe('topics-storage', () => {
       })).to.be.rejectedWith('Failed to create topic');
     });
 
-    it('throws a 409-typed error when the DB returns a 23505 unique violation', async () => {
+    it('throws a 409-typed error echoing the constraint name on a 23505 unique violation', async () => {
       const postgrestClient = {
         from: sinon.stub().returns(createChainableQuery({
           data: null,
@@ -281,8 +281,25 @@ describe('topics-storage', () => {
 
       expect(err).to.be.instanceOf(Error);
       expect(err.status).to.equal(409);
-      expect(err.message).to.match(/already exists/i);
-      expect(err.message).to.include('DupTopic');
+      expect(err.message).to.include('uq_topic_per_org');
+    });
+
+    it('still surfaces 409 with a generic message when the 23505 error lacks a constraint clause', async () => {
+      const postgrestClient = {
+        from: sinon.stub().returns(createChainableQuery({
+          data: null,
+          error: { code: '23505', message: '' },
+        })),
+      };
+
+      const err = await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'Whatever' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.message).to.match(/unique constraint/i);
     });
   });
 


### PR DESCRIPTION
## Summary
- **Eliminates the ~7.5k/day 409 log storm** on `POST /v2/orgs/:spaceCatId/categories` (18,582 errors in 48h) by making `createCategory` idempotent by name: if a non-deleted row with the same name already exists for the org, the storage layer UPDATEs non-key fields and returns the existing row — preserving its stable `category_id` slug so FKs stay valid. See [LLMO-4370](https://jira.corp.adobe.com/browse/LLMO-4370).
- **Mirrors 23505 → 409 mapping on topics** so future unique-constraint drift on `POST /v2/orgs/:spaceCatId/topics` surfaces as a typed 409 instead of a 500. Message echoes the actual constraint name rather than hard-coding `name`.
- **Demotes 409 log severity** in `createTopicForOrg` to `log.warn` so idempotent-retry traffic stops polluting Coralogix ERROR severity, without losing triage visibility on legitimate conflicts.

## Root cause
DRS `ensure_categories_v2` (`llmo-data-retrieval-service`) re-POSTs each LLMO-config category on every scheduler run, treating 409 as "already exists, skip". The server-side upsert used `onConflict: organization_id,category_id`, so when a client's `category.id` (slug from LLMO config) drifted from the DB's `category_id` (e.g., after the `baseurl-*` rename from LLMO-4160 / fix_slug_category_names), the upsert fell back to INSERT and tripped `uq_category_name_per_org` on every daily re-post.

The real fix is server-side: resolve conflicts on name so re-posts with drifted slugs become clean UPDATEs.

## Changes
### Storage
- `src/support/categories-storage.js` — lookup-by-name idempotent create; 23505 race recovery retries the lookup once (original 23505 preserved as `Error.cause` if the retry itself fails); soft-delete resurrection; no-op short-circuit when nothing meaningful changes (preserves audit trail); provenance guard (`origin: 'human'` is never downgraded to `'ai'`); NFC + whitespace + case-insensitive name canonicalization; concurrent hard-delete surfaces as typed 409 "concurrently modified".
- `src/support/topics-storage.js` — 23505 → 409 with constraint-name echo. `Error.cause` chained on all wrapped errors.

### Controller
- `src/controllers/brands.js` — `createCategoryForOrg` returns **201 on insert/resurrect, 200 on idempotent update**, so clients can discriminate creation from re-post without parsing the body. `createTopicForOrg` logs 409 at WARN (was INFO → lost visibility; was ERROR → log storm).

### OpenAPI
- `docs/openapi/categories-v2-api.yaml` — **new**. Documents the 200/201 contract, name canonicalization, provenance guard, resurrection, and no-op semantics. `V2Category*` schemas added to `schemas.yaml`.
- `docs/openapi/topics-v2-api.yaml` — 409 response added with rationale.

### Tests
Comprehensive coverage added: no-op short-circuit, resurrection, provenance guard (block downgrade / allow upgrade), canonical-name storage, case-variant lookup matching, concurrent hard-delete 409, retry-lookup failure preserving original 23505 via `Error.cause`, topic 23505 generic-message fallback.

## Review follow-ups addressed in this PR
A full local-review-team pass surfaced 18 issues. Resolutions:

| # | Score | Status |
|---|-------|--------|
| 1 | 80 | **Fixed** — soft-delete resurrection path |
| 2 | 80 | **Fixed** — 200/201 split + categories OpenAPI + topic 409 response |
| 3 | 75 | **Fixed** — provenance guard blocks `human → ai` downgrade |
| 4 | 70 | **Fixed** — 200 on update-path, 201 on insert/resurrect |
| 5 | 65 | **Fixed** — topic 23505 echoes actual constraint name |
| 6 | 65 | **Fixed** — no-op short-circuit preserves audit trail |
| 7 | 65 | **Partial** — code-level NFC + whitespace + case-insensitive match; schema-level case-insensitive uniqueness deferred to RFC |
| 9 | 55 | **Implicit** — status codes now differ, tests distinguish paths |
| 11 | 50 | **Fixed** — topic 409 → `log.warn` |
| 13 | 40 | **Fixed** — resurrection regression test |
| 14 | 35 | **Fixed** — topic 409 in OpenAPI |
| 15 | 35 | **Fixed** — original insert error preserved as `Error.cause` |
| 16 | 25 | **Fixed** — concurrent-hard-delete test; storage emits typed 409 |
| 17 | 20 | **Fixed** — `Error.cause` applied across storage |
| 18 | 15 | **Fixed** — redundant `data \|\| null` removed |

## Follow-ups (deferred — belong in a taxonomy-idempotency RFC)
The following items surfaced in review but are out of scope for a log-storm triage PR. They should land in a follow-up RFC (`mysticat-architecture/`):

- **#8 — Unify topics / categories idempotency semantics.** Today categories are idempotent by name and topics are not. DRS's `ensure_topics_v2` has the same shape as `ensure_categories_v2`; the log storm will eventually recur on topics. Likely fix: make topics idempotent by `(name, brandId)` after a schema migration (no name-unique on topics today).
- **#10 — Single-round-trip server-side upsert.** Current implementation is 2 PostgREST round-trips on the happy path (lookup + insert/update), 3 on race. A SQL RPC can reduce this to 1 while still discriminating create vs update (e.g., via `xmax = 0` in RETURNING).
- **#7 (completion) — Schema-level case-insensitive uniqueness.** The code-level canonicalization in this PR catches whitespace and NFC variants, and makes lookups case-insensitive, but the underlying `uq_category_name_per_org` constraint is still case-sensitive. Two concurrent inserts with different cases (no pre-existing row) can still both succeed. Fix needs a partial index on `LOWER(name)` or a generated `canonical_name` column.
- **Server-owned slug.** `category.id` should not be client-supplied at all — clients reference existing categories by UUID. Removing the client-side slug kills the LLMO-4160 drift class of bug permanently. Requires DRS and UI migration.
- **Bulk sync endpoint for DRS.** `PUT /v2/orgs/:id/categories` with the canonical set, reconciled server-side in one transaction, is a better fit for DRS's "assert this taxonomy" intent than N individual POSTs.

## Test plan
- [x] `npx mocha test/support/categories-storage.test.js test/support/topics-storage.test.js` — passing
- [x] `npx mocha test/controllers/brands.test.js -g "createCategoryForOrg|createTopicForOrg"` — passing
- [x] `npm test` — 8,295 passing, 100% lines/branches/statements
- [x] `npm run lint` — clean (only pre-existing eslint-env deprecation warnings)
- [x] `npm run docs:lint` — OpenAPI valid (pre-existing warnings on unrelated paths only)
- [ ] Post-deploy: verify Coralogix category-409 count drops to ~0 over 24h after rollout (query: `filter $d.message ~ 'Error creating category for organization'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)