### PR TITLE
fix(plg): set AEM_CS delivery type when auto-resolving author URL

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -1045,14 +1045,15 @@ async function performAsoPlgOnboarding({
       if (presetDeliveryType === SiteModel.DELIVERY_TYPES.AEM_CS && presetAuthorUrl) {
         // Derive programId and environmentId from AEM CS author URL
         const csMatch = presetAuthorUrl.match(AEM_CS_AUTHOR_URL_PATTERN);
+        site.setDeliveryType(SiteModel.DELIVERY_TYPES.AEM_CS);
         /* c8 ignore next */
         const [, programId, environmentId] = csMatch || [];
         site.setDeliveryConfig({
           ...existingDeliveryConfig,
           authorURL: presetAuthorUrl,
-          ...(programId && {
-            programId, environmentId, preferContentApi: true, enableDAMAltTextUpdate: true,
-          }),
+          preferContentApi: true,
+          enableDAMAltTextUpdate: true,
+          ...(programId && { programId, environmentId }),
           imsOrgId,
         });
         log.info(`Set AEM CS delivery config from preset author URL: ${presetAuthorUrl}`);

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -1107,6 +1107,7 @@ async function performAsoPlgOnboarding({
         // Only update deliveryConfig if authorURL is not already set
         const existingDeliveryConfig = site.getDeliveryConfig() || {};
         if (!existingDeliveryConfig.authorURL && resolvedConfig?.authorURL) {
+          site.setDeliveryType(SiteModel.DELIVERY_TYPES.AEM_CS);
           site.setDeliveryConfig({
             ...existingDeliveryConfig,
             authorURL: resolvedConfig.authorURL,

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -1526,6 +1526,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
 
       expect(res.status).to.equal(200);
       expect(autoResolveAuthorUrlStub).to.have.been.calledWith(mockSite, context);
+      expect(mockSite.setDeliveryType).to.have.been.calledWith(SiteModel.DELIVERY_TYPES.AEM_CS);
       expect(mockSite.setDeliveryConfig).to.have.been.calledWith({
         authorURL: 'https://author-p123-e456.adobeaemcloud.com',
         programId: '123',
@@ -1553,6 +1554,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       const res = await controller.onboard(context);
 
       expect(res.status).to.equal(200);
+      expect(mockSite.setDeliveryType).to.have.been.calledWith(SiteModel.DELIVERY_TYPES.AEM_CS);
       expect(mockSite.setDeliveryConfig).to.have.been.calledWith({
         authorURL: 'https://author-p123-e456.adobeaemcloud.com',
         programId: '123',


### PR DESCRIPTION
When autoResolveAuthorUrl detects an AEM CS publish host from RUM bundles, the delivery config (authorURL, programId, etc.) was being set but setDeliveryType(AEM_CS) was never called — unlike the preset delivery type path which always calls setDeliveryType first.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
