### PR TITLE
fix(webhooks): disable labeled trigger; only review_requested counts

### DIFF
--- a/src/utils/github-trigger-rules.js
+++ b/src/utils/github-trigger-rules.js
@@ -47,23 +47,20 @@ export function getSkipReason(data, action, env) {
     }
   }
 
-  // Label-based trigger: label must match the env-configured trigger label.
+  // Only review_requested is supported. Label-based triggers were disabled
+  // because GitHub does not count label-triggered reviews toward branch
+  // protection / merge requirements: an approval only counts when the
+  // reviewer was explicitly *requested* (Reviewers panel) or is listed in
+  // CODEOWNERS for the changed paths. A bot that posts a review off the
+  // back of a label add appears under "Reviewers whose approvals may not
+  // affect merge requirements" — visible but non-binding.
   //
-  // Without an env-specific label, dev and prod GitHub App installations on
-  // the same repo would both react to a single label-add (each App fires the
-  // webhook to its own URL → its own env's worker → duplicate review). The
-  // env var lets dev configure `mysticat-dev:review-requested` while prod
-  // keeps the canonical `mysticat:review-requested`.
-  if (action === 'labeled') {
-    const expectedLabel = env.MYSTICAT_REVIEW_LABEL || 'mysticat:review-requested';
-    const label = data.label?.name;
-    if (label !== expectedLabel) {
-      return `label ${label} does not match trigger`;
-    }
-  }
-
-  // Only review_requested and labeled are supported in Phase 2
-  if (action !== 'review_requested' && action !== 'labeled') {
+  // The env-configurable label hook (env.MYSTICAT_REVIEW_LABEL) and its
+  // dev/prod-specific Vault values were left in place for now. If we ever
+  // re-enable label triggers (e.g., a "comment-only / advisory" mode that
+  // does not pretend to count), restore the matching block here without
+  // re-doing the env-separation work.
+  if (action !== 'review_requested') {
     return `unsupported action: ${action}`;
   }
 

--- a/test/utils/github-trigger-rules.test.js
+++ b/test/utils/github-trigger-rules.test.js
@@ -58,29 +58,23 @@ describe('github-trigger-rules', () => {
       });
     });
 
-    describe('labeled trigger', () => {
-      it('returns null when label matches the default trigger', () => {
+    describe('labeled trigger (disabled)', () => {
+      // Labeled triggers were disabled because GitHub does not count
+      // label-triggered reviews toward branch protection / merge
+      // requirements. All labeled events now fall through to the
+      // unsupported-action skip path.
+      it('returns unsupported-action skip reason regardless of label name', () => {
         const data = {
           ...baseData,
           action: 'labeled',
           label: { name: 'mysticat:review-requested' },
         };
-        expect(getSkipReason(data, 'labeled', defaultEnv)).to.be.null;
+        expect(getSkipReason(data, 'labeled', defaultEnv)).to.include('unsupported action');
       });
 
-      it('returns skip reason when label does not match', () => {
-        const data = {
-          ...baseData,
-          action: 'labeled',
-          label: { name: 'bug' },
-        };
-        const reason = getSkipReason(data, 'labeled', defaultEnv);
-        expect(reason).to.include('bug');
-      });
-
-      it('honors env-configured trigger label', () => {
-        // Dev/prod can use different labels so a single label-add against a
-        // repo with both bots installed routes to only one env's worker.
+      it('ignores MYSTICAT_REVIEW_LABEL env override', () => {
+        // The env hook is left in place for future re-enable but is
+        // currently a no-op.
         const devEnv = {
           ...defaultEnv,
           MYSTICAT_REVIEW_LABEL: 'mysticat-dev:review-requested',
@@ -90,23 +84,7 @@ describe('github-trigger-rules', () => {
           action: 'labeled',
           label: { name: 'mysticat-dev:review-requested' },
         };
-        expect(getSkipReason(data, 'labeled', devEnv)).to.be.null;
-      });
-
-      it('skips the canonical label when env overrides to a different one', () => {
-        // Mirror of the above: the canonical prod label must NOT trigger
-        // a dev-configured worker.
-        const devEnv = {
-          ...defaultEnv,
-          MYSTICAT_REVIEW_LABEL: 'mysticat-dev:review-requested',
-        };
-        const data = {
-          ...baseData,
-          action: 'labeled',
-          label: { name: 'mysticat:review-requested' },
-        };
-        const reason = getSkipReason(data, 'labeled', devEnv);
-        expect(reason).to.include('mysticat:review-requested');
+        expect(getSkipReason(data, 'labeled', devEnv)).to.include('unsupported action');
       });
     });
 
@@ -127,17 +105,12 @@ describe('github-trigger-rules', () => {
       });
     });
 
-    describe('skip rules (parametrized across review_requested and labeled)', () => {
+    describe('skip rules (review_requested only — labeled is disabled)', () => {
       const scenarios = [
         {
           name: 'review_requested',
           action: 'review_requested',
           matchFields: { requested_reviewer: { login: 'mysticat[bot]' } },
-        },
-        {
-          name: 'labeled',
-          action: 'labeled',
-          matchFields: { label: { name: 'mysticat:review-requested' } },
         },
       ];
 


### PR DESCRIPTION
## Why

GitHub does not count label-triggered reviews toward branch protection or merge requirements. An approval only counts when the reviewer was either explicitly **requested** (via the Reviewers panel or API) or is listed in **CODEOWNERS** for the changed paths. The bot's APPROVED review on `adobe/spacecat-scrape-job-manager#163` was correctly recorded but appeared under "Reviewers whose approvals may not affect merge requirements" — visible but non-binding.

Shipping a label trigger that produces non-binding approvals is misleading: the user sees a green check but it doesn't satisfy any required-reviewer count.

## What

Drop `labeled` from the supported-trigger set. `review_requested` remains the only entry point: users invite the bot via GitHub's Reviewers panel, which makes the resulting approval count.

```diff
-  // Label-based trigger: label must match the env-configured trigger label.
-  if (action === 'labeled') {
-    const expectedLabel = env.MYSTICAT_REVIEW_LABEL || 'mysticat:review-requested';
-    const label = data.label?.name;
-    if (label !== expectedLabel) {
-      return `label ${label} does not match trigger`;
-    }
-  }
-
-  // Only review_requested and labeled are supported in Phase 2
-  if (action !== 'review_requested' && action !== 'labeled') {
+  if (action !== 'review_requested') {
     return `unsupported action: ${action}`;
   }
```

`env.MYSTICAT_REVIEW_LABEL` plumbing and the dev/prod-specific Vault values are **intentionally retained but unused**. If we ever re-enable label triggers in an explicitly advisory mode ("comment-only, does not pretend to count"), the env-separation work doesn't need to be redone.

## Test plan

- [x] `npx mocha test/utils/github-trigger-rules.test.js` — 12 passing
  - Replaced 4 labeled-positive tests with 2 labeled-disabled assertions
  - Removed labeled from the parametrized skip-rules describe (no longer reaches those code paths)
- [x] `npx mocha test/controllers/webhooks.test.js` — 17 passing (unchanged)
- [ ] CI green
- [ ] After merge + dev deploy: confirm the existing `mysticat-dev:review-requested` label on `adobe/spacecat-scrape-job-manager#163` no longer triggers anything (worker should not fire)
- [ ] Confirm `review_requested` still works: request a review from `@mysticat-bot-dev` via the Reviewers panel, expect a counting APPROVED review

## Operational follow-up (not in this PR)

The label `mysticat-dev:review-requested` on `adobe/spacecat-scrape-job-manager` is now unused but harmless — leave or delete as preferred. The Vault key `dx_mysticat/dev/api-service.MYSTICAT_REVIEW_LABEL` is similarly dormant.