### PR TITLE
feat: add has-data endpoint for referral traffic | LLMO-4261

### DIFF
--- a/src/controllers/llmo/llmo-mysticat-controller.js
+++ b/src/controllers/llmo/llmo-mysticat-controller.js
@@ -67,6 +67,7 @@ import {
   createReferralTrafficBusinessImpactHandler,
   createReferralTrafficWeeksHandler,
   createReferralTrafficByDeviceHandler,
+  createReferralTrafficHasDataHandler,
 } from './llmo-referral-traffic.js';
 
 /**
@@ -225,6 +226,7 @@ function LlmoMysticatController(ctx) {
   );
   const getReferralTrafficWeeks = createReferralTrafficWeeksHandler(getSiteAndValidateAccess);
   const getReferralTrafficByDevice = createReferralTrafficByDeviceHandler(getSiteAndValidateAccess);
+  const getReferralTrafficHasData = createReferralTrafficHasDataHandler(getSiteAndValidateAccess);
 
   return {
     getFilterDimensions,
@@ -277,6 +279,7 @@ function LlmoMysticatController(ctx) {
     getReferralTrafficBusinessImpact,
     getReferralTrafficWeeks,
     getReferralTrafficByDevice,
+    getReferralTrafficHasData,
   };
 }
 

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -13,6 +13,7 @@
 import {
   ok, badRequest, forbidden, internalServerError,
 } from '@adobe/spacecat-shared-http-utils';
+import { cachedOk } from '../../support/cached-response.js';
 import { generateIsoWeekRange, getWeekDateRange } from './llmo-brand-presence.js';
 
 /**
@@ -725,6 +726,41 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
             revenue: Number(row?.revenue ?? 0),
           },
         });
+      },
+    );
+  };
+}
+
+/**
+ * GET /sites/:siteId/referral-traffic/has-data
+ *
+ * Fast existence check — returns { hasData: boolean } indicating whether any
+ * referral traffic records exist for the site (across all sources). Used by
+ * the PG dashboard to decide whether to show the no-data overlay without
+ * waiting for all parallel data queries to settle.
+ *
+ * Runs a single PostgREST table query with limit(1) — no RPC required.
+ */
+export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
+  return async function getReferralTrafficHasData(context) {
+    return withReferralTrafficAuth(
+      context,
+      getSiteAndValidateAccess,
+      'has-data',
+      async (ctx, client, siteId) => {
+        const { data, error } = await client
+          .from('referral_traffic_optel')
+          .select('traffic_date')
+          .eq('site_id', siteId)
+          .limit(1);
+
+        if (error) {
+          ctx.log.error(`Referral traffic has-data PostgREST error: ${error.message}`);
+          return internalServerError('Failed to check referral traffic data');
+        }
+
+        /* c8 ignore next */
+        return cachedOk({ hasData: (data || []).length > 0 });
       },
     );
   };

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -732,15 +732,29 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
 }
 
 /**
+ * Traffic Insights sources — the only tables that feed the Traffic Insights tab.
+ * Business Impact (adobe_analytics, ga4) has its own DRS provider check and is
+ * intentionally excluded here.
+ */
+const TRAFFIC_INSIGHTS_TABLES = [
+  SOURCE_TO_TABLE.optel,
+  SOURCE_TO_TABLE.cdn,
+];
+
+/**
  * GET /sites/:siteId/referral-traffic/has-data
  *
  * Fast existence check — returns { hasData: boolean } indicating whether any
- * Traffic Insights data exists for the site (optel OR cdn). Used by the PG
+ * Traffic Insights data (optel or cdn) exists for the site. Used by the PG
  * dashboard to decide whether to show the onboarding overlay without waiting
  * for all parallel data queries to settle.
  *
+ * Only optel and cdn are checked because those are the sole sources for the
+ * Traffic Insights tab. Business Impact sources (adobe_analytics, ga4) are
+ * gated separately via the DRS analytics-provider endpoint.
+ *
  * Both tables are checked in parallel with limit(1) — no RPC required.
- * Returns true as soon as either source has at least one row.
+ * Returns true if either result set is non-empty; fails closed if any query errors.
  */
 export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
   return async function getReferralTrafficHasData(context) {
@@ -749,22 +763,24 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
       getSiteAndValidateAccess,
       'has-data',
       async (ctx, client, siteId) => {
-        const [optelResult, cdnResult] = await Promise.all([
-          client.from('referral_traffic_optel').select('traffic_date').eq('site_id', siteId).limit(1),
-          client.from('referral_traffic_cdn').select('traffic_date').eq('site_id', siteId).limit(1),
-        ]);
-
-        if (optelResult.error) {
-          ctx.log.error(`Referral traffic has-data optel error: ${optelResult.error.message}`);
-          return internalServerError('Failed to check referral traffic data');
-        }
-        if (cdnResult.error) {
-          ctx.log.error(`Referral traffic has-data cdn error: ${cdnResult.error.message}`);
+        let results;
+        try {
+          results = await Promise.all(
+            TRAFFIC_INSIGHTS_TABLES.map((table) => client.from(table).select('traffic_date').eq('site_id', siteId).limit(1)),
+          );
+        } catch (err) {
+          ctx.log.error(`Referral traffic has-data PostgREST error: ${err.message} (siteId=${siteId})`);
           return internalServerError('Failed to check referral traffic data');
         }
 
-        const hasData = (optelResult.data || []).length > 0 || (cdnResult.data || []).length > 0;
-        /* c8 ignore next */
+        for (const [i, result] of results.entries()) {
+          if (result.error) {
+            ctx.log.error(`Referral traffic has-data ${TRAFFIC_INSIGHTS_TABLES[i]} PostgREST error: ${result.error.message} (siteId=${siteId})`);
+            return internalServerError('Failed to check referral traffic data');
+          }
+        }
+
+        const hasData = results.some((r) => (r.data || []).length > 0);
         return cachedOk({ hasData });
       },
     );

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -735,11 +735,12 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
  * GET /sites/:siteId/referral-traffic/has-data
  *
  * Fast existence check — returns { hasData: boolean } indicating whether any
- * referral traffic records exist for the site (across all sources). Used by
- * the PG dashboard to decide whether to show the no-data overlay without
- * waiting for all parallel data queries to settle.
+ * Traffic Insights data exists for the site (optel OR cdn). Used by the PG
+ * dashboard to decide whether to show the onboarding overlay without waiting
+ * for all parallel data queries to settle.
  *
- * Runs a single PostgREST table query with limit(1) — no RPC required.
+ * Both tables are checked in parallel with limit(1) — no RPC required.
+ * Returns true as soon as either source has at least one row.
  */
 export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
   return async function getReferralTrafficHasData(context) {
@@ -748,19 +749,23 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
       getSiteAndValidateAccess,
       'has-data',
       async (ctx, client, siteId) => {
-        const { data, error } = await client
-          .from('referral_traffic_optel')
-          .select('traffic_date')
-          .eq('site_id', siteId)
-          .limit(1);
+        const [optelResult, cdnResult] = await Promise.all([
+          client.from('referral_traffic_optel').select('traffic_date').eq('site_id', siteId).limit(1),
+          client.from('referral_traffic_cdn').select('traffic_date').eq('site_id', siteId).limit(1),
+        ]);
 
-        if (error) {
-          ctx.log.error(`Referral traffic has-data PostgREST error: ${error.message}`);
+        if (optelResult.error) {
+          ctx.log.error(`Referral traffic has-data optel error: ${optelResult.error.message}`);
+          return internalServerError('Failed to check referral traffic data');
+        }
+        if (cdnResult.error) {
+          ctx.log.error(`Referral traffic has-data cdn error: ${cdnResult.error.message}`);
           return internalServerError('Failed to check referral traffic data');
         }
 
+        const hasData = (optelResult.data || []).length > 0 || (cdnResult.data || []).length > 0;
         /* c8 ignore next */
-        return cachedOk({ hasData: (data || []).length > 0 });
+        return cachedOk({ hasData });
       },
     );
   };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -453,6 +453,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/agentic-traffic/has-data': llmoMysticatController.getAgenticTrafficHasData,
 
     // Referral Traffic PG — site-scoped endpoints (mysticat PostgREST)
+    'GET /sites/:siteId/referral-traffic/has-data': llmoMysticatController.getReferralTrafficHasData,
     'GET /sites/:siteId/referral-traffic/filter-dimensions': llmoMysticatController.getReferralTrafficFilterDimensions,
     'GET /sites/:siteId/referral-traffic/kpis': llmoMysticatController.getReferralTrafficKpis,
     'GET /sites/:siteId/referral-traffic/trend': llmoMysticatController.getReferralTrafficTrend,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -108,6 +108,7 @@ export const INTERNAL_ROUTES = [
   'GET /sites/:siteId/agentic-traffic/has-data',
 
   // Referral traffic PG dashboard endpoints (site-scoped) - UI only, not yet required by S2S
+  'GET /sites/:siteId/referral-traffic/has-data',
   'GET /sites/:siteId/referral-traffic/filter-dimensions',
   'GET /sites/:siteId/referral-traffic/kpis',
   'GET /sites/:siteId/referral-traffic/trend',

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -58,27 +58,33 @@ function makeWeeksChainClient(
 }
 
 /**
- * Chain-based client — used by the /has-data handler which queries optel and
- * cdn tables in parallel via .from().select().eq().limit().
- *
- * @param {object} optelResult  - PostgREST result for referral_traffic_optel
- * @param {object} cdnResult    - PostgREST result for referral_traffic_cdn
+ * The two Traffic Insights tables checked by the has-data handler.
+ * Must stay in sync with TRAFFIC_INSIGHTS_TABLES in llmo-referral-traffic.js.
  */
-function makeHasDataChainClient(
-  optelResult = { data: [], error: null },
-  cdnResult = { data: [], error: null },
-) {
+const HAS_DATA_TABLES = [
+  'referral_traffic_optel',
+  'referral_traffic_cdn',
+];
+
+/**
+ * Chain-based client for the /has-data handler.
+ *
+ * @param {Record<string, object>} resultsByTable  - Per-table PostgREST results.
+ *   Defaults to { data: [], error: null } for any table not specified.
+ */
+function makeHasDataChainClient(resultsByTable = {}) {
   const makeChain = (result) => ({
     select: sinon.stub().returnsThis(),
     eq: sinon.stub().returnsThis(),
     limit: sinon.stub().resolves(result),
   });
-  const optelChain = makeChain(optelResult);
-  const cdnChain = makeChain(cdnResult);
+  const chains = {};
   const fromStub = sinon.stub();
-  fromStub.withArgs('referral_traffic_optel').returns(optelChain);
-  fromStub.withArgs('referral_traffic_cdn').returns(cdnChain);
-  return { from: fromStub, optelChain, cdnChain };
+  for (const table of HAS_DATA_TABLES) {
+    chains[table] = makeChain(resultsByTable[table] ?? { data: [], error: null });
+    fromStub.withArgs(table).returns(chains[table]);
+  }
+  return { from: fromStub, chains };
 }
 
 function makeContext(overrides = {}) {
@@ -990,137 +996,133 @@ describe('llmo-referral-traffic', () => {
   });
 
   // ── /has-data ─────────────────────────────────────────────────────────────
+  // Checks only Traffic Insights sources (optel, cdn). Business Impact sources
+  // (adobe_analytics, ga4) are gated separately via the DRS provider endpoint.
+
+  const ROW = { traffic_date: '2026-01-05' };
 
   describe('has-data', () => {
-    it('returns { hasData: true } when optel has records', async () => {
-      const client = makeHasDataChainClient(
-        { data: [{ traffic_date: '2026-01-05' }], error: null },
-        { data: [], error: null },
+    it('returns { hasData: true } when only optel has records', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_optel: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
       );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(200);
-      const body = await res.json();
-      expect(body.hasData).to.equal(true);
+      expect((await res.json()).hasData).to.equal(true);
     });
 
-    it('returns { hasData: true } when cdn has records and optel is empty', async () => {
-      const client = makeHasDataChainClient(
-        { data: [], error: null },
-        { data: [{ traffic_date: '2026-01-05' }], error: null },
+    it('returns { hasData: true } when only cdn has records', async () => {
+      const client = makeHasDataChainClient({ referral_traffic_cdn: { data: [ROW], error: null } });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
       );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(200);
-      const body = await res.json();
-      expect(body.hasData).to.equal(true);
+      expect((await res.json()).hasData).to.equal(true);
     });
 
     it('returns { hasData: true } when both optel and cdn have records', async () => {
-      const client = makeHasDataChainClient(
-        { data: [{ traffic_date: '2026-01-05' }], error: null },
-        { data: [{ traffic_date: '2026-01-05' }], error: null },
+      const client = makeHasDataChainClient({
+        referral_traffic_optel: { data: [ROW], error: null },
+        referral_traffic_cdn: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
       );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(200);
-      const body = await res.json();
-      expect(body.hasData).to.equal(true);
+      expect((await res.json()).hasData).to.equal(true);
     });
 
     it('returns { hasData: false } when both optel and cdn are empty', async () => {
-      const client = makeHasDataChainClient(
-        { data: [], error: null },
-        { data: [], error: null },
+      const client = makeHasDataChainClient();
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
       );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(200);
-      const body = await res.json();
-      expect(body.hasData).to.equal(false);
+      expect((await res.json()).hasData).to.equal(false);
     });
 
     it('returns { hasData: false } when both tables return null data', async () => {
-      const client = makeHasDataChainClient(
-        { data: null, error: null },
-        { data: null, error: null },
+      const nullResults = Object.fromEntries(
+        HAS_DATA_TABLES.map((t) => [t, { data: null, error: null }]),
       );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client }));
+      const client = makeHasDataChainClient(nullResults);
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
       expect(res.status).to.equal(200);
-      const body = await res.json();
-      expect(body.hasData).to.equal(false);
+      expect((await res.json()).hasData).to.equal(false);
     });
 
-    it('returns 500 on optel PostgREST error', async () => {
-      const client = makeHasDataChainClient(
-        { data: null, error: { message: 'optel-has-data-fail' } },
-        { data: [], error: null },
+    it('returns 500 and fails closed when one source errors (even if the other has data)', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_optel: { data: [ROW], error: null },
+        referral_traffic_cdn: { data: null, error: { message: 'cdn-fail' } },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
       );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(500);
     });
 
-    it('returns 500 on cdn PostgREST error', async () => {
-      const client = makeHasDataChainClient(
-        { data: [], error: null },
-        { data: null, error: { message: 'cdn-has-data-fail' } },
+    it('returns 500 when both sources error simultaneously', async () => {
+      const errorResults = Object.fromEntries(
+        HAS_DATA_TABLES.map((t) => [t, { data: null, error: { message: `${t}-fail` } }]),
       );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(makeContext({ client }));
+      const client = makeHasDataChainClient(errorResults);
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
       expect(res.status).to.equal(500);
     });
 
-    it('logs the optel error message on optel failure', async () => {
-      const client = makeHasDataChainClient(
-        { data: null, error: { message: 'optel-has-data-fail' } },
-        { data: [], error: null },
-      );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+    it('logs the erroring table name and siteId on PostgREST error', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_cdn: { data: null, error: { message: 'cdn-pg-fail' } },
+      });
       const ctx = makeContext({ client });
-      await handler(ctx);
-      expect(ctx.log.error).to.have.been.calledWithMatch(/optel-has-data-fail/);
+      await createReferralTrafficHasDataHandler(stubbedValidateAccess)(ctx);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/referral_traffic_cdn/);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/cdn-pg-fail/);
+      expect(ctx.log.error).to.have.been.calledWithMatch(new RegExp(SITE_ID));
     });
 
-    it('logs the cdn error message on cdn failure', async () => {
-      const client = makeHasDataChainClient(
-        { data: [], error: null },
-        { data: null, error: { message: 'cdn-has-data-fail' } },
-      );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const ctx = makeContext({ client });
-      await handler(ctx);
-      expect(ctx.log.error).to.have.been.calledWithMatch(/cdn-has-data-fail/);
+    it('returns 500 when limit() rejects (thrown error from PostgREST client)', async () => {
+      const throwingChain = {
+        select: sinon.stub().returnsThis(),
+        eq: sinon.stub().returnsThis(),
+        limit: sinon.stub().rejects(new Error('network timeout')),
+      };
+      const ctx = makeContext({ client: { from: sinon.stub().returns(throwingChain) } });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(ctx);
+      expect(res.status).to.equal(500);
     });
 
-    it('queries both referral_traffic_optel and referral_traffic_cdn with the site id', async () => {
-      const client = makeHasDataChainClient(
-        { data: [], error: null },
-        { data: [], error: null },
-      );
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      await handler(makeContext({ client }));
-      expect(client.from).to.have.been.calledWith('referral_traffic_optel');
-      expect(client.from).to.have.been.calledWith('referral_traffic_cdn');
-      expect(client.optelChain.eq).to.have.been.calledWith('site_id', SITE_ID);
-      expect(client.cdnChain.eq).to.have.been.calledWith('site_id', SITE_ID);
-      expect(client.optelChain.limit).to.have.been.calledWith(1);
-      expect(client.cdnChain.limit).to.have.been.calledWith(1);
+    it('queries only optel and cdn tables with the site id', async () => {
+      const client = makeHasDataChainClient();
+      await createReferralTrafficHasDataHandler(stubbedValidateAccess)(makeContext({ client }));
+      for (const table of HAS_DATA_TABLES) {
+        expect(client.from).to.have.been.calledWith(table);
+        expect(client.chains[table].eq).to.have.been.calledWith('site_id', SITE_ID);
+        expect(client.chains[table].limit).to.have.been.calledWith(1);
+      }
+      expect(client.from).not.to.have.been.calledWith('referral_traffic_adobe_analytics');
+      expect(client.from).not.to.have.been.calledWith('referral_traffic_ga4');
     });
 
     it('returns 400 when Site.postgrestService is missing', async () => {
       const ctx = makeContext({ client: makeHasDataChainClient() });
       ctx.dataAccess.Site.postgrestService = null;
-      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
-      const res = await handler(ctx);
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(ctx);
       expect(res.status).to.equal(400);
     });
 
     it('returns 403 when access validation denies the request', async () => {
       const deny = sinon.stub().rejects(new Error('Only users belonging to the organization'));
-      const handler = createReferralTrafficHasDataHandler(deny);
-      const res = await handler(makeContext({ client: makeHasDataChainClient() }));
+      const res = await createReferralTrafficHasDataHandler(deny)(
+        makeContext({ client: makeHasDataChainClient() }),
+      );
       expect(res.status).to.equal(403);
     });
   });

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -24,6 +24,7 @@ import {
   createReferralTrafficUrlTrendHandler,
   createReferralTrafficBusinessImpactHandler,
   createReferralTrafficWeeksHandler,
+  createReferralTrafficHasDataHandler,
 } from '../../../src/controllers/llmo/llmo-referral-traffic.js';
 
 use(sinonChai);
@@ -52,6 +53,19 @@ function makeWeeksChainClient(
       .onFirstCall().resolves(minResult)
       .onSecondCall()
       .resolves(maxResult),
+  };
+  return { from: sinon.stub().returns(chain), chain };
+}
+
+/**
+ * Chain-based client — used by the /has-data handler which queries the table
+ * directly via .from().select().eq().limit() (single call).
+ */
+function makeHasDataChainClient(result = { data: [], error: null }) {
+  const chain = {
+    select: sinon.stub().returnsThis(),
+    eq: sinon.stub().returnsThis(),
+    limit: sinon.stub().resolves(result),
   };
   return { from: sinon.stub().returns(chain), chain };
 }
@@ -961,6 +975,76 @@ describe('llmo-referral-traffic', () => {
       const handler = createReferralTrafficWeeksHandler(stubbedValidateAccess);
       await handler(makeContext({ client }));
       expect(client.from.calledWith('referral_traffic_optel')).to.be.true;
+    });
+  });
+
+  // ── /has-data ─────────────────────────────────────────────────────────────
+
+  describe('has-data', () => {
+    it('returns { hasData: true } when records exist for the site', async () => {
+      const client = makeHasDataChainClient({ data: [{ traffic_date: '2026-01-05' }], error: null });
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+    });
+
+    it('returns { hasData: false } when no records exist for the site', async () => {
+      const client = makeHasDataChainClient({ data: [], error: null });
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(false);
+    });
+
+    it('returns { hasData: false } when data is null', async () => {
+      const client = makeHasDataChainClient({ data: null, error: null });
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(false);
+    });
+
+    it('returns 500 on PostgREST error', async () => {
+      const client = makeHasDataChainClient({ data: null, error: { message: 'has-data-fail' } });
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(500);
+    });
+
+    it('logs the PostgREST error message on failure', async () => {
+      const client = makeHasDataChainClient({ data: null, error: { message: 'has-data-fail' } });
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const ctx = makeContext({ client });
+      await handler(ctx);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/has-data-fail/);
+    });
+
+    it('queries referral_traffic_optel table with the site id', async () => {
+      const client = makeHasDataChainClient({ data: [], error: null });
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      await handler(makeContext({ client }));
+      expect(client.from).to.have.been.calledWith('referral_traffic_optel');
+      expect(client.chain.eq).to.have.been.calledWith('site_id', SITE_ID);
+      expect(client.chain.limit).to.have.been.calledWith(1);
+    });
+
+    it('returns 400 when Site.postgrestService is missing', async () => {
+      const ctx = makeContext({ client: makeHasDataChainClient() });
+      ctx.dataAccess.Site.postgrestService = null;
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 403 when access validation denies the request', async () => {
+      const deny = sinon.stub().rejects(new Error('Only users belonging to the organization'));
+      const handler = createReferralTrafficHasDataHandler(deny);
+      const res = await handler(makeContext({ client: makeHasDataChainClient() }));
+      expect(res.status).to.equal(403);
     });
   });
 

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -58,16 +58,27 @@ function makeWeeksChainClient(
 }
 
 /**
- * Chain-based client — used by the /has-data handler which queries the table
- * directly via .from().select().eq().limit() (single call).
+ * Chain-based client — used by the /has-data handler which queries optel and
+ * cdn tables in parallel via .from().select().eq().limit().
+ *
+ * @param {object} optelResult  - PostgREST result for referral_traffic_optel
+ * @param {object} cdnResult    - PostgREST result for referral_traffic_cdn
  */
-function makeHasDataChainClient(result = { data: [], error: null }) {
-  const chain = {
+function makeHasDataChainClient(
+  optelResult = { data: [], error: null },
+  cdnResult = { data: [], error: null },
+) {
+  const makeChain = (result) => ({
     select: sinon.stub().returnsThis(),
     eq: sinon.stub().returnsThis(),
     limit: sinon.stub().resolves(result),
-  };
-  return { from: sinon.stub().returns(chain), chain };
+  });
+  const optelChain = makeChain(optelResult);
+  const cdnChain = makeChain(cdnResult);
+  const fromStub = sinon.stub();
+  fromStub.withArgs('referral_traffic_optel').returns(optelChain);
+  fromStub.withArgs('referral_traffic_cdn').returns(cdnChain);
+  return { from: fromStub, optelChain, cdnChain };
 }
 
 function makeContext(overrides = {}) {
@@ -981,8 +992,11 @@ describe('llmo-referral-traffic', () => {
   // ── /has-data ─────────────────────────────────────────────────────────────
 
   describe('has-data', () => {
-    it('returns { hasData: true } when records exist for the site', async () => {
-      const client = makeHasDataChainClient({ data: [{ traffic_date: '2026-01-05' }], error: null });
+    it('returns { hasData: true } when optel has records', async () => {
+      const client = makeHasDataChainClient(
+        { data: [{ traffic_date: '2026-01-05' }], error: null },
+        { data: [], error: null },
+      );
       const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
       const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(200);
@@ -990,8 +1004,35 @@ describe('llmo-referral-traffic', () => {
       expect(body.hasData).to.equal(true);
     });
 
-    it('returns { hasData: false } when no records exist for the site', async () => {
-      const client = makeHasDataChainClient({ data: [], error: null });
+    it('returns { hasData: true } when cdn has records and optel is empty', async () => {
+      const client = makeHasDataChainClient(
+        { data: [], error: null },
+        { data: [{ traffic_date: '2026-01-05' }], error: null },
+      );
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+    });
+
+    it('returns { hasData: true } when both optel and cdn have records', async () => {
+      const client = makeHasDataChainClient(
+        { data: [{ traffic_date: '2026-01-05' }], error: null },
+        { data: [{ traffic_date: '2026-01-05' }], error: null },
+      );
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+    });
+
+    it('returns { hasData: false } when both optel and cdn are empty', async () => {
+      const client = makeHasDataChainClient(
+        { data: [], error: null },
+        { data: [], error: null },
+      );
       const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
       const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(200);
@@ -999,8 +1040,11 @@ describe('llmo-referral-traffic', () => {
       expect(body.hasData).to.equal(false);
     });
 
-    it('returns { hasData: false } when data is null', async () => {
-      const client = makeHasDataChainClient({ data: null, error: null });
+    it('returns { hasData: false } when both tables return null data', async () => {
+      const client = makeHasDataChainClient(
+        { data: null, error: null },
+        { data: null, error: null },
+      );
       const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
       const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(200);
@@ -1008,28 +1052,61 @@ describe('llmo-referral-traffic', () => {
       expect(body.hasData).to.equal(false);
     });
 
-    it('returns 500 on PostgREST error', async () => {
-      const client = makeHasDataChainClient({ data: null, error: { message: 'has-data-fail' } });
+    it('returns 500 on optel PostgREST error', async () => {
+      const client = makeHasDataChainClient(
+        { data: null, error: { message: 'optel-has-data-fail' } },
+        { data: [], error: null },
+      );
       const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
       const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(500);
     });
 
-    it('logs the PostgREST error message on failure', async () => {
-      const client = makeHasDataChainClient({ data: null, error: { message: 'has-data-fail' } });
+    it('returns 500 on cdn PostgREST error', async () => {
+      const client = makeHasDataChainClient(
+        { data: [], error: null },
+        { data: null, error: { message: 'cdn-has-data-fail' } },
+      );
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(500);
+    });
+
+    it('logs the optel error message on optel failure', async () => {
+      const client = makeHasDataChainClient(
+        { data: null, error: { message: 'optel-has-data-fail' } },
+        { data: [], error: null },
+      );
       const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
       const ctx = makeContext({ client });
       await handler(ctx);
-      expect(ctx.log.error).to.have.been.calledWithMatch(/has-data-fail/);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/optel-has-data-fail/);
     });
 
-    it('queries referral_traffic_optel table with the site id', async () => {
-      const client = makeHasDataChainClient({ data: [], error: null });
+    it('logs the cdn error message on cdn failure', async () => {
+      const client = makeHasDataChainClient(
+        { data: [], error: null },
+        { data: null, error: { message: 'cdn-has-data-fail' } },
+      );
+      const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
+      const ctx = makeContext({ client });
+      await handler(ctx);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/cdn-has-data-fail/);
+    });
+
+    it('queries both referral_traffic_optel and referral_traffic_cdn with the site id', async () => {
+      const client = makeHasDataChainClient(
+        { data: [], error: null },
+        { data: [], error: null },
+      );
       const handler = createReferralTrafficHasDataHandler(stubbedValidateAccess);
       await handler(makeContext({ client }));
       expect(client.from).to.have.been.calledWith('referral_traffic_optel');
-      expect(client.chain.eq).to.have.been.calledWith('site_id', SITE_ID);
-      expect(client.chain.limit).to.have.been.calledWith(1);
+      expect(client.from).to.have.been.calledWith('referral_traffic_cdn');
+      expect(client.optelChain.eq).to.have.been.calledWith('site_id', SITE_ID);
+      expect(client.cdnChain.eq).to.have.been.calledWith('site_id', SITE_ID);
+      expect(client.optelChain.limit).to.have.been.calledWith(1);
+      expect(client.cdnChain.limit).to.have.been.calledWith(1);
     });
 
     it('returns 400 when Site.postgrestService is missing', async () => {

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -284,6 +284,18 @@ describe('getRouteHandlers', () => {
     getAgenticTrafficMovers: () => null,
     getAgenticTrafficUrlBrandPresence: () => null,
     getAgenticTrafficHasData: () => null,
+    getReferralTrafficHasData: () => null,
+    getReferralTrafficFilterDimensions: () => null,
+    getReferralTrafficKpis: () => null,
+    getReferralTrafficTrend: () => null,
+    getReferralTrafficByPlatform: () => null,
+    getReferralTrafficByRegion: () => null,
+    getReferralTrafficByDevice: () => null,
+    getReferralTrafficByPageIntent: () => null,
+    getReferralTrafficByUrl: () => null,
+    getReferralTrafficUrlTrend: () => null,
+    getReferralTrafficBusinessImpact: () => null,
+    getReferralTrafficWeeks: () => null,
   };
 
   const mockLlmoOpportunitiesController = {
@@ -931,6 +943,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/agentic-traffic/movers',
       'GET /sites/:siteId/agentic-traffic/url-brand-presence',
       'GET /sites/:siteId/agentic-traffic/has-data',
+      'GET /sites/:siteId/referral-traffic/has-data',
       'GET /sites/:siteId/referral-traffic/filter-dimensions',
       'GET /sites/:siteId/referral-traffic/kpis',
       'GET /sites/:siteId/referral-traffic/trend',


### PR DESCRIPTION
This commit introduces a new endpoint `GET /sites/:siteId/referral-traffic/has-data` that checks for the existence of referral traffic records for a given site. The implementation includes a handler that performs a single PostgREST query to determine if any records exist, returning a boolean response.

- Added `createReferralTrafficHasDataHandler` in `llmo-referral-traffic.js`
- Integrated the handler into `LlmoMysticatController`
- Registered the new route in `src/routes/index.js`
- Comprehensive unit tests added to ensure functionality and error handling

This feature enhances the referral traffic API by allowing quick checks for data availability, improving user experience on the frontend.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
[LLMO-4261](https://jira.corp.adobe.com/browse/LLMO-4261)
