### PR TITLE
feat: add ASO link to PLG onboarding Slack notifications

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -176,7 +176,9 @@ async function postPlgOnboardingNotification(onboarding, context, hints = {}) {
   if (organizationId && siteId) {
     const experienceUrl = env.EXPERIENCE_URL || 'https://experience.adobe.com';
     const asoUrl = `${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${siteId}`;
+    const backofficeUrl = `${experienceUrl}/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/plg-sites`;
     message += `\n• *ASO Link:* ${asoUrl}`;
+    message += `\n• *Backoffice Link:* ${backofficeUrl}`;
   }
 
   if ([STATUSES.WAITLISTED, STATUSES.WAITING_FOR_IP_ALLOWLISTING].includes(status)) {

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -173,6 +173,11 @@ async function postPlgOnboardingNotification(onboarding, context, hints = {}) {
   if (siteId) {
     message += `\n• *Site ID:* \`${siteId}\``;
   }
+  if (organizationId && siteId) {
+    const experienceUrl = env.EXPERIENCE_URL || 'https://experience.adobe.com';
+    const asoUrl = `${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${siteId}`;
+    message += `\n• *ASO Link:* ${asoUrl}`;
+  }
 
   if ([STATUSES.WAITLISTED, STATUSES.WAITING_FOR_IP_ALLOWLISTING].includes(status)) {
     const waitlistReason = onboarding.getWaitlistReason();

--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -173,11 +173,13 @@ async function postPlgOnboardingNotification(onboarding, context, hints = {}) {
   if (siteId) {
     message += `\n• *Site ID:* \`${siteId}\``;
   }
-  if (organizationId && siteId) {
+  if (organizationId) {
     const experienceUrl = env.EXPERIENCE_URL || 'https://experience.adobe.com';
-    const asoUrl = `${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${siteId}`;
+    if (siteId) {
+      const asoUrl = `${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${siteId}`;
+      message += `\n• *ASO Link:* ${asoUrl}`;
+    }
     const backofficeUrl = `${experienceUrl}/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/plg-sites`;
-    message += `\n• *ASO Link:* ${asoUrl}`;
     message += `\n• *Backoffice Link:* ${backofficeUrl}`;
   }
 

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -2052,6 +2052,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include('Test Org');
       expect(message).to.include(TEST_ORG_ID);
       expect(message).to.include(TEST_SITE_ID);
+      expect(message).to.include(`https://experience.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
     });
 
     it('posts notification with botBlocker type but no ipsToAllowlist', async () => {
@@ -2074,6 +2075,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.not.include('IMS Org Name');
       expect(message).to.not.include('SpaceCat Org ID (derived from IMS Org)');
       expect(message).to.not.include('Site ID');
+      expect(message).to.not.include('ASO Link');
     });
 
     it('posts error notification including error message', async () => {
@@ -2151,6 +2153,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       const [, message] = postSlackMessageStub.firstCall.args;
       expect(message).to.include('Waitlisted');
       expect(message).to.not.include('IMS Org Name');
+      expect(message).to.not.include('ASO Link');
       expect(mockLog.warn).to.have.been.calledWith(
         sinon.match(/Failed to look up org name for onboarding notification/),
       );
@@ -2180,6 +2183,25 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.not.include('IMS Org Name');
       expect(message).to.include(TEST_ORG_ID);
       expect(message).to.include(TEST_SITE_ID);
+      expect(message).to.include(`https://experience.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
+    });
+
+    it('uses custom EXPERIENCE_URL for ASO link when provided', async () => {
+      const onboarding = createMockOnboarding({
+        status: 'ONBOARDED',
+        organizationId: TEST_ORG_ID,
+        siteId: TEST_SITE_ID,
+      });
+
+      const ctx = buildSlackContext(onboarding);
+      ctx.env = { ...ctx.env, EXPERIENCE_URL: 'https://experience-stage.adobe.com' };
+
+      await SlackController({ log: mockLog }).onboard(ctx);
+
+      expect(postSlackMessageStub).to.have.been.called;
+      const [, message] = postSlackMessageStub.firstCall.args;
+      expect(message).to.include(`https://experience-stage.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
+      expect(message).to.not.include('https://experience.adobe.com/');
     });
 
     it('posts notification with fast onboarded note via fast path (PRE_ONBOARDING + siteId)', async () => {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -2156,7 +2156,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include('Waitlisted');
       expect(message).to.not.include('IMS Org Name');
       expect(message).to.not.include('ASO Link');
-      expect(message).to.not.include('Backoffice Link');
+      expect(message).to.include('https://experience.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/plg-sites');
       expect(mockLog.warn).to.have.been.calledWith(
         sinon.match(/Failed to look up org name for onboarding notification/),
       );

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -2053,6 +2053,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include(TEST_ORG_ID);
       expect(message).to.include(TEST_SITE_ID);
       expect(message).to.include(`https://experience.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
+      expect(message).to.include('https://experience.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/plg-sites');
     });
 
     it('posts notification with botBlocker type but no ipsToAllowlist', async () => {
@@ -2076,6 +2077,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.not.include('SpaceCat Org ID (derived from IMS Org)');
       expect(message).to.not.include('Site ID');
       expect(message).to.not.include('ASO Link');
+      expect(message).to.not.include('Backoffice Link');
     });
 
     it('posts error notification including error message', async () => {
@@ -2154,6 +2156,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include('Waitlisted');
       expect(message).to.not.include('IMS Org Name');
       expect(message).to.not.include('ASO Link');
+      expect(message).to.not.include('Backoffice Link');
       expect(mockLog.warn).to.have.been.calledWith(
         sinon.match(/Failed to look up org name for onboarding notification/),
       );
@@ -2184,6 +2187,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include(TEST_ORG_ID);
       expect(message).to.include(TEST_SITE_ID);
       expect(message).to.include(`https://experience.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
+      expect(message).to.include('https://experience.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/plg-sites');
     });
 
     it('uses custom EXPERIENCE_URL for ASO link when provided', async () => {
@@ -2201,6 +2205,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(postSlackMessageStub).to.have.been.called;
       const [, message] = postSlackMessageStub.firstCall.args;
       expect(message).to.include(`https://experience-stage.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
+      expect(message).to.include('https://experience-stage.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/plg-sites');
       expect(message).to.not.include('https://experience.adobe.com/');
     });
 


### PR DESCRIPTION
Include a clickable ASO link (experience.adobe.com) in the #spacecat-plg-onboardings Slack message whenever both organizationId and siteId are available, making it easier to do a quick sanity check of the customer UI from the notification.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
