### PR TITLE
feat(plg): enrich onboarding Slack notifications with context notes

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -129,7 +129,7 @@ const PLG_STATUS_NOTIFICATION_CONFIG = {
  * @param {object} context - The request context containing env and log.
  * @returns {Promise<void>}
  */
-async function postPlgOnboardingNotification(onboarding, context) {
+async function postPlgOnboardingNotification(onboarding, context, hints = {}) {
   const { env, log } = context;
   const channelId = env.SLACK_PLG_ONBOARDING_CHANNEL_ID;
   const token = env.SLACK_BOT_TOKEN;
@@ -192,6 +192,21 @@ async function postPlgOnboardingNotification(onboarding, context) {
   const error = onboarding.getError();
   if (error?.message) {
     message += `\n• *Error:* ${error.message}`;
+  }
+
+  const steps = onboarding.getSteps() || {};
+  const notes = [];
+  if (hints.fastOnboarded) {
+    notes.push(':rocket: Fast onboarding (pre-onboarded site)');
+  }
+  if (steps.siteOrgReassigned) {
+    notes.push(':arrows_counterclockwise: Site moved from internal org to customer org');
+  }
+  if (steps.authorUrlResolved) {
+    notes.push(':link: Author URL auto-resolved (AEM CS)');
+  }
+  if (notes.length > 0) {
+    message += `\n• *Notes:* ${notes.join(' · ')}`;
   }
 
   try {
@@ -842,7 +857,7 @@ async function performAsoPlgOnboarding({
           onboarding.setUpdatedBy(updatedBy);
         }
         await onboarding.save();
-        await postPlgOnboardingNotification(onboarding, context);
+        await postPlgOnboardingNotification(onboarding, context, { fastOnboarded: true });
         return onboarding;
       } catch (error) {
         if (error instanceof EntitlementWaitlistError) {
@@ -1332,7 +1347,7 @@ const PLG_REJECTION_MESSAGES = {
   'paid-customer': { emoji: ':no_entry:', label: 'Rejected — Paid Customer' },
 };
 
-async function postPlgRejectionNotification(domain, imsOrgId, reason, context) {
+async function postPlgRejectionNotification(domain, imsOrgId, reason, context, org) {
   const { env, log } = context;
   const channelId = env.SLACK_PLG_ONBOARDING_CHANNEL_ID;
   const token = env.SLACK_BOT_TOKEN;
@@ -1347,9 +1362,14 @@ async function postPlgRejectionNotification(domain, imsOrgId, reason, context) {
     return;
   }
 
-  const message = `${config.emoji} *PLG Onboarding — ${config.label}*\n\n`
+  let message = `${config.emoji} *PLG Onboarding — ${config.label}*\n\n`
     + `• *Domain:* \`${domain}\`\n`
-    + `• *IMS Org:* \`${imsOrgId}\``;
+    + `• *Onboarding requested on IMS Org:* \`${imsOrgId}\``;
+
+  const orgName = org?.getName?.();
+  if (orgName) {
+    message += `\n• *IMS Org Name:* ${orgName}`;
+  }
 
   try {
     await postSlackMessage(channelId, message, token);
@@ -1429,7 +1449,7 @@ function PlgOnboardingController(ctx) {
       const existingOrg = await Organization.findByImsOrgId(imsOrgId);
       if (existingOrg) {
         if (isInternalOrg(existingOrg.getId(), context.env)) {
-          await postPlgRejectionNotification(domain, imsOrgId, 'internal-org', context);
+          await postPlgRejectionNotification(domain, imsOrgId, 'internal-org', context, existingOrg);
           return badRequest('PLG onboarding is not available for internal organizations');
         }
 
@@ -1439,7 +1459,7 @@ function PlgOnboardingController(ctx) {
             && e.getTier() === EntitlementModel.TIERS.PAID,
         );
         if (hasPaidEntitlement) {
-          await postPlgRejectionNotification(domain, imsOrgId, 'paid-customer', context);
+          await postPlgRejectionNotification(domain, imsOrgId, 'paid-customer', context, existingOrg);
           return badRequest('PLG onboarding is not available for paid customers');
         }
       }

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -918,7 +918,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       const [, message] = postSlackMessageStub.firstCall.args;
       expect(message).to.include('Internal Org');
       expect(message).to.include(TEST_DOMAIN);
+      expect(message).to.include('Onboarding requested on IMS Org');
       expect(message).to.include(TEST_IMS_ORG_ID);
+      expect(message).to.include('IMS Org Name');
+      expect(message).to.include('Test Org');
     });
 
     it('posts Slack notification when paid customer is rejected', async () => {
@@ -1024,7 +1027,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       const [, message] = postSlackMessageStub.firstCall.args;
       expect(message).to.include('Paid Customer');
       expect(message).to.include(TEST_DOMAIN);
+      expect(message).to.include('Onboarding requested on IMS Org');
       expect(message).to.include(TEST_IMS_ORG_ID);
+      expect(message).to.include('IMS Org Name');
+      expect(message).to.include('Test Org');
     });
 
     it('logs error and still returns 400 when rejection Slack notification fails', async () => {
@@ -2174,6 +2180,119 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.not.include('IMS Org Name');
       expect(message).to.include(TEST_ORG_ID);
       expect(message).to.include(TEST_SITE_ID);
+    });
+
+    it('posts notification with fast onboarded note via fast path (PRE_ONBOARDING + siteId)', async () => {
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING',
+        siteId: TEST_SITE_ID,
+        organizationId: TEST_ORG_ID,
+        steps: { orgResolved: true },
+      });
+      // setStatus is a stub; make getStatus track the last set value so the
+      // notification function sees ONBOARDED when postPlgOnboardingNotification is called.
+      let currentStatus = 'PRE_ONBOARDING';
+      preonboardedOnboarding.getStatus = () => currentStatus;
+      preonboardedOnboarding.setStatus = (s) => {
+        currentStatus = s;
+      };
+
+      const ctx = {
+        data: { domain: TEST_DOMAIN },
+        dataAccess: {
+          ...mockDataAccess,
+          Organization: {
+            ...mockDataAccess.Organization,
+            findByImsOrgId: sandbox.stub().resolves(null),
+          },
+          PlgOnboarding: {
+            ...mockDataAccess.PlgOnboarding,
+            findByImsOrgIdAndDomain: sandbox.stub().resolves(preonboardedOnboarding),
+          },
+          Site: {
+            ...mockDataAccess.Site,
+            findById: sandbox.stub().resolves(createMockSite()),
+          },
+        },
+        log: mockLog,
+        env: {
+          ...mockEnv,
+          SLACK_PLG_ONBOARDING_CHANNEL_ID: 'C123TEST',
+          SLACK_BOT_TOKEN: 'xoxb-test-token',
+        },
+        sqs: { sendMessage: sandbox.stub().resolves() },
+        attributes: { authInfo: mockAuthInfo() },
+      };
+
+      await SlackController({ log: mockLog }).onboard(ctx);
+
+      expect(postSlackMessageStub).to.have.been.called;
+      const [, message] = postSlackMessageStub.firstCall.args;
+      expect(message).to.include('Notes:');
+      expect(message).to.include('Fast onboarding (pre-onboarded site)');
+    });
+
+    it('posts notification with org reassigned note when steps.siteOrgReassigned is set', async () => {
+      const onboarding = createMockOnboarding({
+        status: 'ONBOARDED',
+        organizationId: TEST_ORG_ID,
+        siteId: TEST_SITE_ID,
+        steps: { siteOrgReassigned: true, entitlementCreated: true },
+      });
+
+      await SlackController({ log: mockLog }).onboard(buildSlackContext(onboarding));
+
+      expect(postSlackMessageStub).to.have.been.called;
+      const [, message] = postSlackMessageStub.firstCall.args;
+      expect(message).to.include('Notes:');
+      expect(message).to.include('Site moved from internal org to customer org');
+    });
+
+    it('posts notification with author URL note when steps.authorUrlResolved is set', async () => {
+      const onboarding = createMockOnboarding({
+        status: 'ONBOARDED',
+        organizationId: TEST_ORG_ID,
+        siteId: TEST_SITE_ID,
+        steps: { authorUrlResolved: true, entitlementCreated: true },
+      });
+
+      await SlackController({ log: mockLog }).onboard(buildSlackContext(onboarding));
+
+      expect(postSlackMessageStub).to.have.been.called;
+      const [, message] = postSlackMessageStub.firstCall.args;
+      expect(message).to.include('Notes:');
+      expect(message).to.include('Author URL auto-resolved (AEM CS)');
+    });
+
+    it('posts notification with multiple notes when several steps are set', async () => {
+      const onboarding = createMockOnboarding({
+        status: 'ONBOARDED',
+        organizationId: TEST_ORG_ID,
+        siteId: TEST_SITE_ID,
+        steps: { siteOrgReassigned: true, authorUrlResolved: true },
+      });
+
+      await SlackController({ log: mockLog }).onboard(buildSlackContext(onboarding));
+
+      expect(postSlackMessageStub).to.have.been.called;
+      const [, message] = postSlackMessageStub.firstCall.args;
+      expect(message).to.include('Site moved from internal org to customer org');
+      expect(message).to.include('Author URL auto-resolved (AEM CS)');
+    });
+
+    it('posts notification without Notes section when no notable steps are set', async () => {
+      const onboarding = createMockOnboarding({
+        status: 'ONBOARDED',
+        organizationId: TEST_ORG_ID,
+        siteId: TEST_SITE_ID,
+        steps: { entitlementCreated: true, orgResolved: true },
+      });
+
+      await SlackController({ log: mockLog }).onboard(buildSlackContext(onboarding));
+
+      expect(postSlackMessageStub).to.have.been.called;
+      const [, message] = postSlackMessageStub.firstCall.args;
+      expect(message).to.not.include('Notes:');
     });
 
     it('INACTIVE notification includes last review reason', async () => {


### PR DESCRIPTION
Add informative notes to PLG onboarding and rejection Slack notifications:
- Rejection messages now include org name and use consistent "Onboarding requested on IMS Org" label
- Onboarding notifications append a Notes line for fast onboarding (pre-onboarded site), site moved from internal org, and AEM CS author URL auto-resolved

Local testing
<img width="683" height="233" alt="image" src="https://github.com/user-attachments/assets/b68a8b85-a7ae-423c-bb74-836c9a7e0d65" />
https://cq-dev.slack.com/archives/C0ASZA8GHK5/p1778152490554919

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
