### PR TITLE
fix: ensure the region gets populated while site creation

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -35,6 +35,7 @@ import {
 import { upsertFeatureFlag } from '../../support/feature-flags-storage.js';
 import { detectCdnForDomain } from '../../support/cdn-detection.js';
 import { upsertBrand } from '../../support/brands-storage.js';
+import { ensureSiteLocale } from '../../support/locale.js';
 
 // LLMO Constants
 const LLMO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.LLMO;
@@ -957,7 +958,7 @@ export async function determineOverrideBaseURL(baseURL, context) {
  * @returns {Promise<object>} The site object
  */
 export async function createOrFindSite(baseURL, organizationId, context, deliveryType) {
-  const { dataAccess } = context;
+  const { dataAccess, log } = context;
   const { Site } = dataAccess;
 
   const site = await Site.findByBaseURL(baseURL);
@@ -981,6 +982,7 @@ export async function createOrFindSite(baseURL, organizationId, context, deliver
   }
 
   const newSite = await Site.create(siteData);
+  await ensureSiteLocale(newSite, baseURL, log);
   return newSite;
 }
 

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -49,6 +49,7 @@ import {
 } from '../../support/edge-routing-utils.js';
 import { triggerBrandProfileAgent } from '../../support/brand-profile-trigger.js';
 import { getImsTokenFromPromiseToken, authorizeEdgeCdnRouting } from '../../support/edge-routing-auth.js';
+import { ensureSiteLocale } from '../../support/locale.js';
 import {
   applyFilters,
   applyInclusions,
@@ -1832,6 +1833,7 @@ function LlmoController(ctx) {
             baseURL: stageBaseURL,
             organizationId,
           });
+          await ensureSiteLocale(stageSite, stageBaseURL, log);
         }
 
         let metaconfig = await tokowakaClient.fetchMetaconfig(stageBaseURL);

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -48,6 +48,7 @@ import AccessControlUtil from '../support/access-control-util.js';
 import { CAP_SITE_READ_ALL } from '../routes/capability-constants.js';
 import { auditTargetURLsPatchGuard } from '../support/audit-target-urls-validation.js';
 import { triggerBrandProfileAgent } from '../support/brand-profile-trigger.js';
+import { ensureSiteLocale } from '../support/locale.js';
 
 /**
  * Sites controller. Provides methods to create, read, update and delete sites.
@@ -308,6 +309,7 @@ function SitesController(ctx, log, env) {
         ...context.data,
         baseURL, // override with normalized value
       });
+      await ensureSiteLocale(site, baseURL, log);
       return createResponse(SiteDto.toJSON(site), 201);
     } catch (error) {
       log.error(`Error creating site: ${error.message}`, error);

--- a/src/support/locale.js
+++ b/src/support/locale.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { detectLocale, hasText } from '@adobe/spacecat-shared-utils';
+
+/**
+ * Best-effort locale population for a freshly-created Site.
+ *
+ * Calls `detectLocale` (live HTTP fetch + indicator analysis) and sets
+ * language and/or region on the site only when both:
+ *   1. the field is currently empty, AND
+ *   2. detection returned a non-empty value.
+ *
+ * If anything is set, the change is persisted via `site.save()`. On any
+ * failure (network error, invalid baseURL, unreachable site, save failure)
+ * the error is logged and swallowed — locale enrichment is best-effort and
+ * must not fail the surrounding site-creation flow.
+ *
+ * Why no `'US' / 'en'` fallback like some legacy onboarding paths use:
+ * defaulting to a hard-coded country/language makes the data appear
+ * classified when in reality detection failed, masking the gap and
+ * producing misleading regional metrics. Empty is honest; a downstream
+ * backfill or manual PATCH can fill genuinely-unknown values later.
+ *
+ * Idempotent: returns immediately if both language and region are already
+ * set, or if the site object does not expose locale getters/setters.
+ *
+ * @param {object} site - Site model instance with getters/setters for language/region
+ * @param {string} baseUrl - Site base URL to probe for locale indicators
+ * @param {{ debug?: Function, warn?: Function }} [log] - Logger; only `debug` is read
+ * @returns {Promise<boolean>} `true` if the site was modified and saved, otherwise `false`
+ */
+export async function ensureSiteLocale(site, baseUrl, log) {
+  if (!site
+    || typeof site.getLanguage !== 'function'
+    || typeof site.getRegion !== 'function'
+    || typeof site.setLanguage !== 'function'
+    || typeof site.setRegion !== 'function') {
+    return false;
+  }
+
+  if (hasText(site.getLanguage()) && hasText(site.getRegion())) {
+    return false;
+  }
+
+  if (!hasText(baseUrl)) {
+    return false;
+  }
+
+  let locale;
+  try {
+    locale = await detectLocale({ baseUrl });
+  } catch (error) {
+    log?.debug?.(`Locale detection skipped for ${baseUrl}: ${error.message}`);
+    return false;
+  }
+
+  let changed = false;
+  if (!hasText(site.getLanguage()) && hasText(locale?.language)) {
+    site.setLanguage(locale.language);
+    changed = true;
+  }
+  if (!hasText(site.getRegion()) && hasText(locale?.region)) {
+    site.setRegion(locale.region);
+    changed = true;
+  }
+
+  if (!changed) {
+    return false;
+  }
+
+  try {
+    await site.save();
+    return true;
+  } catch (error) {
+    log?.warn?.(`Failed to persist detected locale for ${baseUrl}: ${error.message}`);
+    return false;
+  }
+}

--- a/src/support/slack/actions/approve-site-candidate.js
+++ b/src/support/slack/actions/approve-site-candidate.js
@@ -21,6 +21,7 @@ import { BUTTON_LABELS } from '../../../controllers/hooks.js';
 import { composeReply, extractURLFromSlackMessage } from './commons.js';
 import { getHlxConfigMessagePart } from '../../../utils/slack/base.js';
 import OrgDetectorAgent from '../../../agents/org-detector/agent.js';
+import { ensureSiteLocale } from '../../locale.js';
 
 async function announceSiteDiscovery(context, baseURL, source, hlxConfig) {
   const { SLACK_REPORT_CHANNEL_INTERNAL: channel } = context.env;
@@ -69,6 +70,7 @@ export default function approveSiteCandidate(lambdaContext) {
             ? { organizationId: friendsFamilyOrgId }
             : { organizationId: defaultOrgId }),
         });
+        await ensureSiteLocale(site, siteCandidate.getBaseURL(), log);
       } else {
         // site might've been added before manually. In that case, make sure it is promoted to live
         // and set delivery type to aem_edge then update

--- a/src/support/slack/commands/add-site.js
+++ b/src/support/slack/commands/add-site.js
@@ -17,6 +17,7 @@ import {
 } from '../../../utils/slack/base.js';
 
 import { findDeliveryType } from '../../utils.js';
+import { ensureSiteLocale } from '../../locale.js';
 
 import BaseCommand from './base.js';
 
@@ -91,6 +92,8 @@ function AddSiteCommand(context) {
         await say(':x: Problem adding the site. Please contact the admins.');
         return;
       }
+
+      await ensureSiteLocale(newSite, baseURL, log);
 
       let message = `:white_check_mark: *Successfully added new site <${baseURL}|${baseURL}>*.\n`;
       message += `:delivrer: *Delivery type:* ${deliveryType}.\n`;

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -24,7 +24,6 @@ import nock from 'nock';
 import sinonChai from 'sinon-chai';
 import sinon, { stub } from 'sinon';
 
-import SitesController from '../../src/controllers/sites.js';
 import AccessControlUtil from '../../src/support/access-control-util.js';
 
 use(chaiAsPromised);
@@ -143,10 +142,16 @@ describe('Sites Controller', () => {
 
   let mockDataAccess;
   let sitesController;
+  let SitesController;
+  let ensureSiteLocaleStub;
   let context;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     sites = buildSites();
+    ensureSiteLocaleStub = sandbox.stub().resolves();
+    ({ default: SitesController } = await esmock('../../src/controllers/sites.js', {
+      '../../src/support/locale.js': { ensureSiteLocale: ensureSiteLocaleStub },
+    }));
 
     mockDataAccess = {
       Audit: {
@@ -254,11 +259,23 @@ describe('Sites Controller', () => {
 
     expect(mockDataAccess.Site.findByBaseURL).to.have.been.calledOnceWith('https://site1.com');
     expect(mockDataAccess.Site.create).to.have.been.calledOnce;
+    expect(ensureSiteLocaleStub).to.have.been.calledOnce;
+    expect(ensureSiteLocaleStub.firstCall.args[1]).to.equal('https://site1.com');
     expect(response.status).to.equal(201);
 
     const site = await response.json();
     expect(site).to.have.property('id', SITE_IDS[0]);
     expect(site).to.have.property('baseURL', 'https://site1.com');
+  });
+
+  it('invokes ensureSiteLocale with the freshly-created site and normalized baseURL', async () => {
+    mockDataAccess.Site.findByBaseURL.resolves(null);
+    const response = await sitesController.createSite({ data: { baseURL: 'https://WWW.site1.com/' } });
+
+    expect(ensureSiteLocaleStub).to.have.been.calledOnce;
+    expect(ensureSiteLocaleStub.firstCall.args[0]).to.equal(sites[0]);
+    expect(ensureSiteLocaleStub.firstCall.args[1]).to.equal('https://site1.com');
+    expect(response.status).to.equal(201);
   });
 
   it('creates a site for a non-admin user', async () => {

--- a/test/support/locale.test.js
+++ b/test/support/locale.test.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+const BASE_URL = 'https://example.com';
+
+function createMockSite({ language = '', region = '' } = {}) {
+  let currentLanguage = language;
+  let currentRegion = region;
+  return {
+    getLanguage: () => currentLanguage,
+    getRegion: () => currentRegion,
+    setLanguage: sinon.stub().callsFake((value) => { currentLanguage = value; }),
+    setRegion: sinon.stub().callsFake((value) => { currentRegion = value; }),
+    save: sinon.stub().resolves(),
+  };
+}
+
+function createMockLog() {
+  return { debug: sinon.stub(), warn: sinon.stub() };
+}
+
+describe('support/locale.js — ensureSiteLocale', () => {
+  let sandbox;
+  let detectLocaleStub;
+  let ensureSiteLocale;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    detectLocaleStub = sandbox.stub();
+
+    ({ ensureSiteLocale } = await esmock('../../src/support/locale.js', {
+      '@adobe/spacecat-shared-utils': {
+        detectLocale: detectLocaleStub,
+        hasText: (v) => typeof v === 'string' && v.trim().length > 0,
+      },
+    }));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns false when site is null', async () => {
+    const result = await ensureSiteLocale(null, BASE_URL, createMockLog());
+    expect(result).to.equal(false);
+    expect(detectLocaleStub).to.not.have.been.called;
+  });
+
+  it('returns false when site lacks getLanguage', async () => {
+    const site = { getRegion: () => '', setLanguage: () => {}, setRegion: () => {} };
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+    expect(result).to.equal(false);
+    expect(detectLocaleStub).to.not.have.been.called;
+  });
+
+  it('returns false when site lacks getRegion', async () => {
+    const site = { getLanguage: () => '', setLanguage: () => {}, setRegion: () => {} };
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+    expect(result).to.equal(false);
+  });
+
+  it('returns false when site lacks setLanguage', async () => {
+    const site = { getLanguage: () => '', getRegion: () => '', setRegion: () => {} };
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+    expect(result).to.equal(false);
+  });
+
+  it('returns false when site lacks setRegion', async () => {
+    const site = { getLanguage: () => '', getRegion: () => '', setLanguage: () => {} };
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+    expect(result).to.equal(false);
+  });
+
+  it('is a no-op when both language and region are already set', async () => {
+    const site = createMockSite({ language: 'fr', region: 'FR' });
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+
+    expect(result).to.equal(false);
+    expect(detectLocaleStub).to.not.have.been.called;
+    expect(site.setLanguage).to.not.have.been.called;
+    expect(site.setRegion).to.not.have.been.called;
+    expect(site.save).to.not.have.been.called;
+  });
+
+  it('is a no-op when baseUrl is missing', async () => {
+    const site = createMockSite();
+    const result = await ensureSiteLocale(site, '', createMockLog());
+
+    expect(result).to.equal(false);
+    expect(detectLocaleStub).to.not.have.been.called;
+    expect(site.save).to.not.have.been.called;
+  });
+
+  it('is a no-op when baseUrl is undefined', async () => {
+    const site = createMockSite();
+    const result = await ensureSiteLocale(site, undefined, createMockLog());
+
+    expect(result).to.equal(false);
+    expect(detectLocaleStub).to.not.have.been.called;
+  });
+
+  it('sets both language and region when site is empty and detection succeeds, then saves', async () => {
+    const site = createMockSite();
+    const log = createMockLog();
+    detectLocaleStub.resolves({ language: 'de', region: 'DE' });
+
+    const result = await ensureSiteLocale(site, BASE_URL, log);
+
+    expect(result).to.equal(true);
+    expect(detectLocaleStub).to.have.been.calledOnceWithExactly({ baseUrl: BASE_URL });
+    expect(site.setLanguage).to.have.been.calledOnceWithExactly('de');
+    expect(site.setRegion).to.have.been.calledOnceWithExactly('DE');
+    expect(site.save).to.have.been.calledOnce;
+  });
+
+  it('sets only region when language is already set, then saves', async () => {
+    const site = createMockSite({ language: 'en' });
+    detectLocaleStub.resolves({ language: 'de', region: 'DE' });
+
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+
+    expect(result).to.equal(true);
+    expect(site.setLanguage).to.not.have.been.called;
+    expect(site.setRegion).to.have.been.calledOnceWithExactly('DE');
+    expect(site.save).to.have.been.calledOnce;
+  });
+
+  it('sets only language when region is already set, then saves', async () => {
+    const site = createMockSite({ region: 'US' });
+    detectLocaleStub.resolves({ language: 'fr', region: 'FR' });
+
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+
+    expect(result).to.equal(true);
+    expect(site.setLanguage).to.have.been.calledOnceWithExactly('fr');
+    expect(site.setRegion).to.not.have.been.called;
+    expect(site.save).to.have.been.calledOnce;
+  });
+
+  it('leaves site untouched when detectLocale throws', async () => {
+    const site = createMockSite();
+    const log = createMockLog();
+    detectLocaleStub.rejects(new Error('Invalid baseUrl'));
+
+    const result = await ensureSiteLocale(site, BASE_URL, log);
+
+    expect(result).to.equal(false);
+    expect(site.setLanguage).to.not.have.been.called;
+    expect(site.setRegion).to.not.have.been.called;
+    expect(site.save).to.not.have.been.called;
+    expect(log.debug).to.have.been.calledOnce;
+    expect(log.debug.firstCall.args[0]).to.include('Invalid baseUrl');
+  });
+
+  it('does not throw when log.debug is missing on the logger', async () => {
+    const site = createMockSite();
+    detectLocaleStub.rejects(new Error('boom'));
+
+    const result = await ensureSiteLocale(site, BASE_URL, {});
+
+    expect(result).to.equal(false);
+    expect(site.save).to.not.have.been.called;
+  });
+
+  it('does not throw when log itself is missing', async () => {
+    const site = createMockSite();
+    detectLocaleStub.rejects(new Error('boom'));
+
+    const result = await ensureSiteLocale(site, BASE_URL);
+
+    expect(result).to.equal(false);
+    expect(site.save).to.not.have.been.called;
+  });
+
+  it('does not save when detection returns empty values', async () => {
+    const site = createMockSite();
+    detectLocaleStub.resolves({ language: '', region: '' });
+
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+
+    expect(result).to.equal(false);
+    expect(site.setLanguage).to.not.have.been.called;
+    expect(site.setRegion).to.not.have.been.called;
+    expect(site.save).to.not.have.been.called;
+  });
+
+  it('does not save when detection returns null', async () => {
+    const site = createMockSite();
+    detectLocaleStub.resolves(null);
+
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+
+    expect(result).to.equal(false);
+    expect(site.save).to.not.have.been.called;
+  });
+
+  it('sets only the field that detection returns when the other is missing, then saves', async () => {
+    const site = createMockSite();
+    detectLocaleStub.resolves({ region: 'JP' });
+
+    const result = await ensureSiteLocale(site, BASE_URL, createMockLog());
+
+    expect(result).to.equal(true);
+    expect(site.setLanguage).to.not.have.been.called;
+    expect(site.setRegion).to.have.been.calledOnceWithExactly('JP');
+    expect(site.save).to.have.been.calledOnce;
+  });
+
+  it('returns false and logs a warning when site.save fails', async () => {
+    const site = createMockSite();
+    site.save = sinon.stub().rejects(new Error('db down'));
+    const log = createMockLog();
+    detectLocaleStub.resolves({ language: 'es', region: 'ES' });
+
+    const result = await ensureSiteLocale(site, BASE_URL, log);
+
+    expect(result).to.equal(false);
+    expect(site.setLanguage).to.have.been.calledOnceWithExactly('es');
+    expect(site.setRegion).to.have.been.calledOnceWithExactly('ES');
+    expect(site.save).to.have.been.calledOnce;
+    expect(log.warn).to.have.been.calledOnce;
+    expect(log.warn.firstCall.args[0]).to.include('db down');
+  });
+
+  it('does not throw when log.warn is missing during save failure', async () => {
+    const site = createMockSite();
+    site.save = sinon.stub().rejects(new Error('boom'));
+    detectLocaleStub.resolves({ language: 'es', region: 'ES' });
+
+    const result = await ensureSiteLocale(site, BASE_URL, {});
+
+    expect(result).to.equal(false);
+  });
+});

--- a/test/support/slack/actions/approve-site-candidate.test.js
+++ b/test/support/slack/actions/approve-site-candidate.test.js
@@ -16,7 +16,7 @@ import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
-import approveSiteCandidate from '../../../../src/support/slack/actions/approve-site-candidate.js';
+import esmock from 'esmock';
 import {
   expectedAnnouncedMessage,
   expectedApprovedReply,
@@ -29,6 +29,8 @@ use(sinonChai);
 
 describe('approveSiteCandidate', () => {
   const baseURL = 'https://spacecat.com';
+  let approveSiteCandidate;
+  let ensureSiteLocaleStub;
   const hlxConfig = {
     hlxVersion: 4,
     rso: {
@@ -45,7 +47,23 @@ describe('approveSiteCandidate', () => {
   let siteCandidate;
   let clock;
 
+  before(async function loadModule() {
+    this.timeout(10000);
+    ensureSiteLocaleStub = sinon.stub().resolves();
+    ({ default: approveSiteCandidate } = await esmock(
+      '../../../../src/support/slack/actions/approve-site-candidate.js',
+      {
+        '../../../../src/support/locale.js': {
+          ensureSiteLocale: (...args) => ensureSiteLocaleStub(...args),
+        },
+      },
+    ));
+  });
+
   beforeEach(async () => {
+    ensureSiteLocaleStub.resetHistory();
+    ensureSiteLocaleStub.resetBehavior();
+    ensureSiteLocaleStub.resolves();
     clock = sinon.useFakeTimers();
 
     slackClient = {
@@ -130,12 +148,26 @@ describe('approveSiteCandidate', () => {
         organizationId: 'default',
       },
     );
+    expect(ensureSiteLocaleStub).to.have.been.calledOnce;
+    expect(ensureSiteLocaleStub.firstCall.args[1]).to.equal(baseURL);
     expect(site.save.callCount).to.equal(0);
     expect(siteCandidate.setStatus).to.have.been.calledWith('APPROVED');
     expect(siteCandidate.setUpdatedBy).to.have.been.calledWith('approvers-username');
     expect(siteCandidate.save).to.have.been.calledOnce;
     expect(respondMock).to.have.been.calledWith(expectedApprovedReply);
     expect(slackClient.postMessage).to.have.been.calledWith(expectedAnnouncedMessage);
+  });
+
+  it('does not call ensureSiteLocale when site already exists', async () => {
+    context.dataAccess.SiteCandidate.findByBaseURL.withArgs(baseURL).resolves(siteCandidate);
+    site.getIsLive = () => false;
+    context.dataAccess.Site.findByBaseURL.resolves(site);
+    site.save.resolves(site);
+
+    const approveFunction = approveSiteCandidate(context);
+    await approveFunction({ ack: ackMock, body: slackActionResponse, respond: respondMock });
+
+    expect(ensureSiteLocaleStub).to.not.have.been.called;
   });
 
   it('should approve site candidate as friends & family', async () => {

--- a/test/support/slack/commands/add-site.test.js
+++ b/test/support/slack/commands/add-site.test.js
@@ -14,8 +14,7 @@ import { use, expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import nock from 'nock';
-
-import AddSiteCommand from '../../../../src/support/slack/commands/add-site.js';
+import esmock from 'esmock';
 
 use(sinonChai);
 
@@ -26,8 +25,26 @@ describe('AddSiteCommand', () => {
   let slackContext;
   let dataAccessStub;
   let sqsStub;
+  let AddSiteCommand;
+  let ensureSiteLocaleStub;
+
+  before(async function loadModule() {
+    this.timeout(10000);
+    ensureSiteLocaleStub = sinon.stub().resolves();
+    ({ default: AddSiteCommand } = await esmock(
+      '../../../../src/support/slack/commands/add-site.js',
+      {
+        '../../../../src/support/locale.js': {
+          ensureSiteLocale: (...args) => ensureSiteLocaleStub(...args),
+        },
+      },
+    ));
+  });
 
   beforeEach(() => {
+    ensureSiteLocaleStub.resetHistory();
+    ensureSiteLocaleStub.resetBehavior();
+    ensureSiteLocaleStub.resolves();
     const configuration = {
       isHandlerEnabledForSite: sinon.stub(),
     };
@@ -100,9 +117,20 @@ describe('AddSiteCommand', () => {
       expect(dataAccessStub.Site.create).to.have.been.calledWith({
         baseURL: 'https://example.com', deliveryType: 'other', isLive: false, organizationId: 'default',
       });
+      expect(ensureSiteLocaleStub).to.have.been.calledOnce;
+      expect(ensureSiteLocaleStub.firstCall.args[1]).to.equal(baseURL);
       expect(slackContext.say.calledWith(sinon.match.string)).to.be.true;
       expect(slackContext.client.chat.postMessage.calledOnce).to.be.true;
       expect(slackContext.client.chat.update.calledOnce).to.be.true;
+    });
+
+    it('does not call ensureSiteLocale when site is already added', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves({});
+
+      const command = AddSiteCommand(context);
+      await command.handleExecution(['example.com'], slackContext);
+
+      expect(ensureSiteLocaleStub).to.not.have.been.called;
     });
 
     it('warns when an invalid site base URL is provided', async () => {


### PR DESCRIPTION

## Problem

The Tokowaka dashboard recently started rendering a `Region` column for each
monitored site (project-elmo-ui-data commit `cb98b3a`, Apr 29). The column is
populated from `Site.region` returned by `GET /sites`, but ~84% of rows are
empty: of the 7 code paths in `spacecat-api-service` that call `Site.create()`,
only 2 (`plg-onboarding.js` and the Slack `onboard` command) currently invoke
locale detection. The remaining 5 paths create sites with `region: ""` and
`language: ""` — and have done so since the `region` attribute was added in
`spacecat-shared-data-access` PR #995 (Oct 2025).

This PR plugs those 5 holes so new sites going through any creation flow get
their locale detected at creation time.

## Changes

### New helper: `src/support/locale.js`

`ensureSiteLocale(site, baseUrl, log)` is the shared glue around
`detectLocale` from `@adobe/spacecat-shared-utils`:

1. Skips if `site.getLanguage()` and `site.getRegion()` are both already set
   (idempotent — won't overwrite caller-supplied values).
2. Calls `detectLocale({ baseUrl })`.
3. Sets `site.setLanguage(...)` / `site.setRegion(...)` only for fields that
   are currently empty AND for which detection returned a non-empty value.
4. Persists with `site.save()` if anything changed.
5. Swallows all errors (network, invalid URL, save failure) — locale
   enrichment is best-effort and must not block site creation.

**Difference from the existing PLG/Slack-onboard pattern:** the catch block
does NOT fall back to writing `'US'`/`'en'`. When detection genuinely fails
(unreachable host, bot-blocked, timeout) the site is left with empty region
rather than fake-classified as US. Empty values are honest and can be filled
by a future backfill; fake values silently corrupt regional metrics.

### 5 call-sites wired

| File | Location |
|---|---|
| `src/controllers/sites.js` | `POST /sites` |
| `src/support/slack/commands/add-site.js` | Slack `add site` |
| `src/support/slack/actions/approve-site-candidate.js` | Site candidate approval |
| `src/controllers/llmo/llmo-onboarding.js` | `createOrFindSite` (used by LLMO onboarding) |
| `src/controllers/llmo/llmo.js` | `createOrUpdateStageEdgeConfig` (stage-domain creation) |

Each is a single `await ensureSiteLocale(site, baseUrl, log);` line right
after `Site.create(...)`.

### Tests

- New `test/support/locale.test.js`: 19 cases covering every branch of the
  helper at 100% coverage (verified via `c8 --include='src/support/locale.js'`).
- 5 affected call-site test files updated to esmock the helper (matching the
  repo convention used in `cdn-detection.test.js`, `plg-onboarding.test.js`,
  etc.). Each updated test asserts the helper is invoked with the freshly
  created site and the correct base URL.

## Out of scope (follow-ups)

1. **`detectLocale`'s internal `'US'`/`'en'` fallback** (in
   `spacecat-shared-utils/src/locale-detect/locale-detect.js:61-62`,
   pre-existing since PR #1006). When fetch succeeds but no indicator
   (TLD/path/hreflang/htmlLang/headers/metaTag/content) fires, `detectLocale`
   returns `{region:'US', language:'en'}`. Our helper trusts that result, so
   plain `.com` sites with no localization markup still get classified as US.
   Proper fix is to add a `{ allowFallback: false }` option upstream so callers
   can opt out — separate PR to `spacecat-shared`.
2. **Backfill of historical empty-region sites.** This PR fixes only sites
   created from now on. A one-off script that iterates `Site.all()`, calls
   `ensureSiteLocale` on each empty-region site, and saves will be a separate
   PR once we confirm the new write path works in stage.
3. **Refactor `plg-onboarding.js` and `support/utils.js`** to use the new
   helper instead of their inline duplicates of the same pattern. Deferred
   to keep this PR scoped; both already have the (problematic) `'US'`/`'en'`
   catch fallback that we'd want to remove in lockstep.

## Test plan

- [ ] Unit tests pass:
      `npx mocha --spec='test/support/locale.test.js' --spec='test/controllers/sites.test.js' --spec='test/support/slack/commands/add-site.test.js' --spec='test/support/slack/actions/approve-site-candidate.test.js' --spec='test/controllers/llmo/llmo-onboarding.test.js' --spec='test/controllers/llmo/llmo.test.js'`
      (the 14 pre-existing failures in the full repo suite — 9× detectedCdn
      Joi, 1× LlmoController before-all hook, 4× PLG timeouts — are
      unrelated to this change and reproduce on `main`)
- [ ] Stage smoke (curl `POST /sites` against stage):
      - `https://www.bmw.de` → `region: "DE"` (TLD signal)
      - `https://www.toyota.co.jp` → `region: "JP"`
      - `https://www.lemonde.fr` → `region: "FR"`
      - `https://this-host-does-not-exist-xyz.invalid` → `region: ""` (no fallback to US — this is the key behavior change)
- [ ] Stage Slack: `@spacecat add site https://www.lemonde.fr`, then
      `@spacecat get site https://www.lemonde.fr` → confirm `region: "FR"`.
- [ ] Idempotency: POSTing the same site twice doesn't re-run detection or
      modify the saved record.
- [ ] User-supplied region honored: POST `{baseURL: ..., region: "GB"}` is
      not overwritten by detection.
- [ ] Day-after verification: tomorrow's `llmo-usage-data-YYYY-MM-DD.json`
      in `project-elmo-ui-data/usage-tracking/` shows reduced empty-region
      rate for sites created in the last 24h.