### PR TITLE
feat(brands): integrate Brand Governance Agent as primary source in /brand-guidelines (LLMO-4918)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@adobe/mysticat-shared-seo-client": "1.3.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
-        "@adobe/spacecat-shared-brand-client": "1.1.42",
+        "@adobe/spacecat-shared-brand-client": "1.3.0",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
@@ -2052,9 +2052,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-brand-client": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.1.42.tgz",
-      "integrity": "sha512-8OgJ+zEaQs4nSY6yx2ZeOfTX7D7dC2nEC5ynWkfynanqIItFfz+CMhr+bYGOBtRRmlpdbznN3sO2AbrYW9V95Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.3.0.tgz",
+      "integrity": "sha512-lzqCeYYe4G5TqHbBYShOmYissoeQf+vHGDAyP9fbK6ZV8NwboC5AXMYVrdkBE+B1PUWCalb0C+D/5QzO64OCFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@adobe/mysticat-shared-seo-client": "1.3.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
-        "@adobe/spacecat-shared-brand-client": "1.3.0",
+        "@adobe/spacecat-shared-brand-client": "^1.4.0",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
@@ -2052,18 +2052,28 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-brand-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.3.0.tgz",
-      "integrity": "sha512-lzqCeYYe4G5TqHbBYShOmYissoeQf+vHGDAyP9fbK6ZV8NwboC5AXMYVrdkBE+B1PUWCalb0C+D/5QzO64OCFw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.4.0.tgz",
+      "integrity": "sha512-bhR5j9PD70DunbKx9lKuDKpndLJyivK/bW9M+gkeScdP84LTmjhdCUWl4EYq3Anqnr1ZGKMBirxdIFuR2FgspA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/helix-universal": "5.4.1",
+        "@adobe/helix-universal": "5.4.2",
         "@adobe/spacecat-shared-ims-client": "1.11.10",
         "@adobe/spacecat-shared-utils": "1.81.1"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-brand-client/node_modules/@adobe/helix-universal": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.2.tgz",
+      "integrity": "sha512-LIF6K7YQ78/Wxw2OQY+f5HxdIsoZnsJCcNWm9fnBQBRGHBIh3hQq+krD1yRWe/pkBVxAm7o4FJs8SmJkJjU0LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/fetch": "4.3.0",
+        "aws4": "1.13.2"
       }
     },
     "node_modules/@adobe/spacecat-shared-brand-client/node_modules/@adobe/spacecat-shared-ims-client": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@adobe/mysticat-shared-seo-client": "1.3.1",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.12",
-    "@adobe/spacecat-shared-brand-client": "1.1.42",
+    "@adobe/spacecat-shared-brand-client": "1.3.0",
     "@adobe/spacecat-shared-content-client": "1.8.24",
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@adobe/mysticat-shared-seo-client": "1.3.1",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.12",
-    "@adobe/spacecat-shared-brand-client": "1.3.0",
+    "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-content-client": "1.8.24",
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -9,6 +9,8 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { randomUUID } from 'crypto';
+
 import BrandClient, { BrandGovernanceClient } from '@adobe/spacecat-shared-brand-client';
 import {
   badRequest,

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -310,14 +310,18 @@ function BrandsController(ctx, log, env) {
       // Try Brand Governance Agent first (URL-based lookup, no brandId required)
       const govConfig = getImsConfigForBrandGovernance();
       if (govConfig) {
-        const brandGovClient = BrandGovernanceClient.createFrom(context);
-        const brandGovGuidelines = await brandGovClient.getBrandGuidelinesForUrl(
-          site.getBaseURL(),
-          imsOrgId,
-          govConfig,
-        );
-        if (brandGovGuidelines) {
-          return ok(brandGovGuidelines);
+        try {
+          const brandGovClient = BrandGovernanceClient.createFrom(context);
+          const brandGovGuidelines = await brandGovClient.getBrandGuidelinesForUrl(
+            site.getBaseURL(),
+            imsOrgId,
+            govConfig,
+          );
+          if (brandGovGuidelines) {
+            return ok(brandGovGuidelines);
+          }
+        } catch (govError) {
+          log.warn(`Brand Governance Agent failed for site ${siteId}, falling back to Brand Publish: ${govError.message}`);
         }
       }
 

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -305,7 +305,10 @@ function BrandsController(ctx, log, env) {
 
       const organizationId = site.getOrganizationId();
       const organization = await Organization.findById(organizationId);
-      const imsOrgId = organization?.getImsOrgId();
+      if (!organization) {
+        return notFound(`Organization not found for site: ${siteId}`);
+      }
+      const imsOrgId = organization.getImsOrgId();
 
       // Try Brand Governance Agent first (URL-based lookup, no brandId required)
       const govConfig = getImsConfigForBrandGovernance();

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -9,9 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { randomUUID } from 'crypto';
-
-import BrandClient from '@adobe/spacecat-shared-brand-client';
+import BrandClient, { BrandGovernanceClient } from '@adobe/spacecat-shared-brand-client';
 import {
   badRequest,
   notFound,
@@ -265,6 +263,26 @@ function BrandsController(ctx, log, env) {
   }
 
   /**
+   * Gets IMS config for the Brand Governance Agent from the environment.
+   * Returns null if Brand Governance is not configured in this environment.
+   * @returns {object|null} Brand Governance IMS config or null.
+   */
+  function getImsConfigForBrandGovernance() {
+    const {
+      IMS_HOST: host,
+      BRAND_GOV_IMS_CLIENT_ID: clientId,
+      BRAND_GOV_IMS_CLIENT_CODE: clientCode,
+      BRAND_GOV_IMS_CLIENT_SECRET: clientSecret,
+    } = env;
+    if (!hasText(host) || !hasText(clientId) || !hasText(clientCode) || !hasText(clientSecret)) {
+      return null;
+    }
+    return {
+      host, clientId, clientCode, clientSecret,
+    };
+  }
+
+  /**
    * Gets Brand Guidelines for a site.
    *
    * @param {object} context - Context of the request.
@@ -285,22 +303,34 @@ function BrandsController(ctx, log, env) {
         return forbidden('Only users belonging to the organization of the site can view its brand guidelines');
       }
 
-      const brandId = site.getConfig()?.getBrandConfig()?.brandId;
-      const userId = site.getConfig()?.getBrandConfig()?.userId;
-      const brandConfig = {
-        brandId,
-        userId,
-      };
-      if (!hasText(brandId) || !hasText(userId)) {
-        return notFound(`Brand config is missing, brandId or userId for site ID: ${siteId}`);
-      }
       const organizationId = site.getOrganizationId();
       const organization = await Organization.findById(organizationId);
       const imsOrgId = organization?.getImsOrgId();
+
+      // Try Brand Governance Agent first (URL-based lookup, no brandId required)
+      const govConfig = getImsConfigForBrandGovernance();
+      if (govConfig) {
+        const brandGovClient = BrandGovernanceClient.createFrom(context);
+        const brandGovGuidelines = await brandGovClient.getBrandGuidelinesForUrl(
+          site.getBaseURL(),
+          imsOrgId,
+          govConfig,
+        );
+        if (brandGovGuidelines) {
+          return ok(brandGovGuidelines);
+        }
+      }
+
+      // Fall back to Adobe Brand Publish (requires brandId + userId in site config)
+      const brandId = site.getConfig()?.getBrandConfig()?.brandId;
+      const userId = site.getConfig()?.getBrandConfig()?.userId;
+      if (!hasText(brandId) || !hasText(userId)) {
+        return notFound(`Brand config is missing, brandId or userId for site ID: ${siteId}`);
+      }
       const imsConfig = getImsConfig();
       const brandClient = BrandClient.createFrom(context);
       const brandGuidelines = await brandClient.getBrandGuidelines(
-        brandConfig,
+        { brandId, userId },
         imsOrgId,
         imsConfig,
       );

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -422,6 +422,165 @@ describe('Brands Controller', () => {
 
       expect(response.status).to.equal(403);
     });
+
+    describe('Brand Governance Agent priority chain', () => {
+      const BRAND_GOV_ENV = {
+        IMS_HOST: 'https://ims-na1.adobelogin.com',
+        BRAND_GOV_IMS_CLIENT_ID: 'gov-client-id',
+        BRAND_GOV_IMS_CLIENT_CODE: 'gov-client-code',
+        BRAND_GOV_IMS_CLIENT_SECRET: 'gov-client-secret',
+      };
+
+      const makeSiteWithoutBrand = () => new Site(
+        {
+          entities: {
+            site: {
+              model: {
+                indexes: {},
+                schema: {
+                  attributes: {
+                    config: { type: 'any', name: 'config', get: (value) => Config(value) },
+                    organizationId: { type: 'string', name: 'organizationId', get: (value) => value },
+                  },
+                },
+              },
+              patch: sinon.stub().returns({
+                composite: () => ({ go: () => {} }),
+                set: () => {},
+              }),
+            },
+          },
+        },
+        {
+          log: loggerStub,
+          getCollection: stub().returns({ schema: SiteSchema, findById: stub() }),
+        },
+        SiteSchema,
+        { siteId: SITE_ID, config: Config({}) },
+        loggerStub,
+      );
+
+      it('returns Brand Governance guidelines and skips Brand Publish when site is registered in governance', async () => {
+        const mockGovGuidelines = {
+          id: 'frescopa-2A53',
+          name: 'Frescopa Coffee',
+          imsOrgId: IMS_ORG_ID,
+          guidelines: [{ name: 'Sophisticated Voice', text: 'Use sensory language' }],
+        };
+        const brandGovClientStub = {
+          getBrandGuidelinesForUrl: sinon.stub().resolves(mockGovGuidelines),
+        };
+        const brandClientStub = { getBrandGuidelines: sinon.stub() };
+        const govContext = {
+          ...context,
+          brandGovernanceClient: brandGovClientStub,
+          brandClient: brandClientStub,
+        };
+        const govEnv = { ...mockEnv, ...BRAND_GOV_ENV };
+        const govController = BrandsController(govContext, loggerStub, govEnv);
+
+        const response = await govController.getBrandGuidelinesForSite({
+          ...govContext,
+          params: { siteId: SITE_ID },
+        });
+
+        expect(response.status).to.equal(200);
+        const guidelines = await response.json();
+        expect(guidelines).to.deep.equal(mockGovGuidelines);
+        expect(brandGovClientStub.getBrandGuidelinesForUrl).to.have.been.calledOnceWith(
+          'https://site1.com',
+          IMS_ORG_ID,
+          {
+            host: BRAND_GOV_ENV.IMS_HOST,
+            clientId: BRAND_GOV_ENV.BRAND_GOV_IMS_CLIENT_ID,
+            clientCode: BRAND_GOV_ENV.BRAND_GOV_IMS_CLIENT_CODE,
+            clientSecret: BRAND_GOV_ENV.BRAND_GOV_IMS_CLIENT_SECRET,
+          },
+        );
+        expect(brandClientStub.getBrandGuidelines).to.not.have.been.called;
+      });
+
+      it('falls back to Brand Publish when Brand Governance returns null (site not in governance)', async () => {
+        const mockGuidelines = { theme: 'dark', colors: ['#000', '#fff'] };
+        const brandGovClientStub = {
+          getBrandGuidelinesForUrl: sinon.stub().resolves(null),
+        };
+        const brandClientStub = { getBrandGuidelines: sinon.stub().resolves(mockGuidelines) };
+        const govContext = {
+          ...context,
+          brandGovernanceClient: brandGovClientStub,
+          brandClient: brandClientStub,
+        };
+        const govEnv = { ...mockEnv, ...BRAND_GOV_ENV };
+        const govController = BrandsController(govContext, loggerStub, govEnv);
+
+        const response = await govController.getBrandGuidelinesForSite({
+          ...govContext,
+          params: { siteId: SITE_ID },
+          env: { BRAND_API_BASE_URL: 'https://brand-api.com', BRAND_API_KEY: 'brand-api-key' },
+        });
+
+        expect(response.status).to.equal(200);
+        const guidelines = await response.json();
+        expect(guidelines).to.deep.equal(mockGuidelines);
+        expect(brandGovClientStub.getBrandGuidelinesForUrl).to.have.been.calledOnce;
+        expect(brandClientStub.getBrandGuidelines).to.have.been.calledOnce;
+      });
+
+      it('returns 404 when Brand Governance returns null and brand config is also missing', async () => {
+        mockDataAccess.Site.findById.resolves(makeSiteWithoutBrand());
+        const brandGovClientStub = { getBrandGuidelinesForUrl: sinon.stub().resolves(null) };
+        const govContext = { ...context, brandGovernanceClient: brandGovClientStub };
+        const govEnv = { ...mockEnv, ...BRAND_GOV_ENV };
+        const govController = BrandsController(govContext, loggerStub, govEnv);
+
+        const response = await govController.getBrandGuidelinesForSite({
+          ...govContext,
+          params: { siteId: SITE_ID },
+          env: { BRAND_API_BASE_URL: 'https://brand-api.com', BRAND_API_KEY: 'brand-api-key' },
+        });
+
+        expect(response.status).to.equal(404);
+        const error = await response.json();
+        expect(error).to.have.property('message', `Brand config is missing, brandId or userId for site ID: ${SITE_ID}`);
+      });
+
+      it('skips Brand Governance and uses Brand Publish when gov env vars are not configured', async () => {
+        const mockGuidelines = { theme: 'light' };
+        const brandClientStub = { getBrandGuidelines: sinon.stub().resolves(mockGuidelines) };
+        const govClientStub = { getBrandGuidelinesForUrl: sinon.stub() };
+        // mockEnv has no BRAND_GOV_IMS_* vars — govConfig will be null, gov path skipped
+        const noGovContext = {
+          ...context, brandClient: brandClientStub, brandGovernanceClient: govClientStub,
+        };
+
+        const response = await brandsController.getBrandGuidelinesForSite({
+          ...noGovContext,
+          params: { siteId: SITE_ID },
+          env: { BRAND_API_BASE_URL: 'https://brand-api.com', BRAND_API_KEY: 'brand-api-key' },
+        });
+
+        expect(response.status).to.equal(200);
+        expect(govClientStub.getBrandGuidelinesForUrl).to.not.have.been.called;
+        expect(brandClientStub.getBrandGuidelines).to.have.been.calledOnce;
+      });
+
+      it('returns error response when Brand Governance client throws', async () => {
+        const brandGovClientStub = {
+          getBrandGuidelinesForUrl: sinon.stub().rejects(new Error('Brand Governance API unavailable')),
+        };
+        const govContext = { ...context, brandGovernanceClient: brandGovClientStub };
+        const govEnv = { ...mockEnv, ...BRAND_GOV_ENV };
+        const govController = BrandsController(govContext, loggerStub, govEnv);
+
+        const response = await govController.getBrandGuidelinesForSite({
+          ...govContext,
+          params: { siteId: SITE_ID },
+        });
+
+        expect(response.status).to.equal(500);
+      });
+    });
   });
 
   describe('listPromptsByBrand (brand-scoped prompts CRUD)', () => {

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -565,17 +565,44 @@ describe('Brands Controller', () => {
         expect(brandClientStub.getBrandGuidelines).to.have.been.calledOnce;
       });
 
-      it('returns error response when Brand Governance client throws', async () => {
+      it('falls back to Brand Publish when Brand Governance client throws', async () => {
+        const mockGuidelines = { theme: 'dark' };
         const brandGovClientStub = {
           getBrandGuidelinesForUrl: sinon.stub().rejects(new Error('Brand Governance API unavailable')),
         };
-        const govContext = { ...context, brandGovernanceClient: brandGovClientStub };
+        const brandClientStub = { getBrandGuidelines: sinon.stub().resolves(mockGuidelines) };
+        const govContext = {
+          ...context, brandGovernanceClient: brandGovClientStub, brandClient: brandClientStub,
+        };
         const govEnv = { ...mockEnv, ...BRAND_GOV_ENV };
         const govController = BrandsController(govContext, loggerStub, govEnv);
 
         const response = await govController.getBrandGuidelinesForSite({
           ...govContext,
           params: { siteId: SITE_ID },
+          env: { BRAND_API_BASE_URL: 'https://brand-api.com', BRAND_API_KEY: 'brand-api-key' },
+        });
+
+        expect(response.status).to.equal(200);
+        expect(brandGovClientStub.getBrandGuidelinesForUrl).to.have.been.calledOnce;
+        expect(brandClientStub.getBrandGuidelines).to.have.been.calledOnce;
+      });
+
+      it('returns 500 when Brand Governance throws and Brand Publish also fails', async () => {
+        const brandGovClientStub = {
+          getBrandGuidelinesForUrl: sinon.stub().rejects(new Error('Brand Governance API unavailable')),
+        };
+        const brandClientStub = { getBrandGuidelines: sinon.stub().rejects(new Error('Brand Publish also down')) };
+        const govContext = {
+          ...context, brandGovernanceClient: brandGovClientStub, brandClient: brandClientStub,
+        };
+        const govEnv = { ...mockEnv, ...BRAND_GOV_ENV };
+        const govController = BrandsController(govContext, loggerStub, govEnv);
+
+        const response = await govController.getBrandGuidelinesForSite({
+          ...govContext,
+          params: { siteId: SITE_ID },
+          env: { BRAND_API_BASE_URL: 'https://brand-api.com', BRAND_API_KEY: 'brand-api-key' },
         });
 
         expect(response.status).to.equal(500);

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -338,6 +338,19 @@ describe('Brands Controller', () => {
       expect(error).to.have.property('message', `Site not found: ${SITE_ID}`);
     });
 
+    it('returns not found if organization does not exist for site', async () => {
+      mockDataAccess.Organization.findById.resolves(null);
+
+      const response = await brandsController.getBrandGuidelinesForSite({
+        ...context,
+        params: { siteId: SITE_ID },
+      });
+
+      expect(response.status).to.equal(404);
+      const error = await response.json();
+      expect(error).to.have.property('message', `Organization not found for site: ${SITE_ID}`);
+    });
+
     it('returns not found if brand mapping does not exist', async () => {
       const siteWithoutBrand = new Site(
         {


### PR DESCRIPTION
## Summary

- `GET /sites/:siteId/brand-guidelines` now checks Brand Governance Agent first before falling back to Adobe Brand Publish
- Brand Governance lookup is URL-based (`site.getBaseURL()`) — no `brandId` in site config required
- `imsOrgId` for Brand Governance is read from `organization.getImsOrgId()` (same source as Brand Publish)
- If Brand Governance env vars are absent or brand returns 404, falls through to existing Brand Publish path unchanged
- All 9 Mystique workflows and headings/preflight consumers benefit automatically with no changes required on their side

## New env vars required
- `BRAND_GOV_API_BASE_URL` — Brand Governance Agent base URL
- `BRAND_GOV_API_KEY` — `x-api-key` header value
- `BRAND_GOV_IMS_CLIENT_ID`, `BRAND_GOV_IMS_CLIENT_CODE`, `BRAND_GOV_IMS_CLIENT_SECRET` — service account IMS credentials
- `IMS_HOST` — already exists in the service (reused, no new var needed)

## Depends on
[LLMO-4920](https://jira.corp.adobe.com/browse/LLMO-4920) / [spacecat-shared#1605](https://github.com/adobe/spacecat-shared/pull/1605) — `BrandGovernanceClient` must be published before this PR is deployed

## Jira
[LLMO-4918](https://jira.corp.adobe.com/browse/LLMO-4918)

## Test plan
- [ ] Unit tests to be added after team review of the approach (per team agreement)
- [ ] Deploy to stage with Brand Governance env vars set — call `/sites/{siteId}/brand-guidelines` for a site whose domain is registered in Brand Governance; confirm response contains `guidelines: [{ name, text }]` from Brand Governance checks
- [ ] Call same endpoint for a site NOT registered in Brand Governance — confirm response falls back to Brand Publish format
- [ ] Call same endpoint with Brand Governance env vars absent — confirm Brand Publish path works unchanged
- [ ] Verify Mystique summarization/metatags/H1 workflows pick up the new guidelines format

🤖 Generated with [Claude Code](https://claude.ai/code)