### PR TITLE
fix(llmo): onboarding hardening — uq_brand_name_per_org, syncBrandSites, atomic brand+brand_sites (LLMO-4129, 4561, 4656, 4350, 4621)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -140,7 +140,17 @@ function BrandsController(ctx, log, env) {
 
   function createErrorResponse(error) {
     if (error.status) {
-      return createResponse({ message: error.message }, error.status, {
+      const body = { message: error.message };
+      // LLMO-4656: surface structured fields on typed errors (e.g. 409 on
+      // duplicate brand name) so DRS / re-onboarding callers can auto-merge
+      // into the existing brand instead of failing the customer at 0 prompts.
+      if (hasText(error.code)) {
+        body.code = error.code;
+      }
+      if (hasText(error.existingBrandId)) {
+        body.existing_brand_id = error.existingBrandId;
+      }
+      return createResponse(body, error.status, {
         [HEADER_ERROR]: error.message,
       });
     }

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1122,6 +1122,7 @@ function BrandsController(ctx, log, env) {
         brand: brandData,
         postgrestClient,
         updatedBy,
+        log,
       });
 
       return createResponse(created, 201);
@@ -1176,6 +1177,7 @@ function BrandsController(ctx, log, env) {
         updates,
         postgrestClient,
         updatedBy,
+        log,
       });
 
       if (!updated) {

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1345,6 +1345,7 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
           },
           postgrestClient,
           updatedBy: 'llmo-onboarding',
+          log,
         });
         log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
       } catch (brandError) {

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -175,8 +175,32 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
 /**
  * Fully replaces brand_sites for a brand. Groups submitted URLs by normalized base URL
  * (via composeBaseURL) so that multiple paths under the same site share one brand_sites row.
+ *
+ * @param {string} organizationId
+ * @param {string} brandId
+ * @param {Array} urls
+ * @param {object} postgrestClient
+ * @param {string} updatedBy
+ * @param {object} [opts]
+ * @param {string} [opts.fallbackSiteId] - Pattern A fallback (LLMO-4621): when no
+ *   submitted URLs resolve to a site row in the org but the caller knows the
+ *   brand's base site (`brands.site_id`), seed a single `brand_sites` row keyed
+ *   off that site so the brand has at least one linkage. Prevents the
+ *   active-brand / no-linkage / 0-prompts failure mode.
+ * @param {object} [opts.log] - Structured logger. Used to emit
+ *   `event=brand_sites_no_matching_site` WARN per dropped URL and a single
+ *   ERROR summary when ≥1 URL is dropped (LLMO-4350).
  */
-async function syncBrandSites(organizationId, brandId, urls, postgrestClient, updatedBy) {
+async function syncBrandSites(
+  organizationId,
+  brandId,
+  urls,
+  postgrestClient,
+  updatedBy,
+  opts = {},
+) {
+  const { fallbackSiteId, log } = opts;
+
   const { error: deleteError } = await postgrestClient
     .from('brand_sites')
     .delete()
@@ -220,6 +244,79 @@ async function syncBrandSites(organizationId, brandId, urls, postgrestClient, up
     .select('id, base_url')
     .eq('organization_id', organizationId)
     .in('base_url', [...pathsByBase.keys()]);
+
+  // LLMO-4350: every requested base URL that did not resolve to a site row in
+  // this org gets a structured WARN event. Today this happens silently — under
+  // multi-tenant or stale-config scenarios, brand URLs are dropped without a
+  // trace, leaving brands with zero `brand_sites` linkage and zero prompts.
+  const matchedBases = new Set((sites || []).map((s) => s.base_url));
+  const droppedBases = [...pathsByBase.keys()].filter((b) => !matchedBases.has(b));
+  if (droppedBases.length > 0 && log?.warn) {
+    droppedBases.forEach((base) => {
+      try {
+        log.warn(JSON.stringify({
+          event: 'brand_sites_no_matching_site',
+          message: 'Submitted brand URL did not resolve to any site in the target organization',
+          url: base,
+          target_org_id: organizationId,
+          brand_id: brandId,
+        }));
+      } catch (e) {
+        // Defensive: never let log serialization break the brand sync.
+      }
+    });
+    if (log?.error) {
+      try {
+        log.error(JSON.stringify({
+          event: 'brand_sites_cross_org_url_summary',
+          message: `${droppedBases.length} brand URL(s) dropped because they do not match any site in the target organization`,
+          dropped_count: droppedBases.length,
+          dropped_urls: droppedBases.slice(0, 5),
+          target_org_id: organizationId,
+          brand_id: brandId,
+        }));
+      } catch (e) {
+        // Defensive
+      }
+    }
+  }
+
+  // LLMO-4621 Pattern A: when none of the submitted URLs match a site row in
+  // the org but the caller knows the brand's base site (`brands.site_id`),
+  // seed a single brand_sites row keyed off that site_id. Prevents the
+  // active-brand / no-linkage / 0-prompts failure mode.
+  if ((!sites || sites.length === 0) && hasText(fallbackSiteId)) {
+    const { error: fallbackError } = await postgrestClient
+      .from('brand_sites')
+      .upsert(
+        [{
+          organization_id: organizationId,
+          brand_id: brandId,
+          site_id: fallbackSiteId,
+          paths: [],
+          type: 'base',
+          updated_by: updatedBy,
+        }],
+        { onConflict: 'brand_id,site_id' },
+      );
+    if (fallbackError) {
+      throw new Error(`Failed to sync brand_sites: ${fallbackError.message}`);
+    }
+    if (log?.info) {
+      try {
+        log.info(JSON.stringify({
+          event: 'brand_sites_fallback_to_base_site',
+          message: 'Submitted URLs did not match any site; falling back to brands.site_id linkage',
+          brand_id: brandId,
+          site_id: fallbackSiteId,
+          target_org_id: organizationId,
+        }));
+      } catch (e) {
+        // Defensive
+      }
+    }
+    return;
+  }
 
   if (!sites || sites.length === 0) {
     return;
@@ -427,6 +524,7 @@ export async function upsertBrand({
   brand,
   postgrestClient,
   updatedBy = 'system',
+  log,
 }) {
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
@@ -486,6 +584,18 @@ export async function upsertBrand({
       err.status = 409;
       throw err;
     }
+    // LLMO-4656: distinguish the (organization_id, name) unique violation from a
+    // generic 500. DRS / re-onboarding callers can then treat 409 as a known
+    // duplicate rather than a transient. The `onConflict` upsert path normally
+    // handles (organization_id, name) collisions natively; this branch fires
+    // when the constraint surfaces a 23505 anyway (e.g. concurrent insert race
+    // or partial-index quirks).
+    if (error.code === '23505' && error.message?.includes('uq_brand_name_per_org')) {
+      const err = new Error('A brand with this name already exists in this organization');
+      err.status = 409;
+      err.code = 'duplicate_brand_name';
+      throw err;
+    }
     throw new Error(`Failed to upsert brand: ${error.message}`);
   }
 
@@ -499,8 +609,21 @@ export async function upsertBrand({
   ]);
 
   if (brand.urls !== undefined) {
+    // LLMO-4621 Pattern A: pass `brands.site_id` as the fallback so syncBrandSites
+    // can seed a brand_sites row when none of the submitted URLs match a site
+    // row in the org. Honor the request payload first, then the row that was
+    // just upserted. Prefer the persisted `existing.site_id` so the fallback
+    // works on update paths where the caller did not re-send `baseSiteId`.
+    const fallbackSiteId = brand.baseSiteId || existing?.site_id || null;
     await Promise.all([
-      syncBrandSites(organizationId, brandId, brand.urls, postgrestClient, updatedBy),
+      syncBrandSites(
+        organizationId,
+        brandId,
+        brand.urls,
+        postgrestClient,
+        updatedBy,
+        { fallbackSiteId, log },
+      ),
       syncBrandUrls(organizationId, brandId, brand.urls, postgrestClient, updatedBy),
     ]);
   }
@@ -525,6 +648,7 @@ export async function updateBrand({
   updates,
   postgrestClient,
   updatedBy = 'system',
+  log,
 }) {
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
@@ -586,6 +710,14 @@ export async function updateBrand({
       err.status = 409;
       throw err;
     }
+    // LLMO-4656: same 23505 handling as upsertBrand for the
+    // (organization_id, name) unique constraint, surfaced on rename collisions.
+    if (error.code === '23505' && error.message?.includes('uq_brand_name_per_org')) {
+      const err = new Error('A brand with this name already exists in this organization');
+      err.status = 409;
+      err.code = 'duplicate_brand_name';
+      throw err;
+    }
     throw new Error(`Failed to update brand: ${error.message}`);
   }
   if (!data) {
@@ -619,8 +751,28 @@ export async function updateBrand({
   }
 
   if (updates.urls !== undefined) {
+    // LLMO-4621 Pattern A: resolve the brand's persisted base site so
+    // syncBrandSites can fall back to it when none of the submitted URLs
+    // match a site row in the org. Read independently of the patch so we
+    // pick up an existing site_id even when the caller is not updating it.
+    let fallbackSiteId = hasText(updates.baseSiteId) ? updates.baseSiteId : null;
+    if (!fallbackSiteId) {
+      const { data: brandRow } = await postgrestClient
+        .from('brands')
+        .select('site_id')
+        .eq('id', brandId)
+        .maybeSingle();
+      fallbackSiteId = brandRow?.site_id || null;
+    }
     await Promise.all([
-      syncBrandSites(organizationId, brandId, updates.urls, postgrestClient, updatedBy),
+      syncBrandSites(
+        organizationId,
+        brandId,
+        updates.urls,
+        postgrestClient,
+        updatedBy,
+        { fallbackSiteId, log },
+      ),
       syncBrandUrls(organizationId, brandId, updates.urls, postgrestClient, updatedBy),
     ]);
   }

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -589,11 +589,22 @@ export async function upsertBrand({
     // duplicate rather than a transient. The `onConflict` upsert path normally
     // handles (organization_id, name) collisions natively; this branch fires
     // when the constraint surfaces a 23505 anyway (e.g. concurrent insert race
-    // or partial-index quirks).
+    // or partial-index quirks). We also surface `existingBrandId` so DRS can
+    // auto-merge the duplicate request into the row that already exists
+    // instead of leaving the customer at zero prompts.
     if (error.code === '23505' && error.message?.includes('uq_brand_name_per_org')) {
       const err = new Error('A brand with this name already exists in this organization');
       err.status = 409;
       err.code = 'duplicate_brand_name';
+      const { data: dup } = await postgrestClient
+        .from('brands')
+        .select('id')
+        .eq('organization_id', organizationId)
+        .eq('name', brand.name)
+        .maybeSingle();
+      if (dup?.id) {
+        err.existingBrandId = dup.id;
+      }
       throw err;
     }
     throw new Error(`Failed to upsert brand: ${error.message}`);
@@ -712,10 +723,23 @@ export async function updateBrand({
     }
     // LLMO-4656: same 23505 handling as upsertBrand for the
     // (organization_id, name) unique constraint, surfaced on rename collisions.
+    // Surface `existingBrandId` for the conflicting row so DRS can auto-merge
+    // instead of leaving the customer at zero prompts.
     if (error.code === '23505' && error.message?.includes('uq_brand_name_per_org')) {
       const err = new Error('A brand with this name already exists in this organization');
       err.status = 409;
       err.code = 'duplicate_brand_name';
+      if (hasText(patch.name)) {
+        const { data: dup } = await postgrestClient
+          .from('brands')
+          .select('id')
+          .eq('organization_id', organizationId)
+          .eq('name', patch.name)
+          .maybeSingle();
+        if (dup?.id) {
+          err.existingBrandId = dup.id;
+        }
+      }
       throw err;
     }
     throw new Error(`Failed to update brand: ${error.message}`);

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -3641,6 +3641,57 @@ describe('Brands Controller', () => {
       });
       expect(response.status).to.equal(500);
     });
+
+    // LLMO-4656: 409 on duplicate brand name must surface the structured
+    // payload — code='duplicate_brand_name' and existing_brand_id — so DRS
+    // can auto-merge into the existing row instead of stalling at 0 prompts.
+    it('returns 409 with code and existing_brand_id when uq_brand_name_per_org fires', async () => {
+      const EXISTING_BRAND_ID = '99999999-9999-4999-8999-999999999999';
+      const singleStub = sandbox.stub();
+      const maybeSingleStub = sandbox.stub();
+      // existence pre-check (by name) — empty
+      maybeSingleStub.onFirstCall().resolves({ data: null, error: null });
+      // post-collision lookup — resolves the existing brand id
+      maybeSingleStub.onSecondCall().resolves({
+        data: { id: EXISTING_BRAND_ID }, error: null,
+      });
+      // upsert returns 23505 on uq_brand_name_per_org
+      singleStub.resolves({
+        data: null,
+        error: {
+          code: '23505',
+          message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+        },
+      });
+
+      mockDataAccess.services.postgrestClient = {
+        from: sandbox.stub().callsFake(() => ({
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          neq: sandbox.stub().returnsThis(),
+          in: sandbox.stub().returnsThis(),
+          order: sandbox.stub().returnsThis(),
+          upsert: sandbox.stub().returnsThis(),
+          delete: sandbox.stub().returnsThis(),
+          single: singleStub,
+          maybeSingle: maybeSingleStub,
+        })),
+      };
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+
+      const response = await brandsController.createBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'Dup Brand' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(409);
+      const body = await response.json();
+      expect(body.code).to.equal('duplicate_brand_name');
+      expect(body.existing_brand_id).to.equal(EXISTING_BRAND_ID);
+    });
   });
 
   describe('updateBrandForOrg', () => {
@@ -3839,6 +3890,56 @@ describe('Brands Controller', () => {
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(500);
+    });
+
+    // LLMO-4656: PATCH rename collisions must also surface the structured
+    // payload (code, existing_brand_id) so DRS can fold the duplicate.
+    it('returns 409 with code and existing_brand_id when uq_brand_name_per_org fires on rename', async () => {
+      const EXISTING_BRAND_ID = '99999999-9999-4999-8999-999999999999';
+      const maybeSingleStub = sandbox.stub();
+      // 1. resolveBrandUuid lookup — finds the brand being patched
+      maybeSingleStub.onCall(0).resolves({ data: { id: BRAND_UUID }, error: null });
+      // 2. updateBrand UPDATE — surfaces 23505
+      maybeSingleStub.onCall(1).resolves({
+        data: null,
+        error: {
+          code: '23505',
+          message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+        },
+      });
+      // 3. post-collision lookup — resolves the existing row id
+      maybeSingleStub.onCall(2).resolves({
+        data: { id: EXISTING_BRAND_ID }, error: null,
+      });
+
+      mockDataAccess.services.postgrestClient = {
+        from: sandbox.stub().callsFake(() => ({
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          neq: sandbox.stub().returnsThis(),
+          in: sandbox.stub().returnsThis(),
+          order: sandbox.stub().returnsThis(),
+          update: sandbox.stub().returnsThis(),
+          upsert: sandbox.stub().returnsThis(),
+          delete: sandbox.stub().returnsThis(),
+          ilike: sandbox.stub().returnsThis(),
+          maybeSingle: maybeSingleStub,
+        })),
+      };
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+
+      const response = await brandsController.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { name: 'CollidingName' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(409);
+      const body = await response.json();
+      expect(body.code).to.equal('duplicate_brand_name');
+      expect(body.existing_brand_id).to.equal(EXISTING_BRAND_ID);
     });
   });
 

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1951,12 +1951,21 @@ describe('LLMO Onboarding Functions', () => {
       // directly so the legacy LLMO config still gets prompts written (LLMO-4534).
       expect(mockDrsClient.createFrom().submitJob).to.not.have.been.called;
       expect(mockDrsClient.createFrom().submitPromptGenerationJob).to.have.been.calledOnce;
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob.firstCall.args[0]).to.include({
+      const drsClientStub = mockDrsClient.createFrom();
+      const v1PromptGenArgs = drsClientStub.submitPromptGenerationJob.firstCall.args[0];
+      expect(v1PromptGenArgs).to.include({
         brandName: 'Test Brand',
         siteId: 'site123',
         imsOrgId: 'ABC123@AdobeOrg',
         audience: 'Tech-savvy professionals',
       });
+      // LLMO-4129 Bug 3 / LLMO-4561: v1 onboardings must NOT pass onboarding_mode
+      // to the DRS prompt-generation job. The DRS-side `should_sync_spacecat_v2`
+      // gate keys off this metadata; setting it on a v1 org would cross-pollute
+      // the v2 customer-config store. Pin the contract.
+      expect(v1PromptGenArgs).to.not.have.property('onboarding_mode');
+      expect(v1PromptGenArgs).to.not.have.property('onboardingMode');
+      expect(v1PromptGenArgs.metadata?.onboarding_mode).to.be.undefined;
     }).timeout(10000);
 
     it('should skip DRS prompt generation in v1 mode when DRS client is not configured', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1241,6 +1241,353 @@ describe('brands-storage', () => {
         postgrestClient,
       })).to.be.rejectedWith('Failed to sync brand_aliases: insert failed');
     });
+
+    // LLMO-4656: distinguish (organization_id, name) unique violation from
+    // generic 500 so DRS / re-onboarding callers can disambiguate.
+    it('throws structured 409 when uq_brand_name_per_org is violated on upsert', async () => {
+      const postgrestClient = createTableMockClient({
+        brands: {
+          data: null,
+          error: {
+            code: '23505',
+            message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+          },
+        },
+      });
+
+      const err = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err.message).to.equal('A brand with this name already exists in this organization');
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal('duplicate_brand_name');
+    });
+
+    // LLMO-4350: emit a structured WARN per dropped URL plus an ERROR summary
+    // when ≥1 cross-org URL is silently skipped by syncBrandSites.
+    it('logs structured WARN per dropped URL and ERROR summary when sites query is empty', async () => {
+      const fullBrandRow = makeBrandRow();
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        sites: { data: [], error: null },
+        brand_sites: { data: null, error: null },
+      });
+
+      const log = { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() };
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          urls: [
+            { value: 'https://other-org-1.com' },
+            { value: 'https://other-org-2.com/path' },
+          ],
+        },
+        postgrestClient,
+        log,
+      });
+
+      expect(log.warn).to.have.been.calledTwice;
+      const warnedEvents = log.warn.getCalls().map((c) => JSON.parse(c.args[0]));
+      expect(warnedEvents.every((e) => e.event === 'brand_sites_no_matching_site')).to.be.true;
+      expect(warnedEvents.map((e) => e.url)).to.have.members([
+        'https://other-org-1.com',
+        'https://other-org-2.com',
+      ]);
+      expect(log.error).to.have.been.calledOnce;
+      const summary = JSON.parse(log.error.getCall(0).args[0]);
+      expect(summary.event).to.equal('brand_sites_cross_org_url_summary');
+      expect(summary.dropped_count).to.equal(2);
+      expect(summary.dropped_urls).to.have.length(2);
+      expect(summary.target_org_id).to.equal(ORG_ID);
+      expect(summary.brand_id).to.equal(BRAND_ID);
+    });
+
+    it('does not log cross-org events when all URLs match a site', async () => {
+      const fullBrandRow = makeBrandRow({
+        brand_sites: [{ site_id: 'site-1', paths: [], sites: { base_url: 'https://test.com' } }],
+      });
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        sites: { data: [{ id: 'site-1', base_url: 'https://test.com' }], error: null },
+        brand_sites: { data: null, error: null },
+      });
+
+      const log = { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() };
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://test.com' }] },
+        postgrestClient,
+        log,
+      });
+
+      expect(log.warn).to.not.have.been.called;
+      expect(log.error).to.not.have.been.called;
+    });
+
+    // LLMO-4621 Pattern A: when no submitted URLs match a site row but the brand
+    // has a known base site, seed a brand_sites row keyed off brands.site_id so
+    // the brand has at least one linkage. Prevents active-brand / 0-prompts.
+    it('falls back to brands.site_id when URL match is empty and baseSiteId is known', async () => {
+      const fullBrandRow = makeBrandRow({
+        site_id: 'site-fallback',
+        brand_sites: [{
+          site_id: 'site-fallback', paths: [], type: 'base', sites: { base_url: 'https://fallback.example' },
+        }],
+      });
+      const brandSitesUpsert = sinon.stub().returns({
+        then: (resolve) => resolve({ data: null, error: null }),
+      });
+      const upsertReturn = { upsert: brandSitesUpsert };
+
+      // Hand-rolled client to capture the brand_sites upsert payload.
+      const callCounts = {
+        brands: 0, sites: 0, brand_sites: 0, brand_urls: 0,
+      };
+      const responses = {
+        brands: [
+          { data: null, error: null }, // existing lookup (no row)
+          { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert
+          { data: fullBrandRow, error: null }, // getBrandById
+        ],
+        sites: [{ data: [], error: null }],
+        brand_sites: [{ data: null, error: null }],
+        brand_urls: [{ data: null, error: null }],
+      };
+
+      const fromStub = sinon.stub().callsFake((table) => {
+        if (table === 'brand_sites' && callCounts.brand_sites > 0) {
+          // Second brand_sites call is the fallback upsert — capture it.
+          callCounts.brand_sites += 1;
+          return upsertReturn;
+        }
+        const idx = Math.min(callCounts[table] || 0, (responses[table] || []).length - 1);
+        callCounts[table] = (callCounts[table] || 0) + 1;
+        return createChainableQuery((responses[table] || [{ data: null, error: null }])[idx]);
+      });
+
+      const postgrestClient = { from: fromStub };
+
+      const log = { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() };
+      const result = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          baseSiteId: 'site-fallback',
+          urls: [{ value: 'https://stale.example', type: 'base' }],
+        },
+        postgrestClient,
+        log,
+      });
+
+      // Fallback brand_sites row was upserted with site_id and type='base'.
+      expect(brandSitesUpsert).to.have.been.calledOnce;
+      const [rows, opts] = brandSitesUpsert.firstCall.args;
+      expect(rows).to.have.length(1);
+      expect(rows[0]).to.include({
+        organization_id: ORG_ID,
+        brand_id: BRAND_ID,
+        site_id: 'site-fallback',
+        type: 'base',
+      });
+      expect(rows[0].paths).to.deep.equal([]);
+      expect(opts).to.deep.equal({ onConflict: 'brand_id,site_id' });
+
+      // Info log captures the fallback event.
+      expect(log.info).to.have.been.calledOnce;
+      const fallbackEvent = JSON.parse(log.info.firstCall.args[0]);
+      expect(fallbackEvent.event).to.equal('brand_sites_fallback_to_base_site');
+      expect(fallbackEvent.brand_id).to.equal(BRAND_ID);
+      expect(fallbackEvent.site_id).to.equal('site-fallback');
+
+      expect(result).to.not.be.null;
+    });
+
+    it('throws when Pattern A fallback brand_sites upsert fails', async () => {
+      const callCounts = { brands: 0, sites: 0, brand_sites: 0 };
+      const responses = {
+        brands: [
+          { data: null, error: null }, // existing lookup
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow(), error: null },
+        ],
+        sites: [{ data: [], error: null }],
+        brand_sites: [{ data: null, error: null }], // first call: delete
+      };
+
+      const failingUpsert = sinon.stub().returns({
+        then: (resolve) => resolve({ data: null, error: { message: 'fallback upsert failed' } }),
+      });
+
+      const fromStub = sinon.stub().callsFake((table) => {
+        if (table === 'brand_sites' && callCounts.brand_sites > 0) {
+          callCounts.brand_sites += 1;
+          return { upsert: failingUpsert };
+        }
+        const idx = Math.min(callCounts[table] || 0, (responses[table] || []).length - 1);
+        callCounts[table] = (callCounts[table] || 0) + 1;
+        return createChainableQuery((responses[table] || [{ data: null, error: null }])[idx]);
+      });
+
+      const postgrestClient = { from: fromStub };
+
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          baseSiteId: 'site-fallback',
+          urls: [{ value: 'https://stale.example' }],
+        },
+        postgrestClient,
+        log: { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() },
+      })).to.be.rejectedWith('Failed to sync brand_sites: fallback upsert failed');
+    });
+
+    it('handles a null sites response from postgrest (no rows, no array)', async () => {
+      const fullBrandRow = makeBrandRow();
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        // postgrest occasionally returns data:null instead of an empty array
+        sites: { data: null, error: null },
+        brand_sites: { data: null, error: null },
+      });
+
+      const result = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://orphan.example' }] },
+        postgrestClient,
+      });
+
+      expect(result.siteIds).to.deep.equal([]);
+    });
+
+    it('keeps Pattern A fallback resilient when log serialization throws', async () => {
+      const fullBrandRow = makeBrandRow();
+      const captured = sinon.stub().returns({
+        then: (resolve) => resolve({ data: null, error: null }),
+      });
+
+      const callCounts = {
+        brands: 0, sites: 0, brand_sites: 0, brand_urls: 0,
+      };
+      const responses = {
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        sites: [{ data: [], error: null }],
+        brand_sites: [{ data: null, error: null }],
+        brand_urls: [{ data: null, error: null }],
+      };
+      const fromStub = sinon.stub().callsFake((table) => {
+        if (table === 'brand_sites' && callCounts.brand_sites > 0) {
+          callCounts.brand_sites += 1;
+          return { upsert: captured };
+        }
+        const idx = Math.min(callCounts[table] || 0, (responses[table] || []).length - 1);
+        callCounts[table] = (callCounts[table] || 0) + 1;
+        return createChainableQuery((responses[table] || [{ data: null, error: null }])[idx]);
+      });
+      const postgrestClient = { from: fromStub };
+
+      // log.info throws (simulates a misbehaving structured logger). The
+      // syncBrandSites fallback path must swallow it and still return the brand.
+      const log = {
+        warn: sinon.stub(),
+        error: sinon.stub(),
+        info: sinon.stub().throws(new Error('log explode')),
+      };
+
+      const result = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          baseSiteId: 'site-fallback',
+          urls: [{ value: 'https://stale.example' }],
+        },
+        postgrestClient,
+        log,
+      });
+
+      expect(captured).to.have.been.calledOnce;
+      expect(result).to.not.be.null;
+    });
+
+    it('logs cross-org WARN events resiliently when log.warn throws', async () => {
+      const fullBrandRow = makeBrandRow();
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        sites: { data: [], error: null },
+        brand_sites: { data: null, error: null },
+      });
+
+      // log.warn and log.error both throw — exercise both defensive catches
+      // in syncBrandSites without breaking the brand sync.
+      const log = {
+        warn: sinon.stub().throws(new Error('warn explode')),
+        error: sinon.stub().throws(new Error('error explode')),
+        info: sinon.stub(),
+      };
+
+      const result = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://other-org.com' }] },
+        postgrestClient,
+        log,
+      });
+
+      expect(result).to.not.be.null;
+    });
+
+    it('skips Pattern A fallback when neither baseSiteId nor existing.site_id is known', async () => {
+      const fullBrandRow = makeBrandRow();
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: fullBrandRow, error: null },
+        ],
+        sites: { data: [], error: null },
+        brand_sites: { data: null, error: null },
+      });
+
+      const log = { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() };
+
+      const result = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', urls: [{ value: 'https://stale.example' }] },
+        postgrestClient,
+        log,
+      });
+
+      // No fallback — info event for fallback should not fire.
+      const infoEvents = log.info.getCalls().map((c) => {
+        try {
+          return JSON.parse(c.args[0]);
+        } catch (e) {
+          return null;
+        }
+      });
+      expect(infoEvents.some((e) => e?.event === 'brand_sites_fallback_to_base_site')).to.be.false;
+      expect(result).to.not.be.null;
+    });
   });
 
   describe('updateBrand', () => {
@@ -1573,6 +1920,67 @@ describe('brands-storage', () => {
       expect(result.brandAliases).to.deep.equal([]);
       expect(result.competitors).to.deep.equal([]);
       expect(result.urls).to.deep.equal([]);
+    });
+
+    // LLMO-4621 Pattern A: when an update both sets baseSiteId and submits URLs
+    // that resolve to the matching site, the patch path must skip the extra
+    // brands lookup (we already know the new site_id from updates.baseSiteId).
+    it('uses updates.baseSiteId as the syncBrandSites fallback hint when both are present', async () => {
+      const fullBrandRow = makeBrandRow({
+        site_id: 'site-explicit',
+        brand_sites: [{ site_id: 'site-explicit', paths: [], sites: { base_url: 'https://explicit.example' } }],
+      });
+      const postgrestClient = createTableMockClient({
+        brands: [
+          // 1st: select current site_id (null → allow setting)
+          { data: { site_id: null }, error: null },
+          // 2nd: update succeeds
+          { data: { id: BRAND_ID }, error: null },
+          // 3rd: getBrandById re-fetch
+          { data: fullBrandRow, error: null },
+        ],
+        sites: { data: [{ id: 'site-explicit', base_url: 'https://explicit.example' }], error: null },
+        brand_sites: { data: null, error: null },
+        brand_urls: { data: null, error: null },
+      });
+
+      const result = await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: {
+          baseSiteId: 'site-explicit',
+          urls: [{ value: 'https://explicit.example', type: 'base' }],
+        },
+        postgrestClient,
+      });
+
+      expect(result).to.not.be.null;
+      expect(result.baseSiteId).to.equal('site-explicit');
+    });
+
+    // LLMO-4656: rename collisions on (organization_id, name) surface as 23505
+    // and must turn into a structured 409, not a generic 500.
+    it('throws structured 409 when uq_brand_name_per_org is violated on update', async () => {
+      const postgrestClient = createTableMockClient({
+        brands: {
+          data: null,
+          error: {
+            code: '23505',
+            message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+          },
+        },
+      });
+
+      const err = await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { name: 'AnotherBrandsName' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err.message).to.equal('A brand with this name already exists in this organization');
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal('duplicate_brand_name');
     });
   });
 

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1243,16 +1243,25 @@ describe('brands-storage', () => {
     });
 
     // LLMO-4656: distinguish (organization_id, name) unique violation from
-    // generic 500 so DRS / re-onboarding callers can disambiguate.
-    it('throws structured 409 when uq_brand_name_per_org is violated on upsert', async () => {
+    // generic 500 so DRS / re-onboarding callers can disambiguate, and
+    // surface `existingBrandId` so they can auto-merge into the existing row.
+    it('throws structured 409 with existingBrandId when uq_brand_name_per_org is violated on upsert', async () => {
+      const EXISTING_BRAND_ID = '99999999-9999-4999-8999-999999999999';
       const postgrestClient = createTableMockClient({
-        brands: {
-          data: null,
-          error: {
-            code: '23505',
-            message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+        brands: [
+          // 1. existence check (by name) — pre-collision lookup miss
+          { data: null, error: null },
+          // 2. upsert — fires the constraint violation
+          {
+            data: null,
+            error: {
+              code: '23505',
+              message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+            },
           },
-        },
+          // 3. post-collision lookup — resolves the existing row's id
+          { data: { id: EXISTING_BRAND_ID }, error: null },
+        ],
       });
 
       const err = await upsertBrand({
@@ -1264,6 +1273,36 @@ describe('brands-storage', () => {
       expect(err.message).to.equal('A brand with this name already exists in this organization');
       expect(err.status).to.equal(409);
       expect(err.code).to.equal('duplicate_brand_name');
+      expect(err.existingBrandId).to.equal(EXISTING_BRAND_ID);
+    });
+
+    // Defensive: 23505 fires but the post-collision lookup can't find the
+    // duplicate row (race with hard-delete). The 409 still throws cleanly,
+    // just without an existingBrandId field.
+    it('throws structured 409 without existingBrandId when post-collision lookup is empty', async () => {
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: null, error: null },
+          {
+            data: null,
+            error: {
+              code: '23505',
+              message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+            },
+          },
+          { data: null, error: null },
+        ],
+      });
+
+      const err = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal('duplicate_brand_name');
+      expect(err.existingBrandId).to.be.undefined;
     });
 
     // LLMO-4350: emit a structured WARN per dropped URL plus an ERROR summary
@@ -1959,16 +1998,23 @@ describe('brands-storage', () => {
     });
 
     // LLMO-4656: rename collisions on (organization_id, name) surface as 23505
-    // and must turn into a structured 409, not a generic 500.
-    it('throws structured 409 when uq_brand_name_per_org is violated on update', async () => {
+    // and must turn into a structured 409, not a generic 500. Surface
+    // `existingBrandId` so DRS can auto-merge into the conflicting row.
+    it('throws structured 409 with existingBrandId when uq_brand_name_per_org is violated on update', async () => {
+      const EXISTING_BRAND_ID = '99999999-9999-4999-8999-999999999999';
       const postgrestClient = createTableMockClient({
-        brands: {
-          data: null,
-          error: {
-            code: '23505',
-            message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+        brands: [
+          // 1. update — fires the constraint violation
+          {
+            data: null,
+            error: {
+              code: '23505',
+              message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"',
+            },
           },
-        },
+          // 2. post-collision lookup — resolves the existing row's id by new name
+          { data: { id: EXISTING_BRAND_ID }, error: null },
+        ],
       });
 
       const err = await updateBrand({
@@ -1981,6 +2027,7 @@ describe('brands-storage', () => {
       expect(err.message).to.equal('A brand with this name already exists in this organization');
       expect(err.status).to.equal(409);
       expect(err.code).to.equal('duplicate_brand_name');
+      expect(err.existingBrandId).to.equal(EXISTING_BRAND_ID);
     });
   });
 


### PR DESCRIPTION
## Summary

PR-1 of the prompt-generation forward-fix program. Closes the silent-skip and ambiguous-error failure modes that strand brands without prompts on fresh / re-onboarding flows.

Plan: `mysticat-architecture/platform/ops/prompt-generation-forward-fix.md` (PR-1: SpaceCat onboarding hardening).

### Tickets
- **LLMO-4656** — distinguish `(organization_id, name)` unique violation from generic 500. `upsertBrand` and `updateBrand` now throw a structured **HTTP 409** `{ code: 'duplicate_brand_name', existing_brand_id: '<uuid>' }` when Postgres returns 23505 + `uq_brand_name_per_org`. DRS and re-onboarding callers can disambiguate from a transient and auto-merge into the existing brand without an extra round-trip. `existing_brand_id` is best-effort — omitted on the concurrent-hard-delete race where the duplicate row vanishes between the constraint hit and the lookup.
- **LLMO-4350** — cross-org brand URLs are no longer silently dropped. `syncBrandSites` now logs a structured WARN per dropped URL (`event=brand_sites_no_matching_site`) plus a single ERROR summary (`event=brand_sites_cross_org_url_summary`, `dropped_count`, `dropped_urls[≤5]`) when ≥1 URL is dropped. `log` is threaded through `upsertBrand` / `updateBrand`, the v2 onboarding callsite, and the brands controller.
- **LLMO-4621 Pattern A** — brand creation no longer leaves an active brand row with zero `brand_sites` linkage. When none of the submitted URLs match a site row in the org but the brand's `site_id` is known, `syncBrandSites` seeds a fallback `brand_sites` row keyed off `brands.site_id` (`paths=[]`, `type='base'`). Threaded as `opts.fallbackSiteId` from `upsertBrand` / `updateBrand`.
- **LLMO-4129 Bug 3 / LLMO-4561** — pinned the v1-mode contract: `performLlmoOnboarding` in v1 mode does NOT pass `onboarding_mode` to the DRS prompt-generation job. Added explicit assertions in the existing v1 onboarding test so it can't regress (the DRS-side `should_sync_spacecat_v2` gate keys off this metadata; setting it would cross-pollute the v2 customer-config store).

### Scope correction (verified before edits)
The plan claimed `type:'url'` lines at 218/278/1366 of `src/controllers/llmo/llmo-onboarding.js`. Those are already fixed on `origin/main` as `type:'base'` at lines 169/229/1343 (LLMO-4294, commit `ed5363d1`). This PR does not re-touch them.

### Files
- `src/support/brands-storage.js` — `syncBrandSites` (cross-org WARN/ERROR + Pattern A fallback), `upsertBrand` / `updateBrand` (23505 branch, log + fallback threading)
- `src/controllers/brands.js` — pass `log` to `upsertBrand` / `updateBrand`
- `src/controllers/llmo/llmo-onboarding.js` — pass `log` to `upsertBrand` (v2 brand seed)
- `test/support/brands-storage.test.js` — 11 new unit tests (was 79, now 90)
- `test/controllers/llmo/llmo-onboarding.test.js` — explicit `onboarding_mode`-not-set assertion on v1 path

## Validation
- Full suite: **8757 passing**, 100% line / branch / statement coverage.
- Lint: clean.
- Validation gate per plan §3 (post-deploy, 24 h CloudWatch on `/aws/lambda/drs-v2-prod-ProcessJobFunction`):
  ```
  fields @timestamp, @message
  | filter @message like /brand_sites_type_check/
  | stats count(*) as n
  ```
  Must return `n = 0`. New `brand_sites_no_matching_site` events should appear only when expected (multi-tenant URL configured).

## Test plan
- [x] `npx mocha --spec=test/support/brands-storage.test.js` — 90 passing
- [x] `npx mocha --spec=test/controllers/llmo/llmo-onboarding.test.js` — 97 passing
- [x] `npm test` — 8757 passing, 100% coverage
- [x] `npx eslint` — clean on changed files
- [ ] Post-deploy: 24 h CloudWatch query above returns `n=0`
- [ ] Post-deploy: structured WARN `brand_sites_no_matching_site` is observable when triggered (cross-org test)
- [ ] Post-deploy: 23505 + `uq_brand_name_per_org` collision returns 409 with `code=duplicate_brand_name` and `existing_brand_id` set to the conflicting brand UUID (re-onboarding scenario)

## Coordination
- Independent of **PR-2** (`adobe-rnd/llmo-data-retrieval-service` `fix/drs-v2-sync-forward-fix`). Either order is safe; PR-1 first if forced.
- The new `event=` keys (`brand_sites_no_matching_site`, `brand_sites_cross_org_url_summary`, `brand_sites_fallback_to_base_site`) feed alert C6 from the hardening doc — implemented separately in the alert workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
