### PR TITLE
fix: Address review feedback on onboarding cleanup

### DIFF
--- a/src/controllers/plg/plg-constants.js
+++ b/src/controllers/plg/plg-constants.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Shared constants for the PLG onboarding flow. Imported by every module that
+ * participates in PLG onboarding so any change here propagates everywhere and
+ * the constants cannot silently drift between call sites.
+ */
+
+/**
+ * Opportunity types that participate in the PLG auto-fix lifecycle.
+ *
+ * Used by:
+ *   - `plg-onboarding.js` displacement check (`hasActiveSuggestions`) — decides
+ *     whether an already-onboarded site still has active customer work.
+ *   - `plg-onboarding-cleanup.js` — scopes the pre-ONBOARDED status reset and
+ *     FixEntity deletion to only these types.
+ *
+ * Must also stay in sync with `LD_AUTO_FIX_FLAGS` in `plg-onboarding.js`, which
+ * enables LaunchDarkly auto-fix for these same types. Adding a new opportunity
+ * type to the PLG auto-fix lifecycle requires updating both this list and the
+ * LD flag list together.
+ */
+export const PLG_OPPORTUNITY_TYPES = ['cwv', 'alt-text', 'broken-backlinks'];

--- a/src/controllers/plg/plg-onboarding-cleanup.js
+++ b/src/controllers/plg/plg-onboarding-cleanup.js
@@ -12,12 +12,7 @@
 
 import { Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
 
-/**
- * Opportunity types that participate in the PLG auto-fix lifecycle.
- * Kept in sync with the LD auto-fix flags and the displacement check
- * in plg-onboarding.js (PLG_OPPORTUNITY_TYPES).
- */
-export const PLG_CLEANUP_OPPORTUNITY_TYPES = ['cwv', 'alt-text', 'broken-backlinks'];
+import { PLG_OPPORTUNITY_TYPES } from './plg-constants.js';
 
 /**
  * Suggestions in any of these statuses are transitioned to OUTDATED on re-onboarding
@@ -191,9 +186,18 @@ async function removeFixEntitiesForOpportunity(opportunity, FixEntity, log) {
  * because callers (onboarding flow) cannot afford to be blocked by cleanup —
  * orphaned fix/suggestion rows can be reconciled out-of-band.
  *
+ * Authorization contract: `siteId` is treated as a trusted, already-authorized input.
+ * The function performs cross-site mutations (status flips + deletes) without any
+ * tenant/ownership check — callers (currently only `performAsoPlgOnboarding`) must
+ * ensure the `siteId` belongs to the IMS-org being onboarded before invoking this.
+ *
+ * The summary totals are also written to the log for ops visibility, so callers may
+ * safely discard the return value.
+ *
  * @param {string} siteId - The site being (re-)onboarded.
  * @param {object} context - Request context (provides dataAccess + log).
  * @returns {Promise<{outdatedCount: number, resetToNewCount: number, removedFixCount: number}>}
+ *   Per-bucket totals. Currently used only for logging; safe to ignore at call sites.
  */
 export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
   const { dataAccess, log } = context;
@@ -202,7 +206,9 @@ export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
   const emptyResult = { outdatedCount: 0, resetToNewCount: 0, removedFixCount: 0 };
 
   if (!siteId) {
-    log.info('PLG cleanup: no siteId provided, skipping');
+    // Missing siteId here means the caller passed a bad argument — surface it as a
+    // warn so it is visible in log monitoring rather than buried in info noise.
+    log.warn('PLG cleanup: no siteId provided, skipping');
     return emptyResult;
   }
 
@@ -215,7 +221,7 @@ export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
   }
 
   const plgOpportunities = opportunities.filter(
-    (o) => PLG_CLEANUP_OPPORTUNITY_TYPES.includes(o.getType()),
+    (o) => PLG_OPPORTUNITY_TYPES.includes(o.getType()),
   );
 
   if (plgOpportunities.length === 0) {
@@ -242,10 +248,14 @@ export async function cleanupPlgSiteSuggestionsAndFixes(siteId, context) {
     { ...emptyResult },
   );
 
+  // Distinct, structured summary line so ops can grep / aggregate (e.g. in Coralogix)
+  // for cleanup runs that actually found stale rows. The "found=true|false" tag makes
+  // it easy to filter out the no-op majority.
+  const found = totals.outdatedCount + totals.resetToNewCount + totals.removedFixCount > 0;
   log.info(
-    `PLG cleanup complete for site ${siteId}: marked ${totals.outdatedCount} suggestions OUTDATED, `
-    + `reset ${totals.resetToNewCount} suggestions to NEW, removed ${totals.removedFixCount} fix `
-    + `entities across ${plgOpportunities.length} opportunities`,
+    `PLG cleanup summary [found=${found}] for site ${siteId}: `
+    + `outdated=${totals.outdatedCount}, resetToNew=${totals.resetToNewCount}, `
+    + `removedFixes=${totals.removedFixCount}, opportunities=${plgOpportunities.length}`,
   );
 
   return totals;

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -49,6 +49,7 @@ import { triggerBrandProfileAgent } from '../../support/brand-profile-trigger.js
 import { PlgOnboardingDto } from '../../dto/plg-onboarding.js';
 import AccessControlUtil from '../../support/access-control-util.js';
 import { cleanupPlgSiteSuggestionsAndFixes } from './plg-onboarding-cleanup.js';
+import { PLG_OPPORTUNITY_TYPES } from './plg-constants.js';
 
 const { STATUSES, REVIEW_DECISIONS } = PlgOnboardingModel;
 const ASO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.ASO;
@@ -507,10 +508,6 @@ async function updateLaunchDarklyFlags(site, organization, context) {
     }
   });
 }
-
-// The PLG opportunity types that are relevant for the displacement check.
-// Must stay in sync with LD_AUTO_FIX_FLAGS above, which enables auto-fix for the same types.
-const PLG_OPPORTUNITY_TYPES = ['cwv', 'alt-text', 'broken-backlinks'];
 
 /**
  * Returns true if the given site has suggestions that should block displacement.

--- a/test/controllers/plg/plg-onboarding-cleanup.test.js
+++ b/test/controllers/plg/plg-onboarding-cleanup.test.js
@@ -16,10 +16,10 @@ import sinonChai from 'sinon-chai';
 
 import {
   cleanupPlgSiteSuggestionsAndFixes,
-  PLG_CLEANUP_OPPORTUNITY_TYPES,
   STATUSES_TO_OUTDATE,
   STATUSES_TO_RESET_TO_NEW,
 } from '../../../src/controllers/plg/plg-onboarding-cleanup.js';
+import { PLG_OPPORTUNITY_TYPES } from '../../../src/controllers/plg/plg-constants.js';
 
 use(sinonChai);
 
@@ -38,7 +38,6 @@ function createMockSuggestion(id, status) {
   return {
     getId: sinon.stub().returns(id),
     getStatus: sinon.stub().returns(status),
-    setStatus: sinon.stub(),
   };
 }
 
@@ -82,7 +81,7 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
   });
 
   it('exports the PLG opportunity types covered by cleanup', () => {
-    expect(PLG_CLEANUP_OPPORTUNITY_TYPES).to.deep.equal([
+    expect(PLG_OPPORTUNITY_TYPES).to.deep.equal([
       'cwv',
       'alt-text',
       'broken-backlinks',
@@ -100,12 +99,13 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
     expect([...STATUSES_TO_RESET_TO_NEW]).to.deep.equal(['PENDING_VALIDATION']);
   });
 
-  it('skips when no siteId is provided', async () => {
+  it('warns and skips when no siteId is provided (caller bug)', async () => {
     const result = await cleanupPlgSiteSuggestionsAndFixes(null, context);
 
     expect(result).to.deep.equal(EMPTY_RESULT);
     expect(dataAccess.Opportunity.allBySiteId).to.not.have.been.called;
-    expect(log.info).to.have.been.calledWithMatch(/no siteId provided, skipping/);
+    expect(log.warn).to.have.been.calledWithMatch(/no siteId provided, skipping/);
+    expect(log.info).to.not.have.been.calledWithMatch(/no siteId provided/);
   });
 
   it('returns zero counts when listing opportunities fails', async () => {
@@ -218,7 +218,7 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
     expect(dataAccess.FixEntity.removeByIds).to.have.been.calledWith(['f1', 'f2', 'f3']);
     expect(dataAccess.FixEntity.removeByIds).to.have.been.calledWith(['f4']);
 
-    expect(log.info).to.have.been.calledWithMatch(/PLG cleanup complete for site/);
+    expect(log.info).to.have.been.calledWithMatch(/PLG cleanup summary \[found=true\] for site/);
   });
 
   it('logs and continues when listing suggestions fails for one opportunity', async () => {
@@ -324,7 +324,7 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
     expect(dataAccess.FixEntity.removeByIds).to.not.have.been.called;
   });
 
-  it('skips bulkUpdateStatus calls when no suggestions match either transition set', async () => {
+  it('skips bulkUpdateStatus calls and emits a "found=false" summary when no suggestions match either transition set', async () => {
     dataAccess.Opportunity.allBySiteId.resolves([
       createMockOpportunity('o-cwv', 'cwv'),
     ]);
@@ -340,5 +340,6 @@ describe('cleanupPlgSiteSuggestionsAndFixes', () => {
     expect(result).to.deep.equal(EMPTY_RESULT);
     expect(dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
     expect(dataAccess.FixEntity.removeByIds).to.not.have.been.called;
+    expect(log.info).to.have.been.calledWithMatch(/PLG cleanup summary \[found=false\] for site/);
   });
 });


### PR DESCRIPTION
Adding changes for review comment at https://github.com/adobe/spacecat-api-service/pull/2283#issuecomment-4343793964
- Move PLG_OPPORTUNITY_TYPES into shared src/controllers/plg/plg-constants.js
  so plg-onboarding.js (displacement check) and plg-onboarding-cleanup.js
  (status reset + FixEntity deletion) cannot drift.
- Promote the missing-siteId guard log from info to warn (caller-bug signal).
- Drop unused setStatus stub from createMockSuggestion test helper.
- Document the discarded return value and add an authorization-contract
  note to the cleanupPlgSiteSuggestionsAndFixes JSDoc.
- Emit a structured "PLG cleanup summary [found=true|false]" line so ops
  can grep / aggregate runs that actually found stale rows.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
