### PR TITLE
[DEMO — DO NOT MERGE] B3: experiment-tracking endpoint scaffold

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -552,6 +552,8 @@ paths:
     $ref: './llmo-api.yaml#/site-llmo-edge-optimize-routing'
   /sites/{siteId}/llmo/strategy:
     $ref: './llmo-api.yaml#/llmo-strategy'
+  /sites/{siteId}/strategies/{strategyId}/experiment-tracking:
+    $ref: './llmo-api.yaml#/strategy-experiment-tracking'
   /sites/{siteId}/reports:
     $ref: './site-api.yaml#/site-reports'
   /sites/{siteId}/reports/{reportId}:

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -3327,3 +3327,82 @@ brand-presence-prompt-execution-status:
       - api_key: []
       - ims_key: []
       - scoped_api_key: []
+
+strategy-experiment-tracking:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+    - name: strategyId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Strategy identifier
+  post:
+    tags:
+      - llmo
+    summary: Enable Experiment Tracking on a completed strategy
+    description: |
+      Optionally enables Experiment Tracking on a completed (locked) Evolving
+      strategy by linking it to an external GeoExperiment and storing the
+      resulting `experimentId`. Uses a narrow lock-exception save path that
+      only allows mutating the `experimentId` field.
+
+      The GeoExperiment integration is currently a stub — see
+      `TODO(experiment-team)` in `src/support/strategy/geo-experiment-stub.js`.
+    operationId: enableExperimentTracking
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - experimentId
+              - provider
+            properties:
+              experimentId:
+                type: string
+                format: uuid
+                description: GeoExperiment UUID to link to this strategy
+              provider:
+                type: string
+                enum: [geo-experiment]
+                description: Experiment-tracking provider (currently only geo-experiment)
+              startedAt:
+                type: string
+                format: date-time
+                description: Optional ISO-8601 experiment start timestamp
+    responses:
+      '200':
+        description: Tracking enabled successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                strategyId:
+                  type: string
+                experimentId:
+                  type: string
+                  format: uuid
+                provider:
+                  type: string
+                  enum: [geo-experiment]
+                status:
+                  type: string
+                  enum: [tracking]
+                linkedAt:
+                  type: string
+                  format: date-time
+      '400':
+        $ref: './responses.yaml#/400'
+      '404':
+        description: Strategy not found
+      '409':
+        description: Strategy already has tracking enabled
+      '423':
+        description: Strategy is not in `completed` state
+      '502':
+        description: GeoExperiment link failed
+    security:
+      - api_key: []

--- a/src/controllers/strategy/experiment-tracking.js
+++ b/src/controllers/strategy/experiment-tracking.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { enableExperimentTrackingSchema } from '../../schemas/experiment-tracking.js';
+import { saveStrategyWithLockException } from '../../support/strategy/save-with-lock-exception.js';
+
+export const enableExperimentTrackingHandler = ({
+  getStrategy, persist, audit, linkGeoExperiment,
+}) => async (req, res) => {
+  const parsed = enableExperimentTrackingSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'invalid_body', details: parsed.error.flatten() });
+  }
+  const { siteId, strategyId } = req.params;
+  const strategy = await getStrategy(siteId, strategyId);
+  if (!strategy) {
+    return res.status(404).json({ error: 'strategy_not_found' });
+  }
+  if (strategy.status !== 'completed') {
+    return res.status(423).json({ error: 'strategy_not_completed' });
+  }
+  if (strategy.experimentId) {
+    return res.status(409).json({ error: 'already_tracking' });
+  }
+
+  const link = await linkGeoExperiment(parsed.data.experimentId, siteId);
+  if (!link.ok) {
+    return res.status(502).json({ error: 'geo_experiment_link_failed', reason: link.reason });
+  }
+
+  const updated = await saveStrategyWithLockException(
+    strategy,
+    { experimentId: parsed.data.experimentId },
+    {
+      allowedFields: ['experimentId'], persist, audit, actor: req.auth?.actor,
+    },
+  );
+
+  return res.status(200).json({
+    strategyId,
+    experimentId: updated.experimentId,
+    provider: parsed.data.provider,
+    status: 'tracking',
+    linkedAt: updated.updatedAt,
+  });
+};

--- a/src/controllers/strategy/index.js
+++ b/src/controllers/strategy/index.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createResponse } from '@adobe/spacecat-shared-http-utils';
+import { enableExperimentTrackingHandler } from './experiment-tracking.js';
+import { linkGeoExperiment } from '../../support/strategy/geo-experiment-stub.js';
+
+/**
+ * Adapts the dependency-injected Express-style handler in
+ * `experiment-tracking.js` to the context-style controller method shape used
+ * by `src/routes/index.js`. The handler stays test-friendly (pure deps); this
+ * wrapper bridges to the real spacecat HTTP runtime.
+ */
+function StrategyController(_) {
+  const enableExperimentTracking = async (ctx) => {
+    let statusCode = 200;
+    let body;
+    const fakeRes = {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(payload) {
+        body = payload;
+        return this;
+      },
+    };
+    const fakeReq = {
+      params: ctx.params,
+      body: ctx.data,
+      auth: { actor: ctx.attributes?.authInfo?.profile?.email || ctx.pathInfo?.headers?.['x-actor'] || 'unknown' },
+    };
+
+    // TODO(experiment-team): wire real strategy data access + audit log
+    // once the lock-policy spec ships. For demo: persist via S3-backed
+    // strategy storage is intentionally stubbed at the data-access layer.
+    const deps = {
+      getStrategy: async () => null,
+      persist: async () => {},
+      audit: async () => {},
+      linkGeoExperiment,
+    };
+
+    await enableExperimentTrackingHandler(deps)(fakeReq, fakeRes);
+    return createResponse(body, statusCode);
+  };
+
+  return { enableExperimentTracking };
+}
+
+export default StrategyController;

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,7 @@ import ScrapeController from './controllers/scrape.js';
 import ScrapeJobController from './controllers/scrapeJob.js';
 import ReportsController from './controllers/reports.js';
 import LlmoController from './controllers/llmo/llmo.js';
+import StrategyController from './controllers/strategy/index.js';
 import LlmoMysticatController from './controllers/llmo/llmo-mysticat-controller.js';
 import LlmoOpportunitiesController from './controllers/llmo/opportunities/llmo-opportunities-controller.js';
 import UserActivitiesController from './controllers/user-activities.js';
@@ -229,6 +230,7 @@ async function run(request, context) {
     const scrapeJobController = ScrapeJobController(context);
     const reportsController = ReportsController(context, log, context.env);
     const llmoController = LlmoController(context);
+    const strategyController = StrategyController(context);
     const llmoMysticatController = LlmoMysticatController(context);
     const llmoOpportunitiesController = LlmoOpportunitiesController(context);
     const fixesController = new FixesController(context);
@@ -307,6 +309,7 @@ async function run(request, context) {
       plgOnboardingController,
       drsBpPgAuditController,
       webhooksController,
+      strategyController,
     );
 
     const routeMatch = matchPath(method, suffix, routeHandlers);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -151,6 +151,7 @@ export default function getRouteHandlers(
   plgOnboardingController,
   drsBpPgAuditController,
   webhooksController,
+  strategyController,
 ) {
   const staticRoutes = {};
   const dynamicRoutes = {};
@@ -431,6 +432,7 @@ export default function getRouteHandlers(
     'POST /sites/:siteId/llmo/edge-optimize-config/stage': llmoController.createOrUpdateStageEdgeConfig,
     'GET /sites/:siteId/llmo/strategy': llmoController.getStrategy,
     'PUT /sites/:siteId/llmo/strategy': llmoController.saveStrategy,
+    'POST /sites/:siteId/strategies/:strategyId/experiment-tracking': strategyController.enableExperimentTracking,
     'GET /sites/:siteId/llmo/edge-optimize-status': llmoController.checkEdgeOptimizeStatus,
     'GET /sites/:siteId/llmo/probes/edge-optimize': llmoController.checkWafConnectivity,
     'PUT /sites/:siteId/llmo/opportunities-reviewed': llmoController.markOpportunitiesReviewed,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -529,6 +529,7 @@ const routeRequiredCapabilities = {
   'GET /sites/:siteId/llmo/edge-optimize-config': 'site:read',
   'GET /sites/:siteId/llmo/strategy': 'site:read',
   'PUT /sites/:siteId/llmo/strategy': 'site:write',
+  'POST /sites/:siteId/strategies/:strategyId/experiment-tracking': 'site:write',
   'GET /sites/:siteId/llmo/edge-optimize-status': 'site:read',
   'GET /sites/:siteId/llmo/probes/edge-optimize': 'site:read',
   'GET /llmo/agentic-traffic/global': 'report:read',

--- a/src/schemas/experiment-tracking.js
+++ b/src/schemas/experiment-tracking.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { z } from 'zod';
+
+export const enableExperimentTrackingSchema = z.object({
+  experimentId: z.string().uuid(),
+  provider: z.literal('geo-experiment'),
+  startedAt: z.string().datetime().optional(),
+});

--- a/src/support/strategy/geo-experiment-stub.js
+++ b/src/support/strategy/geo-experiment-stub.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// TODO(experiment-team): replace with real Impact Engine / GeoExperiment client.
+// Tracked in OW B3 demo PR (2026-05-06).
+// eslint-disable-next-line no-unused-vars
+export async function linkGeoExperiment(experimentId, siteId) {
+  return { ok: true };
+}

--- a/src/support/strategy/save-with-lock-exception.js
+++ b/src/support/strategy/save-with-lock-exception.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export class LockExceptionError extends Error {
+  constructor(field) {
+    super(`field "${field}" is not in lock-exception allowlist`);
+    this.name = 'LockExceptionError';
+    this.field = field;
+  }
+}
+
+export async function saveStrategyWithLockException(
+  strategy,
+  patch,
+  {
+    allowedFields, persist, audit, actor,
+  },
+) {
+  const fields = Object.keys(patch);
+  for (const f of fields) {
+    if (!allowedFields.includes(f)) {
+      throw new LockExceptionError(f);
+    }
+  }
+  const merged = { ...strategy, ...patch, updatedAt: new Date().toISOString() };
+  await persist(merged);
+  await audit({
+    action: 'lock-exception-write',
+    strategyId: strategy.id,
+    fields,
+    actor,
+  });
+  return merged;
+}

--- a/test/controllers/strategy/experiment-tracking.test.js
+++ b/test/controllers/strategy/experiment-tracking.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { enableExperimentTrackingHandler } from '../../../src/controllers/strategy/experiment-tracking.js';
+
+const makeReq = (params, body, actor = 'tester') => ({ params, body, auth: { actor } });
+const makeRes = () => {
+  const r = { status: sinon.stub(), json: sinon.stub() };
+  r.status.returns(r);
+  r.json.returns(r);
+  return r;
+};
+
+const validBody = {
+  experimentId: '11111111-1111-4111-8111-111111111111',
+  provider: 'geo-experiment',
+};
+
+describe('POST /sites/:siteId/strategies/:strategyId/experiment-tracking', () => {
+  let deps;
+  beforeEach(() => {
+    deps = {
+      getStrategy: sinon.stub(),
+      persist: sinon.stub().resolves(),
+      audit: sinon.stub().resolves(),
+      linkGeoExperiment: sinon.stub().resolves({ ok: true }),
+    };
+  });
+
+  it('400 on bad body', async () => {
+    const res = makeRes();
+    await enableExperimentTrackingHandler(deps)(
+      makeReq(
+        { siteId: 's1', strategyId: 'st1' },
+        { experimentId: 'bad', provider: 'geo-experiment' },
+      ),
+      res,
+    );
+    expect(res.status.calledWith(400)).to.equal(true);
+  });
+
+  it('404 when strategy missing', async () => {
+    deps.getStrategy.resolves(null);
+    const res = makeRes();
+    await enableExperimentTrackingHandler(deps)(
+      makeReq({ siteId: 's1', strategyId: 'st1' }, validBody),
+      res,
+    );
+    expect(res.status.calledWith(404)).to.equal(true);
+  });
+
+  it('423 when strategy state != completed', async () => {
+    deps.getStrategy.resolves({ id: 'st1', status: 'draft', experimentId: null });
+    const res = makeRes();
+    await enableExperimentTrackingHandler(deps)(
+      makeReq({ siteId: 's1', strategyId: 'st1' }, validBody),
+      res,
+    );
+    expect(res.status.calledWith(423)).to.equal(true);
+  });
+
+  it('409 when experimentId already set', async () => {
+    deps.getStrategy.resolves({ id: 'st1', status: 'completed', experimentId: 'old' });
+    const res = makeRes();
+    await enableExperimentTrackingHandler(deps)(
+      makeReq({ siteId: 's1', strategyId: 'st1' }, validBody),
+      res,
+    );
+    expect(res.status.calledWith(409)).to.equal(true);
+  });
+
+  it('502 when GeoExperiment link fails', async () => {
+    deps.getStrategy.resolves({ id: 'st1', status: 'completed', experimentId: null });
+    deps.linkGeoExperiment.resolves({ ok: false, reason: 'down' });
+    const res = makeRes();
+    await enableExperimentTrackingHandler(deps)(
+      makeReq({ siteId: 's1', strategyId: 'st1' }, validBody),
+      res,
+    );
+    expect(res.status.calledWith(502)).to.equal(true);
+  });
+
+  it('200 happy path persists only experimentId and audits', async () => {
+    const strategy = {
+      id: 'st1', status: 'completed', experimentId: null, name: 'A', updatedAt: 'old',
+    };
+    deps.getStrategy.resolves(strategy);
+    const res = makeRes();
+    await enableExperimentTrackingHandler(deps)(
+      makeReq({ siteId: 's1', strategyId: 'st1' }, validBody),
+      res,
+    );
+    expect(res.status.calledWith(200)).to.equal(true);
+    const persisted = deps.persist.firstCall.args[0];
+    expect(persisted.experimentId).to.equal(validBody.experimentId);
+    expect(persisted.name).to.equal('A');
+    expect(persisted.updatedAt).to.not.equal('old');
+    expect(deps.audit.calledOnce).to.equal(true);
+  });
+});

--- a/test/controllers/strategy/index.test.js
+++ b/test/controllers/strategy/index.test.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import StrategyController from '../../../src/controllers/strategy/index.js';
+
+describe('StrategyController (context adapter)', () => {
+  it('exposes enableExperimentTracking method', () => {
+    const ctrl = StrategyController({});
+    expect(ctrl.enableExperimentTracking).to.be.a('function');
+  });
+
+  it('returns 400 invalid_body for malformed payload via context shape', async () => {
+    const ctrl = StrategyController({});
+    const res = await ctrl.enableExperimentTracking({
+      params: { siteId: 's1', strategyId: 'st1' },
+      data: { experimentId: 'bad', provider: 'geo-experiment' },
+      attributes: {},
+      pathInfo: { headers: {} },
+    });
+    expect(res.status).to.equal(400);
+  });
+
+  it('returns 404 strategy_not_found on valid body (stubbed data access)', async () => {
+    const ctrl = StrategyController({});
+    const res = await ctrl.enableExperimentTracking({
+      params: { siteId: 's1', strategyId: 'st1' },
+      data: {
+        experimentId: '11111111-1111-4111-8111-111111111111',
+        provider: 'geo-experiment',
+      },
+      attributes: { authInfo: { profile: { email: 'a@b.com' } } },
+      pathInfo: { headers: {} },
+    });
+    expect(res.status).to.equal(404);
+  });
+
+  it('falls back to x-actor header when authInfo is absent', async () => {
+    const ctrl = StrategyController({});
+    const res = await ctrl.enableExperimentTracking({
+      params: { siteId: 's1', strategyId: 'st1' },
+      data: {
+        experimentId: '11111111-1111-4111-8111-111111111111',
+        provider: 'geo-experiment',
+      },
+      pathInfo: { headers: { 'x-actor': 'header-actor' } },
+    });
+    expect(res.status).to.equal(404);
+  });
+});

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -459,6 +459,10 @@ describe('getRouteHandlers', () => {
     processGitHubWebhook: sinon.stub(),
   };
 
+  const mockStrategyController = {
+    enableExperimentTracking: sinon.stub(),
+  };
+
   it('segregates static and dynamic routes', () => {
     const { staticRoutes, dynamicRoutes } = getRouteHandlers(
       mockAuditsController,
@@ -512,6 +516,7 @@ describe('getRouteHandlers', () => {
       mockPlgOnboardingController,
       mockDrsBpPgAuditController,
       mockWebhooksController,
+      mockStrategyController,
     );
 
     expect(staticRoutes).to.have.all.keys(
@@ -876,6 +881,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/llmo/probes/edge-optimize',
       'GET /sites/:siteId/llmo/strategy',
       'PUT /sites/:siteId/llmo/strategy',
+      'POST /sites/:siteId/strategies/:strategyId/experiment-tracking',
       'PUT /sites/:siteId/llmo/opportunities-reviewed',
       'GET /sites/:siteId/user-activities',
       'POST /sites/:siteId/user-activities',
@@ -1178,6 +1184,8 @@ describe('getRouteHandlers', () => {
     expect(dynamicRoutes['GET /sites/:siteId/llmo/strategy'].paramNames).to.deep.equal(['siteId']);
     expect(dynamicRoutes['PUT /sites/:siteId/llmo/strategy'].handler).to.equal(mockLlmoController.saveStrategy);
     expect(dynamicRoutes['PUT /sites/:siteId/llmo/strategy'].paramNames).to.deep.equal(['siteId']);
+    expect(dynamicRoutes['POST /sites/:siteId/strategies/:strategyId/experiment-tracking'].handler).to.equal(mockStrategyController.enableExperimentTracking);
+    expect(dynamicRoutes['POST /sites/:siteId/strategies/:strategyId/experiment-tracking'].paramNames).to.deep.equal(['siteId', 'strategyId']);
     expect(dynamicRoutes['GET /sites/:siteId/llmo/strategy/demo/brand-presence'].handler).to.equal(mockLlmoController.getDemoBrandPresence);
     expect(dynamicRoutes['GET /sites/:siteId/llmo/strategy/demo/brand-presence'].paramNames).to.deep.equal(['siteId']);
     expect(dynamicRoutes['GET /sites/:siteId/llmo/strategy/demo/recommendations'].handler).to.equal(mockLlmoController.getDemoRecommendations);

--- a/test/schemas/experiment-tracking.test.js
+++ b/test/schemas/experiment-tracking.test.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { enableExperimentTrackingSchema } from '../../src/schemas/experiment-tracking.js';
+
+describe('enableExperimentTrackingSchema', () => {
+  it('accepts a valid payload', () => {
+    const r = enableExperimentTrackingSchema.safeParse({
+      experimentId: '11111111-1111-4111-8111-111111111111',
+      provider: 'geo-experiment',
+    });
+    expect(r.success).to.equal(true);
+  });
+
+  it('accepts an optional ISO startedAt', () => {
+    const r = enableExperimentTrackingSchema.safeParse({
+      experimentId: '11111111-1111-4111-8111-111111111111',
+      provider: 'geo-experiment',
+      startedAt: '2026-05-06T14:00:00Z',
+    });
+    expect(r.success).to.equal(true);
+  });
+
+  it('rejects a non-uuid experimentId', () => {
+    const r = enableExperimentTrackingSchema.safeParse({
+      experimentId: 'not-a-uuid',
+      provider: 'geo-experiment',
+    });
+    expect(r.success).to.equal(false);
+  });
+
+  it('rejects an unknown provider', () => {
+    const r = enableExperimentTrackingSchema.safeParse({
+      experimentId: '11111111-1111-4111-8111-111111111111',
+      provider: 'something-else',
+    });
+    expect(r.success).to.equal(false);
+  });
+
+  it('rejects a malformed startedAt', () => {
+    const r = enableExperimentTrackingSchema.safeParse({
+      experimentId: '11111111-1111-4111-8111-111111111111',
+      provider: 'geo-experiment',
+      startedAt: 'yesterday',
+    });
+    expect(r.success).to.equal(false);
+  });
+});

--- a/test/support/strategy/geo-experiment-stub.test.js
+++ b/test/support/strategy/geo-experiment-stub.test.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { linkGeoExperiment } from '../../../src/support/strategy/geo-experiment-stub.js';
+
+describe('linkGeoExperiment (stub)', () => {
+  it('returns ok:true for any input', async () => {
+    const r = await linkGeoExperiment('e1', 'site1');
+    expect(r).to.deep.equal({ ok: true });
+  });
+});

--- a/test/support/strategy/save-with-lock-exception.test.js
+++ b/test/support/strategy/save-with-lock-exception.test.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinon from 'sinon';
+import chaiAsPromised from 'chai-as-promised';
+import {
+  saveStrategyWithLockException,
+  LockExceptionError,
+} from '../../../src/support/strategy/save-with-lock-exception.js';
+
+use(chaiAsPromised);
+
+describe('saveStrategyWithLockException', () => {
+  const baseStrategy = {
+    id: 's1',
+    siteId: 'site1',
+    status: 'completed',
+    experimentId: null,
+    name: 'A',
+    updatedAt: '2026-05-01T00:00:00Z',
+  };
+
+  it('writes only allowed fields and bumps updatedAt', async () => {
+    const persist = sinon.stub().resolves();
+    const audit = sinon.stub().resolves();
+    const result = await saveStrategyWithLockException(
+      baseStrategy,
+      { experimentId: 'e1' },
+      {
+        allowedFields: ['experimentId'], persist, audit, actor: 'tester',
+      },
+    );
+    expect(result.experimentId).to.equal('e1');
+    expect(result.name).to.equal('A');
+    expect(result.updatedAt).to.not.equal(baseStrategy.updatedAt);
+    expect(persist.calledOnce).to.equal(true);
+    expect(audit.calledOnce).to.equal(true);
+    expect(audit.firstCall.args[0]).to.deep.include({
+      action: 'lock-exception-write',
+      strategyId: 's1',
+      actor: 'tester',
+    });
+    expect(audit.firstCall.args[0].fields).to.deep.equal(['experimentId']);
+  });
+
+  it('rejects writes outside the allowlist', async () => {
+    const persist = sinon.stub().resolves();
+    await expect(
+      saveStrategyWithLockException(
+        baseStrategy,
+        { name: 'hacked' },
+        {
+          allowedFields: ['experimentId'], persist, audit: sinon.stub(), actor: 't',
+        },
+      ),
+    ).to.be.rejectedWith(LockExceptionError);
+    expect(persist.called).to.equal(false);
+  });
+});


### PR DESCRIPTION
> Created during AI-Driven Work session 2026-05-06.

Scaffolds POST `/sites/:siteId/strategies/:strategyId/experiment-tracking` for OW B3.

- Real zod schema, real lock-exception save helper, real unit tests
- GeoExperiment integration is a `TODO(experiment-team)` stub for handoff
- Strategy data access (`getStrategy`/`persist`/`audit`) is intentionally stubbed in the context-adapter (`src/controllers/strategy/index.js`) — the lock-policy spec hasn't shipped yet, so the demo wires schema validation, the lock-exception save helper, and route registration without touching real S3/strategy storage. Real wiring deferred to the lock-policy implementation.
- Spec: linked in workspace `docs/superpowers/specs/2026-05-06-ow-b3-experiment-tracking-design.md`

## Test plan
- [x] \`npm run lint\`
- [x] \`npm test\` (9044 passing, 100% line coverage)
- [ ] curl smoke: 200 happy / 423 draft / 409 duplicate (deferred — adapter currently returns 404 because real data access is stubbed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)