### PR TITLE
feat(llmo): expose referral-traffic trend-by-url endpoint | LLMO-4729

### DIFF
--- a/src/controllers/llmo/llmo-mysticat-controller.js
+++ b/src/controllers/llmo/llmo-mysticat-controller.js
@@ -59,6 +59,7 @@ import {
   createReferralTrafficFilterDimensionsHandler,
   createReferralTrafficKpisHandler,
   createReferralTrafficTrendHandler,
+  createReferralTrafficTrendByUrlHandler,
   createReferralTrafficByPlatformHandler,
   createReferralTrafficByRegionHandler,
   createReferralTrafficByPageIntentHandler,
@@ -208,6 +209,9 @@ function LlmoMysticatController(ctx) {
   );
   const getReferralTrafficKpis = createReferralTrafficKpisHandler(getSiteAndValidateAccess);
   const getReferralTrafficTrend = createReferralTrafficTrendHandler(getSiteAndValidateAccess);
+  const getReferralTrafficTrendByUrl = createReferralTrafficTrendByUrlHandler(
+    getSiteAndValidateAccess,
+  );
   const getReferralTrafficByPlatform = createReferralTrafficByPlatformHandler(
     getSiteAndValidateAccess,
   );
@@ -267,6 +271,7 @@ function LlmoMysticatController(ctx) {
     getReferralTrafficFilterDimensions,
     getReferralTrafficKpis,
     getReferralTrafficTrend,
+    getReferralTrafficTrendByUrl,
     getReferralTrafficByPlatform,
     getReferralTrafficByRegion,
     getReferralTrafficByPageIntent,

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -290,6 +290,56 @@ export function createReferralTrafficTrendHandler(getSiteAndValidateAccess) {
 }
 
 // ============================================================================
+// /trend-by-url
+// ============================================================================
+
+/**
+ * GET /sites/:siteId/referral-traffic/trend-by-url
+ *
+ * Per-URL weekly aggregate of pageviews. Powers the per-URL referral series
+ * inside the URL Inspector PG details dialog (LLMO-4729).
+ *
+ * Mirrors the page-level /trend endpoint, with one extra query param
+ * `urlPathSearch` (alias: `url_path_search`) mapped to `p_url_search` on
+ * the RPC. The filter is a case-insensitive substring match on `url_path`,
+ * matching the same semantics as `/by-url`. An absent or empty
+ * urlPathSearch returns the page-wide trend (parity with the underlying
+ * RPC's NULL contract); the UI always passes a non-empty path.
+ */
+export function createReferralTrafficTrendByUrlHandler(getSiteAndValidateAccess) {
+  return async function getReferralTrafficTrendByUrl(context) {
+    return withReferralTrafficAuth(
+      context,
+      getSiteAndValidateAccess,
+      'trend-by-url',
+      async (ctx, client, siteId) => {
+        const parsed = parseParams(ctx);
+        const q = ctx.data || {};
+        const urlPathSearch = q.urlPathSearch || q.url_path_search || null;
+
+        const { data, error } = await client.rpc('rpc_referral_traffic_trend_by_url', {
+          ...commonRpcParams(siteId, parsed),
+          p_url_search: urlPathSearch,
+        });
+
+        if (error) {
+          ctx.log.error(`Referral traffic trend-by-url PostgREST error: ${error.message}`);
+          return internalServerError('Failed to fetch referral traffic trend by URL');
+        }
+
+        /* c8 ignore next 2 — PostgREST guarantees non-null data when error is null */
+        return ok({
+          trend: (data ?? []).map((row) => ({
+            date: row.traffic_date,
+            pageviews: Number(row.total_pageviews),
+          })),
+        });
+      },
+    );
+  };
+}
+
+// ============================================================================
 // /by-platform
 // ============================================================================
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -455,6 +455,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/referral-traffic/filter-dimensions': llmoMysticatController.getReferralTrafficFilterDimensions,
     'GET /sites/:siteId/referral-traffic/kpis': llmoMysticatController.getReferralTrafficKpis,
     'GET /sites/:siteId/referral-traffic/trend': llmoMysticatController.getReferralTrafficTrend,
+    'GET /sites/:siteId/referral-traffic/trend-by-url': llmoMysticatController.getReferralTrafficTrendByUrl,
     'GET /sites/:siteId/referral-traffic/by-platform': llmoMysticatController.getReferralTrafficByPlatform,
     'GET /sites/:siteId/referral-traffic/by-region': llmoMysticatController.getReferralTrafficByRegion,
     'GET /sites/:siteId/referral-traffic/by-page-intent': llmoMysticatController.getReferralTrafficByPageIntent,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -111,6 +111,7 @@ export const INTERNAL_ROUTES = [
   'GET /sites/:siteId/referral-traffic/filter-dimensions',
   'GET /sites/:siteId/referral-traffic/kpis',
   'GET /sites/:siteId/referral-traffic/trend',
+  'GET /sites/:siteId/referral-traffic/trend-by-url',
   'GET /sites/:siteId/referral-traffic/by-platform',
   'GET /sites/:siteId/referral-traffic/by-region',
   'GET /sites/:siteId/referral-traffic/by-page-intent',

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -23,6 +23,7 @@ import {
   createReferralTrafficByUrlHandler,
   createReferralTrafficBusinessImpactHandler,
   createReferralTrafficWeeksHandler,
+  createReferralTrafficTrendByUrlHandler,
 } from '../../../src/controllers/llmo/llmo-referral-traffic.js';
 
 use(sinonChai);
@@ -315,6 +316,105 @@ describe('llmo-referral-traffic', () => {
       const handler = createReferralTrafficTrendHandler(stubbedValidateAccess);
       const res = await handler(makeContext({ client }));
       expect(res.status).to.equal(500);
+    });
+  });
+
+  // ── /trend-by-url (LLMO-4729) ─────────────────────────────────────────────
+
+  describe('trend-by-url', () => {
+    it('forwards urlPathSearch as p_url_search to the RPC', async () => {
+      const client = makeRpcClient({
+        data: [{ traffic_date: '2026-01-05', total_pageviews: 250 }],
+      });
+      const ctx = makeContext({ client });
+      ctx.data = { ...ctx.data, urlPathSearch: '/products/firefly' };
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      const rpcCall = client.rpc.getCall(0);
+      expect(rpcCall.args[0]).to.equal('rpc_referral_traffic_trend_by_url');
+      expect(rpcCall.args[1].p_url_search).to.equal('/products/firefly');
+    });
+
+    it('accepts snake_case url_path_search alias', async () => {
+      const client = makeRpcClient({ data: [] });
+      const ctx = makeContext({ client });
+      ctx.data = { ...ctx.data, url_path_search: '/about' };
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      expect(client.rpc.getCall(0).args[1].p_url_search).to.equal('/about');
+    });
+
+    it('passes null p_url_search when neither alias is provided', async () => {
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      await handler(makeContext({ client }));
+      expect(client.rpc.getCall(0).args[1].p_url_search).to.be.null;
+    });
+
+    it('defaults source to optel and threads dates + filters', async () => {
+      const client = makeRpcClient({ data: [] });
+      const ctx = makeContext({ client });
+      ctx.data = {
+        ...ctx.data,
+        platform: 'openai',
+        region: 'US',
+        deviceType: 'desktop',
+        pageIntent: 'purchase',
+        urlPathSearch: '/products',
+      };
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      await handler(ctx);
+      const rpcArgs = client.rpc.getCall(0).args[1];
+      expect(rpcArgs.p_source).to.equal('optel');
+      expect(rpcArgs.p_start_date).to.equal('2026-01-01');
+      expect(rpcArgs.p_end_date).to.equal('2026-01-28');
+      expect(rpcArgs.p_platform).to.equal('openai');
+      expect(rpcArgs.p_region).to.equal('US');
+      expect(rpcArgs.p_device).to.equal('desktop');
+      expect(rpcArgs.p_page_intent).to.equal('purchase');
+      expect(rpcArgs.p_url_search).to.equal('/products');
+    });
+
+    it('maps RPC rows to a {date, pageviews} series', async () => {
+      const client = makeRpcClient({
+        data: [
+          { traffic_date: '2026-01-05', total_pageviews: 100 },
+          { traffic_date: '2026-01-12', total_pageviews: 250 },
+        ],
+      });
+      const ctx = makeContext({ client });
+      ctx.data = { ...ctx.data, urlPathSearch: '/products' };
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.trend).to.deep.equal([
+        { date: '2026-01-05', pageviews: 100 },
+        { date: '2026-01-12', pageviews: 250 },
+      ]);
+    });
+
+    it('returns an empty trend array when RPC returns no rows', async () => {
+      const client = makeRpcClient({ data: [], error: null });
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      const body = await res.json();
+      expect(body.trend).to.deep.equal([]);
+    });
+
+    it('returns 500 on PostgREST error', async () => {
+      const client = makeRpcClient({ data: null, error: { message: 'boom' } });
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client }));
+      expect(res.status).to.equal(500);
+    });
+
+    it('returns 400 when Site.postgrestService is missing', async () => {
+      const ctx = makeContext();
+      ctx.dataAccess.Site.postgrestService = null;
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(400);
     });
   });
 

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -416,6 +416,16 @@ describe('llmo-referral-traffic', () => {
       const res = await handler(ctx);
       expect(res.status).to.equal(400);
     });
+
+    it('uses {} when ctx.data is null in trend-by-url handler (covers `ctx.data || {}` branch)', async () => {
+      const client = makeRpcClient({ data: [] });
+      const ctx = makeContext({ client });
+      ctx.data = null;
+      const handler = createReferralTrafficTrendByUrlHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      expect(client.rpc.getCall(0).args[1].p_url_search).to.equal(null);
+    });
   });
 
   // ── /by-platform ──────────────────────────────────────────────────────────

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -933,6 +933,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/referral-traffic/filter-dimensions',
       'GET /sites/:siteId/referral-traffic/kpis',
       'GET /sites/:siteId/referral-traffic/trend',
+      'GET /sites/:siteId/referral-traffic/trend-by-url',
       'GET /sites/:siteId/referral-traffic/by-platform',
       'GET /sites/:siteId/referral-traffic/by-region',
       'GET /sites/:siteId/referral-traffic/by-device',


### PR DESCRIPTION
## Summary

URL Inspector PG's URL Details dialog needs a per-URL × per-week referral pageview series. The companion mysticat PR (adobe/mysticat-data-service#544) adds a new `rpc_referral_traffic_trend_by_url` RPC; this PR exposes it through a new spacecat endpoint at `GET /sites/:siteId/referral-traffic/trend-by-url` and forwards a new `urlPathSearch` query param to `p_url_search` on the RPC.

This is the second of three coordinated PRs for [LLMO-4729](https://jira.corp.adobe.com/browse/LLMO-4729). It must deploy after mysticat#544 is on DEV (the schema cache reload there is what makes the new RPC callable through PostgREST).

## What changed

### `src/controllers/llmo/llmo-referral-traffic.js`

- Adds `createReferralTrafficTrendByUrlHandler` factory mirroring `createReferralTrafficTrendHandler` exactly, plus a `urlPathSearch` (alias `url_path_search`) query param mapped to `p_url_search` on the RPC.
- Reuses the existing `commonRpcParams`, `withReferralTrafficAuth`, source defaulting, and date-window parsing — single source of truth for referral-traffic parameter handling.
- Returns `{ trend: [{ date, pageviews }] }` (same shape as `/trend`), with `pageviews` coerced to `Number` defensively.
- 500 on PostgREST error (mirrors `/trend`).

### `src/controllers/llmo/llmo-mysticat-controller.js`

- Imports the new handler factory and exposes `getReferralTrafficTrendByUrl` on the controller.

### `src/routes/index.js`

- Registers `GET /sites/:siteId/referral-traffic/trend-by-url → llmoMysticatController.getReferralTrafficTrendByUrl`.

### `src/routes/required-capabilities.js`

- Adds the new path to the LLMO capability list (same auth as the rest of `/sites/:siteId/referral-traffic/*`).

### Tests

- `test/controllers/llmo/llmo-referral-traffic.test.js` — new \`trend-by-url\` describe block covering:
  - `urlPathSearch` (camelCase) and `url_path_search` (snake_case) both forward to `p_url_search`
  - default source = `optel`
  - dates and dimension filters thread through
  - RPC row mapping (`traffic_date → date`, `total_pageviews → pageviews`)
  - empty `data` returns `{ trend: [] }`
  - 400 when `postgrestService` missing
  - 500 on PostgREST error
- `test/routes/index.test.js` — adds the new route to the expected route list (segregation snapshot).

## Backwards compatibility

This is a **brand-new endpoint and handler**. No existing endpoint or handler is touched. Existing referral-traffic callers see no change.

## Companion PRs

- **mysticat-data-service**: adobe/mysticat-data-service#544
- **project-elmo-ui**: adobe/project-elmo-ui#1685

## Test plan

- [x] Unit tests pass locally (`npx mocha test/controllers/llmo/llmo-referral-traffic.test.js test/routes/index.test.js` → 71 passing)
- [x] `npx eslint .` clean
- [ ] Manual call against DEV (with mysticat#544 applied via the runbook):
  - `?urlPathSearch=/products/firefly.html&source=optel&startDate=…&endDate=…` returns weekly buckets for that URL only
  - Empty `urlPathSearch` returns the full page-level series (mirrors RPC NULL contract)
  - Unknown source falls back to `optel`
- [ ] CI green

Made with [Cursor](https://cursor.com)