### PR TITLE
fix: restore uuid PK in v2 prompts response (LLMO-4625)

### DIFF
--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -219,7 +219,13 @@ function mapRowToPrompt(row) {
   const category = row.categories;
   const topic = row.topics;
   return {
+    // `id` is the TEXT business key (`prompts.prompt_id`) — used in URL paths
+    // (GET/PATCH/DELETE `/prompts/:promptId`) and as the human-readable handle.
+    // `uuid` is the UUID PK (`prompts.id`) — needed by DRS to populate the
+    // `brand_presence_executions.prompt_id` UUID FK column. Removing `uuid`
+    // (LLMO-4625 / PR #2199) caused 100% NULL prompt_id in BPE — keep both.
     id: row.prompt_id,
+    uuid: row.id,
     prompt: row.text,
     name: row.name,
     regions: row.regions || [],

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -209,6 +209,11 @@ describe('prompts-storage', () => {
       });
       expect(result.items).to.have.lengthOf(1);
       expect(result.items[0].id).to.equal(PROMPT_ID);
+      // Regression guard for LLMO-4625: the UUID PK must be exposed alongside
+      // the text business key. DRS uses `uuid` to populate the
+      // `brand_presence_executions.prompt_id` UUID FK column. PR #2199 dropped
+      // it; missing this assertion is what let the regression ship.
+      expect(result.items[0].uuid).to.equal('prompt-pk-uuid');
       expect(result.items[0].createdAt).to.equal('2026-01-01T00:00:00Z');
       expect(result.items[0].createdBy).to.equal('admin@test.com');
       expect(result.items[0].updatedAt).to.equal('2026-02-01T00:00:00Z');
@@ -582,6 +587,8 @@ describe('prompts-storage', () => {
       });
       expect(result).to.not.be.null;
       expect(result.id).to.equal(PROMPT_ID);
+      // Regression guard for LLMO-4625 — see listPrompts test above for context.
+      expect(result.uuid).to.equal('prompt-pk-uuid');
       expect(result.prompt).to.equal('Prompt');
       expect(result.source).to.equal('sheet');
       expect(result.createdAt).to.equal('2026-01-01T00:00:00Z');


### PR DESCRIPTION
## Summary

Restore the `uuid` field on items returned by `GET /v2/orgs/:org/brands/:brand/prompts` (and the singular `/:promptId` variant). Removed by #2199 as "redundant"; for prompts it is not.

## Background — what broke and how

PR #2199 (merged 2026-04-15 07:35 UTC) dropped `uuid: row.id` from `mapRowToPrompt()` in `src/support/prompts-storage.js`. The PR description called it "redundant with id". This is true for the nested `category`/`topic` objects (where the response `id` is the same UUID PK) — but **not for the prompt itself**:

| field | DB column | type | example | role |
|---|---|---|---|---|
| `id` (response) | `prompts.prompt_id` | TEXT | `7b058150-8dda-464b-a4d8-cceb4f6b7323-0-US` | business key, used in URL paths (`GET/PATCH/DELETE /prompts/:promptId`) |
| `uuid` (response) | `prompts.id` | UUID | `550e8400-...` | DB PK; FK target for `brand_presence_executions.prompt_id` |

The two are different values, different types, and serve different purposes. Removing `uuid` left no way for any consumer to learn the UUID PK of a prompt.

## Impact in production

DRS's `spacecat_client.py:1393` reads `p.get("uuid")` to extract the UUID PK; with `uuid` missing, this is empty for every prompt. `enrich_v1_prompts_with_uuids` then filters out every lookup entry (its `if prompt_uuid` guard at line 1486 drops empties) → `built lookup with 0 entries` → 0 prompts enriched → `prompts.json`, `results.json`, and the CSV bundle all carry empty `promptUuid`/`prompt_id` → DB writes NULL.

The breakage cascaded gradually because the scheduler's `prompts.json` is cached by content hash (`prompts/{site_id}/{sha256}/prompts.json`, scheduler.py:1042). Pre-04-15 cached files retained populated `promptUuid`. Each time a brand's prompt content churned (text/topic/category changes), the hash flipped → new upload via the broken API → empty `promptUuid` from then on.

DB evidence (`brand_presence_executions`, NULL `prompt_id` % per brand):

| | 04-13 | 04-14 | 04-15 (deploy) | 04-26 | 04-27 | 04-28 | 04-29 |
|---|---|---|---|---|---|---|---|
| Adobe (root) | 85% | 91% | **100%** | 100% | 100% | 100% | **100%** |
| Adobe Helpx | 0% | 0% | 0% | 0% | 90% | 100% | **100%** |
| Adobe Express | 0% | 0% | 0% | 1.7% | 84% | 100% | **100%** |
| Adobe Experience League | 0% | 0% | 0% | 0.5% | 82% | 100% | **100%** |
| Adobe Acrobat | 0% | 0% | 0% | 0% | 46% | 100% | **100%** |
| Adobe Stock | 0% | 0% | 0% | 0% | 46% | 100% | **100%** |
| DeveloperAdobe | 0% | 0% | 0% | 0% | 0% | 100% | **100%** |
| Business Adobe | 0% | 0% | 0% | 0% | 0% | 44% | **100%** |

By 2026-04-29 all 8 import-enabled Adobe brands were 100% NULL `prompt_id` in BPE. Several DRS PRs (#1433, #1444, #1447, #1453, #1463, #1467) over the past 3 days addressed adjacent symptoms but none fixed the root cause because none touched api-service.

## Why DRS can't just "read `id` instead of `uuid`"

`brand_presence_executions.prompt_id` is a `uuid NOT NULL` column with FK to `prompts(id)`. The text business key (`7b058150-...-0-US`) is not a valid UUID — Postgres rejects it as `SQLSTATE 22P02`. The UUID PK is the only acceptable value for the FK column.

## Fix

```diff
   return {
+    // `id` is the TEXT business key (`prompts.prompt_id`) — used in URL paths
+    // (GET/PATCH/DELETE `/prompts/:promptId`) and as the human-readable handle.
+    // `uuid` is the UUID PK (`prompts.id`) — needed by DRS to populate the
+    // `brand_presence_executions.prompt_id` UUID FK column. Removing `uuid`
+    // (LLMO-4625 / PR #2199) caused 100% NULL prompt_id in BPE — keep both.
     id: row.prompt_id,
+    uuid: row.id,
     prompt: row.text,
```

OpenAPI `V2Prompt` schema already declares `uuid` (`docs/openapi/schemas.yaml:5950`) — the implementation has been out of compliance with the spec since #2199.

## Test plan

- [x] `npx mocha test/support/prompts-storage.test.js` — 80 passing (regression assertions added in `listPrompts` "returns paginated result with items" and `getPromptById` "returns prompt when found")
- [x] `npx mocha test/controllers/brands.test.js` — 231 passing
- [x] `npx eslint src/support/prompts-storage.js test/support/prompts-storage.test.js` — clean
- [x] OpenAPI spec validation — passes (no spec change needed)
- [ ] Post-deploy: hit `GET /v2/orgs/:org/brands/:brand/prompts?limit=2` for an Adobe brand and confirm response items have non-empty `uuid` matching prompts.id
- [ ] Post-deploy: verify DRS scheduler logs change from `enrich_v1_prompts_with_uuids: built lookup with 0 entries` to a non-zero count for the same site
- [ ] Post-deploy: invalidate stale per-site `prompts.json` (S3 prefix `prompts/{site_id}/`) for 8 import-enabled Adobe brands so today's enrichment-fixed run rewrites the cache
- [ ] Post-deploy: confirm `brand_presence_executions WHERE prompt_id IS NULL` ratio drops on next-day partition for those 8 sites

## Out of scope (follow-ups in DRS / mysticat-data-service)

- DRS: promote `built lookup with 0 entries` from INFO to ERROR with a structured field so silent failures show up in alerts (the `0 enriched` was logged at INFO during the entire 15-day outage)
- DRS: include an enrichment-schema version in the prompts.json content hash so a producer-side fix invalidates cached prompts immediately on deploy instead of waiting for content churn
- mysticat-data-service: backfill rows already written with NULL `prompt_id` since 2026-04-15 by joining `brand_presence_executions` to `prompts` on `(organization_id, brand_id, LOWER(TRIM(prompt_text)), region_code)`
- Coralogix monitor: alert on per-site `prompt_id NULL` ratio > 5% in BPE — would have caught this on 04-15

🤖 Generated with [Claude Code](https://claude.com/claude-code)