### PR TITLE
fix(slack): use HEAD count for agentic-traffic DB status check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,25 +16,25 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.29",
-        "@adobe/mysticat-shared-seo-client": "1.3.0",
+        "@adobe/mysticat-shared-seo-client": "1.3.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
-        "@adobe/spacecat-shared-athena-client": "1.9.11",
-        "@adobe/spacecat-shared-brand-client": "1.1.41",
-        "@adobe/spacecat-shared-content-client": "1.8.23",
-        "@adobe/spacecat-shared-data-access": "3.63.0",
+        "@adobe/spacecat-shared-athena-client": "1.9.12",
+        "@adobe/spacecat-shared-brand-client": "1.1.42",
+        "@adobe/spacecat-shared-content-client": "1.8.24",
+        "@adobe/spacecat-shared-data-access": "3.65.0",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
-        "@adobe/spacecat-shared-drs-client": "1.7.1",
-        "@adobe/spacecat-shared-gpt-client": "1.6.22",
-        "@adobe/spacecat-shared-http-utils": "1.27.1",
-        "@adobe/spacecat-shared-ims-client": "1.12.6",
+        "@adobe/spacecat-shared-drs-client": "1.7.2",
+        "@adobe/spacecat-shared-gpt-client": "1.6.23",
+        "@adobe/spacecat-shared-http-utils": "1.27.2",
+        "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "^1.1.0",
-        "@adobe/spacecat-shared-rum-api-client": "2.40.12",
-        "@adobe/spacecat-shared-scrape-client": "2.6.2",
-        "@adobe/spacecat-shared-slack-client": "1.6.6",
-        "@adobe/spacecat-shared-tier-client": "1.5.0",
-        "@adobe/spacecat-shared-tokowaka-client": "1.16.1",
+        "@adobe/spacecat-shared-rum-api-client": "2.40.13",
+        "@adobe/spacecat-shared-scrape-client": "2.6.3",
+        "@adobe/spacecat-shared-slack-client": "1.6.7",
+        "@adobe/spacecat-shared-tier-client": "1.5.1",
+        "@adobe/spacecat-shared-tokowaka-client": "1.16.2",
         "@adobe/spacecat-shared-utils": "1.115.4",
-        "@adobe/spacecat-shared-vault-secrets": "1.3.4",
+        "@adobe/spacecat-shared-vault-secrets": "1.3.5",
         "@aws-sdk/client-s3": "3.1045.0",
         "@aws-sdk/client-secrets-manager": "3.1045.0",
         "@aws-sdk/client-sfn": "3.1045.0",
@@ -691,7 +691,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -799,9 +798,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.3.0.tgz",
-      "integrity": "sha512-ivkhI+W2HlCQEMPhHLzSTQXmlkLU4EDZld/6ThFXKAskGsW9phLCe4+SLnsJ5hISjBp/quI8VO/gBHhlPjHeSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.3.1.tgz",
+      "integrity": "sha512-z3p42HCkN4Cbg06g4dX/XWfcYb74WM/CqDREWGlqLAch/qptzeOSprI8nb22ck4EJikNgScEvhZgv1kKPyzfIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -1464,13 +1463,13 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-athena-client": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-athena-client/-/spacecat-shared-athena-client-1.9.11.tgz",
-      "integrity": "sha512-YWyQR7FRh404zOG+9WSbhLkJAd55i1lyzctBR9Garcyf8Hhn9U/snEh7SkSeneEbm7LcCOOo6XypfcFE51U6Fw==",
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-athena-client/-/spacecat-shared-athena-client-1.9.12.tgz",
+      "integrity": "sha512-TWeJHY7KpVmb+k/XCJ2xXdpQ5cHAY4LRZfXVoxDShVCPwqzcZQcRvfM8VvOXGmZa5CB7fOwkEwKEZLq/It9j9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.96.3",
-        "@aws-sdk/client-athena": "3.1024.0"
+        "@aws-sdk/client-athena": "3.1045.0"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -2058,9 +2057,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-brand-client": {
-      "version": "1.1.41",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.1.41.tgz",
-      "integrity": "sha512-ZT+AT9WTrZdu2zwvulaGbsEjQGoA7ZQh/VjRaYhWIMtqweqF/Mw+g/2AEjQ27QyRMil9OWSKykKlDBf+8p5qIA==",
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.1.42.tgz",
+      "integrity": "sha512-8OgJ+zEaQs4nSY6yx2ZeOfTX7D7dC2nEC5ynWkfynanqIItFfz+CMhr+bYGOBtRRmlpdbznN3sO2AbrYW9V95Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -2729,15 +2728,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-content-client": {
-      "version": "1.8.23",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-content-client/-/spacecat-shared-content-client-1.8.23.tgz",
-      "integrity": "sha512-OYxjXrPbO2wikU08EOOLwiMkV4/jwWCrNTRfwhf2vNqx4yoLdpHZbMTCu+KZI5vRTxwkZWWe0II20QLQgcMVJQ==",
+      "version": "1.8.24",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-content-client/-/spacecat-shared-content-client-1.8.24.tgz",
+      "integrity": "sha512-6UirRPJ+IcVWdA1GG068OAC87L1i0fpADYjQVf8N0yAYO1Xd5m+akpIDxIgbQEjTYjTW7wYrj0ZblsRr7UQ8Yw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-secrets-manager": "3.1024.0",
+        "@aws-sdk/client-secrets-manager": "3.1045.0",
         "aws-xray-sdk": "3.12.0",
         "graph-data-structure": "4.5.0"
       },
@@ -2834,465 +2833,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1024.0.tgz",
-      "integrity": "sha512-EXbgMqueA5gw/jqpE2zMWAfBnzn6cZWqCISGdfn1201Um9IAIoTcHjyWoQMALQm0f8Lu1NF6yRtngs6zpZcagQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-sqs": {
@@ -3775,26 +3315,6 @@
         }
       }
     },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-content-client/node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -3805,9 +3325,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.63.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.63.0.tgz",
-      "integrity": "sha512-3ZjwhQig41OuhEhRpAO+LyBmViz31E4nb18rFDVIZ2md1Fn0eyGmCaTAvlO49f2dziMBdJUcHeO7TOkF4+RlGw==",
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.65.0.tgz",
+      "integrity": "sha512-if0tvFUn4BjL5ABwwk0PyK8KBkEgsavafDePC5TnG3WF8KdBAvjS8Ef485grrZyHsyfx7HA5o5bd/IKE66rJ3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -4732,9 +4252,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-drs-client": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.7.1.tgz",
-      "integrity": "sha512-5XusGrHHSXtiaR0MPnMsT35KWulyhroyuOk35zGvQGD4S0gady3acZ0+6S35Bh8Gl000G6dHqFL9ZTg+MGYg0A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.7.2.tgz",
+      "integrity": "sha512-ENlvz/0Q4Kp5gsU2kbbYudVAk+Qk8ex5a2Ld0ryWH+4uNL1BWBR1AFtaa0CsTVcWRGkD+cFjV3gHP7QkdC41UA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1",
@@ -5035,9 +4555,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-gpt-client": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-gpt-client/-/spacecat-shared-gpt-client-1.6.22.tgz",
-      "integrity": "sha512-BMzdR+5VPVHNDbtgqfkXn/k7Kfsy6MqARkYUEgFGN3+KydRzDBPp9bTPPM7bI0rMPNhrhgyiijACZX08vpzUtQ==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-gpt-client/-/spacecat-shared-gpt-client-1.6.23.tgz",
+      "integrity": "sha512-R8YiqPAs8aim1jehbaKZrMmnLydcc1yGHtgSEIePPlRiMyWfNz4Ydn9UuQ+pSmvAhRsiiPpcTUP96lHCdurfnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -5707,15 +5227,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-http-utils": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.27.1.tgz",
-      "integrity": "sha512-f8HcDcff8ywX3U+mz1IzemAKqOAYgvnFX6e5INUgHsJvxSZDayMCFpcQdSc8yZluZXfXwJ4SZfDbjjIKYBtyNA==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.27.2.tgz",
+      "integrity": "sha512-/uZRBhLFuBTViSX15v57c1QTld3etzMyku2PMkGHQ5fYU05nEdbx5AVF5E0Bq0DbiQPKFfVS41MLhygJoYRftQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/spacecat-shared-launchdarkly-client": "1.0.4",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "jose": "6.2.2"
+        "jose": "6.2.3"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -6317,15 +5837,6 @@
         }
       }
     },
-    "node_modules/@adobe/spacecat-shared-http-utils/node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-http-utils/node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -6336,15 +5847,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.12.6.tgz",
-      "integrity": "sha512-yVU3hjcsXMBEWVWp/Q/w5agHrjbWQWmThwSMJe9bt4Y8G6qoaXDoV4uOdeU+NA5YlX1f4drH2RT/EaKodGXm2w==",
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.12.7.tgz",
+      "integrity": "sha512-mkO5tLod8s1V0WiLnsK2oikPgOmADd5A3PFA5XGVjIKKMo5ewxVpPIV/Q3mTfi1CvcWYdDMdZCs4Ltxl1PaobQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-secrets-manager": "3.1024.0",
+        "@aws-sdk/client-secrets-manager": "3.1045.0",
         "aws-xray-sdk": "3.12.0"
       },
       "engines": {
@@ -6440,465 +5951,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1024.0.tgz",
-      "integrity": "sha512-EXbgMqueA5gw/jqpE2zMWAfBnzn6cZWqCISGdfn1201Um9IAIoTcHjyWoQMALQm0f8Lu1NF6yRtngs6zpZcagQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-sqs": {
@@ -7379,26 +6431,6 @@
         "aws-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client/node_modules/zod": {
@@ -8005,9 +7037,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-rum-api-client": {
-      "version": "2.40.12",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.40.12.tgz",
-      "integrity": "sha512-96hwODD1Fn9DU3u3GszE3HjtHTs5vI0LOj9FgrNwVE6HdzFNnCgR1h3qckdNgmn6YP4YHCjCw56BPloiYJhoVw==",
+      "version": "2.40.13",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.40.13.tgz",
+      "integrity": "sha512-UcgbDOvUAmuN32WuTAgwRYxXCfN5C8xyD170KBXRn0pPK4Zlp1xQU3p3nEcZd8+iarDzX4LQsfL+jv6PNTj7xA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -8603,9 +7635,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-scrape-client": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.6.2.tgz",
-      "integrity": "sha512-4zqI5P6CuXjh6wxg+W43BQGhF3O4QMjywDMTVh2y9EmLhsZ79ickQeR+mqCaS/PwRuhFkQ/+ex/IkoXamft40Q==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.6.3.tgz",
+      "integrity": "sha512-osYG7IkFwUIvTvH368uAuEvrnNiphzyOLnuxgATeoHQo+CcmsPVBu5zLKfy2soTeHjjjLD8xE2Q5/lFDgKFUAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -9197,14 +8229,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-slack-client": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.6.6.tgz",
-      "integrity": "sha512-+M2NCwrJqUMLggoOIa1ZJ/sMnyc8xNGFYTl5ePwiyzIH1XFbHDf2gsgN44ABj3FW0xap7mX2ohoXe/EMdePvKQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.6.7.tgz",
+      "integrity": "sha512-zchiSmBcg3ck4Lw4WhoL6/kESw0oSaE6etr7K1+gH/+W1gLBDGPV8AfE292YdWYT8tvS8qCWTur/opxKGsOiKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@slack/web-api": "7.15.0"
+        "@slack/web-api": "7.15.2"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -9781,30 +8813,6 @@
         }
       }
     },
-    "node_modules/@adobe/spacecat-shared-slack-client/node_modules/@slack/web-api": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
-      "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
-      "license": "MIT",
-      "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/types": "^2.20.1",
-        "@types/node": ">=18",
-        "@types/retry": "0.12.0",
-        "axios": "^1.13.5",
-        "eventemitter3": "^5.0.1",
-        "form-data": "^4.0.4",
-        "is-electron": "2.2.2",
-        "is-stream": "^2",
-        "p-queue": "^6",
-        "p-retry": "^4",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-slack-client/node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -9815,9 +8823,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tier-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.5.0.tgz",
-      "integrity": "sha512-+OPIzMyeEnsHjvdqZGnKoSygxpO7j1JvfS8TWy2pUnGg7aqEBpH9vRfzEEIfWVFIjFhVtIn8b/3OKlEFCjI6YA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.5.1.tgz",
+      "integrity": "sha512-fNvpkvqaDoatYNnP2XUGdHOVRLil90H4qKQVzoIhhFRogRIRT8vs2rUNjTQvZywBc7NRZfmoXf0oYHzE3OAXMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
@@ -10408,14 +9416,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.16.1.tgz",
-      "integrity": "sha512-VFEtClbLTWwLaF/sGf/OaYgyd0W3arl5kdZl/UkGoEj7/Oeq9pT0UQBupgy65W3kgpwQja5XQYXjzW/I5S1uOQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.16.2.tgz",
+      "integrity": "sha512-l39q27onNu9B7J76NtZypr+8quH7rFhnwHpW8z0Hc4VDKhZ7KRJoCNGzzGpkMEPOE6iRNBxppqZgJVsIBhcbKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-cloudfront": "3.1024.0",
-        "@aws-sdk/client-s3": "3.1024.0",
+        "@aws-sdk/client-cloudfront": "3.1045.0",
+        "@aws-sdk/client-s3": "3.1045.0",
         "hast-util-from-html": "2.0.3",
         "mdast-util-from-markdown": "2.0.3",
         "mdast-util-to-hast": "13.2.1",
@@ -10730,174 +9738,6 @@
         "aws-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1024.0.tgz",
-      "integrity": "sha512-8qdO5aLCzaf9l0RdrSBW1iIroRKP2QBqtZ6lkrtHKiaaH0B18xEn+lrEgiN/eCf3uRAYk4cqbnI2XcWzm+7dDQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
-        "@aws-sdk/middleware-expect-continue": "^3.972.8",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.6",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-location-constraint": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
-        "@aws-sdk/middleware-ssec": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-blob-browser": "^4.2.13",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/hash-stream-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/md5-js": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-stream": "^4.5.21",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-sqs": {
@@ -11633,9 +10473,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-vault-secrets": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.4.tgz",
-      "integrity": "sha512-GWnAsaeComj6i55PE/S4SxVlaYqrgbtXtqNbXS/FIsLe01JQhBxaHHxgB6m6mhf58WGpobe5EDa44n6nDGvy7w==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.5.tgz",
+      "integrity": "sha512-Cki+INCuViMQFEKARcHQ97Z6iHRA91tQkHIsfslnLhIzK9jUWY2yFGy5o0/DBogeX7j6ldy0DBTZEc6RdcoBeA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -12019,48 +10859,48 @@
       }
     },
     "node_modules/@aws-sdk/client-athena": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1024.0.tgz",
-      "integrity": "sha512-kKnsdeh58Se7GL+9HX56KWtjS55W3OuzZwGVXq20PXgY2N53d6+NI9I1w+X0cZJo2pz3JijiJ+3S76YYCBoprw==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1045.0.tgz",
+      "integrity": "sha512-g5E7Bt9FFZSMloQeLlEE1JabVvLh5k9749sv95UPz7r0Lwj6mT0WkMgDZ/3q/YgafeM4Ug+Ttoxpje+0gc5hRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -12069,14 +10909,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.12.tgz",
+      "integrity": "sha512-4QEreU2qPSu19Vsw/eQW8dq5wQEstoyR0nPvguprIa6U/wSA2/fMrisYO4ZZauD8zmYx53SoUodKLipHSi0ZYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12084,13 +10922,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.11.tgz",
+      "integrity": "sha512-n/3aCOOnPnxrfh1+z2zWOi0yNC7xLv5nKx2QR4o5xHBjRHAv+vc/5GM8Rnn3Q2p288RSUOy7FhCKfhsZwlaBjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12098,15 +10935,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.13.tgz",
+      "integrity": "sha512-QZIpAIa6fDeVgJ8BEG1S6EHGKVul1DM6w6u24041Xl31FvgArh0slURCz5ij3oo0p249yjNHVRTw1GPJa7YUkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12114,15 +10948,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.15.tgz",
+      "integrity": "sha512-RROpdNPC4L15h4WE0Zlzxd2n5yRd4VaIY/Pgw/+6YNgiGZo61qavXgMG9Zdb+OnPkBnwfpXIguTcEwhSrjEHGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12130,12 +10961,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12143,15 +10974,13 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.10.tgz",
+      "integrity": "sha512-cdmvh+mmVWFKNhqFv/axpjJOYyaCgw+zta93IOv9sXKZPoL1m0XVhSI/Y7MGKLeVHUkG+ULVZy+q5AEAGivSDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/core": "^3.974.11",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12159,63 +10988,61 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.12.tgz",
+      "integrity": "sha512-Glip9lOu73ttWJPO5OIbbWuivyCerLuCD/Rfk2BC/a23zpMeX3FGY9FMui5fh3YatGFZu1NVllVvA1sQy+PhJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1024.0.tgz",
-      "integrity": "sha512-jd3Mva86RKznPndyzlISIJt6seqc55gBuJprGKFraOq8KDbWjXniFLuz6QTG0qvTA82nVp5+6PX45Yzuye7ArQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1045.0.tgz",
+      "integrity": "sha512-84RIiLrMXcinBK1JXnP1bOavvQ+jxTxN4xsB20e39MfOZMyr7wIxMNn35kTYTg8UTJgN7zwEgzGJo64sU3mtPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.14",
+        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12223,14 +11050,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.12.tgz",
+      "integrity": "sha512-4QEreU2qPSu19Vsw/eQW8dq5wQEstoyR0nPvguprIa6U/wSA2/fMrisYO4ZZauD8zmYx53SoUodKLipHSi0ZYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12238,13 +11063,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.11.tgz",
+      "integrity": "sha512-n/3aCOOnPnxrfh1+z2zWOi0yNC7xLv5nKx2QR4o5xHBjRHAv+vc/5GM8Rnn3Q2p288RSUOy7FhCKfhsZwlaBjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12252,15 +11076,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.13.tgz",
+      "integrity": "sha512-QZIpAIa6fDeVgJ8BEG1S6EHGKVul1DM6w6u24041Xl31FvgArh0slURCz5ij3oo0p249yjNHVRTw1GPJa7YUkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12268,15 +11089,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.15.tgz",
+      "integrity": "sha512-RROpdNPC4L15h4WE0Zlzxd2n5yRd4VaIY/Pgw/+6YNgiGZo61qavXgMG9Zdb+OnPkBnwfpXIguTcEwhSrjEHGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12284,12 +11102,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12297,15 +11115,13 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.10.tgz",
+      "integrity": "sha512-cdmvh+mmVWFKNhqFv/axpjJOYyaCgw+zta93IOv9sXKZPoL1m0XVhSI/Y7MGKLeVHUkG+ULVZy+q5AEAGivSDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/core": "^3.974.11",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12313,14 +11129,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.12.tgz",
+      "integrity": "sha512-Glip9lOu73ttWJPO5OIbbWuivyCerLuCD/Rfk2BC/a23zpMeX3FGY9FMui5fh3YatGFZu1NVllVvA1sQy+PhJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.11",
         "tslib": "^2.6.2"
       }
     },
@@ -12329,7 +11143,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -14030,24 +12843,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.22",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14068,14 +12875,14 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.2",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14083,9 +12890,9 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -14095,7 +12902,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -15386,8 +14193,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -15411,7 +14217,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -16348,7 +15153,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -16646,7 +15450,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -16853,7 +15656,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -17018,7 +15820,6 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -18250,20 +17051,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18646,18 +17440,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18683,9 +17472,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -18999,7 +17788,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -19247,7 +18035,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19295,7 +18082,6 @@
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19761,7 +18547,6 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -20424,7 +19209,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -22619,7 +21403,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -23171,9 +21954,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -23182,7 +21965,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -25628,7 +24412,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -26584,7 +25367,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -27639,7 +26421,6 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -30221,7 +29002,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -30748,7 +29528,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -31936,7 +30715,6 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31947,7 +30725,6 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -32702,7 +31479,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -34068,7 +32844,6 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -35075,7 +33850,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -35828,7 +34602,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -35861,6 +34634,21 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {
@@ -36099,7 +34887,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -36109,7 +34896,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,40 +1,40 @@
 {
   "name": "@adobe/spacecat-api-service",
-  "version": "1.501.0",
+  "version": "1.500.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/spacecat-api-service",
-      "version": "1.501.0",
+      "version": "1.500.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
-        "@adobe/helix-shared-body-data": "2.2.5",
-        "@adobe/helix-shared-bounce": "2.0.31",
+        "@adobe/helix-shared-body-data": "2.2.4",
+        "@adobe/helix-shared-bounce": "2.0.30",
         "@adobe/helix-shared-utils": "3.0.2",
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.29",
-        "@adobe/mysticat-shared-seo-client": "1.3.1",
+        "@adobe/mysticat-shared-seo-client": "1.3.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
-        "@adobe/spacecat-shared-athena-client": "1.9.12",
-        "@adobe/spacecat-shared-brand-client": "1.1.42",
-        "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "3.65.0",
+        "@adobe/spacecat-shared-athena-client": "1.9.11",
+        "@adobe/spacecat-shared-brand-client": "1.1.41",
+        "@adobe/spacecat-shared-content-client": "1.8.23",
+        "@adobe/spacecat-shared-data-access": "3.63.0",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
-        "@adobe/spacecat-shared-drs-client": "1.7.2",
-        "@adobe/spacecat-shared-gpt-client": "1.6.23",
-        "@adobe/spacecat-shared-http-utils": "1.27.2",
-        "@adobe/spacecat-shared-ims-client": "1.12.7",
+        "@adobe/spacecat-shared-drs-client": "1.7.1",
+        "@adobe/spacecat-shared-gpt-client": "1.6.22",
+        "@adobe/spacecat-shared-http-utils": "1.27.1",
+        "@adobe/spacecat-shared-ims-client": "1.12.6",
         "@adobe/spacecat-shared-launchdarkly-client": "^1.1.0",
-        "@adobe/spacecat-shared-rum-api-client": "2.40.13",
-        "@adobe/spacecat-shared-scrape-client": "2.6.3",
-        "@adobe/spacecat-shared-slack-client": "1.6.7",
-        "@adobe/spacecat-shared-tier-client": "1.5.1",
-        "@adobe/spacecat-shared-tokowaka-client": "1.16.2",
+        "@adobe/spacecat-shared-rum-api-client": "2.40.12",
+        "@adobe/spacecat-shared-scrape-client": "2.6.2",
+        "@adobe/spacecat-shared-slack-client": "1.6.6",
+        "@adobe/spacecat-shared-tier-client": "1.5.0",
+        "@adobe/spacecat-shared-tokowaka-client": "1.16.1",
         "@adobe/spacecat-shared-utils": "1.115.4",
-        "@adobe/spacecat-shared-vault-secrets": "1.3.5",
+        "@adobe/spacecat-shared-vault-secrets": "1.3.4",
         "@aws-sdk/client-s3": "3.1045.0",
         "@aws-sdk/client-secrets-manager": "3.1045.0",
         "@aws-sdk/client-sfn": "3.1045.0",
@@ -68,8 +68,8 @@
         "zod": "3.25.76"
       },
       "devDependencies": {
-        "@adobe/eslint-config-helix": "3.0.27",
-        "@adobe/helix-deploy": "14.0.6",
+        "@adobe/eslint-config-helix": "3.0.26",
+        "@adobe/helix-deploy": "14.0.5",
         "@adobe/helix-universal": "5.4.1",
         "@adobe/helix-universal-devserver": "1.1.147",
         "@adobe/semantic-release-coralogix": "1.1.41",
@@ -152,15 +152,15 @@
       "license": "MIT"
     },
     "node_modules/@adobe/eslint-config-helix": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.27.tgz",
-      "integrity": "sha512-tjko8Ut6q+eJnN3XXYAjIQ1zjS1TEFlf/hecjP/JymphFZHUazhiCsGEVvi6WoUM5zMFnxYFhD9qY+ALpEPb5A==",
+      "version": "3.0.26",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.26.tgz",
+      "integrity": "sha512-fF+yS57VSRd7ydKSgY170Q412dqwAB9euugEHDNBv3+qNvKByqiLvgfcAtodY6cwN9aUa6K8z1Yuezi3Q2+RyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/config-helpers": "0.5.5",
         "eslint-plugin-import": "2.32.0",
-        "globals": "17.6.0"
+        "globals": "17.5.0"
       },
       "engines": {
         "node": ">= 12"
@@ -197,20 +197,20 @@
       }
     },
     "node_modules/@adobe/helix-deploy": {
-      "version": "14.0.6",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-14.0.6.tgz",
-      "integrity": "sha512-Zv7f3XWWSB/6ZX69IZ7XEDSn1u7VcNRkqRES4aaJtTkPq5NM6QxrR7B5g035kF9aOVkoyCETF842lNNWzgGpIg==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-14.0.5.tgz",
+      "integrity": "sha512-N/aAzLj78VROfrq10FtWHEWcoV4oA6FxFfYVqI0cD4eBTdrV1WMm3pKJhjiofGTEBHC9D8h+XdKK95O8XVJSXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/helix-shared-process-queue": "3.1.9",
-        "@aws-sdk/client-apigatewayv2": "3.1042.0",
-        "@aws-sdk/client-lambda": "3.1042.0",
-        "@aws-sdk/client-s3": "3.1042.0",
-        "@aws-sdk/client-secrets-manager": "3.1042.0",
-        "@aws-sdk/client-ssm": "3.1042.0",
-        "@aws-sdk/client-sts": "3.1042.0",
+        "@aws-sdk/client-apigatewayv2": "3.1038.0",
+        "@aws-sdk/client-lambda": "3.1038.0",
+        "@aws-sdk/client-s3": "3.1038.0",
+        "@aws-sdk/client-secrets-manager": "3.1038.0",
+        "@aws-sdk/client-ssm": "3.1038.0",
+        "@aws-sdk/client-sts": "3.1038.0",
         "archiver": "7.0.1",
         "chalk-template": "1.1.2",
         "dotenv": "17.4.2",
@@ -243,33 +243,33 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
-      "integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1038.0.tgz",
+      "integrity": "sha512-k60qm50bWkaqNfCJe1z28WaqgpztE0wbWVMZw6ZJcTOGfrWFhsJeLCEqtkH8w00iEozKx9GQwdQXz4G0sMGdKA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
         "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
         "@aws-sdk/middleware-expect-continue": "^3.972.10",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.14",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-location-constraint": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
         "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -283,7 +283,7 @@
         "@smithy/md5-js": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-retry": "^4.5.6",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -299,7 +299,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
@@ -310,25 +310,25 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1042.0.tgz",
-      "integrity": "sha512-doHP17OwqhcuW3e7fKkFfF4rDFM0hY8IVIwqwvBQRLk6IsZXzpl/YRhQWuIiy9O7BSZgzKKE+XytdElsTd9PWQ==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1038.0.tgz",
+      "integrity": "sha512-cTNiqnVErYo8fCb7dw/BnHiubfWJIE1Ur97DT5faTncI8OEibs1A7E1GyD9Y5L77xn8edB5XJ4WBwBlTdyzk+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -336,7 +336,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-retry": "^4.5.6",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -352,7 +352,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -361,13 +361,15 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
-      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -375,13 +377,14 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
-      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -389,13 +392,16 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
-      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -403,13 +409,16 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
-      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -431,14 +440,16 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
-      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@smithy/core": "^3.24.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -446,13 +457,15 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
-      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
@@ -603,9 +616,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/helix-shared-body-data": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-2.2.5.tgz",
-      "integrity": "sha512-wdMxohMOOUUlUSpFki+1KYer2RBbM6F5HZ8KHnk5v/aEMtOrz5wvf4glbzz6ZlCSRhqsjC9vD9zye1GMEMgCaQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-2.2.4.tgz",
+      "integrity": "sha512-Rs4ogFc6BAcnjn9ZmRhr9NOT+6vNJrI7nFQCoIJOCYNUX56FQtofYBzOv2novVVsKrZ4CKskKJFLpqmbZ+E8Kg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.1",
@@ -622,9 +635,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/helix-shared-bounce": {
-      "version": "2.0.31",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-bounce/-/helix-shared-bounce-2.0.31.tgz",
-      "integrity": "sha512-/Fe7BMKWwOfRUzv4fMH87yABLy962P0NXV+iu/kAB5yYWI0tKrlhou8fvobfAX4GP/zO9h6/kX1H0DdcuxRQPg==",
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-bounce/-/helix-shared-bounce-2.0.30.tgz",
+      "integrity": "sha512-M0DSgCSr2YRt5x4SpCTwvMjfhgWuROZk1wdx24+hixWsZFguLHdbX/bxEaW9Z+4qqVTDBdxM7I90x0N+Rh5sQQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.1",
@@ -678,6 +691,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -785,9 +799,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.3.1.tgz",
-      "integrity": "sha512-z3p42HCkN4Cbg06g4dX/XWfcYb74WM/CqDREWGlqLAch/qptzeOSprI8nb22ck4EJikNgScEvhZgv1kKPyzfIQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.3.0.tgz",
+      "integrity": "sha512-ivkhI+W2HlCQEMPhHLzSTQXmlkLU4EDZld/6ThFXKAskGsW9phLCe4+SLnsJ5hISjBp/quI8VO/gBHhlPjHeSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -1450,13 +1464,13 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-athena-client": {
-      "version": "1.9.12",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-athena-client/-/spacecat-shared-athena-client-1.9.12.tgz",
-      "integrity": "sha512-TWeJHY7KpVmb+k/XCJ2xXdpQ5cHAY4LRZfXVoxDShVCPwqzcZQcRvfM8VvOXGmZa5CB7fOwkEwKEZLq/It9j9g==",
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-athena-client/-/spacecat-shared-athena-client-1.9.11.tgz",
+      "integrity": "sha512-YWyQR7FRh404zOG+9WSbhLkJAd55i1lyzctBR9Garcyf8Hhn9U/snEh7SkSeneEbm7LcCOOo6XypfcFE51U6Fw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.96.3",
-        "@aws-sdk/client-athena": "3.1045.0"
+        "@aws-sdk/client-athena": "3.1024.0"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -2044,9 +2058,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-brand-client": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.1.42.tgz",
-      "integrity": "sha512-8OgJ+zEaQs4nSY6yx2ZeOfTX7D7dC2nEC5ynWkfynanqIItFfz+CMhr+bYGOBtRRmlpdbznN3sO2AbrYW9V95Q==",
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.1.41.tgz",
+      "integrity": "sha512-ZT+AT9WTrZdu2zwvulaGbsEjQGoA7ZQh/VjRaYhWIMtqweqF/Mw+g/2AEjQ27QyRMil9OWSKykKlDBf+8p5qIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -2715,15 +2729,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-content-client": {
-      "version": "1.8.24",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-content-client/-/spacecat-shared-content-client-1.8.24.tgz",
-      "integrity": "sha512-6UirRPJ+IcVWdA1GG068OAC87L1i0fpADYjQVf8N0yAYO1Xd5m+akpIDxIgbQEjTYjTW7wYrj0ZblsRr7UQ8Yw==",
+      "version": "1.8.23",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-content-client/-/spacecat-shared-content-client-1.8.23.tgz",
+      "integrity": "sha512-OYxjXrPbO2wikU08EOOLwiMkV4/jwWCrNTRfwhf2vNqx4yoLdpHZbMTCu+KZI5vRTxwkZWWe0II20QLQgcMVJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-secrets-manager": "3.1045.0",
+        "@aws-sdk/client-secrets-manager": "3.1024.0",
         "aws-xray-sdk": "3.12.0",
         "graph-data-structure": "4.5.0"
       },
@@ -2820,6 +2834,465 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.1024.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1024.0.tgz",
+      "integrity": "sha512-EXbgMqueA5gw/jqpE2zMWAfBnzn6cZWqCISGdfn1201Um9IAIoTcHjyWoQMALQm0f8Lu1NF6yRtngs6zpZcagQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/xml-builder": "^3.972.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-login": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/token-providers": "3.1026.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-retry": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-endpoints": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-sqs": {
@@ -3302,6 +3775,26 @@
         }
       }
     },
+    "node_modules/@adobe/spacecat-shared-content-client/node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@adobe/spacecat-shared-content-client/node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -3312,9 +3805,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.65.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.65.0.tgz",
-      "integrity": "sha512-if0tvFUn4BjL5ABwwk0PyK8KBkEgsavafDePC5TnG3WF8KdBAvjS8Ef485grrZyHsyfx7HA5o5bd/IKE66rJ3Q==",
+      "version": "3.63.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.63.0.tgz",
+      "integrity": "sha512-3ZjwhQig41OuhEhRpAO+LyBmViz31E4nb18rFDVIZ2md1Fn0eyGmCaTAvlO49f2dziMBdJUcHeO7TOkF4+RlGw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -4239,9 +4732,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-drs-client": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.7.2.tgz",
-      "integrity": "sha512-ENlvz/0Q4Kp5gsU2kbbYudVAk+Qk8ex5a2Ld0ryWH+4uNL1BWBR1AFtaa0CsTVcWRGkD+cFjV3gHP7QkdC41UA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.7.1.tgz",
+      "integrity": "sha512-5XusGrHHSXtiaR0MPnMsT35KWulyhroyuOk35zGvQGD4S0gady3acZ0+6S35Bh8Gl000G6dHqFL9ZTg+MGYg0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1",
@@ -4542,9 +5035,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-gpt-client": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-gpt-client/-/spacecat-shared-gpt-client-1.6.23.tgz",
-      "integrity": "sha512-R8YiqPAs8aim1jehbaKZrMmnLydcc1yGHtgSEIePPlRiMyWfNz4Ydn9UuQ+pSmvAhRsiiPpcTUP96lHCdurfnw==",
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-gpt-client/-/spacecat-shared-gpt-client-1.6.22.tgz",
+      "integrity": "sha512-BMzdR+5VPVHNDbtgqfkXn/k7Kfsy6MqARkYUEgFGN3+KydRzDBPp9bTPPM7bI0rMPNhrhgyiijACZX08vpzUtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -5214,15 +5707,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-http-utils": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.27.2.tgz",
-      "integrity": "sha512-/uZRBhLFuBTViSX15v57c1QTld3etzMyku2PMkGHQ5fYU05nEdbx5AVF5E0Bq0DbiQPKFfVS41MLhygJoYRftQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.27.1.tgz",
+      "integrity": "sha512-f8HcDcff8ywX3U+mz1IzemAKqOAYgvnFX6e5INUgHsJvxSZDayMCFpcQdSc8yZluZXfXwJ4SZfDbjjIKYBtyNA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/spacecat-shared-launchdarkly-client": "1.0.4",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "jose": "6.2.3"
+        "jose": "6.2.2"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -5824,6 +6317,15 @@
         }
       }
     },
+    "node_modules/@adobe/spacecat-shared-http-utils/node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@adobe/spacecat-shared-http-utils/node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -5834,15 +6336,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.12.7.tgz",
-      "integrity": "sha512-mkO5tLod8s1V0WiLnsK2oikPgOmADd5A3PFA5XGVjIKKMo5ewxVpPIV/Q3mTfi1CvcWYdDMdZCs4Ltxl1PaobQ==",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.12.6.tgz",
+      "integrity": "sha512-yVU3hjcsXMBEWVWp/Q/w5agHrjbWQWmThwSMJe9bt4Y8G6qoaXDoV4uOdeU+NA5YlX1f4drH2RT/EaKodGXm2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-secrets-manager": "3.1045.0",
+        "@aws-sdk/client-secrets-manager": "3.1024.0",
         "aws-xray-sdk": "3.12.0"
       },
       "engines": {
@@ -5938,6 +6440,465 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.1024.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1024.0.tgz",
+      "integrity": "sha512-EXbgMqueA5gw/jqpE2zMWAfBnzn6cZWqCISGdfn1201Um9IAIoTcHjyWoQMALQm0f8Lu1NF6yRtngs6zpZcagQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/xml-builder": "^3.972.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-login": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/token-providers": "3.1026.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-retry": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-endpoints": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-sqs": {
@@ -6418,6 +7379,26 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client/node_modules/zod": {
@@ -7024,9 +8005,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-rum-api-client": {
-      "version": "2.40.13",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.40.13.tgz",
-      "integrity": "sha512-UcgbDOvUAmuN32WuTAgwRYxXCfN5C8xyD170KBXRn0pPK4Zlp1xQU3p3nEcZd8+iarDzX4LQsfL+jv6PNTj7xA==",
+      "version": "2.40.12",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.40.12.tgz",
+      "integrity": "sha512-96hwODD1Fn9DU3u3GszE3HjtHTs5vI0LOj9FgrNwVE6HdzFNnCgR1h3qckdNgmn6YP4YHCjCw56BPloiYJhoVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -7622,9 +8603,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-scrape-client": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.6.3.tgz",
-      "integrity": "sha512-osYG7IkFwUIvTvH368uAuEvrnNiphzyOLnuxgATeoHQo+CcmsPVBu5zLKfy2soTeHjjjLD8xE2Q5/lFDgKFUAw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.6.2.tgz",
+      "integrity": "sha512-4zqI5P6CuXjh6wxg+W43BQGhF3O4QMjywDMTVh2y9EmLhsZ79ickQeR+mqCaS/PwRuhFkQ/+ex/IkoXamft40Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -8216,14 +9197,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-slack-client": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.6.7.tgz",
-      "integrity": "sha512-zchiSmBcg3ck4Lw4WhoL6/kESw0oSaE6etr7K1+gH/+W1gLBDGPV8AfE292YdWYT8tvS8qCWTur/opxKGsOiKA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.6.6.tgz",
+      "integrity": "sha512-+M2NCwrJqUMLggoOIa1ZJ/sMnyc8xNGFYTl5ePwiyzIH1XFbHDf2gsgN44ABj3FW0xap7mX2ohoXe/EMdePvKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@slack/web-api": "7.15.2"
+        "@slack/web-api": "7.15.0"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -8800,6 +9781,30 @@
         }
       }
     },
+    "node_modules/@adobe/spacecat-shared-slack-client/node_modules/@slack/web-api": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
+      "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.13.5",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
     "node_modules/@adobe/spacecat-shared-slack-client/node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -8810,9 +9815,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tier-client": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.5.1.tgz",
-      "integrity": "sha512-fNvpkvqaDoatYNnP2XUGdHOVRLil90H4qKQVzoIhhFRogRIRT8vs2rUNjTQvZywBc7NRZfmoXf0oYHzE3OAXMA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.5.0.tgz",
+      "integrity": "sha512-+OPIzMyeEnsHjvdqZGnKoSygxpO7j1JvfS8TWy2pUnGg7aqEBpH9vRfzEEIfWVFIjFhVtIn8b/3OKlEFCjI6YA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
@@ -9403,14 +10408,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.16.2.tgz",
-      "integrity": "sha512-l39q27onNu9B7J76NtZypr+8quH7rFhnwHpW8z0Hc4VDKhZ7KRJoCNGzzGpkMEPOE6iRNBxppqZgJVsIBhcbKw==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.16.1.tgz",
+      "integrity": "sha512-VFEtClbLTWwLaF/sGf/OaYgyd0W3arl5kdZl/UkGoEj7/Oeq9pT0UQBupgy65W3kgpwQja5XQYXjzW/I5S1uOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-cloudfront": "3.1045.0",
-        "@aws-sdk/client-s3": "3.1045.0",
+        "@aws-sdk/client-cloudfront": "3.1024.0",
+        "@aws-sdk/client-s3": "3.1024.0",
         "hast-util-from-html": "2.0.3",
         "mdast-util-from-markdown": "2.0.3",
         "mdast-util-to-hast": "13.2.1",
@@ -9725,6 +10730,174 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3": {
+      "version": "3.1024.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1024.0.tgz",
+      "integrity": "sha512-8qdO5aLCzaf9l0RdrSBW1iIroRKP2QBqtZ6lkrtHKiaaH0B18xEn+lrEgiN/eCf3uRAYk4cqbnI2XcWzm+7dDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
+        "@aws-sdk/middleware-expect-continue": "^3.972.8",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.6",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-location-constraint": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
+        "@aws-sdk/middleware-ssec": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-blob-browser": "^4.2.13",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/hash-stream-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-sqs": {
@@ -10460,9 +11633,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-vault-secrets": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.5.tgz",
-      "integrity": "sha512-Cki+INCuViMQFEKARcHQ97Z6iHRA91tQkHIsfslnLhIzK9jUWY2yFGy5o0/DBogeX7j6ldy0DBTZEc6RdcoBeA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.4.tgz",
+      "integrity": "sha512-GWnAsaeComj6i55PE/S4SxVlaYqrgbtXtqNbXS/FIsLe01JQhBxaHHxgB6m6mhf58WGpobe5EDa44n6nDGvy7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -10685,25 +11858,25 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.1042.0.tgz",
-      "integrity": "sha512-Pn/2GoRsHaCi3IK4vGbUg3ciQBKwCJVtWeWirO2dt06TamLFtm7sg6P/am4eh9yunXoKl5EsGL+p6SWhwNz53g==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.1038.0.tgz",
+      "integrity": "sha512-i8SoHAmooWuSkqsT0drRsjCJOTlL0IV9fff0xrmPtFKyQGtevt+LGYp62D+S7Zk+0a7EPBxF4kK/pzs+Snu94g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -10711,7 +11884,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-retry": "^4.5.6",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -10727,7 +11900,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -10737,13 +11910,15 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
-      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10751,13 +11926,14 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
-      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10765,13 +11941,16 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
-      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10779,13 +11958,16 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
-      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10807,14 +11989,16 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
-      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@smithy/core": "^3.24.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10822,59 +12006,61 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
-      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-athena": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1045.0.tgz",
-      "integrity": "sha512-g5E7Bt9FFZSMloQeLlEE1JabVvLh5k9749sv95UPz7r0Lwj6mT0WkMgDZ/3q/YgafeM4Ug+Ttoxpje+0gc5hRQ==",
+      "version": "3.1024.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1024.0.tgz",
+      "integrity": "sha512-kKnsdeh58Se7GL+9HX56KWtjS55W3OuzZwGVXq20PXgY2N53d6+NI9I1w+X0cZJo2pz3JijiJ+3S76YYCBoprw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -10883,12 +12069,14 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
-      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10896,12 +12084,13 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
-      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10909,12 +12098,15 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
-      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10922,12 +12114,15 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
-      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10935,12 +12130,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10948,13 +12143,15 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
-      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@smithy/core": "^3.24.2",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10962,61 +12159,63 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
-      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1045.0.tgz",
-      "integrity": "sha512-84RIiLrMXcinBK1JXnP1bOavvQ+jxTxN4xsB20e39MfOZMyr7wIxMNn35kTYTg8UTJgN7zwEgzGJo64sU3mtPw==",
+      "version": "3.1024.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1024.0.tgz",
+      "integrity": "sha512-jd3Mva86RKznPndyzlISIJt6seqc55gBuJprGKFraOq8KDbWjXniFLuz6QTG0qvTA82nVp5+6PX45Yzuye7ArQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-stream": "^4.5.21",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.3.0",
+        "@smithy/util-waiter": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11024,12 +12223,14 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
-      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11037,12 +12238,13 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
-      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11050,12 +12252,15 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
-      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11063,12 +12268,15 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
-      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11076,12 +12284,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11089,13 +12297,15 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
-      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@smithy/core": "^3.24.2",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11103,12 +12313,14 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
-      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
@@ -11117,6 +12329,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -11437,25 +12650,25 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1042.0.tgz",
-      "integrity": "sha512-g2NJMMGjQ18LvPapz75s8UzRaxJ2P5bF2Y025/eyVuBtzdCuW6XYoJxP29Tp39BzYgFb+HEtwATyZss/V6KdZg==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1038.0.tgz",
+      "integrity": "sha512-2AYkZi3h37UJDcyeWNNCmk+S9jInZvj/276OHxdjtG7zahiAPsLoPVBQACzfZwDIQJZFuUy+tDiGVHR/DqMHJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -11466,7 +12679,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-retry": "^4.5.6",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -11482,7 +12695,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
@@ -11493,13 +12706,15 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
-      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11507,13 +12722,14 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
-      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11521,13 +12737,16 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
-      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11535,13 +12754,16 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
-      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11563,14 +12785,16 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
-      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@smithy/core": "^3.24.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11578,13 +12802,15 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
-      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
@@ -12367,25 +13593,25 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1042.0.tgz",
-      "integrity": "sha512-FVX73f1jsms0Ay1DSmivV/jN+unUVI/pUjR2FtbbPoj3N9VA6JZd178xN62jLpfSIN+iBuNGD9gvk3uI3AR9nA==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1038.0.tgz",
+      "integrity": "sha512-xP6CqJkTOvX06+IghNmohu1qvzYQBmdszPHPCkCTJi3FKFQXdKpkSsaeAedBLExLW49GnHg0kVPblMGFFhirXg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -12393,7 +13619,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-retry": "^4.5.6",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -12409,7 +13635,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
@@ -12419,13 +13645,15 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
-      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12433,13 +13661,14 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
-      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12447,13 +13676,16 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
-      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12461,13 +13693,16 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
-      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12489,14 +13724,16 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
-      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@smithy/core": "^3.24.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12504,13 +13741,15 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
-      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
@@ -12630,26 +13869,26 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1042.0.tgz",
-      "integrity": "sha512-CTpdtuLEdClT31afs8eabb9Yhm1fRU8DRLak/+5VTrVSZcWzEvzVhA4ZVHvf4w7EPah2yve//14zwyDYa4IxVQ==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1038.0.tgz",
+      "integrity": "sha512-lboBAXDIr+ot5a357mQgaAwgMMYZW7EwO216LTASUHV3UN4YgqskrEcwsDV9765KH9wUDGxFt8rClS4ixaOgiA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -12657,7 +13896,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-retry": "^4.5.6",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -12673,7 +13912,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -12682,13 +13921,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
-      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12696,13 +13937,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
-      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12710,13 +13952,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
-      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12724,13 +13969,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
-      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12752,14 +14000,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
-      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@smithy/core": "^3.24.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12767,29 +14017,37 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
-      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
-      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
         "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12810,14 +14068,14 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12825,9 +14083,9 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -12837,7 +14095,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
+        "fast-xml-builder": "^1.1.5",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -14128,7 +15386,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -14152,6 +15411,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -15088,6 +16348,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -15385,6 +16646,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -15591,6 +16853,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -15755,6 +17018,7 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -16986,13 +18250,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17375,13 +18646,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17407,9 +18683,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -17723,6 +18999,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -17970,6 +19247,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -18017,6 +19295,7 @@
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18482,6 +19761,7 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -19144,6 +20424,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -21338,6 +22619,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -21889,9 +23171,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -21900,8 +23182,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
+        "path-expression-matcher": "^1.1.3"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -22696,9 +23977,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24347,6 +25628,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -25302,6 +26584,7 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -26356,6 +27639,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -28937,6 +30221,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -29463,6 +30748,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -30650,6 +31936,7 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30660,6 +31947,7 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -31414,6 +32702,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -32779,6 +34068,7 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -33785,6 +35075,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -34537,6 +35828,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -34569,21 +35861,6 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {
@@ -34822,6 +36099,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -34831,6 +36109,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
-        "@adobe/helix-shared-body-data": "2.2.4",
-        "@adobe/helix-shared-bounce": "2.0.30",
+        "@adobe/helix-shared-body-data": "2.2.5",
+        "@adobe/helix-shared-bounce": "2.0.31",
         "@adobe/helix-shared-utils": "3.0.2",
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
@@ -68,8 +68,8 @@
         "zod": "3.25.76"
       },
       "devDependencies": {
-        "@adobe/eslint-config-helix": "3.0.26",
-        "@adobe/helix-deploy": "14.0.5",
+        "@adobe/eslint-config-helix": "3.0.27",
+        "@adobe/helix-deploy": "14.0.6",
         "@adobe/helix-universal": "5.4.1",
         "@adobe/helix-universal-devserver": "1.1.147",
         "@adobe/semantic-release-coralogix": "1.1.41",
@@ -152,15 +152,15 @@
       "license": "MIT"
     },
     "node_modules/@adobe/eslint-config-helix": {
-      "version": "3.0.26",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.26.tgz",
-      "integrity": "sha512-fF+yS57VSRd7ydKSgY170Q412dqwAB9euugEHDNBv3+qNvKByqiLvgfcAtodY6cwN9aUa6K8z1Yuezi3Q2+RyQ==",
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.27.tgz",
+      "integrity": "sha512-tjko8Ut6q+eJnN3XXYAjIQ1zjS1TEFlf/hecjP/JymphFZHUazhiCsGEVvi6WoUM5zMFnxYFhD9qY+ALpEPb5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/config-helpers": "0.5.5",
         "eslint-plugin-import": "2.32.0",
-        "globals": "17.5.0"
+        "globals": "17.6.0"
       },
       "engines": {
         "node": ">= 12"
@@ -197,20 +197,20 @@
       }
     },
     "node_modules/@adobe/helix-deploy": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-14.0.5.tgz",
-      "integrity": "sha512-N/aAzLj78VROfrq10FtWHEWcoV4oA6FxFfYVqI0cD4eBTdrV1WMm3pKJhjiofGTEBHC9D8h+XdKK95O8XVJSXA==",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-14.0.6.tgz",
+      "integrity": "sha512-Zv7f3XWWSB/6ZX69IZ7XEDSn1u7VcNRkqRES4aaJtTkPq5NM6QxrR7B5g035kF9aOVkoyCETF842lNNWzgGpIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/helix-shared-process-queue": "3.1.9",
-        "@aws-sdk/client-apigatewayv2": "3.1038.0",
-        "@aws-sdk/client-lambda": "3.1038.0",
-        "@aws-sdk/client-s3": "3.1038.0",
-        "@aws-sdk/client-secrets-manager": "3.1038.0",
-        "@aws-sdk/client-ssm": "3.1038.0",
-        "@aws-sdk/client-sts": "3.1038.0",
+        "@aws-sdk/client-apigatewayv2": "3.1042.0",
+        "@aws-sdk/client-lambda": "3.1042.0",
+        "@aws-sdk/client-s3": "3.1042.0",
+        "@aws-sdk/client-secrets-manager": "3.1042.0",
+        "@aws-sdk/client-ssm": "3.1042.0",
+        "@aws-sdk/client-sts": "3.1042.0",
         "archiver": "7.0.1",
         "chalk-template": "1.1.2",
         "dotenv": "17.4.2",
@@ -243,33 +243,33 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1038.0.tgz",
-      "integrity": "sha512-k60qm50bWkaqNfCJe1z28WaqgpztE0wbWVMZw6ZJcTOGfrWFhsJeLCEqtkH8w00iEozKx9GQwdQXz4G0sMGdKA==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
+      "integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
         "@aws-sdk/middleware-expect-continue": "^3.972.10",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.14",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-location-constraint": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -283,7 +283,7 @@
         "@smithy/md5-js": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -299,7 +299,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
@@ -310,25 +310,25 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1038.0.tgz",
-      "integrity": "sha512-cTNiqnVErYo8fCb7dw/BnHiubfWJIE1Ur97DT5faTncI8OEibs1A7E1GyD9Y5L77xn8edB5XJ4WBwBlTdyzk+Q==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1042.0.tgz",
+      "integrity": "sha512-doHP17OwqhcuW3e7fKkFfF4rDFM0hY8IVIwqwvBQRLk6IsZXzpl/YRhQWuIiy9O7BSZgzKKE+XytdElsTd9PWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -336,7 +336,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -352,7 +352,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -361,15 +361,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -377,14 +375,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -392,16 +389,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -409,16 +403,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -440,16 +431,14 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -457,15 +446,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -616,9 +603,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/helix-shared-body-data": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-2.2.4.tgz",
-      "integrity": "sha512-Rs4ogFc6BAcnjn9ZmRhr9NOT+6vNJrI7nFQCoIJOCYNUX56FQtofYBzOv2novVVsKrZ4CKskKJFLpqmbZ+E8Kg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-2.2.5.tgz",
+      "integrity": "sha512-wdMxohMOOUUlUSpFki+1KYer2RBbM6F5HZ8KHnk5v/aEMtOrz5wvf4glbzz6ZlCSRhqsjC9vD9zye1GMEMgCaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.1",
@@ -635,9 +622,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/helix-shared-bounce": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-bounce/-/helix-shared-bounce-2.0.30.tgz",
-      "integrity": "sha512-M0DSgCSr2YRt5x4SpCTwvMjfhgWuROZk1wdx24+hixWsZFguLHdbX/bxEaW9Z+4qqVTDBdxM7I90x0N+Rh5sQQ==",
+      "version": "2.0.31",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-bounce/-/helix-shared-bounce-2.0.31.tgz",
+      "integrity": "sha512-/Fe7BMKWwOfRUzv4fMH87yABLy962P0NXV+iu/kAB5yYWI0tKrlhou8fvobfAX4GP/zO9h6/kX1H0DdcuxRQPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.1",
@@ -10698,25 +10685,25 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.1038.0.tgz",
-      "integrity": "sha512-i8SoHAmooWuSkqsT0drRsjCJOTlL0IV9fff0xrmPtFKyQGtevt+LGYp62D+S7Zk+0a7EPBxF4kK/pzs+Snu94g==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.1042.0.tgz",
+      "integrity": "sha512-Pn/2GoRsHaCi3IK4vGbUg3ciQBKwCJVtWeWirO2dt06TamLFtm7sg6P/am4eh9yunXoKl5EsGL+p6SWhwNz53g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -10724,7 +10711,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -10740,7 +10727,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -10750,15 +10737,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10766,14 +10751,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10781,16 +10765,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10798,16 +10779,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10829,16 +10807,14 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10846,15 +10822,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -11463,25 +11437,25 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1038.0.tgz",
-      "integrity": "sha512-2AYkZi3h37UJDcyeWNNCmk+S9jInZvj/276OHxdjtG7zahiAPsLoPVBQACzfZwDIQJZFuUy+tDiGVHR/DqMHJA==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1042.0.tgz",
+      "integrity": "sha512-g2NJMMGjQ18LvPapz75s8UzRaxJ2P5bF2Y025/eyVuBtzdCuW6XYoJxP29Tp39BzYgFb+HEtwATyZss/V6KdZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -11492,7 +11466,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -11508,7 +11482,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
@@ -11519,15 +11493,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11535,14 +11507,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11550,16 +11521,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11567,16 +11535,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11598,16 +11563,14 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11615,15 +11578,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -12406,25 +12367,25 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1038.0.tgz",
-      "integrity": "sha512-xP6CqJkTOvX06+IghNmohu1qvzYQBmdszPHPCkCTJi3FKFQXdKpkSsaeAedBLExLW49GnHg0kVPblMGFFhirXg==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1042.0.tgz",
+      "integrity": "sha512-FVX73f1jsms0Ay1DSmivV/jN+unUVI/pUjR2FtbbPoj3N9VA6JZd178xN62jLpfSIN+iBuNGD9gvk3uI3AR9nA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -12432,7 +12393,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -12448,7 +12409,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
@@ -12458,15 +12419,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12474,14 +12433,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12489,16 +12447,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12506,16 +12461,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12537,16 +12489,14 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12554,15 +12504,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -12682,26 +12630,26 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1038.0.tgz",
-      "integrity": "sha512-lboBAXDIr+ot5a357mQgaAwgMMYZW7EwO216LTASUHV3UN4YgqskrEcwsDV9765KH9wUDGxFt8rClS4ixaOgiA==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1042.0.tgz",
+      "integrity": "sha512-CTpdtuLEdClT31afs8eabb9Yhm1fRU8DRLak/+5VTrVSZcWzEvzVhA4ZVHvf4w7EPah2yve//14zwyDYa4IxVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -12709,7 +12657,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -12725,7 +12673,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -12734,15 +12682,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12750,14 +12696,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12765,16 +12710,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12782,16 +12724,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12813,16 +12752,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12830,22 +12767,20 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -22761,9 +22696,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/spacecat-api-service",
-  "version": "1.500.5",
+  "version": "1.501.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/spacecat-api-service",
-      "version": "1.500.5",
+      "version": "1.501.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -10883,12 +10883,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.12.tgz",
-      "integrity": "sha512-4QEreU2qPSu19Vsw/eQW8dq5wQEstoyR0nPvguprIa6U/wSA2/fMrisYO4ZZauD8zmYx53SoUodKLipHSi0ZYg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10896,12 +10896,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.11.tgz",
-      "integrity": "sha512-n/3aCOOnPnxrfh1+z2zWOi0yNC7xLv5nKx2QR4o5xHBjRHAv+vc/5GM8Rnn3Q2p288RSUOy7FhCKfhsZwlaBjg==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10909,12 +10909,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.13.tgz",
-      "integrity": "sha512-QZIpAIa6fDeVgJ8BEG1S6EHGKVul1DM6w6u24041Xl31FvgArh0slURCz5ij3oo0p249yjNHVRTw1GPJa7YUkQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10922,12 +10922,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.15.tgz",
-      "integrity": "sha512-RROpdNPC4L15h4WE0Zlzxd2n5yRd4VaIY/Pgw/+6YNgiGZo61qavXgMG9Zdb+OnPkBnwfpXIguTcEwhSrjEHGw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10948,12 +10948,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.10.tgz",
-      "integrity": "sha512-cdmvh+mmVWFKNhqFv/axpjJOYyaCgw+zta93IOv9sXKZPoL1m0XVhSI/Y7MGKLeVHUkG+ULVZy+q5AEAGivSDw==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
@@ -10962,12 +10962,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.12.tgz",
-      "integrity": "sha512-Glip9lOu73ttWJPO5OIbbWuivyCerLuCD/Rfk2BC/a23zpMeX3FGY9FMui5fh3YatGFZu1NVllVvA1sQy+PhJg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -11024,12 +11024,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.12.tgz",
-      "integrity": "sha512-4QEreU2qPSu19Vsw/eQW8dq5wQEstoyR0nPvguprIa6U/wSA2/fMrisYO4ZZauD8zmYx53SoUodKLipHSi0ZYg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11037,12 +11037,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.11.tgz",
-      "integrity": "sha512-n/3aCOOnPnxrfh1+z2zWOi0yNC7xLv5nKx2QR4o5xHBjRHAv+vc/5GM8Rnn3Q2p288RSUOy7FhCKfhsZwlaBjg==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11050,12 +11050,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.13.tgz",
-      "integrity": "sha512-QZIpAIa6fDeVgJ8BEG1S6EHGKVul1DM6w6u24041Xl31FvgArh0slURCz5ij3oo0p249yjNHVRTw1GPJa7YUkQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11063,12 +11063,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.15.tgz",
-      "integrity": "sha512-RROpdNPC4L15h4WE0Zlzxd2n5yRd4VaIY/Pgw/+6YNgiGZo61qavXgMG9Zdb+OnPkBnwfpXIguTcEwhSrjEHGw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11089,12 +11089,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.10.tgz",
-      "integrity": "sha512-cdmvh+mmVWFKNhqFv/axpjJOYyaCgw+zta93IOv9sXKZPoL1m0XVhSI/Y7MGKLeVHUkG+ULVZy+q5AEAGivSDw==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
@@ -11103,12 +11103,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.12.tgz",
-      "integrity": "sha512-Glip9lOu73ttWJPO5OIbbWuivyCerLuCD/Rfk2BC/a23zpMeX3FGY9FMui5fh3YatGFZu1NVllVvA1sQy+PhJg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },

--- a/src/support/slack/commands/check-agentic-traffic-db-status.js
+++ b/src/support/slack/commands/check-agentic-traffic-db-status.js
@@ -26,104 +26,37 @@ import { postErrorMessage } from '../../../utils/slack/base.js';
 
 const PHRASES = ['check agentic traffic db status'];
 const CDN_LOGS_REPORT_AUDIT = 'cdn-logs-report';
-const BATCH_SIZE = 25;
+const SITE_CONCURRENCY = 10;
 const AGENTIC_TRAFFIC_TABLES = [
-  {
-    key: 'raw',
-    label: 'raw import',
-    table: 'agentic_traffic',
-    dateColumn: 'traffic_date',
-    select: 'site_id,hits,updated_at',
-  },
-  {
-    key: 'daily',
-    label: 'daily serving',
-    table: 'agentic_traffic_daily',
-    dateColumn: 'traffic_date',
-    select: 'site_id,hits,updated_at',
-  },
-  {
-    key: 'weekly',
-    label: 'weekly serving',
-    table: 'agentic_traffic_weekly',
-    dateColumn: 'week_start',
-    select: 'site_id,hits,updated_at',
-  },
+  { key: 'raw', table: 'agentic_traffic', dateColumn: 'traffic_date' },
+  { key: 'daily', table: 'agentic_traffic_daily', dateColumn: 'traffic_date' },
+  { key: 'weekly', table: 'agentic_traffic_weekly', dateColumn: 'week_start' },
 ];
 
 function isCompletedIsoWeek(date, now = new Date()) {
   return startOfUtcIsoWeek(date) < startOfUtcIsoWeek(now);
 }
 
-function chunkArray(items, size) {
-  const chunks = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
+async function runWithConcurrency(items, concurrency, fn) {
+  const results = [];
+  const executing = [];
+  for (const item of items) {
+    const promise = Promise.resolve().then(() => fn(item));
+    results.push(promise);
+    const tracked = promise.finally(() => {
+      executing.splice(executing.indexOf(tracked), 1);
+    });
+    executing.push(tracked);
+    if (executing.length >= concurrency) {
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.race(executing);
+    }
   }
-  return chunks;
-}
-
-function rowsEmptySummary() {
-  return { rows: 0, hits: 0, latestUpdate: null };
-}
-
-function addRowSummary(summaries, row) {
-  const siteId = row.site_id;
-  if (!siteId) {
-    return;
-  }
-  const summary = summaries.get(siteId) || rowsEmptySummary();
-  const hits = Number(row.hits || 0);
-  summary.rows += 1;
-  summary.hits += Number.isFinite(hits) ? hits : 0;
-  if (row.updated_at && (!summary.latestUpdate || row.updated_at > summary.latestUpdate)) {
-    summary.latestUpdate = row.updated_at;
-  }
-  summaries.set(siteId, summary);
-}
-
-function summarizeRows(rows = []) {
-  const summaries = new Map();
-  for (const row of rows) {
-    addRowSummary(summaries, row);
-  }
-  return summaries;
-}
-
-function getTableSummary(tableSummaries, tableKey, siteId) {
-  return tableSummaries[tableKey].get(siteId) || rowsEmptySummary();
+  return Promise.all(results);
 }
 
 function formatNumber(value) {
   return Number(value || 0).toLocaleString('en-US');
-}
-
-function formatUpdateTime(value) {
-  if (!value) {
-    return 'n/a';
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return date.toISOString().slice(0, 16).replace('T', ' ');
-}
-
-function formatTableSummary(summary) {
-  return `${formatNumber(summary.rows)} rows / ${formatNumber(summary.hits)} hits`;
-}
-
-function sumTable(siteStatuses, tableKey) {
-  return siteStatuses.reduce((summary, siteStatus) => {
-    const tableSummary = siteStatus[tableKey];
-    return {
-      rows: summary.rows + tableSummary.rows,
-      hits: summary.hits + tableSummary.hits,
-      latestUpdate: !summary.latestUpdate || tableSummary.latestUpdate > summary.latestUpdate
-        ? tableSummary.latestUpdate
-        : summary.latestUpdate,
-    };
-  }, rowsEmptySummary());
 }
 
 function renderOmittedSites(omitted) {
@@ -134,75 +67,63 @@ function renderSite(siteStatus) {
   return [
     `• \`${siteStatus.baseURL}\``,
     `  siteId: \`${siteStatus.siteId}\``,
-    `  raw: ${formatTableSummary(siteStatus.raw)} (updated ${formatUpdateTime(siteStatus.raw.latestUpdate)})`,
-    `  daily: ${formatTableSummary(siteStatus.daily)} (updated ${formatUpdateTime(siteStatus.daily.latestUpdate)})`,
-    siteStatus.rawWeek.rows > 0 ? `  raw week: ${formatTableSummary(siteStatus.rawWeek)} for ${siteStatus.weekStart}..${siteStatus.weekEnd}` : '',
-    `  weekly: ${formatTableSummary(siteStatus.weekly)} for week ${siteStatus.weekStart} (updated ${formatUpdateTime(siteStatus.weekly.latestUpdate)})`,
+    `  raw: ${formatNumber(siteStatus.raw)} rows`,
+    `  daily: ${formatNumber(siteStatus.daily)} rows`,
+    siteStatus.rawWeek > 0 ? `  raw week: ${formatNumber(siteStatus.rawWeek)} rows for ${siteStatus.weekStart}..${siteStatus.weekEnd}` : '',
+    `  weekly: ${formatNumber(siteStatus.weekly)} rows for week ${siteStatus.weekStart}`,
     siteStatus.missing.length > 0 ? `  missing: ${siteStatus.missing.join(', ')}` : '',
   ].filter(Boolean).join('\n');
 }
 
-async function queryTable(postgrestClient, tableDef, siteIds, dateValue) {
-  const { data, error } = await postgrestClient
-    .from(tableDef.table)
-    .select(tableDef.select)
-    .in('site_id', siteIds)
-    .eq(tableDef.dateColumn, dateValue);
-
+async function countTable(postgrestClient, table, siteId, dateColumn, dateValue) {
+  const { count, error } = await postgrestClient
+    .from(table)
+    .select('*', { count: 'exact', head: true })
+    .eq('site_id', siteId)
+    .eq(dateColumn, dateValue);
   if (error) {
-    throw new Error(`${tableDef.table}: ${error.message}`);
+    throw new Error(`${table}: ${error.message}`);
   }
-  return data || [];
+  return count || 0;
 }
 
-async function queryRawWeekTable(postgrestClient, siteIds, weekStartStr, weekEndStr) {
-  const summaries = new Map();
-
-  for (const siteIdBatch of chunkArray(siteIds, BATCH_SIZE)) {
-    // eslint-disable-next-line no-await-in-loop
-    const { data, error } = await postgrestClient
-      .from('agentic_traffic')
-      .select('site_id,hits,updated_at')
-      .in('site_id', siteIdBatch)
-      .gte('traffic_date', weekStartStr)
-      .lte('traffic_date', weekEndStr);
-
-    if (error) {
-      throw new Error(`agentic_traffic weekly range: ${error.message}`);
-    }
-
-    const batchSummary = summarizeRows(data || []);
-    for (const [siteId, summary] of batchSummary.entries()) {
-      const existing = summaries.get(siteId) || rowsEmptySummary();
-      summaries.set(siteId, {
-        rows: existing.rows + summary.rows,
-        hits: existing.hits + summary.hits,
-        latestUpdate: !existing.latestUpdate || summary.latestUpdate > existing.latestUpdate
-          ? summary.latestUpdate
-          : existing.latestUpdate,
-      });
-    }
+async function countRawWeek(postgrestClient, siteId, weekStartStr, weekEndStr) {
+  const { count, error } = await postgrestClient
+    .from('agentic_traffic')
+    .select('*', { count: 'exact', head: true })
+    .eq('site_id', siteId)
+    .gte('traffic_date', weekStartStr)
+    .lte('traffic_date', weekEndStr);
+  if (error) {
+    throw new Error(`agentic_traffic weekly range: ${error.message}`);
   }
-
-  return summaries;
+  return count || 0;
 }
 
-async function queryTrafficTables(postgrestClient, siteIds, dateStr, weekStartStr) {
-  const summaries = { raw: new Map(), daily: new Map(), weekly: new Map() };
-
-  for (const siteIdBatch of chunkArray(siteIds, BATCH_SIZE)) {
-    for (const tableDef of AGENTIC_TRAFFIC_TABLES) {
-      const dateValue = tableDef.key === 'weekly' ? weekStartStr : dateStr;
-      // eslint-disable-next-line no-await-in-loop
-      const rows = await queryTable(postgrestClient, tableDef, siteIdBatch, dateValue);
-      summaries[tableDef.key] = new Map([
-        ...summaries[tableDef.key],
-        ...summarizeRows(rows),
-      ]);
-    }
-  }
-
-  return summaries;
+async function countSiteTables(
+  postgrestClient,
+  siteId,
+  dateStr,
+  weekStartStr,
+  weekEndStr,
+  weeklyExpected,
+) {
+  const tableCounts = await Promise.all(
+    AGENTIC_TRAFFIC_TABLES.map((t) => countTable(
+      postgrestClient,
+      t.table,
+      siteId,
+      t.dateColumn,
+      t.key === 'weekly' ? weekStartStr : dateStr,
+    )),
+  );
+  const [raw, daily, weekly] = tableCounts;
+  const rawWeek = weeklyExpected
+    ? await countRawWeek(postgrestClient, siteId, weekStartStr, weekEndStr)
+    : 0;
+  return {
+    raw, daily, weekly, rawWeek,
+  };
 }
 
 /**
@@ -260,6 +181,7 @@ function CheckAgenticTrafficDbStatusCommand(context) {
 
       const dateStr = formatUtcDate(targetDate);
       const weekStartStr = formatUtcDate(startOfUtcIsoWeek(targetDate));
+      const weekEndStr = formatUtcDate(addUtcDays(startOfUtcIsoWeek(targetDate), 6));
       const weeklyExpected = isCompletedIsoWeek(targetDate);
       let siteScopeText = '';
       if (parsedArgs.siteId) {
@@ -290,80 +212,62 @@ function CheckAgenticTrafficDbStatusCommand(context) {
 
       await say(`:gear: Checking ${enabledSites.length} site${enabledSites.length === 1 ? '' : 's'} with cdn-logs-report enabled...`);
 
-      const tableSummaries = await queryTrafficTables(
-        postgrestClient,
-        enabledSites.map((site) => site.getId()),
-        dateStr,
-        weekStartStr,
+      const siteStatuses = await runWithConcurrency(
+        enabledSites,
+        SITE_CONCURRENCY,
+        async (site) => {
+          const siteId = site.getId();
+          const counts = await countSiteTables(
+            postgrestClient,
+            siteId,
+            dateStr,
+            weekStartStr,
+            weekEndStr,
+            weeklyExpected,
+          );
+          const status = {
+            siteId,
+            baseURL: site.getBaseURL(),
+            weekStart: weekStartStr,
+            weekEnd: weekEndStr,
+            raw: counts.raw,
+            daily: counts.daily,
+            weekly: counts.weekly,
+            rawWeek: counts.rawWeek,
+            missing: [],
+          };
+          if (status.raw === 0) {
+            status.missing.push('raw');
+          }
+          if (status.daily === 0) {
+            status.missing.push('daily');
+          }
+          if (weeklyExpected && status.rawWeek > 0 && status.weekly === 0) {
+            status.missing.push('weekly');
+          }
+          return status;
+        },
       );
-      const weekEndStr = formatUtcDate(addUtcDays(startOfUtcIsoWeek(targetDate), 6));
-      tableSummaries.rawWeek = weeklyExpected
-        ? await queryRawWeekTable(
-          postgrestClient,
-          enabledSites.map((site) => site.getId()),
-          weekStartStr,
-          weekEndStr,
-        )
-        : new Map();
 
-      const dashboardReady = [];
-      const rawMissing = [];
-      const dailyMissing = [];
-      const weeklyMissing = [];
-
-      const siteStatuses = enabledSites.map((site) => {
-        const siteId = site.getId();
-        const status = {
-          siteId,
-          baseURL: site.getBaseURL(),
-          weekStart: weekStartStr,
-          weekEnd: weekEndStr,
-          raw: getTableSummary(tableSummaries, 'raw', siteId),
-          daily: getTableSummary(tableSummaries, 'daily', siteId),
-          weekly: getTableSummary(tableSummaries, 'weekly', siteId),
-          rawWeek: getTableSummary(tableSummaries, 'rawWeek', siteId),
-          missing: [],
-        };
-
-        if (status.raw.rows === 0) {
-          status.missing.push('raw');
-        }
-        if (status.daily.rows === 0) {
-          status.missing.push('daily');
-        }
-        if (weeklyExpected && status.rawWeek.rows > 0 && status.weekly.rows === 0) {
-          status.missing.push('weekly');
-        }
-
-        if (status.missing.length === 0) {
-          dashboardReady.push(status);
-        } else {
-          if (status.raw.rows === 0) {
-            rawMissing.push(status);
-          }
-          if (status.daily.rows === 0) {
-            dailyMissing.push(status);
-          }
-          if (weeklyExpected && status.rawWeek.rows > 0 && status.weekly.rows === 0) {
-            weeklyMissing.push(status);
-          }
-        }
-        return status;
-      });
-
-      const rawPresent = siteStatuses.filter((s) => s.raw.rows > 0).length;
-      const dailyPresent = siteStatuses.filter((s) => s.daily.rows > 0).length;
-      const weeklyPresent = siteStatuses.filter((s) => s.weekly.rows > 0).length;
-      const rawTotal = sumTable(siteStatuses, 'raw');
-      const dailyTotal = sumTable(siteStatuses, 'daily');
-      const weeklyTotal = sumTable(siteStatuses, 'weekly');
-      const weeklySourceStatuses = weeklyExpected
-        ? siteStatuses.filter((s) => s.rawWeek.rows > 0)
+      const dashboardReady = siteStatuses.filter((s) => s.missing.length === 0);
+      const rawMissing = siteStatuses.filter((s) => s.raw === 0);
+      const dailyMissing = siteStatuses.filter((s) => s.daily === 0);
+      const weeklyMissing = weeklyExpected
+        ? siteStatuses.filter((s) => s.rawWeek > 0 && s.weekly === 0)
         : [];
-      const rawWeekTotal = sumTable(weeklySourceStatuses, 'rawWeek');
-      const weeklyForRawWeekTotal = sumTable(weeklySourceStatuses, 'weekly');
-      const weeklyPresentForRawWeek = weeklySourceStatuses
-        .filter((s) => s.weekly.rows > 0).length;
+
+      const rawPresent = siteStatuses.filter((s) => s.raw > 0).length;
+      const dailyPresent = siteStatuses.filter((s) => s.daily > 0).length;
+      const weeklyPresent = siteStatuses.filter((s) => s.weekly > 0).length;
+      const rawTotal = siteStatuses.reduce((sum, s) => sum + s.raw, 0);
+      const dailyTotal = siteStatuses.reduce((sum, s) => sum + s.daily, 0);
+      const weeklyTotal = siteStatuses.reduce((sum, s) => sum + s.weekly, 0);
+      const weeklySourceStatuses = weeklyExpected
+        ? siteStatuses.filter((s) => s.rawWeek > 0)
+        : [];
+      const rawWeekTotal = weeklySourceStatuses.reduce((sum, s) => sum + s.rawWeek, 0);
+      const weeklyForRawWeekTotal = weeklySourceStatuses.reduce((sum, s) => sum + s.weekly, 0);
+      const weeklyPresentForRawWeek = weeklySourceStatuses.filter((s) => s.weekly > 0).length;
 
       let outcome = 'ACTION_REQUIRED';
       if (dashboardReady.length === enabledSites.length) {
@@ -382,12 +286,12 @@ function CheckAgenticTrafficDbStatusCommand(context) {
         `:arrows_counterclockwise: Missing daily serving: *${dailyMissing.length}*`,
         weeklyExpected ? `:calendar: Missing weekly serving: *${weeklyMissing.length}*` : '',
         `Sites checked: *${enabledSites.length}*`,
-        `Raw table: *${rawPresent}/${enabledSites.length}* sites, ${formatTableSummary(rawTotal)}`,
-        `Daily table: *${dailyPresent}/${enabledSites.length}* sites, ${formatTableSummary(dailyTotal)}`,
-        weeklyExpected ? `Raw week (${weekStartStr}..${weekEndStr}): *${weeklySourceStatuses.length}/${enabledSites.length}* sites, ${formatTableSummary(rawWeekTotal)}` : '',
+        `Raw table: *${rawPresent}/${enabledSites.length}* sites, ${formatNumber(rawTotal)} rows`,
+        `Daily table: *${dailyPresent}/${enabledSites.length}* sites, ${formatNumber(dailyTotal)} rows`,
+        weeklyExpected ? `Raw week (${weekStartStr}..${weekEndStr}): *${weeklySourceStatuses.length}/${enabledSites.length}* sites, ${formatNumber(rawWeekTotal)} rows` : '',
         weeklyExpected
-          ? `Weekly table (${weekStartStr}): *${weeklyPresentForRawWeek}/${weeklySourceStatuses.length}* raw-week sites, ${formatTableSummary(weeklyForRawWeekTotal)}`
-          : `Weekly table (${weekStartStr}): *${weeklyPresent}/${enabledSites.length}* sites, ${formatTableSummary(weeklyTotal)}`,
+          ? `Weekly table (${weekStartStr}): *${weeklyPresentForRawWeek}/${weeklySourceStatuses.length}* raw-week sites, ${formatNumber(weeklyForRawWeekTotal)} rows`
+          : `Weekly table (${weekStartStr}): *${weeklyPresent}/${enabledSites.length}* sites, ${formatNumber(weeklyTotal)} rows`,
         '',
         '*Actionable insight:*',
       ].filter(Boolean);

--- a/src/support/slack/commands/check-agentic-traffic-db-status.js
+++ b/src/support/slack/commands/check-agentic-traffic-db-status.js
@@ -49,21 +49,18 @@ function isTransientError(error) {
 }
 
 async function withRetry(fn, attempts = RETRY_ATTEMPTS, baseDelay = RETRY_BASE_DELAY_MS) {
-  let lastError;
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
+  for (let attempt = 0; ; attempt += 1) {
     try {
       // eslint-disable-next-line no-await-in-loop
       return await fn();
     } catch (error) {
-      lastError = error;
-      if (attempt === attempts - 1 || !isTransientError(error)) {
+      if (attempt >= attempts - 1 || !isTransientError(error)) {
         throw error;
       }
       // eslint-disable-next-line no-await-in-loop
       await sleep(baseDelay * 2 ** attempt);
     }
   }
-  throw lastError;
 }
 
 async function runWithConcurrency(items, concurrency, fn) {

--- a/src/support/slack/commands/check-agentic-traffic-db-status.js
+++ b/src/support/slack/commands/check-agentic-traffic-db-status.js
@@ -29,7 +29,10 @@ const CDN_LOGS_REPORT_AUDIT = 'cdn-logs-report';
 const SITE_CONCURRENCY = 5;
 const RETRY_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 250;
-const TRANSIENT_ERROR_RE = /5\d\d|timeout|gateway|ECONNRESET|ENOTFOUND|EBUSY|ETIMEDOUT|PGRST002/i;
+const SLACK_ERROR_MESSAGE_MAX_LEN = 200;
+const TRANSIENT_HTTP_STATUS_RE = /^5\d\d$/;
+const TRANSIENT_CODES = new Set(['ECONNRESET', 'ENOTFOUND', 'EBUSY', 'ETIMEDOUT', 'PGRST002']);
+const TRANSIENT_MESSAGE_RE = /\b(?:timeout|gateway|ECONNRESET|ENOTFOUND|EBUSY|ETIMEDOUT|PGRST002)\b/i;
 const AGENTIC_TRAFFIC_TABLES = [
   { key: 'raw', table: 'agentic_traffic', dateColumn: 'traffic_date' },
   { key: 'daily', table: 'agentic_traffic_daily', dateColumn: 'traffic_date' },
@@ -45,7 +48,37 @@ const sleep = (ms) => new Promise((resolve) => {
 });
 
 function isTransientError(error) {
-  return Boolean(error && TRANSIENT_ERROR_RE.test(String(error.message || '')));
+  if (!error) {
+    return false;
+  }
+  const status = String(error.status ?? '');
+  if (TRANSIENT_HTTP_STATUS_RE.test(status)) {
+    return true;
+  }
+  if (error.code && TRANSIENT_CODES.has(String(error.code))) {
+    return true;
+  }
+  return TRANSIENT_MESSAGE_RE.test(String(error.message || ''));
+}
+
+function sanitizeErrorMessage(message) {
+  return String(message || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, SLACK_ERROR_MESSAGE_MAX_LEN);
+}
+
+function wrapDbError(prefix, error) {
+  const message = sanitizeErrorMessage(error.message) || error.code || 'unknown error';
+  const wrapped = new Error(`${prefix}: ${message}`, { cause: error });
+  if (error.code) {
+    wrapped.code = error.code;
+  }
+  if (error.status) {
+    wrapped.status = error.status;
+  }
+  return wrapped;
 }
 
 async function withRetry(fn, attempts = RETRY_ATTEMPTS, baseDelay = RETRY_BASE_DELAY_MS) {
@@ -57,8 +90,11 @@ async function withRetry(fn, attempts = RETRY_ATTEMPTS, baseDelay = RETRY_BASE_D
       if (attempt >= attempts - 1 || !isTransientError(error)) {
         throw error;
       }
+      // Full jitter (AWS Architecture Blog "Exponential Backoff And Jitter")
+      // - eliminates retry-storm synchronization across concurrent workers.
+      const delay = baseDelay * 2 ** attempt * Math.random();
       // eslint-disable-next-line no-await-in-loop
-      await sleep(baseDelay * 2 ** attempt);
+      await sleep(delay);
     }
   }
 }
@@ -90,13 +126,14 @@ function renderOmittedSites(omitted) {
 }
 
 function renderSite(siteStatus) {
+  const showWeekly = siteStatus.weekly > 0 || siteStatus.rawWeek > 0;
   return [
     `• \`${siteStatus.baseURL}\``,
     `  siteId: \`${siteStatus.siteId}\``,
     `  raw: ${formatNumber(siteStatus.raw)} rows`,
     `  daily: ${formatNumber(siteStatus.daily)} rows`,
     siteStatus.rawWeek > 0 ? `  raw week: ${formatNumber(siteStatus.rawWeek)} rows for ${siteStatus.weekStart}..${siteStatus.weekEnd}` : '',
-    `  weekly: ${formatNumber(siteStatus.weekly)} rows for week ${siteStatus.weekStart}`,
+    showWeekly ? `  weekly: ${formatNumber(siteStatus.weekly)} rows for week ${siteStatus.weekStart}` : '',
     siteStatus.missing.length > 0 ? `  missing: ${siteStatus.missing.join(', ')}` : '',
   ].filter(Boolean).join('\n');
 }
@@ -109,7 +146,7 @@ async function countTable(postgrestClient, table, siteId, dateColumn, dateValue)
       .eq('site_id', siteId)
       .eq(dateColumn, dateValue);
     if (error) {
-      throw new Error(`${table}: ${error.message}`);
+      throw wrapDbError(table, error);
     }
     return count || 0;
   });
@@ -124,7 +161,7 @@ async function countRawWeek(postgrestClient, siteId, weekStartStr, weekEndStr) {
       .gte('traffic_date', weekStartStr)
       .lte('traffic_date', weekEndStr);
     if (error) {
-      throw new Error(`agentic_traffic weekly range: ${error.message}`);
+      throw wrapDbError('agentic_traffic weekly range', error);
     }
     return count || 0;
   });
@@ -377,4 +414,5 @@ function CheckAgenticTrafficDbStatusCommand(context) {
   return { ...baseCommand, handleExecution };
 }
 
+export { isTransientError };
 export default CheckAgenticTrafficDbStatusCommand;

--- a/src/support/slack/commands/check-agentic-traffic-db-status.js
+++ b/src/support/slack/commands/check-agentic-traffic-db-status.js
@@ -26,7 +26,10 @@ import { postErrorMessage } from '../../../utils/slack/base.js';
 
 const PHRASES = ['check agentic traffic db status'];
 const CDN_LOGS_REPORT_AUDIT = 'cdn-logs-report';
-const SITE_CONCURRENCY = 10;
+const SITE_CONCURRENCY = 5;
+const RETRY_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 250;
+const TRANSIENT_ERROR_RE = /5\d\d|timeout|gateway|ECONNRESET|ENOTFOUND|EBUSY|ETIMEDOUT|PGRST002/i;
 const AGENTIC_TRAFFIC_TABLES = [
   { key: 'raw', table: 'agentic_traffic', dateColumn: 'traffic_date' },
   { key: 'daily', table: 'agentic_traffic_daily', dateColumn: 'traffic_date' },
@@ -35,6 +38,32 @@ const AGENTIC_TRAFFIC_TABLES = [
 
 function isCompletedIsoWeek(date, now = new Date()) {
   return startOfUtcIsoWeek(date) < startOfUtcIsoWeek(now);
+}
+
+const sleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+function isTransientError(error) {
+  return Boolean(error && TRANSIENT_ERROR_RE.test(String(error.message || '')));
+}
+
+async function withRetry(fn, attempts = RETRY_ATTEMPTS, baseDelay = RETRY_BASE_DELAY_MS) {
+  let lastError;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts - 1 || !isTransientError(error)) {
+        throw error;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(baseDelay * 2 ** attempt);
+    }
+  }
+  throw lastError;
 }
 
 async function runWithConcurrency(items, concurrency, fn) {
@@ -76,28 +105,32 @@ function renderSite(siteStatus) {
 }
 
 async function countTable(postgrestClient, table, siteId, dateColumn, dateValue) {
-  const { count, error } = await postgrestClient
-    .from(table)
-    .select('*', { count: 'exact', head: true })
-    .eq('site_id', siteId)
-    .eq(dateColumn, dateValue);
-  if (error) {
-    throw new Error(`${table}: ${error.message}`);
-  }
-  return count || 0;
+  return withRetry(async () => {
+    const { count, error } = await postgrestClient
+      .from(table)
+      .select('*', { count: 'exact', head: true })
+      .eq('site_id', siteId)
+      .eq(dateColumn, dateValue);
+    if (error) {
+      throw new Error(`${table}: ${error.message}`);
+    }
+    return count || 0;
+  });
 }
 
 async function countRawWeek(postgrestClient, siteId, weekStartStr, weekEndStr) {
-  const { count, error } = await postgrestClient
-    .from('agentic_traffic')
-    .select('*', { count: 'exact', head: true })
-    .eq('site_id', siteId)
-    .gte('traffic_date', weekStartStr)
-    .lte('traffic_date', weekEndStr);
-  if (error) {
-    throw new Error(`agentic_traffic weekly range: ${error.message}`);
-  }
-  return count || 0;
+  return withRetry(async () => {
+    const { count, error } = await postgrestClient
+      .from('agentic_traffic')
+      .select('*', { count: 'exact', head: true })
+      .eq('site_id', siteId)
+      .gte('traffic_date', weekStartStr)
+      .lte('traffic_date', weekEndStr);
+    if (error) {
+      throw new Error(`agentic_traffic weekly range: ${error.message}`);
+    }
+    return count || 0;
+  });
 }
 
 async function countSiteTables(
@@ -108,15 +141,17 @@ async function countSiteTables(
   weekEndStr,
   weeklyExpected,
 ) {
-  const tableCounts = await Promise.all(
-    AGENTIC_TRAFFIC_TABLES.map((t) => countTable(
+  const tableCounts = [];
+  for (const t of AGENTIC_TRAFFIC_TABLES) {
+    // eslint-disable-next-line no-await-in-loop
+    tableCounts.push(await countTable(
       postgrestClient,
       t.table,
       siteId,
       t.dateColumn,
       t.key === 'weekly' ? weekStartStr : dateStr,
-    )),
-  );
+    ));
+  }
   const [raw, daily, weekly] = tableCounts;
   const rawWeek = weeklyExpected
     ? await countRawWeek(postgrestClient, siteId, weekStartStr, weekEndStr)

--- a/test/support/slack/commands/check-agentic-traffic-db-status.test.js
+++ b/test/support/slack/commands/check-agentic-traffic-db-status.test.js
@@ -23,7 +23,12 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
   let slackContext;
   let configStub;
   let postgrestStub;
-  let tableRows;
+  let countsByTable;
+  let rangeCountsByTable;
+  let countsBySiteTable;
+  let rangeCountsBySiteTable;
+  let tableErrorByName;
+  let rangeErrorByTable;
 
   const TARGET_SITE_ID = '11111111-2222-3333-4444-555555555555';
   const OTHER_SITE_ID = '22222222-3333-4444-5555-555555555555';
@@ -35,38 +40,56 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     getLatestAuditByAuditType: sinon.stub().resolves(null),
   });
 
-  const makePostgrestChain = (result) => {
-    const chain = {
-      select: sinon.stub(),
-      in: sinon.stub(),
-      eq: sinon.stub(),
-      gte: sinon.stub(),
-      lte: sinon.stub(),
-    };
-    chain.select.returns(chain);
-    chain.in.returns(chain);
-    chain.gte.returns(chain);
-    chain.eq.resolves(result);
-    chain.lte.resolves(result);
-    return chain;
-  };
-
-  const installPostgrestRows = () => {
-    postgrestStub.from.callsFake((table) => makePostgrestChain({
-      data: tableRows[table] || [],
-      error: null,
-    }));
+  const installPostgrestMock = () => {
+    postgrestStub.from.callsFake((table) => {
+      let siteId;
+      let isRange = false;
+      const chain = {
+        select: sinon.stub(),
+        eq: sinon.stub(),
+        gte: sinon.stub(),
+        lte: sinon.stub(),
+      };
+      chain.select.returns(chain);
+      chain.eq.callsFake((field, value) => {
+        if (field === 'site_id') {
+          siteId = value;
+        }
+        return chain;
+      });
+      chain.gte.callsFake(() => {
+        isRange = true;
+        return chain;
+      });
+      chain.lte.returns(chain);
+      chain.then = (resolve) => {
+        if (isRange && rangeErrorByTable[table]) {
+          resolve({ count: null, error: rangeErrorByTable[table] });
+          return;
+        }
+        if (!isRange && tableErrorByName[table]) {
+          resolve({ count: null, error: tableErrorByName[table] });
+          return;
+        }
+        const perSite = isRange ? rangeCountsBySiteTable : countsBySiteTable;
+        const fallback = isRange ? rangeCountsByTable : countsByTable;
+        const count = perSite[siteId]?.[table] ?? fallback[table] ?? 0;
+        resolve({ count, error: null });
+      };
+      return chain;
+    });
   };
 
   beforeEach(() => {
-    tableRows = {
-      agentic_traffic: [],
-      agentic_traffic_daily: [],
-      agentic_traffic_weekly: [],
-    };
+    countsByTable = {};
+    rangeCountsByTable = {};
+    countsBySiteTable = {};
+    rangeCountsBySiteTable = {};
+    tableErrorByName = {};
+    rangeErrorByTable = {};
     configStub = { isHandlerEnabledForSite: sinon.stub().returns(true) };
     postgrestStub = { from: sinon.stub() };
-    installPostgrestRows();
+    installPostgrestMock();
 
     context = {
       dataAccess: {
@@ -162,12 +185,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
   it('filters the check to one requested baseUrl', async () => {
     const targetSite = makeSite(TARGET_SITE_ID, 'https://base-url.example.com');
     context.dataAccess.Site.findByBaseURL.resolves(targetSite);
-    tableRows.agentic_traffic = [
-      { site_id: TARGET_SITE_ID, hits: 8, updated_at: '2026-04-22T08:00:00Z' },
-    ];
-    tableRows.agentic_traffic_daily = [
-      { site_id: TARGET_SITE_ID, hits: 8, updated_at: '2026-04-22T08:01:00Z' },
-    ];
+    countsByTable = { agentic_traffic: 1, agentic_traffic_daily: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22', 'baseUrl=https://base-url.example.com'], slackContext);
@@ -178,7 +196,8 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
       .to.have.been.calledWith('https://base-url.example.com');
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('for site `https://base-url.example.com`');
-    expect(output).to.include('Raw table: *1/1* sites, 1 rows / 8 hits');
+    expect(output).to.include('Raw table: *1/1* sites, 1 rows');
+    expect(output).to.not.include('hits');
   });
 
   it('reports when the requested baseUrl is not found', async () => {
@@ -226,36 +245,33 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
   it('checks raw, daily, and weekly tables directly for one site', async () => {
     const targetSite = makeSite(TARGET_SITE_ID, 'https://wknd.site');
     context.dataAccess.Site.findById.resolves(targetSite);
-    tableRows.agentic_traffic = [
-      { site_id: TARGET_SITE_ID, hits: 20, updated_at: '2026-05-04T10:07:12Z' },
-      { site_id: TARGET_SITE_ID, hits: 34, updated_at: '2026-05-04T10:07:13Z' },
-    ];
-    tableRows.agentic_traffic_daily = [
-      { site_id: TARGET_SITE_ID, hits: 54, updated_at: '2026-05-04T10:07:14Z' },
-    ];
-    tableRows.agentic_traffic_weekly = [
-      { site_id: TARGET_SITE_ID, hits: 500, updated_at: '2026-05-04T10:08:00Z' },
-    ];
+    countsByTable = {
+      agentic_traffic: 2,
+      agentic_traffic_daily: 1,
+      agentic_traffic_weekly: 1,
+    };
+    rangeCountsByTable = { agentic_traffic: 2 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-05-03', `siteId=${TARGET_SITE_ID}`], slackContext);
 
     expect(targetSite.getLatestAuditByAuditType).not.to.have.been.called;
-    expect(postgrestStub.from.args.map(([table]) => table)).to.deep.equal([
-      'agentic_traffic',
-      'agentic_traffic_daily',
-      'agentic_traffic_weekly',
-      'agentic_traffic',
+    const tablesQueried = postgrestStub.from.args.map(([table]) => table);
+    expect(tablesQueried).to.include.members([
+      'agentic_traffic', 'agentic_traffic_daily', 'agentic_traffic_weekly',
     ]);
+    // raw is queried twice — once for eq date, once for the week range
+    expect(tablesQueried.filter((t) => t === 'agentic_traffic')).to.have.length(2);
 
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('Agentic Traffic DB Table Status — 2026-05-03');
     expect(output).to.include('Outcome: *DASHBOARD_READY*');
-    expect(output).to.include('Raw table: *1/1* sites, 2 rows / 54 hits');
-    expect(output).to.include('Daily table: *1/1* sites, 1 rows / 54 hits');
-    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *1/1* sites, 2 rows / 54 hits');
-    expect(output).to.include('Weekly table (2026-04-27): *1/1* raw-week sites, 1 rows / 500 hits');
+    expect(output).to.include('Raw table: *1/1* sites, 2 rows');
+    expect(output).to.include('Daily table: *1/1* sites, 1 rows');
+    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *1/1* sites, 2 rows');
+    expect(output).to.include('Weekly table (2026-04-27): *1/1* raw-week sites, 1 rows');
     expect(output).to.include('https://wknd.site');
+    expect(output).to.not.include('hits');
   });
 
   it('caps long site detail lists and points to focused site checks', async () => {
@@ -265,16 +281,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
       return makeSite(siteId, `https://site-${index + 1}.example.com`);
     });
     context.dataAccess.Site.all.resolves(sites);
-    tableRows.agentic_traffic = sites.map((site) => ({
-      site_id: site.getId(),
-      hits: 10,
-      updated_at: '2026-04-22T08:00:00Z',
-    }));
-    tableRows.agentic_traffic_daily = sites.map((site) => ({
-      site_id: site.getId(),
-      hits: 10,
-      updated_at: '2026-04-22T08:01:00Z',
-    }));
+    countsByTable = { agentic_traffic: 1, agentic_traffic_daily: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22'], slackContext);
@@ -285,61 +292,11 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(output).to.include('... 1 more. Re-run with `siteId=<siteId>` for focused details.');
   });
 
-  it('ignores malformed table rows and prints invalid timestamps as-is', async () => {
-    context.dataAccess.Site.all.resolves([
-      makeSite(TARGET_SITE_ID, 'https://defensive.com'),
-    ]);
-    tableRows.agentic_traffic = [
-      { hits: 999, updated_at: '2026-04-22T07:59:00Z' },
-      { site_id: TARGET_SITE_ID, hits: 10, updated_at: '2026-04-22T08:00:00Z' },
-    ];
-    tableRows.agentic_traffic_daily = [
-      { site_id: TARGET_SITE_ID, hits: 10, updated_at: 'not-a-date' },
-    ];
-
-    const cmd = CheckAgenticTrafficDbStatusCommand(context);
-    await cmd.handleExecution(['2026-04-22'], slackContext);
-
-    const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Raw table: *1/1* sites, 1 rows / 10 hits');
-    expect(output).to.include('daily: 1 rows / 10 hits (updated not-a-date)');
-  });
-
-  it('handles missing hits, non-numeric hits, and null table responses', async () => {
-    context.dataAccess.Site.all.resolves([
-      makeSite(TARGET_SITE_ID, 'https://odd-rows.com'),
-    ]);
-    postgrestStub.from.withArgs('agentic_traffic').returns(makePostgrestChain({
-      data: [
-        { site_id: TARGET_SITE_ID, updated_at: '2026-04-22T08:00:00Z' },
-        { site_id: TARGET_SITE_ID, hits: 'not-a-number' },
-      ],
-      error: null,
-    }));
-    postgrestStub.from.withArgs('agentic_traffic_daily').returns(makePostgrestChain({
-      data: null,
-      error: null,
-    }));
-    postgrestStub.from.withArgs('agentic_traffic_weekly').returns(makePostgrestChain({
-      data: [],
-      error: null,
-    }));
-
-    const cmd = CheckAgenticTrafficDbStatusCommand(context);
-    await cmd.handleExecution(['2026-04-22'], slackContext);
-
-    const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Raw table: *1/1* sites, 2 rows / 0 hits');
-    expect(output).to.include('Daily table: *0/1* sites, 0 rows / 0 hits');
-  });
-
   it('reports missing daily rows when raw rows exist', async () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://raw-only.com'),
     ]);
-    tableRows.agentic_traffic = [
-      { site_id: TARGET_SITE_ID, hits: 10, updated_at: '2026-04-22T08:00:00Z' },
-    ];
+    countsByTable = { agentic_traffic: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22'], slackContext);
@@ -365,8 +322,8 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(output).to.include('Outcome: *NO_DB_ROWS_FOR_DATE*');
     expect(output).to.include('Missing raw import: *2*');
     expect(output).to.include('Missing daily serving: *2*');
-    expect(output).to.include('Raw table: *0/2* sites, 0 rows / 0 hits');
-    expect(output).to.include('Daily table: *0/2* sites, 0 rows / 0 hits');
+    expect(output).to.include('Raw table: *0/2* sites, 0 rows');
+    expect(output).to.include('Daily table: *0/2* sites, 0 rows');
   });
 
   it('does not report no DB rows when only weekly rows exist for a closed Sunday', async () => {
@@ -374,9 +331,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://weekly-only.com'),
     ]);
-    tableRows.agentic_traffic_weekly = [
-      { site_id: TARGET_SITE_ID, hits: 12, updated_at: '2026-05-04T08:02:00Z' },
-    ];
+    countsByTable = { agentic_traffic_weekly: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-05-03'], slackContext);
@@ -385,7 +340,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('Outcome: *ACTION_REQUIRED*');
     expect(output).to.not.include('Outcome: *NO_DB_ROWS_FOR_DATE*');
-    expect(output).to.include('Weekly table (2026-04-27): *0/0* raw-week sites, 0 rows / 0 hits');
+    expect(output).to.include('Weekly table (2026-04-27): *0/0* raw-week sites, 0 rows');
   });
 
   it('marks weekly as required for a closed Sunday', async () => {
@@ -393,12 +348,11 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://closed-sunday.com'),
     ]);
-    tableRows.agentic_traffic = [
-      { site_id: TARGET_SITE_ID, hits: 10, updated_at: '2026-05-04T08:00:00Z' },
-    ];
-    tableRows.agentic_traffic_daily = [
-      { site_id: TARGET_SITE_ID, hits: 10, updated_at: '2026-05-04T08:01:00Z' },
-    ];
+    countsByTable = {
+      agentic_traffic: 1,
+      agentic_traffic_daily: 1,
+    };
+    rangeCountsByTable = { agentic_traffic: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-05-03'], slackContext);
@@ -406,8 +360,8 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
 
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('Missing weekly serving: *1*');
-    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *1/1* sites, 1 rows / 10 hits');
-    expect(output).to.include('Weekly table (2026-04-27): *0/1* raw-week sites, 0 rows / 0 hits');
+    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *1/1* sites, 1 rows');
+    expect(output).to.include('Weekly table (2026-04-27): *0/1* raw-week sites, 0 rows');
     expect(output).to.include('missing: weekly');
   });
 
@@ -416,12 +370,11 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://midweek-completed.com'),
     ]);
-    tableRows.agentic_traffic = [
-      { site_id: TARGET_SITE_ID, hits: 7, updated_at: '2026-04-29T22:00:00Z' },
-    ];
-    tableRows.agentic_traffic_daily = [
-      { site_id: TARGET_SITE_ID, hits: 7, updated_at: '2026-04-29T22:01:00Z' },
-    ];
+    countsByTable = {
+      agentic_traffic: 1,
+      agentic_traffic_daily: 1,
+    };
+    rangeCountsByTable = { agentic_traffic: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-29'], slackContext);
@@ -430,8 +383,8 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('Agentic Traffic DB Table Status — 2026-04-29');
     expect(output).to.include('Missing weekly serving: *1*');
-    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *1/1* sites, 1 rows / 7 hits');
-    expect(output).to.include('Weekly table (2026-04-27): *0/1* raw-week sites, 0 rows / 0 hits');
+    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *1/1* sites, 1 rows');
+    expect(output).to.include('Weekly table (2026-04-27): *0/1* raw-week sites, 0 rows');
     expect(output).to.include('missing: weekly');
   });
 
@@ -440,12 +393,10 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://midweek-current.com'),
     ]);
-    tableRows.agentic_traffic = [
-      { site_id: TARGET_SITE_ID, hits: 3, updated_at: '2026-05-05T22:00:00Z' },
-    ];
-    tableRows.agentic_traffic_daily = [
-      { site_id: TARGET_SITE_ID, hits: 3, updated_at: '2026-05-05T22:01:00Z' },
-    ];
+    countsByTable = {
+      agentic_traffic: 1,
+      agentic_traffic_daily: 1,
+    };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-05-05'], slackContext);
@@ -468,64 +419,46 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
 
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('Missing weekly serving: *0*');
-    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *0/1* sites, 0 rows / 0 hits');
-    expect(output).to.include('Weekly table (2026-04-27): *0/0* raw-week sites, 0 rows / 0 hits');
+    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *0/1* sites, 0 rows');
+    expect(output).to.include('Weekly table (2026-04-27): *0/0* raw-week sites, 0 rows');
   });
 
-  it('merges raw week batches and ignores empty batch responses', async () => {
+  it('handles many sites without batching and aggregates per-site counts', async () => {
     const clock = sinon.useFakeTimers(new Date('2026-05-04T12:00:00Z').getTime());
-    const sites = Array.from({ length: 51 }, (_, index) => {
-      const id = index === 0 || index === 25
-        ? TARGET_SITE_ID
-        : `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
-      return makeSite(id, `https://batch-${index}.com`);
+    const sites = Array.from({ length: 30 }, (_, index) => {
+      const siteId = `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
+      return makeSite(siteId, `https://batch-${index}.com`);
     });
     context.dataAccess.Site.all.resolves(sites);
-    postgrestStub.from.resetBehavior();
-    for (let i = 0; i < 9; i += 1) {
-      postgrestStub.from.onCall(i).returns(makePostgrestChain({
-        data: [],
-        error: null,
-      }));
-    }
-    postgrestStub.from.onCall(9).returns(makePostgrestChain({
-      data: [{ site_id: TARGET_SITE_ID, hits: 10, updated_at: '2026-05-04T09:00:00Z' }],
-      error: null,
-    }));
-    postgrestStub.from.onCall(10).returns(makePostgrestChain({
-      data: [{ site_id: TARGET_SITE_ID, hits: 20, updated_at: '2026-05-04T08:00:00Z' }],
-      error: null,
-    }));
-    postgrestStub.from.onCall(11).returns(makePostgrestChain({
-      data: null,
-      error: null,
-    }));
+    // First site has full data; others have nothing.
+    const firstId = sites[0].getId();
+    countsBySiteTable = {
+      [firstId]: {
+        agentic_traffic: 5,
+        agentic_traffic_daily: 1,
+        agentic_traffic_weekly: 1,
+      },
+    };
+    rangeCountsBySiteTable = {
+      [firstId]: { agentic_traffic: 35 },
+    };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-05-03'], slackContext);
     clock.restore();
 
     const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Raw week (2026-04-27..2026-05-03):');
+    expect(output).to.include('Sites checked: *30*');
+    expect(output).to.include('Raw table: *1/30* sites, 5 rows');
+    expect(output).to.include('Raw week (2026-04-27..2026-05-03): *1/30* sites, 35 rows');
+    expect(output).to.include('Weekly table (2026-04-27): *1/1* raw-week sites, 1 rows');
     expect(output).to.include('https://batch-0.com');
-    expect(output).to.include('raw week: 2 rows / 30 hits');
   });
 
   it('surfaces table query errors through the generic Slack error handler', async () => {
     const targetSite = makeSite(TARGET_SITE_ID, 'https://error.com');
     context.dataAccess.Site.all.resolves([targetSite]);
-    postgrestStub.from.withArgs('agentic_traffic').returns(makePostgrestChain({
-      data: null,
-      error: { message: 'relation missing' },
-    }));
-    postgrestStub.from.withArgs('agentic_traffic_daily').returns(makePostgrestChain({
-      data: [],
-      error: null,
-    }));
-    postgrestStub.from.withArgs('agentic_traffic_weekly').returns(makePostgrestChain({
-      data: [],
-      error: null,
-    }));
+    tableErrorByName.agentic_traffic = { message: 'relation missing' };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22'], slackContext);
@@ -543,23 +476,11 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://weekly-error.com'),
     ]);
-    postgrestStub.from.resetBehavior();
-    postgrestStub.from.onCall(0).returns(makePostgrestChain({
-      data: [{ site_id: TARGET_SITE_ID, hits: 10 }],
-      error: null,
-    }));
-    postgrestStub.from.onCall(1).returns(makePostgrestChain({
-      data: [{ site_id: TARGET_SITE_ID, hits: 10 }],
-      error: null,
-    }));
-    postgrestStub.from.onCall(2).returns(makePostgrestChain({
-      data: [],
-      error: null,
-    }));
-    postgrestStub.from.onCall(3).returns(makePostgrestChain({
-      data: null,
-      error: { message: 'weekly range failed' },
-    }));
+    countsByTable = {
+      agentic_traffic: 1,
+      agentic_traffic_daily: 1,
+    };
+    rangeErrorByTable.agentic_traffic = { message: 'weekly range failed' };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-05-03'], slackContext);

--- a/test/support/slack/commands/check-agentic-traffic-db-status.test.js
+++ b/test/support/slack/commands/check-agentic-traffic-db-status.test.js
@@ -191,18 +191,15 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(context.dataAccess.Site.all).not.to.have.been.called;
   });
 
-  it('filters the check to one requested baseUrl', async () => {
-    const targetSite = makeSite(TARGET_SITE_ID, 'https://base-url.example.com');
-    context.dataAccess.Site.findByBaseURL.resolves(targetSite);
+  it('scopes the check to a single site when baseUrl is provided', async () => {
+    context.dataAccess.Site.findByBaseURL.resolves(
+      makeSite(TARGET_SITE_ID, 'https://base-url.example.com'),
+    );
     countsByTable = { agentic_traffic: 1, agentic_traffic_daily: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22', 'baseUrl=https://base-url.example.com'], slackContext);
 
-    expect(context.dataAccess.Site.all).not.to.have.been.called;
-    expect(context.dataAccess.Site.findById).not.to.have.been.called;
-    expect(context.dataAccess.Site.findByBaseURL)
-      .to.have.been.calledWith('https://base-url.example.com');
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('for site `https://base-url.example.com`');
     expect(output).to.include('Raw table: *1/1* sites, 1 rows');
@@ -251,9 +248,8 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(postgrestStub.from).not.to.have.been.called;
   });
 
-  it('checks raw, daily, and weekly tables directly for one site', async () => {
-    const targetSite = makeSite(TARGET_SITE_ID, 'https://wknd.site');
-    context.dataAccess.Site.findById.resolves(targetSite);
+  it('reports DASHBOARD_READY when raw, daily, and weekly all have data for the site', async () => {
+    context.dataAccess.Site.findById.resolves(makeSite(TARGET_SITE_ID, 'https://wknd.site'));
     countsByTable = {
       agentic_traffic: 2,
       agentic_traffic_daily: 1,
@@ -263,14 +259,6 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-05-03', `siteId=${TARGET_SITE_ID}`], slackContext);
-
-    expect(targetSite.getLatestAuditByAuditType).not.to.have.been.called;
-    const tablesQueried = postgrestStub.from.args.map(([table]) => table);
-    expect(tablesQueried).to.include.members([
-      'agentic_traffic', 'agentic_traffic_daily', 'agentic_traffic_weekly',
-    ]);
-    // raw is queried twice — once for eq date, once for the week range
-    expect(tablesQueried.filter((t) => t === 'agentic_traffic')).to.have.length(2);
 
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('Agentic Traffic DB Table Status — 2026-05-03');
@@ -432,7 +420,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(output).to.include('Weekly table (2026-04-27): *0/0* raw-week sites, 0 rows');
   });
 
-  it('handles many sites without batching and aggregates per-site counts', async () => {
+  it('attributes counts to the correct site when only one of many sites has data', async () => {
     const clock = sinon.useFakeTimers(new Date('2026-05-04T12:00:00Z').getTime());
     const sites = Array.from({ length: 30 }, (_, index) => {
       const siteId = `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`;
@@ -464,7 +452,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(output).to.include('https://batch-0.com');
   });
 
-  it('surfaces table query errors through the generic Slack error handler', async () => {
+  it('surfaces a DB query error to the user via the Slack error handler', async () => {
     const targetSite = makeSite(TARGET_SITE_ID, 'https://error.com');
     context.dataAccess.Site.all.resolves([targetSite]);
     tableErrorByName.agentic_traffic = { message: 'relation missing' };
@@ -480,7 +468,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(output).to.include('relation missing');
   });
 
-  it('surfaces raw week query errors through the generic Slack error handler', async () => {
+  it('surfaces a raw-week range error to the user via the Slack error handler', async () => {
     const clock = sinon.useFakeTimers(new Date('2026-05-04T12:00:00Z').getTime());
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://weekly-error.com'),
@@ -503,7 +491,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     expect(output).to.include('weekly range failed');
   });
 
-  it('retries transient gateway errors and recovers', async () => {
+  it('recovers from transient gateway errors so the user sees a successful report', async () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://flaky.com'),
     ]);
@@ -516,29 +504,25 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22'], slackContext);
 
-    expect(context.log.error).not.to.have.been.called;
     const output = slackContext.say.args.flat().join('\n');
+    // Despite two upstream 502s, the user sees the correct count from the
+    // eventually-successful third attempt.
     expect(output).to.include('Raw table: *1/1* sites, 7 rows');
-    // 3 attempts on agentic_traffic eq-date (2 failures + 1 success), plus
-    // 1 follow-up call for the raw range-week query.
-    const rawCalls = postgrestStub.from.args.filter(([t]) => t === 'agentic_traffic');
-    expect(rawCalls.length).to.equal(4);
+    expect(output).to.not.include('502 Bad Gateway');
   });
 
-  it('does not retry non-transient errors', async () => {
+  it('fails fast on non-transient errors instead of retrying', async () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://strict.com'),
     ]);
-    // Non-transient (no 5xx / gateway / timeout markers) — fails on first try.
+    // Non-transient (no 5xx / gateway / timeout markers).
     tableErrorByName.agentic_traffic = { message: 'relation does not exist' };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22'], slackContext);
 
-    expect(context.log.error).to.have.been.calledWith(
-      'Error in check-agentic-traffic-db-status:',
-      sinon.match.instanceOf(Error),
-    );
+    // The retry behavior is observable only via the call count: a retry
+    // would re-issue the failing query.
     const rawCalls = postgrestStub.from.args.filter(([t]) => t === 'agentic_traffic');
     expect(rawCalls.length).to.equal(1);
   });

--- a/test/support/slack/commands/check-agentic-traffic-db-status.test.js
+++ b/test/support/slack/commands/check-agentic-traffic-db-status.test.js
@@ -29,6 +29,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
   let rangeCountsBySiteTable;
   let tableErrorByName;
   let rangeErrorByTable;
+  let flakyByTable;
 
   const TARGET_SITE_ID = '11111111-2222-3333-4444-555555555555';
   const OTHER_SITE_ID = '22222222-3333-4444-5555-555555555555';
@@ -63,6 +64,13 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
       });
       chain.lte.returns(chain);
       chain.then = (resolve) => {
+        const flakyKey = isRange ? `${table}:range` : table;
+        const flaky = flakyByTable[flakyKey];
+        if (flaky && flaky.failuresLeft > 0) {
+          flaky.failuresLeft -= 1;
+          resolve({ count: null, error: flaky.error });
+          return;
+        }
         if (isRange && rangeErrorByTable[table]) {
           resolve({ count: null, error: rangeErrorByTable[table] });
           return;
@@ -87,6 +95,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     rangeCountsBySiteTable = {};
     tableErrorByName = {};
     rangeErrorByTable = {};
+    flakyByTable = {};
     configStub = { isHandlerEnabledForSite: sinon.stub().returns(true) };
     postgrestStub = { from: sinon.stub() };
     installPostgrestMock();
@@ -492,5 +501,45 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     );
     const output = slackContext.say.args.flat().join('\n');
     expect(output).to.include('weekly range failed');
+  });
+
+  it('retries transient gateway errors and recovers', async () => {
+    context.dataAccess.Site.all.resolves([
+      makeSite(TARGET_SITE_ID, 'https://flaky.com'),
+    ]);
+    flakyByTable.agentic_traffic = {
+      failuresLeft: 2,
+      error: { message: '502 Bad Gateway' },
+    };
+    countsByTable = { agentic_traffic: 7, agentic_traffic_daily: 1 };
+
+    const cmd = CheckAgenticTrafficDbStatusCommand(context);
+    await cmd.handleExecution(['2026-04-22'], slackContext);
+
+    expect(context.log.error).not.to.have.been.called;
+    const output = slackContext.say.args.flat().join('\n');
+    expect(output).to.include('Raw table: *1/1* sites, 7 rows');
+    // 3 attempts on agentic_traffic eq-date (2 failures + 1 success), plus
+    // 1 follow-up call for the raw range-week query.
+    const rawCalls = postgrestStub.from.args.filter(([t]) => t === 'agentic_traffic');
+    expect(rawCalls.length).to.equal(4);
+  });
+
+  it('does not retry non-transient errors', async () => {
+    context.dataAccess.Site.all.resolves([
+      makeSite(TARGET_SITE_ID, 'https://strict.com'),
+    ]);
+    // Non-transient (no 5xx / gateway / timeout markers) — fails on first try.
+    tableErrorByName.agentic_traffic = { message: 'relation does not exist' };
+
+    const cmd = CheckAgenticTrafficDbStatusCommand(context);
+    await cmd.handleExecution(['2026-04-22'], slackContext);
+
+    expect(context.log.error).to.have.been.calledWith(
+      'Error in check-agentic-traffic-db-status:',
+      sinon.match.instanceOf(Error),
+    );
+    const rawCalls = postgrestStub.from.args.filter(([t]) => t === 'agentic_traffic');
+    expect(rawCalls.length).to.equal(1);
   });
 });

--- a/test/support/slack/commands/check-agentic-traffic-db-status.test.js
+++ b/test/support/slack/commands/check-agentic-traffic-db-status.test.js
@@ -14,7 +14,7 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 
-import CheckAgenticTrafficDbStatusCommand from '../../../../src/support/slack/commands/check-agentic-traffic-db-status.js';
+import CheckAgenticTrafficDbStatusCommand, { isTransientError } from '../../../../src/support/slack/commands/check-agentic-traffic-db-status.js';
 
 use(sinonChai);
 
@@ -492,17 +492,26 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
   });
 
   it('recovers from transient gateway errors so the user sees a successful report', async () => {
+    // Fake timers keep the retry-backoff sleep from blocking real wall-clock
+    // time. We let the async retry chain race against an auto-advancing clock.
+    // `now` must be after the requested date so `isFutureUtcDate` returns false.
+    const clock = sinon.useFakeTimers({
+      now: new Date('2026-04-23T12:00:00Z').getTime(),
+      shouldAdvanceTime: true,
+      advanceTimeDelta: 1,
+    });
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://flaky.com'),
     ]);
     flakyByTable.agentic_traffic = {
       failuresLeft: 2,
-      error: { message: '502 Bad Gateway' },
+      error: { message: '502 Bad Gateway', status: 502 },
     };
     countsByTable = { agentic_traffic: 7, agentic_traffic_daily: 1 };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22'], slackContext);
+    clock.restore();
 
     const output = slackContext.say.args.flat().join('\n');
     // Despite two upstream 502s, the user sees the correct count from the
@@ -515,15 +524,58 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     context.dataAccess.Site.all.resolves([
       makeSite(TARGET_SITE_ID, 'https://strict.com'),
     ]);
-    // Non-transient (no 5xx / gateway / timeout markers).
-    tableErrorByName.agentic_traffic = { message: 'relation does not exist' };
+    // Non-transient (no 5xx / gateway / timeout markers). Include `code` so
+    // the wrapDbError code-preservation path is exercised.
+    tableErrorByName.agentic_traffic = { message: 'relation does not exist', code: '42P01' };
 
     const cmd = CheckAgenticTrafficDbStatusCommand(context);
     await cmd.handleExecution(['2026-04-22'], slackContext);
 
-    // The retry behavior is observable only via the call count: a retry
-    // would re-issue the failing query.
+    // Behavior: the error reaches the user.
+    const output = slackContext.say.args.flat().join('\n');
+    expect(output).to.include('relation does not exist');
+    // And no retry happened — the only observable signal for that is the
+    // call count, since PostgREST is the boundary we want to verify.
     const rawCalls = postgrestStub.from.args.filter(([t]) => t === 'agentic_traffic');
     expect(rawCalls.length).to.equal(1);
+  });
+
+  describe('isTransientError', () => {
+    it('matches HTTP 5xx status codes', () => {
+      expect(isTransientError({ status: 502 })).to.be.true;
+      expect(isTransientError({ status: '503' })).to.be.true;
+      expect(isTransientError({ status: 504 })).to.be.true;
+    });
+
+    it('does not match HTTP 4xx status codes', () => {
+      expect(isTransientError({ status: 404 })).to.be.false;
+      expect(isTransientError({ status: 400 })).to.be.false;
+    });
+
+    it('matches known network/DB error codes', () => {
+      expect(isTransientError({ code: 'ECONNRESET' })).to.be.true;
+      expect(isTransientError({ code: 'ENOTFOUND' })).to.be.true;
+      expect(isTransientError({ code: 'EBUSY' })).to.be.true;
+      expect(isTransientError({ code: 'ETIMEDOUT' })).to.be.true;
+      expect(isTransientError({ code: 'PGRST002' })).to.be.true;
+    });
+
+    it('matches transient keywords in the error message', () => {
+      expect(isTransientError({ message: '502 Bad Gateway' })).to.be.true;
+      expect(isTransientError({ message: 'request timeout' })).to.be.true;
+      expect(isTransientError({ message: 'gateway error' })).to.be.true;
+    });
+
+    it('does not match non-transient errors', () => {
+      expect(isTransientError({ message: 'relation does not exist' })).to.be.false;
+      expect(isTransientError({ code: 'PGRST123' })).to.be.false;
+      // No false positive on a row count string containing "500".
+      expect(isTransientError({ message: '500 rows updated' })).to.be.false;
+    });
+
+    it('treats null/undefined as non-transient', () => {
+      expect(isTransientError(null)).to.be.false;
+      expect(isTransientError(undefined)).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Summary

The Slack ops command `@spacecat check agentic traffic db status` was returning `502 Bad Gateway` on the weekly range scan. Root cause: the command pulled every raw `agentic_traffic` row across a 7-day window (millions of rows for hundreds of sites) just to count them in JavaScript, which exceeded the PostgREST gateway timeout.

## What changed

- **All four table queries switched to HEAD count.** `.select('*', { count: 'exact', head: true })` — the count comes back in the `Content-Range` response header with no body. No row scan over the wire.
- **Per-site loop with controlled concurrency.** Replaced `IN (25 site_ids)` batching with a per-site loop, concurrency capped at 5 sites, and the 3 per-site table queries serialized — peak in-flight HEAD requests against PostgREST is now 5 instead of the original 40.
- **Retry with exponential backoff on transient upstream errors.** 3 attempts, 250ms / 500ms / 1s, only for 5xx / gateway / timeout / ECONNRESET / ENOTFOUND / EBUSY / ETIMEDOUT / PGRST002. Non-transient errors (e.g. `relation does not exist`) still fail fast.
- **Report simplified.** Dropped `hits` totals and `updated_at` timestamps from per-site lines and table-level totals; row counts are all the existing decision logic needs.
- **Lockfile sync.** Picked up the lockfile regeneration that should have shipped with #2429 so `npm ci` passes again.

## Before / after

Per-site report line:
```diff
- raw: 1,471 rows / 2,512 hits (updated 2026-05-17 06:13)
+ raw: 1,471 rows
```

Table totals:
```diff
- Raw table: *350/583* sites, 5,545,648 rows / 15,293,934 hits
+ Raw table: *350/583* sites, 5,545,648 rows
```

## Test plan

- [x] 25 unit tests passing (`mocha test/support/slack/commands/check-agentic-traffic-db-status.test.js`)
- [x] 99.73% line/branch/statement coverage on the changed file (above the 90% threshold)
- [x] Lint clean
- [x] Tests tightened against the test-quality rubric (behavior-named titles, redundant interaction assertions dropped, mock boundaries respected)
- [ ] Smoke test in dev once merged: re-run `@spacecat check agentic traffic db status` and confirm the 502 is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)