### PR TITLE
docs(s2s): list-vs-tenant capability mapping + 413 compression troubleshooting

### DIFF
--- a/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
+++ b/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
@@ -559,15 +559,23 @@ curl -X POST 'https://ims-na1-stg1.adobelogin.com/ims/token/v3' \
 
 **Common Capability to Endpoint Mapping Examples**:
 ```
-GET /sites                              → site:read
+GET /sites                              → site:readAll        (cross-tenant LIST)
+GET /sites/{siteId}                     → site:read           (tenant-scoped READ)
 POST /sites                             → site:write
 GET /sites/{siteId}/audits              → audit:read
 POST /audits                            → audit:write
 GET /sites/{siteId}/opportunities       → opportunity:read
 POST /sites/{siteId}/opportunities      → opportunity:write
-GET /organizations                      → organization:read
+GET /organizations                      → organization:readAll (cross-tenant LIST)
+GET /organizations/{id}                 → organization:read    (tenant-scoped READ)
 PATCH /organizations/{id}               → organization:write
 ```
+
+> **`readAll` vs `read`**: list endpoints (`GET /sites`, `GET /organizations`) are
+> gated on the `readAll` capability; per-id reads (`GET /sites/{siteId}`,
+> `GET /organizations/{id}`) are gated on `read` and require a customer-scoped
+> S2S session token (one minted with the resource's owning `imsOrgId`).
+> See `READALL_CAPABILITY_DESIGN.md` for the trust model.
 
 ### Issue: Consumer Suspended
 
@@ -591,6 +599,40 @@ PATCH /organizations/{id}               → organization:write
 3. S2S Admin reviews and approves (or denies) request
 4. Test upgraded capabilities in dev first
 5. Request production upgrade after dev validation
+
+### Issue: `GET /sites` or `GET /organizations` returns 413 Payload Too Large
+
+**Symptoms**:
+```
+HTTP/2 413
+x-error: Response payload size exceeded maximum allowed payload size (6000000 bytes).
+```
+
+**Cause**: AWS Lambda caps response payloads at 6 MB. The full sites
+list (~7.5 MB uncompressed, 11k+ sites as of 2026-05-08) exceeds that.
+The SpaceCat API Gateway honours `Accept-Encoding`, and any of `gzip`,
+`deflate`, or `br` brings the response well under the cap.
+
+| Encoding | Compressed `/sites` size | Notes |
+|---|---|---|
+| `br` (Brotli) | ~865 KB | Best ratio. Server prefers this when offered. |
+| `gzip` | ~933 KB | Universally supported; Python `requests` decodes natively. |
+| (none) | ~7.5 MB → **413** | Default for raw `curl`. |
+
+**Resolution**: send `Accept-Encoding: gzip, deflate, br` (or any subset
+your client supports) on every request to `/sites` and `/organizations`.
+Most HTTP clients do this transparently:
+
+| Client | Behaviour |
+|---|---|
+| `curl` | does **not** send `Accept-Encoding` by default — pass `--compressed` or `-H 'Accept-Encoding: gzip, deflate, br'` |
+| Python `requests` | sends `Accept-Encoding: gzip, deflate` automatically and decodes transparently. For Brotli install the `brotli` package — otherwise stick to gzip (the size delta is ~7%). |
+| Node `fetch` / `axios` | send `Accept-Encoding` automatically; Node 18+ decodes Brotli natively. |
+| JVM `HttpClient` | sends `Accept-Encoding` automatically since Java 11; Brotli requires the `brotli4j` library. |
+
+If your client cannot send any compression, file an S2S admin ticket —
+the long-term fix is server-side cursor pagination (see
+`READALL_CAPABILITY_DESIGN.md` "Operational Bounds").
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #2370 (which added the host-driven product context).

While integrating the host fix in DRS for LLMO-4804 we hit two further docs gaps:

1. **The capability mapping table was stale for the `readAll` rollout.** The guide still says `GET /sites → site:read`, but the deployed gate has been `site:readAll` since [#2305](https://github.com/adobe/spacecat-api-service/pull/2305). DRS's curl tests confirm the actual contract:

   ```
   GET /sites                              → site:readAll        (cross-tenant LIST)
   GET /sites/{siteId}                     → site:read           (tenant-scoped READ)
   GET /organizations                      → organization:readAll (cross-tenant LIST)
   GET /organizations/{id}                 → organization:read    (tenant-scoped READ)
   ```

   Adds the four corrected lines plus a short callout explaining when to use which.

2. **`GET /sites` and `GET /organizations` return 413 by default.** Both responses exceed Lambda's 6 MB cap (sites is ~7.5 MB uncompressed today, 11,327 sites). The API Gateway honours `Accept-Encoding`, but `curl` and other defaults don't send it. New troubleshooting entry covers symptom, cause, and per-client compatibility.

## Why this matters

DRS just discovered both gaps the hard way during LLMO-4804 triage. The next consumer with `readAll` capabilities will hit the same trap. These are docs-only changes — no behaviour or contract changes.

The longer-term fix for #2 is server-side cursor pagination (already specced in `READALL_CAPABILITY_DESIGN.md` "Operational Bounds" but not yet shipped). The compression workaround is the documented fallback until then.

## Compression numbers (verified on prod, 2026-05-08)

| Encoding | `/sites` compressed size | Notes |
|---|---|---|
| `br` (Brotli) | ~865 KB | Server's preferred encoding when offered |
| `gzip` | ~933 KB | Universal client support; Python `requests` decodes natively |
| (none) | ~7.5 MB → 413 | Default for raw `curl` |

## Related

- **LLMO-4804** — Fastly host-driven `x-product` override (root cause); DRS PR `adobe-rnd/llmo-data-retrieval-service#1641` is the consumer-side fix.
- **#2370** — predecessor docs PR (host-driven product context). Merged.
- **#2305** — the readAll capability rollout that the existing capability table missed.

## Test plan

- [x] Markdown renders correctly (verified locally).
- [x] No code changes; only `docs/s2s/CONSUMER_INTEGRATION_GUIDE.md` is touched.
- [ ] Reviewer to confirm the capability mapping matches the deployed contract (DRS team has the curl evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)