### PR TITLE
chore(ci): grant pull-requests write for DEV deploy status comments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ permissions:
   id-token: write
   contents: write
   issues: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
## Summary

- Bumps `pull-requests` permission from `read` to `write` in `ci.yaml`
- Enables the sticky PR comment feature from [mysticat-ci#8](https://github.com/adobe/mysticat-ci/pull/8), which posts DEV deploy status (skipped/deployed/failed) directly on the PR

## Test plan

- [ ] Verify CI passes on this PR (no behavioral change until mysticat-ci v3 is released)

🤖 Generated with [Claude Code](https://claude.com/claude-code)