### PR TITLE
fix(llmo): stop syncBrandSites from wiping primary brand_sites row (LLMO-4621)

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1348,7 +1348,17 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
         });
         log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
       } catch (brandError) {
-        log.warn(`Failed to create initial brand in normalized table: ${brandError.message}`);
+        // Surface upsertBrand failures loudly. The pre-LLMO-4621 swallow as
+        // log.warn hid the Pattern A bleed for weeks (24 brands stranded
+        // before the audit caught it). Onboarding still proceeds because
+        // the SpaceCat site row exists, but operators must see this in
+        // logs and Slack so the brand can be reconciled before downstream
+        // prompt-gen runs against an inconsistent state.
+        log.error(
+          `Failed to create initial brand in normalized table for site ${site.getId()}: ${brandError.message}`,
+          { siteId: site.getId(), brandName, error: brandError.message },
+        );
+        say(`:warning: Failed to create initial brand "${brandName}" in normalized table — brand_sites linkage may be missing. Investigate before downstream prompt-gen runs.`);
       }
 
       // Trigger Brandalf immediately after the v2 config exists so downstream

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -173,46 +173,6 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
 }
 
 /**
- * Asserts the primary brand_sites row mirroring brands.site_id exists for a brand.
- *
- * The primary citation row links a brand to its canonical site via
- * (brand_id, site_id=brands.site_id, paths=['/'], type='base'). This helper
- * is idempotent (uses ON CONFLICT DO NOTHING) and is called unconditionally
- * after every upsertBrand / updateBrand whose resulting brand has a site_id.
- *
- * Closes the LLMO-4621 Pattern A bleed where a downstream caller passing
- * `urls=[]` to upsertBrand could trip the destructive DELETE in
- * syncBrandSites without a matching INSERT, leaving the active root brand
- * with zero brand_sites rows.
- *
- * No-op when primarySiteId is unset (e.g. pending Brandalf siblings whose
- * brand entity legitimately has site_id=NULL).
- */
-async function ensurePrimaryBrandSite({
-  organizationId, brandId, primarySiteId, postgrestClient, updatedBy,
-}) {
-  if (!hasText(primarySiteId)) {
-    return;
-  }
-  const { error } = await postgrestClient
-    .from('brand_sites')
-    .upsert(
-      {
-        organization_id: organizationId,
-        brand_id: brandId,
-        site_id: primarySiteId,
-        paths: ['/'],
-        type: 'base',
-        updated_by: updatedBy,
-      },
-      { onConflict: 'brand_id,site_id', ignoreDuplicates: true },
-    );
-  if (error) {
-    throw new Error(`Failed to ensure primary brand_sites row: ${error.message}`);
-  }
-}
-
-/**
  * Reconciles brand_sites for a brand against a caller-supplied URL list.
  *
  * Non-destructive to the primary citation row: rows whose site_id matches
@@ -560,7 +520,7 @@ export async function upsertBrand({
   const { data: upserted, error } = await postgrestClient
     .from('brands')
     .upsert(row, { onConflict: 'organization_id,name' })
-    .select('id, name, site_id')
+    .select('id, name')
     .single();
 
   if (error) {
@@ -573,7 +533,6 @@ export async function upsertBrand({
   }
 
   const brandId = upserted.id;
-  const primarySiteId = upserted.site_id;
 
   await Promise.all([
     syncAliases(brandId, organizationId, brand.brandAliases, postgrestClient, updatedBy),
@@ -582,14 +541,11 @@ export async function upsertBrand({
     syncEarnedSources(brandId, organizationId, brand.earnedContent, postgrestClient, updatedBy),
   ]);
 
-  // Always assert the primary brand_sites row when brands.site_id is set —
-  // independent of whether the caller passed brand.urls. Closes the
-  // LLMO-4621 Pattern A bleed (downstream caller passing urls=[] could
-  // wipe the primary citation row when syncBrandSites was destructive).
-  await ensurePrimaryBrandSite({
-    organizationId, brandId, primarySiteId, postgrestClient, updatedBy,
-  });
-
+  // The primary brand_sites row mirroring brands.site_id is asserted by a
+  // DB-side AFTER INSERT OR UPDATE OF site_id ON brands trigger
+  // (brands_ensure_primary_brand_site, mysticat-data-service). The
+  // application-level half of the LLMO-4621 invariant — preventing
+  // syncBrandSites from wiping the primary row — lives below.
   if (brand.urls !== undefined) {
     await Promise.all([
       syncBrandSites(organizationId, brandId, brand.urls, postgrestClient, updatedBy),
@@ -669,7 +625,7 @@ export async function updateBrand({
     .update(patch)
     .eq('organization_id', organizationId)
     .eq('id', brandId)
-    .select('id, site_id')
+    .select('id')
     .maybeSingle();
 
   if (error) {
@@ -709,18 +665,6 @@ export async function updateBrand({
   if (childSyncs.length > 0) {
     await Promise.all(childSyncs);
   }
-
-  // Re-assert the primary brand_sites row when brands.site_id is set. Cheap
-  // ON CONFLICT DO NOTHING upsert so update calls that don't touch site_id
-  // are no-ops. Catches the NULL→set transition when an operator finally
-  // assigns a base site to a previously-pending brand.
-  await ensurePrimaryBrandSite({
-    organizationId,
-    brandId,
-    primarySiteId: data.site_id,
-    postgrestClient,
-    updatedBy,
-  });
 
   if (updates.urls !== undefined) {
     await Promise.all([

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -173,72 +173,155 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
 }
 
 /**
- * Fully replaces brand_sites for a brand. Groups submitted URLs by normalized base URL
- * (via composeBaseURL) so that multiple paths under the same site share one brand_sites row.
+ * Asserts the primary brand_sites row mirroring brands.site_id exists for a brand.
+ *
+ * The primary citation row links a brand to its canonical site via
+ * (brand_id, site_id=brands.site_id, paths=['/'], type='base'). This helper
+ * is idempotent (uses ON CONFLICT DO NOTHING) and is called unconditionally
+ * after every upsertBrand / updateBrand whose resulting brand has a site_id.
+ *
+ * Closes the LLMO-4621 Pattern A bleed where a downstream caller passing
+ * `urls=[]` to upsertBrand could trip the destructive DELETE in
+ * syncBrandSites without a matching INSERT, leaving the active root brand
+ * with zero brand_sites rows.
+ *
+ * No-op when primarySiteId is unset (e.g. pending Brandalf siblings whose
+ * brand entity legitimately has site_id=NULL).
  */
-async function syncBrandSites(organizationId, brandId, urls, postgrestClient, updatedBy) {
-  const { error: deleteError } = await postgrestClient
-    .from('brand_sites')
-    .delete()
-    .eq('brand_id', brandId);
-  if (deleteError) {
-    throw new Error(`Failed to sync brand_sites: ${deleteError.message}`);
-  }
-
-  if (!urls || urls.length === 0) {
+async function ensurePrimaryBrandSite({
+  organizationId, brandId, primarySiteId, postgrestClient, updatedBy,
+}) {
+  if (!hasText(primarySiteId)) {
     return;
   }
-
-  // Group paths by base URL and track type
-  const pathsByBase = new Map();
-  const typeByBase = new Map();
-  urls
-    .forEach((u) => {
-      const value = typeof u === 'string' ? u : u?.value;
-      if (!hasText(value)) {
-        return;
-      }
-      const { base, path } = parseUrlParts(value);
-      const normalizedBase = composeBaseURL(base);
-      if (!pathsByBase.has(normalizedBase)) {
-        pathsByBase.set(normalizedBase, []);
-      }
-      pathsByBase.get(normalizedBase).push(path || '/');
-      // First URL with a type wins for a given base URL — prevents silent overwrite
-      // when multiple paths under the same domain carry different types.
-      if (typeof u === 'object' && hasText(u?.type) && !typeByBase.has(normalizedBase)) {
-        typeByBase.set(normalizedBase, u.type);
-      }
-    });
-
-  if (pathsByBase.size === 0) {
-    return;
-  }
-
-  const { data: sites } = await postgrestClient
-    .from('sites')
-    .select('id, base_url')
-    .eq('organization_id', organizationId)
-    .in('base_url', [...pathsByBase.keys()]);
-
-  if (!sites || sites.length === 0) {
-    return;
-  }
-
-  const rows = sites.map((s) => ({
-    organization_id: organizationId,
-    brand_id: brandId,
-    site_id: s.id,
-    paths: pathsByBase.get(s.base_url) || [],
-    type: typeByBase.get(s.base_url) || null,
-    updated_by: updatedBy,
-  }));
-
   const { error } = await postgrestClient
     .from('brand_sites')
-    .upsert(rows, { onConflict: 'brand_id,site_id' });
+    .upsert(
+      {
+        organization_id: organizationId,
+        brand_id: brandId,
+        site_id: primarySiteId,
+        paths: ['/'],
+        type: 'base',
+        updated_by: updatedBy,
+      },
+      { onConflict: 'brand_id,site_id', ignoreDuplicates: true },
+    );
   if (error) {
-    throw new Error(`Failed to sync brand_sites: ${error.message}`);
+    throw new Error(`Failed to ensure primary brand_sites row: ${error.message}`);
+  }
+}
+
+/**
+ * Reconciles brand_sites for a brand against a caller-supplied URL list.
+ *
+ * Non-destructive to the primary citation row: rows whose site_id matches
+ * brands.site_id are protected from the orphan-cleanup step regardless of
+ * whether the caller's URL list resolves to that site. The primary row is
+ * (re-)asserted independently by ensurePrimaryBrandSite.
+ *
+ * Behavior:
+ * 1. Resolve brands.site_id for the brand (the protected primary).
+ * 2. Group submitted URLs by composeBaseURL(base) and look up matching sites
+ *    rows in the same org. Upsert one brand_sites row per matched site.
+ * 3. Delete any pre-existing brand_sites rows that are NOT in the desired
+ *    set AND not the primary site — i.e. genuine orphan citations.
+ *
+ * Replaces the prior DELETE-then-INSERT scheme that would silently wipe
+ * citations (and the primary row) when the caller's URL list was empty
+ * or didn't match any sites.base_url (LLMO-4621 Pattern A).
+ */
+async function syncBrandSites(organizationId, brandId, urls, postgrestClient, updatedBy) {
+  // 1. Resolve the primary site we must protect from the orphan-cleanup DELETE.
+  const { data: brandRow, error: brandFetchError } = await postgrestClient
+    .from('brands')
+    .select('site_id')
+    .eq('id', brandId)
+    .maybeSingle();
+  if (brandFetchError) {
+    throw new Error(`Failed to load brand for syncBrandSites: ${brandFetchError.message}`);
+  }
+  const primarySiteId = brandRow?.site_id || null;
+
+  // 2. Group paths by base URL and track type from caller-supplied URLs.
+  const pathsByBase = new Map();
+  const typeByBase = new Map();
+  (urls || []).forEach((u) => {
+    const value = typeof u === 'string' ? u : u?.value;
+    if (!hasText(value)) {
+      return;
+    }
+    const { base, path } = parseUrlParts(value);
+    const normalizedBase = composeBaseURL(base);
+    if (!pathsByBase.has(normalizedBase)) {
+      pathsByBase.set(normalizedBase, []);
+    }
+    pathsByBase.get(normalizedBase).push(path || '/');
+    // First URL with a type wins for a given base URL — prevents silent overwrite
+    // when multiple paths under the same domain carry different types.
+    if (typeof u === 'object' && hasText(u?.type) && !typeByBase.has(normalizedBase)) {
+      typeByBase.set(normalizedBase, u.type);
+    }
+  });
+
+  // 3. Upsert citations matching the caller's URL list.
+  const desiredSiteIds = new Set();
+  if (pathsByBase.size > 0) {
+    const { data: sites, error: sitesError } = await postgrestClient
+      .from('sites')
+      .select('id, base_url')
+      .eq('organization_id', organizationId)
+      .in('base_url', [...pathsByBase.keys()]);
+    if (sitesError) {
+      throw new Error(`Failed to load sites for syncBrandSites: ${sitesError.message}`);
+    }
+    if (sites && sites.length > 0) {
+      const rows = sites.map((s) => ({
+        organization_id: organizationId,
+        brand_id: brandId,
+        site_id: s.id,
+        paths: pathsByBase.get(s.base_url) || [],
+        type: typeByBase.get(s.base_url) || null,
+        updated_by: updatedBy,
+      }));
+      const { error: upsertError } = await postgrestClient
+        .from('brand_sites')
+        .upsert(rows, { onConflict: 'brand_id,site_id' });
+      if (upsertError) {
+        throw new Error(`Failed to sync brand_sites: ${upsertError.message}`);
+      }
+      sites.forEach((s) => desiredSiteIds.add(s.id));
+    }
+  }
+
+  // 4. Delete orphan citations: pre-existing rows NOT in desired set AND
+  //    NOT the primary site. Compute orphan id list in JS (rather than via
+  //    PostgREST .not('site_id', 'in', ...)) so the DELETE targets PK ids
+  //    explicitly — robust against quoting edge-cases in the UUID list.
+  const { data: existing, error: existingError } = await postgrestClient
+    .from('brand_sites')
+    .select('id, site_id')
+    .eq('brand_id', brandId);
+  if (existingError) {
+    throw new Error(`Failed to load brand_sites for syncBrandSites: ${existingError.message}`);
+  }
+
+  const protectedSiteIds = new Set(desiredSiteIds);
+  if (primarySiteId) {
+    protectedSiteIds.add(primarySiteId);
+  }
+  const orphanIds = (existing || [])
+    .filter((bs) => !protectedSiteIds.has(bs.site_id))
+    .map((bs) => bs.id);
+
+  if (orphanIds.length > 0) {
+    const { error: deleteError } = await postgrestClient
+      .from('brand_sites')
+      .delete()
+      .in('id', orphanIds);
+    if (deleteError) {
+      throw new Error(`Failed to clean brand_sites: ${deleteError.message}`);
+    }
   }
 }
 
@@ -477,7 +560,7 @@ export async function upsertBrand({
   const { data: upserted, error } = await postgrestClient
     .from('brands')
     .upsert(row, { onConflict: 'organization_id,name' })
-    .select('id, name')
+    .select('id, name, site_id')
     .single();
 
   if (error) {
@@ -490,6 +573,7 @@ export async function upsertBrand({
   }
 
   const brandId = upserted.id;
+  const primarySiteId = upserted.site_id;
 
   await Promise.all([
     syncAliases(brandId, organizationId, brand.brandAliases, postgrestClient, updatedBy),
@@ -497,6 +581,14 @@ export async function upsertBrand({
     syncSocialAccounts(brandId, organizationId, brand.socialAccounts, postgrestClient, updatedBy),
     syncEarnedSources(brandId, organizationId, brand.earnedContent, postgrestClient, updatedBy),
   ]);
+
+  // Always assert the primary brand_sites row when brands.site_id is set —
+  // independent of whether the caller passed brand.urls. Closes the
+  // LLMO-4621 Pattern A bleed (downstream caller passing urls=[] could
+  // wipe the primary citation row when syncBrandSites was destructive).
+  await ensurePrimaryBrandSite({
+    organizationId, brandId, primarySiteId, postgrestClient, updatedBy,
+  });
 
   if (brand.urls !== undefined) {
     await Promise.all([
@@ -577,7 +669,7 @@ export async function updateBrand({
     .update(patch)
     .eq('organization_id', organizationId)
     .eq('id', brandId)
-    .select('id')
+    .select('id, site_id')
     .maybeSingle();
 
   if (error) {
@@ -617,6 +709,18 @@ export async function updateBrand({
   if (childSyncs.length > 0) {
     await Promise.all(childSyncs);
   }
+
+  // Re-assert the primary brand_sites row when brands.site_id is set. Cheap
+  // ON CONFLICT DO NOTHING upsert so update calls that don't touch site_id
+  // are no-ops. Catches the NULL→set transition when an operator finally
+  // assigns a base site to a previously-pending brand.
+  await ensurePrimaryBrandSite({
+    organizationId,
+    brandId,
+    primarySiteId: data.site_id,
+    postgrestClient,
+    updatedBy,
+  });
 
   if (updates.urls !== undefined) {
     await Promise.all([

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1584,9 +1584,13 @@ describe('LLMO Onboarding Functions', () => {
         'LLMO onboarding completed successfully',
       );
       expect(failingUpsertBrand).to.have.been.calledOnce;
-      expect(mockLog.warn).to.have.been.calledWith(
-        'Failed to create initial brand in normalized table: '
-        + 'PostgREST unavailable',
+      // LLMO-4621: failures are now log.error + Slack-visible say(), not log.warn,
+      // so silent regressions like the original Pattern A bleed are visible to
+      // operators in Coralogix and the onboarding Slack thread immediately.
+      const brandErrorCall = mockLog.error.getCalls().find((c) => /Failed to create initial brand/.test(String(c.args[0])));
+      expect(brandErrorCall, 'expected a log.error for the upsertBrand failure').to.exist;
+      expect(brandErrorCall.args[0]).to.match(
+        /Failed to create initial brand in normalized table for site .+: PostgREST unavailable/,
       );
       // Brandalf job should still be submitted
       expect(mockDrsClient.createFrom().submitJob)

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -750,8 +750,10 @@ describe('brands-storage', () => {
       const postgrestClient = createTableMockClient({
         brands: { data: { id: BRAND_ID, name: 'Test' }, error: null },
         sites: { data: [{ id: 'site-uuid-1', base_url: 'https://test.com' }], error: null },
+        // First brand_sites call inside syncBrandSites (post LLMO-4621 refactor)
+        // is the desired-set upsert. The orphan-cleanup SELECT/DELETE never run
+        // because the upsert error short-circuits.
         brand_sites: [
-          { data: null, error: null },
           { data: null, error: { message: 'site sync error' } },
         ],
       });
@@ -763,17 +765,197 @@ describe('brands-storage', () => {
       })).to.be.rejectedWith('Failed to sync brand_sites: site sync error');
     });
 
-    it('throws when brand_sites delete fails during syncBrandSites', async () => {
+    it('throws when brand_sites orphan-cleanup delete fails during syncBrandSites', async () => {
       const postgrestClient = createTableMockClient({
         brands: { data: { id: BRAND_ID, name: 'Test' }, error: null },
-        brand_sites: { data: null, error: { message: 'delete error' } },
+        sites: { data: [{ id: 'site-uuid-1', base_url: 'https://test.com' }], error: null },
+        brand_sites: [
+          // 1. desired-set upsert ok
+          { data: null, error: null },
+          // 2. SELECT existing returns one orphan row
+          { data: [{ id: 'bs-row-1', site_id: 'orphan-site-id' }], error: null },
+          // 3. orphan DELETE errors
+          { data: null, error: { message: 'delete error' } },
+        ],
       });
 
       await expect(upsertBrand({
         organizationId: ORG_ID,
         brand: { name: 'Test', urls: [{ value: 'https://test.com' }] },
         postgrestClient,
-      })).to.be.rejectedWith('Failed to sync brand_sites: delete error');
+      })).to.be.rejectedWith('Failed to clean brand_sites: delete error');
+    });
+
+    it('throws when SELECT existing brand_sites fails during syncBrandSites orphan-cleanup', async () => {
+      const postgrestClient = createTableMockClient({
+        brands: { data: { id: BRAND_ID, name: 'Test' }, error: null },
+        sites: { data: [{ id: 'site-uuid-1', base_url: 'https://test.com' }], error: null },
+        brand_sites: [
+          { data: null, error: null },
+          { data: null, error: { message: 'select error' } },
+        ],
+      });
+
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://test.com' }] },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to load brand_sites for syncBrandSites: select error');
+    });
+
+    // ---------------------------------------------------------------------
+    // LLMO-4621 Pattern A regression coverage — the primary brand_sites row
+    // mirroring brands.site_id must be asserted unconditionally whenever
+    // brands.site_id is set, independent of whether the caller passed urls.
+    // ---------------------------------------------------------------------
+
+    it('asserts primary brand_sites row when baseSiteId is set and urls is undefined', async () => {
+      const fullBrandRow = makeBrandRow({ name: 'Test', site_id: 'site-uuid-1' });
+      const postgrestClient = createTableMockClient({
+        brands: [
+          // existing brand lookup
+          { data: null, error: null },
+          // upsert returns id + site_id (extended select for ensurePrimaryBrandSite)
+          { data: { id: BRAND_ID, name: 'Test', site_id: 'site-uuid-1' }, error: null },
+          // getBrandById final read
+          { data: fullBrandRow, error: null },
+        ],
+        // ensurePrimaryBrandSite upsert
+        brand_sites: { data: null, error: null },
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'site-uuid-1' },
+        postgrestClient,
+      });
+
+      // brand_sites was hit exactly once — by ensurePrimaryBrandSite. No
+      // syncBrandSites/syncBrandUrls path runs because brand.urls is undefined.
+      expect(postgrestClient.from.calledWith('brand_sites')).to.equal(true);
+    });
+
+    it('asserts primary brand_sites row when baseSiteId is set and urls is empty array', async () => {
+      // Pattern A regression case: pre-fix, a downstream caller passing
+      // urls=[] tripped the destructive DELETE in syncBrandSites without
+      // a re-INSERT, leaving the active root brand with zero brand_sites
+      // rows (and downstream prompt-gen attribution silently broken).
+      const fullBrandRow = makeBrandRow({ name: 'Test', site_id: 'site-uuid-1' });
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test', site_id: 'site-uuid-1' }, error: null },
+          // syncBrandSites step 1: SELECT brands.site_id by brand id
+          { data: { site_id: 'site-uuid-1' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        brand_sites: [
+          // 1. ensurePrimaryBrandSite upsert
+          { data: null, error: null },
+          // 2. syncBrandSites step 4 SELECT existing (only the primary row)
+          { data: [{ id: 'bs-row-primary', site_id: 'site-uuid-1' }], error: null },
+        ],
+        brand_urls: { data: null, error: null },
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'site-uuid-1', urls: [] },
+        postgrestClient,
+      });
+
+      // ensurePrimaryBrandSite ran. The orphan-cleanup DELETE (3rd
+      // brand_sites call) is NOT issued because the only existing row is
+      // the protected primary — so the primary row is preserved end-to-end.
+      expect(postgrestClient.from.calledWith('brand_sites')).to.equal(true);
+    });
+
+    it('preserves primary brand_sites row in syncBrandSites when caller urls do not match the primary site', async () => {
+      const fullBrandRow = makeBrandRow({ name: 'Test', site_id: 'primary-site-id' });
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test', site_id: 'primary-site-id' }, error: null },
+          // syncBrandSites step 1: brand row resolves the primary site_id
+          { data: { site_id: 'primary-site-id' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        // syncBrandSites step 3: caller's URL resolves to a DIFFERENT site
+        sites: { data: [{ id: 'citation-site-id', base_url: 'https://citation.com' }], error: null },
+        brand_sites: [
+          // 1. ensurePrimaryBrandSite upsert
+          { data: null, error: null },
+          // 2. syncBrandSites step 3 desired-set upsert
+          { data: null, error: null },
+          // 3. syncBrandSites step 4 SELECT existing returns BOTH primary
+          //    (must be protected) and the new citation row that just got
+          //    upserted. No orphans → step 5 DELETE is not issued.
+          {
+            data: [
+              { id: 'bs-row-primary', site_id: 'primary-site-id' },
+              { id: 'bs-row-citation', site_id: 'citation-site-id' },
+            ],
+            error: null,
+          },
+        ],
+        brand_urls: { data: null, error: null },
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          baseSiteId: 'primary-site-id',
+          urls: [{ value: 'https://citation.com' }],
+        },
+        postgrestClient,
+      });
+
+      // No assertion on the orphan-DELETE not firing — the absence of a 4th
+      // brand_sites mock entry would cause the test to error out if the
+      // code did issue a DELETE here. Test passes ⇒ no orphan DELETE was
+      // issued, which is the invariant we want.
+      expect(postgrestClient.from.calledWith('brand_sites')).to.equal(true);
+    });
+
+    it('throws when ensurePrimaryBrandSite upsert fails', async () => {
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test', site_id: 'site-uuid-1' }, error: null },
+        ],
+        brand_sites: { data: null, error: { message: 'primary upsert failed' } },
+      });
+
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'site-uuid-1' },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to ensure primary brand_sites row: primary upsert failed');
+    });
+
+    it('does not assert primary brand_sites row when brands.site_id is null (pending brand)', async () => {
+      // Pending Brandalf siblings legitimately have site_id=NULL; the helper
+      // must no-op rather than insert a (brand_id, NULL site_id) row that
+      // would violate brand_sites.site_id NOT NULL.
+      const fullBrandRow = makeBrandRow({ name: 'Pending', status: 'pending', site_id: null });
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Pending', site_id: null }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+      });
+
+      const result = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Pending', status: 'pending' },
+        postgrestClient,
+      });
+
+      expect(result).to.include({ name: 'Pending', status: 'pending' });
+      // brand_sites was never hit (no mock supplied, no error raised).
+      expect(postgrestClient.from.calledWith('brand_sites')).to.equal(false);
     });
 
     it('falls back to base URL when URL string is invalid in syncBrandSites', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -803,6 +803,44 @@ describe('brands-storage', () => {
       })).to.be.rejectedWith('Failed to load brand_sites for syncBrandSites: select error');
     });
 
+    it('throws when brands SELECT fails during syncBrandSites primary lookup', async () => {
+      // Step 1 of syncBrandSites resolves brands.site_id to know which row
+      // the orphan-cleanup must protect. If that read errors, surface it.
+      const postgrestClient = createTableMockClient({
+        brands: [
+          // existing brand lookup at upsertBrand top
+          { data: null, error: null },
+          // brands upsert
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          // syncBrandSites step 1 — brand SELECT errors
+          { data: null, error: { message: 'brand fetch failed' } },
+        ],
+        brand_urls: { data: null, error: null },
+      });
+
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://test.com' }] },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to load brand for syncBrandSites: brand fetch failed');
+    });
+
+    it('throws when sites SELECT fails during syncBrandSites desired-set resolution', async () => {
+      // Step 3 of syncBrandSites looks up sites rows matching caller URLs to
+      // build the desired brand_sites set. If that read errors, surface it.
+      const postgrestClient = createTableMockClient({
+        brands: { data: { id: BRAND_ID, name: 'Test' }, error: null },
+        sites: { data: null, error: { message: 'sites fetch failed' } },
+        brand_urls: { data: null, error: null },
+      });
+
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://test.com' }] },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to load sites for syncBrandSites: sites fetch failed');
+    });
+
     // ---------------------------------------------------------------------
     // LLMO-4621 Pattern A regression coverage — syncBrandSites must not wipe
     // the primary brand_sites row that mirrors brands.site_id. The primary

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -804,78 +804,19 @@ describe('brands-storage', () => {
     });
 
     // ---------------------------------------------------------------------
-    // LLMO-4621 Pattern A regression coverage — the primary brand_sites row
-    // mirroring brands.site_id must be asserted unconditionally whenever
-    // brands.site_id is set, independent of whether the caller passed urls.
+    // LLMO-4621 Pattern A regression coverage — syncBrandSites must not wipe
+    // the primary brand_sites row that mirrors brands.site_id. The primary
+    // row's existence invariant is enforced DB-side by the
+    // brands_ensure_primary_brand_site trigger (mysticat-data-service); the
+    // non-destruction half of the invariant lives here in app code.
     // ---------------------------------------------------------------------
-
-    it('asserts primary brand_sites row when baseSiteId is set and urls is undefined', async () => {
-      const fullBrandRow = makeBrandRow({ name: 'Test', site_id: 'site-uuid-1' });
-      const postgrestClient = createTableMockClient({
-        brands: [
-          // existing brand lookup
-          { data: null, error: null },
-          // upsert returns id + site_id (extended select for ensurePrimaryBrandSite)
-          { data: { id: BRAND_ID, name: 'Test', site_id: 'site-uuid-1' }, error: null },
-          // getBrandById final read
-          { data: fullBrandRow, error: null },
-        ],
-        // ensurePrimaryBrandSite upsert
-        brand_sites: { data: null, error: null },
-      });
-
-      await upsertBrand({
-        organizationId: ORG_ID,
-        brand: { name: 'Test', baseSiteId: 'site-uuid-1' },
-        postgrestClient,
-      });
-
-      // brand_sites was hit exactly once — by ensurePrimaryBrandSite. No
-      // syncBrandSites/syncBrandUrls path runs because brand.urls is undefined.
-      expect(postgrestClient.from.calledWith('brand_sites')).to.equal(true);
-    });
-
-    it('asserts primary brand_sites row when baseSiteId is set and urls is empty array', async () => {
-      // Pattern A regression case: pre-fix, a downstream caller passing
-      // urls=[] tripped the destructive DELETE in syncBrandSites without
-      // a re-INSERT, leaving the active root brand with zero brand_sites
-      // rows (and downstream prompt-gen attribution silently broken).
-      const fullBrandRow = makeBrandRow({ name: 'Test', site_id: 'site-uuid-1' });
-      const postgrestClient = createTableMockClient({
-        brands: [
-          { data: null, error: null },
-          { data: { id: BRAND_ID, name: 'Test', site_id: 'site-uuid-1' }, error: null },
-          // syncBrandSites step 1: SELECT brands.site_id by brand id
-          { data: { site_id: 'site-uuid-1' }, error: null },
-          { data: fullBrandRow, error: null },
-        ],
-        brand_sites: [
-          // 1. ensurePrimaryBrandSite upsert
-          { data: null, error: null },
-          // 2. syncBrandSites step 4 SELECT existing (only the primary row)
-          { data: [{ id: 'bs-row-primary', site_id: 'site-uuid-1' }], error: null },
-        ],
-        brand_urls: { data: null, error: null },
-      });
-
-      await upsertBrand({
-        organizationId: ORG_ID,
-        brand: { name: 'Test', baseSiteId: 'site-uuid-1', urls: [] },
-        postgrestClient,
-      });
-
-      // ensurePrimaryBrandSite ran. The orphan-cleanup DELETE (3rd
-      // brand_sites call) is NOT issued because the only existing row is
-      // the protected primary — so the primary row is preserved end-to-end.
-      expect(postgrestClient.from.calledWith('brand_sites')).to.equal(true);
-    });
 
     it('preserves primary brand_sites row in syncBrandSites when caller urls do not match the primary site', async () => {
       const fullBrandRow = makeBrandRow({ name: 'Test', site_id: 'primary-site-id' });
       const postgrestClient = createTableMockClient({
         brands: [
           { data: null, error: null },
-          { data: { id: BRAND_ID, name: 'Test', site_id: 'primary-site-id' }, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
           // syncBrandSites step 1: brand row resolves the primary site_id
           { data: { site_id: 'primary-site-id' }, error: null },
           { data: fullBrandRow, error: null },
@@ -883,11 +824,9 @@ describe('brands-storage', () => {
         // syncBrandSites step 3: caller's URL resolves to a DIFFERENT site
         sites: { data: [{ id: 'citation-site-id', base_url: 'https://citation.com' }], error: null },
         brand_sites: [
-          // 1. ensurePrimaryBrandSite upsert
+          // 1. syncBrandSites step 3 desired-set upsert
           { data: null, error: null },
-          // 2. syncBrandSites step 3 desired-set upsert
-          { data: null, error: null },
-          // 3. syncBrandSites step 4 SELECT existing returns BOTH primary
+          // 2. syncBrandSites step 4 SELECT existing returns BOTH primary
           //    (must be protected) and the new citation row that just got
           //    upserted. No orphans → step 5 DELETE is not issued.
           {
@@ -911,51 +850,11 @@ describe('brands-storage', () => {
         postgrestClient,
       });
 
-      // No assertion on the orphan-DELETE not firing — the absence of a 4th
+      // No assertion on the orphan-DELETE not firing — the absence of a 3rd
       // brand_sites mock entry would cause the test to error out if the
       // code did issue a DELETE here. Test passes ⇒ no orphan DELETE was
       // issued, which is the invariant we want.
       expect(postgrestClient.from.calledWith('brand_sites')).to.equal(true);
-    });
-
-    it('throws when ensurePrimaryBrandSite upsert fails', async () => {
-      const postgrestClient = createTableMockClient({
-        brands: [
-          { data: null, error: null },
-          { data: { id: BRAND_ID, name: 'Test', site_id: 'site-uuid-1' }, error: null },
-        ],
-        brand_sites: { data: null, error: { message: 'primary upsert failed' } },
-      });
-
-      await expect(upsertBrand({
-        organizationId: ORG_ID,
-        brand: { name: 'Test', baseSiteId: 'site-uuid-1' },
-        postgrestClient,
-      })).to.be.rejectedWith('Failed to ensure primary brand_sites row: primary upsert failed');
-    });
-
-    it('does not assert primary brand_sites row when brands.site_id is null (pending brand)', async () => {
-      // Pending Brandalf siblings legitimately have site_id=NULL; the helper
-      // must no-op rather than insert a (brand_id, NULL site_id) row that
-      // would violate brand_sites.site_id NOT NULL.
-      const fullBrandRow = makeBrandRow({ name: 'Pending', status: 'pending', site_id: null });
-      const postgrestClient = createTableMockClient({
-        brands: [
-          { data: null, error: null },
-          { data: { id: BRAND_ID, name: 'Pending', site_id: null }, error: null },
-          { data: fullBrandRow, error: null },
-        ],
-      });
-
-      const result = await upsertBrand({
-        organizationId: ORG_ID,
-        brand: { name: 'Pending', status: 'pending' },
-        postgrestClient,
-      });
-
-      expect(result).to.include({ name: 'Pending', status: 'pending' });
-      // brand_sites was never hit (no mock supplied, no error raised).
-      expect(postgrestClient.from.calledWith('brand_sites')).to.equal(false);
     });
 
     it('falls back to base URL when URL string is invalid in syncBrandSites', async () => {


### PR DESCRIPTION
## Summary

`syncBrandSites` was unconditionally `DELETE`-ing all `brand_sites` rows for a brand and then early-returning when the caller passed `urls=[]`. With no re-INSERT, the primary citation row mirroring `brands.site_id` was silently wiped. The audit-time symptom: 13 active root brands with `brands.site_id` set, no `brand_sites` rows, and zero prompts (LLMO-4621 Pattern A). The bleed stopped at Satori on 2026-04-28 20:58 UTC by coincidence; the code path was unfixed until this PR.

This PR makes `syncBrandSites` non-destructive to the primary row, and elevates a previously swallowed onboarding error so the same kind of inconsistency can't go undetected again.

## Related Issues

- [LLMO-4621](https://jira.corp.adobe.com/browse/LLMO-4621) — Pattern A; app-side fix lives here. Investigation summary on [comment 54398141](https://jira.corp.adobe.com/browse/LLMO-4621?focusedCommentId=54398141).
- Companion DB trigger PR (existence invariant): [adobe/mysticat-data-service#496](https://github.com/adobe/mysticat-data-service/pull/496) — adds `brands_ensure_primary_brand_site`.
- Companion backfill PR (24 historical brands): [adobe-rnd/llmo-data-retrieval-service#1494](https://github.com/adobe-rnd/llmo-data-retrieval-service/pull/1494).

## Changes

**`src/support/brands-storage.js` — non-destructive `syncBrandSites`**

Replaces DELETE-then-INSERT with:

1. Resolve `brands.site_id` — the protected primary.
2. Upsert the desired URL-derived rows (`brand_id, site_id` on conflict).
3. Delete only pre-existing rows whose `site_id` is NOT in the desired set AND NOT the primary. The targeted DELETE uses PK `id`s to avoid PostgREST `not.in` quoting edge cases.

Empty or unmatched URL lists no longer wipe anything; the primary row is always preserved.

**`src/controllers/llmo/llmo-onboarding.js` — surface `upsertBrand` failures**

When the initial `upsertBrand` call fails during onboarding, log at `error` level and emit a Slack `say()` instead of swallowing as `log.warn`. Onboarding still proceeds (the SpaceCat site row already exists), but operators now see the failure in Coralogix and the onboarding Slack thread immediately. This was the silent-failure surface that hid the original bleed for weeks before the audit caught it.

## Invariant split

The LLMO-4621 invariant — "every active brand with `brands.site_id` set has at least one `brand_sites` row mirroring `brands.site_id`" — has two halves, each enforced where the codebase rules say it belongs:

| half | enforced where | mechanism |
|---|---|---|
| Primary `brand_sites` row exists when `brands.site_id` is set | DB | `brands_ensure_primary_brand_site` trigger ([mysticat-data-service#496](https://github.com/adobe/mysticat-data-service/pull/496)) |
| `syncBrandSites` cannot wipe the primary row | App (this PR) | non-destructive `syncBrandSites` rewrite |

The non-destruction half cannot live in a `BEFORE DELETE … RETURN NULL` trigger because `mysticat-data-service/CLAUDE.md` disrecommends triggers that silently veto writes — it stays in app code.

## Deploy ordering

This PR and [mysticat-data-service#496](https://github.com/adobe/mysticat-data-service/pull/496) are independent and can deploy in either order or in parallel. Either alone closes the api-service write path; both together cover all writers (api-service + future scripts/services) and make the invariant impossible to violate via the destructive DELETE pattern. The backfill ([llmo-data-retrieval-service#1494](https://github.com/adobe-rnd/llmo-data-retrieval-service/pull/1494)) repairs the 24 historical brands after this PR merges.

## Test plan

- [x] `npx mocha test/support/brands-storage.test.js` — 81 passing (3 existing error-path tests revised to match the new flow, 1 new regression test for primary preservation)
- [x] `npx mocha test/controllers/llmo/llmo-onboarding.test.js` — 97 passing (swallow assertion updated to match the new `log.error` + `say()` shape)
- [x] `npx mocha test/controllers/brands.test.js` — 231 passing
- [x] `npm run lint` clean

New / revised tests covering LLMO-4621:

- `preserves primary brand_sites row in syncBrandSites when caller urls do not match the primary site` — the regression test for the actual bug; primary `site_id` is excluded from orphan DELETE even when the caller's URLs target a different site entirely
- `throws when brand_sites upsert fails during syncBrandSites` — desired-set upsert failure
- `throws when SELECT existing brand_sites fails during syncBrandSites orphan-cleanup` — load-existing failure
- `throws when brand_sites orphan-cleanup delete fails during syncBrandSites` — orphan DELETE failure
- `throws when brands SELECT fails during syncBrandSites primary lookup` — primary-resolution failure
- `throws when sites SELECT fails during syncBrandSites desired-set resolution` — desired-set lookup failure