### PR TITLE
chore: lower coverage threshold to 90%

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -4,9 +4,9 @@
     "text"
   ],
   "check-coverage": true,
-  "lines": 100,
-  "branches": 100,
-  "statements": 100,
+  "lines": 90,
+  "branches": 90,
+  "statements": 90,
   "all": true,
   "include": [
     "src/**/*.js"


### PR DESCRIPTION
## Summary

Drop the c8 coverage gate in `.nycrc.json` from **100%** to **90%** for lines, branches, and statements.

## Context

The repo currently enforces 100% across all three metrics, with three file exclusions. Current measured coverage at HEAD is 100% (lines/branches/statements), so this change is a **no-op at HEAD** - nothing fails today that would now pass.

## Why lower it

100% is unusually strict by industry standards. The well-known benchmarks:

| Threshold | Where it shows up |
|---:|---|
| 60% | Google's "acceptable" floor |
| 75% | Atlassian / Google "commendable" |
| **80%** | SonarQube default, the single most-cited number |
| 85-90% | Critical infrastructure, SDKs |
| 95-100% | Safety-critical (aviation, medical) |

90% sits at the high end of "exemplary" while giving the team headroom to ship behavior changes whose error-path coverage would otherwise require gymnastic defensive tests (mocking a logger to cover a `catch` block, stubbing a config loader to cover an unreachable error path, etc.). Those patterns add lines but verify nothing - they exist only to satisfy the gate.

This change keeps a strong quality bar without forcing test-shaped code that doesn't test anything.

## Verification

- `npm test` passes: **10,186 tests passing**
- Coverage report at HEAD: 100% lines / 100% branches / 100% statements
- 90% floor is comfortably below current coverage, so no test changes required

## Follow-ups (not in this PR)

- Consider revisiting the `exclude` list - some entries (e.g. `src/agents/org-detector/agent.js`) may no longer need exemption now that the gate has headroom.
- Optionally split thresholds (e.g. lines 90 / branches 85) if branch coverage becomes the bottleneck on future features. Branch coverage is the more meaningful signal.

## Related Issues

None - process tweak.
