### PR TITLE
fix: remove aem-cs-fastly

### DIFF
--- a/src/controllers/llmo/cdn-opt-in-notification.js
+++ b/src/controllers/llmo/cdn-opt-in-notification.js
@@ -17,6 +17,7 @@
  * - Triggered only on the first opt-in (isNewlyOpted=true) — not on subsequent config updates.
  * - CDN type is read from llmo.cdnBucketConfig.cdnProvider (populated by llmo-config-wrapper
  *   in auth-service during provisioning).
+ * - AEM CS Fastly is excluded from this notification flow.
  * - Email failures never block the opt-in response — notification is fire-and-forget.
  * - Recipients must be set via OPT_IN_NOTIFICATION_RECIPIENTS in Vault (comma-separated
  *   @adobe.com addresses). If missing, notification is skipped with an error log.
@@ -30,6 +31,7 @@ import { CDN_TYPES, CDN_DISPLAY_NAMES } from './llmo-utils.js';
 
 const OPT_IN_NOTIFICATION_TEMPLATE = 'llmo_cdn_opt_in_notification';
 const EXCLUDED_MEMBER_STATUSES = new Set(['BLOCKED', 'DELETED']);
+const EXCLUDED_CDN_TYPES = new Set([CDN_TYPES.AEM_CS_FASTLY]);
 
 // Pre-encoded HTML entities — the Post Office template renders this string
 // as HTML, so raw < / > would be stripped or treated as a tag.
@@ -131,6 +133,11 @@ export async function notifyOptInIfNeeded(context, params) {
   } = params || {};
 
   try {
+    if (EXCLUDED_CDN_TYPES.has(cdnType)) {
+      log.info(`[cdn-opt-in-notification] Skipping notification for excluded cdnType="${cdnType}" site=${siteId}`);
+      return { sent: false, reason: 'excluded-cdn' };
+    }
+
     const recipients = parseRecipients(env?.OPT_IN_NOTIFICATION_RECIPIENTS);
     if (recipients.length === 0) {
       log.error('[cdn-opt-in-notification] OPT_IN_NOTIFICATION_RECIPIENTS is not configured — skipping notification');

--- a/src/controllers/llmo/cdn-opt-in-notification.js
+++ b/src/controllers/llmo/cdn-opt-in-notification.js
@@ -69,6 +69,10 @@ function parseRecipients(raw) {
   return raw.split(',').map((s) => s.trim()).filter((e) => /^[^@]+@adobe\.com$/.test(e));
 }
 
+function normalizeCdnType(cdnType) {
+  return typeof cdnType === 'string' ? cdnType.trim().toLowerCase() : '';
+}
+
 function formatOrgMembersCsv(trialUsers) {
   if (!Array.isArray(trialUsers) || trialUsers.length === 0) {
     return '';
@@ -133,8 +137,11 @@ export async function notifyOptInIfNeeded(context, params) {
   } = params || {};
 
   try {
-    if (EXCLUDED_CDN_TYPES.has(cdnType)) {
-      log.info(`[cdn-opt-in-notification] Skipping notification for excluded cdnType="${cdnType}" site=${siteId}`);
+    const normalizedCdnType = normalizeCdnType(cdnType);
+    log.info(`[cdn-opt-in-notification] Resolved cdnType="${cdnType ?? ''}" normalizedCdnType="${normalizedCdnType}" for site=${siteId}`);
+
+    if (EXCLUDED_CDN_TYPES.has(normalizedCdnType)) {
+      log.info(`[cdn-opt-in-notification] Skipping notification for excluded cdnType="${normalizedCdnType}" site=${siteId}`);
       return { sent: false, reason: 'excluded-cdn' };
     }
 
@@ -144,8 +151,8 @@ export async function notifyOptInIfNeeded(context, params) {
       return { sent: false, reason: 'no-recipients' };
     }
 
-    const cdnEntry = CDN_CONFIG[cdnType];
-    const cdnDisplayName = CDN_DISPLAY_NAMES[cdnType] || '';
+    const cdnEntry = CDN_CONFIG[normalizedCdnType];
+    const cdnDisplayName = CDN_DISPLAY_NAMES[normalizedCdnType] || '';
     const cdnKnown = Boolean(cdnDisplayName);
     const docLink = cdnEntry?.docLink || '';
     const adobeManaged = Boolean(cdnEntry?.adobeManaged);
@@ -154,7 +161,7 @@ export async function notifyOptInIfNeeded(context, params) {
     const orgMembers = await getOrgMembersCsv(context, orgId);
 
     if (!cdnKnown) {
-      log.warn(`[cdn-opt-in-notification] Unknown CDN type for site=${siteId} — sending notification without CDN-specific guidance (cdnType="${cdnType ?? ''}")`);
+      log.warn(`[cdn-opt-in-notification] Unknown CDN type for site=${siteId} — sending notification without CDN-specific guidance (cdnType="${normalizedCdnType || cdnType || ''}")`);
     }
 
     const templateData = {
@@ -169,7 +176,7 @@ export async function notifyOptInIfNeeded(context, params) {
       replyAllTeam,
     };
 
-    log.info(`[cdn-opt-in-notification] Sending ${OPT_IN_NOTIFICATION_TEMPLATE} for site=${siteId} cdnType=${cdnType} cdnKnown=${cdnKnown}`);
+    log.info(`[cdn-opt-in-notification] Sending ${OPT_IN_NOTIFICATION_TEMPLATE} for site=${siteId} cdnType=${normalizedCdnType || cdnType || ''} cdnKnown=${cdnKnown}`);
 
     const result = await sendEmail(context, {
       recipients,

--- a/test/controllers/llmo/cdn-opt-in-notification.test.js
+++ b/test/controllers/llmo/cdn-opt-in-notification.test.js
@@ -249,13 +249,15 @@ describe('cdn-opt-in-notification', () => {
       expect(templateData.replyAllTeam).to.include('Customer CSE');
     });
 
-    it('flags aem-cs-fastly as adobe-managed with CSE reply-all team and commerceManaged=false', async () => {
-      await notifyOptInIfNeeded(mockContext, { ...baseParams, cdnType: 'aem-cs-fastly' });
+    it('skips notification for aem-cs-fastly', async () => {
+      const result = await notifyOptInIfNeeded(mockContext, { ...baseParams, cdnType: 'aem-cs-fastly' });
 
-      const { templateData } = sendEmailStub.firstCall.args[1];
-      expect(templateData.adobeManaged).to.be.true;
-      expect(templateData.commerceManaged).to.be.false;
-      expect(templateData.replyAllTeam).to.include('Customer CSE');
+      expect(result.sent).to.be.false;
+      expect(result.reason).to.equal('excluded-cdn');
+      expect(sendEmailStub).to.not.have.been.called;
+      expect(mockContext.log.info).to.have.been.calledWithMatch(
+        /Skipping notification for excluded cdnType="aem-cs-fastly"/,
+      );
     });
 
     it('flags commerce-fastly as adobe-managed and commerceManaged=true with Commerce team reply-all', async () => {

--- a/test/controllers/llmo/cdn-opt-in-notification.test.js
+++ b/test/controllers/llmo/cdn-opt-in-notification.test.js
@@ -260,6 +260,20 @@ describe('cdn-opt-in-notification', () => {
       );
     });
 
+    it('skips notification for aem-cs-fastly with mixed-case and spaces', async () => {
+      const result = await notifyOptInIfNeeded(mockContext, { ...baseParams, cdnType: '  AeM-Cs-Fastly  ' });
+
+      expect(result.sent).to.be.false;
+      expect(result.reason).to.equal('excluded-cdn');
+      expect(sendEmailStub).to.not.have.been.called;
+      expect(mockContext.log.info).to.have.been.calledWithMatch(
+        /normalizedCdnType="aem-cs-fastly"/,
+      );
+      expect(mockContext.log.info).to.have.been.calledWithMatch(
+        /Skipping notification for excluded cdnType="aem-cs-fastly"/,
+      );
+    });
+
     it('flags commerce-fastly as adobe-managed and commerceManaged=true with Commerce team reply-all', async () => {
       await notifyOptInIfNeeded(mockContext, { ...baseParams, cdnType: 'commerce-fastly' });
 


### PR DESCRIPTION
email should not trigger for aem-cs-fastly, as it will lead to confusion after 1-click CDN ONboarding already there for AEM-CS-FASLTY 