### PR TITLE
fix: adds rbac to brandalf endpoints

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -394,8 +394,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -448,8 +448,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -505,8 +505,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -567,8 +567,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -740,8 +740,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -807,8 +807,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -862,8 +862,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -951,8 +951,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -1004,8 +1004,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -1052,8 +1052,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -1105,8 +1105,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -1150,8 +1150,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -1206,8 +1206,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       const unavailable = requirePostgrestForV2Config(context);
@@ -1251,8 +1251,8 @@ function BrandsController(ctx, log, env) {
       if (organization.status) {
         return organization;
       }
-      if (!await accessControlUtil.hasAccess(organization)) {
-        return forbidden('User does not have access to this organization');
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only admins can perform this operation');
       }
 
       if (!hasText(siteId) || !isValidUUID(siteId)) {


### PR DESCRIPTION
## Summary

Enforces admin-only access control on all Brandalf write operations. Previously, any org member could create, update, or delete brands, categories, topics, and prompts. After this change, only admins (full JWT admins, API key auth, S2S) can perform those operations — non-admin org members are restricted to read-only access.

Read (GET) endpoints are unchanged.

## Affected endpoints

| Method | Path | Change |
|--------|------|--------|
| `POST` | `/v2/orgs/:spaceCatId/brands` | admin-only |
| `PATCH` | `/v2/orgs/:spaceCatId/brands/:brandId` | admin-only |
| `DELETE` | `/v2/orgs/:spaceCatId/brands/:brandId` | admin-only |
| `POST` | `/v2/orgs/:spaceCatId/categories` | admin-only |
| `PATCH` | `/v2/orgs/:spaceCatId/categories/:categoryId` | admin-only |
| `DELETE` | `/v2/orgs/:spaceCatId/categories/:categoryId` | admin-only |
| `POST` | `/v2/orgs/:spaceCatId/topics` | admin-only |
| `PATCH` | `/v2/orgs/:spaceCatId/topics/:topicId` | admin-only |
| `DELETE` | `/v2/orgs/:spaceCatId/topics/:topicId` | admin-only |
| `POST` | `/v2/orgs/:spaceCatId/brands/:brandId/prompts` | admin-only |
| `PATCH` | `/v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId` | admin-only |
| `DELETE` | `/v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId` | admin-only |
| `POST` | `/v2/orgs/:spaceCatId/brands/:brandId/prompts/delete` | admin-only |
| `POST` | `/v2/orgs/:spaceCatId/sites/:siteId/sync-config` | admin-only |

## Implementation

Each write operation now calls `accessControlUtil.hasAdminAccess()` instead of `accessControlUtil.hasAccess(organization)`. Non-admin users receive a `403 Forbidden` response with the message `"Only admins can perform this operation"`.

## Related Issues

Fixes [LLMO-4279](https://jira.corp.adobe.com/browse/LLMO-4279)

## Test plan

- [x] All 231 existing `brands.test.js` tests pass — existing 403 paths (non-admin) and success paths (admin) both covered
- [x] Full unit test suite: 8399 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)