### PR TITLE
ci: declare contents:read on End-to-end API Tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -5,6 +5,9 @@ on:
     - cron: "0 14 * * *" # Runs daily at 14:00 UTC
   workflow_dispatch: # Allows us to manually trigger the workflow if needed
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins `e2e-tests.yaml` to `contents: read` at workflow scope. The job checks out (with `persist-credentials: false`), sets up Node, configures git auth via `MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN`, runs `npm ci` and `npm run test-e2e`. Authentication for the data-service repo is via an external PAT, not the workflow `GITHUB_TOKEN`, so `contents: read` is sufficient.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3): a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs. The cap bounds the blast radius.

Style matches the workflow-level block already in `ci.yaml`. YAML validated locally with `yaml.safe_load`.