### PR TITLE
fix(brands): reject brand URLs that don't match a site in the org | LLMO-4435

### DIFF
--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -128,10 +128,68 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
 }
 
 /**
- * Fully replaces brand_sites for a brand. Groups submitted URLs by normalized base URL
- * (via composeBaseURL) so that multiple paths under the same site share one brand_sites row.
+ * Groups submitted URLs by normalized base URL (via composeBaseURL) and resolves each
+ * base against the sites table in the brand's organization.
+ *
+ * Throws a 400 BRAND_URLS_UNRESOLVED error if any submitted base URL has no matching
+ * `sites` row. Callers invoke this BEFORE any destructive brand writes so invalid
+ * requests leave the brand untouched. See LLMO-4435.
+ *
+ * Returns the matched `sites` rows plus the `pathsByBase`/`typeByBase` maps so
+ * `syncBrandSites` can upsert without re-querying.
  */
-async function syncBrandSites(organizationId, brandId, urls, postgrestClient, updatedBy) {
+async function resolveBrandSiteUrls(organizationId, urls, postgrestClient) {
+  const pathsByBase = new Map();
+  const typeByBase = new Map();
+  (urls || []).forEach((u) => {
+    const value = typeof u === 'string' ? u : u?.value;
+    if (!hasText(value)) {
+      return;
+    }
+    const { base, path } = parseUrlParts(value);
+    const normalizedBase = composeBaseURL(base);
+    if (!pathsByBase.has(normalizedBase)) {
+      pathsByBase.set(normalizedBase, []);
+    }
+    pathsByBase.get(normalizedBase).push(path || '/');
+    // First URL with a type wins for a given base URL — prevents silent overwrite
+    // when multiple paths under the same domain carry different types.
+    if (typeof u === 'object' && hasText(u?.type) && !typeByBase.has(normalizedBase)) {
+      typeByBase.set(normalizedBase, u.type);
+    }
+  });
+
+  if (pathsByBase.size === 0) {
+    return { sites: [], pathsByBase, typeByBase };
+  }
+
+  const { data: sites, error } = await postgrestClient
+    .from('sites')
+    .select('id, base_url')
+    .eq('organization_id', organizationId)
+    .in('base_url', [...pathsByBase.keys()]);
+  if (error) {
+    throw new Error(`Failed to resolve brand sites: ${error.message}`);
+  }
+
+  const resolvedBases = new Set(sites.map((s) => s.base_url));
+  const unresolved = [...pathsByBase.keys()].filter((base) => !resolvedBases.has(base));
+  if (unresolved.length > 0) {
+    const err = new Error(
+      `The following URL(s) could not be saved because no matching site exists in this organization: ${unresolved.join(', ')}`,
+    );
+    err.status = 400;
+    err.code = 'BRAND_URLS_UNRESOLVED';
+    throw err;
+  }
+
+  return { sites, pathsByBase, typeByBase };
+}
+
+/**
+ * Fully replaces brand_sites for a brand using the output of `resolveBrandSiteUrls`.
+ */
+async function syncBrandSites(organizationId, brandId, resolved, postgrestClient, updatedBy) {
   const { error: deleteError } = await postgrestClient
     .from('brand_sites')
     .delete()
@@ -140,43 +198,8 @@ async function syncBrandSites(organizationId, brandId, urls, postgrestClient, up
     throw new Error(`Failed to sync brand_sites: ${deleteError.message}`);
   }
 
-  if (!urls || urls.length === 0) {
-    return;
-  }
-
-  // Group paths by base URL and track type
-  const pathsByBase = new Map();
-  const typeByBase = new Map();
-  urls
-    .forEach((u) => {
-      const value = typeof u === 'string' ? u : u?.value;
-      if (!hasText(value)) {
-        return;
-      }
-      const { base, path } = parseUrlParts(value);
-      const normalizedBase = composeBaseURL(base);
-      if (!pathsByBase.has(normalizedBase)) {
-        pathsByBase.set(normalizedBase, []);
-      }
-      pathsByBase.get(normalizedBase).push(path || '/');
-      // First URL with a type wins for a given base URL — prevents silent overwrite
-      // when multiple paths under the same domain carry different types.
-      if (typeof u === 'object' && hasText(u?.type) && !typeByBase.has(normalizedBase)) {
-        typeByBase.set(normalizedBase, u.type);
-      }
-    });
-
-  if (pathsByBase.size === 0) {
-    return;
-  }
-
-  const { data: sites } = await postgrestClient
-    .from('sites')
-    .select('id, base_url')
-    .eq('organization_id', organizationId)
-    .in('base_url', [...pathsByBase.keys()]);
-
-  if (!sites || sites.length === 0) {
+  const { sites, pathsByBase, typeByBase } = resolved;
+  if (sites.length === 0) {
     return;
   }
 
@@ -184,7 +207,7 @@ async function syncBrandSites(organizationId, brandId, urls, postgrestClient, up
     organization_id: organizationId,
     brand_id: brandId,
     site_id: s.id,
-    paths: pathsByBase.get(s.base_url) || [],
+    paths: pathsByBase.get(s.base_url),
     type: typeByBase.get(s.base_url) || null,
     updated_by: updatedBy,
   }));
@@ -362,6 +385,11 @@ export async function upsertBrand({
     throw new Error('Brand name is required');
   }
 
+  // Resolve URLs BEFORE any destructive writes so an invalid request leaves the DB untouched.
+  const resolvedUrls = brand.urls !== undefined
+    ? await resolveBrandSiteUrls(organizationId, brand.urls, postgrestClient)
+    : null;
+
   const regions = (brand.region || [])
     .map((r) => (typeof r === 'string' ? r : String(r))).filter(hasText);
 
@@ -425,8 +453,8 @@ export async function upsertBrand({
     syncEarnedSources(brandId, organizationId, brand.earnedContent, postgrestClient, updatedBy),
   ]);
 
-  if (brand.urls !== undefined) {
-    await syncBrandSites(organizationId, brandId, brand.urls, postgrestClient, updatedBy);
+  if (resolvedUrls !== null) {
+    await syncBrandSites(organizationId, brandId, resolvedUrls, postgrestClient, updatedBy);
   }
 
   return getBrandById(organizationId, brandId, postgrestClient);
@@ -453,6 +481,11 @@ export async function updateBrand({
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
   }
+
+  // Resolve URLs BEFORE any destructive writes so an invalid request leaves the DB untouched.
+  const resolvedUrls = updates.urls !== undefined
+    ? await resolveBrandSiteUrls(organizationId, updates.urls, postgrestClient)
+    : null;
 
   const patch = { updated_by: updatedBy };
 
@@ -542,8 +575,8 @@ export async function updateBrand({
     await Promise.all(childSyncs);
   }
 
-  if (updates.urls !== undefined) {
-    await syncBrandSites(organizationId, brandId, updates.urls, postgrestClient, updatedBy);
+  if (resolvedUrls !== null) {
+    await syncBrandSites(organizationId, brandId, resolvedUrls, postgrestClient, updatedBy);
   }
 
   return getBrandById(organizationId, brandId, postgrestClient);

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -750,6 +750,7 @@ describe('brands-storage', () => {
     it('throws when brand_sites delete fails during syncBrandSites', async () => {
       const postgrestClient = createTableMockClient({
         brands: { data: { id: BRAND_ID, name: 'Test' }, error: null },
+        sites: { data: [{ id: 'site-uuid-1', base_url: 'https://test.com' }], error: null },
         brand_sites: { data: null, error: { message: 'delete error' } },
       });
 
@@ -760,9 +761,76 @@ describe('brands-storage', () => {
       })).to.be.rejectedWith('Failed to sync brand_sites: delete error');
     });
 
+    it('throws BRAND_URLS_UNRESOLVED when a submitted URL has no matching site in the org', async () => {
+      const postgrestClient = createTableMockClient({
+        // brands + brand_sites intentionally omitted — we assert neither is touched.
+        sites: { data: [], error: null },
+      });
+
+      let thrown;
+      try {
+        await upsertBrand({
+          organizationId: ORG_ID,
+          brand: { name: 'Test', urls: [{ value: 'https://yahoo.com' }] },
+          postgrestClient,
+        });
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).to.exist;
+      expect(thrown.status).to.equal(400);
+      expect(thrown.code).to.equal('BRAND_URLS_UNRESOLVED');
+      expect(thrown.message).to.include('https://yahoo.com');
+      // No destructive writes happen — 'brands' and 'brand_sites' should never be touched.
+      expect(postgrestClient.from).to.not.have.been.calledWith('brands');
+      expect(postgrestClient.from).to.not.have.been.calledWith('brand_sites');
+    });
+
+    it('lists every unresolved URL in the error message when multiple are missing', async () => {
+      const postgrestClient = createTableMockClient({
+        sites: { data: [{ id: 'site-1', base_url: 'https://valid.com' }], error: null },
+      });
+
+      let thrown;
+      try {
+        await upsertBrand({
+          organizationId: ORG_ID,
+          brand: {
+            name: 'Test',
+            urls: [
+              { value: 'https://valid.com' },
+              { value: 'https://yahoo.com' },
+              { value: 'https://example.com' },
+            ],
+          },
+          postgrestClient,
+        });
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown.code).to.equal('BRAND_URLS_UNRESOLVED');
+      expect(thrown.message).to.include('https://yahoo.com');
+      expect(thrown.message).to.include('https://example.com');
+      expect(thrown.message).to.not.include('https://valid.com');
+    });
+
+    it('throws when the sites resolution query fails', async () => {
+      const postgrestClient = createTableMockClient({
+        sites: { data: null, error: { message: 'sites lookup error' } },
+      });
+
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://test.com' }] },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to resolve brand sites: sites lookup error');
+    });
+
     it('falls back to base URL when URL string is invalid in syncBrandSites', async () => {
       const fullBrandRow = makeBrandRow({
-        brand_sites: [{ site_id: 'site-1', paths: [], sites: { base_url: 'not-a-valid-url' } }],
+        brand_sites: [{ site_id: 'site-1', paths: [], sites: { base_url: 'https://not-a-valid-url' } }],
       });
 
       const postgrestClient = createTableMockClient({
@@ -770,7 +838,7 @@ describe('brands-storage', () => {
           { data: { id: BRAND_ID, name: 'Test' }, error: null },
           { data: fullBrandRow, error: null },
         ],
-        sites: { data: [{ id: 'site-1', base_url: 'not-a-valid-url' }], error: null },
+        sites: { data: [{ id: 'site-1', base_url: 'https://not-a-valid-url' }], error: null },
         brand_sites: { data: null, error: null },
       });
 
@@ -886,27 +954,6 @@ describe('brands-storage', () => {
         { value: 'https://adobe.com/products' },
         { value: 'https://adobe.com/help' },
       ]);
-    });
-
-    it('skips syncBrandSites when urls resolve to no matching sites', async () => {
-      const fullBrandRow = makeBrandRow();
-
-      const postgrestClient = createTableMockClient({
-        brands: [
-          { data: { id: BRAND_ID, name: 'Test' }, error: null },
-          { data: fullBrandRow, error: null },
-        ],
-        sites: { data: [], error: null },
-        brand_sites: { data: null, error: null },
-      });
-
-      const result = await upsertBrand({
-        organizationId: ORG_ID,
-        brand: { name: 'Test', urls: [{ value: 'https://test.com' }] },
-        postgrestClient,
-      });
-
-      expect(result.siteIds).to.deep.equal([]);
     });
 
     it('upserts brand with socialAccounts and earnedContent to normalized tables', async () => {
@@ -1028,32 +1075,6 @@ describe('brands-storage', () => {
       });
 
       expect(result.competitors).to.deep.equal([{ name: 'StringRival', url: null, regions: [] }]);
-    });
-
-    it('uses empty paths array when site base_url is not in pathsByBase map', async () => {
-      // Sites mock returns a different base_url than what was submitted,
-      // triggering the `pathsByBase.get(s.base_url) || []` fallback branch.
-      const fullBrandRow = makeBrandRow({
-        brand_sites: [{ site_id: 'site-1', paths: [], sites: { base_url: 'https://other.com' } }],
-      });
-
-      const postgrestClient = createTableMockClient({
-        brands: [
-          { data: { id: BRAND_ID, name: 'Test' }, error: null },
-          { data: fullBrandRow, error: null },
-        ],
-        // sites returns a base_url not present in pathsByBase (which has 'https://a.com')
-        sites: { data: [{ id: 'site-1', base_url: 'https://other.com' }], error: null },
-        brand_sites: { data: null, error: null },
-      });
-
-      const result = await upsertBrand({
-        organizationId: ORG_ID,
-        brand: { name: 'Test', urls: [{ value: 'https://a.com/products' }] },
-        postgrestClient,
-      });
-
-      expect(result.siteIds).to.deep.equal(['site-1']);
     });
 
     it('handles empty urls array in syncBrandSites (early return branch)', async () => {
@@ -1440,6 +1461,75 @@ describe('brands-storage', () => {
 
       expect(result.brandAliases).to.deep.equal([]);
       expect(result.competitors).to.deep.equal([]);
+    });
+
+    it('throws BRAND_URLS_UNRESOLVED without touching the brand when a submitted URL has no matching site', async () => {
+      const postgrestClient = createTableMockClient({
+        sites: { data: [], error: null },
+        // 'brands' and 'brand_sites' intentionally omitted — asserting neither is touched.
+      });
+
+      let thrown;
+      try {
+        await updateBrand({
+          organizationId: ORG_ID,
+          brandId: BRAND_ID,
+          updates: { urls: [{ value: 'https://yahoo.com' }] },
+          postgrestClient,
+        });
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).to.exist;
+      expect(thrown.status).to.equal(400);
+      expect(thrown.code).to.equal('BRAND_URLS_UNRESOLVED');
+      expect(thrown.message).to.include('https://yahoo.com');
+      expect(postgrestClient.from).to.not.have.been.calledWith('brands');
+      expect(postgrestClient.from).to.not.have.been.calledWith('brand_sites');
+    });
+
+    it('treats null urls the same as an empty array (no validation, brand_sites cleared)', async () => {
+      const fullBrandRow = makeBrandRow();
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: { id: BRAND_ID }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        brand_sites: { data: null, error: null },
+      });
+
+      const result = await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { urls: null },
+        postgrestClient,
+      });
+
+      expect(result).to.not.be.null;
+      // Null urls skips site resolution entirely.
+      expect(postgrestClient.from).to.not.have.been.calledWith('sites');
+    });
+
+    it('still allows other field updates when updates.urls is not provided', async () => {
+      const fullBrandRow = makeBrandRow({ name: 'Renamed' });
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: { id: BRAND_ID }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+      });
+
+      const result = await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { name: 'Renamed' },
+        postgrestClient,
+      });
+
+      expect(result.name).to.equal('Renamed');
+      // With no urls in the update payload, no sites lookup runs.
+      expect(postgrestClient.from).to.not.have.been.calledWith('sites');
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes LLMO-4435 (Brandalf silent save failure). Previously, submitting a brand URL whose normalized base did not match a `sites` row in the brand's IMS organization was silently dropped by `syncBrandSites`: the PATCH returned 200 with `urls: []`, leaving the UI to show a misleading "saved" state. Users reported adding `yahoo.com` (and similar) to Adobe Acrobat and never seeing it appear — with no error surfaced.

### What changes
- Extract resolution into `resolveBrandSiteUrls` in `src/support/brands-storage.js`. It groups submitted URLs by normalized base URL, queries `sites` scoped to the org, and if any base URL can't be resolved, throws an `Error` with `status: 400`, `code: 'BRAND_URLS_UNRESOLVED'`, and a message listing every unresolved URL.
- Invoke the resolver at the top of both `upsertBrand` (create) and `updateBrand` (edit), BEFORE any `brands` or child-table writes — so an invalid request leaves all brand data untouched. The controller's existing `try/catch → createErrorResponse` path propagates the thrown error to a 400 response.
- `syncBrandSites` now takes the pre-resolved `{ sites, pathsByBase, typeByBase }` struct instead of raw URLs, removing the silent early-return behaviour on unresolved sites.

### Tests
- New: `throws BRAND_URLS_UNRESOLVED when a submitted URL has no matching site in the org` — verifies `status`, `code`, error message content, and that neither `brands` nor `brand_sites` were touched.
- New: `lists every unresolved URL in the error message when multiple are missing` — pluralization / partial-mismatch case.
- New: `throws when the sites resolution query fails` — covers the resolver's own error path.
- New: `throws BRAND_URLS_UNRESOLVED without touching the brand when a submitted URL has no matching site` (`updateBrand` mirror).
- New: `treats null urls the same as an empty array (no validation, brand_sites cleared)` — edge case.
- New: `still allows other field updates when updates.urls is not provided` — confirms non-URL patches don't trigger a needless sites query.
- Removed: the two obsolete tests that encoded the silent-drop behaviour (`skips syncBrandSites when urls resolve to no matching sites` and `uses empty paths array when site base_url is not in pathsByBase map`).
- Updated: `falls back to base URL when URL string is invalid in syncBrandSites` — mock `sites.base_url` aligned with `composeBaseURL` normalization (`not-a-valid-url` → `https://not-a-valid-url`).

Full suite: 8313 passing. Coverage: 100% / 100% branches.

## Jira
https://jira.corp.adobe.com/browse/LLMO-4435

## How to Test
1. In stage, pick any brand in an IMS org where `yahoo.com` is not registered as a `sites` row. Open the brand's URLs tab in Brandalf.
2. Add URL `https://yahoo.com` → Save.
3. Expected: Network tab shows PATCH `/v2/orgs/:orgId/brands/:brandId` returning **400** with a body like `The following URL(s) could not be saved because no matching site exists in this organization: https://yahoo.com`. The UI shows a negative toast surfacing that message. Re-opening the brand shows its URL list **unchanged** from before the save.
4. Happy path: add a URL that IS a registered site → 200, success toast, URL appears. No regression.
5. Edge case: submit a mix of valid + invalid URLs in one save. Expected: 400 listing only the invalid ones; the valid URLs are NOT persisted (the whole request is rejected — no partial writes).

## Rollback
Additive pre-validation. Reverting the commit restores the current silent-drop behavior. Low risk, no schema changes.

## Related
Replaces PR [project-elmo-ui#1580](https://github.com/adobe/project-elmo-ui/pull/1580) which attempted a UI-layer workaround; that approach was rejected in favor of this backend fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)