### PR TITLE
feat: add URL trend endpoint for referral traffic | LLMO-4261

### DIFF
--- a/src/controllers/llmo/llmo-mysticat-controller.js
+++ b/src/controllers/llmo/llmo-mysticat-controller.js
@@ -63,6 +63,7 @@ import {
   createReferralTrafficByRegionHandler,
   createReferralTrafficByPageIntentHandler,
   createReferralTrafficByUrlHandler,
+  createReferralTrafficUrlTrendHandler,
   createReferralTrafficBusinessImpactHandler,
   createReferralTrafficWeeksHandler,
   createReferralTrafficByDeviceHandler,
@@ -218,6 +219,7 @@ function LlmoMysticatController(ctx) {
     getSiteAndValidateAccess,
   );
   const getReferralTrafficByUrl = createReferralTrafficByUrlHandler(getSiteAndValidateAccess);
+  const getReferralTrafficUrlTrend = createReferralTrafficUrlTrendHandler(getSiteAndValidateAccess);
   const getReferralTrafficBusinessImpact = createReferralTrafficBusinessImpactHandler(
     getSiteAndValidateAccess,
   );
@@ -271,6 +273,7 @@ function LlmoMysticatController(ctx) {
     getReferralTrafficByRegion,
     getReferralTrafficByPageIntent,
     getReferralTrafficByUrl,
+    getReferralTrafficUrlTrend,
     getReferralTrafficBusinessImpact,
     getReferralTrafficWeeks,
     getReferralTrafficByDevice,

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -631,11 +631,11 @@ export function createReferralTrafficWeeksHandler(getSiteAndValidateAccess) {
 const VALID_BUSINESS_IMPACT_SOURCES = new Set(['ga4', 'adobe_analytics']);
 
 // ============================================================================
-// /url-trend
+// /by-url-trend
 // ============================================================================
 
 /**
- * GET /sites/:siteId/referral-traffic/url-trend
+ * GET /sites/:siteId/referral-traffic/by-url-trend
  *
  * Weekly pageview totals for a single URL path.
  * Required query param: urlPath (exact path, e.g. /blog/my-post).
@@ -646,10 +646,10 @@ export function createReferralTrafficUrlTrendHandler(getSiteAndValidateAccess) {
     return withReferralTrafficAuth(
       context,
       getSiteAndValidateAccess,
-      'url-trend',
+      'by-url-trend',
       async (ctx, client, siteId) => {
         const q = ctx.data || {};
-        const urlPath = q.urlPath || q.url_path || null;
+        const urlPath = (q.urlPath || '').trim() || null;
 
         if (!urlPath) {
           return badRequest('urlPath query parameter is required');
@@ -663,11 +663,11 @@ export function createReferralTrafficUrlTrendHandler(getSiteAndValidateAccess) {
         });
 
         if (error) {
-          ctx.log.error(`Referral traffic url-trend PostgREST error: ${error.message}`);
+          ctx.log.error(`Referral traffic by-url-trend PostgREST error: ${error.message}`);
           return internalServerError('Failed to fetch referral traffic URL trend');
         }
 
-        /* c8 ignore next 2 — PostgREST guarantees non-null data when error is null */
+        /* c8 ignore next 2 — same null-safety pattern as sibling handlers */
         return ok({
           trend: (data ?? []).map((row) => ({
             weekStart: row.week_start,

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -630,6 +630,59 @@ export function createReferralTrafficWeeksHandler(getSiteAndValidateAccess) {
  */
 const VALID_BUSINESS_IMPACT_SOURCES = new Set(['ga4', 'adobe_analytics']);
 
+// ============================================================================
+// /url-trend
+// ============================================================================
+
+/**
+ * GET /sites/:siteId/referral-traffic/url-trend
+ *
+ * Weekly pageview totals for a single URL path.
+ * Required query param: urlPath (exact path, e.g. /blog/my-post).
+ * Returns: { trend: [{ weekStart: "YYYY-MM-DD", pageviews: N }, ...] }
+ */
+export function createReferralTrafficUrlTrendHandler(getSiteAndValidateAccess) {
+  return async function getReferralTrafficUrlTrend(context) {
+    return withReferralTrafficAuth(
+      context,
+      getSiteAndValidateAccess,
+      'url-trend',
+      async (ctx, client, siteId) => {
+        const q = ctx.data || {};
+        const urlPath = q.urlPath || q.url_path || null;
+
+        if (!urlPath) {
+          return badRequest('urlPath query parameter is required');
+        }
+
+        const parsed = parseParams(ctx);
+
+        const { data, error } = await client.rpc('rpc_referral_traffic_url_trend', {
+          ...commonRpcParams(siteId, parsed),
+          p_url_path: urlPath,
+        });
+
+        if (error) {
+          ctx.log.error(`Referral traffic url-trend PostgREST error: ${error.message}`);
+          return internalServerError('Failed to fetch referral traffic URL trend');
+        }
+
+        /* c8 ignore next 2 — PostgREST guarantees non-null data when error is null */
+        return ok({
+          trend: (data ?? []).map((row) => ({
+            weekStart: row.week_start,
+            pageviews: Number(row.total_pageviews),
+          })),
+        });
+      },
+    );
+  };
+}
+
+// ============================================================================
+// /business-impact
+// ============================================================================
+
 export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAccess) {
   return async function getReferralTrafficBusinessImpact(context) {
     return withReferralTrafficAuth(

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -459,7 +459,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/referral-traffic/by-region': llmoMysticatController.getReferralTrafficByRegion,
     'GET /sites/:siteId/referral-traffic/by-page-intent': llmoMysticatController.getReferralTrafficByPageIntent,
     'GET /sites/:siteId/referral-traffic/by-url': llmoMysticatController.getReferralTrafficByUrl,
-    'GET /sites/:siteId/referral-traffic/url-trend': llmoMysticatController.getReferralTrafficUrlTrend,
+    'GET /sites/:siteId/referral-traffic/by-url-trend': llmoMysticatController.getReferralTrafficUrlTrend,
     'GET /sites/:siteId/referral-traffic/by-device': llmoMysticatController.getReferralTrafficByDevice,
     'GET /sites/:siteId/referral-traffic/business-impact': llmoMysticatController.getReferralTrafficBusinessImpact,
     'GET /sites/:siteId/referral-traffic/weeks': llmoMysticatController.getReferralTrafficWeeks,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -459,6 +459,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/referral-traffic/by-region': llmoMysticatController.getReferralTrafficByRegion,
     'GET /sites/:siteId/referral-traffic/by-page-intent': llmoMysticatController.getReferralTrafficByPageIntent,
     'GET /sites/:siteId/referral-traffic/by-url': llmoMysticatController.getReferralTrafficByUrl,
+    'GET /sites/:siteId/referral-traffic/url-trend': llmoMysticatController.getReferralTrafficUrlTrend,
     'GET /sites/:siteId/referral-traffic/by-device': llmoMysticatController.getReferralTrafficByDevice,
     'GET /sites/:siteId/referral-traffic/business-impact': llmoMysticatController.getReferralTrafficBusinessImpact,
     'GET /sites/:siteId/referral-traffic/weeks': llmoMysticatController.getReferralTrafficWeeks,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -115,6 +115,7 @@ export const INTERNAL_ROUTES = [
   'GET /sites/:siteId/referral-traffic/by-region',
   'GET /sites/:siteId/referral-traffic/by-page-intent',
   'GET /sites/:siteId/referral-traffic/by-url',
+  'GET /sites/:siteId/referral-traffic/by-url-trend',
   'GET /sites/:siteId/referral-traffic/by-device',
   'GET /sites/:siteId/referral-traffic/business-impact',
   'GET /sites/:siteId/referral-traffic/weeks',

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -686,9 +686,9 @@ describe('llmo-referral-traffic', () => {
     });
   });
 
-  // ── /url-trend ────────────────────────────────────────────────────────────
+  // ── /by-url-trend ─────────────────────────────────────────────────────────
 
-  describe('url-trend', () => {
+  describe('by-url-trend', () => {
     it('returns 400 when urlPath param is missing', async () => {
       const client = makeRpcClient({ data: [] });
       const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
@@ -696,12 +696,11 @@ describe('llmo-referral-traffic', () => {
       expect(res.status).to.equal(400);
     });
 
-    it('accepts url_path snake_case alias', async () => {
+    it('returns 400 when urlPath is only whitespace', async () => {
       const client = makeRpcClient({ data: [] });
       const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client, data: { url_path: '/blog' } }));
-      expect(res.status).to.equal(200);
-      expect(client.rpc.getCall(0).args[1].p_url_path).to.equal('/blog');
+      const res = await handler(makeContext({ client, data: { urlPath: '   ' } }));
+      expect(res.status).to.equal(400);
     });
 
     it('returns empty trend array when RPC returns no rows', async () => {
@@ -775,12 +774,12 @@ describe('llmo-referral-traffic', () => {
     });
 
     it('returns 500 and logs error on PostgREST failure', async () => {
-      const client = makeRpcClient({ data: null, error: { message: 'url-trend-fail' } });
+      const client = makeRpcClient({ data: null, error: { message: 'by-url-trend-fail' } });
       const ctx = makeContext({ client, data: { urlPath: '/fail' } });
       const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
       const res = await handler(ctx);
       expect(res.status).to.equal(500);
-      expect(ctx.log.error).to.have.been.calledWithMatch(/url-trend-fail/);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/by-url-trend-fail/);
     });
   });
 

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -21,6 +21,7 @@ import {
   createReferralTrafficByRegionHandler,
   createReferralTrafficByPageIntentHandler,
   createReferralTrafficByUrlHandler,
+  createReferralTrafficUrlTrendHandler,
   createReferralTrafficBusinessImpactHandler,
   createReferralTrafficWeeksHandler,
 } from '../../../src/controllers/llmo/llmo-referral-traffic.js';
@@ -682,6 +683,104 @@ describe('llmo-referral-traffic', () => {
       const handler = createReferralTrafficByUrlHandler(stubbedValidateAccess);
       const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(500);
+    });
+  });
+
+  // ── /url-trend ────────────────────────────────────────────────────────────
+
+  describe('url-trend', () => {
+    it('returns 400 when urlPath param is missing', async () => {
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(400);
+    });
+
+    it('accepts url_path snake_case alias', async () => {
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client, data: { url_path: '/blog' } }));
+      expect(res.status).to.equal(200);
+      expect(client.rpc.getCall(0).args[1].p_url_path).to.equal('/blog');
+    });
+
+    it('returns empty trend array when RPC returns no rows', async () => {
+      const client = makeRpcClient({ data: [], error: null });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client, data: { urlPath: '/blog' } }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.trend).to.deep.equal([]);
+    });
+
+    it('maps week_start and total_pageviews to camelCase response shape', async () => {
+      const client = makeRpcClient({
+        data: [
+          { week_start: '2026-04-14', total_pageviews: 120 },
+          { week_start: '2026-04-21', total_pageviews: 200 },
+        ],
+      });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client, data: { urlPath: '/products' } }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.trend).to.deep.equal([
+        { weekStart: '2026-04-14', pageviews: 120 },
+        { weekStart: '2026-04-21', pageviews: 200 },
+      ]);
+    });
+
+    it('passes urlPath to RPC as p_url_path', async () => {
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { urlPath: '/products' } }));
+      expect(client.rpc.getCall(0).args[1].p_url_path).to.equal('/products');
+    });
+
+    it('passes the RPC name rpc_referral_traffic_url_trend', async () => {
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { urlPath: '/products' } }));
+      expect(client.rpc.getCall(0).args[0]).to.equal('rpc_referral_traffic_url_trend');
+    });
+
+    it('forwards common params (source, dates, platform) to RPC', async () => {
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      await handler(makeContext({
+        client,
+        data: {
+          urlPath: '/blog',
+          source: 'adobe_analytics',
+          startDate: '2026-01-01',
+          endDate: '2026-01-28',
+          platform: 'openai',
+        },
+      }));
+      const rpcArgs = client.rpc.getCall(0).args[1];
+      expect(rpcArgs.p_source).to.equal('adobe_analytics');
+      expect(rpcArgs.p_start_date).to.equal('2026-01-01');
+      expect(rpcArgs.p_end_date).to.equal('2026-01-28');
+      expect(rpcArgs.p_platform).to.equal('openai');
+    });
+
+    it('uses {} when context.data is null', async () => {
+      const client = makeRpcClient({ data: [] });
+      const ctx = makeContext({ client });
+      ctx.data = null;
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      // urlPath will be null → 400
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 500 and logs error on PostgREST failure', async () => {
+      const client = makeRpcClient({ data: null, error: { message: 'url-trend-fail' } });
+      const ctx = makeContext({ client, data: { urlPath: '/fail' } });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(500);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/url-trend-fail/);
     });
   });
 

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -938,7 +938,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/referral-traffic/by-device',
       'GET /sites/:siteId/referral-traffic/by-page-intent',
       'GET /sites/:siteId/referral-traffic/by-url',
-      'GET /sites/:siteId/referral-traffic/url-trend',
+      'GET /sites/:siteId/referral-traffic/by-url-trend',
       'GET /sites/:siteId/referral-traffic/business-impact',
       'GET /sites/:siteId/referral-traffic/weeks',
       'GET /admin/users/:userId',

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -938,6 +938,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/referral-traffic/by-device',
       'GET /sites/:siteId/referral-traffic/by-page-intent',
       'GET /sites/:siteId/referral-traffic/by-url',
+      'GET /sites/:siteId/referral-traffic/url-trend',
       'GET /sites/:siteId/referral-traffic/business-impact',
       'GET /sites/:siteId/referral-traffic/weeks',
       'GET /admin/users/:userId',


### PR DESCRIPTION
## Summary

Adds a new `GET /sites/:siteId/referral-traffic/url-trend` endpoint that returns weekly pageview totals for a specific URL path. This powers the per-URL trend chart in the referral traffic dialog on the frontend.

- Introduced `createReferralTrafficUrlTrendHandler` in `llmo-referral-traffic.js`; validates the required `urlPath` param and calls the new `rpc_referral_traffic_url_trend` Postgres RPC
- Wired the handler into `LlmoMysticatController` and registered the route in `src/routes/index.js`
- Added full unit-test coverage (`describe('url-trend', ...)`) and updated the route catalogue test

## Related Issues

https://jira.corp.adobe.com/browse/LLMO-4261