### PR TITLE
docs(s2s): document host-driven x-product context for LLMO vs ASO consumers

### DIFF
--- a/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
+++ b/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
@@ -16,6 +16,21 @@ This guide helps service teams request and integrate Service-to-Service (S2S) au
 
 ---
 
+## ⚠️ Host-driven product context
+
+**The Fastly edge sets the `x-product` request header based on the request `Host`. Any client-supplied `x-product` value is overwritten.** Choose the host that matches your product:
+
+| Consumer product | Production host | Dev / CI host |
+|---|---|---|
+| **LLMO** | `https://llmo.experiencecloud.live` | `https://llmo.experiencecloud.page` |
+| **ASO** (and everything else) | `https://spacecat.experiencecloud.live` | `https://spacecat.experiencecloud.live` |
+
+This affects every S2S call, including `/auth/s2s/login`. Mint your session token via the same host you intend to call APIs on. An LLMO consumer that mints a token via `spacecat.experiencecloud.live` receives an ASO-context JWT and will fail the per-product entitlement check on tenant-scoped reads even if the underlying org has a valid LLMO entitlement.
+
+The examples and URL table below use `spacecat.experiencecloud.live` for ASO consumers; LLMO consumers should substitute the LLMO host throughout.
+
+---
+
 ## Prerequisites
 
 Before requesting an S2S account, ensure you have:
@@ -665,10 +680,21 @@ curl -X GET https://spacecat.experiencecloud.live/api/ci/sites/${SITE_ID}/opport
 
 ### Environment URLs
 
+The host you call determines the `x-product` value at the edge — see [Host-driven product context](#️-host-driven-product-context).
+
+**ASO consumers (and everything that is not LLMO):**
+
 | Environment | IMS Token Endpoint | SpaceCat S2S Login | SpaceCat API Base |
 |-------------|-------------------|-------------------|-------------------|
 | **Development/Stage** | `https://ims-na1-stg1.adobelogin.com/ims/token/v3` | `https://spacecat.experiencecloud.live/api/ci/auth/s2s/login` | `https://spacecat.experiencecloud.live/api/ci` |
 | **Production** | `https://ims-na1.adobelogin.com/ims/token/v3` | `https://spacecat.experiencecloud.live/api/v1/auth/s2s/login` | `https://spacecat.experiencecloud.live/api/v1` |
+
+**LLMO consumers:**
+
+| Environment | IMS Token Endpoint | SpaceCat S2S Login | SpaceCat API Base |
+|-------------|-------------------|-------------------|-------------------|
+| **Development/Stage** | `https://ims-na1-stg1.adobelogin.com/ims/token/v3` | `https://llmo.experiencecloud.page/api/ci/auth/s2s/login` | `https://llmo.experiencecloud.page/api/ci` |
+| **Production** | `https://ims-na1.adobelogin.com/ims/token/v3` | `https://llmo.experiencecloud.live/api/v1/auth/s2s/login` | `https://llmo.experiencecloud.live/api/v1` |
 
 ### Token Lifetimes
 


### PR DESCRIPTION
## Summary

Documents that the Fastly aso-prod VCL sets `x-product` based on the request `Host`:

```
llmo.experiencecloud.{live,page}  -> 'LLMO'
everything else                    -> 'ASO'
```

Any client-supplied `x-product` value is overwritten. The current guide tells every consumer to use `https://spacecat.experiencecloud.live/api/v1/auth/s2s/login`, so an LLMO consumer who follows it verbatim mints an ASO-context token and silently fails the per-product entitlement check downstream. That trapped DRS on 2026-05-08 — 46 brandalf-cohort sites had been silently skipping DB sync for days before a `StructuredLogger` crash surfaced it.

## Changes

- New ⚠️ callout near the top of `CONSUMER_INTEGRATION_GUIDE.md` listing the host-to-product mapping and explaining that the client-supplied header is dropped.
- "Environment URLs" table split into two — one for ASO consumers (unchanged values) and one for LLMO consumers — so copy-paste lands on the right host.

The body of the integration steps is unchanged; the existing examples now live under the ASO section by default with a note pointing LLMO consumers to substitute the LLMO host.

## Why docs-only

The underlying VCL behavior — overwriting a security-relevant client header without a fail-loud signal — is tracked in **SITES-44260** with proposed remediations (honor client-supplied value, or fail-loud on disagreement). This PR is the immediate mitigation so the next consumer does not hit the same trap.

## Related

- **LLMO-4804** — root cause investigation and DRS-side fix.
- **SITES-44260** — proposed Fastly VCL change.
- **adobe-rnd/llmo-data-retrieval-service#1641** — DRS PR that mints S2S tokens via the LLMO host, the workaround that unblocked the brandalf cohort.

## Test plan

- [x] Markdown renders correctly (verified locally).
- [x] No code changes; only `docs/s2s/CONSUMER_INTEGRATION_GUIDE.md` is touched.
- [ ] Reviewer to confirm the host-selection table matches their understanding of the Fastly VCL contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)