### PR TITLE
feat: add has-data endpoint for agentic traffic | LLMO-4608

### DIFF
--- a/docs/llmo-brandalf-apis/agentic-traffic-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-api.md
@@ -228,5 +228,6 @@ All site-scoped RPCs receive these parameters:
 - [Agentic Traffic by URL API](./agentic-traffic-by-url-api.md) — Per-URL breakdown, user-agent breakdown, URL movers
 - [Agentic Traffic Filter Dimensions API](./agentic-traffic-filter-dimensions-api.md) — Available filter values for the UI
 - [Agentic Traffic Weeks API](./agentic-traffic-weeks-api.md) — ISO weeks with data, for the date picker
+- [Agentic Traffic Has-Data API](./agentic-traffic-has-data-api.md) — Fast existence check for the no-data onboarding overlay
 - [Agentic Traffic URL Brand Presence API](./agentic-traffic-url-brand-presence-api.md) — Brand presence citation detail for a specific URL
 - [Agentic Traffic Global API](./agentic-traffic-global-api.md) — Cross-site global weekly hit totals

--- a/docs/llmo-brandalf-apis/agentic-traffic-by-url-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-by-url-api.md
@@ -64,6 +64,7 @@ Returns a **paginated** per-URL breakdown with traffic volume, performance, and 
       "urlPath": "/blog/ai-tools",
       "totalHits": 4200,
       "uniqueAgents": 8,
+      "uniqueAgentNames": ["GPTBot", "ChatGPT-User", "ClaudeBot"],
       "topAgent": "GPTBot",
       "topAgentType": "crawler",
       "responseCodes": [200, 301],
@@ -84,7 +85,8 @@ Returns a **paginated** per-URL breakdown with traffic volume, performance, and 
 | `rows[].host` | string | Hostname (e.g. `www.example.com`) |
 | `rows[].urlPath` | string | URL path (e.g. `/blog/ai-tools`) |
 | `rows[].totalHits` | number | Total AI-crawler requests to this URL |
-| `rows[].uniqueAgents` | number | Number of distinct user-agent strings |
+| `rows[].uniqueAgents` | number | Number of distinct user-agent strings (true count from DB; may exceed `uniqueAgentNames.length` when the RPC caps names) |
+| `rows[].uniqueAgentNames` | string[] | Agent name strings for tooltip display (capped at 20 by the RPC) |
 | `rows[].topAgent` | string | Most frequent user-agent string |
 | `rows[].topAgentType` | string | Agent type of `topAgent` |
 | `rows[].responseCodes` | number[] | Distinct HTTP status codes seen for this URL |
@@ -121,12 +123,14 @@ Returns traffic grouped by `(pageType, agentType)`. Useful for understanding whi
     "pageType": "article",
     "agentType": "crawler",
     "uniqueAgents": 5,
+    "uniqueAgentNames": ["GPTBot", "ChatGPT-User", "ClaudeBot"],
     "totalHits": 18400
   },
   {
     "pageType": "product",
     "agentType": "assistant",
     "uniqueAgents": 2,
+    "uniqueAgentNames": ["Claude-User"],
     "totalHits": 6100
   }
 ]
@@ -136,7 +140,8 @@ Returns traffic grouped by `(pageType, agentType)`. Useful for understanding whi
 |-------|------|-------------|
 | `pageType` | string | Page type (e.g. `article`, `product`) |
 | `agentType` | string | Agent type (e.g. `crawler`, `assistant`) |
-| `uniqueAgents` | number | Number of distinct user-agent strings in this group |
+| `uniqueAgents` | number | Number of distinct user-agent strings in this group (true count from DB; may exceed `uniqueAgentNames.length` when the RPC caps names) |
+| `uniqueAgentNames` | string[] | Agent name strings for tooltip display (capped at 20 by the RPC) |
 | `totalHits` | number | Total hits for this `(pageType, agentType)` combination |
 
 ---

--- a/docs/llmo-brandalf-apis/agentic-traffic-has-data-api.md
+++ b/docs/llmo-brandalf-apis/agentic-traffic-has-data-api.md
@@ -1,0 +1,81 @@
+# Agentic Traffic Has-Data API
+
+Fast existence check that tells the caller whether any agentic traffic records exist for a site. Used by the Postgres-backed Agentic Traffic dashboard to decide whether to show the no-data onboarding overlay — without waiting for all parallel data queries to settle.
+
+---
+
+## API Path
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/sites/:siteId/agentic-traffic/has-data` | Returns `{ hasData: boolean }` for the site |
+
+**Path parameters:**
+- `siteId` — Site UUID
+
+---
+
+## Query Parameters
+
+None. No date range or filter parameters are accepted.
+
+---
+
+## Data Source
+
+Single PostgREST table query with `limit(1)` — no RPC required:
+
+```javascript
+client.from('agentic_traffic')
+  .select('traffic_date')
+  .eq('site_id', siteId)
+  .limit(1)
+```
+
+`hasData` is `true` if at least one row is returned, `false` otherwise.
+
+---
+
+## Response Shape
+
+```json
+{ "hasData": true }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hasData` | boolean | `true` if the site has any agentic traffic records, `false` otherwise |
+
+---
+
+## Sample URLs
+
+```
+GET /sites/c2473d89-e997-458d-a86d-b4096649c12b/agentic-traffic/has-data
+```
+
+---
+
+## Error Responses
+
+| Status | Condition |
+|--------|-----------|
+| 400 | PostgREST not configured (`DATA_SERVICE_PROVIDER` ≠ `postgres`) |
+| 400 | Site or organization not found |
+| 403 | User does not belong to the site's organization |
+| 500 | PostgREST query error |
+
+---
+
+## Authentication & Access
+
+- Requires LLMO product access for the site's organization (`hasLlmoOrganizationAccess`)
+- Route is listed in `REQUIRED_CAPABILITIES`
+
+---
+
+## Related APIs
+
+- [Agentic Traffic API](./agentic-traffic-api.md) — KPIs, trend, and grouping by region/category/page-type/status
+- [Agentic Traffic Weeks API](./agentic-traffic-weeks-api.md) — ISO weeks with data, for the date picker
+- [Agentic Traffic by URL API](./agentic-traffic-by-url-api.md) — Per-URL breakdown, user-agent breakdown, URL movers

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -385,6 +385,7 @@ export function createAgenticTrafficByUserAgentHandler(getSiteAndValidateAccess)
           pageType: row.page_type || '',
           agentType: row.agent_type || '',
           uniqueAgents: Number(row.unique_agents ?? 0),
+          uniqueAgentNames: Array.isArray(row.unique_agent_names) ? row.unique_agent_names : [],
           totalHits: Number(row.total_hits ?? 0),
         })));
       },
@@ -448,6 +449,7 @@ export function createAgenticTrafficByUrlHandler(getSiteAndValidateAccess) {
             urlPath: row.url_path || '',
             totalHits: Number(row.total_hits ?? 0),
             uniqueAgents: Number(row.unique_agents ?? 0),
+            uniqueAgentNames: Array.isArray(row.unique_agent_names) ? row.unique_agent_names : [],
             topAgent: row.top_agent || '',
             topAgentType: row.top_agent_type || '',
             responseCodes: Array.isArray(row.response_codes) ? row.response_codes.map(Number) : [],
@@ -606,6 +608,41 @@ export function createAgenticTrafficWeeksHandler(getSiteAndValidateAccess) {
         });
 
         return cachedOk({ weeks });
+      },
+    );
+  };
+}
+
+/**
+ * GET /sites/:siteId/agentic-traffic/has-data
+ *
+ * Fast existence check — returns { hasData: boolean } indicating whether any
+ * agentic traffic records exist for the site. Used by the PG dashboard to
+ * decide whether to show the no-data overlay without waiting for all parallel
+ * queries to settle.
+ *
+ * Runs a single PostgREST table query with limit(1) — no RPC required.
+ */
+export function createAgenticTrafficHasDataHandler(getSiteAndValidateAccess) {
+  return async function getAgenticTrafficHasData(context) {
+    return withAgenticTrafficAuth(
+      context,
+      getSiteAndValidateAccess,
+      'has-data',
+      async (ctx, client, siteId) => {
+        const { data, error } = await client
+          .from('agentic_traffic')
+          .select('traffic_date')
+          .eq('site_id', siteId)
+          .limit(1);
+
+        if (error) {
+          ctx.log.error(`Agentic traffic has-data PostgREST error: ${error.message}`);
+          return internalServerError('Failed to check agentic traffic data');
+        }
+
+        /* c8 ignore next */
+        return cachedOk({ hasData: (data || []).length > 0 });
       },
     );
   };

--- a/src/controllers/llmo/llmo-mysticat-controller.js
+++ b/src/controllers/llmo/llmo-mysticat-controller.js
@@ -51,6 +51,7 @@ import {
   createAgenticTrafficWeeksHandler,
   createAgenticTrafficMoversHandler,
   createAgenticTrafficUrlBrandPresenceHandler,
+  createAgenticTrafficHasDataHandler,
 } from './llmo-agentic-traffic.js';
 
 /**
@@ -184,6 +185,7 @@ function LlmoMysticatController(ctx) {
   const getAgenticTrafficUrlBrandPresence = createAgenticTrafficUrlBrandPresenceHandler(
     getSiteAndValidateAccess,
   );
+  const getAgenticTrafficHasData = createAgenticTrafficHasDataHandler(getSiteAndValidateAccess);
 
   return {
     getFilterDimensions,
@@ -222,6 +224,7 @@ function LlmoMysticatController(ctx) {
     getAgenticTrafficWeeks,
     getAgenticTrafficMovers,
     getAgenticTrafficUrlBrandPresence,
+    getAgenticTrafficHasData,
   };
 }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -445,6 +445,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/agentic-traffic/weeks': llmoMysticatController.getAgenticTrafficWeeks,
     'GET /sites/:siteId/agentic-traffic/movers': llmoMysticatController.getAgenticTrafficMovers,
     'GET /sites/:siteId/agentic-traffic/url-brand-presence': llmoMysticatController.getAgenticTrafficUrlBrandPresence,
+    'GET /sites/:siteId/agentic-traffic/has-data': llmoMysticatController.getAgenticTrafficHasData,
 
     // Brand Presence filter dimensions (PostgREST/mysticat-data-service)
     // spaceCatId = organization_id. brandId = 'all' for all brands, or UUID for single brand.

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -101,6 +101,7 @@ export const INTERNAL_ROUTES = [
   'GET /sites/:siteId/agentic-traffic/filter-dimensions',
   'GET /sites/:siteId/agentic-traffic/weeks',
   'GET /sites/:siteId/agentic-traffic/movers',
+  'GET /sites/:siteId/agentic-traffic/has-data',
 
   // LLMO operations not exposed to S2S - onboard, offboard, edge config, brand claims, etc.
   'GET /sites/:siteId/llmo/brand-claims',

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -26,6 +26,7 @@ import {
   createAgenticTrafficFilterDimensionsHandler,
   createAgenticTrafficWeeksHandler,
   createAgenticTrafficUrlBrandPresenceHandler,
+  createAgenticTrafficHasDataHandler,
 } from '../../../src/controllers/llmo/llmo-agentic-traffic.js';
 
 use(sinonChai);
@@ -557,7 +558,11 @@ describe('llmo-agentic-traffic', () => {
       const client = createMockClient({
         rpc_agentic_traffic_by_user_agent: {
           data: [{
-            page_type: 'article', agent_type: 'Chatbots', unique_agents: 5, total_hits: 200,
+            page_type: 'article',
+            agent_type: 'Chatbots',
+            unique_agents: 5,
+            unique_agent_names: ['ChatGPT-User', 'GPTBot'],
+            total_hits: 200,
           }],
           error: null,
         },
@@ -569,13 +574,18 @@ describe('llmo-agentic-traffic', () => {
       expect(body[0].pageType).to.equal('article');
       expect(body[0].agentType).to.equal('Chatbots');
       expect(body[0].uniqueAgents).to.equal(5);
+      expect(body[0].uniqueAgentNames).to.deep.equal(['ChatGPT-User', 'GPTBot']);
     });
 
     it('handles null row fields with safe defaults', async () => {
       const client = createMockClient({
         rpc_agentic_traffic_by_user_agent: {
           data: [{
-            page_type: null, agent_type: null, unique_agents: null, total_hits: null,
+            page_type: null,
+            agent_type: null,
+            unique_agents: null,
+            unique_agent_names: null,
+            total_hits: null,
           }],
           error: null,
         },
@@ -588,6 +598,7 @@ describe('llmo-agentic-traffic', () => {
       expect(body[0].agentType).to.equal('');
       expect(body[0].uniqueAgents).to.equal(0);
       expect(body[0].totalHits).to.equal(0);
+      expect(body[0].uniqueAgentNames).to.deep.equal([]);
     });
 
     it('does not include p_user_agent in the RPC call', async () => {
@@ -644,6 +655,7 @@ describe('llmo-agentic-traffic', () => {
             total_count: 1,
             total_hits: 150,
             unique_agents: 3,
+            unique_agent_names: ['ChatGPT-User', 'GPTBot'],
             top_agent: 'ChatGPT-User',
             top_agent_type: 'Chatbots',
             response_codes: [200, 301],
@@ -663,6 +675,7 @@ describe('llmo-agentic-traffic', () => {
       expect(body.totalCount).to.equal(1);
       expect(body.rows[0].host).to.equal('example.com');
       expect(body.rows[0].urlPath).to.equal('/page');
+      expect(body.rows[0].uniqueAgentNames).to.deep.equal(['ChatGPT-User', 'GPTBot']);
       expect(body.rows[0].topAgent).to.equal('ChatGPT-User');
       expect(body.rows[0].topAgentType).to.equal('Chatbots');
       expect(body.rows[0].responseCodes).to.deep.equal([200, 301]);
@@ -795,6 +808,7 @@ describe('llmo-agentic-traffic', () => {
             url_path: null,
             total_hits: null,
             unique_agents: null,
+            unique_agent_names: null,
             top_agent: null,
             top_agent_type: null,
             response_codes: null,
@@ -813,6 +827,7 @@ describe('llmo-agentic-traffic', () => {
       const body = await res.json();
       expect(body.rows[0].host).to.equal('');
       expect(body.rows[0].urlPath).to.equal('');
+      expect(body.rows[0].uniqueAgentNames).to.deep.equal([]);
       expect(body.rows[0].topAgent).to.equal('');
       expect(body.rows[0].responseCodes).to.deep.equal([]);
       expect(body.rows[0].successRate).to.be.null;
@@ -1195,6 +1210,57 @@ describe('llmo-agentic-traffic', () => {
       const handler = createAgenticTrafficUrlBrandPresenceHandler(stubbedValidateAccess);
       const res = await handler(ctx);
       expect(res.status).to.equal(500);
+    });
+  });
+
+  // ── Has Data ───────────────────────────────────────────────────────────────
+
+  describe('createAgenticTrafficHasDataHandler', () => {
+    it('returns hasData: true when agentic_traffic has rows for the site', async () => {
+      const client = createMockClient({}, {
+        agentic_traffic: { data: [{ traffic_date: '2026-01-05' }], error: null },
+      });
+      const ctx = makeContext({ client });
+      const handler = createAgenticTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+    });
+
+    it('returns hasData: false when no rows exist for the site', async () => {
+      const client = createMockClient({}, {
+        agentic_traffic: { data: [], error: null },
+      });
+      const ctx = makeContext({ client });
+      const handler = createAgenticTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(false);
+    });
+
+    it('returns 500 when the PostgREST query errors', async () => {
+      const client = createMockClient({}, {
+        agentic_traffic: { data: null, error: { message: 'db error' } },
+      });
+      const ctx = makeContext({ client });
+      const handler = createAgenticTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(500);
+    });
+
+    it('queries the agentic_traffic table with the site id and a limit of 1', async () => {
+      const client = createMockClient({}, {
+        agentic_traffic: { data: [], error: null },
+      });
+      const ctx = makeContext({ client });
+      const handler = createAgenticTrafficHasDataHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.from).to.have.been.calledWith('agentic_traffic');
+      const chain = client.from.firstCall.returnValue;
+      expect(chain.eq).to.have.been.calledWith('site_id', SITE_ID);
+      expect(chain.limit).to.have.been.calledWith(1);
     });
   });
 });

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -283,6 +283,7 @@ describe('getRouteHandlers', () => {
     getAgenticTrafficWeeks: () => null,
     getAgenticTrafficMovers: () => null,
     getAgenticTrafficUrlBrandPresence: () => null,
+    getAgenticTrafficHasData: () => null,
   };
 
   const mockLlmoOpportunitiesController = {
@@ -916,6 +917,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/agentic-traffic/weeks',
       'GET /sites/:siteId/agentic-traffic/movers',
       'GET /sites/:siteId/agentic-traffic/url-brand-presence',
+      'GET /sites/:siteId/agentic-traffic/has-data',
       'GET /admin/users/:userId',
     ];
     expect(Object.keys(dynamicRoutes)).to.have.members(expectedDynamicRouteKeys);


### PR DESCRIPTION
## Summary

- Add `GET /sites/:siteId/agentic-traffic/has-data` endpoint — fast existence check that returns `{ hasData: boolean }` by running a single `limit(1)` query on the `agentic_traffic` table (no RPC required). Used by the Postgres-backed Agentic Traffic dashboard to show the CDN onboarding overlay before any parallel data queries settle.
- Forward `unique_agent_names` (already returned by `rpc_agentic_traffic_by_user_agent` and `rpc_agentic_traffic_by_url`) through the controller mappings so the Agentic Traffic PG dashboard can populate the unique-agents tooltip with real agent name strings.

## Changes

**`src/controllers/llmo/llmo-agentic-traffic.js`**
- `createAgenticTrafficByUserAgentHandler`: add `uniqueAgentNames` field to the row mapping, defaulting to `[]` when the RPC returns `null`.
- `createAgenticTrafficByUrlHandler`: same addition.
- New `createAgenticTrafficHasDataHandler`: queries `agentic_traffic` with `.select('traffic_date').eq('site_id', siteId).limit(1)` and returns `{ hasData: boolean }`.

**`src/controllers/llmo/llmo-mysticat-controller.js`**
- Import and register `createAgenticTrafficHasDataHandler` as `getAgenticTrafficHasData`.

**`src/routes/index.js`**
- Register `GET /sites/:siteId/agentic-traffic/has-data`.

**`src/routes/required-capabilities.js`**
- Add `GET /sites/:siteId/agentic-traffic/has-data` to the internal-routes allowlist.

**`test/controllers/llmo/llmo-agentic-traffic.test.js`**
- `createAgenticTrafficByUserAgentHandler`: add `unique_agent_names` to happy-path and null-defaults mocks; assert `uniqueAgentNames` in both cases.
- `createAgenticTrafficByUrlHandler`: same for the by-url happy-path and null-fields mocks.
- New `describe('createAgenticTrafficHasDataHandler')`: four tests covering `hasData: true`, `hasData: false`, 500 on error, and correct query shape (`from`, `eq`, `limit`).

**`test/routes/index.test.js`**
- Add `getAgenticTrafficHasData` to the mock controller and `GET /sites/:siteId/agentic-traffic/has-data` to the expected dynamic route keys.

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
[LLMO-4608](https://jira.corp.adobe.com/browse/LLMO-4608)