### PR TITLE
feat(plg): clean up stale FIXED suggestions and FixEntities on PLG onboarding

### DIFF
--- a/src/controllers/plg/plg-onboarding-cleanup.js
+++ b/src/controllers/plg/plg-onboarding-cleanup.js
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
+
+/**
+ * Opportunity types that participate in the PLG auto-fix lifecycle.
+ * Kept in sync with the LD auto-fix flags and the displacement check
+ * in plg-onboarding.js (PLG_OPPORTUNITY_TYPES).
+ */
+export const PLG_CLEANUP_OPPORTUNITY_TYPES = ['cwv', 'alt-text', 'broken-backlinks'];
+
+/**
+ * Marks every FIXED suggestion under the given PLG opportunity as OUTDATED.
+ * FIXED suggestions represent past customer wins; once the site is offboarded
+ * we want the next audit run to start from a clean slate rather than re-surface
+ * stale "fixed" entries.
+ *
+ * Failures are logged and swallowed — cleanup is best-effort and must never
+ * block the higher-level offboarding flow.
+ *
+ * @param {object} opportunity - Opportunity model instance.
+ * @param {object} Suggestion - Suggestion collection from dataAccess.
+ * @param {object} log - Logger.
+ * @returns {Promise<number>} Count of suggestions transitioned (0 on failure).
+ */
+async function outdateFixedSuggestionsForOpportunity(opportunity, Suggestion, log) {
+  const opportunityId = opportunity.getId();
+  const opportunityType = opportunity.getType();
+  try {
+    const fixedSuggestions = await Suggestion.allByOpportunityIdAndStatus(
+      opportunityId,
+      SuggestionModel.STATUSES.FIXED,
+    );
+
+    if (fixedSuggestions.length === 0) {
+      return 0;
+    }
+
+    await Suggestion.bulkUpdateStatus(fixedSuggestions, SuggestionModel.STATUSES.OUTDATED);
+    log.info(
+      `PLG cleanup: marked ${fixedSuggestions.length} ${opportunityType} suggestions as OUTDATED `
+      + `for opportunity ${opportunityId}`,
+    );
+    return fixedSuggestions.length;
+  } catch (error) {
+    log.warn(
+      `PLG cleanup: failed to mark FIXED suggestions OUTDATED for ${opportunityType} opportunity `
+      + `${opportunityId}: ${error.message}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Deletes every FixEntity attached to the given PLG opportunity. A FixEntity
+ * may be re-created on the next audit run — leaving stale ones around can
+ * confuse downstream auto-fix logic that resumes/replays past fixes.
+ *
+ * Failures are logged and swallowed — cleanup is best-effort.
+ *
+ * @param {object} opportunity - Opportunity model instance.
+ * @param {object} FixEntity - FixEntity collection from dataAccess.
+ * @param {object} log - Logger.
+ * @returns {Promise<number>} Count of fix entities removed (0 on failure).
+ */
+async function removeFixEntitiesForOpportunity(opportunity, FixEntity, log) {
+  const opportunityId = opportunity.getId();
+  const opportunityType = opportunity.getType();
+  try {
+    const fixEntities = await FixEntity.allByOpportunityId(opportunityId);
+
+    if (fixEntities.length === 0) {
+      return 0;
+    }
+
+    await FixEntity.removeByIds(fixEntities.map((f) => f.getId()));
+    log.info(
+      `PLG cleanup: removed ${fixEntities.length} ${opportunityType} fix entities for `
+      + `opportunity ${opportunityId}`,
+    );
+    return fixEntities.length;
+  } catch (error) {
+    log.warn(
+      `PLG cleanup: failed to remove fix entities for ${opportunityType} opportunity `
+      + `${opportunityId}: ${error.message}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Cleans up PLG site state when a site is offboarded (waitlisted from ONBOARDED, or
+ * displaced by a new domain in the same IMS org). For each PLG opportunity type
+ * (cwv, alt-text, broken-backlinks) on the site:
+ *   1. FIXED suggestions are transitioned to OUTDATED so the site does not retain
+ *      stale "fixed" wins from the previous engagement.
+ *   2. All associated FixEntity rows are removed so a future re-onboarding starts
+ *      from an empty fix history.
+ *
+ * Non-PLG opportunities (e.g. structured-data, product-meta) are left untouched.
+ * This is best-effort: the function never throws and never aborts on partial failure,
+ * because callers (offboarding/displacement flows) cannot afford to be blocked by
+ * cleanup — orphaned fix/suggestion rows can be reconciled out-of-band.
+ *
+ * @param {string} siteId - The offboarded site's id.
+ * @param {object} context - Request context (provides dataAccess + log).
+ * @returns {Promise<{outdatedCount: number, removedFixCount: number}>}
+ */
+export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
+  const { dataAccess, log } = context;
+  const { Opportunity, Suggestion, FixEntity } = dataAccess;
+
+  if (!siteId) {
+    log.info('PLG cleanup: no siteId provided, skipping');
+    return { outdatedCount: 0, removedFixCount: 0 };
+  }
+
+  let opportunities;
+  try {
+    opportunities = await Opportunity.allBySiteId(siteId);
+  } catch (error) {
+    log.warn(`PLG cleanup: failed to list opportunities for site ${siteId}: ${error.message}`);
+    return { outdatedCount: 0, removedFixCount: 0 };
+  }
+
+  const plgOpportunities = opportunities.filter(
+    (o) => PLG_CLEANUP_OPPORTUNITY_TYPES.includes(o.getType()),
+  );
+
+  if (plgOpportunities.length === 0) {
+    log.info(`PLG cleanup: no PLG opportunities found for site ${siteId}`);
+    return { outdatedCount: 0, removedFixCount: 0 };
+  }
+
+  // Process each opportunity in parallel; per-opportunity helpers swallow their own
+  // errors so one failure cannot abort the rest of the cleanup.
+  const results = await Promise.all(plgOpportunities.map(async (opportunity) => {
+    const [outdatedCount, removedFixCount] = await Promise.all([
+      outdateFixedSuggestionsForOpportunity(opportunity, Suggestion, log),
+      removeFixEntitiesForOpportunity(opportunity, FixEntity, log),
+    ]);
+    return { outdatedCount, removedFixCount };
+  }));
+
+  const totals = results.reduce(
+    (acc, r) => ({
+      outdatedCount: acc.outdatedCount + r.outdatedCount,
+      removedFixCount: acc.removedFixCount + r.removedFixCount,
+    }),
+    { outdatedCount: 0, removedFixCount: 0 },
+  );
+
+  log.info(
+    `PLG cleanup complete for site ${siteId}: marked ${totals.outdatedCount} suggestions OUTDATED, `
+    + `removed ${totals.removedFixCount} fix entities across ${plgOpportunities.length} opportunities`,
+  );
+
+  return totals;
+}

--- a/src/controllers/plg/plg-onboarding-cleanup.js
+++ b/src/controllers/plg/plg-onboarding-cleanup.js
@@ -20,45 +20,121 @@ import { Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-acces
 export const PLG_CLEANUP_OPPORTUNITY_TYPES = ['cwv', 'alt-text', 'broken-backlinks'];
 
 /**
- * Marks every FIXED suggestion under the given PLG opportunity as OUTDATED.
- * FIXED suggestions represent past customer wins; once the site is offboarded
- * we want the next audit run to start from a clean slate rather than re-surface
- * stale "fixed" entries.
+ * Suggestions in any of these statuses are transitioned to OUTDATED on re-onboarding
+ * so the next audit run starts from a clean slate without re-surfacing prior-lifecycle
+ * wins (FIXED), in-flight work (IN_PROGRESS), or terminal/dismissed entries
+ * (SKIPPED, ERROR, REJECTED).
+ */
+export const STATUSES_TO_OUTDATE = new Set([
+  SuggestionModel.STATUSES.FIXED,
+  SuggestionModel.STATUSES.IN_PROGRESS,
+  SuggestionModel.STATUSES.SKIPPED,
+  SuggestionModel.STATUSES.ERROR,
+  SuggestionModel.STATUSES.REJECTED,
+]);
+
+/**
+ * Suggestions in any of these statuses are reset to NEW on re-onboarding so they
+ * re-enter the normal pipeline rather than stay stuck in a mid-flight state from the
+ * previous lifecycle.
+ */
+export const STATUSES_TO_RESET_TO_NEW = new Set([
+  SuggestionModel.STATUSES.PENDING_VALIDATION,
+]);
+
+/**
+ * Bulk-transitions the given suggestions to `targetStatus`. No-op when the input is
+ * empty. Failures are logged and swallowed — cleanup is best-effort.
  *
- * Failures are logged and swallowed — cleanup is best-effort and must never
- * block the higher-level offboarding flow.
+ * @param {object} Suggestion - Suggestion collection from dataAccess.
+ * @param {Array} suggestions - Suggestion model instances to transition.
+ * @param {string} targetStatus - The target Suggestion status.
+ * @param {string} opportunityType - Opportunity type, for logging.
+ * @param {string} opportunityId - Opportunity id, for logging.
+ * @param {object} log - Logger.
+ * @returns {Promise<number>} Count of suggestions transitioned (0 on failure / no-op).
+ */
+async function bulkTransitionSuggestions(
+  Suggestion,
+  suggestions,
+  targetStatus,
+  opportunityType,
+  opportunityId,
+  log,
+) {
+  if (suggestions.length === 0) {
+    return 0;
+  }
+  try {
+    await Suggestion.bulkUpdateStatus(suggestions, targetStatus);
+    log.info(
+      `PLG cleanup: transitioned ${suggestions.length} ${opportunityType} suggestions to `
+      + `${targetStatus} for opportunity ${opportunityId}`,
+    );
+    return suggestions.length;
+  } catch (error) {
+    log.warn(
+      `PLG cleanup: failed to transition ${opportunityType} suggestions to ${targetStatus} for `
+      + `opportunity ${opportunityId}: ${error.message}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Resets all suggestions for the given PLG opportunity to a clean baseline:
+ *   - statuses in {@link STATUSES_TO_OUTDATE} → OUTDATED
+ *   - statuses in {@link STATUSES_TO_RESET_TO_NEW} → NEW
+ *   - everything else (e.g. NEW, APPROVED) is left untouched.
+ *
+ * Does a single fetch via `allByOpportunityId` and partitions in memory to keep the
+ * round-trip count down. Failures are logged and swallowed — cleanup is best-effort.
  *
  * @param {object} opportunity - Opportunity model instance.
  * @param {object} Suggestion - Suggestion collection from dataAccess.
  * @param {object} log - Logger.
- * @returns {Promise<number>} Count of suggestions transitioned (0 on failure).
+ * @returns {Promise<{outdatedCount: number, resetToNewCount: number}>}
  */
-async function outdateFixedSuggestionsForOpportunity(opportunity, Suggestion, log) {
+async function resetSuggestionsForOpportunity(opportunity, Suggestion, log) {
   const opportunityId = opportunity.getId();
   const opportunityType = opportunity.getType();
+
+  let suggestions;
   try {
-    const fixedSuggestions = await Suggestion.allByOpportunityIdAndStatus(
-      opportunityId,
-      SuggestionModel.STATUSES.FIXED,
-    );
-
-    if (fixedSuggestions.length === 0) {
-      return 0;
-    }
-
-    await Suggestion.bulkUpdateStatus(fixedSuggestions, SuggestionModel.STATUSES.OUTDATED);
-    log.info(
-      `PLG cleanup: marked ${fixedSuggestions.length} ${opportunityType} suggestions as OUTDATED `
-      + `for opportunity ${opportunityId}`,
-    );
-    return fixedSuggestions.length;
+    suggestions = await Suggestion.allByOpportunityId(opportunityId);
   } catch (error) {
     log.warn(
-      `PLG cleanup: failed to mark FIXED suggestions OUTDATED for ${opportunityType} opportunity `
+      `PLG cleanup: failed to list suggestions for ${opportunityType} opportunity `
       + `${opportunityId}: ${error.message}`,
     );
-    return 0;
+    return { outdatedCount: 0, resetToNewCount: 0 };
   }
+
+  const toOutdate = suggestions.filter((s) => STATUSES_TO_OUTDATE.has(s.getStatus()));
+  const toResetToNew = suggestions.filter((s) => STATUSES_TO_RESET_TO_NEW.has(s.getStatus()));
+
+  // Run both transitions in parallel; each helper isolates its own failure so a single
+  // bulk-update error does not block the other transition.
+  const [outdatedCount, resetToNewCount] = await Promise.all([
+    bulkTransitionSuggestions(
+      Suggestion,
+      toOutdate,
+      SuggestionModel.STATUSES.OUTDATED,
+      opportunityType,
+      opportunityId,
+      log,
+    ),
+    bulkTransitionSuggestions(
+      Suggestion,
+      toResetToNew,
+      SuggestionModel.STATUSES.NEW,
+      opportunityType,
+      opportunityId,
+      log,
+    ),
+  ]);
+
+  return { outdatedCount, resetToNewCount };
 }
 
 /**
@@ -99,30 +175,35 @@ async function removeFixEntitiesForOpportunity(opportunity, FixEntity, log) {
 }
 
 /**
- * Cleans up PLG site state when a site is offboarded (waitlisted from ONBOARDED, or
- * displaced by a new domain in the same IMS org). For each PLG opportunity type
- * (cwv, alt-text, broken-backlinks) on the site:
- *   1. FIXED suggestions are transitioned to OUTDATED so the site does not retain
- *      stale "fixed" wins from the previous engagement.
- *   2. All associated FixEntity rows are removed so a future re-onboarding starts
+ * Cleans up PLG site state right before a `PlgOnboarding` record transitions to
+ * `ONBOARDED`. For each PLG opportunity type (cwv, alt-text, broken-backlinks) on
+ * the site:
+ *   1. Suggestions in {@link STATUSES_TO_OUTDATE} are transitioned to OUTDATED so
+ *      stale wins / in-flight / terminal entries from the previous PLG lifecycle do
+ *      not re-surface.
+ *   2. Suggestions in {@link STATUSES_TO_RESET_TO_NEW} are reset to NEW so they
+ *      re-enter the normal pipeline.
+ *   3. All associated FixEntity rows are removed so a future re-onboarding starts
  *      from an empty fix history.
  *
  * Non-PLG opportunities (e.g. structured-data, product-meta) are left untouched.
  * This is best-effort: the function never throws and never aborts on partial failure,
- * because callers (offboarding/displacement flows) cannot afford to be blocked by
- * cleanup — orphaned fix/suggestion rows can be reconciled out-of-band.
+ * because callers (onboarding flow) cannot afford to be blocked by cleanup —
+ * orphaned fix/suggestion rows can be reconciled out-of-band.
  *
- * @param {string} siteId - The offboarded site's id.
+ * @param {string} siteId - The site being (re-)onboarded.
  * @param {object} context - Request context (provides dataAccess + log).
- * @returns {Promise<{outdatedCount: number, removedFixCount: number}>}
+ * @returns {Promise<{outdatedCount: number, resetToNewCount: number, removedFixCount: number}>}
  */
 export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
   const { dataAccess, log } = context;
   const { Opportunity, Suggestion, FixEntity } = dataAccess;
 
+  const emptyResult = { outdatedCount: 0, resetToNewCount: 0, removedFixCount: 0 };
+
   if (!siteId) {
     log.info('PLG cleanup: no siteId provided, skipping');
-    return { outdatedCount: 0, removedFixCount: 0 };
+    return emptyResult;
   }
 
   let opportunities;
@@ -130,7 +211,7 @@ export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
     opportunities = await Opportunity.allBySiteId(siteId);
   } catch (error) {
     log.warn(`PLG cleanup: failed to list opportunities for site ${siteId}: ${error.message}`);
-    return { outdatedCount: 0, removedFixCount: 0 };
+    return emptyResult;
   }
 
   const plgOpportunities = opportunities.filter(
@@ -139,30 +220,32 @@ export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
 
   if (plgOpportunities.length === 0) {
     log.info(`PLG cleanup: no PLG opportunities found for site ${siteId}`);
-    return { outdatedCount: 0, removedFixCount: 0 };
+    return emptyResult;
   }
 
   // Process each opportunity in parallel; per-opportunity helpers swallow their own
   // errors so one failure cannot abort the rest of the cleanup.
   const results = await Promise.all(plgOpportunities.map(async (opportunity) => {
-    const [outdatedCount, removedFixCount] = await Promise.all([
-      outdateFixedSuggestionsForOpportunity(opportunity, Suggestion, log),
+    const [{ outdatedCount, resetToNewCount }, removedFixCount] = await Promise.all([
+      resetSuggestionsForOpportunity(opportunity, Suggestion, log),
       removeFixEntitiesForOpportunity(opportunity, FixEntity, log),
     ]);
-    return { outdatedCount, removedFixCount };
+    return { outdatedCount, resetToNewCount, removedFixCount };
   }));
 
   const totals = results.reduce(
     (acc, r) => ({
       outdatedCount: acc.outdatedCount + r.outdatedCount,
+      resetToNewCount: acc.resetToNewCount + r.resetToNewCount,
       removedFixCount: acc.removedFixCount + r.removedFixCount,
     }),
-    { outdatedCount: 0, removedFixCount: 0 },
+    { ...emptyResult },
   );
 
   log.info(
     `PLG cleanup complete for site ${siteId}: marked ${totals.outdatedCount} suggestions OUTDATED, `
-    + `removed ${totals.removedFixCount} fix entities across ${plgOpportunities.length} opportunities`,
+    + `reset ${totals.resetToNewCount} suggestions to NEW, removed ${totals.removedFixCount} fix `
+    + `entities across ${plgOpportunities.length} opportunities`,
   );
 
   return totals;

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -48,6 +48,7 @@ import { loadProfileConfig, postSlackMessage } from '../../utils/slack/base.js';
 import { triggerBrandProfileAgent } from '../../support/brand-profile-trigger.js';
 import { PlgOnboardingDto } from '../../dto/plg-onboarding.js';
 import AccessControlUtil from '../../support/access-control-util.js';
+import { cleanupPlgSiteSuggestionsAndFixes } from './plg-onboarding-cleanup.js';
 
 const { STATUSES, REVIEW_DECISIONS } = PlgOnboardingModel;
 const ASO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.ASO;
@@ -805,6 +806,10 @@ async function performAsoPlgOnboarding({
         if (needsOrgReassignment) {
           steps.siteOrgReassigned = true;
         }
+        // Best-effort: clear out any stale FIXED suggestions and FixEntity rows from a
+        // prior onboarding lifecycle so the newly onboarded site starts from a clean slate.
+        // Never fatal — orphans can be reconciled out-of-band.
+        await cleanupPlgSiteSuggestionsAndFixes(site.getId(), context);
         onboarding.setStatus(STATUSES.ONBOARDED);
         onboarding.setWaitlistReason(null);
         onboarding.setBotBlocker(null);
@@ -1242,6 +1247,11 @@ async function performAsoPlgOnboarding({
     } catch (error) {
       log.warn(`Failed to trigger brand-profile for site ${site.getId()}: ${error.message}`);
     }
+
+    // Best-effort: clear out any stale FIXED suggestions and FixEntity rows from a
+    // prior onboarding lifecycle so the newly onboarded site starts from a clean slate.
+    // Never fatal — orphans can be reconciled out-of-band.
+    await cleanupPlgSiteSuggestionsAndFixes(site.getId(), context);
 
     // Mark as completed
     onboarding.setStatus(STATUSES.ONBOARDED);

--- a/test/controllers/plg/plg-onboarding-cleanup.test.js
+++ b/test/controllers/plg/plg-onboarding-cleanup.test.js
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import {
+  cleanupPlgSiteSuggestionsAndFixes,
+  PLG_CLEANUP_OPPORTUNITY_TYPES,
+} from '../../../src/controllers/plg/plg-onboarding-cleanup.js';
+
+use(sinonChai);
+
+const SITE_ID = 'site-uuid-1';
+
+function createMockOpportunity(id, type) {
+  return {
+    getId: sinon.stub().returns(id),
+    getType: sinon.stub().returns(type),
+  };
+}
+
+function createMockSuggestion(id, status) {
+  return {
+    getId: sinon.stub().returns(id),
+    getStatus: sinon.stub().returns(status),
+    setStatus: sinon.stub(),
+  };
+}
+
+function createMockFixEntity(id) {
+  return {
+    getId: sinon.stub().returns(id),
+  };
+}
+
+describe('cleanupPlgSiteSuggestionsAndFixes', () => {
+  let sandbox;
+  let log;
+  let dataAccess;
+  let context;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+    };
+    dataAccess = {
+      Opportunity: {
+        allBySiteId: sandbox.stub().resolves([]),
+      },
+      Suggestion: {
+        allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+        bulkUpdateStatus: sandbox.stub().resolves(),
+      },
+      FixEntity: {
+        allByOpportunityId: sandbox.stub().resolves([]),
+        removeByIds: sandbox.stub().resolves(),
+      },
+    };
+    context = { dataAccess, log };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('exports the PLG opportunity types covered by cleanup', () => {
+    expect(PLG_CLEANUP_OPPORTUNITY_TYPES).to.deep.equal([
+      'cwv',
+      'alt-text',
+      'broken-backlinks',
+    ]);
+  });
+
+  it('skips when no siteId is provided', async () => {
+    const result = await cleanupPlgSiteSuggestionsAndFixes(null, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(dataAccess.Opportunity.allBySiteId).to.not.have.been.called;
+    expect(log.info).to.have.been.calledWithMatch(/no siteId provided, skipping/);
+  });
+
+  it('returns zero counts when listing opportunities fails', async () => {
+    dataAccess.Opportunity.allBySiteId.rejects(new Error('DB unavailable'));
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(log.warn).to.have.been.calledWithMatch(/failed to list opportunities/);
+  });
+
+  it('returns zero counts when site has no PLG opportunities', async () => {
+    dataAccess.Opportunity.allBySiteId.resolves([
+      createMockOpportunity('o1', 'structured-data'),
+      createMockOpportunity('o2', 'product-meta'),
+    ]);
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(dataAccess.Suggestion.allByOpportunityIdAndStatus).to.not.have.been.called;
+    expect(dataAccess.FixEntity.allByOpportunityId).to.not.have.been.called;
+    expect(log.info).to.have.been.calledWithMatch(/no PLG opportunities found/);
+  });
+
+  it('outdates FIXED suggestions and removes fix entities for PLG opportunities only', async () => {
+    const cwvOppty = createMockOpportunity('o-cwv', 'cwv');
+    const altTextOppty = createMockOpportunity('o-alt', 'alt-text');
+    const brokenBacklinksOppty = createMockOpportunity('o-bb', 'broken-backlinks');
+    const otherOppty = createMockOpportunity('o-other', 'structured-data');
+
+    dataAccess.Opportunity.allBySiteId.resolves([
+      cwvOppty, altTextOppty, brokenBacklinksOppty, otherOppty,
+    ]);
+
+    const cwvFixed = [createMockSuggestion('s1', 'FIXED'), createMockSuggestion('s2', 'FIXED')];
+    const altFixed = [createMockSuggestion('s3', 'FIXED')];
+    dataAccess.Suggestion.allByOpportunityIdAndStatus
+      .withArgs('o-cwv', 'FIXED').resolves(cwvFixed)
+      .withArgs('o-alt', 'FIXED').resolves(altFixed)
+      .withArgs('o-bb', 'FIXED')
+      .resolves([]);
+
+    const cwvFixes = [createMockFixEntity('f1'), createMockFixEntity('f2'), createMockFixEntity('f3')];
+    const bbFixes = [createMockFixEntity('f4')];
+    dataAccess.FixEntity.allByOpportunityId
+      .withArgs('o-cwv').resolves(cwvFixes)
+      .withArgs('o-alt').resolves([])
+      .withArgs('o-bb')
+      .resolves(bbFixes);
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 3, removedFixCount: 4 });
+
+    // Non-PLG opportunity is skipped entirely.
+    expect(dataAccess.Suggestion.allByOpportunityIdAndStatus)
+      .to.not.have.been.calledWith('o-other', sinon.match.any);
+    expect(dataAccess.FixEntity.allByOpportunityId)
+      .to.not.have.been.calledWith('o-other');
+
+    // bulkUpdateStatus called once per opportunity that had FIXED suggestions.
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledTwice;
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(cwvFixed, 'OUTDATED');
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(altFixed, 'OUTDATED');
+
+    // removeByIds called once per opportunity that had fix entities.
+    expect(dataAccess.FixEntity.removeByIds).to.have.been.calledTwice;
+    expect(dataAccess.FixEntity.removeByIds).to.have.been.calledWith(['f1', 'f2', 'f3']);
+    expect(dataAccess.FixEntity.removeByIds).to.have.been.calledWith(['f4']);
+
+    expect(log.info).to.have.been.calledWithMatch(/PLG cleanup complete for site/);
+  });
+
+  it('logs and continues when outdating FIXED suggestions fails for one opportunity', async () => {
+    const cwvOppty = createMockOpportunity('o-cwv', 'cwv');
+    const altTextOppty = createMockOpportunity('o-alt', 'alt-text');
+    dataAccess.Opportunity.allBySiteId.resolves([cwvOppty, altTextOppty]);
+
+    dataAccess.Suggestion.allByOpportunityIdAndStatus
+      .withArgs('o-cwv', 'FIXED').rejects(new Error('lookup boom'))
+      .withArgs('o-alt', 'FIXED')
+      .resolves([createMockSuggestion('s1', 'FIXED')]);
+
+    dataAccess.FixEntity.allByOpportunityId.resolves([]);
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 1, removedFixCount: 0 });
+    expect(log.warn).to.have.been.calledWithMatch(/failed to mark FIXED suggestions OUTDATED for cwv/);
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+  });
+
+  it('logs and continues when bulkUpdateStatus rejects', async () => {
+    dataAccess.Opportunity.allBySiteId.resolves([
+      createMockOpportunity('o-cwv', 'cwv'),
+    ]);
+    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([
+      createMockSuggestion('s1', 'FIXED'),
+    ]);
+    dataAccess.Suggestion.bulkUpdateStatus.rejects(new Error('save failed'));
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(log.warn).to.have.been.calledWithMatch(/save failed/);
+  });
+
+  it('logs and continues when removing fix entities fails', async () => {
+    dataAccess.Opportunity.allBySiteId.resolves([
+      createMockOpportunity('o-cwv', 'cwv'),
+    ]);
+    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
+
+    dataAccess.FixEntity.allByOpportunityId.resolves([
+      createMockFixEntity('f1'),
+    ]);
+    dataAccess.FixEntity.removeByIds.rejects(new Error('delete blew up'));
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(log.warn).to.have.been.calledWithMatch(/failed to remove fix entities for cwv/);
+  });
+
+  it('logs and continues when listing fix entities throws', async () => {
+    dataAccess.Opportunity.allBySiteId.resolves([
+      createMockOpportunity('o-cwv', 'cwv'),
+    ]);
+    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
+    dataAccess.FixEntity.allByOpportunityId.rejects(new Error('list boom'));
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(log.warn).to.have.been.calledWithMatch(/list boom/);
+    expect(dataAccess.FixEntity.removeByIds).to.not.have.been.called;
+  });
+
+  it('skips bulkUpdateStatus when no FIXED suggestions exist for the opportunity', async () => {
+    dataAccess.Opportunity.allBySiteId.resolves([
+      createMockOpportunity('o-cwv', 'cwv'),
+    ]);
+    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
+    dataAccess.FixEntity.allByOpportunityId.resolves([]);
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+    expect(dataAccess.FixEntity.removeByIds).to.not.have.been.called;
+  });
+});

--- a/test/controllers/plg/plg-onboarding-cleanup.test.js
+++ b/test/controllers/plg/plg-onboarding-cleanup.test.js
@@ -17,11 +17,15 @@ import sinonChai from 'sinon-chai';
 import {
   cleanupPlgSiteSuggestionsAndFixes,
   PLG_CLEANUP_OPPORTUNITY_TYPES,
+  STATUSES_TO_OUTDATE,
+  STATUSES_TO_RESET_TO_NEW,
 } from '../../../src/controllers/plg/plg-onboarding-cleanup.js';
 
 use(sinonChai);
 
 const SITE_ID = 'site-uuid-1';
+
+const EMPTY_RESULT = { outdatedCount: 0, resetToNewCount: 0, removedFixCount: 0 };
 
 function createMockOpportunity(id, type) {
   return {
@@ -62,7 +66,7 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
         allBySiteId: sandbox.stub().resolves([]),
       },
       Suggestion: {
-        allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+        allByOpportunityId: sandbox.stub().resolves([]),
         bulkUpdateStatus: sandbox.stub().resolves(),
       },
       FixEntity: {
@@ -85,10 +89,21 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
     ]);
   });
 
+  it('exports the status sets the cleanup transitions', () => {
+    expect([...STATUSES_TO_OUTDATE]).to.have.members([
+      'FIXED',
+      'IN_PROGRESS',
+      'SKIPPED',
+      'ERROR',
+      'REJECTED',
+    ]);
+    expect([...STATUSES_TO_RESET_TO_NEW]).to.deep.equal(['PENDING_VALIDATION']);
+  });
+
   it('skips when no siteId is provided', async () => {
     const result = await cleanupPlgSiteSuggestionsAndFixes(null, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(result).to.deep.equal(EMPTY_RESULT);
     expect(dataAccess.Opportunity.allBySiteId).to.not.have.been.called;
     expect(log.info).to.have.been.calledWithMatch(/no siteId provided, skipping/);
   });
@@ -98,7 +113,7 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(result).to.deep.equal(EMPTY_RESULT);
     expect(log.warn).to.have.been.calledWithMatch(/failed to list opportunities/);
   });
 
@@ -110,13 +125,13 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
-    expect(dataAccess.Suggestion.allByOpportunityIdAndStatus).to.not.have.been.called;
+    expect(result).to.deep.equal(EMPTY_RESULT);
+    expect(dataAccess.Suggestion.allByOpportunityId).to.not.have.been.called;
     expect(dataAccess.FixEntity.allByOpportunityId).to.not.have.been.called;
     expect(log.info).to.have.been.calledWithMatch(/no PLG opportunities found/);
   });
 
-  it('outdates FIXED suggestions and removes fix entities for PLG opportunities only', async () => {
+  it('outdates configured statuses, resets PENDING_VALIDATION to NEW, and removes fix entities for PLG opportunities only', async () => {
     const cwvOppty = createMockOpportunity('o-cwv', 'cwv');
     const altTextOppty = createMockOpportunity('o-alt', 'alt-text');
     const brokenBacklinksOppty = createMockOpportunity('o-bb', 'broken-backlinks');
@@ -126,15 +141,30 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
       cwvOppty, altTextOppty, brokenBacklinksOppty, otherOppty,
     ]);
 
-    const cwvFixed = [createMockSuggestion('s1', 'FIXED'), createMockSuggestion('s2', 'FIXED')];
-    const altFixed = [createMockSuggestion('s3', 'FIXED')];
-    dataAccess.Suggestion.allByOpportunityIdAndStatus
-      .withArgs('o-cwv', 'FIXED').resolves(cwvFixed)
-      .withArgs('o-alt', 'FIXED').resolves(altFixed)
-      .withArgs('o-bb', 'FIXED')
-      .resolves([]);
+    // cwv: mix of statuses across both buckets and statuses that should be left alone.
+    const cwvFixed = createMockSuggestion('s-cwv-fixed', 'FIXED');
+    const cwvInProgress = createMockSuggestion('s-cwv-inprog', 'IN_PROGRESS');
+    const cwvSkipped = createMockSuggestion('s-cwv-skip', 'SKIPPED');
+    const cwvPending = createMockSuggestion('s-cwv-pending', 'PENDING_VALIDATION');
+    const cwvNew = createMockSuggestion('s-cwv-new', 'NEW'); // untouched
+    const cwvApproved = createMockSuggestion('s-cwv-app', 'APPROVED'); // untouched
+    const altError = createMockSuggestion('s-alt-err', 'ERROR');
+    const altRejected = createMockSuggestion('s-alt-rej', 'REJECTED');
+    const altPending = createMockSuggestion('s-alt-pending', 'PENDING_VALIDATION');
+    // broken-backlinks has only NEW suggestions → no transitions, but fix entities exist.
+    const bbNew = createMockSuggestion('s-bb-new', 'NEW');
 
-    const cwvFixes = [createMockFixEntity('f1'), createMockFixEntity('f2'), createMockFixEntity('f3')];
+    dataAccess.Suggestion.allByOpportunityId
+      .withArgs('o-cwv').resolves([
+        cwvFixed, cwvInProgress, cwvSkipped, cwvPending, cwvNew, cwvApproved,
+      ])
+      .withArgs('o-alt').resolves([altError, altRejected, altPending])
+      .withArgs('o-bb')
+      .resolves([bbNew]);
+
+    const cwvFixes = [
+      createMockFixEntity('f1'), createMockFixEntity('f2'), createMockFixEntity('f3'),
+    ];
     const bbFixes = [createMockFixEntity('f4')];
     dataAccess.FixEntity.allByOpportunityId
       .withArgs('o-cwv').resolves(cwvFixes)
@@ -144,20 +174,46 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 3, removedFixCount: 4 });
+    expect(result).to.deep.equal({
+      outdatedCount: 5, // cwv: 3 (FIXED, IN_PROGRESS, SKIPPED) + alt: 2 (ERROR, REJECTED)
+      resetToNewCount: 2, // cwv: 1 + alt: 1
+      removedFixCount: 4, // cwv: 3 + bb: 1
+    });
 
     // Non-PLG opportunity is skipped entirely.
-    expect(dataAccess.Suggestion.allByOpportunityIdAndStatus)
-      .to.not.have.been.calledWith('o-other', sinon.match.any);
+    expect(dataAccess.Suggestion.allByOpportunityId)
+      .to.not.have.been.calledWith('o-other');
     expect(dataAccess.FixEntity.allByOpportunityId)
       .to.not.have.been.calledWith('o-other');
 
-    // bulkUpdateStatus called once per opportunity that had FIXED suggestions.
-    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledTwice;
-    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(cwvFixed, 'OUTDATED');
-    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(altFixed, 'OUTDATED');
+    // OUTDATED bulk updates (one per opportunity that had outdate-worthy suggestions).
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(
+      [cwvFixed, cwvInProgress, cwvSkipped],
+      'OUTDATED',
+    );
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(
+      [altError, altRejected],
+      'OUTDATED',
+    );
 
-    // removeByIds called once per opportunity that had fix entities.
+    // PENDING_VALIDATION → NEW resets.
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(
+      [cwvPending],
+      'NEW',
+    );
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(
+      [altPending],
+      'NEW',
+    );
+
+    // NEW / APPROVED suggestions are never passed to bulkUpdateStatus.
+    const allBulkCalls = dataAccess.Suggestion.bulkUpdateStatus.getCalls();
+    const allUpdatedSuggestions = allBulkCalls.flatMap((call) => call.args[0]);
+    expect(allUpdatedSuggestions).to.not.include(cwvNew);
+    expect(allUpdatedSuggestions).to.not.include(cwvApproved);
+    expect(allUpdatedSuggestions).to.not.include(bbNew);
+
+    // Fix entity removals.
     expect(dataAccess.FixEntity.removeByIds).to.have.been.calledTwice;
     expect(dataAccess.FixEntity.removeByIds).to.have.been.calledWith(['f1', 'f2', 'f3']);
     expect(dataAccess.FixEntity.removeByIds).to.have.been.calledWith(['f4']);
@@ -165,45 +221,83 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
     expect(log.info).to.have.been.calledWithMatch(/PLG cleanup complete for site/);
   });
 
-  it('logs and continues when outdating FIXED suggestions fails for one opportunity', async () => {
+  it('logs and continues when listing suggestions fails for one opportunity', async () => {
     const cwvOppty = createMockOpportunity('o-cwv', 'cwv');
     const altTextOppty = createMockOpportunity('o-alt', 'alt-text');
     dataAccess.Opportunity.allBySiteId.resolves([cwvOppty, altTextOppty]);
 
-    dataAccess.Suggestion.allByOpportunityIdAndStatus
-      .withArgs('o-cwv', 'FIXED').rejects(new Error('lookup boom'))
-      .withArgs('o-alt', 'FIXED')
-      .resolves([createMockSuggestion('s1', 'FIXED')]);
+    dataAccess.Suggestion.allByOpportunityId
+      .withArgs('o-cwv').rejects(new Error('lookup boom'))
+      .withArgs('o-alt')
+      .resolves([
+        createMockSuggestion('s-alt-fixed', 'FIXED'),
+        createMockSuggestion('s-alt-pending', 'PENDING_VALIDATION'),
+      ]);
 
     dataAccess.FixEntity.allByOpportunityId.resolves([]);
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 1, removedFixCount: 0 });
-    expect(log.warn).to.have.been.calledWithMatch(/failed to mark FIXED suggestions OUTDATED for cwv/);
-    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+    expect(result).to.deep.equal({
+      outdatedCount: 1,
+      resetToNewCount: 1,
+      removedFixCount: 0,
+    });
+    expect(log.warn).to.have.been.calledWithMatch(/failed to list suggestions for cwv/);
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledTwice;
   });
 
-  it('logs and continues when bulkUpdateStatus rejects', async () => {
+  it('logs and continues when the OUTDATED transition fails but the NEW reset succeeds', async () => {
     dataAccess.Opportunity.allBySiteId.resolves([
       createMockOpportunity('o-cwv', 'cwv'),
     ]);
-    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([
+    dataAccess.Suggestion.allByOpportunityId.resolves([
       createMockSuggestion('s1', 'FIXED'),
+      createMockSuggestion('s2', 'PENDING_VALIDATION'),
     ]);
-    dataAccess.Suggestion.bulkUpdateStatus.rejects(new Error('save failed'));
+    dataAccess.Suggestion.bulkUpdateStatus
+      .withArgs(sinon.match.any, 'OUTDATED').rejects(new Error('save failed'))
+      .withArgs(sinon.match.any, 'NEW')
+      .resolves();
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
-    expect(log.warn).to.have.been.calledWithMatch(/save failed/);
+    expect(result).to.deep.equal({
+      outdatedCount: 0,
+      resetToNewCount: 1,
+      removedFixCount: 0,
+    });
+    expect(log.warn).to.have.been.calledWithMatch(/failed to transition cwv suggestions to OUTDATED/);
+  });
+
+  it('logs and continues when the NEW reset fails but the OUTDATED transition succeeds', async () => {
+    dataAccess.Opportunity.allBySiteId.resolves([
+      createMockOpportunity('o-cwv', 'cwv'),
+    ]);
+    dataAccess.Suggestion.allByOpportunityId.resolves([
+      createMockSuggestion('s1', 'FIXED'),
+      createMockSuggestion('s2', 'PENDING_VALIDATION'),
+    ]);
+    dataAccess.Suggestion.bulkUpdateStatus
+      .withArgs(sinon.match.any, 'NEW').rejects(new Error('reset failed'))
+      .withArgs(sinon.match.any, 'OUTDATED')
+      .resolves();
+
+    const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
+
+    expect(result).to.deep.equal({
+      outdatedCount: 1,
+      resetToNewCount: 0,
+      removedFixCount: 0,
+    });
+    expect(log.warn).to.have.been.calledWithMatch(/failed to transition cwv suggestions to NEW/);
   });
 
   it('logs and continues when removing fix entities fails', async () => {
     dataAccess.Opportunity.allBySiteId.resolves([
       createMockOpportunity('o-cwv', 'cwv'),
     ]);
-    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
+    dataAccess.Suggestion.allByOpportunityId.resolves([]);
 
     dataAccess.FixEntity.allByOpportunityId.resolves([
       createMockFixEntity('f1'),
@@ -212,7 +306,7 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(result).to.deep.equal(EMPTY_RESULT);
     expect(log.warn).to.have.been.calledWithMatch(/failed to remove fix entities for cwv/);
   });
 
@@ -220,26 +314,30 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
     dataAccess.Opportunity.allBySiteId.resolves([
       createMockOpportunity('o-cwv', 'cwv'),
     ]);
-    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
+    dataAccess.Suggestion.allByOpportunityId.resolves([]);
     dataAccess.FixEntity.allByOpportunityId.rejects(new Error('list boom'));
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(result).to.deep.equal(EMPTY_RESULT);
     expect(log.warn).to.have.been.calledWithMatch(/list boom/);
     expect(dataAccess.FixEntity.removeByIds).to.not.have.been.called;
   });
 
-  it('skips bulkUpdateStatus when no FIXED suggestions exist for the opportunity', async () => {
+  it('skips bulkUpdateStatus calls when no suggestions match either transition set', async () => {
     dataAccess.Opportunity.allBySiteId.resolves([
       createMockOpportunity('o-cwv', 'cwv'),
     ]);
-    dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([]);
+    // Only NEW + APPROVED → neither bucket should match.
+    dataAccess.Suggestion.allByOpportunityId.resolves([
+      createMockSuggestion('s1', 'NEW'),
+      createMockSuggestion('s2', 'APPROVED'),
+    ]);
     dataAccess.FixEntity.allByOpportunityId.resolves([]);
 
     const result = await cleanupPlgSiteSuggestionsAndFixes(SITE_ID, context);
 
-    expect(result).to.deep.equal({ outdatedCount: 0, removedFixCount: 0 });
+    expect(result).to.deep.equal(EMPTY_RESULT);
     expect(dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
     expect(dataAccess.FixEntity.removeByIds).to.not.have.been.called;
   });

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -290,7 +290,6 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       },
       Suggestion: {
         allByOpportunityId: sandbox.stub().resolves([]),
-        allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
         bulkUpdateStatus: sandbox.stub().resolves(),
       },
       FixEntity: {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -29,7 +29,10 @@ const DEFAULT_ORG_ID = 'default-org-id';
 const DEMO_ORG_ID = '66331367-70e6-4a49-8445-4f6d9c265af9';
 const OTHER_CUSTOMER_ORG_ID = 'other-customer-org-id';
 
-describe('PlgOnboardingController', () => {
+describe('PlgOnboardingController', function describePlgOnboarding() {
+  // esmock + extensive sinon stubs make individual tests slower than the 2000ms default.
+  this.timeout(10000);
+
   let sandbox;
   let PlgOnboardingController;
 
@@ -287,6 +290,12 @@ describe('PlgOnboardingController', () => {
       },
       Suggestion: {
         allByOpportunityId: sandbox.stub().resolves([]),
+        allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+        bulkUpdateStatus: sandbox.stub().resolves(),
+      },
+      FixEntity: {
+        allByOpportunityId: sandbox.stub().resolves([]),
+        removeByIds: sandbox.stub().resolves(),
       },
     };
 


### PR DESCRIPTION
## Summary

When a domain is (re-)onboarded into PLG, suggestions and `FixEntity` rows left
behind from a prior PLG lifecycle on the same site can re-surface in the UI and
confuse downstream auto-fix logic. This PR adds a best-effort cleanup pass that
runs immediately before each `PlgOnboarding` record transitions to `ONBOARDED`,
so the newly onboarded site starts from a clean slate.

For each PLG opportunity on the site (`cwv`, `alt-text`, `broken-backlinks`):

| Suggestion status                                  | Action                                             |
|----------------------------------------------------|----------------------------------------------------|
| `FIXED`, `IN_PROGRESS`, `SKIPPED`, `ERROR`, `REJECTED` | → `OUTDATED` (via `Suggestion.bulkUpdateStatus`)   |
| `PENDING_VALIDATION`                               | → `NEW` (re-enters the normal pipeline)            |
| `NEW`, `APPROVED`                                  | left untouched                                     |

In addition, all associated `FixEntity` rows for these PLG opportunities are
deleted via `FixEntity.removeByIds` so a future re-onboarding starts from an
empty fix history.

Non-PLG opportunities (e.g. `structured-data`, `product-meta`) are left
untouched.

## Changes

- New utility `src/controllers/plg/plg-onboarding-cleanup.js` exporting:
  - `cleanupPlgSiteSuggestionsAndFixes(siteId, context)` — main entry point.
  - `PLG_CLEANUP_OPPORTUNITY_TYPES` — the opportunity types in scope.
  - `STATUSES_TO_OUTDATE` / `STATUSES_TO_RESET_TO_NEW` — the per-status
    transition sets.

  Extracted into a separate module to keep `plg-onboarding.js` from growing
  further. A single `Suggestion.allByOpportunityId` fetch per opportunity is
  partitioned in memory into the two transition buckets, so the round-trip
  count is minimal.

- `src/controllers/plg/plg-onboarding.js` invokes the cleanup in both
  onboarding paths, immediately before `setStatus(STATUSES.ONBOARDED)`:
  - Fast-path (`PRE_ONBOARDING → ONBOARDED`)
  - Full onboarding flow (`IN_PROGRESS → ONBOARDED`)

- Per-opportunity work runs in parallel; per-status transitions inside an
  opportunity also run in parallel. Errors at every layer (opportunity list,
  suggestion list, each `bulkUpdateStatus`, fix-entity list, `removeByIds`)
  are caught and logged at warn level. Cleanup is best-effort and never blocks
  onboarding — orphaned rows can be reconciled out-of-band, but blocking
  onboarding on a cleanup failure is unacceptable.

## Why "before ONBOARDED" (not on offboarding)

Offboarding paths (admin `ONBOARDED → WAITLISTED` and displacement)
intentionally do not run cleanup. Performing the cleanup at the *next*
onboarding instead means:

- The offboarding hot path stays minimal.
- Sites that are offboarded and never re-onboarded don't pay the cleanup cost.
- Re-onboarding always sees a fresh start regardless of how the previous
  lifecycle ended (admin-driven waitlist, displacement, error, etc.).

## Test plan

- [x] `test/controllers/plg/plg-onboarding-cleanup.test.js` — 12 unit tests
      covering: empty `siteId`, opportunity-list failure, no PLG opportunities,
      happy path with mixed `OUTDATE` / `RESET_TO_NEW` / untouched statuses
      across all three PLG opportunity types and a non-PLG opportunity, and
      every error branch (suggestion-list failure for one opportunity,
      independent failure of the OUTDATED bulk update, independent failure of
      the NEW reset, fix-entity list failure, `removeByIds` failure, no-op when
      nothing matches either transition set).
- [x] 100% line / branch / statement / function coverage on the new utility.
- [x] All existing `plg-onboarding.test.js` controller tests still pass; test
      setup updated to add `Suggestion.bulkUpdateStatus`,
      `FixEntity.allByOpportunityId`, and `FixEntity.removeByIds` stubs to the
      default `mockDataAccess` so the cleanup is a fast no-op in existing
      tests; bumped the suite-level mocha timeout to 10s (matching other
      esmock-heavy suites in this repo) to eliminate flakes at the 2s default
      boundary.
- [ ] Stage smoke test: onboard a domain that previously had a mix of `FIXED`,
      `PENDING_VALIDATION`, `IN_PROGRESS` `cwv` suggestions and a `FixEntity`,
      confirm that on `ONBOARDED` the first three buckets are `OUTDATED`,
      `PENDING_VALIDATION` rows become `NEW`, and the `FixEntity` rows are
      gone.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
