### PR TITLE
feat: POST endpoint for query fan-out report regeneration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "iso-639-3": "3.0.1",
         "js-yaml": "4.1.1",
         "node-html-parser": "7.1.0",
+        "p-limit": "3.1.0",
         "package-lock.json": "^1.0.0",
         "package.json": "^2.0.1",
         "slack-block-builder": "2.8.0",
@@ -691,6 +692,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -12538,6 +12540,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -15594,7 +15597,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -15618,6 +15622,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -16554,6 +16559,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -16851,6 +16857,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -17057,6 +17064,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -17221,6 +17229,7 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -19201,6 +19210,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -19448,6 +19458,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19495,6 +19506,7 @@
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19960,6 +19972,7 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -20622,6 +20635,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -22816,6 +22830,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -26780,6 +26795,7 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -27834,6 +27850,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -30415,6 +30432,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -30941,6 +30959,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -31150,7 +31169,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -32128,6 +32146,7 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -32138,6 +32157,7 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -32892,6 +32912,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -34257,6 +34278,7 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -35263,6 +35285,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -36015,6 +36038,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -36243,7 +36267,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -36285,6 +36308,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -36294,6 +36318,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "iso-639-3": "3.0.1",
     "js-yaml": "4.1.1",
     "node-html-parser": "7.1.0",
+    "p-limit": "3.1.0",
     "package-lock.json": "^1.0.0",
     "package.json": "^2.0.1",
     "slack-block-builder": "2.8.0",

--- a/src/controllers/llmo/fanout-report.js
+++ b/src/controllers/llmo/fanout-report.js
@@ -11,13 +11,27 @@
  */
 
 import {
-  badRequest, found, notFound,
+  badRequest, created, found, internalServerError, notFound,
 } from '@adobe/spacecat-shared-http-utils';
-import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { HeadObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { COUNTRY_ENUM, LLM_ENUM } from '@quazar/ai-seo-ts/common/types_pb.js';
 import AccessControlUtil from '../../support/access-control-util.js';
+import { getGrpcClients } from '../../support/ai-visibility/grpc-transport.js';
+import { curateFanoutReport, gzipReport } from '../../support/fanout/curate.js';
 
 const PRESIGNED_URL_TTL_SECONDS = 60 * 60; // 1 hour — mirrors brand-claims
 const REPORT_FILENAME = 'data.json.gz';
+
+// Hardcoded constants for the initial version (Q2). Promote to query params
+// when we expand market/LLM coverage.
+const COUNTRY_NAME = 'US';
+const LLM_NAME = 'chatgpt';
+const COUNTRY_VALUE = COUNTRY_ENUM.US;
+const LLM_VALUE = LLM_ENUM.CHAT_GPT;
+const WINDOW_DAYS = 7; // Q15
+
+const DEFAULT_CONCURRENCY = 5; // Q29
+const DEFAULT_BATCH_SIZE = 100; // Q25 (Semrush max)
 
 const buildS3Key = (spaceCatId, brandId) => (
   `fanout/llmo/${spaceCatId}/${brandId}/${REPORT_FILENAME}`
@@ -101,7 +115,90 @@ export default function FanoutReportController(ctx) {
     return found(url);
   };
 
+  /**
+   * POST /org/{spaceCatId}/brands/{brandId}/fanout-report
+   *
+   * Synchronously regenerates the report: reads tracked topics + per-prompt
+   * rates from Mysticat, calls Semrush's fan-out service in batches, drops
+   * topics below the similarity threshold, keeps the top 5 by priority score,
+   * writes the gzipped JSON to S3. Returns 201 with an empty body. Caller
+   * follows up with GET to fetch the presigned URL.
+   *
+   * country and llm are hard-coded to US/chatgpt for the initial version.
+   */
+  const triggerFanoutReport = async (context) => {
+    const { log, s3, env } = context;
+    const { spaceCatId, brandId } = context.params;
+
+    if (!s3 || !s3.s3Client || !s3.s3Bucket) {
+      return badRequest('S3 storage is not configured for this environment');
+    }
+
+    const { error } = await getOrgAndValidateAccess(context);
+    if (error) {
+      return error;
+    }
+
+    const postgrestClient = context.dataAccess?.services?.postgrestClient;
+    if (!postgrestClient) {
+      return badRequest('PostgREST is not configured for this environment');
+    }
+
+    let fanoutClient;
+    try {
+      ({ fanoutClient } = getGrpcClients(env));
+    } catch (e) {
+      log.error(`Failed to initialize Semrush gRPC clients: ${e.message}`, e);
+      return badRequest(`Semrush is not configured for this environment: ${e.message}`);
+    }
+
+    const t0 = Date.now();
+    try {
+      const { report, stats } = await curateFanoutReport({
+        organizationId: spaceCatId,
+        brandId,
+        country: COUNTRY_VALUE,
+        llm: LLM_VALUE,
+        countryName: COUNTRY_NAME,
+        llmName: LLM_NAME,
+        windowDays: WINDOW_DAYS,
+        postgrestClient,
+        fanoutClient,
+        concurrency: Number(env.SEMRUSH_FANOUT_CONCURRENCY ?? DEFAULT_CONCURRENCY),
+        batchSize: Number(env.SEMRUSH_FANOUT_BATCH_SIZE ?? DEFAULT_BATCH_SIZE),
+        log,
+      });
+
+      const body = gzipReport(report);
+      const key = buildS3Key(spaceCatId, brandId);
+      await s3.s3Client.send(new PutObjectCommand({
+        Bucket: s3.s3Bucket,
+        Key: key,
+        Body: body,
+        ContentType: 'application/json',
+        ContentEncoding: 'gzip',
+      }));
+
+      const totalMs = Date.now() - t0;
+      log.info('fanout-report curated', {
+        orgId: spaceCatId,
+        brandId,
+        key,
+        totalMs,
+        ...stats,
+      });
+      return created();
+    } catch (e) {
+      log.error(
+        `fanout-report POST failed for org ${spaceCatId}, brand ${brandId}: ${e.message}`,
+        e,
+      );
+      return internalServerError(`Failed to generate fan-out report: ${e.message}`);
+    }
+  };
+
   return {
     getFanoutReport,
+    triggerFanoutReport,
   };
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -477,6 +477,7 @@ export default function getRouteHandlers(
     // Brand Presence filter dimensions (PostgREST/mysticat-data-service)
     // spaceCatId = organization_id. brandId = 'all' for all brands, or UUID for single brand.
     'GET /org/:spaceCatId/brands/:brandId/fanout-report': fanoutReportController.getFanoutReport,
+    'POST /org/:spaceCatId/brands/:brandId/fanout-report': fanoutReportController.triggerFanoutReport,
     'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions': llmoMysticatController.getFilterDimensions,
     'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions': llmoMysticatController.getFilterDimensions,
     'GET /org/:spaceCatId/brands/all/brand-presence/weeks': llmoMysticatController.getBrandPresenceWeeks,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -263,6 +263,7 @@ const routeRequiredCapabilities = {
   'POST /v2/orgs/:spaceCatId/sites/:siteId/sync-config': 'organization:write',
   'GET /v2/orgs/:spaceCatId/sites/:siteId/brand': 'organization:read',
   'GET /org/:spaceCatId/brands/:brandId/fanout-report': 'brand:read',
+  'POST /org/:spaceCatId/brands/:brandId/fanout-report': 'brand:write',
   'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions': 'brand:read',
   'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/weeks': 'brand:read',

--- a/src/support/ai-visibility/grpc-transport.js
+++ b/src/support/ai-visibility/grpc-transport.js
@@ -17,6 +17,7 @@ import { TopicService } from '@quazar/ai-seo-ts/v2/topic/service_pb.js';
 import { PromptService } from '@quazar/ai-seo-ts/v2/prompt/service_pb.js';
 import { SourceService } from '@quazar/ai-seo-ts/v2/source/service_pb.js';
 import { CompetitorService } from '@quazar/ai-seo-ts/v2/competitor/service_pb.js';
+import { FanoutService } from '@quazar/ai-seo-ts/v2/fanout/service_pb.js';
 import {
   CompetitorsMetrics,
   Meta as CrMeta,
@@ -37,7 +38,18 @@ function semrushAiSeoOAuthTokenUrl(env) {
   return new URL(path, 'https://api.semrush.com').href;
 }
 
+// Process-wide token cache. The OAuth roundtrip is otherwise issued on every
+// gRPC call, which with p-limit(5) fan-out and 10 batches means up to 10
+// redundant token fetches. Cache by expiry with a small leeway to avoid
+// edge-of-expiry races.
+let cachedToken = null;
+const TOKEN_LEEWAY_MS = 30_000;
+
 async function getAccessToken(env) {
+  if (cachedToken && Date.now() + TOKEN_LEEWAY_MS < cachedToken.expiresAt) {
+    return cachedToken.token;
+  }
+
   const id = env.SEO_CLIENT_ID;
   const secret = env.SEO_CLIENT_SECRET;
   if (!id?.trim() || !secret?.trim()) {
@@ -64,7 +76,18 @@ async function getAccessToken(env) {
     });
     throw new Error('Semrush OAuth token request failed');
   }
-  return j.access_token;
+
+  const expiresInSec = Number(j.expires_in) || 3600;
+  cachedToken = {
+    token: j.access_token,
+    expiresAt: Date.now() + (expiresInSec * 1000),
+  };
+  return cachedToken.token;
+}
+
+/** @visibleForTesting */
+export function resetTokenCache() {
+  cachedToken = null;
 }
 
 function createAuthInterceptor(env) {
@@ -98,6 +121,7 @@ export function getGrpcClients(env) {
     promptClient: createClient(PromptService, transport),
     sourceClient: createClient(SourceService, transport),
     competitorClient: createClient(CompetitorService, transport),
+    fanoutClient: createClient(FanoutService, transport),
     crMetricsClient: createClient(CompetitorsMetrics, transport),
     crMetaClient: createClient(CrMeta, transport),
     voSourcesClient: createClient(VoSources, transport),

--- a/src/support/fanout/curate.js
+++ b/src/support/fanout/curate.js
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { gzipSync } from 'node:zlib';
+import { getBrandById } from '../brands-storage.js';
+import { fetchFanoutTopics } from './topics-rpc.js';
+import { resolveTopicMetricsBatched, intentNameFromEnum } from './semrush-client.js';
+
+export const SCHEMA_VERSION = 1;
+export const SIMILARITY_THRESHOLD = 70; // Semrush range 0..100 (Q22)
+export const TOPICS_DB_LIMIT = 1000; // Q6a-iii
+export const TOP_N_TOPICS = 5; // Q20
+
+/**
+ * Mirror of the UI's `extractDomain` (project-elmo-ui/src/utils/urlParser.ts).
+ * Returns the hostname with leading `www.` stripped, or null on parse failure.
+ * Subdomains other than `www.` are kept — matches what Semrush returns in
+ * `rankings[].domain` (confirmed with Semrush engineering).
+ */
+export function extractDomain(value) {
+  if (value == null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const normalized = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    return new URL(normalized).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Server-side equivalent of the UI's `collectBrandUrlDomains` (true-mirror,
+ * Q18). Primary source is `brand.urls[].value`; falls back to `brand.baseUrl`
+ * only when no valid hostname was extracted from urls[].
+ */
+export function brandDomainsFromBrand(brand) {
+  const fromUrls = [...new Set(
+    (brand?.urls ?? [])
+      .map((u) => extractDomain(u?.value))
+      .filter((d) => d !== null),
+  )];
+  if (fromUrls.length > 0) {
+    return fromUrls;
+  }
+  const fromBase = extractDomain(brand?.baseUrl);
+  return fromBase ? [fromBase] : [];
+}
+
+/**
+ * Returns the lowest (best) SERP position at which any of the brand's
+ * domains appears in `rankings[]`, or null if none match. Matching is
+ * exact-hostname against the apex-stripped set in `brandDomainSet`.
+ */
+export function brandPositionOf(rankings, brandDomainSet) {
+  let best = null;
+  for (const r of rankings) {
+    if (brandDomainSet.has(r.domain) && (best === null || r.position < best)) {
+      best = r.position;
+    }
+  }
+  return best;
+}
+
+function toRankings(fanoutQuery) {
+  return (fanoutQuery.rankings ?? []).map((r) => ({
+    domain: r.domain,
+    position: Number(r.position ?? 0),
+  }));
+}
+
+function buildSubQuery(fanoutQuery, brandDomainSet) {
+  const rankings = toRankings(fanoutQuery);
+  const top = rankings[0];
+  const intent = intentNameFromEnum(fanoutQuery.intents);
+  const subQuery = {
+    keyword: fanoutQuery.keyword,
+    volume: Number(fanoutQuery.volume ?? 0),
+    brandPosition: brandPositionOf(rankings, brandDomainSet),
+    topDomain: top?.domain ?? '',
+    rankings,
+  };
+  if (intent !== undefined) {
+    subQuery.intent = intent;
+  }
+  return subQuery;
+}
+
+function buildTopic(dbTopic, sem, brandDomainSet) {
+  // Semrush's metrics.volume is uint64 → BigInt in TS. Safe to coerce to
+  // Number — monthly search volume never approaches Number.MAX_SAFE_INTEGER.
+  const volume = Number(sem.metrics?.volume ?? 0n);
+  const citation = dbTopic.citationRate ?? 0;
+  return {
+    topicUuid: dbTopic.topicUuid,
+    name: dbTopic.name,
+    matchedTopicName: sem.matchedTopicName,
+    volume,
+    promptsTotal: dbTopic.promptsTotal,
+    mentionRate: dbTopic.mentionRate,
+    citationRate: dbTopic.citationRate,
+    priorityScore: volume * (1 - citation),
+    subQueries: (sem.fanoutQueries ?? []).map((fq) => buildSubQuery(fq, brandDomainSet)),
+  };
+}
+
+function emptyReport({
+  organizationId, brandId, brandName, brandDomains, country, llm, windowDays, isoDate,
+}) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    isoDate: isoDate ?? new Date().toISOString().slice(0, 10),
+    orgId: organizationId,
+    brandId,
+    brandName,
+    brandDomains,
+    country,
+    llm,
+    windowDays,
+    topics: [],
+  };
+}
+
+/**
+ * Runs the full curation pipeline:
+ *   1. Fetch up to TOPICS_DB_LIMIT tracked topics from Mysticat
+ *      (`rpc_fanout_topics`) — already in `id DESC` order, with rates.
+ *   2. Load the brand and compute the apex-stripped `brandDomains` set
+ *      using the same logic the UI applies (Q18).
+ *   3. Call Semrush `resolveTopicMetrics` in batches with bounded concurrency.
+ *   4. Drop topics whose Semrush `similarityScore < SIMILARITY_THRESHOLD`.
+ *   5. Sort the survivors by `priorityScore` desc and keep the top
+ *      TOP_N_TOPICS.
+ *   6. Return the assembled `FanoutReport` (matches the OpenAPI schema) plus
+ *      a stats block for observability.
+ *
+ * The result is plain JSON — gzip via `gzipReport` before writing to S3.
+ */
+export async function curateFanoutReport({
+  organizationId,
+  brandId,
+  country,
+  llm,
+  countryName,
+  llmName,
+  windowDays,
+  postgrestClient,
+  fanoutClient,
+  concurrency,
+  batchSize,
+  log,
+}) {
+  const t0 = Date.now();
+
+  const dbTopics = await fetchFanoutTopics(postgrestClient, {
+    organizationId,
+    brandId,
+    limit: TOPICS_DB_LIMIT,
+  });
+  const tDb = Date.now() - t0;
+
+  const brand = await getBrandById(organizationId, brandId, postgrestClient);
+  const brandName = brand?.name ?? '';
+  const brandDomains = brandDomainsFromBrand(brand);
+  const brandDomainSet = new Set(brandDomains);
+
+  if (dbTopics.length === 0) {
+    log?.info?.('fanout: brand has no tracked topics; writing empty report', {
+      orgId: organizationId, brandId,
+    });
+    return {
+      report: emptyReport({
+        organizationId,
+        brandId,
+        brandName,
+        brandDomains,
+        country: countryName,
+        llm: llmName,
+        windowDays,
+        isoDate: null,
+      }),
+      stats: {
+        dbTopics: 0,
+        semrushReturned: 0,
+        similarityPassed: 0,
+        topicsPicked: 0,
+        tDb,
+        tSem: 0,
+      },
+    };
+  }
+
+  const tSemStart = Date.now();
+  const { byOriginal, isoDate } = await resolveTopicMetricsBatched({
+    fanoutClient,
+    topics: dbTopics.map((t) => t.name),
+    country,
+    llm,
+    concurrency,
+    batchSize,
+    log,
+  });
+  const tSem = Date.now() - tSemStart;
+
+  const joined = [];
+  for (const t of dbTopics) {
+    const sem = byOriginal.get(t.name);
+    if (!sem) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const sim = Number(sem.similarityScore ?? 0);
+    if (sim < SIMILARITY_THRESHOLD) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    joined.push(buildTopic(t, sem, brandDomainSet));
+  }
+  const similarityPassed = joined.length;
+
+  joined.sort((a, b) => b.priorityScore - a.priorityScore);
+  const topics = joined.slice(0, TOP_N_TOPICS);
+
+  const report = {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    isoDate: isoDate ?? new Date().toISOString().slice(0, 10),
+    orgId: organizationId,
+    brandId,
+    brandName,
+    brandDomains,
+    country: countryName,
+    llm: llmName,
+    windowDays,
+    topics,
+  };
+
+  return {
+    report,
+    stats: {
+      dbTopics: dbTopics.length,
+      semrushReturned: byOriginal.size,
+      similarityPassed,
+      topicsPicked: topics.length,
+      tDb,
+      tSem,
+    },
+  };
+}
+
+export function gzipReport(report) {
+  return gzipSync(Buffer.from(JSON.stringify(report)));
+}

--- a/src/support/fanout/semrush-client.js
+++ b/src/support/fanout/semrush-client.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import pLimit from 'p-limit';
+import { KEYWORD_INTENT_ENUM } from '@quazar/ai-seo-ts/v2/fanout/enums_pb.js';
+
+const RETRY_DELAYS_MS = [500, 2000, 8000];
+const GRPC_RESOURCE_EXHAUSTED = 8; // RESOURCE_EXHAUSTED ≈ HTTP 429
+const RATE_LIMIT_PATTERN = /rate.?limit|429/i;
+
+const INTENT_NAME = {
+  [KEYWORD_INTENT_ENUM.UNSPECIFIED]: 'UNSPECIFIED',
+  [KEYWORD_INTENT_ENUM.COMMERCIAL]: 'COMMERCIAL',
+  [KEYWORD_INTENT_ENUM.INFORMATIONAL]: 'INFORMATIONAL',
+  [KEYWORD_INTENT_ENUM.NAVIGATIONAL]: 'NAVIGATIONAL',
+  [KEYWORD_INTENT_ENUM.TRANSACTIONAL]: 'TRANSACTIONAL',
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+function isRateLimited(err) {
+  if (!err) {
+    return false;
+  }
+  if (err.code === GRPC_RESOURCE_EXHAUSTED) {
+    return true;
+  }
+  return RATE_LIMIT_PATTERN.test(err.message ?? '');
+}
+
+async function callBatchWithRetry(fanoutClient, payload, log) {
+  let lastErr;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- sequential retries are intentional
+      return await fanoutClient.resolveTopicMetrics(payload);
+    } catch (e) {
+      lastErr = e;
+      if (!isRateLimited(e) || attempt === RETRY_DELAYS_MS.length) {
+        break;
+      }
+      const delay = RETRY_DELAYS_MS[attempt];
+      log?.warn?.(`fanout: rate-limited, retrying in ${delay}ms (attempt ${attempt + 1})`);
+      // eslint-disable-next-line no-await-in-loop -- sequential retries are intentional
+      await sleep(delay);
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Picks the first intent from Semrush's multi-label intents[] and converts the
+ * KEYWORD_INTENT_ENUM int to the string form we surface in the report JSON.
+ *
+ * Returns `undefined` (not `null`) when the input is empty so callers can use
+ * the value directly in a spread without producing an explicit `null` field.
+ */
+export function intentNameFromEnum(intents) {
+  if (!Array.isArray(intents) || intents.length === 0) {
+    return undefined;
+  }
+  return INTENT_NAME[intents[0]] ?? 'UNSPECIFIED';
+}
+
+/**
+ * Calls `FanoutService.resolveTopicMetrics` in batches with bounded
+ * concurrency and exponential backoff on rate-limit errors.
+ *
+ * @param {object} opts
+ * @param {object} opts.fanoutClient - The connectrpc client (from grpc-transport.js).
+ * @param {string[]} opts.topics - Topic names to resolve. May exceed batchSize.
+ * @param {number} opts.country - COUNTRY_ENUM int.
+ * @param {number} opts.llm - LLM_ENUM int.
+ * @param {number} [opts.concurrency=5] - In-flight batches cap.
+ * @param {number} [opts.batchSize=100] - Topics per RPC call (Semrush max).
+ * @param {object} [opts.log] - Optional logger.
+ * @returns {Promise<{
+ *   byOriginal: Map<string, object>,
+ *   isoDate: string|null
+ * }>}
+ */
+export async function resolveTopicMetricsBatched({
+  fanoutClient,
+  topics,
+  country,
+  llm,
+  concurrency = 5,
+  batchSize = 100,
+  log,
+}) {
+  if (!topics?.length) {
+    return { byOriginal: new Map(), isoDate: null };
+  }
+
+  const limit = pLimit(concurrency);
+  const batches = chunk(topics, batchSize);
+
+  const results = await Promise.all(batches.map((batch) => limit(async () => {
+    const payload = { country, llm, topics: batch };
+    return callBatchWithRetry(fanoutClient, payload, log);
+  })));
+
+  const byOriginal = new Map();
+  let isoDate = null;
+  for (const r of results) {
+    if (isoDate == null && r?.isoDate) {
+      isoDate = r.isoDate;
+    }
+    for (const tm of r?.topicMetrics ?? []) {
+      byOriginal.set(tm.originalTopic, tm);
+    }
+  }
+  return { byOriginal, isoDate };
+}

--- a/src/support/fanout/topics-rpc.js
+++ b/src/support/fanout/topics-rpc.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Thin wrapper around the `rpc_fanout_topics` PL/pgSQL function in
+ * mysticat-data-service. Returns the brand's tracked topics together with
+ * per-prompt mention rate and citation rate over a trailing window.
+ *
+ * The RPC is org-scoped and brand-scoped; the window, model, region, and
+ * cap are passed as parameters (defaulted in the SQL function).
+ *
+ * @param {import('@supabase/postgrest-js').PostgrestClient} postgrestClient
+ * @param {object} opts
+ * @param {string} opts.organizationId
+ * @param {string} opts.brandId
+ * @param {number} [opts.limit=1000]
+ * @returns {Promise<Array<{
+ *   topicUuid: string,
+ *   topicId: string,
+ *   name: string,
+ *   description: string|null,
+ *   promptsTotal: number,
+ *   mentionRate: number|null,
+ *   citationRate: number|null
+ * }>>}
+ */
+export async function fetchFanoutTopics(postgrestClient, {
+  organizationId,
+  brandId,
+  limit = 1000,
+}) {
+  const { data, error } = await postgrestClient.rpc('rpc_fanout_topics', {
+    p_organization_id: organizationId,
+    p_brand_id: brandId,
+    p_limit: limit,
+  });
+  if (error) {
+    throw new Error(`rpc_fanout_topics failed: ${error.message}`);
+  }
+  return (data || []).map((row) => ({
+    topicUuid: row.topic_uuid,
+    topicId: row.topic_id,
+    name: row.name,
+    description: row.description ?? null,
+    promptsTotal: Number(row.prompts_total ?? 0),
+    mentionRate: row.mention_rate == null ? null : Number(row.mention_rate),
+    citationRate: row.citation_rate == null ? null : Number(row.citation_rate),
+  }));
+}

--- a/test/controllers/llmo/fanout-report.test.js
+++ b/test/controllers/llmo/fanout-report.test.js
@@ -14,7 +14,7 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
-import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { HeadObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 
 use(sinonChai);
 
@@ -31,15 +31,48 @@ describe('FanoutReportController', () => {
   let mockAccessControlUtil;
   let mockS3Send;
   let mockGetSignedUrl;
+  let mockCurate;
+  let mockGetGrpcClients;
   let FanoutReportController;
+  const FAKE_REPORT = {
+    schemaVersion: 1,
+    generatedAt: '2026-05-13T10:00:00Z',
+    isoDate: '2026-05-08',
+    orgId: SPACE_CAT_ID,
+    brandId: BRAND_ID,
+    brandName: 'Acme',
+    brandDomains: ['acme.com'],
+    country: 'US',
+    llm: 'chatgpt',
+    windowDays: 7,
+    topics: [],
+  };
 
   before(async () => {
     // Single esmock cold-start; reused across all tests.
+    mockCurate = sinon.stub().resolves({
+      report: FAKE_REPORT,
+      stats: {
+        dbTopics: 0, semrushReturned: 0, similarityPassed: 0, topicsPicked: 0, tDb: 1, tSem: 1,
+      },
+    });
+    mockGetGrpcClients = sinon.stub().returns({
+      fanoutClient: { resolveTopicMetrics: sinon.stub() },
+    });
+
     const mod = await esmock('../../../src/controllers/llmo/fanout-report.js', {
       '../../../src/support/access-control-util.js': {
         default: {
           fromContext: () => mockAccessControlUtil,
         },
+      },
+      '../../../src/support/ai-visibility/grpc-transport.js': {
+        getGrpcClients: (...args) => mockGetGrpcClients(...args),
+      },
+      '../../../src/support/fanout/curate.js': {
+        curateFanoutReport: (...args) => mockCurate(...args),
+        // Real gzip implementation is fine here — output is just a buffer.
+        gzipReport: (report) => Buffer.from(JSON.stringify(report)),
       },
     });
     FanoutReportController = mod.default;
@@ -50,7 +83,7 @@ describe('FanoutReportController', () => {
 
     mockOrganization = { getId: sandbox.stub().returns(SPACE_CAT_ID) };
 
-    mockS3Send = sandbox.stub().resolves({ /* HeadObject 200 */ });
+    mockS3Send = sandbox.stub().resolves({ /* HeadObject / PutObject 200 */ });
     mockGetSignedUrl = sandbox.stub().resolves(PRESIGNED_URL);
 
     mockContext = {
@@ -60,9 +93,13 @@ describe('FanoutReportController', () => {
         error: sandbox.stub(),
       },
       params: { spaceCatId: SPACE_CAT_ID, brandId: BRAND_ID },
+      env: {},
       dataAccess: {
         Organization: {
           findById: sandbox.stub().resolves(mockOrganization),
+        },
+        services: {
+          postgrestClient: { rpc: sandbox.stub() },
         },
       },
       s3: {
@@ -79,6 +116,17 @@ describe('FanoutReportController', () => {
       hasAccess: sandbox.stub().resolves(true),
       hasAdminAccess: sandbox.stub().returns(false),
     };
+
+    // Full reset so behaviors don't leak across tests; then re-apply defaults.
+    mockCurate.reset();
+    mockCurate.resolves({
+      report: FAKE_REPORT,
+      stats: {
+        dbTopics: 0, semrushReturned: 0, similarityPassed: 0, topicsPicked: 0, tDb: 1, tSem: 1,
+      },
+    });
+    mockGetGrpcClients.reset();
+    mockGetGrpcClients.returns({ fanoutClient: { resolveTopicMetrics: sinon.stub() } });
   });
 
   afterEach(() => {
@@ -183,6 +231,120 @@ describe('FanoutReportController', () => {
 
       expect(result.status).to.equal(400);
       expect(mockContext.log.error).to.have.been.called;
+    });
+  });
+
+  describe('triggerFanoutReport', () => {
+    it('returns 201 and writes a gzipped report to S3', async () => {
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(201);
+
+      // Curation called with the hardcoded country/llm + window
+      const curateArgs = mockCurate.firstCall.args[0];
+      expect(curateArgs.organizationId).to.equal(SPACE_CAT_ID);
+      expect(curateArgs.brandId).to.equal(BRAND_ID);
+      expect(curateArgs.countryName).to.equal('US');
+      expect(curateArgs.llmName).to.equal('chatgpt');
+      expect(curateArgs.windowDays).to.equal(7);
+      expect(curateArgs.concurrency).to.equal(5); // default
+      expect(curateArgs.batchSize).to.equal(100); // default
+
+      // PutObject called with the expected key + gzip encoding
+      expect(mockS3Send).to.have.been.calledOnce;
+      const putCommand = mockS3Send.firstCall.args[0];
+      expect(putCommand).to.be.instanceOf(PutObjectCommand);
+      expect(putCommand.input.Bucket).to.equal(S3_BUCKET);
+      expect(putCommand.input.Key).to.equal(EXPECTED_S3_KEY);
+      expect(putCommand.input.ContentEncoding).to.equal('gzip');
+      expect(putCommand.input.ContentType).to.equal('application/json');
+      expect(putCommand.input.Body).to.be.instanceOf(Buffer);
+    });
+
+    it('honours SEMRUSH_FANOUT_CONCURRENCY and SEMRUSH_FANOUT_BATCH_SIZE env vars', async () => {
+      mockContext.env = {
+        SEMRUSH_FANOUT_CONCURRENCY: '3',
+        SEMRUSH_FANOUT_BATCH_SIZE: '50',
+      };
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(201);
+      const curateArgs = mockCurate.firstCall.args[0];
+      expect(curateArgs.concurrency).to.equal(3);
+      expect(curateArgs.batchSize).to.equal(50);
+    });
+
+    it('returns 400 when S3 is not configured', async () => {
+      mockContext.s3 = null;
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(400);
+      expect(mockCurate).not.to.have.been.called;
+    });
+
+    it('returns 404 when the organization is not found', async () => {
+      mockContext.dataAccess.Organization.findById.resolves(null);
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(404);
+      expect(mockCurate).not.to.have.been.called;
+      expect(mockS3Send).not.to.have.been.called;
+    });
+
+    it('returns 404 when the caller lacks LLMO access', async () => {
+      mockAccessControlUtil.hasAccess.resolves(false);
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(404);
+      expect(mockCurate).not.to.have.been.called;
+    });
+
+    it('returns 400 when PostgREST is not configured', async () => {
+      mockContext.dataAccess.services = {};
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(400);
+      expect(mockCurate).not.to.have.been.called;
+    });
+
+    it('returns 400 when gRPC client init fails', async () => {
+      mockGetGrpcClients.throws(new Error('missing creds'));
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(400);
+      expect(mockCurate).not.to.have.been.called;
+    });
+
+    it('returns 500 when curation throws', async () => {
+      mockCurate.rejects(new Error('semrush exploded'));
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(500);
+      expect(mockContext.log.error).to.have.been.called;
+    });
+
+    it('returns 500 when S3 PutObject throws', async () => {
+      mockS3Send.rejects(new Error('S3 down'));
+
+      const controller = FanoutReportController(mockContext);
+      const result = await controller.triggerFanoutReport(mockContext);
+
+      expect(result.status).to.equal(500);
     });
   });
 });

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -492,6 +492,7 @@ describe('getRouteHandlers', () => {
 
   const mockFanoutReportController = {
     getFanoutReport: sinon.stub(),
+    triggerFanoutReport: sinon.stub(),
   };
 
   it('segregates static and dynamic routes', () => {
@@ -711,6 +712,7 @@ describe('getRouteHandlers', () => {
       'POST /v2/orgs/:spaceCatId/sites/:siteId/sync-config',
       'GET /v2/orgs/:spaceCatId/sites/:siteId/brand',
       'GET /org/:spaceCatId/brands/:brandId/fanout-report',
+      'POST /org/:spaceCatId/brands/:brandId/fanout-report',
       'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions',
       'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions',
       'GET /org/:spaceCatId/brands/all/brand-presence/weeks',

--- a/test/support/fanout/curate.test.js
+++ b/test/support/fanout/curate.test.js
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import { gunzipSync } from 'node:zlib';
+import { KEYWORD_INTENT_ENUM } from '@quazar/ai-seo-ts/v2/fanout/enums_pb.js';
+
+use(sinonChai);
+
+const ORG_ID = '5d4e5082-b030-433d-9dbd-7007116f701f';
+const BRAND_ID = '3e3556f0-6494-4e8f-858f-01f2c358861a';
+
+function dbTopic(overrides = {}) {
+  return {
+    topicUuid: '11111111-1111-7111-8111-111111111111',
+    topicId: 'best-crm',
+    name: 'Best CRM',
+    description: null,
+    promptsTotal: 10,
+    mentionRate: 0.5,
+    citationRate: 0.1,
+    ...overrides,
+  };
+}
+
+function semTopic(overrides = {}) {
+  return {
+    originalTopic: 'Best CRM',
+    matchedTopicId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    matchedTopicName: 'Best CRM',
+    similarityScore: 90,
+    metrics: { volume: 1000n },
+    fanoutQueries: [],
+    ...overrides,
+  };
+}
+
+function fanoutQuery(overrides = {}) {
+  return {
+    keyword: 'best crm for smb',
+    intents: [KEYWORD_INTENT_ENUM.COMMERCIAL],
+    volume: 100,
+    rankings: [
+      { domain: 'hubspot.com', position: 1 },
+      { domain: 'acme.com', position: 3 },
+    ],
+    ...overrides,
+  };
+}
+
+describe('curateFanoutReport', () => {
+  let sandbox;
+  let mockFetchFanoutTopics;
+  let mockResolveTopicMetricsBatched;
+  let mockGetBrandById;
+  let curate;
+
+  before(async () => {
+    const stubs = {
+      fetchFanoutTopics: sinon.stub(),
+      resolveTopicMetricsBatched: sinon.stub(),
+      getBrandById: sinon.stub(),
+    };
+    mockFetchFanoutTopics = stubs.fetchFanoutTopics;
+    mockResolveTopicMetricsBatched = stubs.resolveTopicMetricsBatched;
+    mockGetBrandById = stubs.getBrandById;
+
+    const mod = await esmock('../../../src/support/fanout/curate.js', {
+      '../../../src/support/fanout/topics-rpc.js': {
+        fetchFanoutTopics: (...args) => mockFetchFanoutTopics(...args),
+      },
+      '../../../src/support/fanout/semrush-client.js': {
+        resolveTopicMetricsBatched: (...args) => mockResolveTopicMetricsBatched(...args),
+        intentNameFromEnum: (intents) => {
+          if (!Array.isArray(intents) || intents.length === 0) {
+            return undefined;
+          }
+          const NAME = {
+            [KEYWORD_INTENT_ENUM.UNSPECIFIED]: 'UNSPECIFIED',
+            [KEYWORD_INTENT_ENUM.COMMERCIAL]: 'COMMERCIAL',
+            [KEYWORD_INTENT_ENUM.INFORMATIONAL]: 'INFORMATIONAL',
+            [KEYWORD_INTENT_ENUM.NAVIGATIONAL]: 'NAVIGATIONAL',
+            [KEYWORD_INTENT_ENUM.TRANSACTIONAL]: 'TRANSACTIONAL',
+          };
+          return NAME[intents[0]] ?? 'UNSPECIFIED';
+        },
+      },
+      '../../../src/support/brands-storage.js': {
+        getBrandById: (...args) => mockGetBrandById(...args),
+      },
+    });
+    curate = mod;
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    mockFetchFanoutTopics.reset();
+    mockResolveTopicMetricsBatched.reset();
+    mockGetBrandById.reset();
+
+    mockGetBrandById.resolves({
+      name: 'Acme',
+      urls: [{ value: 'https://acme.com' }],
+      baseUrl: 'https://acme.com',
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const callerArgs = (overrides = {}) => ({
+    organizationId: ORG_ID,
+    brandId: BRAND_ID,
+    country: 1, // COUNTRY_ENUM.US (don't care which int)
+    llm: 1, // LLM_ENUM.CHAT_GPT (don't care which int)
+    countryName: 'US',
+    llmName: 'chatgpt',
+    windowDays: 7,
+    postgrestClient: { rpc: sinon.stub() },
+    fanoutClient: { resolveTopicMetrics: sinon.stub() },
+    concurrency: 5,
+    batchSize: 100,
+    log: { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() },
+    ...overrides,
+  });
+
+  it('returns an empty report when the brand has no tracked topics', async () => {
+    mockFetchFanoutTopics.resolves([]);
+
+    const { report, stats } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.topics).to.deep.equal([]);
+    expect(report.brandName).to.equal('Acme');
+    expect(report.brandDomains).to.deep.equal(['acme.com']);
+    expect(report.country).to.equal('US');
+    expect(report.llm).to.equal('chatgpt');
+    expect(stats.dbTopics).to.equal(0);
+    expect(stats.semrushReturned).to.equal(0);
+    expect(mockResolveTopicMetricsBatched).not.to.have.been.called;
+  });
+
+  it('drops topics with similarityScore < 70', async () => {
+    mockFetchFanoutTopics.resolves([
+      dbTopic({ name: 'A' }),
+      dbTopic({ name: 'B', topicUuid: '22222222-2222-7222-8222-222222222222' }),
+    ]);
+    const byOriginal = new Map([
+      ['A', semTopic({ originalTopic: 'A', similarityScore: 50 })], // dropped
+      ['B', semTopic({ originalTopic: 'B', similarityScore: 80 })], // kept
+    ]);
+    mockResolveTopicMetricsBatched.resolves({ byOriginal, isoDate: '2026-05-08' });
+
+    const { report, stats } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.topics).to.have.length(1);
+    expect(report.topics[0].name).to.equal('B');
+    expect(stats.similarityPassed).to.equal(1);
+  });
+
+  it('keeps top 5 by priorityScore desc when more than 5 pass similarity', async () => {
+    const topics = Array.from({ length: 7 }, (_, i) => dbTopic({
+      name: `T${i}`,
+      topicUuid: `${i}1111111-1111-7111-8111-111111111111`,
+      // citationRate ascending — index 0 has highest priority after × volume
+      citationRate: i * 0.1,
+    }));
+    mockFetchFanoutTopics.resolves(topics);
+
+    const byOriginal = new Map(topics.map((t, i) => [
+      t.name,
+      semTopic({
+        originalTopic: t.name,
+        similarityScore: 90,
+        // volume ascending — but priority = volume × (1 − citationRate)
+        // makes the middle indices the highest-priority winners.
+        metrics: { volume: BigInt(1000 + i * 100) },
+      }),
+    ]));
+    mockResolveTopicMetricsBatched.resolves({ byOriginal, isoDate: '2026-05-08' });
+
+    const { report, stats } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.topics).to.have.length(5);
+    // priorityScore descending
+    for (let i = 1; i < report.topics.length; i += 1) {
+      expect(report.topics[i].priorityScore).to.be.at.most(report.topics[i - 1].priorityScore);
+    }
+    expect(stats.topicsPicked).to.equal(5);
+  });
+
+  it('treats null citationRate as 0 in priorityScore', async () => {
+    mockFetchFanoutTopics.resolves([
+      dbTopic({ name: 'NoData', citationRate: null }),
+    ]);
+    mockResolveTopicMetricsBatched.resolves({
+      byOriginal: new Map([
+        ['NoData', semTopic({ originalTopic: 'NoData', metrics: { volume: 2000n } })],
+      ]),
+      isoDate: '2026-05-08',
+    });
+
+    const { report } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.topics[0].priorityScore).to.equal(2000);
+    expect(report.topics[0].citationRate).to.equal(null);
+  });
+
+  it('computes brandPosition as the lowest position across all brand domains', async () => {
+    mockGetBrandById.resolves({
+      name: 'Acme',
+      urls: [
+        { value: 'https://acme.com' },
+        { value: 'https://blog.acme.com' },
+      ],
+      baseUrl: 'https://acme.com',
+    });
+    mockFetchFanoutTopics.resolves([dbTopic()]);
+    mockResolveTopicMetricsBatched.resolves({
+      byOriginal: new Map([['Best CRM', semTopic({
+        fanoutQueries: [
+          fanoutQuery({
+            rankings: [
+              { domain: 'hubspot.com', position: 1 },
+              { domain: 'blog.acme.com', position: 3 },
+              { domain: 'acme.com', position: 7 },
+            ],
+          }),
+        ],
+      })]]),
+      isoDate: '2026-05-08',
+    });
+
+    const { report } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.topics[0].subQueries[0].brandPosition).to.equal(3);
+  });
+
+  it('omits the intent field when Semrush returns no intents', async () => {
+    mockFetchFanoutTopics.resolves([dbTopic()]);
+    mockResolveTopicMetricsBatched.resolves({
+      byOriginal: new Map([['Best CRM', semTopic({
+        fanoutQueries: [fanoutQuery({ intents: [] })],
+      })]]),
+      isoDate: '2026-05-08',
+    });
+
+    const { report } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.topics[0].subQueries[0]).not.to.have.property('intent');
+  });
+
+  it('falls back to brand.baseUrl when brand.urls is empty', async () => {
+    mockGetBrandById.resolves({
+      name: 'Acme',
+      urls: [],
+      baseUrl: 'https://acme.com',
+    });
+    mockFetchFanoutTopics.resolves([]);
+
+    const { report } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.brandDomains).to.deep.equal(['acme.com']);
+  });
+
+  it('reports brandDomains: [] when neither urls nor baseUrl is set', async () => {
+    mockGetBrandById.resolves({ name: '', urls: [], baseUrl: null });
+    mockFetchFanoutTopics.resolves([]);
+
+    const { report } = await curate.curateFanoutReport(callerArgs());
+
+    expect(report.brandDomains).to.deep.equal([]);
+  });
+});
+
+describe('extractDomain / brandDomainsFromBrand / brandPositionOf', () => {
+  let helpers;
+
+  before(async () => {
+    helpers = await esmock('../../../src/support/fanout/curate.js', {
+      '../../../src/support/fanout/topics-rpc.js': { fetchFanoutTopics: sinon.stub() },
+      '../../../src/support/fanout/semrush-client.js': {
+        resolveTopicMetricsBatched: sinon.stub(),
+        intentNameFromEnum: () => 'COMMERCIAL',
+      },
+      '../../../src/support/brands-storage.js': { getBrandById: sinon.stub() },
+    });
+  });
+
+  describe('extractDomain', () => {
+    it('strips leading www.', () => {
+      expect(helpers.extractDomain('https://www.acme.com/x')).to.equal('acme.com');
+    });
+    it('keeps non-www subdomains', () => {
+      expect(helpers.extractDomain('https://blog.acme.com/x')).to.equal('blog.acme.com');
+    });
+    it('prepends https:// when no scheme', () => {
+      expect(helpers.extractDomain('acme.com')).to.equal('acme.com');
+    });
+    it('returns null for null/empty/whitespace input', () => {
+      expect(helpers.extractDomain(null)).to.equal(null);
+      expect(helpers.extractDomain('')).to.equal(null);
+      expect(helpers.extractDomain('   ')).to.equal(null);
+    });
+  });
+
+  describe('brandDomainsFromBrand', () => {
+    it('prefers urls[] over baseUrl', () => {
+      expect(helpers.brandDomainsFromBrand({
+        urls: [{ value: 'https://blog.acme.com' }],
+        baseUrl: 'https://acme.com',
+      })).to.deep.equal(['blog.acme.com']);
+    });
+    it('falls back to baseUrl only when urls[] yields no valid hostnames', () => {
+      expect(helpers.brandDomainsFromBrand({
+        urls: [{ value: '' }, { value: null }],
+        baseUrl: 'https://acme.com',
+      })).to.deep.equal(['acme.com']);
+    });
+    it('returns [] when neither produces a domain', () => {
+      expect(helpers.brandDomainsFromBrand({ urls: [], baseUrl: null })).to.deep.equal([]);
+    });
+    it('dedupes the urls[] extraction', () => {
+      expect(helpers.brandDomainsFromBrand({
+        urls: [
+          { value: 'https://acme.com' },
+          { value: 'https://www.acme.com' }, // same after www-strip
+        ],
+        baseUrl: null,
+      })).to.deep.equal(['acme.com']);
+    });
+  });
+
+  describe('brandPositionOf', () => {
+    it('returns null when no brand domain appears', () => {
+      expect(helpers.brandPositionOf(
+        [{ domain: 'foo.com', position: 1 }],
+        new Set(['acme.com']),
+      )).to.equal(null);
+    });
+    it('returns the lowest matching position', () => {
+      expect(helpers.brandPositionOf(
+        [
+          { domain: 'acme.com', position: 5 },
+          { domain: 'blog.acme.com', position: 2 },
+          { domain: 'acme.com', position: 9 },
+        ],
+        new Set(['acme.com', 'blog.acme.com']),
+      )).to.equal(2);
+    });
+  });
+
+  describe('gzipReport', () => {
+    it('round-trips through gunzip', () => {
+      const report = { schemaVersion: 1, topics: [] };
+      const buf = helpers.gzipReport(report);
+      expect(buf).to.be.instanceOf(Buffer);
+      expect(JSON.parse(gunzipSync(buf).toString('utf-8'))).to.deep.equal(report);
+    });
+  });
+});

--- a/test/support/fanout/semrush-client.test.js
+++ b/test/support/fanout/semrush-client.test.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { KEYWORD_INTENT_ENUM } from '@quazar/ai-seo-ts/v2/fanout/enums_pb.js';
+import {
+  intentNameFromEnum,
+  resolveTopicMetricsBatched,
+} from '../../../src/support/fanout/semrush-client.js';
+
+use(sinonChai);
+
+describe('intentNameFromEnum', () => {
+  it('maps known enum values to their string names', () => {
+    expect(intentNameFromEnum([KEYWORD_INTENT_ENUM.COMMERCIAL])).to.equal('COMMERCIAL');
+    expect(intentNameFromEnum([KEYWORD_INTENT_ENUM.INFORMATIONAL])).to.equal('INFORMATIONAL');
+    expect(intentNameFromEnum([KEYWORD_INTENT_ENUM.NAVIGATIONAL])).to.equal('NAVIGATIONAL');
+    expect(intentNameFromEnum([KEYWORD_INTENT_ENUM.TRANSACTIONAL])).to.equal('TRANSACTIONAL');
+    expect(intentNameFromEnum([KEYWORD_INTENT_ENUM.UNSPECIFIED])).to.equal('UNSPECIFIED');
+  });
+
+  it('picks the first intent from a multi-label array', () => {
+    expect(intentNameFromEnum([
+      KEYWORD_INTENT_ENUM.COMMERCIAL,
+      KEYWORD_INTENT_ENUM.INFORMATIONAL,
+    ])).to.equal('COMMERCIAL');
+  });
+
+  it('returns undefined for empty or null input', () => {
+    expect(intentNameFromEnum([])).to.equal(undefined);
+    expect(intentNameFromEnum(null)).to.equal(undefined);
+    expect(intentNameFromEnum(undefined)).to.equal(undefined);
+  });
+
+  it('falls back to UNSPECIFIED for unknown enum values', () => {
+    expect(intentNameFromEnum([999])).to.equal('UNSPECIFIED');
+  });
+});
+
+describe('resolveTopicMetricsBatched', () => {
+  let fanoutClient;
+  let log;
+
+  beforeEach(() => {
+    fanoutClient = { resolveTopicMetrics: sinon.stub() };
+    log = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+  });
+
+  it('returns an empty result for empty topic input without calling Semrush', async () => {
+    const out = await resolveTopicMetricsBatched({ fanoutClient, topics: [], log });
+
+    expect(out.byOriginal.size).to.equal(0);
+    expect(out.isoDate).to.equal(null);
+    expect(fanoutClient.resolveTopicMetrics).not.to.have.been.called;
+  });
+
+  it('chunks the topic list into batches of batchSize', async () => {
+    fanoutClient.resolveTopicMetrics.callsFake(({ topics }) => Promise.resolve({
+      isoDate: '2026-05-08',
+      topicMetrics: topics.map((name) => ({ originalTopic: name })),
+    }));
+
+    const topics = Array.from({ length: 7 }, (_, i) => `t${i}`);
+    const out = await resolveTopicMetricsBatched({
+      fanoutClient, topics, batchSize: 3, concurrency: 1, log,
+    });
+
+    expect(fanoutClient.resolveTopicMetrics).to.have.been.calledThrice;
+    expect(fanoutClient.resolveTopicMetrics.getCall(0).args[0].topics).to.have.length(3);
+    expect(fanoutClient.resolveTopicMetrics.getCall(1).args[0].topics).to.have.length(3);
+    expect(fanoutClient.resolveTopicMetrics.getCall(2).args[0].topics).to.have.length(1);
+    expect(out.byOriginal.size).to.equal(7);
+    expect(out.isoDate).to.equal('2026-05-08');
+  });
+
+  it('retries with backoff on rate-limit errors (code 8)', async () => {
+    const rateErr = Object.assign(new Error('quota'), { code: 8 });
+    fanoutClient.resolveTopicMetrics
+      .onFirstCall().rejects(rateErr)
+      .onSecondCall().resolves({ isoDate: '2026-05-08', topicMetrics: [] });
+
+    // Avoid sleeping for real in the test.
+    const clock = sinon.useFakeTimers();
+    try {
+      const promise = resolveTopicMetricsBatched({
+        fanoutClient, topics: ['a'], batchSize: 100, concurrency: 1, log,
+      });
+      await clock.tickAsync(600); // ≥ 500ms first retry delay
+      await promise;
+      expect(fanoutClient.resolveTopicMetrics).to.have.been.calledTwice;
+      expect(log.warn).to.have.been.called;
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('rethrows after exhausting retries', async () => {
+    const rateErr = Object.assign(new Error('quota'), { code: 8 });
+    fanoutClient.resolveTopicMetrics.rejects(rateErr);
+
+    const clock = sinon.useFakeTimers();
+    try {
+      const promise = resolveTopicMetricsBatched({
+        fanoutClient, topics: ['a'], batchSize: 100, concurrency: 1, log,
+      });
+      // Tick past 500 + 2000 + 8000 = 10500ms of retries
+      await clock.tickAsync(15_000);
+      let thrown;
+      try {
+        await promise;
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown?.message).to.equal('quota');
+      // initial + 3 retries
+      expect(fanoutClient.resolveTopicMetrics.callCount).to.equal(4);
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('does not retry non-rate-limit errors', async () => {
+    fanoutClient.resolveTopicMetrics.rejects(new Error('schema mismatch'));
+
+    let thrown;
+    try {
+      await resolveTopicMetricsBatched({
+        fanoutClient, topics: ['a'], batchSize: 100, concurrency: 1, log,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown?.message).to.equal('schema mismatch');
+    expect(fanoutClient.resolveTopicMetrics).to.have.been.calledOnce;
+  });
+});

--- a/test/support/fanout/topics-rpc.test.js
+++ b/test/support/fanout/topics-rpc.test.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { fetchFanoutTopics } from '../../../src/support/fanout/topics-rpc.js';
+
+use(sinonChai);
+
+const ORG_ID = '5d4e5082-b030-433d-9dbd-7007116f701f';
+const BRAND_ID = '3e3556f0-6494-4e8f-858f-01f2c358861a';
+
+describe('fetchFanoutTopics', () => {
+  let postgrestClient;
+
+  beforeEach(() => {
+    postgrestClient = { rpc: sinon.stub() };
+  });
+
+  it('calls rpc_fanout_topics with the expected parameters', async () => {
+    postgrestClient.rpc.resolves({ data: [], error: null });
+
+    await fetchFanoutTopics(postgrestClient, { organizationId: ORG_ID, brandId: BRAND_ID });
+
+    expect(postgrestClient.rpc).to.have.been.calledWith('rpc_fanout_topics', {
+      p_organization_id: ORG_ID,
+      p_brand_id: BRAND_ID,
+      p_limit: 1000,
+    });
+  });
+
+  it('honours an explicit limit', async () => {
+    postgrestClient.rpc.resolves({ data: [], error: null });
+
+    await fetchFanoutTopics(postgrestClient, {
+      organizationId: ORG_ID,
+      brandId: BRAND_ID,
+      limit: 50,
+    });
+
+    expect(postgrestClient.rpc.firstCall.args[1].p_limit).to.equal(50);
+  });
+
+  it('maps snake_case rows to camelCase with numeric rates', async () => {
+    postgrestClient.rpc.resolves({
+      data: [{
+        topic_uuid: '11111111-1111-7111-8111-111111111111',
+        topic_id: 'best-crm',
+        name: 'Best CRM',
+        description: 'A description',
+        prompts_total: 8,
+        mention_rate: '0.47',
+        citation_rate: '0.03',
+      }],
+      error: null,
+    });
+
+    const out = await fetchFanoutTopics(postgrestClient, {
+      organizationId: ORG_ID,
+      brandId: BRAND_ID,
+    });
+
+    expect(out).to.deep.equal([{
+      topicUuid: '11111111-1111-7111-8111-111111111111',
+      topicId: 'best-crm',
+      name: 'Best CRM',
+      description: 'A description',
+      promptsTotal: 8,
+      mentionRate: 0.47,
+      citationRate: 0.03,
+    }]);
+  });
+
+  it('preserves null rates for topics with no executions', async () => {
+    postgrestClient.rpc.resolves({
+      data: [{
+        topic_uuid: 'x',
+        topic_id: 'x',
+        name: 'X',
+        description: null,
+        prompts_total: 0,
+        mention_rate: null,
+        citation_rate: null,
+      }],
+      error: null,
+    });
+
+    const [row] = await fetchFanoutTopics(postgrestClient, {
+      organizationId: ORG_ID,
+      brandId: BRAND_ID,
+    });
+
+    expect(row.mentionRate).to.equal(null);
+    expect(row.citationRate).to.equal(null);
+    expect(row.description).to.equal(null);
+  });
+
+  it('handles empty results', async () => {
+    postgrestClient.rpc.resolves({ data: null, error: null });
+
+    const out = await fetchFanoutTopics(postgrestClient, {
+      organizationId: ORG_ID,
+      brandId: BRAND_ID,
+    });
+
+    expect(out).to.deep.equal([]);
+  });
+
+  it('throws when the RPC returns an error', async () => {
+    postgrestClient.rpc.resolves({ data: null, error: { message: 'permission denied' } });
+
+    let thrown;
+    try {
+      await fetchFanoutTopics(postgrestClient, { organizationId: ORG_ID, brandId: BRAND_ID });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown?.message).to.include('rpc_fanout_topics failed: permission denied');
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the Query Fan-Out report feature: the regeneration endpoint that does the actual work.

`POST /org/{spaceCatId}/brands/{brandId}/fanout-report`

Builds on the read endpoint from PR #2407. The GET contract did **not** change.

### Pipeline (synchronous, in-Lambda)

| Step | What | Knobs |
|---|---|---|
| 1 | Auth: org-exists + `hasAccess(org, '', 'LLMO')` — 404 on either failure (no leak). | — |
| 2 | Fetch up to 1,000 tracked topics + per-prompt rates via new `rpc_fanout_topics`. | trailing 7d window, model=`chatgpt`, region=`US`, ordered `id DESC` |
| 3 | Load brand and derive `brandDomains` using the UI's `extractDomain` (true-mirror, Q18). | — |
| 4 | Call Semrush `FanoutService.resolveTopicMetrics` in batches with bounded concurrency. | batches of 100; `p-limit(5)`; exp-backoff on RESOURCE_EXHAUSTED |
| 5 | Drop topics where `similarityScore < 70` (Semrush range is 0..100). | — |
| 6 | Sort survivors by `priorityScore = volume × (1 − citationRate)`, take top 5. | — |
| 7 | Gzip the report and `PutObject` to `fanout/llmo/{spaceCatId}/{brandId}/data.json.gz` (last-writer-wins). | `ContentEncoding: gzip`, `ContentType: application/json` |
| 8 | `201 Created` with empty body. | — |

The report JSON matches the `FanoutReport` OpenAPI schema merged in PR #2402.

### Hardcoded constants for the initial version

Per `tmp/fanout/questions.md`:

| Constant | Value | Question |
|---|---|---|
| `country` | `US` | Q2 |
| `llm` | `chatgpt` (CHAT_GPT enum) | Q2 |
| `windowDays` | 7 | Q15 |
| Topic-count cap | 1,000 (`id DESC` slice, soft) | Q6a-iii |
| Similarity threshold | ≥ 70 | Q22 |
| Top-N topics in report | 5 | Q20 |
| Semrush concurrency | 5 | Q29 — env `SEMRUSH_FANOUT_CONCURRENCY` |
| Semrush batch size | 100 | Q25 — env `SEMRUSH_FANOUT_BATCH_SIZE` |

### Side improvements

- **OAuth token caching** in `grpc-transport.js`. The old `getAccessToken` re-fetched on every gRPC call — meaningful with `p-limit(5)` and 10 batches. Now cached process-wide, refreshed 30s before `expires_in`.
- Exposes a new `fanoutClient` from `getGrpcClients(env)` alongside the existing service clients.

### Dependency

This PR depends on a **new `rpc_fanout_topics` PostgreSQL function** in `mysticat-data-service` (separate repo). Spec is in `tmp/fanout/spec.md#5.1`. The endpoint will return 500 until that migration is deployed alongside.

### Response codes

| Status | When |
|---|---|
| 201 | Report regenerated and written to S3. |
| 400 | S3 / PostgREST / Semrush gRPC not configured for the env. |
| 404 | Org not found, or caller lacks LLMO entitlement. |
| 500 | Curation pipeline or S3 write threw. |

### Test plan

- [x] Unit tests: controller (8 new POST cases), `curate.js` (8 cases — empty input, similarity filter, priority sort + top-5, null citationRate, multi-domain `brandPosition`, empty `intents`, baseUrl fallback, no domains), `semrush-client.js` (5 cases including fake-clock retry), `topics-rpc.js` (6 cases).
- [x] `npx eslint` clean on all touched files.
- [x] 2306 tests passing locally on the targeted slice (controllers/llmo + support/fanout + routes).
- [ ] CI green.
- [ ] Reviewer: confirm the mysticat-data-service PR for `rpc_fanout_topics` is staged before this merges.

### Files

| File | Action |
|---|---|
| `src/controllers/llmo/fanout-report.js` | edit — add `triggerFanoutReport` POST handler |
| `src/support/ai-visibility/grpc-transport.js` | edit — add `fanoutClient`, OAuth token cache |
| `src/support/fanout/curate.js` | **new** — pipeline orchestration + helpers |
| `src/support/fanout/semrush-client.js` | **new** — batched Semrush calls + retry |
| `src/support/fanout/topics-rpc.js` | **new** — thin `rpc_fanout_topics` wrapper |
| `src/routes/index.js` | edit — register POST route |
| `src/routes/required-capabilities.js` | edit — `brand:write` for the POST |
| `package.json` + `package-lock.json` | edit — add `p-limit@3.1.0` |
| `test/controllers/llmo/fanout-report.test.js` | edit — 8 POST cases |
| `test/support/fanout/{curate,semrush-client,topics-rpc}.test.js` | **new** |
| `test/routes/index.test.js` | edit — register POST in expected-routes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)