### PR TITLE
fix(scrape): sanitize x-error header to prevent ERR_INVALID_CHAR on non-ASCII

### DIFF
--- a/src/controllers/scrapeJob.js
+++ b/src/controllers/scrapeJob.js
@@ -48,7 +48,7 @@ function ScrapeJobController(context) {
 
   function createErrorResponse(error) {
     return createResponse({}, error.status || 500, {
-      [HEADER_ERROR]: cleanupHeaderValue(error.message),
+      [HEADER_ERROR]: cleanupHeaderValue(error.message ?? ''),
     });
   }
 

--- a/src/controllers/scrapeJob.js
+++ b/src/controllers/scrapeJob.js
@@ -22,6 +22,7 @@ import {
   isValidUrl,
   hasText,
 } from '@adobe/spacecat-shared-utils';
+import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 
 /**
  * Scrape controller. Provides methods to create, read, and fetch the result of scrape jobs.
@@ -47,7 +48,7 @@ function ScrapeJobController(context) {
 
   function createErrorResponse(error) {
     return createResponse({}, error.status || 500, {
-      [HEADER_ERROR]: error.message,
+      [HEADER_ERROR]: cleanupHeaderValue(error.message),
     });
   }
 

--- a/src/controllers/scrapeJob.js
+++ b/src/controllers/scrapeJob.js
@@ -48,7 +48,7 @@ function ScrapeJobController(context) {
 
   function createErrorResponse(error) {
     return createResponse({}, error.status || 500, {
-      [HEADER_ERROR]: cleanupHeaderValue(error.message ?? ''),
+      [HEADER_ERROR]: cleanupHeaderValue(error.message),
     });
   }
 

--- a/test/controllers/scrape-job.test.js
+++ b/test/controllers/scrape-job.test.js
@@ -265,6 +265,17 @@ describe('ScrapeJobController tests', () => {
       expect(response.headers.get('x-error')).to.equal('Failed to create a new scrape job: Queue error');
     });
 
+    it('should sanitize non-ASCII and control chars in x-error header', async () => {
+      baseContext.sqs.sendMessage = sandbox.stub().throws(new Error('Failed: https://пример.com/page\r\nX-Injected: yes'));
+      const response = await scrapeJobController.createScrapeJob(baseContext);
+      expect(response.status).to.equal(500);
+      const xerr = response.headers.get('x-error');
+      expect(xerr).to.be.a('string');
+      expect(/[^\x20-\x7E]/.test(xerr)).to.equal(false);
+      expect(xerr).to.not.include('\r');
+      expect(xerr).to.not.include('\n');
+    });
+
     it('should start a new scrape job', async () => {
       baseContext.data.customHeaders = {
         ...exampleCustomHeaders,


### PR DESCRIPTION
## Summary

Applies `cleanupHeaderValue()` from `@adobe/helix-shared-utils` to the `x-error` header in `scrapeJob.js`'s `createErrorResponse()` function, matching the pattern already used in `slack.js` and `llmo.js`.

## Root Cause

Mystique's SEO suggestion generator passes LLM-hallucinated URLs containing non-ASCII characters (Cyrillic, Georgian script) to the scrape API. When these fail validation, the error message is placed in the `x-error` HTTP header unsanitized, causing Node.js `ERR_INVALID_CHAR` crashes. This controller was the only one missing the sanitization.

## Changes

- Import `cleanupHeaderValue` from `@adobe/helix-shared-utils`
- Wrap `error.message` with `cleanupHeaderValue()` in `createErrorResponse()`

## Jira

[SITES-43989](https://jira.corp.adobe.com/browse/SITES-43989)