### PR TITLE
feat: add trigger handler for weekly scheduled audit dispatch

### DIFF
--- a/src/controllers/trigger.js
+++ b/src/controllers/trigger.js
@@ -19,6 +19,7 @@ import canonical from './trigger/canonical.js';
 import sitemap from './trigger/sitemap.js';
 import backlinks from './trigger/backlinks.js';
 import organictraffic from './trigger/organictraffic.js';
+import rumConfigRefresh from './trigger/rum-config-refresh.js';
 
 const AUDITS = {
   apex,
@@ -27,6 +28,7 @@ const AUDITS = {
   sitemap,
   'broken-backlinks': backlinks,
   'organic-traffic': organictraffic,
+  'rum-config-refresh': rumConfigRefresh,
 };
 
 /**

--- a/src/controllers/trigger/rum-config-refresh.js
+++ b/src/controllers/trigger/rum-config-refresh.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { triggerFromData } from './common/trigger.js';
+
+export default async function triggerAudit(context) {
+  const { type, url } = context.data;
+  return triggerFromData(context, { url, auditTypes: [type] }, {});
+}

--- a/test/controllers/trigger.test.js
+++ b/test/controllers/trigger.test.js
@@ -105,4 +105,13 @@ describe('trigger handler', () => {
     context.sqs = { sendMessage: () => {} };
     await expect(handler(context)).to.be.fulfilled;
   });
+
+  it('successfully triggers rum-config-refresh audit', async () => {
+    context.data.type = 'rum-config-refresh';
+    context.env = {
+      AUDIT_JOBS_QUEUE_URL: 'queueUrl',
+    };
+    context.sqs = { sendMessage: () => {} };
+    await expect(handler(context)).to.be.fulfilled;
+  });
 });


### PR DESCRIPTION


Without this, the EventBridge weekly job had no route in the trigger controller and silently dropped every scheduled run. The Slack run-audit command worked because it bypasses the trigger endpoint entirely and sends SQS messages directly per site.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
