### PR TITLE
fix(brands): dispatch llmo-customer-analysis on v2 customer-config writes (LLMO-4744)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -66,6 +66,7 @@ import {
   updateTopic,
   deleteTopic,
 } from '../support/topics-storage.js';
+import { dispatchCustomerAnalysisV2 } from '../support/llmo-customer-analysis-dispatch.js';
 
 const HEADER_ERROR = 'x-error';
 
@@ -424,6 +425,8 @@ function BrandsController(ctx, log, env) {
         updatedBy,
       });
 
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'prompts', log);
+
       return createResponse({ created, updated, prompts: outPrompts }, 201);
     } catch (error) {
       log.error(`Error creating prompts for brand ${brandId}:`, error);
@@ -482,6 +485,9 @@ function BrandsController(ctx, log, env) {
       if (!prompt) {
         return notFound(`Prompt not found: ${promptId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'prompts', log);
+
       return ok(prompt);
     } catch (error) {
       log.error(`Error updating prompt ${promptId}:`, error);
@@ -538,6 +544,9 @@ function BrandsController(ctx, log, env) {
       if (!deleted) {
         return notFound(`Prompt not found: ${promptId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'prompts', log);
+
       return createResponse(null, 204);
     } catch (error) {
       log.error(`Error deleting prompt ${promptId}:`, error);
@@ -596,6 +605,8 @@ function BrandsController(ctx, log, env) {
         postgrestClient,
         updatedBy,
       });
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'prompts', log);
 
       return ok(result);
     } catch (error) {
@@ -849,6 +860,8 @@ function BrandsController(ctx, log, env) {
         outcome,
       });
 
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'categories', log);
+
       // 201 on insert, 200 on idempotent update — lets callers (UI toast,
       // DRS audit log) distinguish "created new" from "ensured existing".
       return createResponse(category, created ? 201 : 200);
@@ -909,6 +922,9 @@ function BrandsController(ctx, log, env) {
       if (!updated) {
         return notFound(`Category not found: ${categoryId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'categories', log);
+
       return ok(updated);
     } catch (error) {
       // PATCH to a name colliding with a sibling row in the same org
@@ -963,6 +979,9 @@ function BrandsController(ctx, log, env) {
       if (!deleted) {
         return notFound(`Category not found: ${categoryId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'categories', log);
+
       return createResponse(null, 204);
     } catch (error) {
       log.error(`Error deleting category ${categoryId} for organization ${spaceCatId}:`, error);
@@ -1050,6 +1069,8 @@ function BrandsController(ctx, log, env) {
         log,
       });
 
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'topics', log);
+
       return createResponse(created, 201);
     } catch (error) {
       if (error?.status === 409) {
@@ -1106,6 +1127,9 @@ function BrandsController(ctx, log, env) {
       if (!updated) {
         return notFound(`Topic not found: ${topicId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'topics', log);
+
       return ok(updated);
     } catch (error) {
       log.error(`Error updating topic ${topicId} for organization ${spaceCatId}:`, error);
@@ -1153,6 +1177,9 @@ function BrandsController(ctx, log, env) {
       if (!deleted) {
         return notFound(`Topic not found: ${topicId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'topics', log);
+
       return createResponse(null, 204);
     } catch (error) {
       log.error(`Error deleting topic ${topicId} for organization ${spaceCatId}:`, error);
@@ -1202,6 +1229,8 @@ function BrandsController(ctx, log, env) {
         postgrestClient,
         updatedBy,
       });
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'brands', log);
 
       return createResponse(created, 201);
     } catch (error) {
@@ -1260,6 +1289,9 @@ function BrandsController(ctx, log, env) {
       if (!updated) {
         return notFound(`Brand not found: ${brandId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'brands', log);
+
       return ok(updated);
     } catch (error) {
       log.error(`Error updating brand ${brandId} for organization ${spaceCatId}:`, error);
@@ -1308,6 +1340,9 @@ function BrandsController(ctx, log, env) {
       if (!deleted) {
         return notFound(`Brand not found: ${brandId}`);
       }
+
+      await dispatchCustomerAnalysisV2(context, spaceCatId, 'brands', log);
+
       return createResponse(null, 204);
     } catch (error) {
       log.error(`Error deleting brand ${brandId} for organization ${spaceCatId}:`, error);

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -606,7 +606,13 @@ function BrandsController(ctx, log, env) {
         updatedBy,
       });
 
-      await dispatchCustomerAnalysisV2(context, spaceCatId, 'prompts', log);
+      // Skip dispatch when nothing was actually deleted (every requested
+      // promptId was already gone), to match the implicit guard the other
+      // mutating endpoints get from their `if (!result) return notFound`
+      // branches.
+      if (result?.metadata?.success > 0) {
+        await dispatchCustomerAnalysisV2(context, spaceCatId, 'prompts', log);
+      }
 
       return ok(result);
     } catch (error) {

--- a/src/support/llmo-customer-analysis-dispatch.js
+++ b/src/support/llmo-customer-analysis-dispatch.js
@@ -81,6 +81,7 @@ export async function dispatchCustomerAnalysisV2(context, organizationId, change
       return;
     }
 
+    let sent = 0;
     await Promise.all(sites.map(async (site) => {
       const siteId = site.getId?.() || site.getSiteId?.();
       if (!siteId) {
@@ -97,12 +98,13 @@ export async function dispatchCustomerAnalysisV2(context, organizationId, change
             changeKind,
           },
         });
+        sent += 1;
       } catch (sendError) {
         logger.warn(`[${AUDIT_TYPE}] Failed to dispatch for site ${siteId} (org ${organizationId}, changeKind=${changeKind}): ${sendError.message}`);
       }
     }));
 
-    logger.info(`[${AUDIT_TYPE}] Dispatched ${sites.length} message(s) for org ${organizationId} changeKind=${changeKind}`);
+    logger.info(`[${AUDIT_TYPE}] Dispatched ${sent}/${sites.length} message(s) for org ${organizationId} changeKind=${changeKind}`);
   } catch (error) {
     logger.warn(`[${AUDIT_TYPE}] Unexpected error during dispatch for org ${organizationId} changeKind=${changeKind}: ${error.message}`);
   }

--- a/src/support/llmo-customer-analysis-dispatch.js
+++ b/src/support/llmo-customer-analysis-dispatch.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const AUDIT_TYPE = 'llmo-customer-analysis';
+const ONBOARDING_MODE_V2 = 'v2';
+
+/**
+ * Allowed values for the `changeKind` field. Audit-worker
+ * (`spacecat-audit-worker/src/llmo-customer-analysis/handler.js`) routes by
+ * this discriminant — keep both repos in sync when adding new kinds.
+ */
+export const CUSTOMER_ANALYSIS_CHANGE_KINDS = Object.freeze({
+  BRANDS: 'brands',
+  COMPETITORS: 'competitors',
+  CATEGORIES: 'categories',
+  TOPICS: 'topics',
+  ENTITIES: 'entities',
+  PROMPTS: 'prompts',
+});
+
+const VALID_CHANGE_KINDS = new Set(Object.values(CUSTOMER_ANALYSIS_CHANGE_KINDS));
+
+const NOOP_LOG = Object.freeze({
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+});
+
+/**
+ * Dispatch one `llmo-customer-analysis` audit message per site for the given
+ * organization. Used after every v2 (brandalf) customer-config mutation in
+ * BrandsController so the audit-worker can fan out brand-detection and
+ * brand-presence-refresh triggers.
+ *
+ * Never throws. Failures are logged at warn level so the original mutation's
+ * HTTP response is unaffected. The audit-worker performs its own brandalf
+ * feature-flag check and silently no-ops for non-brandalf orgs (LLMO-4744),
+ * so this helper does not need to gate.
+ *
+ * @param {object} context - Request context (sqs, env, dataAccess)
+ * @param {string} organizationId - SpaceCat organization UUID
+ * @param {string} changeKind - One of CUSTOMER_ANALYSIS_CHANGE_KINDS values
+ * @param {object} [log] - Logger; falls back to a no-op logger when omitted
+ * @returns {Promise<void>}
+ */
+export async function dispatchCustomerAnalysisV2(context, organizationId, changeKind, log) {
+  const logger = log || context?.log || NOOP_LOG;
+
+  if (!VALID_CHANGE_KINDS.has(changeKind)) {
+    logger.warn(`[${AUDIT_TYPE}] Refusing to dispatch with invalid changeKind="${changeKind}" for org ${organizationId}`);
+    return;
+  }
+
+  try {
+    const Site = context?.dataAccess?.Site;
+    const queueUrl = context?.env?.AUDIT_JOBS_QUEUE_URL;
+
+    if (!queueUrl) {
+      logger.warn(`[${AUDIT_TYPE}] AUDIT_JOBS_QUEUE_URL not configured; skipping dispatch for org ${organizationId} changeKind=${changeKind}`);
+      return;
+    }
+
+    if (!Site || typeof Site.allByOrganizationId !== 'function') {
+      logger.warn(`[${AUDIT_TYPE}] Site.allByOrganizationId not available; skipping dispatch for org ${organizationId} changeKind=${changeKind}`);
+      return;
+    }
+
+    const sites = await Site.allByOrganizationId(organizationId);
+    if (!Array.isArray(sites) || sites.length === 0) {
+      logger.warn(`[${AUDIT_TYPE}] No sites found for org ${organizationId}; skipping dispatch (changeKind=${changeKind})`);
+      return;
+    }
+
+    await Promise.all(sites.map(async (site) => {
+      const siteId = site.getId?.() || site.getSiteId?.();
+      if (!siteId) {
+        logger.warn(`[${AUDIT_TYPE}] Site without id encountered for org ${organizationId}; skipping`);
+        return;
+      }
+      try {
+        await context.sqs.sendMessage(queueUrl, {
+          type: AUDIT_TYPE,
+          siteId,
+          auditContext: {
+            onboardingMode: ONBOARDING_MODE_V2,
+            organizationId,
+            changeKind,
+          },
+        });
+      } catch (sendError) {
+        logger.warn(`[${AUDIT_TYPE}] Failed to dispatch for site ${siteId} (org ${organizationId}, changeKind=${changeKind}): ${sendError.message}`);
+      }
+    }));
+
+    logger.info(`[${AUDIT_TYPE}] Dispatched ${sites.length} message(s) for org ${organizationId} changeKind=${changeKind}`);
+  } catch (error) {
+    logger.warn(`[${AUDIT_TYPE}] Unexpected error during dispatch for org ${organizationId} changeKind=${changeKind}: ${error.message}`);
+  }
+}

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -4425,4 +4425,145 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(500);
     });
   });
+
+  describe('llmo-customer-analysis dispatch (LLMO-4744)', () => {
+    const ANALYSIS_QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/0/audits-queue';
+    const BRAND_UUID = 'a1111111-1111-4111-b111-111111111111';
+    let dispatchSqs;
+    let dispatchEnv;
+    let dispatchAuthAttrs;
+
+    beforeEach(() => {
+      // Augment mockDataAccess with Site.allByOrganizationId so the dispatch helper
+      // produces real SQS sends. Use the existing in-memory `sites` fixture.
+      mockDataAccess.Site.allByOrganizationId = sinon.stub().resolves(sites);
+
+      // PostgREST mock that satisfies all 13 success paths with a single from() shape.
+      mockDataAccess.services.postgrestClient = {
+        from: sinon.stub().callsFake(() => ({
+          select: sinon.stub().returnsThis(),
+          eq: sinon.stub().returnsThis(),
+          neq: sinon.stub().returnsThis(),
+          in: sinon.stub().returnsThis(),
+          order: sinon.stub().returnsThis(),
+          upsert: sinon.stub().returnsThis(),
+          delete: sinon.stub().returnsThis(),
+          update: sinon.stub().returnsThis(),
+          single: sinon.stub().resolves({
+            data: {
+              id: BRAND_UUID, name: 'Brand', status: 'active', origin: 'human',
+            },
+            error: null,
+          }),
+          maybeSingle: sinon.stub().resolves({
+            data: {
+              id: BRAND_UUID,
+              name: 'Brand',
+              status: 'active',
+              origin: 'human',
+              updated_at: '2026-01-01T00:00:00Z',
+              updated_by: 'user@test.com',
+              brand_aliases: [],
+              brand_social_accounts: [],
+              brand_earned_sources: [],
+              competitors: [],
+              brand_sites: [],
+            },
+            error: null,
+          }),
+        })),
+      };
+
+      dispatchSqs = { sendMessage: sinon.stub().resolves() };
+      dispatchEnv = { AUDIT_JOBS_QUEUE_URL: ANALYSIS_QUEUE_URL };
+      dispatchAuthAttrs = { authInfo: { profile: { email: 'user@test.com' } } };
+
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+    });
+
+    const buildCtx = (overrides = {}) => ({
+      ...context,
+      sqs: dispatchSqs,
+      env: dispatchEnv,
+      attributes: dispatchAuthAttrs,
+      dataAccess: mockDataAccess,
+      ...overrides,
+    });
+
+    const findAnalysisCall = () => dispatchSqs.sendMessage.getCalls().find(
+      (c) => c.args[1]?.type === 'llmo-customer-analysis',
+    );
+
+    it('createBrandForOrg dispatches changeKind=brands per site on success', async () => {
+      const response = await brandsController.createBrandForOrg(buildCtx({
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'Brand' },
+      }));
+
+      expect(response.status).to.equal(201);
+      const call = findAnalysisCall();
+      expect(call, 'expected llmo-customer-analysis dispatch').to.exist;
+      expect(call.args[0]).to.equal(ANALYSIS_QUEUE_URL);
+      expect(call.args[1]).to.deep.equal({
+        type: 'llmo-customer-analysis',
+        siteId: SITE_ID,
+        auditContext: {
+          onboardingMode: 'v2',
+          organizationId: ORGANIZATION_ID,
+          changeKind: 'brands',
+        },
+      });
+    });
+
+    it('createTopicForOrg dispatches changeKind=topics on success', async () => {
+      const response = await brandsController.createTopicForOrg(buildCtx({
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'Topic' },
+      }));
+
+      expect(response.status).to.equal(201);
+      const call = findAnalysisCall();
+      expect(call, 'expected llmo-customer-analysis dispatch').to.exist;
+      expect(call.args[1].auditContext.changeKind).to.equal('topics');
+    });
+
+    it('does NOT dispatch on validation failure (400)', async () => {
+      const response = await brandsController.createBrandForOrg(buildCtx({
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { description: 'no name' },
+      }));
+
+      expect(response.status).to.equal(400);
+      expect(findAnalysisCall()).to.not.exist;
+    });
+
+    it('does NOT dispatch when SQS dispatch helper fails — keeps HTTP response intact', async () => {
+      // Helper swallows errors; response is unaffected
+      dispatchSqs.sendMessage = sinon.stub().rejects(new Error('SQS down'));
+
+      const response = await brandsController.createBrandForOrg(buildCtx({
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'Brand' },
+      }));
+
+      // Original mutation still succeeds — dispatch failure is non-fatal
+      expect(response.status).to.equal(201);
+    });
+
+    it('updateBrandForOrg + deleteBrandForOrg both dispatch changeKind=brands on success', async () => {
+      let response = await brandsController.updateBrandForOrg(buildCtx({
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { name: 'Updated' },
+      }));
+      expect(response.status).to.equal(200);
+      expect(findAnalysisCall()?.args[1].auditContext.changeKind).to.equal('brands');
+
+      dispatchSqs.sendMessage.resetHistory();
+      response = await brandsController.deleteBrandForOrg(buildCtx({
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+      }));
+      expect(response.status).to.equal(204);
+      expect(findAnalysisCall()?.args[1].auditContext.changeKind).to.equal('brands');
+    });
+  });
 });

--- a/test/support/llmo-customer-analysis-dispatch.test.js
+++ b/test/support/llmo-customer-analysis-dispatch.test.js
@@ -93,7 +93,7 @@ describe('dispatchCustomerAnalysisV2', () => {
         changeKind: 'brands',
       },
     });
-    expect(log.info).to.have.been.calledWithMatch(/Dispatched 2 message\(s\)/);
+    expect(log.info).to.have.been.calledWithMatch(/Dispatched 2\/2 message\(s\)/);
   });
 
   it('falls back to site.getSiteId() when getId is not present', async () => {
@@ -165,7 +165,8 @@ describe('dispatchCustomerAnalysisV2', () => {
 
     expect(sqs.sendMessage).to.have.been.calledTwice;
     expect(log.warn).to.have.been.calledWithMatch(/Failed to dispatch for site site-1/);
-    expect(log.info).to.have.been.calledWithMatch(/Dispatched 2 message\(s\)/);
+    // Final log reports successful sends out of total — site-1 failed, site-2 succeeded
+    expect(log.info).to.have.been.calledWithMatch(/Dispatched 1\/2 message\(s\)/);
   });
 
   it('does not throw when Site lookup fails — logs unexpected error', async () => {
@@ -220,7 +221,7 @@ describe('dispatchCustomerAnalysisV2', () => {
 
     await dispatchCustomerAnalysisV2(context, ORG_ID, 'brands', explicitLog);
 
-    expect(explicitLog.info).to.have.been.calledWithMatch(/Dispatched 1 message/);
+    expect(explicitLog.info).to.have.been.calledWithMatch(/Dispatched 1\/1 message/);
     expect(log.info).to.not.have.been.called;
   });
 

--- a/test/support/llmo-customer-analysis-dispatch.test.js
+++ b/test/support/llmo-customer-analysis-dispatch.test.js
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import {
+  CUSTOMER_ANALYSIS_CHANGE_KINDS,
+  dispatchCustomerAnalysisV2,
+} from '../../src/support/llmo-customer-analysis-dispatch.js';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+describe('dispatchCustomerAnalysisV2', () => {
+  const ORG_ID = '9033554c-de8a-44ac-a356-09b51af8cc28';
+  const QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/123456789/audits-queue';
+
+  let sandbox;
+  let log;
+  let sqs;
+  let allByOrganizationId;
+  let context;
+
+  const makeSite = (id) => ({ getId: () => id });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    };
+    sqs = { sendMessage: sandbox.stub().resolves() };
+    allByOrganizationId = sandbox.stub();
+    context = {
+      sqs,
+      log,
+      env: { AUDIT_JOBS_QUEUE_URL: QUEUE_URL },
+      dataAccess: { Site: { allByOrganizationId } },
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('exposes the canonical changeKind enum', () => {
+    expect(CUSTOMER_ANALYSIS_CHANGE_KINDS).to.deep.equal({
+      BRANDS: 'brands',
+      COMPETITORS: 'competitors',
+      CATEGORIES: 'categories',
+      TOPICS: 'topics',
+      ENTITIES: 'entities',
+      PROMPTS: 'prompts',
+    });
+    // Frozen so callers cannot mutate.
+    expect(Object.isFrozen(CUSTOMER_ANALYSIS_CHANGE_KINDS)).to.equal(true);
+  });
+
+  it('dispatches one message per site for the org with full payload', async () => {
+    allByOrganizationId.resolves([makeSite('site-1'), makeSite('site-2')]);
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'brands');
+
+    expect(sqs.sendMessage).to.have.been.calledTwice;
+    expect(sqs.sendMessage).to.have.been.calledWith(QUEUE_URL, {
+      type: 'llmo-customer-analysis',
+      siteId: 'site-1',
+      auditContext: {
+        onboardingMode: 'v2',
+        organizationId: ORG_ID,
+        changeKind: 'brands',
+      },
+    });
+    expect(sqs.sendMessage).to.have.been.calledWith(QUEUE_URL, {
+      type: 'llmo-customer-analysis',
+      siteId: 'site-2',
+      auditContext: {
+        onboardingMode: 'v2',
+        organizationId: ORG_ID,
+        changeKind: 'brands',
+      },
+    });
+    expect(log.info).to.have.been.calledWithMatch(/Dispatched 2 message\(s\)/);
+  });
+
+  it('falls back to site.getSiteId() when getId is not present', async () => {
+    allByOrganizationId.resolves([{ getSiteId: () => 'site-legacy' }]);
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'topics');
+
+    expect(sqs.sendMessage).to.have.been.calledOnceWith(QUEUE_URL, sinon.match({
+      siteId: 'site-legacy',
+      auditContext: sinon.match({ changeKind: 'topics' }),
+    }));
+  });
+
+  it('skips sites that do not expose an id and continues with the rest', async () => {
+    allByOrganizationId.resolves([
+      { /* no getId / getSiteId */ },
+      makeSite('site-ok'),
+    ]);
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'categories');
+
+    expect(sqs.sendMessage).to.have.been.calledOnce;
+    expect(sqs.sendMessage).to.have.been.calledWith(QUEUE_URL, sinon.match({ siteId: 'site-ok' }));
+    expect(log.warn).to.have.been.calledWithMatch(/Site without id encountered/);
+  });
+
+  it('warns and returns when no sites exist for the org', async () => {
+    allByOrganizationId.resolves([]);
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'brands');
+
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledWithMatch(/No sites found/);
+  });
+
+  it('warns and returns when allByOrganizationId yields a non-array', async () => {
+    allByOrganizationId.resolves(null);
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'topics');
+
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledWithMatch(/No sites found/);
+  });
+
+  it('warns and never throws when changeKind is invalid', async () => {
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'invalid-kind');
+
+    expect(allByOrganizationId).to.not.have.been.called;
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledWithMatch(/invalid changeKind/);
+  });
+
+  it('warns when AUDIT_JOBS_QUEUE_URL is missing', async () => {
+    context.env = {};
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'brands');
+
+    expect(allByOrganizationId).to.not.have.been.called;
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledWithMatch(/AUDIT_JOBS_QUEUE_URL not configured/);
+  });
+
+  it('does not throw when sendMessage rejects, but logs per-site warning', async () => {
+    allByOrganizationId.resolves([makeSite('site-1'), makeSite('site-2')]);
+    sqs.sendMessage.onFirstCall().rejects(new Error('SQS down'));
+    sqs.sendMessage.onSecondCall().resolves();
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'prompts');
+
+    expect(sqs.sendMessage).to.have.been.calledTwice;
+    expect(log.warn).to.have.been.calledWithMatch(/Failed to dispatch for site site-1/);
+    expect(log.info).to.have.been.calledWithMatch(/Dispatched 2 message\(s\)/);
+  });
+
+  it('does not throw when Site lookup fails — logs unexpected error', async () => {
+    allByOrganizationId.rejects(new Error('DDB unavailable'));
+
+    await expect(dispatchCustomerAnalysisV2(context, ORG_ID, 'topics', log)).to.be.fulfilled;
+
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledWithMatch(/Unexpected error during dispatch/);
+  });
+
+  it('warns when dataAccess.Site is unavailable', async () => {
+    context.dataAccess = {};
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'brands', log);
+
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledWithMatch(/Site\.allByOrganizationId not available/);
+  });
+
+  it('warns when dataAccess is missing entirely', async () => {
+    context.dataAccess = undefined;
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'brands', log);
+
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledWithMatch(/Site\.allByOrganizationId not available/);
+  });
+
+  it('falls back to no-op logger when neither log argument nor context.log is provided', async () => {
+    // No `log` argument, and no context.log
+    delete context.log;
+    allByOrganizationId.resolves([makeSite('site-1')]);
+
+    // Should not throw despite no logger anywhere
+    await expect(
+      dispatchCustomerAnalysisV2(context, ORG_ID, 'brands'),
+    ).to.be.fulfilled;
+
+    expect(sqs.sendMessage).to.have.been.calledOnce;
+  });
+
+  it('prefers explicit log argument over context.log', async () => {
+    const explicitLog = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    };
+    context.log = log; // shouldn't be used
+    allByOrganizationId.resolves([makeSite('site-1')]);
+
+    await dispatchCustomerAnalysisV2(context, ORG_ID, 'brands', explicitLog);
+
+    expect(explicitLog.info).to.have.been.calledWithMatch(/Dispatched 1 message/);
+    expect(log.info).to.not.have.been.called;
+  });
+
+  it('accepts every documented changeKind', async () => {
+    allByOrganizationId.resolves([makeSite('site-only')]);
+    const kinds = Object.values(CUSTOMER_ANALYSIS_CHANGE_KINDS);
+
+    for (const kind of kinds) {
+      sqs.sendMessage.resetHistory();
+      // eslint-disable-next-line no-await-in-loop
+      await dispatchCustomerAnalysisV2(context, ORG_ID, kind);
+      expect(sqs.sendMessage).to.have.been.calledOnce;
+      expect(sqs.sendMessage.firstCall.args[1].auditContext.changeKind).to.equal(kind);
+    }
+  });
+});


### PR DESCRIPTION
Pre-cutover blocker for the Adobe brandalf_migration. Companion to adobe/spacecat-audit-worker `#2480`.

## Problem

Under `brandalf`, BrandsController v2 endpoints write directly to the normalized customer-config tables (`brands`, `categories`, `topics`, `prompts`) but **never enqueue an `llmo-customer-analysis` audit**. The legacy v1 PUT path (`controllers/llmo/llmo.js:586-595`) was the only dispatcher, and it is bypassed by elmo-UI / brandalf-UI v2 writes.

As a result, the audit-worker's three downstream triggers (`triggerBrandDetection`, `triggerGeoBrandPresenceRefresh`, CDN-logs report) silently never fired on real user edits — the pre-cutover blocker described in [LLMO-4744](https://jira.corp.adobe.com/browse/LLMO-4744). (The audit-worker side also has a frozen-S3-mirror diff that would have returned empty even if dispatch had fired; that's fixed in the companion PR.)

## Architecture choice

Three options were considered for the cross-repo fix (full notes in chat thread). Picked **Option C — explicit `changeKind` dispatch**: the writer already knows what changed, so pass that signal forward instead of having the audit-worker re-derive it via a diff against a stale source. Smallest blast radius, no DB migration, no snapshot mechanism.

## Fix

Add a thin dispatch helper and wire it into all 13 mutating BrandsController endpoints. The helper enumerates org sites via `Site.allByOrganizationId` and sends one `llmo-customer-analysis` SQS message per site with `auditContext: { onboardingMode: 'v2', organizationId, changeKind }`.

**Endpoints + changeKind:**

| Endpoint | changeKind |
|---|---|
| `createBrandForOrg` / `updateBrandForOrg` / `deleteBrandForOrg` | `'brands'` |
| `createCategoryForOrg` / `updateCategoryForOrg` / `deleteCategoryForOrg` | `'categories'` |
| `createTopicForOrg` / `updateTopicForOrg` / `deleteTopicForOrg` | `'topics'` |
| `createPromptsByBrand` / `updatePromptByBrandAndId` / `deletePromptByBrandAndId` / `bulkDeletePromptsByBrand` | `'prompts'` |

The companion audit-worker PR routes by `changeKind`:
- `brands`, `competitors` → `triggerGeoBrandPresenceRefresh`
- `categories`, `topics`, `entities` → `drsClient.triggerBrandDetection`
- `prompts` → both
- CDN logs trigger is skipped (out of scope under brandalf)

### Downstream effect on the BP database

`triggerGeoBrandPresenceRefresh` is not the end of the chain — it ultimately publishes a DRS `JOB_COMPLETED` SNS event with `reanalysis: true`, which causes DRS to re-run BP analysis using the **current Postgres v2 config** and write fresh rows into `brand_presence_executions`. So a brandalf user editing brands/competitors causes the BP database to land eventually-consistent with the edit; we don't run the analysis ourselves, we just signal DRS to re-run it with the new config.

## Helper behavior

- **Never throws.** Failures are logged at warn so the original mutation's HTTP response is unaffected.
- **Dispatch happens only on the success path** (after `notFound`/validation gates). For `bulkDeletePromptsByBrand`, dispatch is gated on `result.metadata.success > 0` so a no-op bulk delete (every requested promptId already deleted) doesn't fire a spurious audit.
- **Defensive checks**: invalid changeKind, missing `AUDIT_JOBS_QUEUE_URL`, missing Site model, no sites for org, per-site SQS failures all warn-and-return cleanly. The final log line reports `Dispatched sent/total message(s)` so partial failures are visible at a glance.
- **Brandalf gating happens in audit-worker.** Sites whose orgs are not on brandalf produce a no-op completed audit. This dispatcher does not need to gate.

## Files

- `src/support/llmo-customer-analysis-dispatch.js` — new helper (`dispatchCustomerAnalysisV2`, `CUSTOMER_ANALYSIS_CHANGE_KINDS`)
- `src/controllers/brands.js` — 13 dispatch call sites + 1 import line
- `test/support/llmo-customer-analysis-dispatch.test.js` — 15 unit tests (helper)
- `test/controllers/brands.test.js` — 5 wiring tests (controller integration)

## Test plan

- Helper unit tests cover all 6 changeKind values, defensive paths, log fallback semantics, and partial-failure log shape
- Controller wiring tests cover: success → dispatch fires with correct changeKind; validation 400 → no dispatch; SQS error → response intact
- All 244 existing brands-controller tests still pass
- `npm test` (affected suites) — 264 passing total
- ESLint clean
- Verified on a brandalf_migration test org: real user edit via brandalf-UI → appropriate downstream trigger fires (post-deploy validation, requires audit-worker PR to be deployed first)

## Deferred follow-ups (not in this PR)

- Bump dispatch-failure logs from `warn` → `error` so silent-no-op cases page on alerts. Currently a "write succeeded but SQS dispatch failed" condition is only visible at warn level.
- Track an explicit retry / DLQ for failed dispatches (today, a failed SQS send is logged and lost — there is no retry).

## Related

- Jira: https://jira.corp.adobe.com/browse/LLMO-4744
- Audit-worker companion: adobe/spacecat-audit-worker `#2480`
- Parent: LLMO-4715
- Sibling: LLMO-4743 (Reader 4 — v1-write ban enforcement)
- Epic: LLMO-4587 (Brand Presence brandalf migration)

## Deployment ordering

**Deploy the audit-worker PR first.** Until it ships, the new SQS messages from this PR will reach the existing audit-worker handler, which will see `auditContext.changeKind` as an unknown field and fall through to the existing v1 diff path (no harm — same as current behavior). Once the audit-worker PR is live, the changeKind branch routes correctly.

## Related Issues

- LLMO-4744