### PR TITLE
chore(renovate): pin worker to Node 24 so lockfile updates apply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,31 +10,31 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
-        "@adobe/helix-shared-body-data": "2.2.4",
-        "@adobe/helix-shared-bounce": "2.0.30",
+        "@adobe/helix-shared-body-data": "2.2.5",
+        "@adobe/helix-shared-bounce": "2.0.31",
         "@adobe/helix-shared-utils": "3.0.2",
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.29",
-        "@adobe/mysticat-shared-seo-client": "1.3.0",
+        "@adobe/mysticat-shared-seo-client": "1.3.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
-        "@adobe/spacecat-shared-athena-client": "1.9.11",
-        "@adobe/spacecat-shared-brand-client": "1.1.41",
-        "@adobe/spacecat-shared-content-client": "1.8.23",
-        "@adobe/spacecat-shared-data-access": "3.63.0",
+        "@adobe/spacecat-shared-athena-client": "1.9.12",
+        "@adobe/spacecat-shared-brand-client": "1.1.42",
+        "@adobe/spacecat-shared-content-client": "1.8.24",
+        "@adobe/spacecat-shared-data-access": "3.65.0",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
-        "@adobe/spacecat-shared-drs-client": "1.7.1",
-        "@adobe/spacecat-shared-gpt-client": "1.6.22",
-        "@adobe/spacecat-shared-http-utils": "1.27.1",
-        "@adobe/spacecat-shared-ims-client": "1.12.6",
+        "@adobe/spacecat-shared-drs-client": "1.7.2",
+        "@adobe/spacecat-shared-gpt-client": "1.6.23",
+        "@adobe/spacecat-shared-http-utils": "1.27.2",
+        "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "^1.1.0",
-        "@adobe/spacecat-shared-rum-api-client": "2.40.12",
-        "@adobe/spacecat-shared-scrape-client": "2.6.2",
-        "@adobe/spacecat-shared-slack-client": "1.6.6",
-        "@adobe/spacecat-shared-tier-client": "1.5.0",
-        "@adobe/spacecat-shared-tokowaka-client": "1.16.1",
+        "@adobe/spacecat-shared-rum-api-client": "2.40.13",
+        "@adobe/spacecat-shared-scrape-client": "2.6.3",
+        "@adobe/spacecat-shared-slack-client": "1.6.7",
+        "@adobe/spacecat-shared-tier-client": "1.5.1",
+        "@adobe/spacecat-shared-tokowaka-client": "1.16.2",
         "@adobe/spacecat-shared-utils": "1.115.4",
-        "@adobe/spacecat-shared-vault-secrets": "1.3.4",
+        "@adobe/spacecat-shared-vault-secrets": "1.3.5",
         "@aws-sdk/client-s3": "3.1045.0",
         "@aws-sdk/client-secrets-manager": "3.1045.0",
         "@aws-sdk/client-sfn": "3.1045.0",
@@ -68,8 +68,8 @@
         "zod": "3.25.76"
       },
       "devDependencies": {
-        "@adobe/eslint-config-helix": "3.0.26",
-        "@adobe/helix-deploy": "14.0.5",
+        "@adobe/eslint-config-helix": "3.0.27",
+        "@adobe/helix-deploy": "14.0.6",
         "@adobe/helix-universal": "5.4.1",
         "@adobe/helix-universal-devserver": "1.1.147",
         "@adobe/semantic-release-coralogix": "1.1.41",
@@ -152,15 +152,15 @@
       "license": "MIT"
     },
     "node_modules/@adobe/eslint-config-helix": {
-      "version": "3.0.26",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.26.tgz",
-      "integrity": "sha512-fF+yS57VSRd7ydKSgY170Q412dqwAB9euugEHDNBv3+qNvKByqiLvgfcAtodY6cwN9aUa6K8z1Yuezi3Q2+RyQ==",
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.27.tgz",
+      "integrity": "sha512-tjko8Ut6q+eJnN3XXYAjIQ1zjS1TEFlf/hecjP/JymphFZHUazhiCsGEVvi6WoUM5zMFnxYFhD9qY+ALpEPb5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/config-helpers": "0.5.5",
         "eslint-plugin-import": "2.32.0",
-        "globals": "17.5.0"
+        "globals": "17.6.0"
       },
       "engines": {
         "node": ">= 12"
@@ -197,20 +197,20 @@
       }
     },
     "node_modules/@adobe/helix-deploy": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-14.0.5.tgz",
-      "integrity": "sha512-N/aAzLj78VROfrq10FtWHEWcoV4oA6FxFfYVqI0cD4eBTdrV1WMm3pKJhjiofGTEBHC9D8h+XdKK95O8XVJSXA==",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-deploy/-/helix-deploy-14.0.6.tgz",
+      "integrity": "sha512-Zv7f3XWWSB/6ZX69IZ7XEDSn1u7VcNRkqRES4aaJtTkPq5NM6QxrR7B5g035kF9aOVkoyCETF842lNNWzgGpIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/helix-shared-process-queue": "3.1.9",
-        "@aws-sdk/client-apigatewayv2": "3.1038.0",
-        "@aws-sdk/client-lambda": "3.1038.0",
-        "@aws-sdk/client-s3": "3.1038.0",
-        "@aws-sdk/client-secrets-manager": "3.1038.0",
-        "@aws-sdk/client-ssm": "3.1038.0",
-        "@aws-sdk/client-sts": "3.1038.0",
+        "@aws-sdk/client-apigatewayv2": "3.1042.0",
+        "@aws-sdk/client-lambda": "3.1042.0",
+        "@aws-sdk/client-s3": "3.1042.0",
+        "@aws-sdk/client-secrets-manager": "3.1042.0",
+        "@aws-sdk/client-ssm": "3.1042.0",
+        "@aws-sdk/client-sts": "3.1042.0",
         "archiver": "7.0.1",
         "chalk-template": "1.1.2",
         "dotenv": "17.4.2",
@@ -243,33 +243,33 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1038.0.tgz",
-      "integrity": "sha512-k60qm50bWkaqNfCJe1z28WaqgpztE0wbWVMZw6ZJcTOGfrWFhsJeLCEqtkH8w00iEozKx9GQwdQXz4G0sMGdKA==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
+      "integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
         "@aws-sdk/middleware-expect-continue": "^3.972.10",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.14",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-location-constraint": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -283,7 +283,7 @@
         "@smithy/md5-js": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -299,7 +299,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
@@ -310,25 +310,25 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1038.0.tgz",
-      "integrity": "sha512-cTNiqnVErYo8fCb7dw/BnHiubfWJIE1Ur97DT5faTncI8OEibs1A7E1GyD9Y5L77xn8edB5XJ4WBwBlTdyzk+Q==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1042.0.tgz",
+      "integrity": "sha512-doHP17OwqhcuW3e7fKkFfF4rDFM0hY8IVIwqwvBQRLk6IsZXzpl/YRhQWuIiy9O7BSZgzKKE+XytdElsTd9PWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -336,7 +336,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -352,7 +352,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -361,15 +361,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -377,14 +375,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -392,16 +389,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -409,16 +403,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -440,16 +431,14 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -457,15 +446,13 @@
       }
     },
     "node_modules/@adobe/helix-deploy/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -616,9 +603,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/helix-shared-body-data": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-2.2.4.tgz",
-      "integrity": "sha512-Rs4ogFc6BAcnjn9ZmRhr9NOT+6vNJrI7nFQCoIJOCYNUX56FQtofYBzOv2novVVsKrZ4CKskKJFLpqmbZ+E8Kg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-body-data/-/helix-shared-body-data-2.2.5.tgz",
+      "integrity": "sha512-wdMxohMOOUUlUSpFki+1KYer2RBbM6F5HZ8KHnk5v/aEMtOrz5wvf4glbzz6ZlCSRhqsjC9vD9zye1GMEMgCaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.1",
@@ -635,9 +622,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/helix-shared-bounce": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-bounce/-/helix-shared-bounce-2.0.30.tgz",
-      "integrity": "sha512-M0DSgCSr2YRt5x4SpCTwvMjfhgWuROZk1wdx24+hixWsZFguLHdbX/bxEaW9Z+4qqVTDBdxM7I90x0N+Rh5sQQ==",
+      "version": "2.0.31",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-bounce/-/helix-shared-bounce-2.0.31.tgz",
+      "integrity": "sha512-/Fe7BMKWwOfRUzv4fMH87yABLy962P0NXV+iu/kAB5yYWI0tKrlhou8fvobfAX4GP/zO9h6/kX1H0DdcuxRQPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.0.1",
@@ -691,7 +678,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -799,9 +785,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.3.0.tgz",
-      "integrity": "sha512-ivkhI+W2HlCQEMPhHLzSTQXmlkLU4EDZld/6ThFXKAskGsW9phLCe4+SLnsJ5hISjBp/quI8VO/gBHhlPjHeSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.3.1.tgz",
+      "integrity": "sha512-z3p42HCkN4Cbg06g4dX/XWfcYb74WM/CqDREWGlqLAch/qptzeOSprI8nb22ck4EJikNgScEvhZgv1kKPyzfIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -1464,13 +1450,13 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-athena-client": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-athena-client/-/spacecat-shared-athena-client-1.9.11.tgz",
-      "integrity": "sha512-YWyQR7FRh404zOG+9WSbhLkJAd55i1lyzctBR9Garcyf8Hhn9U/snEh7SkSeneEbm7LcCOOo6XypfcFE51U6Fw==",
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-athena-client/-/spacecat-shared-athena-client-1.9.12.tgz",
+      "integrity": "sha512-TWeJHY7KpVmb+k/XCJ2xXdpQ5cHAY4LRZfXVoxDShVCPwqzcZQcRvfM8VvOXGmZa5CB7fOwkEwKEZLq/It9j9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.96.3",
-        "@aws-sdk/client-athena": "3.1024.0"
+        "@aws-sdk/client-athena": "3.1045.0"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -2058,9 +2044,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-brand-client": {
-      "version": "1.1.41",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.1.41.tgz",
-      "integrity": "sha512-ZT+AT9WTrZdu2zwvulaGbsEjQGoA7ZQh/VjRaYhWIMtqweqF/Mw+g/2AEjQ27QyRMil9OWSKykKlDBf+8p5qIA==",
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-brand-client/-/spacecat-shared-brand-client-1.1.42.tgz",
+      "integrity": "sha512-8OgJ+zEaQs4nSY6yx2ZeOfTX7D7dC2nEC5ynWkfynanqIItFfz+CMhr+bYGOBtRRmlpdbznN3sO2AbrYW9V95Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -2729,15 +2715,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-content-client": {
-      "version": "1.8.23",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-content-client/-/spacecat-shared-content-client-1.8.23.tgz",
-      "integrity": "sha512-OYxjXrPbO2wikU08EOOLwiMkV4/jwWCrNTRfwhf2vNqx4yoLdpHZbMTCu+KZI5vRTxwkZWWe0II20QLQgcMVJQ==",
+      "version": "1.8.24",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-content-client/-/spacecat-shared-content-client-1.8.24.tgz",
+      "integrity": "sha512-6UirRPJ+IcVWdA1GG068OAC87L1i0fpADYjQVf8N0yAYO1Xd5m+akpIDxIgbQEjTYjTW7wYrj0ZblsRr7UQ8Yw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-secrets-manager": "3.1024.0",
+        "@aws-sdk/client-secrets-manager": "3.1045.0",
         "aws-xray-sdk": "3.12.0",
         "graph-data-structure": "4.5.0"
       },
@@ -2834,465 +2820,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1024.0.tgz",
-      "integrity": "sha512-EXbgMqueA5gw/jqpE2zMWAfBnzn6cZWqCISGdfn1201Um9IAIoTcHjyWoQMALQm0f8Lu1NF6yRtngs6zpZcagQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-content-client/node_modules/@aws-sdk/client-sqs": {
@@ -3775,26 +3302,6 @@
         }
       }
     },
-    "node_modules/@adobe/spacecat-shared-content-client/node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-content-client/node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -3805,9 +3312,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.63.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.63.0.tgz",
-      "integrity": "sha512-3ZjwhQig41OuhEhRpAO+LyBmViz31E4nb18rFDVIZ2md1Fn0eyGmCaTAvlO49f2dziMBdJUcHeO7TOkF4+RlGw==",
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.65.0.tgz",
+      "integrity": "sha512-if0tvFUn4BjL5ABwwk0PyK8KBkEgsavafDePC5TnG3WF8KdBAvjS8Ef485grrZyHsyfx7HA5o5bd/IKE66rJ3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -4732,9 +4239,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-drs-client": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.7.1.tgz",
-      "integrity": "sha512-5XusGrHHSXtiaR0MPnMsT35KWulyhroyuOk35zGvQGD4S0gady3acZ0+6S35Bh8Gl000G6dHqFL9ZTg+MGYg0A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.7.2.tgz",
+      "integrity": "sha512-ENlvz/0Q4Kp5gsU2kbbYudVAk+Qk8ex5a2Ld0ryWH+4uNL1BWBR1AFtaa0CsTVcWRGkD+cFjV3gHP7QkdC41UA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1",
@@ -5035,9 +4542,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-gpt-client": {
-      "version": "1.6.22",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-gpt-client/-/spacecat-shared-gpt-client-1.6.22.tgz",
-      "integrity": "sha512-BMzdR+5VPVHNDbtgqfkXn/k7Kfsy6MqARkYUEgFGN3+KydRzDBPp9bTPPM7bI0rMPNhrhgyiijACZX08vpzUtQ==",
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-gpt-client/-/spacecat-shared-gpt-client-1.6.23.tgz",
+      "integrity": "sha512-R8YiqPAs8aim1jehbaKZrMmnLydcc1yGHtgSEIePPlRiMyWfNz4Ydn9UuQ+pSmvAhRsiiPpcTUP96lHCdurfnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -5707,15 +5214,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-http-utils": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.27.1.tgz",
-      "integrity": "sha512-f8HcDcff8ywX3U+mz1IzemAKqOAYgvnFX6e5INUgHsJvxSZDayMCFpcQdSc8yZluZXfXwJ4SZfDbjjIKYBtyNA==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.27.2.tgz",
+      "integrity": "sha512-/uZRBhLFuBTViSX15v57c1QTld3etzMyku2PMkGHQ5fYU05nEdbx5AVF5E0Bq0DbiQPKFfVS41MLhygJoYRftQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/spacecat-shared-launchdarkly-client": "1.0.4",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "jose": "6.2.2"
+        "jose": "6.2.3"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -6317,15 +5824,6 @@
         }
       }
     },
-    "node_modules/@adobe/spacecat-shared-http-utils/node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-http-utils/node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -6336,15 +5834,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.12.6.tgz",
-      "integrity": "sha512-yVU3hjcsXMBEWVWp/Q/w5agHrjbWQWmThwSMJe9bt4Y8G6qoaXDoV4uOdeU+NA5YlX1f4drH2RT/EaKodGXm2w==",
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.12.7.tgz",
+      "integrity": "sha512-mkO5tLod8s1V0WiLnsK2oikPgOmADd5A3PFA5XGVjIKKMo5ewxVpPIV/Q3mTfi1CvcWYdDMdZCs4Ltxl1PaobQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-secrets-manager": "3.1024.0",
+        "@aws-sdk/client-secrets-manager": "3.1045.0",
         "aws-xray-sdk": "3.12.0"
       },
       "engines": {
@@ -6440,465 +5938,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1024.0.tgz",
-      "integrity": "sha512-EXbgMqueA5gw/jqpE2zMWAfBnzn6cZWqCISGdfn1201Um9IAIoTcHjyWoQMALQm0f8Lu1NF6yRtngs6zpZcagQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client/node_modules/@aws-sdk/client-sqs": {
@@ -7379,26 +6418,6 @@
         "aws-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-ims-client/node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@adobe/spacecat-shared-ims-client/node_modules/zod": {
@@ -8005,9 +7024,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-rum-api-client": {
-      "version": "2.40.12",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.40.12.tgz",
-      "integrity": "sha512-96hwODD1Fn9DU3u3GszE3HjtHTs5vI0LOj9FgrNwVE6HdzFNnCgR1h3qckdNgmn6YP4YHCjCw56BPloiYJhoVw==",
+      "version": "2.40.13",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.40.13.tgz",
+      "integrity": "sha512-UcgbDOvUAmuN32WuTAgwRYxXCfN5C8xyD170KBXRn0pPK4Zlp1xQU3p3nEcZd8+iarDzX4LQsfL+jv6PNTj7xA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -8603,9 +7622,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-scrape-client": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.6.2.tgz",
-      "integrity": "sha512-4zqI5P6CuXjh6wxg+W43BQGhF3O4QMjywDMTVh2y9EmLhsZ79ickQeR+mqCaS/PwRuhFkQ/+ex/IkoXamft40Q==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.6.3.tgz",
+      "integrity": "sha512-osYG7IkFwUIvTvH368uAuEvrnNiphzyOLnuxgATeoHQo+CcmsPVBu5zLKfy2soTeHjjjLD8xE2Q5/lFDgKFUAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -9197,14 +8216,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-slack-client": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.6.6.tgz",
-      "integrity": "sha512-+M2NCwrJqUMLggoOIa1ZJ/sMnyc8xNGFYTl5ePwiyzIH1XFbHDf2gsgN44ABj3FW0xap7mX2ohoXe/EMdePvKQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-slack-client/-/spacecat-shared-slack-client-1.6.7.tgz",
+      "integrity": "sha512-zchiSmBcg3ck4Lw4WhoL6/kESw0oSaE6etr7K1+gH/+W1gLBDGPV8AfE292YdWYT8tvS8qCWTur/opxKGsOiKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@slack/web-api": "7.15.0"
+        "@slack/web-api": "7.15.2"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -9781,30 +8800,6 @@
         }
       }
     },
-    "node_modules/@adobe/spacecat-shared-slack-client/node_modules/@slack/web-api": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
-      "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
-      "license": "MIT",
-      "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/types": "^2.20.1",
-        "@types/node": ">=18",
-        "@types/retry": "0.12.0",
-        "axios": "^1.13.5",
-        "eventemitter3": "^5.0.1",
-        "form-data": "^4.0.4",
-        "is-electron": "2.2.2",
-        "is-stream": "^2",
-        "p-queue": "^6",
-        "p-retry": "^4",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-slack-client/node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -9815,9 +8810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tier-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.5.0.tgz",
-      "integrity": "sha512-+OPIzMyeEnsHjvdqZGnKoSygxpO7j1JvfS8TWy2pUnGg7aqEBpH9vRfzEEIfWVFIjFhVtIn8b/3OKlEFCjI6YA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tier-client/-/spacecat-shared-tier-client-1.5.1.tgz",
+      "integrity": "sha512-fNvpkvqaDoatYNnP2XUGdHOVRLil90H4qKQVzoIhhFRogRIRT8vs2rUNjTQvZywBc7NRZfmoXf0oYHzE3OAXMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
@@ -10408,14 +9403,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.16.1.tgz",
-      "integrity": "sha512-VFEtClbLTWwLaF/sGf/OaYgyd0W3arl5kdZl/UkGoEj7/Oeq9pT0UQBupgy65W3kgpwQja5XQYXjzW/I5S1uOQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.16.2.tgz",
+      "integrity": "sha512-l39q27onNu9B7J76NtZypr+8quH7rFhnwHpW8z0Hc4VDKhZ7KRJoCNGzzGpkMEPOE6iRNBxppqZgJVsIBhcbKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-cloudfront": "3.1024.0",
-        "@aws-sdk/client-s3": "3.1024.0",
+        "@aws-sdk/client-cloudfront": "3.1045.0",
+        "@aws-sdk/client-s3": "3.1045.0",
         "hast-util-from-html": "2.0.3",
         "mdast-util-from-markdown": "2.0.3",
         "mdast-util-to-hast": "13.2.1",
@@ -10730,174 +9725,6 @@
         "aws-crt": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1024.0.tgz",
-      "integrity": "sha512-8qdO5aLCzaf9l0RdrSBW1iIroRKP2QBqtZ6lkrtHKiaaH0B18xEn+lrEgiN/eCf3uRAYk4cqbnI2XcWzm+7dDQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
-        "@aws-sdk/middleware-expect-continue": "^3.972.8",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.6",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-location-constraint": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
-        "@aws-sdk/middleware-ssec": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-blob-browser": "^4.2.13",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/hash-stream-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/md5-js": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-stream": "^4.5.21",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.14",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/client-sqs": {
@@ -11633,9 +10460,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-vault-secrets": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.4.tgz",
-      "integrity": "sha512-GWnAsaeComj6i55PE/S4SxVlaYqrgbtXtqNbXS/FIsLe01JQhBxaHHxgB6m6mhf58WGpobe5EDa44n6nDGvy7w==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-vault-secrets/-/spacecat-shared-vault-secrets-1.3.5.tgz",
+      "integrity": "sha512-Cki+INCuViMQFEKARcHQ97Z6iHRA91tQkHIsfslnLhIzK9jUWY2yFGy5o0/DBogeX7j6ldy0DBTZEc6RdcoBeA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -11858,25 +10685,25 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.1038.0.tgz",
-      "integrity": "sha512-i8SoHAmooWuSkqsT0drRsjCJOTlL0IV9fff0xrmPtFKyQGtevt+LGYp62D+S7Zk+0a7EPBxF4kK/pzs+Snu94g==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewayv2/-/client-apigatewayv2-3.1042.0.tgz",
+      "integrity": "sha512-Pn/2GoRsHaCi3IK4vGbUg3ciQBKwCJVtWeWirO2dt06TamLFtm7sg6P/am4eh9yunXoKl5EsGL+p6SWhwNz53g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -11884,7 +10711,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -11900,7 +10727,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -11910,15 +10737,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11926,14 +10751,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11941,16 +10765,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11958,16 +10779,13 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11989,16 +10807,14 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12006,61 +10822,59 @@
       }
     },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-athena": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1024.0.tgz",
-      "integrity": "sha512-kKnsdeh58Se7GL+9HX56KWtjS55W3OuzZwGVXq20PXgY2N53d6+NI9I1w+X0cZJo2pz3JijiJ+3S76YYCBoprw==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.1045.0.tgz",
+      "integrity": "sha512-g5E7Bt9FFZSMloQeLlEE1JabVvLh5k9749sv95UPz7r0Lwj6mT0WkMgDZ/3q/YgafeM4Ug+Ttoxpje+0gc5hRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -12069,14 +10883,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12084,13 +10896,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12098,15 +10909,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12114,15 +10922,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12130,12 +10935,12 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12143,15 +10948,13 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12159,63 +10962,61 @@
       }
     },
     "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1024.0.tgz",
-      "integrity": "sha512-jd3Mva86RKznPndyzlISIJt6seqc55gBuJprGKFraOq8KDbWjXniFLuz6QTG0qvTA82nVp5+6PX45Yzuye7ArQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1045.0.tgz",
+      "integrity": "sha512-84RIiLrMXcinBK1JXnP1bOavvQ+jxTxN4xsB20e39MfOZMyr7wIxMNn35kTYTg8UTJgN7zwEgzGJo64sU3mtPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.14",
+        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12223,14 +11024,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12238,13 +11037,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12252,15 +11050,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12268,15 +11063,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12284,12 +11076,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12297,15 +11089,13 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12313,14 +11103,12 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -12329,7 +11117,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -12650,25 +11437,25 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1038.0.tgz",
-      "integrity": "sha512-2AYkZi3h37UJDcyeWNNCmk+S9jInZvj/276OHxdjtG7zahiAPsLoPVBQACzfZwDIQJZFuUy+tDiGVHR/DqMHJA==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1042.0.tgz",
+      "integrity": "sha512-g2NJMMGjQ18LvPapz75s8UzRaxJ2P5bF2Y025/eyVuBtzdCuW6XYoJxP29Tp39BzYgFb+HEtwATyZss/V6KdZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -12679,7 +11466,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -12695,7 +11482,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
@@ -12706,15 +11493,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12722,14 +11507,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12737,16 +11521,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12754,16 +11535,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12785,16 +11563,14 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12802,15 +11578,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -13593,25 +12367,25 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1038.0.tgz",
-      "integrity": "sha512-xP6CqJkTOvX06+IghNmohu1qvzYQBmdszPHPCkCTJi3FKFQXdKpkSsaeAedBLExLW49GnHg0kVPblMGFFhirXg==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1042.0.tgz",
+      "integrity": "sha512-FVX73f1jsms0Ay1DSmivV/jN+unUVI/pUjR2FtbbPoj3N9VA6JZd178xN62jLpfSIN+iBuNGD9gvk3uI3AR9nA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -13619,7 +12393,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -13635,7 +12409,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
@@ -13645,15 +12419,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13661,14 +12433,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13676,16 +12447,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13693,16 +12461,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13724,16 +12489,14 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13741,15 +12504,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
@@ -13869,26 +12630,26 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1038.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1038.0.tgz",
-      "integrity": "sha512-lboBAXDIr+ot5a357mQgaAwgMMYZW7EwO216LTASUHV3UN4YgqskrEcwsDV9765KH9wUDGxFt8rClS4ixaOgiA==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1042.0.tgz",
+      "integrity": "sha512-CTpdtuLEdClT31afs8eabb9Yhm1fRU8DRLak/+5VTrVSZcWzEvzVhA4ZVHvf4w7EPah2yve//14zwyDYa4IxVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.6",
-        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -13896,7 +12657,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -13912,7 +12673,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -13921,15 +12682,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.13.tgz",
+      "integrity": "sha512-EA3+u2LD3kGcfRNmCSjyJuzX4XvG4zYv57i4ZksH+1IEciuSyHQGvzivEz7vZ+jbRPdAAe7WWKy/4M8InCKDcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13937,14 +12696,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.12.tgz",
+      "integrity": "sha512-NxB2dS4/mV3380hNkC72TkhMaLLjWGGBeTAEucqlJptVVovTbNmQWZLwaMC74ICo9NZHmFiBVVTHzDfAh/3y6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13952,16 +12710,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.14.tgz",
+      "integrity": "sha512-bqL+upATpOJ/7px4IVfMVxcM6Lyt9uRizmEx3mNg4N6+IQlnOaYXXOJ4TNX6P0mKPPW0lwn9ZW8QEhXwQuCH9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13969,16 +12724,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.16.tgz",
+      "integrity": "sha512-/YaivCvKUkEeMN9VTKBSvBn5w/4osAM1YboM58DKaLF/vqFGf/FdJCLmppqiPPJWZaXcASqByVjc3evE7KHKdA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14000,16 +12752,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.11.tgz",
+      "integrity": "sha512-BUMJ6VoL54r6Udj/wKy8uKRIndL04rGbaS/wTIV0dM1ewxSrR8yARBHdvZKQsK55ZSW2JrmAPk3KP15kBDxJMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@smithy/core": "^3.24.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14017,37 +12767,29 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.13.tgz",
+      "integrity": "sha512-wfk9ZdVwh187gdGXB1EyAoprwjSMt/bSfVtva+OaZx+LyNdKD7smlZf611yMd42UpfQ9vaS8NOftjSajgpdd+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
+        "@aws-sdk/core": "^3.974.12",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.22",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14068,14 +12810,14 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.2",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -14083,9 +12825,9 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -14095,7 +12837,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -15386,8 +14128,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -15411,7 +14152,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -16348,7 +15088,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -16646,7 +15385,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -16853,7 +15591,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -17018,7 +15755,6 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -18250,20 +16986,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18646,18 +17375,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18683,9 +17407,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -18999,7 +17723,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -19247,7 +17970,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19295,7 +18017,6 @@
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19761,7 +18482,6 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -20424,7 +19144,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -22619,7 +21338,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -23171,9 +21889,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -23182,7 +21900,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -23977,9 +22696,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25628,7 +24347,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -26584,7 +25302,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -27639,7 +26356,6 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -30221,7 +28937,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -30748,7 +29463,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -31936,7 +30650,6 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31947,7 +30660,6 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -32702,7 +31414,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -34068,7 +32779,6 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -35075,7 +33785,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -35828,7 +34537,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -35861,6 +34569,21 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {
@@ -36099,7 +34822,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -36109,7 +34831,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,13 @@
   "extends": [
     "local>adobe/spacecat-api-service"
   ],
+  // Pin Renovate's worker to Node 24 so `npm install` succeeds against the
+  // repo's strict engines.node range. Without this, Renovate silently skips
+  // updating package-lock.json on every dep PR, breaking `npm ci` on main
+  // until someone re-syncs the lock manually.
+  "constraints": {
+    "node": "24"
+  },
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

Every Renovate dep-update PR ships with **package.json changes only** and leaves `package-lock.json` untouched, which breaks `npm ci` on main until someone manually re-syncs the lockfile. This has happened on at least the last three Renovate PRs ([#2429](https://github.com/adobe/spacecat-api-service/pull/2429), [#2435](https://github.com/adobe/spacecat-api-service/pull/2435), [#2437](https://github.com/adobe/spacecat-api-service/pull/2437)).

## Root cause

The repo declares:
```json
"engines": { "node": ">=24.0.0 <25.0.0", "npm": ">=10.9.0" }
```

Renovate's worker runs on a Node version older than 24 by default. When it tries to run `npm install` to regenerate the lockfile, npm aborts with `EBADENGINE`, Renovate silently degrades to "update package.json only" mode, and the PR is opened without a lockfile diff. There is no warning in the PR body when this happens.

## Fix

Add `constraints.node: "24"` to `renovate.json5`. This tells Mend's hosted Renovate worker to use Node 24 (which it does ship as an available binary), so `npm install` succeeds and the lockfile gets updated in the same PR.

## Test plan

- [ ] Watch the next Renovate PR — it should now touch both `package.json` AND `package-lock.json`.
- [ ] If a Renovate PR is open at merge time, close-and-reopen it (or wait for the next scheduled run) so Renovate re-evaluates with the new config.

## References

- [Renovate `constraints` docs](https://docs.renovatebot.com/configuration-options/#constraints)
- Recent affected PRs: [#2429](https://github.com/adobe/spacecat-api-service/pull/2429), [#2435](https://github.com/adobe/spacecat-api-service/pull/2435), [#2437](https://github.com/adobe/spacecat-api-service/pull/2437)

🤖 Generated with [Claude Code](https://claude.com/claude-code)