### PR TITLE
feat: enhance has-data endpoint to return available sources | LLMO-4261

### DIFF
--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -735,26 +735,30 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
  * Traffic Insights sources — the only tables that feed the Traffic Insights tab.
  * Business Impact (adobe_analytics, ga4) has its own DRS provider check and is
  * intentionally excluded here.
+ *
+ * Order matters: optel is listed first because it is the preferred source.
+ * The has-data response preserves this order in availableSources so callers
+ * can pick the first entry as the active source (optel wins over cdn).
  */
-const TRAFFIC_INSIGHTS_TABLES = [
-  SOURCE_TO_TABLE.optel,
-  SOURCE_TO_TABLE.cdn,
-];
+const TRAFFIC_INSIGHTS_SOURCES = ['optel', 'cdn'];
+const TRAFFIC_INSIGHTS_TABLES = TRAFFIC_INSIGHTS_SOURCES.map((s) => SOURCE_TO_TABLE[s]);
 
 /**
  * GET /sites/:siteId/referral-traffic/has-data
  *
- * Fast existence check — returns { hasData: boolean } indicating whether any
- * Traffic Insights data (optel or cdn) exists for the site. Used by the PG
- * dashboard to decide whether to show the onboarding overlay without waiting
- * for all parallel data queries to settle.
+ * Fast existence check for Traffic Insights data (optel and cdn).
+ * Business Impact sources (adobe_analytics, ga4) are gated separately via DRS.
  *
- * Only optel and cdn are checked because those are the sole sources for the
- * Traffic Insights tab. Business Impact sources (adobe_analytics, ga4) are
- * gated separately via the DRS analytics-provider endpoint.
+ * Response:
+ *   { hasData: boolean, availableSources: Array<'optel'|'cdn'> }
+ *
+ * availableSources lists whichever of optel/cdn has at least one row, in
+ * priority order (optel first). Callers should use the first entry as the
+ * active source so they naturally prefer optel over cdn.
+ * hasData is true iff availableSources is non-empty.
  *
  * Both tables are checked in parallel with limit(1) — no RPC required.
- * Returns true if either result set is non-empty; fails closed if any query errors.
+ * Fails closed: if any query errors, returns 500 rather than a partial result.
  */
 export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
   return async function getReferralTrafficHasData(context) {
@@ -780,8 +784,10 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
           }
         }
 
-        const hasData = results.some((r) => (r.data || []).length > 0);
-        return cachedOk({ hasData });
+        const availableSources = TRAFFIC_INSIGHTS_SOURCES.filter(
+          (_, i) => (results[i].data || []).length > 0,
+        );
+        return cachedOk({ hasData: availableSources.length > 0, availableSources });
       },
     );
   };

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -1002,7 +1002,7 @@ describe('llmo-referral-traffic', () => {
   const ROW = { traffic_date: '2026-01-05' };
 
   describe('has-data', () => {
-    it('returns { hasData: true } when only optel has records', async () => {
+    it('returns hasData:true and availableSources:["optel"] when only optel has records', async () => {
       const client = makeHasDataChainClient({
         referral_traffic_optel: { data: [ROW], error: null },
       });
@@ -1010,19 +1010,25 @@ describe('llmo-referral-traffic', () => {
         makeContext({ client }),
       );
       expect(res.status).to.equal(200);
-      expect((await res.json()).hasData).to.equal(true);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+      expect(body.availableSources).to.deep.equal(['optel']);
     });
 
-    it('returns { hasData: true } when only cdn has records', async () => {
-      const client = makeHasDataChainClient({ referral_traffic_cdn: { data: [ROW], error: null } });
+    it('returns hasData:true and availableSources:["cdn"] when only cdn has records', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_cdn: { data: [ROW], error: null },
+      });
       const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
         makeContext({ client }),
       );
       expect(res.status).to.equal(200);
-      expect((await res.json()).hasData).to.equal(true);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+      expect(body.availableSources).to.deep.equal(['cdn']);
     });
 
-    it('returns { hasData: true } when both optel and cdn have records', async () => {
+    it('returns hasData:true and availableSources:["optel","cdn"] when both have records', async () => {
       const client = makeHasDataChainClient({
         referral_traffic_optel: { data: [ROW], error: null },
         referral_traffic_cdn: { data: [ROW], error: null },
@@ -1031,19 +1037,23 @@ describe('llmo-referral-traffic', () => {
         makeContext({ client }),
       );
       expect(res.status).to.equal(200);
-      expect((await res.json()).hasData).to.equal(true);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+      expect(body.availableSources).to.deep.equal(['optel', 'cdn']);
     });
 
-    it('returns { hasData: false } when both optel and cdn are empty', async () => {
+    it('returns hasData:false and availableSources:[] when both tables are empty', async () => {
       const client = makeHasDataChainClient();
       const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
         makeContext({ client }),
       );
       expect(res.status).to.equal(200);
-      expect((await res.json()).hasData).to.equal(false);
+      const body = await res.json();
+      expect(body.hasData).to.equal(false);
+      expect(body.availableSources).to.deep.equal([]);
     });
 
-    it('returns { hasData: false } when both tables return null data', async () => {
+    it('returns hasData:false and availableSources:[] when both tables return null data', async () => {
       const nullResults = Object.fromEntries(
         HAS_DATA_TABLES.map((t) => [t, { data: null, error: null }]),
       );
@@ -1052,7 +1062,9 @@ describe('llmo-referral-traffic', () => {
         makeContext({ client }),
       );
       expect(res.status).to.equal(200);
-      expect((await res.json()).hasData).to.equal(false);
+      const body = await res.json();
+      expect(body.hasData).to.equal(false);
+      expect(body.availableSources).to.deep.equal([]);
     });
 
     it('returns 500 and fails closed when one source errors (even if the other has data)', async () => {


### PR DESCRIPTION
- Updated the `createReferralTrafficHasDataHandler` to return an array of available sources (`availableSources`) alongside the `hasData` boolean.
- Adjusted the logic to prioritize `optel` over `cdn` in the response.
- Updated unit tests to reflect changes in the response structure, ensuring accurate assertions for `hasData` and `availableSources`.

This change improves the clarity of the API response, allowing clients to easily identify which data sources are available.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
[LLMO-4261](https://jira.corp.adobe.com/browse/LLMO-4261)