### PR TITLE
feat(llmo): add Akamai PAPI config download endpoint (LLMO-4341)

### DIFF
--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -72,6 +72,7 @@ import { handleLlmoRationale } from './llmo-rationale.js';
 import { handleBrandClaims } from './brand-claims.js';
 import { handleDemoBrandPresence, handleDemoRecommendations } from './opportunity-workspace-demo.js';
 import { notifyStrategyChanges } from '../../support/opportunity-workspace-notifications.js';
+import { generateAkamaiPapiConfig } from '../../support/akamai-papi-template.js';
 import {
   LLMO_CONFIG_DB_SYNC_TYPE,
   isSyncEnabledForSite,
@@ -1492,6 +1493,58 @@ function LlmoController(ctx) {
   };
 
   /**
+   * GET /sites/{siteId}/llmo/edge-optimize-config/akamai-papi
+   * Generates and returns a pre-filled Akamai PAPI JSON configuration for
+   * "Optimize at Edge" CDN routing.
+   * @param {object} context - Request context
+   * @returns {Promise<Response>} PAPI JSON file download
+   */
+  const getAkamaiPapiConfig = async (context) => {
+    const { log, dataAccess } = context;
+    const { siteId } = context.params;
+    const { Site } = dataAccess;
+
+    try {
+      const site = await Site.findById(siteId);
+
+      if (!site) {
+        return notFound('Site not found');
+      }
+
+      if (!await accessControlUtil.hasAccess(site)) {
+        return forbidden('User does not have access to this site');
+      }
+
+      if (!accessControlUtil.isLLMOAdministrator()) {
+        return forbidden('Only LLMO administrators can download the Akamai config');
+      }
+
+      const baseURL = site.getBaseURL();
+      const { hostname } = new URL(baseURL.startsWith('http') ? baseURL : `https://${baseURL}`);
+
+      const tokowakaClient = TokowakaClient.createFrom(context);
+      const metaconfig = await tokowakaClient.fetchMetaconfig(baseURL);
+
+      if (!metaconfig || !Array.isArray(metaconfig.apiKeys) || metaconfig.apiKeys.length === 0) {
+        return badRequest('Edge Optimize API key not found. Please enable edge optimizations first to generate your API key.');
+      }
+
+      const [apiKey] = metaconfig.apiKeys;
+      const papiConfig = generateAkamaiPapiConfig(hostname, apiKey);
+
+      log.info(`Generated Akamai PAPI config for site ${siteId}, domain: ${hostname}`);
+
+      return ok(papiConfig, {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="akamai-edge-optimize-${hostname}.json"`,
+      });
+    } catch (error) {
+      log.error(`Failed to generate Akamai PAPI config for site ${siteId}:, error`);
+      return badRequest(cleanupHeaderValue(error.message));
+    }
+  };
+
+  /**
    * GET /sites/{siteId}/llmo/strategy
    * Retrieves LLMO strategy data from S3
    * @param {object} context - Request context
@@ -1883,6 +1936,7 @@ function LlmoController(ctx) {
     getDemoRecommendations,
     createOrUpdateEdgeConfig,
     getEdgeConfig,
+    getAkamaiPapiConfig,
     createOrUpdateStageEdgeConfig,
     getStrategy,
     saveStrategy,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -424,6 +424,7 @@ export default function getRouteHandlers(
     'POST /sites/:siteId/llmo/offboard': llmoController.offboardCustomer,
     'POST /sites/:siteId/llmo/edge-optimize-config': llmoController.createOrUpdateEdgeConfig,
     'GET /sites/:siteId/llmo/edge-optimize-config': llmoController.getEdgeConfig,
+    'GET /sites/:siteId/llmo/edge-optimize-config/akamai-papi': llmoController.getAkamaiPapiConfig,
     'POST /sites/:siteId/llmo/edge-optimize-config/stage': llmoController.createOrUpdateStageEdgeConfig,
     'GET /sites/:siteId/llmo/strategy': llmoController.getStrategy,
     'PUT /sites/:siteId/llmo/strategy': llmoController.saveStrategy,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -481,6 +481,7 @@ const routeRequiredCapabilities = {
   'GET /sites/:siteId/llmo/global-sheet-data/:configName': 'site:read',
   'GET /sites/:siteId/llmo/rationale': 'site:read',
   'GET /sites/:siteId/llmo/edge-optimize-config': 'site:read',
+  'GET /sites/:siteId/llmo/edge-optimize-config/akamai-papi': 'site:read',
   'GET /sites/:siteId/llmo/strategy': 'site:read',
   'PUT /sites/:siteId/llmo/strategy': 'site:write',
   'GET /sites/:siteId/llmo/edge-optimize-status': 'site:read',

--- a/src/support/akamai-papi-template.js
+++ b/src/support/akamai-papi-template.js
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Builds the Akamai origin behavior pointing to live.edgeoptimize.net.
+ * @returns {object} Origin behavior object.
+ */
+function buildOriginBehavior() {
+  return {
+    name: 'origin',
+    options: {
+      originType: 'CUSTOMER',
+      hostname: 'live.edgeoptimize.net',
+      forwardHostHeader: 'REQUEST_HOST_HEADER',
+      cacheKeyHostname: 'ORIGIN_HOSTNAME',
+      compress: true,
+      enableTrueClientIp: false,
+      httpPort: 80,
+      httpsPort: 443,
+      originSni: true,
+      verificationMode: 'CUSTOM_CODES',
+      originSslProtocols: {
+        TLSv1_2: true,
+        TLSv1_3: true,
+      },
+      customValidCnValues: [
+        '{{Origin Hostname}}',
+        '{{Forward Host Header}}',
+        '*.edgeoptimize.net',
+      ],
+      customCertificateAuthorities: [],
+      customCertificates: [],
+    },
+  };
+}
+
+/**
+ * Builds the setVariable behavior for the Edge Optimize cache key.
+ * @returns {object} setVariable behavior object.
+ */
+function buildSetVariableBehavior() {
+  return {
+    name: 'setVariable',
+    options: {
+      variableName: 'PMUSER_EDGE_OPTIMIZE_CACHE_KEY',
+      valueSource: 'EXPRESSION',
+      variableValue: 'LLMCLIENT=TRUE;X_FORWARDED_HOST={{builtin.AK_HOST}}',
+    },
+  };
+}
+
+/**
+ * Builds a modifyIncomingRequestHeader behavior.
+ * @param {string} headerName - The name of the header to add.
+ * @param {string} headerValue - The value of the header to add.
+ * @returns {object} modifyIncomingRequestHeader behavior object.
+ */
+function buildModifyIncomingHeaderBehavior(headerName, headerValue) {
+  return {
+    name: 'modifyIncomingRequestHeader',
+    options: {
+      action: 'ADD',
+      standardAddHeaderName: 'OTHER',
+      headerName,
+      headerValue,
+    },
+  };
+}
+
+/**
+ * Builds a modifyOutgoingRequestHeader behavior.
+ * @param {string} headerName - The name of the header to add.
+ * @param {string} headerValue - The value of the header to add.
+ * @returns {object} modifyOutgoingRequestHeader behavior object.
+ */
+function buildModifyOutgoingHeaderBehavior(headerName, headerValue) {
+  return {
+    name: 'modifyOutgoingRequestHeader',
+    options: {
+      action: 'ADD',
+      standardAddHeaderName: 'OTHER',
+      headerName,
+      headerValue,
+    },
+  };
+}
+
+/**
+ * Builds the Edge Optimize AI Bot Routing child rule.
+ * @param {string} domain - The customer domain.
+ * @param {string} apiKey - The Edge Optimize API key.
+ * @returns {object} Child rule object.
+ */
+function buildEdgeOptimizeRule(domain, apiKey) {
+  return {
+    name: 'Edge Optimize – AI Bot Routing',
+    criteriaMustSatisfy: 'all',
+    comments: `Routes AI bot traffic for ${domain} to live.edgeoptimize.net`,
+    criteria: [
+      {
+        name: 'userAgent',
+        options: {
+          matchOperator: 'IS_ONE_OF',
+          matchWildcard: true,
+          matchCaseSensitive: false,
+          values: [
+            '*ChatGPT-User*',
+            '*GPTBot*',
+            '*OAI-SearchBot*',
+            '*PerplexityBot*',
+            '*anthropic-ai*',
+            '*ClaudeBot*',
+            '*Applebot-Extended*',
+            '*Google-Extended*',
+            '*Bytespider*',
+            '*Meta-ExternalAgent*',
+            '*DuckAssistBot*',
+          ],
+        },
+      },
+      {
+        name: 'fileExtension',
+        options: {
+          matchCaseSensitive: false,
+          matchOperator: 'IS_NOT_ONE_OF',
+          values: [
+            'css', 'js', 'jpg', 'jpeg', 'png', 'gif', 'svg', 'ico',
+            'woff', 'woff2', 'ttf', 'eot', 'otf', 'mp4', 'mp3',
+            'avi', 'mov', 'pdf', 'zip', 'tar', 'gz', 'xml', 'txt',
+          ],
+        },
+      },
+    ],
+    behaviors: [
+      buildOriginBehavior(),
+      buildSetVariableBehavior(),
+      buildModifyIncomingHeaderBehavior('x-edgeoptimize-api-key', apiKey),
+      buildModifyIncomingHeaderBehavior('x-edgeoptimize-config', 'LLMCLIENT=TRUE;'),
+      buildModifyIncomingHeaderBehavior('x-edgeoptimize-url', '{{builtin.AK_SCHEME}}://{{builtin.AK_HOST}}{{builtin.AK_URL}}'),
+      buildModifyOutgoingHeaderBehavior('x-forwarded-host', '{{builtin.AK_HOST}}'),
+    ],
+    children: [],
+  };
+}
+
+/**
+ * Generates a pre-filled Akamai Property Manager API (PAPI) JSON configuration
+ * for "Optimize at Edge" CDN routing.
+ *
+ * @param {string} domain - The customer domain (hostname).
+ * @param {string} apiKey - The Edge Optimize API key.
+ * @returns {object} PAPI JSON configuration object.
+ */
+export function generateAkamaiPapiConfig(domain, apiKey) {
+  return {
+    rules: {
+      name: 'default',
+      comments: `Edge Optimize configuration for ${domain}. Generated by LLM Optimizer.`,
+      variables: [
+        {
+          name: 'PMUSER_EDGE_OPTIMIZE_CACHE_KEY',
+          value: '',
+          description: 'Cache key for Edge Optimize AI bot routing',
+          hidden: false,
+          sensitive: false,
+        },
+      ],
+      behaviors: [],
+      children: [
+        buildEdgeOptimizeRule(domain, apiKey),
+      ],
+      options: {
+        is_secure: false,
+      },
+    },
+  };
+}

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -6108,6 +6108,127 @@ describe('LlmoController', () => {
     });
   });
 
+  describe('getAkamaiPapiConfig', () => {
+    let akamaiPapiContext;
+
+    beforeEach(() => {
+      mockSite.getBaseURL = sinon.stub().returns('https://www.example.com');
+
+      akamaiPapiContext = {
+        ...mockContext,
+        params: { siteId: TEST_SITE_ID },
+      };
+    });
+
+    it('should return 200 with PAPI JSON when site exists, has access, is admin, and metaconfig has apiKeys', async () => {
+      const metaconfig = {
+        siteId: TEST_SITE_ID,
+        apiKeys: ['test-papi-api-key'],
+        tokowakaEnabled: true,
+      };
+
+      mockTokowakaClient.fetchMetaconfig.resolves(metaconfig);
+
+      const result = await controller.getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(200);
+      const responseBody = await result.json();
+      expect(responseBody).to.have.property('rules');
+      expect(responseBody.rules.name).to.equal('default');
+      expect(responseBody.rules.children).to.be.an('array').with.lengthOf(1);
+      const apiKeyBehavior = responseBody.rules.children[0].behaviors.find(
+        (b) => b.name === 'modifyIncomingRequestHeader'
+          && b.options.headerName === 'x-edgeoptimize-api-key',
+      );
+      expect(apiKeyBehavior.options.headerValue).to.equal('test-papi-api-key');
+    });
+
+    it('should return 400 when metaconfig has no apiKeys (empty array)', async () => {
+      mockTokowakaClient.fetchMetaconfig.resolves({ siteId: TEST_SITE_ID, apiKeys: [] });
+
+      const result = await controller.getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(400);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('Edge Optimize API key not found');
+    });
+
+    it('should return 400 when metaconfig is null', async () => {
+      mockTokowakaClient.fetchMetaconfig.resolves(null);
+
+      const result = await controller.getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(400);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('Edge Optimize API key not found');
+    });
+
+    it('should return 403 when user does not have access to the site', async () => {
+      const deniedController = controllerWithAccessDenied(mockContext);
+
+      const result = await deniedController.getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(403);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('User does not have access to this site');
+    });
+
+    it('should return 403 when user is not an LLMO administrator', async () => {
+      const LlmoControllerNonAdmin = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/support/access-control-util.js': {
+          default: createMockAccessControlUtil(true, true, false),
+        },
+        '@adobe/spacecat-shared-http-utils': mockHttpUtils,
+        '../../../src/support/brand-profile-trigger.js': {
+          triggerBrandProfileAgent: (...args) => triggerBrandProfileAgentStub(...args),
+        },
+        ...getCommonMocks(),
+      });
+      const nonAdminController = LlmoControllerNonAdmin;
+
+      const result = await nonAdminController(mockContext).getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(403);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.equal('Only LLMO administrators can download the Akamai config');
+    });
+
+    it('should return 404 when site not found', async () => {
+      mockDataAccess.Site.findById.resolves(null);
+
+      const result = await controller.getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(404);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('Site not found');
+    });
+
+    it('should return 400 when tokowakaClient.fetchMetaconfig throws', async () => {
+      mockTokowakaClient.fetchMetaconfig.rejects(new Error('S3 fetch failed'));
+
+      const result = await controller.getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(400);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('S3 fetch failed');
+    });
+
+    it('should handle baseURL without http prefix by prepending https://', async () => {
+      mockSite.getBaseURL = sinon.stub().returns('www.example.com');
+      const metaconfig = {
+        siteId: TEST_SITE_ID,
+        apiKeys: ['bare-domain-api-key'],
+      };
+      mockTokowakaClient.fetchMetaconfig.resolves(metaconfig);
+
+      const result = await controller.getAkamaiPapiConfig(akamaiPapiContext);
+
+      expect(result.status).to.equal(200);
+      const responseBody = await result.json();
+      expect(responseBody.rules.comments).to.include('www.example.com');
+    });
+  });
+
   describe('getStrategy', () => {
     const mockStrategyData = {
       opportunities: [

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -311,6 +311,7 @@ describe('getRouteHandlers', () => {
     getBrandClaims: () => null,
     createOrUpdateEdgeConfig: () => null,
     getEdgeConfig: () => null,
+    getAkamaiPapiConfig: () => null,
     createOrUpdateStageEdgeConfig: () => null,
     checkEdgeOptimizeStatus: () => null,
     getStrategy: () => null,
@@ -831,6 +832,7 @@ describe('getRouteHandlers', () => {
       'POST /sites/:siteId/llmo/offboard',
       'POST /sites/:siteId/llmo/edge-optimize-config',
       'GET /sites/:siteId/llmo/edge-optimize-config',
+      'GET /sites/:siteId/llmo/edge-optimize-config/akamai-papi',
       'POST /sites/:siteId/llmo/edge-optimize-config/stage',
       'GET /sites/:siteId/llmo/edge-optimize-status',
       'GET /sites/:siteId/llmo/strategy',
@@ -1111,6 +1113,8 @@ describe('getRouteHandlers', () => {
     expect(dynamicRoutes['POST /sites/:siteId/llmo/edge-optimize-config'].paramNames).to.deep.equal(['siteId']);
     expect(dynamicRoutes['GET /sites/:siteId/llmo/edge-optimize-config'].handler).to.equal(mockLlmoController.getEdgeConfig);
     expect(dynamicRoutes['GET /sites/:siteId/llmo/edge-optimize-config'].paramNames).to.deep.equal(['siteId']);
+    expect(dynamicRoutes['GET /sites/:siteId/llmo/edge-optimize-config/akamai-papi'].handler).to.equal(mockLlmoController.getAkamaiPapiConfig);
+    expect(dynamicRoutes['GET /sites/:siteId/llmo/edge-optimize-config/akamai-papi'].paramNames).to.deep.equal(['siteId']);
     expect(dynamicRoutes['POST /sites/:siteId/llmo/edge-optimize-config/stage'].handler).to.equal(mockLlmoController.createOrUpdateStageEdgeConfig);
     expect(dynamicRoutes['POST /sites/:siteId/llmo/edge-optimize-config/stage'].paramNames).to.deep.equal(['siteId']);
     expect(dynamicRoutes['GET /sites/:siteId/llmo/edge-optimize-status'].handler).to.equal(mockLlmoController.checkEdgeOptimizeStatus);

--- a/test/support/akamai-papi-template.test.js
+++ b/test/support/akamai-papi-template.test.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { generateAkamaiPapiConfig } from '../../src/support/akamai-papi-template.js';
+
+describe('generateAkamaiPapiConfig', () => {
+  const TEST_DOMAIN = 'www.example.com';
+  const TEST_API_KEY = 'test-api-key-12345';
+
+  let config;
+
+  beforeEach(() => {
+    config = generateAkamaiPapiConfig(TEST_DOMAIN, TEST_API_KEY);
+  });
+
+  it('returns a valid PAPI structure with rules.name === "default"', () => {
+    expect(config).to.be.an('object');
+    expect(config.rules).to.be.an('object');
+    expect(config.rules.name).to.equal('default');
+  });
+
+  it('includes the domain in rules.comments', () => {
+    expect(config.rules.comments).to.include(TEST_DOMAIN);
+  });
+
+  it('has PMUSER_EDGE_OPTIMIZE_CACHE_KEY variable defined', () => {
+    const variable = config.rules.variables.find(
+      (v) => v.name === 'PMUSER_EDGE_OPTIMIZE_CACHE_KEY',
+    );
+    expect(variable).to.exist;
+    expect(variable.hidden).to.equal(false);
+    expect(variable.sensitive).to.equal(false);
+  });
+
+  it('has a child rule named "Edge Optimize – AI Bot Routing"', () => {
+    expect(config.rules.children).to.be.an('array').with.lengthOf(1);
+    const childRule = config.rules.children[0];
+    expect(childRule.name).to.equal('Edge Optimize – AI Bot Routing');
+  });
+
+  it('has criteriaMustSatisfy === "all" on the child rule', () => {
+    const childRule = config.rules.children[0];
+    expect(childRule.criteriaMustSatisfy).to.equal('all');
+  });
+
+  it('child rule comments include domain', () => {
+    const childRule = config.rules.children[0];
+    expect(childRule.comments).to.include(TEST_DOMAIN);
+  });
+
+  it('user-agent criteria includes *GPTBot*', () => {
+    const childRule = config.rules.children[0];
+    const uaCriteria = childRule.criteria.find((c) => c.name === 'userAgent');
+    expect(uaCriteria).to.exist;
+    expect(uaCriteria.options.values).to.include('*GPTBot*');
+  });
+
+  it('user-agent criteria includes *ChatGPT-User*', () => {
+    const childRule = config.rules.children[0];
+    const uaCriteria = childRule.criteria.find((c) => c.name === 'userAgent');
+    expect(uaCriteria.options.values).to.include('*ChatGPT-User*');
+  });
+
+  it('user-agent criteria includes *anthropic-ai*', () => {
+    const childRule = config.rules.children[0];
+    const uaCriteria = childRule.criteria.find((c) => c.name === 'userAgent');
+    expect(uaCriteria.options.values).to.include('*anthropic-ai*');
+  });
+
+  it('user-agent criteria includes *PerplexityBot*', () => {
+    const childRule = config.rules.children[0];
+    const uaCriteria = childRule.criteria.find((c) => c.name === 'userAgent');
+    expect(uaCriteria.options.values).to.include('*PerplexityBot*');
+  });
+
+  it('file extension criteria uses IS_NOT_ONE_OF operator', () => {
+    const childRule = config.rules.children[0];
+    const extCriteria = childRule.criteria.find((c) => c.name === 'fileExtension');
+    expect(extCriteria).to.exist;
+    expect(extCriteria.options.matchOperator).to.equal('IS_NOT_ONE_OF');
+  });
+
+  it('file extension criteria includes "css" and "js"', () => {
+    const childRule = config.rules.children[0];
+    const extCriteria = childRule.criteria.find((c) => c.name === 'fileExtension');
+    expect(extCriteria.options.values).to.include('css');
+    expect(extCriteria.options.values).to.include('js');
+  });
+
+  it('origin behavior has hostname === "live.edgeoptimize.net"', () => {
+    const childRule = config.rules.children[0];
+    const originBehavior = childRule.behaviors.find((b) => b.name === 'origin');
+    expect(originBehavior).to.exist;
+    expect(originBehavior.options.hostname).to.equal('live.edgeoptimize.net');
+  });
+
+  it('origin customValidCnValues includes "*.edgeoptimize.net"', () => {
+    const childRule = config.rules.children[0];
+    const originBehavior = childRule.behaviors.find((b) => b.name === 'origin');
+    expect(originBehavior.options.customValidCnValues).to.include('*.edgeoptimize.net');
+  });
+
+  it('x-edgeoptimize-api-key header value equals the passed apiKey', () => {
+    const childRule = config.rules.children[0];
+    const apiKeyBehavior = childRule.behaviors.find(
+      (b) => b.name === 'modifyIncomingRequestHeader'
+        && b.options.headerName === 'x-edgeoptimize-api-key',
+    );
+    expect(apiKeyBehavior).to.exist;
+    expect(apiKeyBehavior.options.headerValue).to.equal(TEST_API_KEY);
+  });
+
+  it('x-edgeoptimize-config header value equals "LLMCLIENT=TRUE;"', () => {
+    const childRule = config.rules.children[0];
+    const configBehavior = childRule.behaviors.find(
+      (b) => b.name === 'modifyIncomingRequestHeader'
+        && b.options.headerName === 'x-edgeoptimize-config',
+    );
+    expect(configBehavior).to.exist;
+    expect(configBehavior.options.headerValue).to.equal('LLMCLIENT=TRUE;');
+  });
+
+  it('x-forwarded-host outgoing header uses "{{builtin.AK_HOST}}"', () => {
+    const childRule = config.rules.children[0];
+    const fwdHostBehavior = childRule.behaviors.find(
+      (b) => b.name === 'modifyOutgoingRequestHeader'
+        && b.options.headerName === 'x-forwarded-host',
+    );
+    expect(fwdHostBehavior).to.exist;
+    expect(fwdHostBehavior.options.headerValue).to.equal('{{builtin.AK_HOST}}');
+  });
+
+  it('setVariable behavior for PMUSER_EDGE_OPTIMIZE_CACHE_KEY includes LLMCLIENT=TRUE and {{builtin.AK_HOST}}', () => {
+    const childRule = config.rules.children[0];
+    const setVarBehavior = childRule.behaviors.find((b) => b.name === 'setVariable');
+    expect(setVarBehavior).to.exist;
+    expect(setVarBehavior.options.variableName).to.equal('PMUSER_EDGE_OPTIMIZE_CACHE_KEY');
+    expect(setVarBehavior.options.variableValue).to.include('LLMCLIENT=TRUE');
+    expect(setVarBehavior.options.variableValue).to.include('{{builtin.AK_HOST}}');
+  });
+
+  it('has no failover behavior (simplified config)', () => {
+    const childRule = config.rules.children[0];
+    const failoverBehavior = childRule.behaviors.find((b) => b.name === 'failoverOrigin' || b.name === 'failover');
+    expect(failoverBehavior).to.be.undefined;
+    expect(childRule.children).to.be.an('array').with.lengthOf(0);
+  });
+
+  it('has empty behaviors array at the top-level rules', () => {
+    expect(config.rules.behaviors).to.be.an('array').with.lengthOf(0);
+  });
+
+  it('has options.is_secure === false at top level', () => {
+    expect(config.rules.options).to.deep.equal({ is_secure: false });
+  });
+});


### PR DESCRIPTION
Adds GET /sites/:siteId/llmo/akamai-papi-config endpoint that generates and returns a pre-filled Akamai Property Manager API (PAPI) JSON configuration for "Optimize at Edge" CDN routing, embedding the customer's domain and Edge Optimize API key from Tokowaka metaconfig.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
