### PR TITLE
fix(cdn-detection): remove ipinfo.io ASN lookup and DNS-over-HTTPS fallbacks

### DIFF
--- a/src/support/cdn-detection.js
+++ b/src/support/cdn-detection.js
@@ -178,9 +178,8 @@ async function detectAdobeManagedCdn(domain, log) {
  * of truth. Until that lands, this is an intentional duplicate of
  * spacecat-audit-worker/src/detect-cdn/cdn-detector.js.
  *
- * Probes HTTP headers first; on miss, walks the CNAME chain (system resolver
- * then DoH), then maps a single A-record IP to its ASN via ipinfo.io, then
- * runs PTR keyword matching as a final tiebreaker.
+ * Probes HTTP headers first; on miss, walks the CNAME chain (system resolver),
+ * then runs PTR keyword matching as a final tiebreaker.
  *
  * The detector returns descriptive labels (e.g. "Cloudflare", "Vercel"). The
  * LABEL_TO_LLMO_TOKEN adapter collapses every detected non-Adobe CDN to one
@@ -199,19 +198,6 @@ const CDN_DOMAIN_SIGNATURES = [
   { domains: ['azureedge.net', 'msecnd.net'], cdn: 'Azure Front Door / Azure CDN' },
   { domains: ['googleusercontent.com'], cdn: 'Google Cloud CDN' },
   { domains: ['alicdn.com', 'yundunwaf3.com'], cdn: 'Alibaba Cloud CDN' },
-];
-
-/**
- * CDN identification by ASN when CNAME chain doesn't match a known provider.
- */
-const CDN_ASN_SIGNATURES = [
-  { asns: [13335], cdn: 'Cloudflare' },
-  { asns: [54113], cdn: 'Fastly' },
-  { asns: [16509], cdn: 'CloudFront' },
-  { asns: [20940, 16625, 21342], cdn: 'Akamai' },
-  { asns: [8075], cdn: 'Azure Front Door / Azure CDN' },
-  { asns: [15169], cdn: 'Google Cloud CDN' },
-  { asns: [24429, 37963], cdn: 'Alibaba Cloud CDN' },
 ];
 
 /**
@@ -392,90 +378,6 @@ function headersFromResponse(response) {
   return { cdn };
 }
 
-/** DoH JSON endpoints. Google primary; Cloudflare fallback so a single-provider
- * outage doesn't take down Phase 2 fallback for every customer. */
-const DOH_GOOGLE_RESOLVE = 'https://dns.google/resolve';
-const DOH_CLOUDFLARE_RESOLVE = 'https://cloudflare-dns.com/dns-query';
-
-async function dohQuerySingle(endpoint, name, typeNum, timeout) {
-  const url = `${endpoint}?name=${encodeURIComponent(name)}&type=${typeNum}`;
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: { Accept: 'application/dns-json' },
-      redirect: 'follow',
-      follow: 5,
-    });
-    clearTimeout(id);
-    if (!response.ok) {
-      return null;
-    }
-    const data = await response.json();
-    return data && Array.isArray(data.Answer) ? data : { Answer: [] };
-  } catch {
-    clearTimeout(id);
-    return null;
-  }
-}
-
-async function dohQuery(name, typeNum, opts = {}) {
-  const { timeout = 3000, log } = opts;
-  let data = await dohQuerySingle(DOH_GOOGLE_RESOLVE, name, typeNum, timeout);
-  if (data) {
-    return data;
-  }
-  data = await dohQuerySingle(DOH_CLOUDFLARE_RESOLVE, name, typeNum, timeout);
-  if (data) {
-    return data;
-  }
-  log?.warn?.('[cdn-detection] DoH query failed (both providers)', { name, type: typeNum });
-  return { Answer: [] };
-}
-
-function normalizeDohName(data) {
-  /* c8 ignore next 3 -- defensive; callers only pass string values from DoH Answer.data */
-  if (typeof data !== 'string') {
-    return '';
-  }
-  return data.replace(/\.$/, '').trim();
-}
-
-async function getCnameChainDoh(hostname, log) {
-  const chain = [];
-  let current = hostname.replace(/\.$/, '');
-  const maxHops = 10;
-
-  /* eslint-disable no-await-in-loop -- Each CNAME hop depends on the previous answer. */
-  for (let hop = 0; hop < maxHops; hop += 1) {
-    chain.push(current);
-    const { Answer = [] } = await dohQuery(current, 5, { timeout: 3000, log });
-    const cname = Answer.find((a) => a.type === 5);
-    if (!cname?.data) {
-      break;
-    }
-    current = normalizeDohName(cname.data);
-    if (!current) {
-      break;
-    }
-  }
-  /* eslint-enable no-await-in-loop */
-
-  return chain;
-}
-
-async function getOneIpDoh(hostname, log) {
-  const { Answer = [] } = await dohQuery(hostname, 1, { timeout: 3000, log });
-  const ipv4 = /^(\d{1,3}\.){3}\d{1,3}$/;
-  for (const a of Answer) {
-    if (a.type === 1 && typeof a.data === 'string' && ipv4.test(a.data)) {
-      return a.data;
-    }
-  }
-  return null;
-}
-
 async function getCnameChain(hostname, log) {
   const chain = [];
   let current = hostname.replace(/\.$/, '');
@@ -527,35 +429,6 @@ async function getPtrHostnames(ip, log) {
   }
 }
 
-async function getAsnForIp(ip, options = {}) {
-  const { timeout = 3000, log } = options;
-  const url = `https://ipinfo.io/${ip}/json`;
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      redirect: 'follow',
-      follow: 5,
-    });
-    clearTimeout(id);
-    if (!response.ok) {
-      return null;
-    }
-    const data = await response.json();
-    const org = data?.org;
-    if (typeof org !== 'string') {
-      return null;
-    }
-    const m = org.match(/^AS(\d+)/);
-    return m ? parseInt(m[1], 10) : null;
-  } catch (err) {
-    clearTimeout(id);
-    log?.warn?.('[cdn-detection] ASN lookup failed', { ip, message: err?.message });
-    return null;
-  }
-}
-
 // Suffix-anchored CNAME match: a hostname matches a signature domain `d`
 // only when it equals `d` or ends with `.d`. Substring `includes()` would
 // classify `evil.fastly.net.attacker.com` as Fastly, which is the bug the
@@ -567,24 +440,11 @@ function matchCdnByCname(cnameChain) {
   }
   for (const { domains, cdn } of CDN_DOMAIN_SIGNATURES) {
     for (const hostname of cnameChain) {
-      /* c8 ignore next -- defensive; getCnameChain/getCnameChainDoh always push strings */
+      /* c8 ignore next -- defensive; getCnameChain always pushes strings */
       const lower = (hostname || '').toLowerCase().replace(/\.$/, '');
       if (domains.some((d) => lower === d || lower.endsWith(`.${d}`))) {
         return cdn;
       }
-    }
-  }
-  return null;
-}
-
-function matchCdnByAsn(asn) {
-  /* c8 ignore next 3 -- defensive; caller passes parseInt output filtered for null */
-  if (typeof asn !== 'number' || Number.isNaN(asn)) {
-    return null;
-  }
-  for (const { asns, cdn } of CDN_ASN_SIGNATURES) {
-    if (asns.includes(asn)) {
-      return cdn;
     }
   }
   return null;
@@ -601,7 +461,7 @@ async function detectCdnFromDnsFallback(url, options = {}) {
   }
   /* c8 ignore stop */
 
-  // Track whether any DNS / DoH / ASN / PTR stage produced usable data.
+  // Track whether any DNS / PTR stage produced usable data.
   // Distinguishes a clean "no match" from a fully inconclusive run, which
   // detectCdnForDomain uses to choose between 'byocdn-other' and null.
   let probeSucceeded = false;
@@ -610,7 +470,7 @@ async function detectCdnFromDnsFallback(url, options = {}) {
   if (cnameChainSystem.length > 1) {
     probeSucceeded = true;
   }
-  let cdnFromCname = matchCdnByCname(cnameChainSystem);
+  const cdnFromCname = matchCdnByCname(cnameChainSystem);
   if (cdnFromCname) {
     log?.info?.('[cdn-detection] Phase 2: detected by CNAME', { cdn: cdnFromCname, hostname });
     return { cdn: cdnFromCname, probeSucceeded: true };
@@ -621,30 +481,9 @@ async function detectCdnFromDnsFallback(url, options = {}) {
     return { cdn: cdnFromChainKw, probeSucceeded: true };
   }
 
-  const cnameChainDoh = await getCnameChainDoh(hostname, log);
-  if (cnameChainDoh.length > 1) {
-    probeSucceeded = true;
-  }
-  cdnFromCname = matchCdnByCname(cnameChainDoh);
-  if (cdnFromCname) {
-    log?.info?.('[cdn-detection] Phase 2: detected by CNAME (DoH)', { cdn: cdnFromCname, hostname });
-    return { cdn: cdnFromCname, probeSucceeded: true };
-  }
-  const cdnFromDohKw = matchCdnByKeywords(cnameChainDoh.join(' '));
-  if (cdnFromDohKw) {
-    log?.info?.('[cdn-detection] Phase 2: detected by DNS name keywords (DoH)', { cdn: cdnFromDohKw, hostname });
-    return { cdn: cdnFromDohKw, probeSucceeded: true };
-  }
-
-  const ip = (await getOneIp(hostname, log)) || (await getOneIpDoh(hostname, log));
+  const ip = await getOneIp(hostname, log);
   if (ip) {
     probeSucceeded = true;
-    const asn = await getAsnForIp(ip, { timeout: 3000, log });
-    const cdnFromAsn = asn !== null ? matchCdnByAsn(asn) : null;
-    if (cdnFromAsn) {
-      log?.info?.('[cdn-detection] Phase 2: detected by ASN', { cdn: cdnFromAsn, asn });
-      return { cdn: cdnFromAsn, probeSucceeded: true };
-    }
     const ptrHostnames = await getPtrHostnames(ip, log);
     for (const ptr of ptrHostnames) {
       const fromPtrKw = matchCdnByKeywords(ptr);
@@ -747,7 +586,7 @@ async function detectCdnFromUrl(url, options = {}) {
 /**
  * Phase 2 entry: returns { token, probeSucceeded } where token is the LLMO
  * byocdn-X token (or null when no signal matched). probeSucceeded reflects
- * whether at least one underlying probe (HTTP HEAD/GET, DNS, DoH, ASN, PTR)
+ * whether at least one underlying probe (HTTP HEAD/GET, DNS, PTR)
  * produced data, so callers can distinguish a clean miss from an inconclusive
  * run.
  */
@@ -776,9 +615,9 @@ async function detectGenericCdnToken(url, log) {
  *   Phase 1 — DNS-only check for Adobe-managed CDNs (AEM CS Fastly,
  *             Adobe Commerce Cloud Fastly). Cheap and authoritative when matched.
  *   Phase 2 — When Phase 1 doesn't match, runs a multi-signal probe ported from
- *             spacecat-audit-worker (HTTP headers → CNAME chain → DoH → ASN →
- *             PTR keywords). Result is mapped from a descriptive label to the
- *             LLMO byocdn-X token via LABEL_TO_LLMO_TOKEN.
+ *             spacecat-audit-worker (HTTP headers → CNAME chain → PTR keywords).
+ *             Result is mapped from a descriptive label to the LLMO byocdn-X
+ *             token via LABEL_TO_LLMO_TOKEN.
  *
  * Returns:
  *   - 'aem-cs-fastly' | 'commerce-fastly'  — Phase 1 hit
@@ -851,8 +690,8 @@ export async function detectCdnForDomain(input, log) {
       return 'byocdn-other';
     }
     // Phase 1 succeeded with no match, Phase 2 produced no data anywhere
-    // (HTTP probes, DNS, DoH, ASN/PTR all failed). Treat as inconclusive
-    // rather than mislead callers with a stale 'byocdn-other'.
+    // (HTTP probes, DNS, PTR all failed). Treat as inconclusive rather than
+    // mislead callers with a stale 'byocdn-other'.
     return null;
     /* c8 ignore next 4 */
   } catch (err) {

--- a/test/support/cdn-detection.test.js
+++ b/test/support/cdn-detection.test.js
@@ -40,7 +40,7 @@ describe('cdn-detection', () => {
       reverse: sandbox.stub().rejects(dnsError('ENOTFOUND')),
     };
 
-    // Default Phase 2 to a no-op: every HTTP probe (HEAD/GET, DoH, ipinfo) rejects,
+    // Default Phase 2 to a no-op: every HTTP probe (HEAD/GET) rejects,
     // so the detector falls back to DNS-only behaviour and existing Phase 1 tests
     // remain authoritative.
     fetchStub = sandbox.stub().rejects(new Error('test: network disabled'));
@@ -528,7 +528,7 @@ describe('cdn-detection', () => {
       });
     }
 
-    it('returns other when HTTP probe fails and DNS/ASN fallback finds nothing', async () => {
+    it('returns other when HTTP probe fails and DNS fallback finds nothing', async () => {
       // fetchStub default rejects everything; DNS fallback also misses.
       const result = await detectCdnForDomain('example.com');
       expect(result).to.equal('byocdn-other');
@@ -554,60 +554,10 @@ describe('cdn-detection', () => {
       expect(result).to.equal('byocdn-akamai');
     });
 
-    it('detects via ASN when CNAME and headers miss (AS13335 → Cloudflare)', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ org: 'AS13335 Cloudflare, Inc.' }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-cloudflare');
-    });
-
-    it('detects via ASN (AS54113 → Fastly BYOCDN)', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ org: 'AS54113 Fastly, Inc.' }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-fastly');
-    });
-
     it('detects via PTR keyword (Akamai PTR record)', async () => {
       dnsStubs.reverse.resolves(['a23-45-67-89.deploy.static.akamaitechnologies.com']);
       const result = await detectCdnForDomain('example.com');
       expect(result).to.equal('byocdn-akamai');
-    });
-
-    it('detects via DoH CNAME (system DNS misses, DoH carries it)', async () => {
-      // System resolver returns no signature; DoH returns a Cloudflare CNAME.
-      dnsStubs.resolveCname.resolves([]);
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve') && url.includes('type=5')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Answer: [{ type: 5, data: 'edge.cloudflare.com.' }] }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-cloudflare');
     });
 
     it('Phase 1 wins over Phase 2: AEM CS Fastly DNS match short-circuits HTTP probe', async () => {
@@ -619,10 +569,7 @@ describe('cdn-detection', () => {
 
       const probedSite = fetchStub.getCalls().some((c) => {
         const url = c.args[0];
-        return typeof url === 'string'
-          && url.includes('example.com')
-          && !url.startsWith('https://dns.google')
-          && !url.startsWith('https://ipinfo.io');
+        return typeof url === 'string' && url.includes('example.com');
       });
       expect(probedSite, 'Phase 2 HTTP probe should not run when Phase 1 hits').to.be.false;
     });
@@ -667,9 +614,9 @@ describe('cdn-detection', () => {
     });
 
     // -----------------------------------------------------------------
-    // Additional coverage tests: exercise the keyword-blob fallback,
-    // DoH edge cases, ASN edge cases, and PTR domain-signature path so
-    // every reachable branch in cdn-detection.js is hit.
+    // Additional coverage tests: exercise the keyword-blob fallback
+    // and PTR domain-signature path so every reachable branch in
+    // cdn-detection.js is hit.
     // -----------------------------------------------------------------
 
     it('returns other when probe responds 200 with no identifying headers (empty keyword blob)', async () => {
@@ -684,178 +631,14 @@ describe('cdn-detection', () => {
       expect(result).to.equal('byocdn-other');
     });
 
-    it('continues when DoH responds with non-OK status (ok: false) and falls back to other', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve')) {
-          return Promise.resolve({
-            ok: false,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({}),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
-    it('breaks DoH chain when CNAME data normalizes to empty string', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve') && url.includes('type=5')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Answer: [{ type: 5, data: '.' }] }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
-    it('falls back to DoH A-record when system resolve4 is empty, then resolves ASN → Cloudflare', async () => {
-      dnsStubs.resolve4.resolves([]);
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve') && url.includes('type=1')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Answer: [{ type: 1, data: '1.2.3.4' }] }),
-          });
-        }
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ org: 'AS13335 Cloudflare, Inc.' }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-cloudflare');
-    });
-
-    it('treats ipinfo non-OK status as null ASN (falls through to other)', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: false,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({}),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
-    it('treats ipinfo response without an "org" field as null ASN', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ city: 'SF' }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
-    it('falls through to other when ASN resolves to an unknown AS number', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ org: 'AS99999 Unknown Provider' }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
     it('detects via CNAME keyword (no domain-suffix match): edge.cachefly.mycorp.com → byocdn-other', async () => {
       dnsStubs.resolveCname.resolves(['edge.cachefly.mycorp.com']);
       const result = await detectCdnForDomain('example.com');
       expect(result).to.equal('byocdn-other');
     });
 
-    it('detects via DoH CNAME keyword (system DNS empty, DoH has llnw keyword) — collapses to byocdn-other', async () => {
-      dnsStubs.resolveCname.resolves([]);
-      let dohCalls = 0;
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve') && url.includes('type=5')) {
-          dohCalls += 1;
-          if (dohCalls === 1) {
-            return Promise.resolve({
-              ok: true,
-              headers: { forEach: () => {} },
-              body: { cancel: () => {} },
-              json: async () => ({ Answer: [{ type: 5, data: 'edge.llnw.net.' }] }),
-            });
-          }
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Answer: [] }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
     it('detects via PTR domain signature (no keyword match): googleusercontent.com → byocdn-other', async () => {
       dnsStubs.reverse.resolves(['x.googleusercontent.com']);
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
-    it('treats DoH response missing an Answer field as empty (covers data.Answer ternary fallback)', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Status: 0 }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-other');
-    });
-
-    it('treats ASN org string without an "AS<digits>" prefix as null ASN', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ org: 'Some Unknown Provider' }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
       const result = await detectCdnForDomain('example.com');
       expect(result).to.equal('byocdn-other');
     });
@@ -898,18 +681,12 @@ describe('cdn-detection', () => {
       dnsStubs.resolve6.resolves([]);
     });
 
-    it('logs warn on HEAD failure, DoH failure, reverse DNS failure, and ASN failure', async () => {
-      // fetchStub default rejects everything → HEAD/GET, DoH (both providers),
-      // ipinfo all fail. dnsStubs.reverse default rejects ENOTFOUND → reverse
-      // DNS failure is logged.
+    it('logs warn on HEAD failure and reverse DNS failure', async () => {
+      // fetchStub default rejects everything → HEAD/GET fail.
+      // dnsStubs.reverse default rejects ENOTFOUND → reverse DNS failure is logged.
       await detectCdnForDomain('example.com', log);
       expect(log.warn).to.have.been.calledWith(sinon.match(/HEAD failed/));
-      expect(log.warn).to.have.been.calledWith(
-        '[cdn-detection] DoH query failed (both providers)',
-        sinon.match.any,
-      );
       expect(log.warn).to.have.been.calledWith('[cdn-detection] reverse DNS failed', sinon.match.any);
-      expect(log.warn).to.have.been.calledWith('[cdn-detection] ASN lookup failed', sinon.match.any);
     });
 
     it('logs warn when Phase 2 getCnameChain encounters a non-ENODATA error', async () => {
@@ -942,69 +719,6 @@ describe('cdn-detection', () => {
       expect(log.info).to.have.been.calledWith('[cdn-detection] Phase 2: detected by DNS name keywords', sinon.match.any);
     });
 
-    it('logs info when Phase 2 detects via CNAME suffix (DoH)', async () => {
-      dnsStubs.resolveCname.resolves([]);
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve') && url.includes('type=5')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Answer: [{ type: 5, data: 'edge.cloudflare.com.' }] }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com', log);
-      expect(result).to.equal('byocdn-cloudflare');
-      expect(log.info).to.have.been.calledWith('[cdn-detection] Phase 2: detected by CNAME (DoH)', sinon.match.any);
-    });
-
-    it('logs info when Phase 2 detects via DNS name keywords (DoH)', async () => {
-      dnsStubs.resolveCname.resolves([]);
-      let dohCalls = 0;
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve') && url.includes('type=5')) {
-          dohCalls += 1;
-          if (dohCalls === 1) {
-            return Promise.resolve({
-              ok: true,
-              headers: { forEach: () => {} },
-              body: { cancel: () => {} },
-              json: async () => ({ Answer: [{ type: 5, data: 'edge.llnw.net.' }] }),
-            });
-          }
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Answer: [] }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com', log);
-      expect(result).to.equal('byocdn-other');
-      expect(log.info).to.have.been.calledWith('[cdn-detection] Phase 2: detected by DNS name keywords (DoH)', sinon.match.any);
-    });
-
-    it('logs info when Phase 2 detects via ASN', async () => {
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://ipinfo.io/')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ org: 'AS13335 Cloudflare' }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com', log);
-      expect(result).to.equal('byocdn-cloudflare');
-      expect(log.info).to.have.been.calledWith('[cdn-detection] Phase 2: detected by ASN', sinon.match.any);
-    });
-
     it('logs info when Phase 2 detects via PTR keywords', async () => {
       dnsStubs.reverse.resolves(['a1.deploy.static.akamaitechnologies.com']);
       const result = await detectCdnForDomain('example.com', log);
@@ -1021,9 +735,9 @@ describe('cdn-detection', () => {
   });
 
   // -----------------------------------------------------------------------
-  // SSRF mitigation, suffix-anchored CNAME, DoH-fallback (Cloudflare),
-  // probeSucceeded null-vs-other semantics, and timer-leak coverage for
-  // changes landing alongside the LABEL_TO_LLMO_TOKEN collapse.
+  // SSRF mitigation, suffix-anchored CNAME, probeSucceeded null-vs-other
+  // semantics, and timer-leak coverage for changes landing alongside the
+  // LABEL_TO_LLMO_TOKEN collapse.
   // -----------------------------------------------------------------------
   describe('input hardening and probe-success semantics', () => {
     let log;
@@ -1057,30 +771,6 @@ describe('cdn-detection', () => {
       dnsStubs.resolve4.resolves(['1.2.3.4']);
       const result = await detectCdnForDomain('example.com');
       expect(result).to.equal('byocdn-other');
-    });
-
-    it('falls back to Cloudflare DoH when Google DoH errors (smoke check)', async () => {
-      // Force Phase 1 to a clean miss and the Phase 2 system resolver to be empty
-      // so we exercise the DoH path. Google DoH errors; Cloudflare DoH returns a
-      // Cloudflare CNAME → byocdn-cloudflare via the suffix matcher.
-      dnsStubs.resolveCname.resolves([]);
-      dnsStubs.resolve4.resolves(['1.2.3.4']);
-      fetchStub.callsFake((url) => {
-        if (url.startsWith('https://dns.google/resolve') && url.includes('type=5')) {
-          return Promise.reject(new Error('google doh down'));
-        }
-        if (url.startsWith('https://cloudflare-dns.com/dns-query') && url.includes('type=5')) {
-          return Promise.resolve({
-            ok: true,
-            headers: { forEach: () => {} },
-            body: { cancel: () => {} },
-            json: async () => ({ Answer: [{ type: 5, data: 'edge.cloudflare.com.' }] }),
-          });
-        }
-        return Promise.reject(new Error('blocked'));
-      });
-      const result = await detectCdnForDomain('example.com');
-      expect(result).to.equal('byocdn-cloudflare');
     });
 
     it('returns other when Phase 1 misses cleanly AND at least one Phase 2 probe ran (DNS chain present)', async () => {


### PR DESCRIPTION
## Related Issues                                                                                                                                                     
  SITES-41613                                                                                                                                                           
                                                                                                                                                                        
  Removes the ipinfo.io (ASN lookup) and DNS-over-HTTPS (dns.google /                                                                                                   
  cloudflare-dns.com) fallback phases from CDN detection.                                                                                                               
                                                                                                                                                                        
  These were last-resort fallbacks that fired only when HTTP headers and                                                                                                
  system DNS CNAME chain both failed to identify a CDN. In practice they                                                                                                
  rarely matched anything useful, and both endpoints are blocked on the 
  Adobe corporate network (ipinfo.io times out, dns.google gets TLS errors                                                                                              
  due to certificate interception).                                                                                                                                     
                                                                                                                                                                        
  CDN detection now uses: HTTP headers → CNAME chain (system resolver) →                                                                                                
  PTR keyword matching. Anything that can't be identified through these                                                                                                 
  steps returns null / 'byocdn-other' as before.                       
                                                                                                                                                                        
  Mirrors the equivalent cleanup already done in spacecat-audit-worker                                                                                                  
  (#2456).                                                                                                                                                              
                                                                                                                                                                        
  - [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you describe here the problem you're solving.               
  - [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes  