### PR TITLE
fix(prompts): prevent upsert from reactivating deleted prompts

### DIFF
--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -509,7 +509,8 @@ export async function upsertPrompts({
     .from('prompts')
     .select('id,prompt_id,text,regions')
     .eq('organization_id', organizationId)
-    .eq('brand_id', brandUuid);
+    .eq('brand_id', brandUuid)
+    .neq('status', 'deleted');
 
   if (incomingIds.length > 0) {
     existingQuery = existingQuery.in('prompt_id', incomingIds);

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -774,7 +774,13 @@ describe('Brands Controller', () => {
         if (table === 'prompts') {
           const insertChain = { select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) };
           return {
-            select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  neq: () => thenable({ data: [], error: null }),
+                }),
+              }),
+            }),
             insert: () => insertChain,
             update: () => ({ eq: () => thenable({ error: null }) }),
           };

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -711,7 +711,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -744,8 +750,10 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    ...thenable(existingData),
-                    in: () => thenable(existingData),
+                    neq: () => ({
+                      ...thenable(existingData),
+                      in: () => thenable(existingData),
+                    }),
                   }),
                 }),
               }),
@@ -766,12 +774,54 @@ describe('prompts-storage', () => {
       expect(result.updated).to.equal(1);
     });
 
+    it('does not reactivate a deleted prompt matched by prompt_id', async () => {
+      // The existingQuery now filters out deleted rows (.neq('status', 'deleted')).
+      // So a deleted row is invisible to the lookup and the UPDATE branch is never reached.
+      const updateStub = sinon.stub().returns({ eq: () => ({ then: (r) => r({ error: null }) }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    // neq filters out deleted row; returns no results
+                    neq: () => ({
+                      ...thenable({ data: [], error: null }),
+                      in: () => thenable({ data: [], error: null }),
+                    }),
+                  }),
+                }),
+              }),
+              insert: () => ({ select: () => thenable({ data: [], error: null }) }),
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ id: 'deleted-prompt-id', prompt: 'Deleted prompt text', regions: [] }],
+        postgrestClient: client,
+      });
+      expect(result.updated).to.equal(0);
+      expect(updateStub.callCount).to.equal(0);
+    });
+
     it('throws on insert error', async () => {
       const client = {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: null, error: { message: 'Insert failed' } }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -803,8 +853,10 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    ...thenable(existingData),
-                    in: () => thenable(existingData),
+                    neq: () => ({
+                      ...thenable(existingData),
+                      in: () => thenable(existingData),
+                    }),
                   }),
                 }),
               }),
@@ -830,7 +882,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: null, error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -852,7 +910,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -883,7 +947,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -891,7 +961,13 @@ describe('prompts-storage', () => {
           // buildLookupMaps returns empty arrays → maps will be empty
           // ensureLookupEntries will upsert the missing entries by name
           return {
-            select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  neq: () => thenable({ data: [], error: null }),
+                }),
+              }),
+            }),
             upsert: (rows) => {
               if (rows[0]?.category_id !== undefined) {
                 upsertedRows.categories = rows;
@@ -935,7 +1011,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -989,7 +1071,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -1041,7 +1129,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -1090,7 +1184,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -1125,7 +1225,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -1160,7 +1266,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -1195,7 +1307,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -1238,8 +1356,10 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    ...thenable(existingData),
-                    in: () => thenable(existingData),
+                    neq: () => ({
+                      ...thenable(existingData),
+                      in: () => thenable(existingData),
+                    }),
                   }),
                 }),
               }),
@@ -1268,8 +1388,10 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    ...thenable({ data: null, error: null }),
-                    in: () => thenable({ data: null, error: null }),
+                    neq: () => ({
+                      ...thenable({ data: null, error: null }),
+                      in: () => thenable({ data: null, error: null }),
+                    }),
                   }),
                 }),
               }),
@@ -1298,8 +1420,10 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    ...thenable({ data: [], error: null }),
-                    in: () => thenable({ data: [], error: null }),
+                    neq: () => ({
+                      ...thenable({ data: [], error: null }),
+                      in: () => thenable({ data: [], error: null }),
+                    }),
                   }),
                 }),
               }),
@@ -1343,8 +1467,10 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    ...thenable({ data: [], error: null }),
-                    in: () => thenable({ data: [], error: null }),
+                    neq: () => ({
+                      ...thenable({ data: [], error: null }),
+                      in: () => thenable({ data: [], error: null }),
+                    }),
                   }),
                 }),
               }),
@@ -1719,7 +1845,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };
@@ -1743,7 +1875,13 @@ describe('prompts-storage', () => {
         from: (table) => {
           if (table === 'prompts') {
             return {
-              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    neq: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
               update: () => ({ eq: () => thenable({ error: null }) }),
             };


### PR DESCRIPTION
Deleted prompts were being returned by the existingQuery in upsertPrompts and then overwritten back to status='active' via the default in the patch object. Adding .neq('status', 'deleted') to the query makes deleted rows invisible to the upsert lookup, so they are never matched and never updated.

Fixes SITES-43723

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [x] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [x] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [x] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [x] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
