### PR TITLE
fix: Update docker-compose.yml

### DIFF
--- a/test/it/postgres/docker-compose.yml
+++ b/test/it/postgres/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   data-service:
-    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v1.67.8
+    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.1.1
     container_name: spacecat-it-data-service
     depends_on:
       db:

--- a/test/it/postgres/harness.js
+++ b/test/it/postgres/harness.js
@@ -29,8 +29,17 @@ import { startPostgres, stopPostgres } from './setup.js';
 /** Shared state populated during beforeAll, consumed by test files. */
 export const ctx = {};
 
+// Extended timeout for the harness hooks: docker compose pull + container startup
+// + dbmate migrations + PostgREST readiness can routinely exceed mocha's default
+// 2s hook timeout (and the prior 30s ceiling that caused IT failures on heavier
+// data-service image versions). 180s gives enough headroom on cold CI runs without
+// masking real bugs.
+const HARNESS_HOOK_TIMEOUT_MS = 180_000;
+
 export const mochaHooks = {
   async beforeAll() {
+    this.timeout(HARNESS_HOOK_TIMEOUT_MS);
+
     const { publicKeyB64 } = await initAuth();
     const tokens = await createAllTokens();
 
@@ -45,6 +54,7 @@ export const mochaHooks = {
   },
 
   async afterAll() {
+    this.timeout(HARNESS_HOOK_TIMEOUT_MS);
     await stopServer();
     await stopPostgres();
   },


### PR DESCRIPTION

## Summary

Fixes the IT CI pipeline that was broken by the unavailable `mysticat-data-service:v1.67.8` image and a too-short mocha hook timeout for v5.x images.

## Changes

- **`test/it/postgres/docker-compose.yml`** — bumped `mysticat-data-service` image to the latest version available in our ECR account.
- **`test/it/postgres/harness.js`** — extended the `beforeAll` / `afterAll` mocha hook timeouts from the default 30s to 180s. The v5.x image runs `dbmate -d db/migrations up && exec postgrest` on container start, and on cold CI runs the cumulative time (image pull + db readiness + migrations + PostgREST start + dev server start) routinely exceeded the 30s ceiling, producing:

  ```
  Error: Timeout of 30000ms exceeded. For async tests and hooks,
  ensure "done()" is called; if returning a Promise, ensure it resolves.
    (in beforeAll)
  ```

  180s gives enough headroom on cold CI runs without masking real bugs — individual test cases keep their own (lower) timeouts. Both hooks get the bump to keep startup and teardown symmetric.

## Why this was blocking everyone

- `v1.67.8` was removed from ECR (manifest unknown), failing every PR that hadn't bumped the image.
- The naive bump to a current image surfaced a latent timeout issue in the harness — the `setup.js` polling logic already had a 60s budget, but mocha's hook timeout was capping it at 30s.

## Test plan

- [x] CI it-postgres job passes on this branch
- [ ] Re-run CI on a few in-flight PRs that were blocked by the same failure to confirm the fix unblocks them