### PR TITLE
feat: bypass PLG gating in sites-resolve for ASO_PLG_EXCLUDED_ORGS

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -1187,6 +1187,11 @@ function SitesController(ctx, log, env) {
       { 'x-error': message },
     );
 
+    const excludedOrgs = hasText(env.ASO_PLG_EXCLUDED_ORGS)
+      ? env.ASO_PLG_EXCLUDED_ORGS.split(',').map((id) => id.trim()).filter(Boolean)
+      : [];
+    const isPlgExcludedOrg = (org) => excludedOrgs.includes(org.getImsOrgId());
+
     let organization;
     let site;
 
@@ -1216,7 +1221,8 @@ function SitesController(ctx, log, env) {
                 );
               }
 
-              if (!CUSTOMER_VISIBLE_TIERS.includes(entitlement.getTier())) {
+              if (!isPlgExcludedOrg(organization)
+                && !CUSTOMER_VISIBLE_TIERS.includes(entitlement.getTier())) {
                 return resolveFailure(
                   'No site found for the provided parameters',
                   'aso_pre_onboard',
@@ -1253,6 +1259,7 @@ function SitesController(ctx, log, env) {
             .getFirstEnrollment();
 
           if (enrolledSite && (accessControlUtil.hasAdminAccess()
+            || isPlgExcludedOrg(organization)
             || CUSTOMER_VISIBLE_TIERS.includes(orgEntitlement?.getTier()))) {
             const isSummitPlgEnabled = await getIsSummitPlgEnabled(enrolledSite, context);
             const data = {
@@ -1272,6 +1279,7 @@ function SitesController(ctx, log, env) {
             .getFirstEnrollment();
 
           if (enrolledSite && (accessControlUtil.hasAdminAccess()
+            || isPlgExcludedOrg(organization)
             || CUSTOMER_VISIBLE_TIERS.includes(imsOrgEntitlement?.getTier()))) {
             const isSummitPlgEnabled = await getIsSummitPlgEnabled(enrolledSite, context);
             const data = {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -4958,6 +4958,150 @@ describe('Sites Controller', () => {
       expect(body.details).to.not.have.property('tier');
     });
 
+    it('should return 200 for PRE_ONBOARD org when its IMS org ID is in ASO_PLG_EXCLUDED_ORGS (siteId path)', async () => {
+      const validSiteId = SITE_IDS[1];
+      const excludedImsOrgId = testOrganizations[3].getImsOrgId();
+
+      context.data = { siteId: validSiteId, imsOrg: excludedImsOrgId };
+      context.pathInfo = { headers: { 'x-product': 'ASO' } };
+      context.env = { ...context.env, ASO_PLG_EXCLUDED_ORGS: excludedImsOrgId };
+      const controller = SitesController(context, loggerStub, context.env);
+
+      mockTierClientStub.getAllEnrollment.resolves({
+        entitlement: {
+          getId: () => 'entitlement-pre-onboard',
+          getProductCode: () => 'ASO',
+          getTier: () => 'PRE_ONBOARD',
+        },
+        enrollments: [{ getId: () => 'enrollment-pre-onboard', getSiteId: () => validSiteId }],
+      });
+
+      mockDataAccess.Site.findById.resolves(testSites[1]);
+      mockDataAccess.Organization.findById.resolves(testOrganizations[3]);
+
+      const response = await controller.resolveSite(context);
+
+      expect(response.status).to.equal(200);
+      const body = await response.json();
+      expect(body).to.have.property('data');
+      expect(body.data).to.have.property('organization');
+      expect(body.data).to.have.property('site');
+    });
+
+    it('should return 404 aso_pre_onboard for PRE_ONBOARD org NOT in ASO_PLG_EXCLUDED_ORGS (siteId path)', async () => {
+      const validSiteId = SITE_IDS[1];
+      const excludedImsOrgId = testOrganizations[3].getImsOrgId();
+      const otherImsOrgId = '9999999999ABCDEF12345678@AdobeOrg';
+
+      context.data = { siteId: validSiteId, imsOrg: excludedImsOrgId };
+      context.pathInfo = { headers: { 'x-product': 'ASO' } };
+      context.env = { ...context.env, ASO_PLG_EXCLUDED_ORGS: otherImsOrgId };
+      const controller = SitesController(context, loggerStub, context.env);
+
+      mockTierClientStub.getAllEnrollment.resolves({
+        entitlement: {
+          getId: () => 'entitlement-pre-onboard',
+          getProductCode: () => 'ASO',
+          getTier: () => 'PRE_ONBOARD',
+        },
+        enrollments: [{ getId: () => 'enrollment-pre-onboard', getSiteId: () => validSiteId }],
+      });
+
+      mockDataAccess.Site.findById.resolves(testSites[1]);
+      mockDataAccess.Organization.findById.resolves(testOrganizations[3]);
+
+      const response = await controller.resolveSite(context);
+
+      expect(response.status).to.equal(404);
+      const body = await response.json();
+      expect(body.resolveStatus).to.equal('aso_pre_onboard');
+    });
+
+    it('should return 404 site_not_enrolled for excluded org with no enrollments (siteId path)', async () => {
+      const validSiteId = SITE_IDS[1];
+      const excludedImsOrgId = testOrganizations[3].getImsOrgId();
+
+      context.data = { siteId: validSiteId, imsOrg: excludedImsOrgId };
+      context.pathInfo = { headers: { 'x-product': 'ASO' } };
+      context.env = { ...context.env, ASO_PLG_EXCLUDED_ORGS: excludedImsOrgId };
+      const controller = SitesController(context, loggerStub, context.env);
+
+      mockTierClientStub.getAllEnrollment.resolves({
+        entitlement: {
+          getId: () => 'entitlement-pre-onboard',
+          getProductCode: () => 'ASO',
+          getTier: () => 'PRE_ONBOARD',
+        },
+        enrollments: [],
+      });
+
+      mockDataAccess.Site.findById.resolves(testSites[1]);
+      mockDataAccess.Organization.findById.resolves(testOrganizations[3]);
+
+      const response = await controller.resolveSite(context);
+
+      expect(response.status).to.equal(404);
+      const body = await response.json();
+      expect(body.resolveStatus).to.equal('site_not_enrolled');
+    });
+
+    it('should return 200 for excluded PRE_ONBOARD org via organizationId path', async () => {
+      const validOrgId = testOrganizations[3].getId();
+      const excludedImsOrgId = testOrganizations[3].getImsOrgId();
+
+      context.data = { organizationId: validOrgId };
+      context.pathInfo = { headers: { 'x-product': 'ASO' } };
+      context.env = { ...context.env, ASO_PLG_EXCLUDED_ORGS: excludedImsOrgId };
+      const controller = SitesController(context, loggerStub, context.env);
+
+      mockTierClientStub.getFirstEnrollment.resolves({
+        entitlement: {
+          getId: () => 'entitlement-pre-onboard',
+          getProductCode: () => 'ASO',
+          getTier: () => 'PRE_ONBOARD',
+        },
+        site: testSites[1],
+      });
+
+      mockDataAccess.Organization.findById.resolves(testOrganizations[3]);
+
+      const response = await controller.resolveSite(context);
+
+      expect(response.status).to.equal(200);
+      const body = await response.json();
+      expect(body).to.have.property('data');
+      expect(body.data).to.have.property('organization');
+      expect(body.data).to.have.property('site');
+    });
+
+    it('should return 200 for excluded PRE_ONBOARD org via imsOrg path', async () => {
+      const excludedImsOrgId = testOrganizations[3].getImsOrgId();
+
+      context.data = { imsOrg: excludedImsOrgId };
+      context.pathInfo = { headers: { 'x-product': 'ASO' } };
+      context.env = { ...context.env, ASO_PLG_EXCLUDED_ORGS: excludedImsOrgId };
+      const controller = SitesController(context, loggerStub, context.env);
+
+      mockTierClientStub.getFirstEnrollment.resolves({
+        entitlement: {
+          getId: () => 'entitlement-pre-onboard',
+          getProductCode: () => 'ASO',
+          getTier: () => 'PRE_ONBOARD',
+        },
+        site: testSites[1],
+      });
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(testOrganizations[3]);
+
+      const response = await controller.resolveSite(context);
+
+      expect(response.status).to.equal(200);
+      const body = await response.json();
+      expect(body).to.have.property('data');
+      expect(body.data).to.have.property('organization');
+      expect(body.data).to.have.property('site');
+    });
+
     it('should return 404 with no_entitlement_for_product resolveStatus when product has no entitlement', async () => {
       const validSiteId = SITE_IDS[1];
 


### PR DESCRIPTION
## **Summary**

- Adds `ASO_PLG_EXCLUDED_ORGS` env variable (comma-separated IMS org IDs) to `sites-resolve`
- If an org's IMS org ID is in the list, the `aso_pre_onboard` tier check is skipped in all three resolution paths (siteId, organizationId, imsOrg)
- Allows PRE_ONBOARD orgs to access the ASO dashboard without being shown the PLG onboarding wizard
- `no_entitlement_for_product` and `site_not_enrolled` checks are still enforced — only the tier gate is bypassed

## Test plan
- [x] Excluded org with PRE_ONBOARD tier → 200 (siteId, organizationId, imsOrg paths)
- [x] Non-excluded PRE_ONBOARD org → 404 aso_pre_onboard (unchanged)
- [x] Excluded org with no enrollments → 404 site_not_enrolled (enrollment check still enforced)
- [x] All existing resolveSite tests pass (27 passing, 0 failing)

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
