### PR TITLE
feat(backfill): add refreshAgenticDailyExport to cdn-logs-report weekly backfill

### DIFF
--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -213,6 +213,7 @@ async function triggerBackfill(
           siteId,
           auditContext: {
             weekOffset,
+            refreshAgenticDailyExport: true,
           },
         };
         // eslint-disable-next-line no-await-in-loop

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -177,6 +177,7 @@ describe('BackfillLlmoCommand', () => {
       expect(message).to.have.property('siteId', 'test-site-id');
       expect(message).to.have.property('auditContext');
       expect(message.auditContext).to.have.property('weekOffset', -1);
+      expect(message.auditContext).to.have.property('refreshAgenticDailyExport', true);
     });
 
     it('sends correct SQS message structure for current week (weeks=0)', async () => {
@@ -192,6 +193,7 @@ describe('BackfillLlmoCommand', () => {
       expect(message).to.have.property('siteId', 'test-site-id');
       expect(message).to.have.property('auditContext');
       expect(message.auditContext).to.have.property('weekOffset', 0);
+      expect(message.auditContext).to.have.property('refreshAgenticDailyExport', true);
     });
 
     it('sends a cdn-logs-report daily DB import message using traffic date + 1 as auditContext.date', async () => {


### PR DESCRIPTION
## Summary

When triggering `cdn-logs-report` weekly backfills via `backfill-llmo`, the SQS messages for week-offset runs were missing `refreshAgenticDailyExport: true`. This flag is required for the audit worker to queue per-day agentic DB exports for the backfilled week.

The `mode=db` daily path already sets this flag (existing behaviour). The weekly offset loop was the only path that didn't.

## Changes

- Added `refreshAgenticDailyExport: true` to the `CDN_LOGS_REPORT` week-offset `auditContext` in `backfill-llmo.js`
- Updated two SQS message structure tests to assert the new field

## Related Issues

N/A — operational fix for backfill tooling.

---

- [x] No API spec changes
- [x] Tests updated and passing

Thanks for contributing!