### PR TITLE
fix(llmo): sanitize error message in updateLlmoConfig catch block

### DIFF
--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -590,7 +590,7 @@ function LlmoController(ctx) {
     } catch (error) {
       const msg = `${error?.message || /* c8 ignore next */ error}`;
       log.error(`User ${userId} error updating llmo config for siteId: ${siteId}, error: ${msg}`);
-      return badRequest(msg);
+      return badRequest(cleanupHeaderValue(msg));
     }
   }
 


### PR DESCRIPTION
## Summary

- The `updateLlmoConfig` catch block was calling `badRequest(msg)` without `cleanupHeaderValue()`, unlike every other error handler in the same file
- When an error message contained newlines or non-ASCII characters, Node.js rejected setting the `x-error` response header and returned a misleading 500 instead of a 400
- This could also mask successful writes — the S3 write would complete but the client would receive a 500

## Root cause

[llmo.js:593](src/controllers/llmo/llmo.js#L593) was the only `badRequest()` call in the LLMO controller missing `cleanupHeaderValue()` sanitization.

## Test plan

- [ ] Trigger a config update that causes an error with special characters in the message and verify a clean 400 is returned instead of 500
- [ ] Verify successful config updates still return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)