### PR TITLE
fix: revert structured resolveStatus envelope on /sites-resolve 404s (#2253)

### DIFF
--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -354,23 +354,7 @@ sites-resolve:
                 value:
                   message: 'Failed to resolve site'
       '404':
-        description: |
-          Not found - no site could be resolved.
-
-          When the failure is reached via the `siteId` resolution path, the body
-          carries a structured `resolveStatus` discriminator so clients can
-          distinguish "not enrolled" from "site doesn't exist" without
-          re-querying entitlements:
-
-          - `no_entitlement_for_product` — org has no entitlement for the
-            resolved product.
-          - `aso_pre_onboard` — entitlement tier is not in
-            `CUSTOMER_VISIBLE_TIERS` (e.g. `PRE_ONBOARD`).
-          - `site_not_enrolled` — entitlement is visible but no `SiteEnrollment`
-            links the site.
-
-          Generic 404s (e.g. site / org not found) omit `resolveStatus` and
-          `details`.
+        description: Not found - no site found for the provided parameters
         headers:
           X-Error:
             $ref: './headers.yaml#/xError'
@@ -381,62 +365,8 @@ sites-resolve:
               properties:
                 message:
                   type: string
-                resolveStatus:
-                  type: string
-                  enum:
-                    - no_entitlement_for_product
-                    - aso_pre_onboard
-                    - site_not_enrolled
-                  description: |
-                    Structured resolution status. Present only on the
-                    `siteId`-resolution path; absent on generic 404s.
-                details:
-                  type: object
-                  description: |
-                    Context for the resolution failure. Always
-                    `{ productCode, siteId, organizationId }` when
-                    `resolveStatus` is set (these branches are reached only
-                    via the `siteId` resolution path).
-                  properties:
-                    productCode:
-                      type: string
-                      example: 'ASO'
-                    siteId:
-                      $ref: './schemas.yaml#/Id'
-                    organizationId:
-                      $ref: './schemas.yaml#/Id'
-            examples:
-              no-entitlement-for-product:
-                summary: Org has no entitlement for the resolved product
-                value:
-                  message: 'No site found for the provided parameters'
-                  resolveStatus: 'no_entitlement_for_product'
-                  details:
-                    productCode: 'ASO'
-                    siteId: '0b4dcf79-fe5f-410b-b11f-641f0bf56da3'
-                    organizationId: '9033554c-de8a-44ac-a356-09b51af8cc28'
-              aso-pre-onboard:
-                summary: Entitlement tier is not in CUSTOMER_VISIBLE_TIERS
-                value:
-                  message: 'No site found for the provided parameters'
-                  resolveStatus: 'aso_pre_onboard'
-                  details:
-                    productCode: 'ASO'
-                    siteId: '0b4dcf79-fe5f-410b-b11f-641f0bf56da3'
-                    organizationId: '9033554c-de8a-44ac-a356-09b51af8cc28'
-              site-not-enrolled:
-                summary: Visible entitlement but site has no enrollment
-                value:
-                  message: 'No site found for the provided parameters'
-                  resolveStatus: 'site_not_enrolled'
-                  details:
-                    productCode: 'ASO'
-                    siteId: '0b4dcf79-fe5f-410b-b11f-641f0bf56da3'
-                    organizationId: '9033554c-de8a-44ac-a356-09b51af8cc28'
-              generic-not-found:
-                summary: Generic 404 (no resolveStatus discriminator)
-                value:
-                  message: 'No site found for the provided parameters'
+            example:
+              message: 'No site found for the provided parameters'
       '500':
         description: Internal server error
         headers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,9 @@
       "engines": {
         "node": ">=24.0.0 <25.0.0",
         "npm": ">=10.9.0"
+      },
+      "optionalDependencies": {
+        "mark.js": "^8.11.1"
       }
     },
     "node_modules/@actions/core": {
@@ -26546,7 +26549,7 @@
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/markdown-table": {

--- a/package.json
+++ b/package.json
@@ -177,5 +177,8 @@
       "."
     ],
     "ext": ".js, .cjs, .ejs, .css"
+  },
+  "optionalDependencies": {
+    "mark.js": "^8.11.1"
   }
 }

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -1154,17 +1154,6 @@ function SitesController(ctx, log, env) {
   /**
    * Resolves site and organization data based on query parameters.
    * Tries siteId first, then checks either organizationId or imsOrg (mutually exclusive).
-   *
-   * On failure, returns HTTP 404 with a structured body:
-   *   { message, resolveStatus, details? }
-   * where `resolveStatus` is one of:
-   *   - 'no_entitlement_for_product' — org has no entitlement for the requested x-product.
-   *   - 'aso_pre_onboard' — entitlement tier is not in CUSTOMER_VISIBLE_TIERS (e.g. PRE_ONBOARD).
-   *   - 'site_not_enrolled' — entitlement is visible but no SiteEnrollment links this site.
-   * `details` shape is `{ productCode, siteId, organizationId }` for all three statuses
-   * (these branches are reached only via the siteId path, so siteId is always present).
-   * Unspecified 404s fall through without resolveStatus (unknown/generic not-found).
-   *
    * @param {object} context - Context of the request.
    * @returns {Promise<Response>} Resolved site and organization data response.
    */
@@ -1180,12 +1169,6 @@ function SitesController(ctx, log, env) {
     if (!hasText(organizationId) && !hasText(imsOrg)) {
       return badRequest('Either organizationId or imsOrg must be provided');
     }
-
-    const resolveFailure = (message, resolveStatus, details) => createResponse(
-      { message, resolveStatus, details },
-      404,
-      { 'x-error': message },
-    );
 
     let organization;
     let site;
@@ -1208,38 +1191,18 @@ function SitesController(ctx, log, env) {
               const tierClient = await TierClient.createForSite(context, site, productCode);
               const { entitlement, enrollments } = await tierClient.getAllEnrollment();
 
-              if (!entitlement) {
-                return resolveFailure(
-                  'No site found for the provided parameters',
-                  'no_entitlement_for_product',
-                  { productCode, siteId, organizationId: orgId },
-                );
+              const tierVisible = entitlement
+                && CUSTOMER_VISIBLE_TIERS.includes(entitlement.getTier());
+              if (tierVisible && enrollments?.length) {
+                const isSummitPlgEnabled = await getIsSummitPlgEnabled(site, context);
+                const data = {
+                  organization: OrganizationDto.toJSON(organization),
+                  site: SiteDto.toJSON(site),
+                  isSummitPlgEnabled,
+                };
+
+                return ok({ data });
               }
-
-              if (!CUSTOMER_VISIBLE_TIERS.includes(entitlement.getTier())) {
-                return resolveFailure(
-                  'No site found for the provided parameters',
-                  'aso_pre_onboard',
-                  { productCode, siteId, organizationId: orgId },
-                );
-              }
-
-              if (!enrollments?.length) {
-                return resolveFailure(
-                  'No site found for the provided parameters',
-                  'site_not_enrolled',
-                  { productCode, siteId, organizationId: orgId },
-                );
-              }
-
-              const isSummitPlgEnabled = await getIsSummitPlgEnabled(site, context);
-              const data = {
-                organization: OrganizationDto.toJSON(organization),
-                site: SiteDto.toJSON(site),
-                isSummitPlgEnabled,
-              };
-
-              return ok({ data });
             }
           }
         }

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -4927,7 +4927,7 @@ describe('Sites Controller', () => {
       expect(body.data.organization.imsOrgId).to.equal('9876567890ABCDEF12345678@AdobeOrg');
     });
 
-    it('should return 404 with aso_pre_onboard resolveStatus for PRE_ONBOARD-tier site via siteId path', async () => {
+    it('should return 404 for PRE_ONBOARD-tier site via siteId path', async () => {
       const validSiteId = SITE_IDS[1];
 
       context.data = { siteId: validSiteId, imsOrg: testOrganizations[3].getImsOrgId() };
@@ -4953,57 +4953,6 @@ describe('Sites Controller', () => {
       expect(response.status).to.equal(404);
       const body = await response.json();
       expect(body.message).to.include('No site found for the provided parameters');
-      expect(body.resolveStatus).to.equal('aso_pre_onboard');
-      expect(body.details).to.deep.include({ productCode: 'ASO' });
-      expect(body.details).to.not.have.property('tier');
-    });
-
-    it('should return 404 with no_entitlement_for_product resolveStatus when product has no entitlement', async () => {
-      const validSiteId = SITE_IDS[1];
-
-      context.data = { siteId: validSiteId, imsOrg: testOrganizations[3].getImsOrgId() };
-      context.pathInfo = { headers: { 'x-product': 'ASO' } };
-
-      mockTierClientStub.getAllEnrollment.resolves({
-        entitlement: null,
-        enrollments: [],
-      });
-
-      mockDataAccess.Site.findById.resolves(testSites[1]);
-      mockDataAccess.Organization.findById.resolves(testOrganizations[3]);
-
-      const response = await sitesController.resolveSite(context);
-
-      expect(response.status).to.equal(404);
-      const body = await response.json();
-      expect(body.resolveStatus).to.equal('no_entitlement_for_product');
-      expect(body.details).to.deep.include({ productCode: 'ASO' });
-    });
-
-    it('should return 404 with site_not_enrolled resolveStatus when entitlement is visible but site has no enrollment', async () => {
-      const validSiteId = SITE_IDS[1];
-
-      context.data = { siteId: validSiteId, imsOrg: testOrganizations[3].getImsOrgId() };
-      context.pathInfo = { headers: { 'x-product': 'ASO' } };
-
-      mockTierClientStub.getAllEnrollment.resolves({
-        entitlement: {
-          getId: () => 'entitlement-visible',
-          getProductCode: () => 'ASO',
-          getTier: () => 'FREE_TRIAL',
-        },
-        enrollments: [],
-      });
-
-      mockDataAccess.Site.findById.resolves(testSites[1]);
-      mockDataAccess.Organization.findById.resolves(testOrganizations[3]);
-
-      const response = await sitesController.resolveSite(context);
-
-      expect(response.status).to.equal(404);
-      const body = await response.json();
-      expect(body.resolveStatus).to.equal('site_not_enrolled');
-      expect(body.details).to.deep.include({ productCode: 'ASO' });
     });
 
     it('should return 404 for PRE_ONBOARD-tier site via organizationId path for non-admin', async () => {


### PR DESCRIPTION
Reverts the changes introduced in `PR #2253` which added explicit failure states (no_entitlement_for_product, aso_pre_onboard, site_not_enrolled) to the siteId-resolve path.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
