### PR TITLE
fix(prompts): replace denylist filter with in-loop allowlist gate for deleted prompts

### DIFF
--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -507,10 +507,9 @@ export async function upsertPrompts({
 
   let existingQuery = postgrestClient
     .from('prompts')
-    .select('id,prompt_id,text,regions')
+    .select('id,prompt_id,text,regions,status')
     .eq('organization_id', organizationId)
-    .eq('brand_id', brandUuid)
-    .neq('status', 'deleted');
+    .eq('brand_id', brandUuid);
 
   if (incomingIds.length > 0) {
     existingQuery = existingQuery.in('prompt_id', incomingIds);
@@ -572,6 +571,11 @@ export async function upsertPrompts({
       updated_by: updatedBy,
     };
 
+    if (match && match.status !== 'active') {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
     if (match) {
       toUpdate.push({ ...row, id: match.id });
       processed.push({ ...row, prompt_id: promptId });
@@ -583,6 +587,7 @@ export async function upsertPrompts({
 
   let created = 0;
   let updated = 0;
+  const skipped = prompts.length - toInsert.length - toUpdate.length;
 
   if (toInsert.length > 0) {
     const { data: inserted, error } = await postgrestClient.from('prompts').insert(toInsert).select();
@@ -615,7 +620,9 @@ export async function upsertPrompts({
     updatedAt: r.updated_at,
   }));
 
-  return { created, updated, prompts: promptsOut };
+  return {
+    created, updated, skipped, prompts: promptsOut,
+  };
 }
 
 /**

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -776,9 +776,7 @@ describe('Brands Controller', () => {
           return {
             select: () => ({
               eq: () => ({
-                eq: () => ({
-                  neq: () => thenable({ data: [], error: null }),
-                }),
+                eq: () => thenable({ data: [], error: null }),
               }),
             }),
             insert: () => insertChain,

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -713,9 +713,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
@@ -739,7 +737,7 @@ describe('prompts-storage', () => {
     it('updates existing prompts by id', async () => {
       const existingData = {
         data: [{
-          id: 'row-id', prompt_id: 'p1', text: 'old', regions: [],
+          id: 'row-id', prompt_id: 'p1', text: 'old', regions: [], status: 'active',
         }],
         error: null,
       };
@@ -750,10 +748,8 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    neq: () => ({
-                      ...thenable(existingData),
-                      in: () => thenable(existingData),
-                    }),
+                    ...thenable(existingData),
+                    in: () => thenable(existingData),
                   }),
                 }),
               }),
@@ -774,10 +770,12 @@ describe('prompts-storage', () => {
       expect(result.updated).to.equal(1);
     });
 
-    it('does not reactivate a deleted prompt matched by prompt_id', async () => {
-      // The existingQuery now filters out deleted rows (.neq('status', 'deleted')).
-      // So a deleted row is invisible to the lookup and the UPDATE branch is never reached.
-      const updateStub = sinon.stub().returns({ eq: () => ({ then: (r) => r({ error: null }) }) });
+    it('skips a deleted prompt matched by prompt_id without updating or inserting', async () => {
+      const deletedRow = {
+        id: 'row-uuid', prompt_id: 'del-1', text: 'Deleted text', regions: [], status: 'deleted',
+      };
+      const existingData = { data: [deletedRow], error: null };
+      const updateStub = sinon.stub().returns({ eq: () => thenable({ error: null }) });
       const client = {
         from: (table) => {
           if (table === 'prompts') {
@@ -785,11 +783,8 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    // neq filters out deleted row; returns no results
-                    neq: () => ({
-                      ...thenable({ data: [], error: null }),
-                      in: () => thenable({ data: [], error: null }),
-                    }),
+                    ...thenable(existingData),
+                    in: () => thenable(existingData),
                   }),
                 }),
               }),
@@ -803,11 +798,49 @@ describe('prompts-storage', () => {
       const result = await upsertPrompts({
         organizationId: ORG_ID,
         brandUuid: BRAND_UUID,
-        prompts: [{ id: 'deleted-prompt-id', prompt: 'Deleted prompt text', regions: [] }],
+        prompts: [{ id: 'del-1', prompt: 'Deleted text', regions: [] }],
         postgrestClient: client,
       });
       expect(result.updated).to.equal(0);
+      expect(result.created).to.equal(0);
+      expect(result.skipped).to.equal(1);
       expect(updateStub.callCount).to.equal(0);
+    });
+
+    it('skips a deleted prompt matched by text+regions without inserting', async () => {
+      const deletedRow = {
+        id: 'row-uuid', prompt_id: 'del-2', text: 'Same text', regions: ['us'], status: 'deleted',
+      };
+      const existingData = { data: [deletedRow], error: null };
+      const insertSpy = sinon.stub().returns({
+        select: () => thenable({ data: [], error: null }),
+      });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => thenable(existingData),
+                }),
+              }),
+              insert: insertSpy,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({});
+        },
+      };
+      // Incoming prompt has no id but matches the deleted row by text+regions
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ prompt: 'Same text', regions: ['us'] }],
+        postgrestClient: client,
+      });
+      expect(result.skipped).to.equal(1);
+      expect(result.created).to.equal(0);
+      expect(insertSpy.callCount).to.equal(0);
     });
 
     it('throws on insert error', async () => {
@@ -817,9 +850,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: null, error: { message: 'Insert failed' } }) }),
@@ -842,7 +873,7 @@ describe('prompts-storage', () => {
     it('throws on update error', async () => {
       const existingData = {
         data: [{
-          id: 'row-id', prompt_id: 'p1', text: 'old', regions: [],
+          id: 'row-id', prompt_id: 'p1', text: 'old', regions: [], status: 'active',
         }],
         error: null,
       };
@@ -853,10 +884,8 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    neq: () => ({
-                      ...thenable(existingData),
-                      in: () => thenable(existingData),
-                    }),
+                    ...thenable(existingData),
+                    in: () => thenable(existingData),
                   }),
                 }),
               }),
@@ -884,9 +913,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: null, error: null }) }),
@@ -912,9 +939,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
@@ -949,9 +974,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
@@ -1013,9 +1036,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
@@ -1073,9 +1094,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
@@ -1131,9 +1150,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
@@ -1186,9 +1203,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
@@ -1227,9 +1242,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'p-1' }], error: null }) }),
@@ -1268,9 +1281,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [], error: null }) }),
@@ -1309,9 +1320,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [], error: null }) }),
@@ -1345,7 +1354,7 @@ describe('prompts-storage', () => {
     it('handles existing prompts with null regions', async () => {
       const existingData = {
         data: [{
-          id: 'row-id', prompt_id: 'p1', text: 'existing', regions: null,
+          id: 'row-id', prompt_id: 'p1', text: 'existing', regions: null, status: 'active',
         }],
         error: null,
       };
@@ -1356,10 +1365,8 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    neq: () => ({
-                      ...thenable(existingData),
-                      in: () => thenable(existingData),
-                    }),
+                    ...thenable(existingData),
+                    in: () => thenable(existingData),
                   }),
                 }),
               }),
@@ -1388,10 +1395,8 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    neq: () => ({
-                      ...thenable({ data: null, error: null }),
-                      in: () => thenable({ data: null, error: null }),
-                    }),
+                    ...thenable({ data: null, error: null }),
+                    in: () => thenable({ data: null, error: null }),
                   }),
                 }),
               }),
@@ -1420,10 +1425,8 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    neq: () => ({
-                      ...thenable({ data: [], error: null }),
-                      in: () => thenable({ data: [], error: null }),
-                    }),
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
                   }),
                 }),
               }),
@@ -1467,10 +1470,8 @@ describe('prompts-storage', () => {
               select: () => ({
                 eq: () => ({
                   eq: () => ({
-                    neq: () => ({
-                      ...thenable({ data: [], error: null }),
-                      in: () => thenable({ data: [], error: null }),
-                    }),
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
                   }),
                 }),
               }),
@@ -1847,9 +1848,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),
@@ -1877,9 +1876,7 @@ describe('prompts-storage', () => {
             return {
               select: () => ({
                 eq: () => ({
-                  eq: () => ({
-                    neq: () => thenable({ data: [], error: null }),
-                  }),
+                  eq: () => thenable({ data: [], error: null }),
                 }),
               }),
               insert: () => ({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) }),


### PR DESCRIPTION
## Summary

Follow-up to #2349, addressing review comments from @rainer-friederich.

**Problems with the previous fix (`.neq('status', 'deleted')`):**

- **Denylist instead of allowlist** — any future non-active status (`archived`, `paused`) would be silently overwritten back to `active` by the default `p.status || 'active'` patch
- **Constraint violation** — deleted rows became invisible to the lookup, so a resubmitted `prompt_id` fell into `toInsert` and hit `UNIQUE(brand_id, prompt_id)`, replacing silent reactivation with a hard 500 that also aborted every other valid insert in the same batch call
- **Broken `500 when storage throws` test** — the test mock had no `.neq()` handler, so calling `.neq()` threw `TypeError: .neq is not a function`; the 500 assertion passed for the wrong reason

**This fix:**

- Removes the status filter from `existingQuery` entirely; adds `status` to the selected columns instead
- Adds an explicit in-loop gate: `if (match && match.status !== 'active') { skipped++; continue }` — deleted (and any future non-active) rows are matched in the lookup (no constraint collision) but skipped without update or insert
- Returns a `skipped` count alongside `created` and `updated`
- Rewrites the regression test to exercise the actual skip path (deleted row returned by query, match found, skipped)
- Adds a second regression test for the `existingByKey` (text+regions) path
- Restores the `500 when storage throws` mock to test the right failure path

## Test plan

- [ ] `npx mocha test/support/prompts-storage.test.js` — 82 tests pass
- [ ] `npx mocha test/controllers/brands.test.js -g createPromptsByBrand` — all pass, including `returns 500 when storage throws`
- [ ] `npm test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)