### PR TITLE
feat: GET endpoint for query fan-out report

### DIFF
--- a/src/controllers/llmo/fanout-report.js
+++ b/src/controllers/llmo/fanout-report.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  badRequest, found, notFound,
+} from '@adobe/spacecat-shared-http-utils';
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import AccessControlUtil from '../../support/access-control-util.js';
+
+const PRESIGNED_URL_TTL_SECONDS = 60 * 60; // 1 hour — mirrors brand-claims
+const REPORT_FILENAME = 'data.json.gz';
+
+const buildS3Key = (spaceCatId, brandId) => (
+  `fanout/llmo/${spaceCatId}/${brandId}/${REPORT_FILENAME}`
+);
+
+/**
+ * Controller for the Query Fan-Out report.
+ *
+ * Two endpoints under `/org/{spaceCatId}/brands/{brandId}/fanout-report`:
+ *   GET  — 302 redirect to a presigned S3 URL (or 404 if no report exists).
+ *   POST — synchronously regenerate the report. (Phase 2 — not yet implemented.)
+ *
+ * The Lambda never loads the report body — the client follows the redirect
+ * straight to S3 and decodes the gzipped JSON itself.
+ *
+ * @param {object} ctx - Request context (carries log, dataAccess, s3, env, params).
+ */
+export default function FanoutReportController(ctx) {
+  const accessControlUtil = AccessControlUtil.fromContext(ctx);
+  const hasLlmoOrganizationAccess = (organization) => (
+    accessControlUtil.hasAccess(organization, '', 'LLMO')
+  );
+
+  const getOrgAndValidateAccess = async (context) => {
+    const { spaceCatId } = context.params;
+    const { Organization } = context.dataAccess;
+
+    const organization = await Organization.findById(spaceCatId);
+    if (!organization) {
+      return { error: notFound(`Organization not found: ${spaceCatId}`) };
+    }
+    if (!await hasLlmoOrganizationAccess(organization)) {
+      // Mirror "not found" rather than 403 to avoid leaking org existence.
+      return { error: notFound(`Organization not found: ${spaceCatId}`) };
+    }
+    return { organization };
+  };
+
+  /**
+   * GET /org/{spaceCatId}/brands/{brandId}/fanout-report
+   *
+   * Returns 302 with `Location: <presigned S3 URL>` when the report exists,
+   * or 404 when it doesn't. The presigned URL is valid for 1 hour.
+   */
+  const getFanoutReport = async (context) => {
+    const { log, s3 } = context;
+    const { spaceCatId, brandId } = context.params;
+
+    if (!s3 || !s3.s3Client || !s3.s3Bucket) {
+      return badRequest('S3 storage is not configured for this environment');
+    }
+
+    const { error } = await getOrgAndValidateAccess(context);
+    if (error) {
+      return error;
+    }
+
+    const key = buildS3Key(spaceCatId, brandId);
+
+    // HeadObject first — avoids signing a URL for a missing object and lets
+    // us return a clean 404 instead of letting the client hit S3 with a doomed
+    // request.
+    try {
+      await s3.s3Client.send(new HeadObjectCommand({ Bucket: s3.s3Bucket, Key: key }));
+    } catch (e) {
+      if (e.name === 'NotFound' || e.$metadata?.httpStatusCode === 404) {
+        log.info(`Fan-out report not found at ${key}`);
+        return notFound('Fan-out report not found for this brand');
+      }
+      log.error(`HeadObject failed for ${key}: ${e.message}`, e);
+      return badRequest(`Error retrieving fan-out report: ${e.message}`);
+    }
+
+    const { getSignedUrl, GetObjectCommand } = s3;
+    const command = new GetObjectCommand({ Bucket: s3.s3Bucket, Key: key });
+    const url = await getSignedUrl(s3.s3Client, command, {
+      expiresIn: PRESIGNED_URL_TTL_SECONDS,
+    });
+
+    log.info(`Fan-out report served for org ${spaceCatId}, brand ${brandId}`);
+    return found(url);
+  };
+
+  return {
+    getFanoutReport,
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ import ReportsController from './controllers/reports.js';
 import LlmoController from './controllers/llmo/llmo.js';
 import LlmoMysticatController from './controllers/llmo/llmo-mysticat-controller.js';
 import LlmoOpportunitiesController from './controllers/llmo/opportunities/llmo-opportunities-controller.js';
+import FanoutReportController from './controllers/llmo/fanout-report.js';
 import UserActivitiesController from './controllers/user-activities.js';
 import SiteEnrollmentsController from './controllers/site-enrollments.js';
 import TrialUsersController from './controllers/trial-users.js';
@@ -234,6 +235,7 @@ async function run(request, context) {
     const llmoController = LlmoController(context);
     const llmoMysticatController = LlmoMysticatController(context);
     const llmoOpportunitiesController = LlmoOpportunitiesController(context);
+    const fanoutReportController = FanoutReportController(context);
     const fixesController = new FixesController(context);
     const userActivitiesController = UserActivitiesController(context);
     const siteEnrollmentsController = SiteEnrollmentsController(context);
@@ -313,6 +315,7 @@ async function run(request, context) {
       drsBpPgAuditController,
       webhooksController,
       aiVisibilityController,
+      fanoutReportController,
     );
 
     const routeMatch = matchPath(method, suffix, routeHandlers);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -98,6 +98,8 @@ function isStaticRoute(routePattern) {
  * @param {Object} plgOnboardingController - The PLG onboarding controller.
  * @param {Object} drsBpPgAuditController - DRS Brand Presence PostgREST audit proxy controller.
  * @param {Object} webhooksController - GitHub webhook handler controller.
+ * @param {Object} aiVisibilityController - AI Visibility (Semrush) controller.
+ * @param {Object} fanoutReportController - Query Fan-Out report controller.
  * @return {{staticRoutes: {}, dynamicRoutes: {}}} - An object with static and dynamic routes.
  */
 export default function getRouteHandlers(
@@ -154,6 +156,7 @@ export default function getRouteHandlers(
   drsBpPgAuditController,
   webhooksController,
   aiVisibilityController,
+  fanoutReportController,
 ) {
   const staticRoutes = {};
   const dynamicRoutes = {};
@@ -473,6 +476,7 @@ export default function getRouteHandlers(
 
     // Brand Presence filter dimensions (PostgREST/mysticat-data-service)
     // spaceCatId = organization_id. brandId = 'all' for all brands, or UUID for single brand.
+    'GET /org/:spaceCatId/brands/:brandId/fanout-report': fanoutReportController.getFanoutReport,
     'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions': llmoMysticatController.getFilterDimensions,
     'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions': llmoMysticatController.getFilterDimensions,
     'GET /org/:spaceCatId/brands/all/brand-presence/weeks': llmoMysticatController.getBrandPresenceWeeks,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -262,6 +262,7 @@ const routeRequiredCapabilities = {
   'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/delete': 'organization:write',
   'POST /v2/orgs/:spaceCatId/sites/:siteId/sync-config': 'organization:write',
   'GET /v2/orgs/:spaceCatId/sites/:siteId/brand': 'organization:read',
+  'GET /org/:spaceCatId/brands/:brandId/fanout-report': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions': 'brand:read',
   'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/weeks': 'brand:read',

--- a/test/controllers/llmo/fanout-report.test.js
+++ b/test/controllers/llmo/fanout-report.test.js
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+
+use(sinonChai);
+
+const SPACE_CAT_ID = '5d4e5082-b030-433d-9dbd-7007116f701f';
+const BRAND_ID = '3e3556f0-6494-4e8f-858f-01f2c358861a';
+const S3_BUCKET = 'spacecat-prod-importer';
+const EXPECTED_S3_KEY = `fanout/llmo/${SPACE_CAT_ID}/${BRAND_ID}/data.json.gz`;
+const PRESIGNED_URL = 'https://s3.amazonaws.com/spacecat-prod-importer/fanout/llmo/5d4e5082-b030-433d-9dbd-7007116f701f/3e3556f0-6494-4e8f-858f-01f2c358861a/data.json.gz?X-Amz-Signature=abc';
+
+describe('FanoutReportController', () => {
+  let sandbox;
+  let mockContext;
+  let mockOrganization;
+  let mockAccessControlUtil;
+  let mockS3Send;
+  let mockGetSignedUrl;
+  let FanoutReportController;
+
+  before(async () => {
+    // Single esmock cold-start; reused across all tests.
+    const mod = await esmock('../../../src/controllers/llmo/fanout-report.js', {
+      '../../../src/support/access-control-util.js': {
+        default: {
+          fromContext: () => mockAccessControlUtil,
+        },
+      },
+    });
+    FanoutReportController = mod.default;
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    mockOrganization = { getId: sandbox.stub().returns(SPACE_CAT_ID) };
+
+    mockS3Send = sandbox.stub().resolves({ /* HeadObject 200 */ });
+    mockGetSignedUrl = sandbox.stub().resolves(PRESIGNED_URL);
+
+    mockContext = {
+      log: {
+        info: sandbox.stub(),
+        warn: sandbox.stub(),
+        error: sandbox.stub(),
+      },
+      params: { spaceCatId: SPACE_CAT_ID, brandId: BRAND_ID },
+      dataAccess: {
+        Organization: {
+          findById: sandbox.stub().resolves(mockOrganization),
+        },
+      },
+      s3: {
+        s3Client: { send: mockS3Send },
+        s3Bucket: S3_BUCKET,
+        getSignedUrl: mockGetSignedUrl,
+        GetObjectCommand: function MockGetObjectCommand(params) {
+          this.params = params;
+        },
+      },
+    };
+
+    mockAccessControlUtil = {
+      hasAccess: sandbox.stub().resolves(true),
+      hasAdminAccess: sandbox.stub().returns(false),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getFanoutReport', () => {
+    it('returns 302 with presigned URL when the report exists', async () => {
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(302);
+      expect(result.headers.get('Location')).to.equal(PRESIGNED_URL);
+
+      // HeadObject called with the expected bucket/key
+      expect(mockS3Send).to.have.been.calledOnce;
+      const headCommand = mockS3Send.firstCall.args[0];
+      expect(headCommand).to.be.instanceOf(HeadObjectCommand);
+      expect(headCommand.input.Bucket).to.equal(S3_BUCKET);
+      expect(headCommand.input.Key).to.equal(EXPECTED_S3_KEY);
+
+      // Presigned URL generated for the same key with 1h TTL
+      const signedArgs = mockGetSignedUrl.firstCall.args;
+      expect(signedArgs[1].params.Bucket).to.equal(S3_BUCKET);
+      expect(signedArgs[1].params.Key).to.equal(EXPECTED_S3_KEY);
+      expect(signedArgs[2].expiresIn).to.equal(3600);
+    });
+
+    it('returns 404 when HeadObject throws NotFound', async () => {
+      const err = new Error('Not Found');
+      err.name = 'NotFound';
+      mockS3Send.rejects(err);
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(404);
+      expect(mockGetSignedUrl).not.to.have.been.called;
+    });
+
+    it('returns 404 when HeadObject error carries httpStatusCode 404', async () => {
+      const err = new Error('Object not found');
+      err.name = 'SomethingElse';
+      err.$metadata = { httpStatusCode: 404 };
+      mockS3Send.rejects(err);
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(404);
+    });
+
+    it('returns 404 when the organization is not found', async () => {
+      mockContext.dataAccess.Organization.findById.resolves(null);
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(404);
+      // Did not even touch S3
+      expect(mockS3Send).not.to.have.been.called;
+      expect(mockGetSignedUrl).not.to.have.been.called;
+    });
+
+    it('returns 404 (not 403) when the caller lacks LLMO access — does not leak org existence', async () => {
+      mockAccessControlUtil.hasAccess.resolves(false);
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(404);
+      expect(mockS3Send).not.to.have.been.called;
+      // Confirm access check used the LLMO product code
+      expect(mockAccessControlUtil.hasAccess).to.have.been.calledWith(mockOrganization, '', 'LLMO');
+    });
+
+    it('returns 400 when S3 is not configured at all', async () => {
+      mockContext.s3 = null;
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(400);
+    });
+
+    it('returns 400 when the S3 bucket is missing', async () => {
+      mockContext.s3.s3Bucket = null;
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(400);
+    });
+
+    it('returns 400 when HeadObject throws an unexpected error', async () => {
+      const err = new Error('boom');
+      err.name = 'AccessDenied';
+      mockS3Send.rejects(err);
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.getFanoutReport(mockContext);
+
+      expect(result.status).to.equal(400);
+      expect(mockContext.log.error).to.have.been.called;
+    });
+  });
+});

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -490,6 +490,10 @@ describe('getRouteHandlers', () => {
     getTopicsStats: sinon.stub(),
   };
 
+  const mockFanoutReportController = {
+    getFanoutReport: sinon.stub(),
+  };
+
   it('segregates static and dynamic routes', () => {
     const { staticRoutes, dynamicRoutes } = getRouteHandlers(
       mockAuditsController,
@@ -545,6 +549,7 @@ describe('getRouteHandlers', () => {
       mockDrsBpPgAuditController,
       mockWebhooksController,
       mockAiVisibilityController,
+      mockFanoutReportController,
     );
 
     expect(staticRoutes).to.have.all.keys(
@@ -705,6 +710,7 @@ describe('getRouteHandlers', () => {
       'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/delete',
       'POST /v2/orgs/:spaceCatId/sites/:siteId/sync-config',
       'GET /v2/orgs/:spaceCatId/sites/:siteId/brand',
+      'GET /org/:spaceCatId/brands/:brandId/fanout-report',
       'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions',
       'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions',
       'GET /org/:spaceCatId/brands/all/brand-presence/weeks',


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the Query Fan-Out report feature: the read endpoint.

`GET /org/{spaceCatId}/brands/{brandId}/fanout-report`

- Returns **`302 Found`** with `Location: <presigned S3 URL>` when a report exists at `s3://<bucket>/fanout/llmo/{spaceCatId}/{brandId}/data.json.gz`.
- Returns **`404 Not Found`** when the report doesn't exist (UI handles empty state).
- Access control: `AccessControlUtil.hasAccess(org, '', 'LLMO')` — same as brand-presence endpoints. 403 is collapsed into 404 to avoid leaking org existence.
- Presigned URL TTL: 1 hour (matches `brand-claims`).
- Lambda **never loads the report body** — the client follows the redirect straight to S3, which auto-decompresses via `Content-Encoding: gzip`.

OpenAPI contract was merged in [#2402](https://github.com/adobe/spacecat-api-service/pull/2402); this PR is the implementation against it.

## Behaviour summary

| Scenario | Status | Notes |
|---|---|---|
| Report exists | 302 | `Location` = signed S3 URL, 1h TTL |
| Report missing (S3 NotFound) | 404 | `notFound('Fan-out report not found for this brand')` |
| Org not found | 404 | Avoids leaking org existence |
| User lacks LLMO entitlement | 404 | Symmetric with above |
| S3 not configured for env | 400 | Same envelope brand-claims uses |
| Unexpected S3 error (e.g. AccessDenied) | 400 | Logged at `error` level |

## Phase 2 (POST — synchronous regeneration)

Follow-up PR per [`tmp/fanout/spec.md`](https://github.com/adobe/spacecat-api-service/blob/ekremney/fanout-report-get/tmp/fanout/spec.md). The GET contract above does not change between phases. For now, reports can be **manually curated and uploaded** to S3 to exercise this endpoint — see `tmp/fanout/example-adobe-fanout-report.json` for a worked example.

## Test plan

- [x] Unit tests cover all six response branches (302 + 4× 404 + 2× 400).
- [x] `npx eslint` clean on all touched files.
- [x] `npm test` exit code 0 locally (full suite, full coverage report shows 100% lines on the new controller).
- [ ] Reviewer: hand-upload `example-adobe-fanout-report.json.gz` to the brand path under `s3://spacecat-prod-importer/fanout/llmo/<spaceCatId>/<brandId>/data.json.gz` and curl the endpoint — confirm 302 + browser follows to S3 and parses the JSON.

## Files

- **New** `src/controllers/llmo/fanout-report.js` — `FanoutReportController(ctx)` factory, exports `getFanoutReport`.
- **New** `test/controllers/llmo/fanout-report.test.js` — unit tests.
- **Edit** `src/index.js` — instantiate controller, pass into `getRouteHandlers`.
- **Edit** `src/routes/index.js` — register the GET route alongside other `/org/:spaceCatId/brands/:brandId/...` endpoints.
- **Edit** `src/routes/required-capabilities.js` — `brand:read` for S2S callers (consistent with brand-presence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)