### PR TITLE
feat: PLG bind aso entitlement to ims org

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -71,6 +71,13 @@ const REVIEW_REASONS = {
 const DOMAIN_ALREADY_ASSIGNED = 'already assigned to another organization';
 const DOMAIN_ALREADY_ONBOARDED_IN_ORG = 'another domain is already onboarded for this IMS org';
 
+class EntitlementWaitlistError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'EntitlementWaitlistError';
+  }
+}
+
 /**
  * Derives the review check key from the onboarding record's current state.
  * @param {object} onboarding - The PlgOnboarding record.
@@ -278,14 +285,21 @@ async function ensureAsoEntitlement(site, organization, context) {
   let entitlement;
   try {
     ({ entitlement } = await orgClient.createEntitlement(ASO_TIER));
-  } catch (error) {
-    log.info(`ensureAsoEntitlement: entitlement exists for org ${organizationId}, fetching existing`);
-    ({ entitlement } = await orgClient.checkValidEntitlement());
+  } catch (createError) {
+    log.warn(`ensureAsoEntitlement: createEntitlement failed for org ${organizationId}: ${createError.message}, fetching existing`);
+    try {
+      ({ entitlement } = await orgClient.checkValidEntitlement());
+    } catch (fetchError) {
+      log.warn(`ensureAsoEntitlement: checkValidEntitlement also failed for org ${organizationId}: ${fetchError.message}`);
+    }
   }
-  const entitlementOrgId = entitlement?.getOrganizationId();
-  const entitlementTier = entitlement?.getTier?.();
+  if (!entitlement) {
+    throw new EntitlementWaitlistError(`Unable to create or fetch ASO entitlement for org ${organizationId}`);
+  }
+  const entitlementOrgId = entitlement.getOrganizationId();
+  const entitlementTier = entitlement.getTier?.();
 
-  if (entitlementOrgId && entitlementOrgId !== organizationId) {
+  if (entitlementOrgId !== organizationId) {
     log.warn(
       `ensureAsoEntitlement: entitlement org drift — expected ${organizationId}, `
       + `got ${entitlementOrgId} (site ${siteId})`,
@@ -297,9 +311,16 @@ async function ensureAsoEntitlement(site, organization, context) {
   let siteEnrollment;
   try {
     ({ siteEnrollment } = await siteClient.createEntitlement(entitlementTier ?? ASO_TIER));
-  } catch (error) {
-    log.info(`ensureAsoEntitlement: enrollment exists for site ${siteId}, fetching existing`);
-    ({ siteEnrollment } = await siteClient.checkValidEntitlement());
+  } catch (createError) {
+    log.warn(`ensureAsoEntitlement: createEntitlement failed for site ${siteId}: ${createError.message}, fetching existing`);
+    try {
+      ({ siteEnrollment } = await siteClient.checkValidEntitlement());
+    } catch (fetchError) {
+      log.warn(`ensureAsoEntitlement: checkValidEntitlement also failed for site ${siteId}: ${fetchError.message}`);
+    }
+  }
+  if (!siteEnrollment) {
+    throw new EntitlementWaitlistError(`Unable to create or fetch ASO enrollment for site ${siteId}`);
   }
 
   return { entitlement, siteEnrollment };
@@ -755,6 +776,7 @@ async function performAsoPlgOnboarding({
     log.info(`Fast-tracking preonboarded record ${onboarding.getId()}`);
     let site = await Site.findById(onboarding.getSiteId());
     if (site) {
+      try {
       // Resolve customer's organization from imsOrgId
       const organization = await createOrFindOrganization(imsOrgId, context);
         const customerOrgId = organization.getId();
@@ -839,6 +861,23 @@ async function performAsoPlgOnboarding({
         await onboarding.save();
         await postPlgOnboardingNotification(onboarding, context);
         return onboarding;
+      } catch (error) {
+        if (error instanceof EntitlementWaitlistError) {
+          onboarding.setStatus(STATUSES.WAITLISTED);
+          onboarding.setWaitlistReason(error.message);
+          if (updatedBy) {
+            onboarding.setUpdatedBy(updatedBy);
+          }
+          try {
+            await onboarding.save();
+            await postPlgOnboardingNotification(onboarding, context);
+          } catch (saveError) {
+            log.error(`Failed to persist waitlist state for onboarding ${onboarding.getId()}: ${saveError.message}`);
+          }
+          return onboarding;
+        }
+        throw error;
+      }
     }
     log.warn(`Preonboarded site ${onboarding.getSiteId()} not found, falling through to full onboarding`);
   }
@@ -1266,6 +1305,20 @@ async function performAsoPlgOnboarding({
 
     return onboarding;
   } catch (error) {
+    if (error instanceof EntitlementWaitlistError) {
+      onboarding.setStatus(STATUSES.WAITLISTED);
+      onboarding.setWaitlistReason(error.message);
+      if (updatedBy) {
+        onboarding.setUpdatedBy(updatedBy);
+      }
+      try {
+        await onboarding.save();
+        await postPlgOnboardingNotification(onboarding, context);
+      } catch (saveError) {
+        log.error(`Failed to persist waitlist state for onboarding ${onboarding.getId()}: ${saveError.message}`);
+      }
+      return onboarding;
+    }
     // Persist the error in the onboarding record
     onboarding.setStatus(STATUSES.ERROR);
     onboarding.setSteps(steps);

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -249,27 +249,9 @@ function getReviewerIdentity(context) {
   return hasText(profile?.email) ? profile.email : 'admin';
 }
 
-/**
- * Assigns a site to the given organization, persists, and returns a fresh instance
- * fetched from DB so downstream consumers (e.g. TierClient) read the updated org.
- * @param {object} site - The site to reassign.
- * @param {string} organizationId - Target org id.
- * @param {object} dataAccess - Data access layer.
- * @returns {Promise<object>} Site instance from DB, or the original in-memory site if
- *   re-fetch was unavailable.
- */
-async function reassignSiteOrganization(site, organizationId, dataAccess, log) {
-  const siteId = site.getId();
+async function reassignSiteOrganization(site, organizationId) {
   site.setOrganizationId(organizationId);
-  await site.save();
-
-  // Re-fetch to get a fresh instance where this.record reflects the DB value.
-  const refreshed = await dataAccess.Site.findById(siteId);
-  const refreshedOrgId = refreshed?.getOrganizationId();
-  if (!refreshed || refreshedOrgId !== organizationId) {
-    log?.warn?.(`Site ${siteId} org not reflected in DB after save: expected ${organizationId}, got ${refreshedOrgId ?? 'undefined'}`);
-  }
-  return refreshed ?? site;
+  return site.save();
 }
 
 // Resolves entitlement against the IMS-derived organization (passed in by the caller),
@@ -834,7 +816,7 @@ async function performAsoPlgOnboarding({
         // This ensures ensureAsoEntitlement gets the correct customer org's entitlement.
         // The onboarding record's organizationId was already anchored above.
         if (needsOrgReassignment) {
-          site = await reassignSiteOrganization(site, customerOrgId, dataAccess, log);
+          site = await reassignSiteOrganization(site, customerOrgId);
           log.info(`Reassigned preonboarded site ${site.getId()} from internal org to customer org ${customerOrgId}`);
         }
 
@@ -1263,7 +1245,7 @@ async function performAsoPlgOnboarding({
     // This must happen BEFORE entitlement operations to ensure we get the correct org's entitlement
     if (needsOrgReassignment) {
       log.info(`Reassigning site ${site.getId()} to org ${organizationId} (was in internal/demo org)`);
-      site = await reassignSiteOrganization(site, organizationId, dataAccess, log);
+      site = await reassignSiteOrganization(site, organizationId);
       // Update PlgOnboarding's organizationId to match the site's new org
       onboarding.setOrganizationId(organizationId);
       steps.siteOrgReassigned = true;
@@ -1825,7 +1807,7 @@ function PlgOnboardingController(ctx) {
             if (existingDeliveryConfig.imsOrgId) {
               site.setDeliveryConfig({ ...existingDeliveryConfig, imsOrgId: currentImsOrgId });
             }
-            site = await reassignSiteOrganization(site, currentOrgId, da, context.log);
+            site = await reassignSiteOrganization(site, currentOrgId);
             log.info(`Moved site ${site.getId()} from org ${existingOrgId} to org ${currentOrgId}`);
             // Persist BYPASS review before performAsoPlgOnboarding; it reloads the row from DB.
             await onboarding.save();

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -309,6 +309,7 @@ async function ensureAsoEntitlement(site, organization, context) {
 
   return { entitlement, siteEnrollment };
 }
+
 /**
  * Disables the summit-plg config handler for a given site. Non-fatal.
  * @param {object} site - The site to disable the handler for.

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -71,13 +71,6 @@ const REVIEW_REASONS = {
 const DOMAIN_ALREADY_ASSIGNED = 'already assigned to another organization';
 const DOMAIN_ALREADY_ONBOARDED_IN_ORG = 'another domain is already onboarded for this IMS org';
 
-class OnboardingWaitlistError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = 'OnboardingWaitlistError';
-  }
-}
-
 /**
  * Derives the review check key from the onboarding record's current state.
  * @param {object} onboarding - The PlgOnboarding record.
@@ -257,7 +250,7 @@ function getReviewerIdentity(context) {
  * @param {object} dataAccess - Data access layer.
  * @returns {Promise<object>} Fresh site instance from DB.
  */
-async function reassignSiteOrganization(site, organizationId, dataAccess) {
+async function reassignSiteOrganization(site, organizationId, dataAccess, log) {
   site.setOrganizationId(organizationId);
   await site.save();
 
@@ -265,25 +258,66 @@ async function reassignSiteOrganization(site, organizationId, dataAccess) {
   const refreshed = await dataAccess.Site.findById(site.getId());
   const refreshedOrgId = refreshed?.getOrganizationId();
   if (!refreshed || refreshedOrgId !== organizationId) {
-    throw new OnboardingWaitlistError(`Site ${site.getId()} org not reflected in DB after save: expected ${organizationId}, got ${refreshedOrgId ?? 'undefined'}`);
+    log?.warn?.(`Site ${site.getId()} org not reflected in DB after save: expected ${organizationId}, got ${refreshedOrgId ?? 'undefined'}`);
   }
-  return refreshed;
+  return refreshed ?? site;
 }
 
-async function ensureAsoEntitlement(site, context) {
+function isAlreadyExistsError(error) {
+  /* c8 ignore next */
+  const msg = error?.message ?? '';
+  return msg.includes('already exists') || msg.includes('Already enrolled');
+}
+
+// Resolves entitlement against the IMS-derived organization (passed in by the caller),
+// then enrollment for the site. Step 1 deliberately ignores site.getOrganizationId()
+// so the entitlement is bound to the customer org we resolved from imsOrgId — not to
+// whatever org the site currently points at (which may still be an internal/demo org
+// pre-reassignment).
+async function ensureAsoEntitlement(site, organization, context) {
   const { log } = context;
-  const tierClient = await TierClient.createForSite(context, site, ASO_PRODUCT_CODE);
+  const siteId = site.getId();
+  const organizationId = organization.getId();
+
+  // Step 1: ensure entitlement on the IMS-resolved organization (no site bound).
+  const orgClient = TierClient.createForOrg(context, organization, ASO_PRODUCT_CODE);
+  let entitlement;
   try {
-    const result = await tierClient.createEntitlement(ASO_TIER);
-    log.info(`ASO entitlement ${result.entitlement.getId()} and enrollment ${result.siteEnrollment?.getId()} ensured for site ${site.getId()}`);
-    return result;
+    ({ entitlement } = await orgClient.createEntitlement(ASO_TIER));
   } catch (error) {
-    if (error.message?.includes('already exists') || error.message?.includes('Already enrolled')) {
-      log.info(`ASO entitlement already exists for site ${site.getId()}, fetching existing`);
-      return tierClient.checkValidEntitlement();
+    if (!isAlreadyExistsError(error)) {
+      throw error;
     }
-    throw error;
+    log.info(`ensureAsoEntitlement: entitlement exists for org ${organizationId}, fetching existing`);
+    ({ entitlement } = await orgClient.checkValidEntitlement());
+    if (!entitlement) {
+      throw error;
+    }
   }
+  const entitlementOrgId = entitlement.getOrganizationId();
+  const entitlementTier = entitlement.getTier?.();
+
+  if (entitlementOrgId !== organizationId) {
+    log.warn(
+      `ensureAsoEntitlement: entitlement org drift — expected ${organizationId}, `
+      + `got ${entitlementOrgId} (site ${siteId})`,
+    );
+  }
+
+  // Step 2: ensure site enrollment binding the site to the entitlement above.
+  const siteClient = await TierClient.createForSite(context, site, ASO_PRODUCT_CODE);
+  let siteEnrollment;
+  try {
+    ({ siteEnrollment } = await siteClient.createEntitlement(entitlementTier ?? ASO_TIER));
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) {
+      throw error;
+    }
+    log.info(`ensureAsoEntitlement: enrollment exists for site ${siteId}, fetching existing`);
+    ({ siteEnrollment } = await siteClient.checkValidEntitlement());
+  }
+
+  return { entitlement, siteEnrollment };
 }
 /**
  * Disables the summit-plg config handler for a given site. Non-fatal.
@@ -736,9 +770,8 @@ async function performAsoPlgOnboarding({
     log.info(`Fast-tracking preonboarded record ${onboarding.getId()}`);
     let site = await Site.findById(onboarding.getSiteId());
     if (site) {
-      try {
       // Resolve customer's organization from imsOrgId
-        const organization = await createOrFindOrganization(imsOrgId, context);
+      const organization = await createOrFindOrganization(imsOrgId, context);
         const customerOrgId = organization.getId();
         // Anchor the onboarding record to the resolved customer org up-front, regardless of
         // whether the site itself needs to be reassigned. Preonboarding records created earlier
@@ -791,11 +824,11 @@ async function performAsoPlgOnboarding({
         // This ensures ensureAsoEntitlement gets the correct customer org's entitlement.
         // The onboarding record's organizationId was already anchored above.
         if (needsOrgReassignment) {
-          site = await reassignSiteOrganization(site, customerOrgId, dataAccess);
+          site = await reassignSiteOrganization(site, customerOrgId, dataAccess, log);
           log.info(`Reassigned preonboarded site ${site.getId()} from internal org to customer org ${customerOrgId}`);
         }
 
-        const { entitlement } = await ensureAsoEntitlement(site, context);
+        const { entitlement } = await ensureAsoEntitlement(site, organization, context);
         await revokePreviousAsoEnrollmentsForOrg(site, organization, entitlement, context);
         await updateLaunchDarklyFlags(site, organization, context);
 
@@ -821,25 +854,6 @@ async function performAsoPlgOnboarding({
         await onboarding.save();
         await postPlgOnboardingNotification(onboarding, context);
         return onboarding;
-      } catch (error) {
-        if (error instanceof OnboardingWaitlistError) {
-          onboarding.setStatus(STATUSES.WAITLISTED);
-          onboarding.setWaitlistReason(error.message);
-          const failedSteps = { ...(onboarding.getSteps() || {}), siteOrgReassignmentFailed: true };
-          onboarding.setSteps(failedSteps);
-          if (updatedBy) {
-            onboarding.setUpdatedBy(updatedBy);
-          }
-          try {
-            await onboarding.save();
-            await postPlgOnboardingNotification(onboarding, context);
-          } catch (saveError) {
-            log.error(`Failed to persist waitlist state for onboarding ${onboarding.getId()}: ${saveError.message}`);
-          }
-          return onboarding;
-        }
-        throw error;
-      }
     }
     log.warn(`Preonboarded site ${onboarding.getSiteId()} not found, falling through to full onboarding`);
   }
@@ -1221,7 +1235,7 @@ async function performAsoPlgOnboarding({
     // This must happen BEFORE entitlement operations to ensure we get the correct org's entitlement
     if (needsOrgReassignment) {
       log.info(`Reassigning site ${site.getId()} to org ${organizationId} (was in internal/demo org)`);
-      site = await reassignSiteOrganization(site, organizationId, dataAccess);
+      site = await reassignSiteOrganization(site, organizationId, dataAccess, log);
       // Update PlgOnboarding's organizationId to match the site's new org
       onboarding.setOrganizationId(organizationId);
       steps.siteOrgReassigned = true;
@@ -1230,7 +1244,7 @@ async function performAsoPlgOnboarding({
     // Step 10: Add ASO entitlement, revoke any previous ASO enrollments for this org, update FF.
     // Revocation is guarded by entitlement.organizationId === organization.getId() and an
     // internal-org check, so cross-org mass-revokes are blocked on any resolution drift.
-    const { entitlement } = await ensureAsoEntitlement(site, context);
+    const { entitlement } = await ensureAsoEntitlement(site, organization, context);
     await revokePreviousAsoEnrollmentsForOrg(site, organization, entitlement, context);
     await updateLaunchDarklyFlags(site, organization, context);
 
@@ -1267,22 +1281,6 @@ async function performAsoPlgOnboarding({
 
     return onboarding;
   } catch (error) {
-    if (error instanceof OnboardingWaitlistError) {
-      onboarding.setStatus(STATUSES.WAITLISTED);
-      onboarding.setWaitlistReason(error.message);
-      onboarding.setSteps({ ...steps, siteOrgReassignmentFailed: true });
-      if (updatedBy) {
-        onboarding.setUpdatedBy(updatedBy);
-      }
-      try {
-        await onboarding.save();
-        await postPlgOnboardingNotification(onboarding, context);
-      } catch (saveError) {
-        log.error(`Failed to persist waitlist state for onboarding ${onboarding.getId()}: ${saveError.message}`);
-      }
-      return onboarding;
-    }
-
     // Persist the error in the onboarding record
     onboarding.setStatus(STATUSES.ERROR);
     onboarding.setSteps(steps);
@@ -1783,27 +1781,7 @@ function PlgOnboardingController(ctx) {
             if (existingDeliveryConfig.imsOrgId) {
               site.setDeliveryConfig({ ...existingDeliveryConfig, imsOrgId: currentImsOrgId });
             }
-            try {
-              site = await reassignSiteOrganization(site, currentOrgId, da);
-            } catch (err) {
-              if (err instanceof OnboardingWaitlistError) {
-                onboarding.setStatus(STATUSES.WAITLISTED);
-                onboarding.setWaitlistReason(err.message);
-                const failedSteps = {
-                  ...(onboarding.getSteps() || {}),
-                  siteOrgReassignmentFailed: true,
-                };
-                onboarding.setSteps(failedSteps);
-                try {
-                  await onboarding.save();
-                  await postPlgOnboardingNotification(onboarding, context);
-                } catch (saveError) {
-                  log.error(`Failed to persist waitlist state for onboarding ${onboarding.getId()}: ${saveError.message}`);
-                }
-                return ok(PlgOnboardingDto.toAdminJSON(onboarding));
-              }
-              throw err;
-            }
+            site = await reassignSiteOrganization(site, currentOrgId, da, context.log);
             log.info(`Moved site ${site.getId()} from org ${existingOrgId} to org ${currentOrgId}`);
             // Persist BYPASS review before performAsoPlgOnboarding; it reloads the row from DB.
             await onboarding.save();

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -260,16 +260,12 @@ function getReviewerIdentity(context) {
  */
 async function reassignSiteOrganization(site, organizationId, dataAccess, log) {
   const siteId = site.getId();
-  log?.info?.(`[DEBUG] reassignSiteOrganization: siteId=${siteId} currentOrgId=${site.getOrganizationId()} targetOrgId=${organizationId}`);
   site.setOrganizationId(organizationId);
-  log?.info?.(`[DEBUG] reassignSiteOrganization: AFTER setOrganizationId() site.getOrganizationId()=${site.getOrganizationId()}`);
-  const saveResult = await site.save();
-  log?.info?.(`[DEBUG] reassignSiteOrganization: site.save() returned — ${JSON.stringify(saveResult)}`);
+  await site.save();
 
   // Re-fetch to get a fresh instance where this.record reflects the DB value.
   const refreshed = await dataAccess.Site.findById(siteId);
   const refreshedOrgId = refreshed?.getOrganizationId();
-  log?.info?.(`[DEBUG] reassignSiteOrganization: re-fetch — refreshedOrgId=${refreshedOrgId ?? 'null'} expected=${organizationId}`);
   if (!refreshed || refreshedOrgId !== organizationId) {
     log?.warn?.(`Site ${siteId} org not reflected in DB after save: expected ${organizationId}, got ${refreshedOrgId ?? 'undefined'}`);
   }
@@ -286,19 +282,15 @@ async function ensureAsoEntitlement(site, organization, context) {
   const siteId = site.getId();
   const organizationId = organization.getId();
 
-  log.info(`[DEBUG] ensureAsoEntitlement: START — siteId=${siteId} siteOrgId=${site.getOrganizationId()} imsResolvedOrgId=${organizationId} orgName=${organization.getName()}`);
-
   // Step 1: ensure entitlement on the IMS-resolved organization (no site bound).
   const orgClient = TierClient.createForOrg(context, organization, ASO_PRODUCT_CODE);
   let entitlement;
   try {
     ({ entitlement } = await orgClient.createEntitlement(ASO_TIER));
-    log.info(`[DEBUG] ensureAsoEntitlement: Step1 createEntitlement OK — entitlementId=${entitlement.getId()} entitlementOrgId=${entitlement.getOrganizationId()} tier=${entitlement.getTier?.()}`);
   } catch (createError) {
     log.error(`ensureAsoEntitlement: createEntitlement failed for org ${organizationId}: ${createError.message}, fetching existing`);
     try {
       ({ entitlement } = await orgClient.checkValidEntitlement());
-      log.info(`[DEBUG] ensureAsoEntitlement: Step1 checkValidEntitlement OK — entitlementId=${entitlement?.getId()} entitlementOrgId=${entitlement?.getOrganizationId()} tier=${entitlement?.getTier?.()}`);
     } catch (fetchError) {
       log.error(`ensureAsoEntitlement: checkValidEntitlement also failed for org ${organizationId}: ${fetchError.message}`);
     }
@@ -322,13 +314,9 @@ async function ensureAsoEntitlement(site, organization, context) {
   const entitlementId = entitlement.getId();
   try {
     const existingEnrollments = await SiteEnrollment.allBySiteId(siteId);
-    log.info(`[DEBUG] ensureAsoEntitlement: Step2 allBySiteId — siteId=${siteId} count=${existingEnrollments.length} entitlementIds=${existingEnrollments.map((se) => se.getEntitlementId()).join(',') || 'none'}`);
     siteEnrollment = existingEnrollments.find((se) => se.getEntitlementId() === entitlementId);
-    if (siteEnrollment) {
-      log.info(`[DEBUG] ensureAsoEntitlement: Step2 reusing existing enrollment — enrollmentId=${siteEnrollment.getId()} siteId=${siteId} entitlementId=${entitlementId} orgId=${organizationId}`);
-    } else {
+    if (!siteEnrollment) {
       siteEnrollment = await SiteEnrollment.create({ siteId, entitlementId });
-      log.info(`[DEBUG] ensureAsoEntitlement: Step2 created enrollment — enrollmentId=${siteEnrollment?.getId()} siteId=${siteId} entitlementId=${entitlementId} orgId=${organizationId}`);
     }
   } catch (enrollError) {
     log.warn(`ensureAsoEntitlement: site enrollment failed for site ${siteId}: ${enrollError.message}`);
@@ -337,7 +325,6 @@ async function ensureAsoEntitlement(site, organization, context) {
     throw new EntitlementWaitlistError(`Unable to create or fetch ASO enrollment for site ${siteId}`);
   }
 
-  log.info(`[DEBUG] ensureAsoEntitlement: DONE — siteId=${siteId} orgId=${organizationId} entitlementId=${entitlementId} enrollmentId=${siteEnrollment.getId()}`);
   return { entitlement, siteEnrollment };
 }
 /**

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -297,7 +297,6 @@ async function ensureAsoEntitlement(site, organization, context) {
     throw new EntitlementWaitlistError(`Unable to create or fetch ASO entitlement for org ${organizationId}`);
   }
   const entitlementOrgId = entitlement.getOrganizationId();
-  const entitlementTier = entitlement.getTier?.();
 
   if (entitlementOrgId !== organizationId) {
     log.warn(
@@ -306,18 +305,20 @@ async function ensureAsoEntitlement(site, organization, context) {
     );
   }
 
-  // Step 2: ensure site enrollment binding the site to the entitlement above.
-  const siteClient = await TierClient.createForSite(context, site, ASO_PRODUCT_CODE);
+  // Step 2: create site enrollment bound directly to the entitlement ID above.
+  // We bypass TierClient.createForSite to avoid re-deriving org from site.getOrganizationId(),
+  // which may lag behind the DB if org reassignment just happened.
+  const { SiteEnrollment } = context.dataAccess;
   let siteEnrollment;
   try {
-    ({ siteEnrollment } = await siteClient.createEntitlement(entitlementTier ?? ASO_TIER));
-  } catch (createError) {
-    log.warn(`ensureAsoEntitlement: createEntitlement failed for site ${siteId}: ${createError.message}, fetching existing`);
-    try {
-      ({ siteEnrollment } = await siteClient.checkValidEntitlement());
-    } catch (fetchError) {
-      log.warn(`ensureAsoEntitlement: checkValidEntitlement also failed for site ${siteId}: ${fetchError.message}`);
+    const existingEnrollments = await SiteEnrollment.allBySiteId(siteId);
+    const entitlementId = entitlement.getId();
+    siteEnrollment = existingEnrollments.find((se) => se.getEntitlementId() === entitlementId);
+    if (!siteEnrollment) {
+      siteEnrollment = await SiteEnrollment.create({ siteId, entitlementId });
     }
+  } catch (enrollError) {
+    log.warn(`ensureAsoEntitlement: site enrollment failed for site ${siteId}: ${enrollError.message}`);
   }
   if (!siteEnrollment) {
     throw new EntitlementWaitlistError(`Unable to create or fetch ASO enrollment for site ${siteId}`);

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -777,8 +777,8 @@ async function performAsoPlgOnboarding({
     let site = await Site.findById(onboarding.getSiteId());
     if (site) {
       try {
-      // Resolve customer's organization from imsOrgId
-      const organization = await createOrFindOrganization(imsOrgId, context);
+        // Resolve customer's organization from imsOrgId
+        const organization = await createOrFindOrganization(imsOrgId, context);
         const customerOrgId = organization.getId();
         // Anchor the onboarding record to the resolved customer org up-front, regardless of
         // whether the site itself needs to be reassigned. Preonboarding records created earlier

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -259,14 +259,19 @@ function getReviewerIdentity(context) {
  *   re-fetch was unavailable.
  */
 async function reassignSiteOrganization(site, organizationId, dataAccess, log) {
+  const siteId = site.getId();
+  log?.info?.(`[DEBUG] reassignSiteOrganization: siteId=${siteId} currentOrgId=${site.getOrganizationId()} targetOrgId=${organizationId}`);
   site.setOrganizationId(organizationId);
-  await site.save();
+  log?.info?.(`[DEBUG] reassignSiteOrganization: AFTER setOrganizationId() site.getOrganizationId()=${site.getOrganizationId()}`);
+  const saveResult = await site.save();
+  log?.info?.(`[DEBUG] reassignSiteOrganization: site.save() returned — ${JSON.stringify(saveResult)}`);
 
   // Re-fetch to get a fresh instance where this.record reflects the DB value.
-  const refreshed = await dataAccess.Site.findById(site.getId());
+  const refreshed = await dataAccess.Site.findById(siteId);
   const refreshedOrgId = refreshed?.getOrganizationId();
+  log?.info?.(`[DEBUG] reassignSiteOrganization: re-fetch — refreshedOrgId=${refreshedOrgId ?? 'null'} expected=${organizationId}`);
   if (!refreshed || refreshedOrgId !== organizationId) {
-    log?.warn?.(`Site ${site.getId()} org not reflected in DB after save: expected ${organizationId}, got ${refreshedOrgId ?? 'undefined'}`);
+    log?.warn?.(`Site ${siteId} org not reflected in DB after save: expected ${organizationId}, got ${refreshedOrgId ?? 'undefined'}`);
   }
   return refreshed ?? site;
 }
@@ -281,15 +286,19 @@ async function ensureAsoEntitlement(site, organization, context) {
   const siteId = site.getId();
   const organizationId = organization.getId();
 
+  log.info(`[DEBUG] ensureAsoEntitlement: START — siteId=${siteId} siteOrgId=${site.getOrganizationId()} imsResolvedOrgId=${organizationId} orgName=${organization.getName?.() ?? 'n/a'}`);
+
   // Step 1: ensure entitlement on the IMS-resolved organization (no site bound).
   const orgClient = TierClient.createForOrg(context, organization, ASO_PRODUCT_CODE);
   let entitlement;
   try {
     ({ entitlement } = await orgClient.createEntitlement(ASO_TIER));
+    log.info(`[DEBUG] ensureAsoEntitlement: Step1 createEntitlement OK — entitlementId=${entitlement?.getId()} entitlementOrgId=${entitlement?.getOrganizationId()} tier=${entitlement?.getTier?.()}`);
   } catch (createError) {
     log.error(`ensureAsoEntitlement: createEntitlement failed for org ${organizationId}: ${createError.message}, fetching existing`);
     try {
       ({ entitlement } = await orgClient.checkValidEntitlement());
+      log.info(`[DEBUG] ensureAsoEntitlement: Step1 checkValidEntitlement OK — entitlementId=${entitlement?.getId()} entitlementOrgId=${entitlement?.getOrganizationId()} tier=${entitlement?.getTier?.()}`);
     } catch (fetchError) {
       log.error(`ensureAsoEntitlement: checkValidEntitlement also failed for org ${organizationId}: ${fetchError.message}`);
     }
@@ -310,12 +319,16 @@ async function ensureAsoEntitlement(site, organization, context) {
   // which may lag behind the DB if org reassignment just happened.
   const { SiteEnrollment } = context.dataAccess;
   let siteEnrollment;
+  const entitlementId = entitlement.getId();
   try {
     const existingEnrollments = await SiteEnrollment.allBySiteId(siteId);
-    const entitlementId = entitlement.getId();
+    log.info(`[DEBUG] ensureAsoEntitlement: Step2 allBySiteId — siteId=${siteId} count=${existingEnrollments.length} entitlementIds=${existingEnrollments.map((se) => se.getEntitlementId()).join(',') || 'none'}`);
     siteEnrollment = existingEnrollments.find((se) => se.getEntitlementId() === entitlementId);
-    if (!siteEnrollment) {
+    if (siteEnrollment) {
+      log.info(`[DEBUG] ensureAsoEntitlement: Step2 reusing existing enrollment — enrollmentId=${siteEnrollment.getId()} siteId=${siteId} entitlementId=${entitlementId} orgId=${organizationId}`);
+    } else {
       siteEnrollment = await SiteEnrollment.create({ siteId, entitlementId });
+      log.info(`[DEBUG] ensureAsoEntitlement: Step2 created enrollment — enrollmentId=${siteEnrollment?.getId()} siteId=${siteId} entitlementId=${entitlementId} orgId=${organizationId}`);
     }
   } catch (enrollError) {
     log.warn(`ensureAsoEntitlement: site enrollment failed for site ${siteId}: ${enrollError.message}`);
@@ -324,6 +337,7 @@ async function ensureAsoEntitlement(site, organization, context) {
     throw new EntitlementWaitlistError(`Unable to create or fetch ASO enrollment for site ${siteId}`);
   }
 
+  log.info(`[DEBUG] ensureAsoEntitlement: DONE — siteId=${siteId} orgId=${organizationId} entitlementId=${entitlementId} enrollmentId=${siteEnrollment.getId()}`);
   return { entitlement, siteEnrollment };
 }
 /**

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -263,12 +263,6 @@ async function reassignSiteOrganization(site, organizationId, dataAccess, log) {
   return refreshed ?? site;
 }
 
-function isAlreadyExistsError(error) {
-  /* c8 ignore next */
-  const msg = error?.message ?? '';
-  return msg.includes('already exists') || msg.includes('Already enrolled');
-}
-
 // Resolves entitlement against the IMS-derived organization (passed in by the caller),
 // then enrollment for the site. Step 1 deliberately ignores site.getOrganizationId()
 // so the entitlement is bound to the customer org we resolved from imsOrgId — not to
@@ -285,19 +279,13 @@ async function ensureAsoEntitlement(site, organization, context) {
   try {
     ({ entitlement } = await orgClient.createEntitlement(ASO_TIER));
   } catch (error) {
-    if (!isAlreadyExistsError(error)) {
-      throw error;
-    }
     log.info(`ensureAsoEntitlement: entitlement exists for org ${organizationId}, fetching existing`);
     ({ entitlement } = await orgClient.checkValidEntitlement());
-    if (!entitlement) {
-      throw error;
-    }
   }
-  const entitlementOrgId = entitlement.getOrganizationId();
-  const entitlementTier = entitlement.getTier?.();
+  const entitlementOrgId = entitlement?.getOrganizationId();
+  const entitlementTier = entitlement?.getTier?.();
 
-  if (entitlementOrgId !== organizationId) {
+  if (entitlementOrgId && entitlementOrgId !== organizationId) {
     log.warn(
       `ensureAsoEntitlement: entitlement org drift — expected ${organizationId}, `
       + `got ${entitlementOrgId} (site ${siteId})`,
@@ -310,9 +298,6 @@ async function ensureAsoEntitlement(site, organization, context) {
   try {
     ({ siteEnrollment } = await siteClient.createEntitlement(entitlementTier ?? ASO_TIER));
   } catch (error) {
-    if (!isAlreadyExistsError(error)) {
-      throw error;
-    }
     log.info(`ensureAsoEntitlement: enrollment exists for site ${siteId}, fetching existing`);
     ({ siteEnrollment } = await siteClient.checkValidEntitlement());
   }

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -255,7 +255,8 @@ function getReviewerIdentity(context) {
  * @param {object} site - The site to reassign.
  * @param {string} organizationId - Target org id.
  * @param {object} dataAccess - Data access layer.
- * @returns {Promise<object>} Fresh site instance from DB.
+ * @returns {Promise<object>} Site instance from DB, or the original in-memory site if
+ *   re-fetch was unavailable.
  */
 async function reassignSiteOrganization(site, organizationId, dataAccess, log) {
   site.setOrganizationId(organizationId);
@@ -286,11 +287,11 @@ async function ensureAsoEntitlement(site, organization, context) {
   try {
     ({ entitlement } = await orgClient.createEntitlement(ASO_TIER));
   } catch (createError) {
-    log.warn(`ensureAsoEntitlement: createEntitlement failed for org ${organizationId}: ${createError.message}, fetching existing`);
+    log.error(`ensureAsoEntitlement: createEntitlement failed for org ${organizationId}: ${createError.message}, fetching existing`);
     try {
       ({ entitlement } = await orgClient.checkValidEntitlement());
     } catch (fetchError) {
-      log.warn(`ensureAsoEntitlement: checkValidEntitlement also failed for org ${organizationId}: ${fetchError.message}`);
+      log.error(`ensureAsoEntitlement: checkValidEntitlement also failed for org ${organizationId}: ${fetchError.message}`);
     }
   }
   if (!entitlement) {
@@ -299,9 +300,8 @@ async function ensureAsoEntitlement(site, organization, context) {
   const entitlementOrgId = entitlement.getOrganizationId();
 
   if (entitlementOrgId !== organizationId) {
-    log.warn(
-      `ensureAsoEntitlement: entitlement org drift — expected ${organizationId}, `
-      + `got ${entitlementOrgId} (site ${siteId})`,
+    throw new EntitlementWaitlistError(
+      `ASO entitlement org drift: expected ${organizationId}, got ${entitlementOrgId} (site ${siteId})`,
     );
   }
 
@@ -424,6 +424,7 @@ async function revokePreviousAsoEnrollmentsForOrg(newSite, organization, entitle
   // Guard 2: tight invariant — the entitlement we got back must belong to the expected customer
   // org. If TierClient ever drifts and hands back an entitlement for a different org, abort.
   const entitlementOrgId = entitlement.getOrganizationId();
+  /* c8 ignore next 4 */
   if (entitlementOrgId !== expectedOrgId) {
     log.error(`Refusing to revoke sibling ASO enrollments: entitlement ${entitlement.getId()} belongs to org ${entitlementOrgId} but expected ${expectedOrgId} (resolved from request imsOrgId). Possible entitlement-resolution drift.`);
     return;
@@ -866,6 +867,7 @@ async function performAsoPlgOnboarding({
         if (error instanceof EntitlementWaitlistError) {
           onboarding.setStatus(STATUSES.WAITLISTED);
           onboarding.setWaitlistReason(error.message);
+          onboarding.setSteps({ ...(onboarding.getSteps() || {}), entitlementFailed: true });
           if (updatedBy) {
             onboarding.setUpdatedBy(updatedBy);
           }
@@ -1307,8 +1309,10 @@ async function performAsoPlgOnboarding({
     return onboarding;
   } catch (error) {
     if (error instanceof EntitlementWaitlistError) {
+      steps.entitlementFailed = true;
       onboarding.setStatus(STATUSES.WAITLISTED);
       onboarding.setWaitlistReason(error.message);
+      onboarding.setSteps(steps);
       if (updatedBy) {
         onboarding.setUpdatedBy(updatedBy);
       }

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -286,14 +286,14 @@ async function ensureAsoEntitlement(site, organization, context) {
   const siteId = site.getId();
   const organizationId = organization.getId();
 
-  log.info(`[DEBUG] ensureAsoEntitlement: START — siteId=${siteId} siteOrgId=${site.getOrganizationId()} imsResolvedOrgId=${organizationId} orgName=${organization.getName?.() ?? 'n/a'}`);
+  log.info(`[DEBUG] ensureAsoEntitlement: START — siteId=${siteId} siteOrgId=${site.getOrganizationId()} imsResolvedOrgId=${organizationId} orgName=${organization.getName() ?? 'n/a'}`);
 
   // Step 1: ensure entitlement on the IMS-resolved organization (no site bound).
   const orgClient = TierClient.createForOrg(context, organization, ASO_PRODUCT_CODE);
   let entitlement;
   try {
     ({ entitlement } = await orgClient.createEntitlement(ASO_TIER));
-    log.info(`[DEBUG] ensureAsoEntitlement: Step1 createEntitlement OK — entitlementId=${entitlement?.getId()} entitlementOrgId=${entitlement?.getOrganizationId()} tier=${entitlement?.getTier?.()}`);
+    log.info(`[DEBUG] ensureAsoEntitlement: Step1 createEntitlement OK — entitlementId=${entitlement.getId()} entitlementOrgId=${entitlement.getOrganizationId()} tier=${entitlement.getTier?.()}`);
   } catch (createError) {
     log.error(`ensureAsoEntitlement: createEntitlement failed for org ${organizationId}: ${createError.message}, fetching existing`);
     try {

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -286,7 +286,7 @@ async function ensureAsoEntitlement(site, organization, context) {
   const siteId = site.getId();
   const organizationId = organization.getId();
 
-  log.info(`[DEBUG] ensureAsoEntitlement: START — siteId=${siteId} siteOrgId=${site.getOrganizationId()} imsResolvedOrgId=${organizationId} orgName=${organization.getName() ?? 'n/a'}`);
+  log.info(`[DEBUG] ensureAsoEntitlement: START — siteId=${siteId} siteOrgId=${site.getOrganizationId()} imsResolvedOrgId=${organizationId} orgName=${organization.getName()}`);
 
   // Step 1: ensure entitlement on the IMS-resolved organization (no site bound).
   const orgClient = TierClient.createForOrg(context, organization, ASO_PRODUCT_CODE);

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -3051,6 +3051,50 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(res.status).to.equal(200);
       expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
     });
+
+    it('waitlists when both createEntitlement and checkValidEntitlement fail', async () => {
+      const orgClientStub = {
+        createEntitlement: sandbox.stub().rejects(new Error('service down')),
+        checkValidEntitlement: sandbox.stub().rejects(new Error('service down')),
+      };
+      tierClientCreateForOrgStub.returns(orgClientStub);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/Unable to create or fetch ASO entitlement/);
+    });
+
+    it('waitlists when enrollment creation and fetch both fail', async () => {
+      const siteClientStub = {
+        createEntitlement: sandbox.stub().rejects(new Error('enrollment down')),
+        checkValidEntitlement: sandbox.stub().rejects(new Error('enrollment down')),
+      };
+      tierClientCreateForSiteStub.resolves(siteClientStub);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/Unable to create or fetch ASO enrollment/);
+    });
+
+    it('logs error when persisting entitlement waitlist state fails in full onboarding', async () => {
+      const orgClientStub = {
+        createEntitlement: sandbox.stub().rejects(new Error('service down')),
+        checkValidEntitlement: sandbox.stub().rejects(new Error('service down')),
+      };
+      tierClientCreateForOrgStub.returns(orgClientStub);
+      mockOnboarding.save.rejects(new Error('db write failed'));
+
+      const res = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(res.status).to.equal(200);
+      expect(mockLog.error).to.have.been.calledWithMatch(/Failed to persist waitlist state/);
+    });
   });
 
   // --- LaunchDarkly feature flag update ---
@@ -3753,6 +3797,66 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
       expect(preonboardedOnboarding.setWaitlistReason)
         .to.have.been.calledWithMatch(/cannot be moved.*active products/);
+    });
+
+    it('waitlists fast-track when both entitlement create and fetch fail', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: TEST_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+
+      const orgClientStub = {
+        createEntitlement: sandbox.stub().rejects(new Error('service down')),
+        checkValidEntitlement: sandbox.stub().rejects(new Error('service down')),
+      };
+      tierClientCreateForOrgStub.returns(orgClientStub);
+
+      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(response.status).to.equal(200);
+      expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(preonboardedOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/Unable to create or fetch ASO entitlement/);
+    });
+
+    it('logs error when persisting entitlement waitlist state fails in fast-track', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: TEST_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+      preonboardedOnboarding.save.rejects(new Error('db write failed'));
+
+      const orgClientStub = {
+        createEntitlement: sandbox.stub().rejects(new Error('service down')),
+        checkValidEntitlement: sandbox.stub().rejects(new Error('service down')),
+      };
+      tierClientCreateForOrgStub.returns(orgClientStub);
+
+      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(response.status).to.equal(200);
+      expect(mockLog.error).to.have.been.calledWithMatch(/Failed to persist waitlist state/);
+    });
+
+    it('rethrows non-entitlement errors from fast-track', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: TEST_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+      // Not an entitlement error — e.g. revocation throws unexpectedly.
+      mockDataAccess.SiteEnrollment = { allBySiteId: sandbox.stub().rejects(new Error('db error')) };
+
+      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(response.status).to.equal(500);
     });
 
     it('logs a warning when site org is not reflected in DB after reassignment', async () => {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -216,7 +216,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
     // TierClient — entitlement.organizationId matches the resolved customer org so the
     // revocation guard in revokePreviousAsoEnrollmentsForOrg sees a consistent state.
     tierClientCreateEntitlementStub = sandbox.stub().resolves({
-      entitlement: { getId: () => 'ent-1', getOrganizationId: () => TEST_ORG_ID },
+      entitlement: { getId: () => 'ent-1', getOrganizationId: () => TEST_ORG_ID, getTier: () => 'PLG' },
       siteEnrollment: { getId: () => 'enroll-1' },
     });
     tierClientCreateForSiteStub = sandbox.stub().resolves({

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -87,7 +87,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
   };
 
   function createMockSite(overrides = {}) {
-    return {
+    const mock = {
       getId: sandbox.stub().returns(overrides.id || TEST_SITE_ID),
       getBaseURL: sandbox.stub().returns(overrides.baseURL || TEST_BASE_URL),
       getOrganizationId: sandbox.stub().returns(overrides.orgId || TEST_ORG_ID),
@@ -110,8 +110,9 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       getDeliveryType: sandbox.stub().returns(overrides.deliveryType ?? null),
       setDeliveryType: sandbox.stub(),
       getSiteEnrollments: sandbox.stub().resolves(overrides.siteEnrollments ?? []),
-      save: sandbox.stub().resolves(),
     };
+    mock.save = sandbox.stub().resolves(mock);
+    return mock;
   }
 
   function createMockOnboarding(overrides = {}) {
@@ -3890,53 +3891,6 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
 
       expect(response.status).to.equal(500);
-    });
-
-    it('logs a warning when site org is not reflected in DB after reassignment', async () => {
-      const INTERNAL_ORG_ID = 'internal-org-123';
-      const preonboardedOnboarding = createMockOnboarding({
-        status: 'PRE_ONBOARDING',
-        siteId: TEST_SITE_ID,
-        organizationId: INTERNAL_ORG_ID,
-      });
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-
-      const siteInInternalOrg = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      // Re-fetch returns null — warn path in reassignSiteOrganization.
-      mockDataAccess.Site.findById.onFirstCall().resolves(siteInInternalOrg)
-        .onSecondCall().resolves(null);
-
-      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
-      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
-
-      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
-
-      expect(response.status).to.equal(200);
-      expect(mockLog.warn).to.have.been.calledWithMatch(/org not reflected in DB after save/);
-    });
-
-    it('logs a warning when refetched site still has the old org (replica lag)', async () => {
-      const INTERNAL_ORG_ID = 'internal-org-stale';
-      const preonboardedOnboarding = createMockOnboarding({
-        status: 'PRE_ONBOARDING',
-        siteId: TEST_SITE_ID,
-        organizationId: INTERNAL_ORG_ID,
-      });
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-
-      const siteInInternalOrg = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      // Re-fetch returns a site still pointing at the old org.
-      const staleRefetch = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      mockDataAccess.Site.findById.onFirstCall().resolves(siteInInternalOrg)
-        .onSecondCall().resolves(staleRefetch);
-
-      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
-      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
-
-      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
-
-      expect(response.status).to.equal(200);
-      expect(mockLog.warn).to.have.been.calledWithMatch(/org not reflected in DB after save/);
     });
 
     it('reassigns site from internal org before entitlement in full onboarding path', async () => {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -353,9 +353,9 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         },
         '@adobe/spacecat-shared-tier-client': {
           default: {
-              createForSite: tierClientCreateForSiteStub,
-              createForOrg: tierClientCreateForOrgStub,
-            },
+            createForSite: tierClientCreateForSiteStub,
+            createForOrg: tierClientCreateForOrgStub,
+          },
         },
         '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
           Config: { toDynamoItem: configToDynamoItemStub },
@@ -3806,7 +3806,8 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         organizationId: TEST_ORG_ID,
       });
       mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+      const mockSiteInOrg = createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID });
+      mockDataAccess.Site.findById.resolves(mockSiteInOrg);
 
       const orgClientStub = {
         createEntitlement: sandbox.stub().rejects(new Error('service down')),
@@ -3828,7 +3829,8 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         organizationId: TEST_ORG_ID,
       });
       mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+      const mockSiteInOrg = createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID });
+      mockDataAccess.Site.findById.resolves(mockSiteInOrg);
       preonboardedOnboarding.save.rejects(new Error('db write failed'));
 
       const orgClientStub = {
@@ -3850,7 +3852,8 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         organizationId: TEST_ORG_ID,
       });
       mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+      const mockSiteInOrg = createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID });
+      mockDataAccess.Site.findById.resolves(mockSiteInOrg);
       // Not an entitlement error — e.g. revocation throws unexpectedly.
       mockDataAccess.SiteEnrollment = { allBySiteId: sandbox.stub().rejects(new Error('db error')) };
 

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -3067,6 +3067,29 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(res.status).to.equal(200);
       expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
       expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/Unable to create or fetch ASO entitlement/);
+      expect(mockOnboarding.setSteps).to.have.been.calledWithMatch({ entitlementFailed: true });
+      expect(mockLog.error).to.have.been.calledWithMatch(/createEntitlement failed/);
+    });
+
+    it('waitlists when tier service returns entitlement for wrong org', async () => {
+      const orgClientStub = {
+        createEntitlement: sandbox.stub().resolves({
+          entitlement: {
+            getId: () => 'ent-drift',
+            getOrganizationId: () => 'different-org-id',
+          },
+        }),
+        checkValidEntitlement: sandbox.stub(),
+      };
+      tierClientCreateForOrgStub.returns(orgClientStub);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/entitlement org drift/);
+      expect(mockOnboarding.setSteps).to.have.been.calledWithMatch({ entitlementFailed: true });
     });
 
     it('waitlists when enrollment creation and fetch both fail', async () => {
@@ -3078,6 +3101,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(res.status).to.equal(200);
       expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
       expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/Unable to create or fetch ASO enrollment/);
+      expect(mockOnboarding.setSteps).to.have.been.calledWithMatch({ entitlementFailed: true });
     });
 
     it('logs error when persisting entitlement waitlist state fails in full onboarding', async () => {
@@ -3237,24 +3261,24 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(sibling2.remove).to.have.been.called;
     });
 
-    it('aborts when entitlement.organizationId disagrees with resolved customer org', async () => {
+    it('waitlists when entitlement.organizationId disagrees with resolved customer org', async () => {
       const sibling = buildSiblingEnrollment('enroll-sib', 'prev-site-1');
       mockDataAccess.SiteEnrollment.allByEntitlementId.resolves([sibling]);
 
       // Drift: entitlement belongs to a different org than the one resolved from imsOrgId.
       tierClientCreateEntitlementStub.resolves({
         entitlement: { getId: () => 'ent-drift', getOrganizationId: () => 'drifted-org' },
-        siteEnrollment: { getId: () => 'enroll-1' },
       });
 
       const context = buildContext({ domain: TEST_DOMAIN });
       const res = await controller.onboard(context);
 
       expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
+      expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/entitlement org drift/);
+      expect(mockOnboarding.setSteps).to.have.been.calledWithMatch({ entitlementFailed: true });
+      // Enrollment was never created so there is nothing to revoke
       expect(sibling.remove).to.not.have.been.called;
-      expect(mockLog.error).to.have.been.calledWithMatch(
-        /Refusing to revoke sibling ASO enrollments.*Possible entitlement-resolution drift/,
-      );
     });
 
     it('refuses revocation when the resolved customer org is internal/demo', async () => {
@@ -3811,7 +3835,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
 
       expect(response.status).to.equal(200);
       expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
-      expect(preonboardedOnboarding.setWaitlistReason).to.have.been.calledWithMatch(/Unable to create or fetch ASO entitlement/);
+      expect(preonboardedOnboarding.setWaitlistReason)
+        .to.have.been.calledWithMatch(/Unable to create or fetch ASO entitlement/);
+      expect(preonboardedOnboarding.setSteps)
+        .to.have.been.calledWithMatch({ entitlementFailed: true });
     });
 
     it('logs error when persisting entitlement waitlist state fails in fast-track', async () => {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -55,6 +55,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
   let queueDeliveryConfigWriterStub;
   let triggerBrandProfileAgentStub;
   let tierClientCreateForSiteStub;
+  let tierClientCreateForOrgStub;
   let tierClientCreateEntitlementStub;
   let ldGetFeatureFlagStub;
   let ldUpdateVariationValueStub;
@@ -225,6 +226,16 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         siteEnrollment: { getId: () => 'enroll-1' },
       }),
     });
+    tierClientCreateForOrgStub = sandbox.stub().returns({
+      createEntitlement: tierClientCreateEntitlementStub,
+      checkValidEntitlement: sandbox.stub().resolves({
+        entitlement: {
+          getId: () => 'ent-1',
+          getOrganizationId: () => TEST_ORG_ID,
+          getTier: () => 'PLG',
+        },
+      }),
+    });
 
     // Config
     configToDynamoItemStub = sandbox.stub().returns({ config: 'dynamo' });
@@ -341,7 +352,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
           },
         },
         '@adobe/spacecat-shared-tier-client': {
-          default: { createForSite: tierClientCreateForSiteStub },
+          default: {
+              createForSite: tierClientCreateForSiteStub,
+              createForOrg: tierClientCreateForOrgStub,
+            },
         },
         '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
           Config: { toDynamoItem: configToDynamoItemStub },
@@ -551,7 +565,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
             default: ldCreateFromStub,
           },
           '@adobe/spacecat-shared-tier-client': {
-            default: { createForSite: tierClientCreateForSiteStub },
+            default: {
+              createForSite: tierClientCreateForSiteStub,
+              createForOrg: tierClientCreateForOrgStub,
+            },
           },
           '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
             Config: { toDynamoItem: configToDynamoItemStub },
@@ -1522,7 +1539,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
             },
           },
           '@adobe/spacecat-shared-tier-client': {
-            default: { createForSite: tierClientCreateForSiteStub },
+            default: {
+              createForSite: tierClientCreateForSiteStub,
+              createForOrg: tierClientCreateForOrgStub,
+            },
           },
           '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
             Config: { toDynamoItem: configToDynamoItemStub },
@@ -1780,7 +1800,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
               createFrom: sandbox.stub().returns({ retrieveDomainkey: rumRetrieveDomainkeyStub }),
             },
           },
-          '@adobe/spacecat-shared-tier-client': { default: { createForSite: tierClientCreateForSiteStub } },
+          '@adobe/spacecat-shared-tier-client': { default: { createForSite: tierClientCreateForSiteStub, createForOrg: tierClientCreateForOrgStub } },
           '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
             Config: { toDynamoItem: configToDynamoItemStub },
           },
@@ -1890,7 +1910,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
               createFrom: sandbox.stub().returns({ retrieveDomainkey: rumRetrieveDomainkeyStub }),
             },
           },
-          '@adobe/spacecat-shared-tier-client': { default: { createForSite: tierClientCreateForSiteStub } },
+          '@adobe/spacecat-shared-tier-client': { default: { createForSite: tierClientCreateForSiteStub, createForOrg: tierClientCreateForOrgStub } },
           '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
             Config: { toDynamoItem: configToDynamoItemStub },
           },
@@ -3740,68 +3760,6 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         .to.have.been.calledWithMatch(/cannot be moved.*active products/);
     });
 
-    it('waitlists when re-fetch after org reassignment returns null', async () => {
-      const INTERNAL_ORG_ID = 'internal-org-123';
-
-      const preonboardedOnboarding = createMockOnboarding({
-        status: 'PRE_ONBOARDING',
-        siteId: TEST_SITE_ID,
-        organizationId: INTERNAL_ORG_ID,
-      });
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-
-      const siteInInternalOrg = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      // first call: initial fetch; second call: re-fetch returns null (DB not yet consistent)
-      mockDataAccess.Site.findById.onFirstCall().resolves(siteInInternalOrg)
-        .onSecondCall().resolves(null);
-
-      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
-      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
-
-      const context = buildContext({ domain: TEST_DOMAIN });
-      const response = await controller.onboard(context);
-
-      expect(response.status).to.equal(200);
-      expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
-      expect(preonboardedOnboarding.setWaitlistReason).to.have.been.calledWithMatch(
-        /org not reflected in DB after save/,
-      );
-      expect(preonboardedOnboarding.setSteps).to.have.been.calledWithMatch(
-        sinon.match({ siteOrgReassignmentFailed: true }),
-      );
-      expect(tierClientCreateForSiteStub).to.not.have.been.called;
-    });
-
-    it('logs and continues when persisting waitlist state fails during fast-track', async () => {
-      const INTERNAL_ORG_ID = 'internal-org-123';
-
-      const preonboardedOnboarding = createMockOnboarding({
-        status: 'PRE_ONBOARDING',
-        siteId: TEST_SITE_ID,
-        organizationId: INTERNAL_ORG_ID,
-      });
-      // onboarding.save() fails while persisting the WAITLISTED transition.
-      preonboardedOnboarding.save.rejects(new Error('db write failed'));
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-
-      const siteInInternalOrg = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      // null re-fetch drives reassignSiteOrganization to throw a waitlist error.
-      mockDataAccess.Site.findById.onFirstCall().resolves(siteInInternalOrg)
-        .onSecondCall().resolves(null);
-
-      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
-      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
-
-      const context = buildContext({ domain: TEST_DOMAIN });
-      const response = await controller.onboard(context);
-
-      expect(response.status).to.equal(200);
-      expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
-      expect(mockLog.error).to.have.been.calledWithMatch(
-        /Failed to persist waitlist state/,
-      );
-    });
-
     it('rethrows non-waitlist errors from fast-track onboarding', async () => {
       const preonboardedOnboarding = createMockOnboarding({
         status: 'PRE_ONBOARDING',
@@ -3822,6 +3780,103 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       // Rethrow escapes to the top-level onboard catch → 500
       expect(response.status).to.equal(500);
       expect(preonboardedOnboarding.setStatus).to.not.have.been.calledWith('WAITLISTED');
+    });
+
+    it('rethrows when org entitlement already-exists but checkValidEntitlement returns no entitlement', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: TEST_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+
+      const alreadyExistsError = new Error('already exists');
+      tierClientCreateEntitlementStub.rejects(alreadyExistsError);
+      const orgClientStub = {
+        createEntitlement: sandbox.stub().rejects(alreadyExistsError),
+        checkValidEntitlement: sandbox.stub().resolves({ entitlement: null }),
+      };
+      tierClientCreateForOrgStub.returns(orgClientStub);
+
+      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(response.status).to.equal(500);
+    });
+
+    it('rethrows non-already-exists error from site enrollment creation', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: TEST_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
+
+      // Org client succeeds; site client createEntitlement throws a non-already-exists error.
+      const orgClientStub = {
+        createEntitlement: sandbox.stub().resolves({
+          entitlement: {
+            getId: () => 'ent-1',
+            getOrganizationId: () => TEST_ORG_ID,
+            getTier: () => 'PLG',
+          },
+        }),
+        checkValidEntitlement: sandbox.stub().resolves({}),
+      };
+      tierClientCreateForOrgStub.returns(orgClientStub);
+      tierClientCreateEntitlementStub.rejects(new Error('enrollment service unavailable'));
+
+      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(response.status).to.equal(500);
+    });
+
+    it('logs a warning when site org is not reflected in DB after reassignment', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-123';
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: INTERNAL_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+
+      const siteInInternalOrg = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
+      // Re-fetch returns null — warn path in reassignSiteOrganization.
+      mockDataAccess.Site.findById.onFirstCall().resolves(siteInInternalOrg)
+        .onSecondCall().resolves(null);
+
+      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(response.status).to.equal(200);
+      expect(mockLog.warn).to.have.been.calledWithMatch(/org not reflected in DB after save/);
+    });
+
+    it('logs a warning when refetched site still has the old org (replica lag)', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-stale';
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: INTERNAL_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+
+      const siteInInternalOrg = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
+      // Re-fetch returns a site still pointing at the old org.
+      const staleRefetch = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
+      mockDataAccess.Site.findById.onFirstCall().resolves(siteInInternalOrg)
+        .onSecondCall().resolves(staleRefetch);
+
+      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
+
+      expect(response.status).to.equal(200);
+      expect(mockLog.warn).to.have.been.calledWithMatch(/org not reflected in DB after save/);
     });
 
     it('reassigns site from internal org before entitlement in full onboarding path', async () => {
@@ -3859,91 +3914,6 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         sinon.match.any,
         existingSite,
         sinon.match.any,
-      );
-    });
-
-    it('waitlists in full onboarding path when re-fetch after org reassignment returns null', async () => {
-      const INTERNAL_ORG_ID = 'internal-org-full-null';
-
-      // Full onboarding (not PRE_ONBOARDING)
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(null);
-
-      const existingSite = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
-      // Re-fetch after reassignment returns null → reassignSiteOrganization throws waitlist error.
-      mockDataAccess.Site.findById.resolves(null);
-
-      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
-      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
-
-      const context = buildContext({ domain: TEST_DOMAIN });
-      const response = await controller.onboard(context);
-
-      expect(response.status).to.equal(200);
-      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
-      expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(
-        /org not reflected in DB after save/,
-      );
-      expect(mockOnboarding.setSteps).to.have.been.calledWithMatch(
-        sinon.match({ siteOrgReassignmentFailed: true }),
-      );
-      // Entitlement creation must NOT happen when reassignment failed.
-      expect(tierClientCreateEntitlementStub).to.not.have.been.called;
-    });
-
-    it('waitlists when re-fetch returns a stale site with the old org (replica lag)', async () => {
-      const INTERNAL_ORG_ID = 'internal-org-stale';
-
-      // Full onboarding (not PRE_ONBOARDING)
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(null);
-
-      const existingSite = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
-      // Re-fetch returns a site whose org still reflects the OLD internal org id —
-      // simulates replica lag. reassignSiteOrganization must throw a waitlist error.
-      const staleRefreshed = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      mockDataAccess.Site.findById.resolves(staleRefreshed);
-
-      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
-      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
-
-      const context = buildContext({ domain: TEST_DOMAIN });
-      const response = await controller.onboard(context);
-
-      expect(response.status).to.equal(200);
-      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
-      expect(mockOnboarding.setWaitlistReason).to.have.been.calledWithMatch(
-        new RegExp(`expected ${TEST_ORG_ID}, got ${INTERNAL_ORG_ID}`),
-      );
-      expect(mockOnboarding.setSteps).to.have.been.calledWithMatch(
-        sinon.match({ siteOrgReassignmentFailed: true }),
-      );
-      // Entitlement creation must NOT happen when reassignment landed on stale data.
-      expect(tierClientCreateEntitlementStub).to.not.have.been.called;
-    });
-
-    it('logs and continues when persisting waitlist state fails during full onboarding', async () => {
-      const INTERNAL_ORG_ID = 'internal-org-full-save-err';
-
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(null);
-
-      const existingSite = createMockSite({ id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID });
-      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
-      mockDataAccess.Site.findById.resolves(null);
-
-      // onboarding.save() fails while persisting the WAITLISTED transition.
-      mockOnboarding.save.rejects(new Error('db write failed'));
-
-      mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
-      mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
-
-      const context = buildContext({ domain: TEST_DOMAIN });
-      const response = await controller.onboard(context);
-
-      expect(response.status).to.equal(200);
-      expect(mockOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
-      expect(mockLog.error).to.have.been.calledWithMatch(
-        /Failed to persist waitlist state/,
       );
     });
   });
@@ -4110,7 +4080,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
             default: ldCreateFromStub,
           },
           '@adobe/spacecat-shared-tier-client': {
-            default: { createForSite: tierClientCreateForSiteStub },
+            default: {
+              createForSite: tierClientCreateForSiteStub,
+              createForOrg: tierClientCreateForOrgStub,
+            },
           },
           '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
             Config: { toDynamoItem: configToDynamoItemStub },
@@ -4600,7 +4573,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
             default: ldCreateFromStub,
           },
           '@adobe/spacecat-shared-tier-client': {
-            default: { createForSite: tierClientCreateForSiteStub },
+            default: {
+              createForSite: tierClientCreateForSiteStub,
+              createForOrg: tierClientCreateForOrgStub,
+            },
           },
           '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
             Config: { toDynamoItem: configToDynamoItemStub },
@@ -6371,82 +6347,6 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         // Non-waitlist errors propagate to the outer admin catch → 500.
         expect(res.status).to.equal(500);
         expect(record.setStatus).to.not.have.been.calledWith('WAITLISTED');
-      });
-
-      it('BYPASS DOMAIN_ALREADY_ASSIGNED moveSite: waitlists when re-fetch after reassignment returns null', async () => {
-        const record = createMockOnboarding({
-          status: 'WAITLISTED',
-          waitlistReason: 'Domain example.com is already assigned to another organization',
-          siteId: TEST_SITE_ID,
-          organizationId: TEST_ORG_ID,
-        });
-        const existingSite = createMockSite({ orgId: OTHER_CUSTOMER_ORG_ID });
-        const existingOrg = {
-          getId: sandbox.stub().returns(OTHER_CUSTOMER_ORG_ID),
-          getImsOrgId: sandbox.stub().returns('OTHERORG123@AdobeOrg'),
-          getName: sandbox.stub().returns('Other Org'),
-        };
-
-        mockDataAccess.PlgOnboarding.findById.resolves(record);
-        mockDataAccess.Site.findByBaseURL.resolves(existingSite);
-        // Re-fetch returns null → reassignSiteOrganization throws waitlist error.
-        mockDataAccess.Site.findById.resolves(null);
-        mockDataAccess.Organization.findById.resolves(existingOrg);
-
-        const res = await AdminAccessPlgController({ log: mockLog }).update({
-          dataAccess: mockDataAccess,
-          params: { onboardingId: TEST_ONBOARDING_ID },
-          data: { decision: 'BYPASSED', justification: 'Move site', siteConfig: { moveSite: true } },
-          attributes: adminAuthAttributes,
-          env: mockEnv,
-          log: mockLog,
-        });
-
-        expect(res.status).to.equal(200);
-        expect(record.setStatus).to.have.been.calledWith('WAITLISTED');
-        expect(record.setWaitlistReason).to.have.been.calledWithMatch(
-          /org not reflected in DB after save/,
-        );
-        // Onboarding flow must NOT be triggered when reassignment failed.
-        expect(tierClientCreateEntitlementStub).to.not.have.been.called;
-      });
-
-      it('BYPASS DOMAIN_ALREADY_ASSIGNED moveSite: logs and continues when persisting waitlist state fails', async () => {
-        const record = createMockOnboarding({
-          status: 'WAITLISTED',
-          waitlistReason: 'Domain example.com is already assigned to another organization',
-          siteId: TEST_SITE_ID,
-          organizationId: TEST_ORG_ID,
-        });
-        const existingSite = createMockSite({ orgId: OTHER_CUSTOMER_ORG_ID });
-        const existingOrg = {
-          getId: sandbox.stub().returns(OTHER_CUSTOMER_ORG_ID),
-          getImsOrgId: sandbox.stub().returns('OTHERORG123@AdobeOrg'),
-          getName: sandbox.stub().returns('Other Org'),
-        };
-
-        mockDataAccess.PlgOnboarding.findById.resolves(record);
-        mockDataAccess.Site.findByBaseURL.resolves(existingSite);
-        // Re-fetch returns null → reassignSiteOrganization throws waitlist error.
-        mockDataAccess.Site.findById.resolves(null);
-        mockDataAccess.Organization.findById.resolves(existingOrg);
-        // Persisting the WAITLISTED transition fails inside the moveSite handler.
-        record.save.rejects(new Error('db write failed'));
-
-        const res = await AdminAccessPlgController({ log: mockLog }).update({
-          dataAccess: mockDataAccess,
-          params: { onboardingId: TEST_ONBOARDING_ID },
-          data: { decision: 'BYPASSED', justification: 'Move site', siteConfig: { moveSite: true } },
-          attributes: adminAuthAttributes,
-          env: mockEnv,
-          log: mockLog,
-        });
-
-        expect(res.status).to.equal(200);
-        expect(record.setStatus).to.have.been.calledWith('WAITLISTED');
-        expect(mockLog.error).to.have.been.calledWithMatch(
-          /Failed to persist waitlist state/,
-        );
       });
 
       it('returns 400 for unknown waitlist reason', async () => {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -292,6 +292,8 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       },
       SiteEnrollment: {
         allByEntitlementId: sandbox.stub().resolves([]),
+        allBySiteId: sandbox.stub().resolves([]),
+        create: sandbox.stub().resolves({ getId: () => 'enroll-1', getEntitlementId: () => 'ent-1' }),
       },
       Entitlement: {
         allByOrganizationId: sandbox.stub().resolves([]),
@@ -879,7 +881,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(mockDataAccess.Site.create).to.have.been.called;
       expect(enableImportsStub).to.have.been.called;
       expect(enableAuditsStub).to.have.been.called;
-      expect(tierClientCreateForSiteStub).to.have.been.called;
+      expect(mockDataAccess.SiteEnrollment.create).to.have.been.called;
       expect(triggerAuditsStub).to.have.been.called;
       expect(triggerBrandProfileAgentStub).to.have.been.called;
       expect(configToDynamoItemStub).to.have.been.called;
@@ -2034,7 +2036,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       // Should still enable audits, imports, entitlement
       expect(enableAuditsStub).to.have.been.called;
       expect(enableImportsStub).to.have.been.called;
-      expect(tierClientCreateForSiteStub).to.have.been.called;
+      expect(mockDataAccess.SiteEnrollment.create).to.have.been.called;
       // Verify onboarding record completed
       expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
     });
@@ -3068,11 +3070,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
     });
 
     it('waitlists when enrollment creation and fetch both fail', async () => {
-      const siteClientStub = {
-        createEntitlement: sandbox.stub().rejects(new Error('enrollment down')),
-        checkValidEntitlement: sandbox.stub().rejects(new Error('enrollment down')),
-      };
-      tierClientCreateForSiteStub.resolves(siteClientStub);
+      mockDataAccess.SiteEnrollment.allBySiteId.rejects(new Error('enrollment down'));
 
       const context = buildContext({ domain: TEST_DOMAIN });
       const res = await controller.onboard(context);
@@ -3520,7 +3518,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       const response = await controller.onboard(context);
 
       expect(response.status).to.equal(200);
-      expect(tierClientCreateForSiteStub).to.have.been.called;
+      expect(mockDataAccess.SiteEnrollment.create).to.have.been.called;
       expect(triggerAuditsStub).to.not.have.been.called;
       expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
       expect(preonboardedOnboarding.setCompletedAt).to.have.been.called;
@@ -3623,19 +3621,12 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(siteInInternalOrg.save).to.have.been.called;
       expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
       expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
-      // Verify order: site org reassignment happens BEFORE entitlement operations
-      expect(siteInInternalOrg.save).to.have.been.calledBefore(tierClientCreateForSiteStub);
-      // Verify TierClient.createForSite gets the REFRESHED instance, not the stale one —
-      // this is the core invariant of the post-save re-fetch design.
-      expect(tierClientCreateForSiteStub).to.have.been.calledWith(
-        sinon.match.any,
-        refreshedSite,
-        sinon.match.any,
-      );
-      expect(tierClientCreateForSiteStub).to.not.have.been.calledWith(
-        sinon.match.any,
-        siteInInternalOrg,
-        sinon.match.any,
+      // Verify order: site org reassignment happens BEFORE enrollment creation
+      const { create: enrollCreate } = mockDataAccess.SiteEnrollment;
+      expect(siteInInternalOrg.save).to.have.been.calledBefore(enrollCreate);
+      // Enrollment is bound directly to the entitlement ID — org is not re-derived from site
+      expect(mockDataAccess.SiteEnrollment.create).to.have.been.calledWith(
+        sinon.match({ entitlementId: 'ent-1' }),
       );
     });
 
@@ -3723,8 +3714,9 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       // PlgOnboarding org is anchored to the requesting customer's resolved org up-front,
       // even when we then waitlist — the record is the trace of the request attempt.
       expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
-      // Should NOT create entitlement
-      expect(tierClientCreateForSiteStub).to.not.have.been.called;
+      // Should NOT create entitlement or enrollment
+      expect(tierClientCreateForOrgStub).to.not.have.been.called;
+      expect(mockDataAccess.SiteEnrollment.create).to.not.have.been.called;
     });
 
     it('waitlists with "safely moved" hint when preonboarded site in different org has no enrollments', async () => {
@@ -3854,8 +3846,8 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
       const mockSiteInOrg = createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID });
       mockDataAccess.Site.findById.resolves(mockSiteInOrg);
-      // Not an entitlement error — e.g. revocation throws unexpectedly.
-      mockDataAccess.SiteEnrollment = { allBySiteId: sandbox.stub().rejects(new Error('db error')) };
+      // Not an EntitlementWaitlistError — revocation throws unexpectedly → should 500.
+      mockDataAccess.SiteEnrollment.allByEntitlementId.rejects(new Error('db error'));
 
       const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
 
@@ -3931,19 +3923,11 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       // Verify site was reassigned
       expect(existingSite.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
       expect(existingSite.save).to.have.been.called;
-      // Verify order: site org reassignment happens BEFORE entitlement operations
-      expect(existingSite.save).to.have.been.calledBefore(tierClientCreateForSiteStub);
-      // Verify TierClient.createForSite gets the REFRESHED instance, not the stale one —
-      // this is the core invariant of the post-save re-fetch design.
-      expect(tierClientCreateForSiteStub).to.have.been.calledWith(
-        sinon.match.any,
-        refreshedSiteFullPath,
-        sinon.match.any,
-      );
-      expect(tierClientCreateForSiteStub).to.not.have.been.calledWith(
-        sinon.match.any,
-        existingSite,
-        sinon.match.any,
+      // Verify order: site org reassignment happens BEFORE enrollment creation
+      expect(existingSite.save).to.have.been.calledBefore(mockDataAccess.SiteEnrollment.create);
+      // Enrollment is bound directly to the entitlement ID — org is not re-derived from site
+      expect(mockDataAccess.SiteEnrollment.create).to.have.been.calledWith(
+        sinon.match({ entitlementId: 'ent-1' }),
       );
     });
   });
@@ -4699,7 +4683,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
               default: ldCreateFromStub,
             },
             '@adobe/spacecat-shared-tier-client': {
-              default: { createForSite: sandbox.stub() },
+              default: { createForOrg: sandbox.stub() },
             },
             '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
               Config: { toDynamoItem: sandbox.stub() },

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -3104,6 +3104,17 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(mockOnboarding.setSteps).to.have.been.calledWithMatch({ entitlementFailed: true });
     });
 
+    it('reuses an existing site enrollment when one already matches the entitlement', async () => {
+      const existingEnrollment = { getId: () => 'enroll-existing', getEntitlementId: () => 'ent-1' };
+      mockDataAccess.SiteEnrollment.allBySiteId.resolves([existingEnrollment]);
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const res = await controller.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockDataAccess.SiteEnrollment.create).not.to.have.been.called;
+    });
+
     it('logs error when persisting entitlement waitlist state fails in full onboarding', async () => {
       const orgClientStub = {
         createEntitlement: sandbox.stub().rejects(new Error('service down')),

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -3039,7 +3039,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
     });
 
-    it('returns 500 when entitlement creation fails unexpectedly', async () => {
+    it('falls back to checkValidEntitlement when entitlement creation fails', async () => {
       tierClientCreateEntitlementStub.rejects(
         new Error('Tier service unavailable'),
       );
@@ -3048,13 +3048,8 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
 
       const res = await controller.onboard(context);
 
-      expect(res.status).to.equal(500);
-      expect(res.value).to.equal('Onboarding failed. Please try again later.');
-      // Verify error was recorded with sanitized message
-      expect(mockOnboarding.setStatus).to.have.been.calledWith('ERROR');
-      expect(mockOnboarding.setError).to.have.been.calledWith({
-        message: 'An internal error occurred',
-      });
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
     });
   });
 
@@ -3758,78 +3753,6 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(preonboardedOnboarding.setStatus).to.have.been.calledWith('WAITLISTED');
       expect(preonboardedOnboarding.setWaitlistReason)
         .to.have.been.calledWithMatch(/cannot be moved.*active products/);
-    });
-
-    it('rethrows non-waitlist errors from fast-track onboarding', async () => {
-      const preonboardedOnboarding = createMockOnboarding({
-        status: 'PRE_ONBOARDING',
-        siteId: TEST_SITE_ID,
-        organizationId: TEST_ORG_ID,
-      });
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-
-      const siteInCustomerOrg = createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID });
-      mockDataAccess.Site.findById.resolves(siteInCustomerOrg);
-
-      // Unrelated error (not a waitlist error) during entitlement creation.
-      tierClientCreateEntitlementStub.rejects(new Error('entitlement service unavailable'));
-
-      const context = buildContext({ domain: TEST_DOMAIN });
-      const response = await controller.onboard(context);
-
-      // Rethrow escapes to the top-level onboard catch → 500
-      expect(response.status).to.equal(500);
-      expect(preonboardedOnboarding.setStatus).to.not.have.been.calledWith('WAITLISTED');
-    });
-
-    it('rethrows when org entitlement already-exists but checkValidEntitlement returns no entitlement', async () => {
-      const preonboardedOnboarding = createMockOnboarding({
-        status: 'PRE_ONBOARDING',
-        siteId: TEST_SITE_ID,
-        organizationId: TEST_ORG_ID,
-      });
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
-
-      const alreadyExistsError = new Error('already exists');
-      tierClientCreateEntitlementStub.rejects(alreadyExistsError);
-      const orgClientStub = {
-        createEntitlement: sandbox.stub().rejects(alreadyExistsError),
-        checkValidEntitlement: sandbox.stub().resolves({ entitlement: null }),
-      };
-      tierClientCreateForOrgStub.returns(orgClientStub);
-
-      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
-
-      expect(response.status).to.equal(500);
-    });
-
-    it('rethrows non-already-exists error from site enrollment creation', async () => {
-      const preonboardedOnboarding = createMockOnboarding({
-        status: 'PRE_ONBOARDING',
-        siteId: TEST_SITE_ID,
-        organizationId: TEST_ORG_ID,
-      });
-      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
-      mockDataAccess.Site.findById.resolves(createMockSite({ id: TEST_SITE_ID, orgId: TEST_ORG_ID }));
-
-      // Org client succeeds; site client createEntitlement throws a non-already-exists error.
-      const orgClientStub = {
-        createEntitlement: sandbox.stub().resolves({
-          entitlement: {
-            getId: () => 'ent-1',
-            getOrganizationId: () => TEST_ORG_ID,
-            getTier: () => 'PLG',
-          },
-        }),
-        checkValidEntitlement: sandbox.stub().resolves({}),
-      };
-      tierClientCreateForOrgStub.returns(orgClientStub);
-      tierClientCreateEntitlementStub.rejects(new Error('enrollment service unavailable'));
-
-      const response = await controller.onboard(buildContext({ domain: TEST_DOMAIN }));
-
-      expect(response.status).to.equal(500);
     });
 
     it('logs a warning when site org is not reflected in DB after reassignment', async () => {


### PR DESCRIPTION
## Summary

  - **Bind entitlement to IMS-resolved org**: `ensureAsoEntitlement` uses `TierClient.createForOrg` with the org       
  resolved from the request's `imsOrgId` (not `site.getOrganizationId()`), so the entitlement is always bound to the
  correct customer org regardless of what org the site currently points at (e.g. internal/demo org pre-reassignment)   
  - **Direct site enrollment from entitlement ID**: Step 2 creates `SiteEnrollment` directly using
  `entitlement.getId()` — bypasses `TierClient.createForSite` which re-derives org from `site.getOrganizationId()` and 
  can read a stale value after reassignment
  - **Waitlist on entitlement/enrollment failure**: Both create and fetch failures result in `WAITLISTED` status;      
  `createEntitlement` failures are logged at `error` level for alerting
  `EntitlementWaitlistError` instead of warn-and-continue                                        
  - **Step flags on failure**: WAITLISTED records carry `entitlementFailed: true` in the steps field for programmatic  
  triage                                                                                                             
  - **Log warn on reassign mismatch**: `reassignSiteOrganization` logs a warning instead of throwing when the          
  re-fetched site doesn't reflect the new org (replica lag) 

- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
