### PR TITLE
feat: return topic + prompt ids in bp responses; add lookup by prompt id endpoint | LLMO-4440

### DIFF
--- a/docs/llmo-brandalf-apis/prompt-detail-api.md
+++ b/docs/llmo-brandalf-apis/prompt-detail-api.md
@@ -1,10 +1,10 @@
 # Brand Presence Prompt Detail API
 
-Returns all execution rows, weekly aggregated statistics, and citation sources for a specific **prompt+region** combination within a topic — powering the **detail dialog** that opens when a user clicks "Details" on a prompt row in the Data Insights table.
+Returns all execution rows, weekly aggregated statistics, and citation sources for a specific **prompt** over a date range — either scoped under a **topic path** (legacy UI) or keyed directly by **`prompt_id`** (UUID). Used for the **detail dialog** when a user opens prompt-level history in the Data Insights table.
 
 ---
 
-## API Paths
+## API Paths (topic-scoped)
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -18,11 +18,27 @@ Returns all execution rows, weekly aggregated statistics, and citation sources f
 
 ---
 
+## API Paths (by `prompt_id` — same JSON shape)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/org/:spaceCatId/brands/all/brand-presence/prompts/:promptId/detail` | Prompt detail for all brands, filtered by `prompt_id` |
+| GET | `/org/:spaceCatId/brands/:brandId/brand-presence/prompts/:promptId/detail` | Prompt detail for one brand, filtered by `prompt_id` |
+
+**Path parameters:** same `spaceCatId` / `brandId` as above, plus:
+
+- `promptId` — Prompt UUID (`brand_presence_executions.prompt_id`). No `topicId` path segment or `prompt` query string is required.
+
+Executions are filtered by **organization**, **date range**, **model**, optional **site** / **origin**, optional **`promptRegion`**, and **`prompt_id`**. Topic and prompt text on the envelope are taken from the returned rows when present (see field reference).
+
+---
+
 ## Query Parameters
+
+Shared by both path families (topic-scoped and by `prompt_id`):
 
 | Parameter | Aliases | Type | Default | Description |
 |-----------|---------|------|---------|-------------|
-| `prompt` | — | string | **(required)** | The prompt text to look up |
 | `promptRegion` | `prompt_region` | string | — | Region code to scope the prompt (e.g. US, DE) |
 | `startDate` | `start_date` | string (YYYY-MM-DD) | 28 days ago | Start of date range |
 | `endDate` | `end_date` | string (YYYY-MM-DD) | today | End of date range |
@@ -30,12 +46,26 @@ Returns all execution rows, weekly aggregated statistics, and citation sources f
 | `siteId` | `site_id` | string (UUID) | — | Filter by site |
 | `origin` | — | string | — | Filter by origin (case-insensitive; e.g. `human`, `ai`) |
 
+**Topic-scoped routes only:**
+
+| Parameter | Aliases | Type | Default | Description |
+|-----------|---------|------|---------|-------------|
+| `prompt` | — | string | **(required)** | The prompt text to look up |
+
 ---
 
 ## Sample URL
 
+**Topic + prompt text:**
+
 ```
 GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/PDF%20Editing/prompt-detail?prompt=best%20pdf%20editor%20for%20mac&promptRegion=US&startDate=2026-02-09&endDate=2026-03-09&model=chatgpt
+```
+
+**By `prompt_id`:**
+
+```
+GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/prompts/019cb903-1184-7f92-8325-f9d1176af316/detail?startDate=2026-02-09&endDate=2026-03-09&model=chatgpt&promptRegion=US
 ```
 
 ---
@@ -47,6 +77,7 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
   "topic": "PDF Editing",
   "topicId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "prompt": "best pdf editor for mac",
+  "promptId": "019cb903-1184-7f92-8325-f9d1176af316",
   "region": "US",
   "stats": {
     "visibilityScore": 82.5,
@@ -121,10 +152,13 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `topic` | string | Display label for the topic (from `topics` on the first execution row when present, otherwise the decoded `:topicId` path value) |
-| `topicId` | string \| null | Stable topic UUID: prefers `topic_id` from the first execution row; if missing, uses `:topicId` when the path is a valid UUID; `null` when the path is a topic name and rows have no `topic_id` |
-| `prompt` | string | Prompt text from the required `prompt` query parameter |
+| `topic` | string | Display label: newest execution row with non-empty `topics`, then older rows; otherwise the decoded `:topicId` path value (topic-scoped routes) or empty string (by `prompt_id` route when no labels) |
+| `topicId` | string \| null | Stable topic UUID: newest row with `topic_id`, then older rows; if still missing, uses `:topicId` when the path is a valid UUID; `null` when the path is a topic name and no row has `topic_id` |
+| `prompt` | string | Topic-scoped: required `prompt` query parameter. By `prompt_id`: newest row with prompt text, then older rows; empty string when no rows |
+| `promptId` | string | Prompt UUID: prefers `prompt_id` on the newest execution row (by `execution_date`), then older rows; `""` when no row has `prompt_id` (including when there are no executions) |
 | `region` | string | Region filter applied for this response (from `promptRegion` / `prompt_region`, or empty when not scoped) |
+
+**Stable ids caveat:** Root **`topicId`** can be `null` when the topic cannot be resolved to a UUID (same as topic detail). Root **`promptId`** is always present as a string but may be `""` if executions lack `prompt_id`. Each **`executions[]`** entry includes **`topicId`** and **`promptId`** as strings, using `""` when the column is null.
 
 ### `stats` Object
 
@@ -158,6 +192,7 @@ All execution rows for this prompt+region within the date range. Sorted newest-f
 |-------|------|-------------|
 | `prompt` | string | The prompt text |
 | `promptId` | string | Prompt UUID from `brand_presence_executions.prompt_id` (stringified); empty string when null |
+| `topicId` | string | Topic UUID from `brand_presence_executions.topic_id` (stringified); empty string when null |
 | `executionId` | string | Execution row UUID from `brand_presence_executions.id` (stringified); empty string when null |
 | `region` | string | Region code |
 | `executionDate` | string | Execution date (YYYY-MM-DD) |
@@ -193,7 +228,7 @@ Aggregated citation sources for this prompt. Deduplicated by URL. Same structure
 
 ## Aggregation Logic
 
-1. Query all `brand_presence_executions` rows matching the topic, prompt text, and (optionally) region code (selected columns include `id`, `topic_id`, `prompt_id`, `business_competitors`, `detected_brand_mentions`, and fields used for stats and display)
+1. Query all `brand_presence_executions` rows matching either **(topic path + prompt text)** or **`prompt_id`**, plus optional region code and the shared filters (selected columns include `id`, `topic_id`, `prompt_id`, `business_competitors`, `detected_brand_mentions`, and fields used for stats and display)
 2. Compute prompt-level stats inline:
    - Average `visibility_score` (excluding null/NaN)
    - Average `position` (excluding "Not Mentioned" and non-numeric)
@@ -213,7 +248,8 @@ Aggregated citation sources for this prompt. Deduplicated by URL. Same structure
 | 400 | PostgREST not configured (DATA_SERVICE_PROVIDER ≠ postgres) |
 | 400 | Organization not found |
 | 400 | Invalid topic ID encoding (malformed percent-encoding in `:topicId`) |
-| 400 | Missing required query parameter: `prompt` |
+| 400 | Missing required query parameter: `prompt` (topic-scoped routes only) |
+| 400 | Invalid `promptId` (not a UUID) on `/prompts/:promptId/detail` |
 | 400 | PostgREST/PostgreSQL query error |
 | 403 | User does not belong to the organization |
 | 403 | Site does not belong to the organization |

--- a/docs/llmo-brandalf-apis/topic-detail-api.md
+++ b/docs/llmo-brandalf-apis/topic-detail-api.md
@@ -44,6 +44,7 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
 ```json
 {
   "topic": "PDF Editing",
+  "topicId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "stats": {
     "averageVisibilityScore": 72.5,
     "averagePosition": 3.2,
@@ -77,6 +78,9 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
   "executions": [
     {
       "prompt": "best pdf editor for mac",
+      "promptId": "019cb903-1184-7f92-8325-f9d1176af316",
+      "topicId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "executionId": "019cb903-1184-7f92-8325-f9d1176af317",
       "region": "US",
       "executionDate": "2026-03-08",
       "week": "2026-W10",
@@ -108,9 +112,18 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
 }
 ```
 
+**Stable ids caveat:** Root **`topicId`** is `null` when the path is a topic **name** (not a UUID) and execution rows have no `topic_id` in Postgres. Each **`executions[]`** entry always includes **`topicId`** and **`promptId`** as strings; they are `""` when the corresponding column is null (legacy rows).
+
 ---
 
 ## Response Field Reference
+
+### Top-level fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `topic` | string | Display label: newest row with non-empty `topics`, else older rows, else decoded path |
+| `topicId` | string \| null | Stable topic UUID: newest row with `topic_id`, else older rows, else path UUID or null (see caveat) |
 
 ### `stats` Object
 
@@ -146,6 +159,9 @@ All execution rows for the topic within the date range. Sorted newest-first by `
 | Field | Type | Description |
 |-------|------|-------------|
 | `prompt` | string | The prompt text |
+| `promptId` | string | Prompt UUID; `""` when null |
+| `topicId` | string | Topic UUID for this execution row; `""` when null |
+| `executionId` | string | Execution row UUID; `""` when null |
 | `region` | string | Region code (e.g. US, DE) |
 | `executionDate` | string | Execution date (YYYY-MM-DD) |
 | `week` | string | ISO week string derived from `executionDate` |

--- a/docs/llmo-brandalf-apis/topics-api.md
+++ b/docs/llmo-brandalf-apis/topics-api.md
@@ -115,7 +115,9 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
   "items": [
     {
       "topic": "PDF Editing",
+      "topicId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       "prompt": "best pdf editor for mac",
+      "promptId": "019cb903-1184-7f92-8325-f9d1176af316",
       "region": "US",
       "category": "Acrobat",
       "executionDate": "2026-03-08",
@@ -136,14 +138,18 @@ GET /org/44568c3e-efd4-4a7f-8ecd-8caf615f836c/brands/all/brand-presence/topics/P
 }
 ```
 
-Root **`topic`** and **`topicId`** mirror the [Topic Detail API](topic-detail-api.md) conventions: same resolution from execution rows and the `:topicId` path (UUID path filters by `topic_id` but still returns a display label and stable id when the query returns rows). `topicId` is `null` when the path is a topic name and rows have no `topic_id`.
+Root **`topic`** and **`topicId`** mirror the [Topic Detail API](topic-detail-api.md) conventions: values are taken from execution rows (preferring the **newest `execution_date`** row that has `topics` / `topic_id`, then scanning older rows), with the same `:topicId` path fallbacks as topic detail. `topicId` is `null` when the path is a topic name and no row carries a `topic_id`.
+
+Each **`items[]`** row includes **`topicId`** and **`promptId`** as strings when the backing execution row has `topic_id` / `prompt_id`; otherwise those fields are the empty string (`""`). Legacy data may omit UUIDs in Postgres — clients should treat empty string like “unknown id” (same as [Topic Detail](topic-detail-api.md) / [Prompt Detail](prompt-detail-api.md) envelopes, where `topicId` can still be `null` at the root when the topic cannot be resolved to a UUID).
 
 ### Prompt Object Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `topic` | string | Topic name |
+| `topicId` | string | Topic UUID from the latest execution row for this prompt+region; `""` when null |
 | `prompt` | string | The prompt text |
+| `promptId` | string | Prompt UUID from the latest execution row; `""` when null |
 | `region` | string | Region code (e.g. US, DE) |
 | `category` | string | Category name |
 | `executionDate` | string | Date of the latest execution (YYYY-MM-DD) |

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -517,7 +517,7 @@ export function promptTextForDetailEnvelope(rows) {
   }
   const sorted = sortDetailRowsByExecutionDateDesc(rows);
   const row = sorted.find((r) => hasText(r.prompt != null ? String(r.prompt) : ''));
-  return row && row.prompt != null ? String(row.prompt) : '';
+  return row ? String(row.prompt) : '';
 }
 
 export function parseFilterDimensionsParams(context) {

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -442,8 +442,19 @@ export function applyTopicPathFilter(query, decodedTopicParam) {
 }
 
 /**
- * Response topic label: use row topics when present, else the path param
- * (e.g. UUID when no rows or null topics).
+ * Newest-first sort for detail / envelope helpers (PostgREST row order is not guaranteed).
+ * @param {Array<Object>} rows - Raw execution rows (mutated copy only)
+ * @returns {Array<Object>}
+ */
+export function sortDetailRowsByExecutionDateDesc(rows) {
+  return [...rows].sort(
+    (a, b) => (b.execution_date || '').localeCompare(a.execution_date || ''),
+  );
+}
+
+/**
+ * Response topic label: prefer `topics` on the newest `execution_date` row with a label,
+ * then older rows; else the path param (e.g. UUID when no rows or no labels).
  * @param {Array<Object>} rows - execution rows
  * @param {string} decodedTopicParam - decoded :topicId
  */
@@ -451,26 +462,62 @@ export function topicLabelForDetailResponse(rows, decodedTopicParam) {
   if (!rows || rows.length === 0) {
     return decodedTopicParam;
   }
-  const label = rows[0].topics;
-  return hasText(label) ? label : decodedTopicParam;
+  const sorted = sortDetailRowsByExecutionDateDesc(rows);
+  const row = sorted.find((r) => hasText(r.topics != null ? String(r.topics) : ''));
+  return row ? String(row.topics) : decodedTopicParam;
 }
 
 /**
- * Stable topic id for JSON: prefer DB topic_id on first row, else UUID path param if valid.
+ * Stable topic id for JSON: prefer `topic_id` on the newest row that has one, then older
+ * rows; else UUID path param if valid; else null.
  * @param {Array<Object>} rows - execution rows (may be empty)
  * @param {string} decodedTopicParam - decoded :topicId
  * @returns {string|null}
  */
 export function topicIdForDetailResponse(rows, decodedTopicParam) {
   const trimmedParam = String(decodedTopicParam).trim();
-  const rowId = rows?.[0]?.topic_id;
-  if (hasText(rowId)) {
-    return String(rowId).trim();
+  if (!rows || rows.length === 0) {
+    return isValidUUID(trimmedParam) ? trimmedParam : null;
+  }
+  const sorted = sortDetailRowsByExecutionDateDesc(rows);
+  const row = sorted.find((r) => hasText(r.topic_id != null ? String(r.topic_id) : ''));
+  if (row) {
+    return String(row.topic_id).trim();
   }
   if (isValidUUID(trimmedParam)) {
     return trimmedParam;
   }
   return null;
+}
+
+/**
+ * Prompt id for prompt-detail envelope: prefers `prompt_id` on the newest execution row
+ * (by `execution_date`), then scans older rows. Empty string when no row carries an id.
+ * @param {Array<Object>} rows - Raw `brand_presence_executions` rows
+ * @returns {string}
+ */
+export function promptIdForDetailResponse(rows) {
+  if (!rows?.length) {
+    return '';
+  }
+  const sorted = sortDetailRowsByExecutionDateDesc(rows);
+  const row = sorted.find((r) => hasText(r.prompt_id != null ? String(r.prompt_id) : ''));
+  return row && row.prompt_id != null ? String(row.prompt_id) : '';
+}
+
+/**
+ * Prompt text for prompt-detail envelope when rows were loaded by `prompt_id`
+ * (newest execution with non-empty `prompt` wins).
+ * @param {Array<Object>} rows - Raw `brand_presence_executions` rows
+ * @returns {string}
+ */
+export function promptTextForDetailEnvelope(rows) {
+  if (!rows?.length) {
+    return '';
+  }
+  const sorted = sortDetailRowsByExecutionDateDesc(rows);
+  const row = sorted.find((r) => hasText(r.prompt != null ? String(r.prompt) : ''));
+  return row && row.prompt != null ? String(row.prompt) : '';
 }
 
 export function parseFilterDimensionsParams(context) {
@@ -1835,7 +1882,9 @@ export function buildPromptDetails(rows) {
 
     return {
       topic: r.topics || 'Unknown',
+      topicId: r.topic_id != null ? String(r.topic_id) : '',
       prompt: r.prompt || '',
+      promptId: r.prompt_id != null ? String(r.prompt_id) : '',
       region: r.region_code || '',
       category: r.category_name || '',
       executionDate: r.execution_date || '',
@@ -1968,7 +2017,7 @@ export function createTopicsHandler(getOrgAndValidateAccess) {
 }
 
 // eslint-disable-next-line max-len
-const PROMPTS_SELECT = 'topic_id, topics, prompt, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, url, error_code';
+const PROMPTS_SELECT = 'topic_id, topics, prompt, prompt_id, region_code, mentions, citations, visibility_score, position, sentiment, volume, origin, category_name, execution_date, url, error_code';
 
 /**
  * Creates the getTopicPrompts handler.
@@ -2253,6 +2302,7 @@ function mapBrandPresenceDetailExecutionRow(r, { includeAnswer = true } = {}) {
   return {
     prompt: r.prompt || '',
     promptId: r.prompt_id != null ? String(r.prompt_id) : '',
+    topicId: r.topic_id != null ? String(r.topic_id) : '',
     executionId: r.id != null ? String(r.id) : '',
     region: r.region_code || '',
     executionDate: r.execution_date || '',
@@ -2723,6 +2773,137 @@ export function createTopicDetailHandler(getOrgAndValidateAccess) {
 }
 
 /**
+ * Builds the JSON body for prompt-detail and prompt-detail-by-prompt-id responses.
+ * @param {Object} client - PostgREST client
+ * @param {string} organizationId - Organization UUID
+ * @param {Object} params - Parsed filter params (includes startDate, endDate, model, siteId, …)
+ * @param {Object} defaults - Default date range
+ * @param {Array<Object>} rows - Raw execution rows (possibly empty)
+ * @param {Object} envelope
+ * @param {string} envelope.topicPathParam - Decoded `:topicId` path segment, or empty string if N/A
+ * @param {string} envelope.promptEnvelopeText - Human-readable prompt text for the envelope
+ * @param {string} envelope.envelopePromptId - Stable `promptId` field for the envelope
+ * @param {string} [envelope.regionCode] - Optional region filter applied for this response
+ * @returns {Promise<Object>} Serializable payload (not wrapped in `ok()`)
+ */
+async function assemblePromptDetailPayload(
+  client,
+  organizationId,
+  params,
+  defaults,
+  rows,
+  {
+    topicPathParam,
+    promptEnvelopeText,
+    envelopePromptId,
+    regionCode,
+  },
+) {
+  const topicResponseLabel = topicLabelForDetailResponse(rows, topicPathParam);
+  const topicIdResponse = topicIdForDetailResponse(rows, topicPathParam);
+  const region = regionCode || '';
+
+  if (!rows.length) {
+    return {
+      topic: topicResponseLabel,
+      topicId: topicIdResponse,
+      prompt: promptEnvelopeText,
+      promptId: envelopePromptId,
+      region,
+      stats: {
+        visibilityScore: 0,
+        position: '',
+        sentiment: -1,
+        mentions: 0,
+        citations: 0,
+      },
+      weeklyStats: [],
+      executions: [],
+      sources: [],
+    };
+  }
+
+  let visSum = 0;
+  let visCount = 0;
+  let posSum = 0;
+  let posCount = 0;
+  let sentSum = 0;
+  let sentCount = 0;
+  let mentionTotal = 0;
+  let citationTotal = 0;
+
+  rows.forEach((r) => {
+    const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
+    if (!Number.isNaN(vs)) {
+      visSum += vs;
+      visCount += 1;
+    }
+    const pos = r.position;
+    if (pos && pos !== 'Not Mentioned' && /^\d+\.?\d*$/.test(String(pos))) {
+      posSum += Number(pos);
+      posCount += 1;
+    }
+    const sentiment = (r.sentiment || '').toLowerCase().trim();
+    if (sentiment === 'positive') {
+      sentSum += 100;
+      sentCount += 1;
+    } else if (sentiment === 'neutral') {
+      sentSum += 50;
+      sentCount += 1;
+    } else if (sentiment === 'negative') {
+      sentCount += 1;
+    }
+    if (r.mentions === true || r.mentions === 'true') {
+      mentionTotal += 1;
+    }
+    if (r.citations === true || r.citations === 'true') {
+      citationTotal += 1;
+    }
+  });
+
+  const avgVisibility = visCount > 0
+    ? Math.round((visSum / visCount) * 100) / 100 : 0;
+  const avgPosition = posCount > 0
+    ? Math.round((posSum / posCount) * 100) / 100 : 0;
+  const avgSentiment = sentCount > 0
+    ? Math.round(sentSum / sentCount) : -1;
+
+  const weeklyStats = aggregateWeeklyDetailStats(rows);
+
+  const executions = rows
+    .sort((a, b) => (b.execution_date || '').localeCompare(a.execution_date || ''))
+    .map(mapBrandPresenceDetailExecutionRow);
+
+  const execIdMap = new Map(rows.map((r) => [r.id, r]));
+  const execIds = rows.map((r) => r.id).filter(Boolean);
+  const startDate = params.startDate || defaults.startDate;
+  const endDate = params.endDate || defaults.endDate;
+
+  // eslint-disable-next-line max-len
+  const rawSources = await fetchSourcesForExecutions(client, organizationId, execIds, startDate, endDate);
+  const flatSources = rawSources.map((s) => flattenSourceRow(s, execIdMap));
+  const sources = aggregateDetailSources(flatSources);
+
+  return {
+    topic: topicResponseLabel,
+    topicId: topicIdResponse,
+    prompt: promptEnvelopeText,
+    promptId: envelopePromptId,
+    region,
+    stats: {
+      visibilityScore: avgVisibility,
+      position: avgPosition > 0 ? String(avgPosition) : '',
+      sentiment: avgSentiment,
+      mentions: mentionTotal,
+      citations: citationTotal,
+    },
+    weeklyStats,
+    executions,
+    sources,
+  };
+}
+
+/**
  * Creates the getPromptDetail handler.
  * Returns all execution rows, weekly stats, and sources for a specific
  * prompt+region combination within a topic.
@@ -2782,106 +2963,95 @@ export function createPromptDetailHandler(getOrgAndValidateAccess) {
       }
 
       const rows = execRows || [];
-      const topicResponseLabel = topicLabelForDetailResponse(rows, topicName);
-      const topicIdResponse = topicIdForDetailResponse(rows, topicName);
-      if (rows.length === 0) {
-        return cachedOk({
-          topic: topicResponseLabel,
-          topicId: topicIdResponse,
-          prompt: promptText,
-          region: regionCode || '',
-          stats: {
-            visibilityScore: 0,
-            position: '',
-            sentiment: -1,
-            mentions: 0,
-            citations: 0,
-          },
-          weeklyStats: [],
-          executions: [],
-          sources: [],
-        });
+      const envelopePromptId = promptIdForDetailResponse(rows);
+      const payload = await assemblePromptDetailPayload(
+        client,
+        organizationId,
+        params,
+        defaults,
+        rows,
+        {
+          topicPathParam: topicName,
+          promptEnvelopeText: promptText,
+          envelopePromptId,
+          regionCode,
+        },
+      );
+      return cachedOk(payload);
+    },
+  );
+}
+
+/**
+ * Creates the getPromptDetailByPromptId handler.
+ * Same response shape as {@link createPromptDetailHandler}, but scopes executions by
+ * `prompt_id` (path UUID) and the shared date/model/site/origin filters — no topic path
+ * or `prompt` query string required.
+ * @param {Function} getOrgAndValidateAccess - Async (context) => { organization }
+ */
+export function createPromptDetailByPromptIdHandler(getOrgAndValidateAccess) {
+  return (context) => withBrandPresenceAuth(
+    context,
+    getOrgAndValidateAccess,
+    'prompt-detail-by-prompt-id',
+    async (ctx, client) => {
+      const { spaceCatId, brandId, promptId } = ctx.params;
+      const trimmedPromptId = String(promptId || '').trim();
+      if (!isValidUUID(trimmedPromptId)) {
+        return badRequest('Invalid prompt id');
       }
 
-      // Compute stats
-      let visSum = 0;
-      let visCount = 0;
-      let posSum = 0;
-      let posCount = 0;
-      let sentSum = 0;
-      let sentCount = 0;
-      let mentionTotal = 0;
-      let citationTotal = 0;
+      const params = parseFilterDimensionsParams(ctx);
+      const defaults = defaultDateRange();
+      const organizationId = spaceCatId;
+      const filterByBrandId = brandId && brandId !== 'all' ? brandId : null;
 
-      rows.forEach((r) => {
-        const vs = r.visibility_score != null ? Number(r.visibility_score) : NaN;
-        if (!Number.isNaN(vs)) {
-          visSum += vs;
-          visCount += 1;
+      const promptData = ctx.data || {};
+      const regionCode = promptData.promptRegion || promptData.prompt_region;
+
+      if (shouldApplyFilter(params.siteId)) {
+        const siteBelongsToOrg = await validateSiteBelongsToOrg(
+          client,
+          organizationId,
+          params.siteId,
+        );
+        if (!siteBelongsToOrg) {
+          return forbidden('Site does not belong to the organization');
         }
-        const pos = r.position;
-        if (pos && pos !== 'Not Mentioned' && /^\d+\.?\d*$/.test(String(pos))) {
-          posSum += Number(pos);
-          posCount += 1;
-        }
-        const sentiment = (r.sentiment || '').toLowerCase().trim();
-        if (sentiment === 'positive') {
-          sentSum += 100;
-          sentCount += 1;
-        } else if (sentiment === 'neutral') {
-          sentSum += 50;
-          sentCount += 1;
-        } else if (sentiment === 'negative') {
-          sentCount += 1;
-        }
-        if (r.mentions === true || r.mentions === 'true') {
-          mentionTotal += 1;
-        }
-        if (r.citations === true || r.citations === 'true') {
-          citationTotal += 1;
-        }
-      });
+      }
 
-      const avgVisibility = visCount > 0
-        ? Math.round((visSum / visCount) * 100) / 100 : 0;
-      const avgPosition = posCount > 0
-        ? Math.round((posSum / posCount) * 100) / 100 : 0;
-      const avgSentiment = sentCount > 0
-        ? Math.round(sentSum / sentCount) : -1;
+      let q = buildDetailExecQuery(client, organizationId, params, defaults, filterByBrandId)
+        .eq('prompt_id', trimmedPromptId);
 
-      const weeklyStats = aggregateWeeklyDetailStats(rows);
+      if (shouldApplyFilter(regionCode)) {
+        q = q.eq('region_code', regionCode);
+      }
 
-      const executions = rows
-        .sort((a, b) => (b.execution_date || '').localeCompare(a.execution_date || ''))
-        .map(mapBrandPresenceDetailExecutionRow);
+      const { data: execRows, error: execError } = await q.limit(WEEKS_QUERY_LIMIT);
 
-      // Fetch sources
-      const execIdMap = new Map(rows.map((r) => [r.id, r]));
-      const execIds = rows.map((r) => r.id).filter(Boolean);
-      const startDate = params.startDate || defaults.startDate;
-      const endDate = params.endDate || defaults.endDate;
+      if (execError) {
+        ctx.log.error(
+          `Brand presence prompt-detail-by-prompt-id PostgREST error: ${execError.message}`,
+        );
+        return badRequest(execError.message);
+      }
 
-      // eslint-disable-next-line max-len
-      const rawSources = await fetchSourcesForExecutions(client, organizationId, execIds, startDate, endDate);
-      const flatSources = rawSources.map((s) => flattenSourceRow(s, execIdMap));
-      const sources = aggregateDetailSources(flatSources);
-
-      return cachedOk({
-        topic: topicResponseLabel,
-        topicId: topicIdResponse,
-        prompt: promptText,
-        region: regionCode || '',
-        stats: {
-          visibilityScore: avgVisibility,
-          position: avgPosition > 0 ? String(avgPosition) : '',
-          sentiment: avgSentiment,
-          mentions: mentionTotal,
-          citations: citationTotal,
+      const rows = execRows || [];
+      const promptEnvelopeText = promptTextForDetailEnvelope(rows);
+      const payload = await assemblePromptDetailPayload(
+        client,
+        organizationId,
+        params,
+        defaults,
+        rows,
+        {
+          topicPathParam: '',
+          promptEnvelopeText,
+          envelopePromptId: trimmedPromptId,
+          regionCode,
         },
-        weeklyStats,
-        executions,
-        sources,
-      });
+      );
+      return cachedOk(payload);
     },
   );
 }

--- a/src/controllers/llmo/llmo-mysticat-controller.js
+++ b/src/controllers/llmo/llmo-mysticat-controller.js
@@ -19,6 +19,7 @@ import {
   createSearchHandler,
   createTopicDetailHandler,
   createPromptDetailHandler,
+  createPromptDetailByPromptIdHandler,
   createExecutionSourcesHandler,
   createSentimentMoversHandler,
   createShareOfVoiceHandler,
@@ -117,6 +118,7 @@ function LlmoMysticatController(ctx) {
   const getSearch = createSearchHandler(getOrgAndValidateAccess);
   const getTopicDetail = createTopicDetailHandler(getOrgAndValidateAccess);
   const getPromptDetail = createPromptDetailHandler(getOrgAndValidateAccess);
+  const getPromptDetailByPromptId = createPromptDetailByPromptIdHandler(getOrgAndValidateAccess);
   const getExecutionSources = createExecutionSourcesHandler(getOrgAndValidateAccess);
   const getSentimentMovers = createSentimentMoversHandler(getOrgAndValidateAccess);
   const getShareOfVoice = createShareOfVoiceHandler(getOrgAndValidateAccess);
@@ -198,6 +200,7 @@ function LlmoMysticatController(ctx) {
     getSearch,
     getTopicDetail,
     getPromptDetail,
+    getPromptDetailByPromptId,
     getExecutionSources,
     getSentimentMovers,
     getShareOfVoice,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -469,6 +469,8 @@ export default function getRouteHandlers(
     'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/detail': llmoMysticatController.getTopicDetail,
     'GET /org/:spaceCatId/brands/all/brand-presence/topics/:topicId/prompt-detail': llmoMysticatController.getPromptDetail,
     'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/prompt-detail': llmoMysticatController.getPromptDetail,
+    'GET /org/:spaceCatId/brands/all/brand-presence/prompts/:promptId/detail': llmoMysticatController.getPromptDetailByPromptId,
+    'GET /org/:spaceCatId/brands/:brandId/brand-presence/prompts/:promptId/detail': llmoMysticatController.getPromptDetailByPromptId,
     'GET /org/:spaceCatId/brands/all/brand-presence/executions/:executionId/sources': llmoMysticatController.getExecutionSources,
     'GET /org/:spaceCatId/brands/:brandId/brand-presence/executions/:executionId/sources': llmoMysticatController.getExecutionSources,
     'GET /org/:spaceCatId/brands/all/brand-presence/sentiment-movers': llmoMysticatController.getSentimentMovers,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -267,6 +267,8 @@ const routeRequiredCapabilities = {
   'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/detail': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/topics/:topicId/prompt-detail': 'brand:read',
   'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/prompt-detail': 'brand:read',
+  'GET /org/:spaceCatId/brands/all/brand-presence/prompts/:promptId/detail': 'brand:read',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/prompts/:promptId/detail': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/executions/:executionId/sources': 'brand:read',
   'GET /org/:spaceCatId/brands/:brandId/brand-presence/executions/:executionId/sources': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/sentiment-movers': 'brand:read',

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -19,6 +19,7 @@ import {
   applyExecutionRegionFilter,
   applyTopicPathFilter,
   topicIdForDetailResponse,
+  promptIdForDetailResponse,
   topicLabelForDetailResponse,
   aggregateDetailSources,
   aggregateSentimentByWeek,
@@ -40,6 +41,8 @@ import {
   fetchBrandsForOrgSite,
   resolveSiteIdsForConfigPageIntents,
   createPromptDetailHandler,
+  createPromptDetailByPromptIdHandler,
+  promptTextForDetailEnvelope,
   createExecutionSourcesHandler,
   createSentimentOverviewHandler,
   createMarketTrackingTrendsHandler,
@@ -743,9 +746,26 @@ describe('llmo-brand-presence', () => {
   });
 
   describe('topicIdForDetailResponse', () => {
-    it('returns topic_id from first row when present', () => {
+    it('returns topic_id from the only row when present', () => {
       const id = 'f6a7b8c9-d0e1-2345-f678-901234567890';
       expect(topicIdForDetailResponse([{ topic_id: id }], 'Any Topic')).to.equal(id);
+    });
+
+    it('prefers topic_id on the newest execution_date row', () => {
+      const newest = '019cb903-1184-7f92-8325-f9d1176af099';
+      const older = '019cb903-1184-7f92-8325-f9d1176af088';
+      expect(topicIdForDetailResponse([
+        { topic_id: older, execution_date: '2026-03-01' },
+        { topic_id: newest, execution_date: '2026-03-08' },
+      ], 'Any Topic')).to.equal(newest);
+    });
+
+    it('falls back to an older row when newest has no topic_id', () => {
+      const older = '019cb903-1184-7f92-8325-f9d1176af088';
+      expect(topicIdForDetailResponse([
+        { topic_id: older, execution_date: '2026-03-01' },
+        { topic_id: null, execution_date: '2026-03-08' },
+      ], 'Any Topic')).to.equal(older);
     });
 
     it('returns trimmed UUID path when rows lack topic_id', () => {
@@ -758,9 +778,75 @@ describe('llmo-brand-presence', () => {
       expect(topicIdForDetailResponse([], 'My Topic')).to.be.null;
     });
 
-    it('returns UUID path when first row topic_id is empty string', () => {
+    it('returns UUID path when no row has a usable topic_id', () => {
       const id = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
-      expect(topicIdForDetailResponse([{ topic_id: '' }], id)).to.equal(id);
+      expect(topicIdForDetailResponse([{ topic_id: '', execution_date: '2026-03-01' }], id)).to.equal(id);
+    });
+  });
+
+  describe('promptIdForDetailResponse', () => {
+    it('returns empty string when there are no rows', () => {
+      expect(promptIdForDetailResponse([])).to.equal('');
+      expect(promptIdForDetailResponse(null)).to.equal('');
+    });
+
+    it('returns empty string when no row has prompt_id', () => {
+      expect(promptIdForDetailResponse([
+        { prompt_id: null, execution_date: '2026-03-02' },
+        { execution_date: '2026-03-01' },
+      ])).to.equal('');
+    });
+
+    it('prefers prompt_id on the newest execution_date row', () => {
+      const newest = '019cb903-1184-7f92-8325-f9d1176af099';
+      const older = '019cb903-1184-7f92-8325-f9d1176af088';
+      expect(promptIdForDetailResponse([
+        { prompt_id: older, execution_date: '2026-03-01' },
+        { prompt_id: newest, execution_date: '2026-03-08' },
+      ])).to.equal(newest);
+    });
+
+    it('falls back to an older row when newest has no prompt_id', () => {
+      const older = '019cb903-1184-7f92-8325-f9d1176af088';
+      expect(promptIdForDetailResponse([
+        { prompt_id: older, execution_date: '2026-03-01' },
+        { prompt_id: null, execution_date: '2026-03-08' },
+      ])).to.equal(older);
+    });
+  });
+
+  describe('promptTextForDetailEnvelope', () => {
+    it('returns empty string when there are no rows', () => {
+      expect(promptTextForDetailEnvelope([])).to.equal('');
+      expect(promptTextForDetailEnvelope(null)).to.equal('');
+    });
+
+    it('prefers prompt text on the newest execution_date row', () => {
+      expect(promptTextForDetailEnvelope([
+        { prompt: 'older text', execution_date: '2026-03-01' },
+        { prompt: 'newer text', execution_date: '2026-03-08' },
+      ])).to.equal('newer text');
+    });
+
+    it('falls back to an older row when newest has empty prompt', () => {
+      expect(promptTextForDetailEnvelope([
+        { prompt: 'older text', execution_date: '2026-03-01' },
+        { prompt: '', execution_date: '2026-03-08' },
+      ])).to.equal('older text');
+    });
+
+    it('falls back to an older row when newest has null prompt', () => {
+      expect(promptTextForDetailEnvelope([
+        { prompt: 'older text', execution_date: '2026-03-01' },
+        { prompt: null, execution_date: '2026-03-08' },
+      ])).to.equal('older text');
+    });
+
+    it('returns empty string when no row has prompt text', () => {
+      expect(promptTextForDetailEnvelope([
+        { prompt: null, execution_date: '2026-03-08' },
+        { prompt: '', execution_date: '2026-03-01' },
+      ])).to.equal('');
     });
   });
 
@@ -769,8 +855,22 @@ describe('llmo-brand-presence', () => {
       expect(topicLabelForDetailResponse([], 'My Topic')).to.equal('My Topic');
     });
 
-    it('returns first row topics when present', () => {
+    it('returns topics from the only row when present', () => {
       expect(topicLabelForDetailResponse([{ topics: 'AI Overview' }], 'ignored')).to.equal('AI Overview');
+    });
+
+    it('prefers topics on the newest execution_date row', () => {
+      expect(topicLabelForDetailResponse([
+        { topics: 'Older Label', execution_date: '2026-03-01' },
+        { topics: 'Newer Label', execution_date: '2026-03-08' },
+      ], 'ignored')).to.equal('Newer Label');
+    });
+
+    it('falls back to an older row when newest has empty topics', () => {
+      expect(topicLabelForDetailResponse([
+        { topics: 'Legacy Label', execution_date: '2026-03-01' },
+        { topics: '', execution_date: '2026-03-08' },
+      ], 'fallback')).to.equal('Legacy Label');
     });
 
     it('returns path when first row topics is null', () => {
@@ -5087,6 +5187,8 @@ describe('llmo-brand-presence', () => {
       expect(item.position).to.equal('3');
       expect(item.sentiment).to.equal('Positive');
       expect(item.origin).to.equal('human');
+      expect(item.topicId).to.equal('');
+      expect(item.promptId).to.equal('');
     });
 
     it('deduplicates by prompt|region_code keeping latest execution', () => {
@@ -5110,6 +5212,8 @@ describe('llmo-brand-presence', () => {
       expect(result).to.have.lengthOf(1);
       expect(result[0].executionDate).to.equal('2026-03-10');
       expect(result[0].visibilityScore).to.equal(90);
+      expect(result[0].topicId).to.equal('');
+      expect(result[0].promptId).to.equal('');
     });
 
     it('sets isAnswered to false when error_code is present', () => {
@@ -5154,6 +5258,8 @@ describe('llmo-brand-presence', () => {
       expect(result[0].sentiment).to.equal('');
       expect(result[0].errorCode).to.equal('');
       expect(result[0].origin).to.equal('');
+      expect(result[0].topicId).to.equal('');
+      expect(result[0].promptId).to.equal('');
     });
 
     it('aggregates mentions and citations across all execution rows per prompt', () => {
@@ -5193,6 +5299,8 @@ describe('llmo-brand-presence', () => {
       // Latest execution's metadata is used
       expect(result[0].executionDate).to.equal('2026-03-15');
       expect(result[0].visibilityScore).to.equal(90);
+      expect(result[0].topicId).to.equal('');
+      expect(result[0].promptId).to.equal('');
     });
 
     it('uses "Unknown" for null topics and counts citations correctly', () => {
@@ -5211,6 +5319,37 @@ describe('llmo-brand-presence', () => {
       expect(result[0].topic).to.equal('Unknown');
       expect(result[0].citationsCount).to.equal(1);
       expect(result[0].mentionsCount).to.equal(0);
+      expect(result[0].topicId).to.equal('');
+      expect(result[0].promptId).to.equal('');
+    });
+
+    it('includes topicId and promptId from the latest execution row', () => {
+      const topicUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const promptUuid = 'f1e2d3c4-b5a6-9876-5432-10fedcba9876';
+      const rows = [
+        {
+          topics: 'PDF',
+          topic_id: topicUuid,
+          prompt: 'q1',
+          prompt_id: promptUuid,
+          region_code: 'US',
+          execution_date: '2026-03-01',
+          visibility_score: 50,
+        },
+        {
+          topics: 'PDF',
+          topic_id: topicUuid,
+          prompt: 'q1',
+          prompt_id: 'should-not-win',
+          region_code: 'US',
+          execution_date: '2026-03-10',
+          visibility_score: 90,
+        },
+      ];
+      const result = buildPromptDetails(rows);
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].topicId).to.equal(topicUuid);
+      expect(result[0].promptId).to.equal('should-not-win');
     });
   });
 
@@ -5629,6 +5768,8 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.items).to.have.lengthOf(1);
       expect(body.items[0].prompt).to.equal('q1');
+      expect(body.items[0].topicId).to.equal('');
+      expect(body.items[0].promptId).to.equal('');
       expect(body.totalCount).to.equal(1);
       expect(body.topic).to.equal('PDF');
       expect(body.topicId).to.be.null;
@@ -5641,6 +5782,7 @@ describe('llmo-brand-presence', () => {
           topic_id: topicUuid,
           topics: 'Resolved Label',
           prompt: 'q1',
+          prompt_id: 'prompt-row-uuid',
           region_code: 'US',
           mentions: true,
           citations: false,
@@ -5667,6 +5809,8 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.topic).to.equal('Resolved Label');
       expect(body.topicId).to.equal(topicUuid);
+      expect(body.items[0].topicId).to.equal(topicUuid);
+      expect(body.items[0].promptId).to.equal('prompt-row-uuid');
       expect(body.totalCount).to.equal(1);
     });
 
@@ -7119,8 +7263,10 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[1].executionDate).to.equal('2026-03-01');
       expect(body.executions[0].prompt).to.equal('q2');
       expect(body.executions[0].promptId).to.equal('p2-id');
+      expect(body.executions[0].topicId).to.equal(topicRowId);
       expect(body.executions[0].executionId).to.equal('exec-2');
       expect(body.executions[1].promptId).to.equal('p1-id');
+      expect(body.executions[1].topicId).to.equal(topicRowId);
       expect(body.executions[1].executionId).to.equal('exec-1');
       expect(body.executions[0].mentions).to.equal(false);
       expect(body.executions[0].citations).to.equal(true);
@@ -7318,6 +7464,7 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.executions[0].prompt).to.equal('');
       expect(body.executions[0].promptId).to.equal('');
+      expect(body.executions[0].topicId).to.equal('');
       expect(body.executions[0].executionId).to.equal('');
       expect(body.executions[0].region).to.equal('');
       expect(body.executions[0].executionDate).to.equal('');
@@ -7396,6 +7543,7 @@ describe('llmo-brand-presence', () => {
       expect(body.topic).to.equal('AI Overview');
       expect(body.topicId).to.be.null;
       expect(body.prompt).to.equal('What is AI?');
+      expect(body.promptId).to.equal('');
       expect(body.weeklyStats).to.deep.equal([]);
       expect(body.executions).to.deep.equal([]);
       expect(body.sources).to.deep.equal([]);
@@ -7419,6 +7567,7 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.topic).to.equal(topicUuid);
       expect(body.topicId).to.equal(topicUuid);
+      expect(body.promptId).to.equal('');
     });
 
     it('returns ok with zeroed stats when data is null', async () => {
@@ -7485,6 +7634,7 @@ describe('llmo-brand-presence', () => {
           topics: 'Shown Topic Name',
           topic_id: topicUuid,
           prompt: 'What is AI?',
+          prompt_id: 'prompt-envelope-1',
           region_code: 'US',
           mentions: true,
           citations: true,
@@ -7517,6 +7667,7 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.topic).to.equal('Shown Topic Name');
       expect(body.topicId).to.equal(topicUuid);
+      expect(body.promptId).to.equal('prompt-envelope-1');
     });
 
     it('uses path param for body.topic when rows have null topics (prompt-detail)', async () => {
@@ -7560,6 +7711,7 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.topic).to.equal(topicUuid);
       expect(body.topicId).to.equal(topicUuid);
+      expect(body.promptId).to.equal('p1');
     });
 
     it('applies region_code filter when promptRegion is provided', async () => {
@@ -7676,6 +7828,8 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[1].executionDate).to.equal('2026-03-01');
       expect(body.executions[0].promptId).to.equal('pd-newer');
       expect(body.executions[1].promptId).to.equal('pd-older');
+      expect(body.executions[0].topicId).to.equal(topicRowId);
+      expect(body.executions[1].topicId).to.equal(topicRowId);
       expect(body.executions[0].executionId).to.equal('e2');
       expect(body.executions[1].executionId).to.equal('e1');
       expect(body.executions[0].businessCompetitors).to.equal('Rival;OtherCo');
@@ -7683,6 +7837,7 @@ describe('llmo-brand-presence', () => {
       expect(body.executions[1].businessCompetitors).to.equal('');
       expect(body.executions[1].detectedBrandMentions).to.equal('');
       expect(body.topicId).to.equal(topicRowId);
+      expect(body.promptId).to.equal('pd-newer');
     });
 
     it('counts negative sentiment rows but scores them at 0', async () => {
@@ -7855,12 +8010,14 @@ describe('llmo-brand-presence', () => {
       const body = await result.json();
       expect(body.executions[0].prompt).to.equal('');
       expect(body.executions[0].promptId).to.equal('');
+      expect(body.executions[0].topicId).to.equal('');
       expect(body.executions[0].executionId).to.equal('e1');
       expect(body.executions[0].region).to.equal('');
       expect(body.executions[0].executionDate).to.equal('');
       expect(body.executions[0].businessCompetitors).to.equal('');
       expect(body.executions[0].detectedBrandMentions).to.equal('');
       expect(body.executions[1].executionId).to.equal('e2');
+      expect(body.promptId).to.equal('');
     });
 
     it('returns empty executionId when execution row id is null (prompt detail map)', async () => {
@@ -7950,6 +8107,121 @@ describe('llmo-brand-presence', () => {
       expect(body.sources).to.have.lengthOf(1);
       expect(body.sources[0].hostname).to.equal('docs.example.com');
       expect(body.sources[0].contentType).to.equal('pdf');
+    });
+  });
+
+  // ── createPromptDetailByPromptIdHandler ─────────────────────────────────────
+  describe('createPromptDetailByPromptIdHandler', () => {
+    const promptUuid = 'c3d4e5f6-a7b8-9012-cdef-123456789012';
+
+    beforeEach(() => {
+      mockContext.params.promptId = promptUuid;
+      delete mockContext.params.topicId;
+      mockContext.data = {};
+    });
+
+    it('returns badRequest when prompt id is not a UUID', async () => {
+      mockContext.params.promptId = 'not-a-uuid';
+      mockContext.dataAccess.Site.postgrestService = createChainableMock({ data: [], error: null });
+
+      const handler = createPromptDetailByPromptIdHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(400);
+    });
+
+    it('returns badRequest when postgrestService is missing', async () => {
+      mockContext.dataAccess.Site.postgrestService = null;
+
+      const handler = createPromptDetailByPromptIdHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(400);
+    });
+
+    it('filters brand_presence_executions_active by prompt_id', async () => {
+      const client = createTableAwareMock({
+        brand_presence_executions_active: { data: [], error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createPromptDetailByPromptIdHandler(getOrgAndValidateAccess);
+      await handler(mockContext);
+
+      expect(client.eq).to.have.been.calledWith('prompt_id', promptUuid);
+    });
+
+    it('returns prompt detail shape scoped by prompt_id', async () => {
+      const topicUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const rows = [
+        {
+          id: 'e1',
+          topic_id: topicUuid,
+          topics: 'AI Overview',
+          prompt: 'What is AI?',
+          prompt_id: promptUuid,
+          region_code: 'US',
+          mentions: true,
+          citations: false,
+          visibility_score: 80,
+          position: '2',
+          sentiment: 'Positive',
+          volume: '100',
+          origin: 'organic',
+          category_name: 'Search',
+          execution_date: '2026-03-01',
+          answer: 'Answer A',
+          url: 'https://a.com',
+          error_code: null,
+          business_competitors: '',
+          detected_brand_mentions: '',
+        },
+      ];
+      const client = createTableAwareMock({
+        brand_presence_executions_active: { data: rows, error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createPromptDetailByPromptIdHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.promptId).to.equal(promptUuid);
+      expect(body.prompt).to.equal('What is AI?');
+      expect(body.topic).to.equal('AI Overview');
+      expect(body.topicId).to.equal(topicUuid);
+      expect(body.region).to.equal('');
+      expect(body.executions).to.have.lengthOf(1);
+    });
+
+    it('returns empty executions but keeps requested promptId when no rows', async () => {
+      mockContext.dataAccess.Site.postgrestService = createChainableMock({ data: [], error: null });
+
+      const handler = createPromptDetailByPromptIdHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.promptId).to.equal(promptUuid);
+      expect(body.prompt).to.equal('');
+      expect(body.executions).to.deep.equal([]);
+    });
+
+    it('applies optional promptRegion filter', async () => {
+      const client = createTableAwareMock({
+        brand_presence_executions_active: { data: [], error: null },
+        brand_presence_sources: { data: [], error: null },
+      });
+      mockContext.data = { promptRegion: 'DE' };
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createPromptDetailByPromptIdHandler(getOrgAndValidateAccess);
+      await handler(mockContext);
+
+      expect(client.eq).to.have.been.calledWith('region_code', 'DE');
     });
   });
 

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -846,6 +846,7 @@ describe('llmo-brand-presence', () => {
       expect(promptTextForDetailEnvelope([
         { prompt: null, execution_date: '2026-03-08' },
         { prompt: '', execution_date: '2026-03-01' },
+        { prompt: undefined, execution_date: '2026-03-02' },
       ])).to.equal('');
     });
   });

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -627,6 +627,8 @@ describe('getRouteHandlers', () => {
       'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/detail',
       'GET /org/:spaceCatId/brands/all/brand-presence/topics/:topicId/prompt-detail',
       'GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/prompt-detail',
+      'GET /org/:spaceCatId/brands/all/brand-presence/prompts/:promptId/detail',
+      'GET /org/:spaceCatId/brands/:brandId/brand-presence/prompts/:promptId/detail',
       'GET /org/:spaceCatId/brands/all/brand-presence/executions/:executionId/sources',
       'GET /org/:spaceCatId/brands/:brandId/brand-presence/executions/:executionId/sources',
       'GET /org/:spaceCatId/brands/all/brand-presence/sentiment-movers',


### PR DESCRIPTION
## Summary

Brand Presence (Postgres / PostgREST) responses are clearer for clients that work in UUIDs: prompt-level detail can be loaded **by `prompt_id` and date range** without a topic path or `prompt` query string; list/detail payloads consistently expose **`topicId` / `promptId`** where we have columns; envelope **topic label / topic id** resolution now matches **newest `execution_date` first** (same ordering as prompt text / `prompt_id` on the envelope), so PostgREST row order cannot mix mismatched metadata.

## New routes

- `GET /org/:spaceCatId/brands/all/brand-presence/prompts/:promptId/detail`
- `GET /org/:spaceCatId/brands/:brandId/brand-presence/prompts/:promptId/detail`

`:promptId` must be a UUID (`brand_presence_executions.prompt_id`). Same query filters as existing prompt detail (`startDate` / `endDate`, `model` / `platform`, `siteId`, `origin`, optional `promptRegion` / `prompt_region`). Same JSON shape as `.../topics/:topicId/prompt-detail` (stats, `weeklyStats`, `executions`, `sources`). Envelope `promptId` is always the path id; envelope `prompt` text is derived from rows when present.

## Response / behavior changes

- **Topic prompts** (`.../topics/:topicId/prompts`): each item includes `topicId` and `promptId` (strings; `""` when null). `PROMPTS_SELECT` includes `prompt_id`.
- **Topic & prompt detail** `executions[]`: each row includes `topicId` (string; `""` when null), alongside existing `promptId` / `executionId`.
- **Prompt detail** (topic-scoped): top-level `promptId` added (existing `promptIdForDetailResponse` logic).
- **Envelope ordering**: `topicLabelForDetailResponse`, `topicIdForDetailResponse`, `promptIdForDetailResponse`, and `promptTextForDetailEnvelope` use shared **`sortDetailRowsByExecutionDateDesc`** so envelope fields agree on “newest execution first, then scan older rows.”

## Caveats (unchanged intent, documented)

- Root `topicId` can still be `null` when the topic cannot be resolved to a UUID (e.g. name-only path and no `topic_id` on rows).
- String ids on rows / items may be `""` when Postgres has nulls (legacy data).

## Implementation notes

- **`assemblePromptDetailPayload`**: shared builder for topic-scoped and by-`prompt_id` prompt detail to avoid drift.
- **`createPromptDetailByPromptIdHandler`**: wired through `llmo-mysticat-controller`, `routes/index.js`, `required-capabilities.js` (`brand:read`).
- **`sortDetailRowsByExecutionDateDesc`**: exported for reuse / tests.

## Tests

- Extended `llmo-brand-presence.test.js` (envelope helpers, new handler, updated expectations where ordering matters).

## Docs

- `docs/llmo-brandalf-apis/topics-api.md`
- `docs/llmo-brandalf-apis/topic-detail-api.md`
- `docs/llmo-brandalf-apis/prompt-detail-api.md` (includes new paths, query split, errors, aggregation wording)