### PR TITLE
feat(webhooks): env-configurable label trigger for dev/prod separation

### DIFF
--- a/src/utils/github-trigger-rules.js
+++ b/src/utils/github-trigger-rules.js
@@ -47,10 +47,17 @@ export function getSkipReason(data, action, env) {
     }
   }
 
-  // Label-based trigger: label must match
+  // Label-based trigger: label must match the env-configured trigger label.
+  //
+  // Without an env-specific label, dev and prod GitHub App installations on
+  // the same repo would both react to a single label-add (each App fires the
+  // webhook to its own URL → its own env's worker → duplicate review). The
+  // env var lets dev configure `mysticat-dev:review-requested` while prod
+  // keeps the canonical `mysticat:review-requested`.
   if (action === 'labeled') {
+    const expectedLabel = env.MYSTICAT_REVIEW_LABEL || 'mysticat:review-requested';
     const label = data.label?.name;
-    if (label !== 'mysticat:review-requested') {
+    if (label !== expectedLabel) {
       return `label ${label} does not match trigger`;
     }
   }

--- a/test/utils/github-trigger-rules.test.js
+++ b/test/utils/github-trigger-rules.test.js
@@ -59,7 +59,7 @@ describe('github-trigger-rules', () => {
     });
 
     describe('labeled trigger', () => {
-      it('returns null when label matches', () => {
+      it('returns null when label matches the default trigger', () => {
         const data = {
           ...baseData,
           action: 'labeled',
@@ -76,6 +76,37 @@ describe('github-trigger-rules', () => {
         };
         const reason = getSkipReason(data, 'labeled', defaultEnv);
         expect(reason).to.include('bug');
+      });
+
+      it('honors env-configured trigger label', () => {
+        // Dev/prod can use different labels so a single label-add against a
+        // repo with both bots installed routes to only one env's worker.
+        const devEnv = {
+          ...defaultEnv,
+          MYSTICAT_REVIEW_LABEL: 'mysticat-dev:review-requested',
+        };
+        const data = {
+          ...baseData,
+          action: 'labeled',
+          label: { name: 'mysticat-dev:review-requested' },
+        };
+        expect(getSkipReason(data, 'labeled', devEnv)).to.be.null;
+      });
+
+      it('skips the canonical label when env overrides to a different one', () => {
+        // Mirror of the above: the canonical prod label must NOT trigger
+        // a dev-configured worker.
+        const devEnv = {
+          ...defaultEnv,
+          MYSTICAT_REVIEW_LABEL: 'mysticat-dev:review-requested',
+        };
+        const data = {
+          ...baseData,
+          action: 'labeled',
+          label: { name: 'mysticat:review-requested' },
+        };
+        const reason = getSkipReason(data, 'labeled', devEnv);
+        expect(reason).to.include('mysticat:review-requested');
       });
     });
 


### PR DESCRIPTION
## Why

A single label-add against a repo where both `mysticat-bot-dev` and `mysticat-bot` are installed produces **two webhook deliveries** (each App fires to its own configured URL → its own env's API Gateway → its own worker). Both env's `getSkipReason` rules previously matched the same hardcoded `mysticat:review-requested` label, so both workers ran and posted duplicate reviews.

`review_requested` triggers were already env-discriminated (the `requested_reviewer.login` check matches each env's `GITHUB_APP_SLUG`). This PR closes the same gap on the `labeled` trigger.

## What

```diff
-  // Label-based trigger: label must match
   if (action === 'labeled') {
+    const expectedLabel = env.MYSTICAT_REVIEW_LABEL || 'mysticat:review-requested';
     const label = data.label?.name;
-    if (label !== 'mysticat:review-requested') {
+    if (label !== expectedLabel) {
       return `label ${label} does not match trigger`;
     }
   }
```

- Default unchanged → prod retains the canonical `mysticat:review-requested` label without any Vault patch
- Dev sets `MYSTICAT_REVIEW_LABEL=mysticat-dev:review-requested` in Vault so the dev bot only fires on its own label

## Test plan

- [x] Two new unit tests in `test/utils/github-trigger-rules.test.js`:
  - Env override → matching env-specific label returns null (proceed)
  - Env override → canonical label returns skip reason (don't fire)
- [x] Existing 15 tests in this file still pass (17 total)
- [x] Webhook controller tests still pass (17)
- [ ] CI green
- [ ] After merge + dev deploy: I'll patch `dx_mysticat/dev/api-service.MYSTICAT_REVIEW_LABEL`, create the new label on `adobe/spacecat-scrape-job-manager`, and re-test.