### PR TITLE
fix(plg): allow preOnboarded onboarding step patch

### DIFF
--- a/src/controllers/plg/plg-onboarding.js
+++ b/src/controllers/plg/plg-onboarding.js
@@ -2095,7 +2095,7 @@ function PlgOnboardingController(ctx) {
         'orgResolved', 'rumVerified', 'siteCreated', 'siteResolved', 'siteOrgReassigned',
         'authorUrlResolved', 'hlxConfigSet', 'codeConfigResolved', 'configUpdated',
         'auditsEnabled', 'deliveryConfigQueued', 'entitlementCreated', 'entitlementFailed',
-        'orgResolutionFailed',
+        'orgResolutionFailed', 'preOnboarded',
       ]);
       const invalidKeys = Object.keys(steps).filter((k) => !VALID_STEP_KEYS.has(k));
       if (invalidKeys.length > 0) {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -7982,7 +7982,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
               status: 'WAITLISTED',
               siteId: newSiteId,
               organizationId: newOrgId,
-              steps: { orgResolved: true, rumVerified: true },
+              steps: { orgResolved: true, rumVerified: true, preOnboarded: true },
               botBlocker: { type: 'cloudflare', ipsToAllowlist: ['1.2.3.4'], userAgent: 'bot' },
               waitlistReason: 'pending review',
               updatedBy: 'admin@example.com',
@@ -8005,7 +8005,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
           expect(mockOnboarding.setUpdatedBy).to.have.been.calledWith('admin@example.com');
           expect(mockOnboarding.setCreatedBy).to.have.been.calledWith('admin@example.com');
           expect(mockOnboarding.setSteps).to.have.been.calledWith(
-            { orgResolved: true, rumVerified: true },
+            { orgResolved: true, rumVerified: true, preOnboarded: true },
           );
           expect(mockOnboarding.save).to.have.been.called;
         });


### PR DESCRIPTION
Summary: Allow PATCH /plg/records to merge steps.preOnboarded and cover the allowed step key in the PLG onboarding controller test. Testing: npx eslint src/controllers/plg/plg-onboarding.js test/controllers/plg/plg-onboarding.test.js; npx mocha --grep 'admin onboarding management' test/controllers/plg/plg-onboarding.test.js