### PR TITLE
fix(webhooks): read headers from pathInfo and short-circuit unmapped events early

### DIFF
--- a/src/controllers/webhooks.js
+++ b/src/controllers/webhooks.js
@@ -78,8 +78,12 @@ function WebhooksController(context) {
   }
 
   const processGitHubWebhook = wrap(async (ctx) => {
-    const event = ctx.headers?.['x-github-event'];
-    const deliveryId = ctx.headers?.['x-github-delivery'];
+    // Headers are populated onto context.pathInfo.headers by the enrichPathInfo
+    // middleware (request.headers.plain() — lowercase plain object). Reading
+    // ctx.headers directly silently returns undefined and short-circuits every
+    // delivery to a 204 noContent at the EVENT_JOB_MAP check below.
+    const event = ctx.pathInfo?.headers?.['x-github-event'];
+    const deliveryId = ctx.pathInfo?.headers?.['x-github-delivery'];
     const { data } = ctx;
 
     // Validate required config up front. GITHUB_APP_SLUG is a security-relevant
@@ -92,19 +96,24 @@ function WebhooksController(context) {
       return internalServerError('GITHUB_APP_SLUG not configured');
     }
 
-    // Validate required payload fields
+    // Filter on event type BEFORE validating payload fields. Unmapped events
+    // (ping, push, issues, ...) do not necessarily carry `action` or
+    // `installation.id`. GitHub's app-install ping has neither — validating
+    // first would 400 the install handshake and surface as red Xs in the
+    // app's "Recent Deliveries" UI. Mapped events still get full validation
+    // below.
+    const jobType = EVENT_JOB_MAP[event];
+    if (!jobType) {
+      log.info('Skipping unmapped event', { event, deliveryId });
+      return noContent();
+    }
+
+    // Validate required payload fields (mapped events only)
     if (!data?.action) {
       return badRequest('Missing required field: action');
     }
     if (!data?.installation?.id) {
       return badRequest('Missing required field: installation.id');
-    }
-
-    // Check event-to-job-type mapping
-    const jobType = EVENT_JOB_MAP[event];
-    if (!jobType) {
-      log.info('Skipping unmapped event', { event, deliveryId });
-      return noContent();
     }
 
     const { action, pull_request: pr } = data;

--- a/test/controllers/webhooks.test.js
+++ b/test/controllers/webhooks.test.js
@@ -22,9 +22,11 @@ describe('WebhooksController', () => {
   const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123/mysticat-github-service-jobs';
 
   const validContext = {
-    headers: {
-      'x-github-event': 'pull_request',
-      'x-github-delivery': 'delivery-uuid-123',
+    pathInfo: {
+      headers: {
+        'x-github-event': 'pull_request',
+        'x-github-delivery': 'delivery-uuid-123',
+      },
     },
     data: {
       action: 'review_requested',
@@ -99,7 +101,34 @@ describe('WebhooksController', () => {
   it('returns 204 for non-pull_request event', async () => {
     const context = {
       ...validContext,
-      headers: { ...validContext.headers, 'x-github-event': 'issue_comment' },
+      pathInfo: {
+        headers: { ...validContext.pathInfo.headers, 'x-github-event': 'issue_comment' },
+      },
+    };
+
+    const response = await controller.processGitHubWebhook(context);
+
+    expect(response.status).to.equal(204);
+    expect(mockSqs.sendMessage.called).to.be.false;
+  });
+
+  it('returns 204 for GitHub install ping (no action, no installation)', async () => {
+    // Real GitHub `ping` payloads carry neither `action` nor `installation.id`.
+    // Verifies the controller short-circuits on event type before payload
+    // validation, so install pings do not appear as failed deliveries in the
+    // App's "Recent Deliveries" UI.
+    const context = {
+      pathInfo: {
+        headers: {
+          'x-github-event': 'ping',
+          'x-github-delivery': 'delivery-uuid-ping',
+        },
+      },
+      data: {
+        zen: 'Anything added dilutes everything else.',
+        hook_id: 12345,
+        hook: { type: 'App', id: 12345, events: ['pull_request'] },
+      },
     };
 
     const response = await controller.processGitHubWebhook(context);
@@ -293,7 +322,9 @@ describe('WebhooksController', () => {
   it('logs structured skip reason (not interpolated) for untrusted event header', async () => {
     const context = {
       ...validContext,
-      headers: { ...validContext.headers, 'x-github-event': 'evil\ninjected' },
+      pathInfo: {
+        headers: { ...validContext.pathInfo.headers, 'x-github-event': 'evil\ninjected' },
+      },
     };
 
     await controller.processGitHubWebhook(context);


### PR DESCRIPTION
## Summary

Two bugs in the GitHub webhook controller (`src/controllers/webhooks.js`) found while validating the dev endpoint end-to-end (SITES-42733):

1. **Headers wired to the wrong context key.** The controller read `ctx.headers?.['x-github-event']`, but `enrichPathInfo` puts headers on `ctx.pathInfo.headers` (lowercase plain object). The lookup silently returned `undefined`, `EVENT_JOB_MAP[undefined]` is falsy, and **every** delivery resolved to 204 noContent without enqueueing a job. Real PR events would have been dropped silently. This pattern matches `slack.js` and `sites.js`.
2. **Field validation ran before event filter.** `data.action` and `data.installation.id` were checked before `EVENT_JOB_MAP[event]`. GitHub's app-install `ping` carries neither field, so the install handshake produced 400 and showed as red Xs in the App's Recent Deliveries panel. Now the event filter runs first; mapped events still get the same validation immediately after.

Both fixes are local to the controller. The auth handler, HMAC verification, and Vault wiring were already correct.

## Verification

Manually probed the dev endpoint at `https://spacecat.experiencecloud.live/api/ci/webhooks/github` with curl + a manually-signed body using the dev webhook secret from `dx_mysticat/dev/api-service`:

| Probe | Sent | Got | What it verifies |
|---|---|---|---|
| no signature | empty body | 401 | route live, all auth handlers reject |
| bad signature | sha256=000... | 401 | HMAC mismatch path |
| valid HMAC, ping (with synthetic action+installation.id) | signed JSON | 204 | Vault → Lambda env → HMAC verify → controller → unmapped-event short-circuit |

Coralogix log on the 204 confirmed the bug — `event: undefined, deliveryId: undefined` even though the request had both headers set. After this PR the same probe will log `event: ping, deliveryId: <uuid>`.

## Test plan

- [x] `npx mocha test/controllers/webhooks.test.js` — 17 passing (16 existing tests pass with updated `pathInfo.headers` fixture; 1 new test covers the install-ping shape with no `action` and no `installation.id`)
- [x] `npx mocha test/routes/index.test.js` — 1 passing
- [ ] CI green
- [ ] After merge + dev deploy: re-run the same curl probes and confirm `event: ping` appears in Coralogix; install dev app on a test repo and observe the install ping land as 204 (not 400)

## Notes for reviewers

- Header source change is a one-liner per accessor; the comment explains why for future readers.
- Reorder is correctness-driven, not style. The new comment block on the EVENT_JOB_MAP check explains the trade-off (mapped events still get full payload validation).
- No dependency or middleware changes.