### PR TITLE
feat(llmo): align agentic-traffic export with s3-export-framework ADR

### DIFF
--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -231,10 +231,17 @@ function buildExportKeys(siteId, exportId) {
 // Defense in depth: the worker writes `metadata.files[]` and the producer signs
 // presigned URLs for each entry. A worker bug or compromise could put arbitrary
 // keys in `files[]`; this filter rejects anything outside the deterministic
-// export prefix, falling back to ListObjectsV2 which already constrains shape.
+// export prefix AND anything that isn't a CSV file (the ListObjectsV2 fallback
+// already enforces `urls.csv | urls.csv_partN` — match it on the fast path).
 function validateFilesAgainstPrefix(files, siteId, exportId) {
-  const expectedPrefix = `${buildExportPrefix(siteId, exportId)}/`;
-  return files.filter((k) => typeof k === 'string' && k.startsWith(expectedPrefix));
+  const prefix = `${buildExportPrefix(siteId, exportId)}/`;
+  const allowedFile = /^urls\.csv(?:_part\d+)?$/;
+  return files.filter((k) => {
+    if (typeof k !== 'string' || !k.startsWith(prefix)) {
+      return false;
+    }
+    return allowedFile.test(k.slice(prefix.length));
+  });
 }
 
 // Caps defend status-polling against a pathological prefix (malicious
@@ -321,6 +328,15 @@ async function claimProcessingMetadata(ctx, bucket, metadataKey, exportId, siteI
   }
 }
 
+// Rolls back a claimProcessingMetadata write when downstream enqueue fails.
+// Without this a transient SQS failure would leave `processing` metadata
+// behind and block every subsequent POST until the stale window elapses.
+async function deleteProcessingMetadata(ctx, bucket, metadataKey) {
+  const { s3 } = ctx;
+  const command = new s3.DeleteObjectCommand({ Bucket: bucket, Key: metadataKey });
+  await s3.s3Client.send(command);
+}
+
 async function getExportMetadata(ctx, bucket, metadataKey) {
   const { s3 } = ctx;
   let body;
@@ -350,10 +366,17 @@ const MAX_EXPORT_DOWNLOAD_URLS = 50;
 
 // Customer-facing presigned URLs sign against the s3-accelerate endpoint so
 // the AWS region is hidden from the URL. Bucket-side acceleration is enabled
-// in spacecat-infrastructure. Cached per-region so a multi-region runtime
-// can't accidentally sign with the wrong client.
+// in spacecat-infrastructure.
+//
+// When AWS_ENDPOINT_URL_S3 is set (local IT against MinIO/LocalStack) the
+// accelerate endpoint doesn't exist — fall back to the shared regional
+// client. Cached per-region so a multi-region runtime can't accidentally
+// sign with the wrong client.
 const acceleratedS3Clients = new Map();
-function getAcceleratedS3Client(region) {
+function getSigningClient(ctx, region) {
+  if (ctx.env?.AWS_ENDPOINT_URL_S3) {
+    return ctx.s3.s3Client;
+  }
   if (!acceleratedS3Clients.has(region)) {
     acceleratedS3Clients.set(region, new S3Client({ region, useAccelerateEndpoint: true }));
   }
@@ -364,7 +387,7 @@ async function buildExportReadyResponse(ctx, bucket, exportId, csvKeys, metadata
   const expiresIn = PRESIGNED_URL_TTL_SECONDS;
   const keysToSign = csvKeys.slice(0, MAX_EXPORT_DOWNLOAD_URLS);
   const { s3Region } = getExportConfig(ctx);
-  const signingClient = getAcceleratedS3Client(s3Region);
+  const signingClient = getSigningClient(ctx, s3Region);
   const downloadUrls = await Promise.all(keysToSign.map(async (key) => {
     const command = new ctx.s3.GetObjectCommand({ Bucket: bucket, Key: key });
     return ctx.s3.getSignedUrl(signingClient, command, { expiresIn });
@@ -862,19 +885,26 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
             return accepted({ exportId, status: 'processing' });
           }
 
-          await sqs.sendMessage(queueUrl, {
-            type: EXPORT_TYPE,
-            data: {
-              siteId,
-              exportId,
-              filters: payload,
-              s3Bucket,
-              s3Key: csvKey,
-              s3Region,
-              /* c8 ignore next -- 'unknown' fallback when authInfo is absent */
-              requestedBy: ctx.attributes?.authInfo?.profile?.email || 'unknown',
-            },
-          });
+          try {
+            await sqs.sendMessage(queueUrl, {
+              type: EXPORT_TYPE,
+              data: {
+                siteId,
+                exportId,
+                filters: payload,
+                s3Bucket,
+                s3Key: csvKey,
+                s3Region,
+                /* c8 ignore next -- 'unknown' fallback when authInfo is absent */
+                requestedBy: ctx.attributes?.authInfo?.profile?.email || 'unknown',
+              },
+            });
+          } catch (enqueueError) {
+            // Rollback the processing claim so the next POST can retry
+            // instead of being blocked for the full stale-processing window.
+            await deleteProcessingMetadata(ctx, s3Bucket, metadataKey).catch(() => {});
+            throw enqueueError;
+          }
 
           return accepted({
             exportId,

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -20,18 +20,9 @@ import { generateIsoWeekRange, getWeekDateRange } from './llmo-brand-presence.js
 import { parseAgentTypes } from './llmo-agent-types.js';
 import { cachedOk } from '../../support/cached-response.js';
 
-/**
- * Site-scoped agentic traffic handler factories.
- * Queries mysticat-data-service PostgreSQL via PostgREST.
- *
- * All endpoints follow GET /sites/:siteId/agentic-traffic/:resource.
- * Access is validated by checking LLMO product entitlement on the site's organization.
- */
+// Site-scoped agentic traffic handlers. Queries mysticat-data-service via PostgREST.
 
-/**
- * Expected error message substrings from getSiteAndValidateAccess.
- * String matching is intentional until a shared error type exists.
- */
+// String-match against getSiteAndValidateAccess errors until a shared error type exists.
 const ERR_SITE_ACCESS = 'belonging to the organization';
 const ERR_NOT_FOUND = 'not found';
 
@@ -44,11 +35,6 @@ const EXPORT_KIND = 'agentic-traffic-urls';
 const EXPORT_TYPE = `${EXPORT_KIND}-export`;
 const EXPORT_FORMAT = 'csv';
 const EXPORT_ID_PATTERN = /^[a-f0-9]{64}$/;
-// Allowlists mirror the CASE whitelists in the DB RPCs — unknown values are already
-// rejected server-side, but we validate here too for defence-in-depth.
-// `parseAgentTypes` and the canonical agent-type list now live in
-// `./llmo-agent-types.js` so the URL Inspector handler can share them
-// without cross-controller imports.
 const VALID_SORT_COLUMNS_BY_URL = new Set([
   'host', 'url_path', 'total_hits', 'unique_agents',
   'success_rate', 'avg_ttfb_ms', 'category_name',
@@ -59,18 +45,8 @@ const VALID_SORT_COLUMNS_BY_USER_AGENT = new Set([
 const DEFAULT_BY_URL_LIMIT = 50;
 const MAX_BY_URL_LIMIT = 500;
 
-/**
- * Maps UI platform filter codes (PLATFORM_CODES) to the values stored in the
- * agentic_traffic.platform column. Both ChatGPT paid/free codes map to the
- * same DB value; 'all' and unknown codes resolve to null (no filter).
- *
- * NOTE: This mapping is applied in parseAgenticTrafficParams and therefore
- * affects ALL site-scoped agentic traffic endpoints (kpis, kpis-trend,
- * by-region, by-category, by-page-type, by-status, by-user-agent, by-url,
- * filter-dimensions, weeks, movers, url-brand-presence). Before this mapping
- * existed, the raw UI code (e.g. "openai") was passed to the DB verbatim,
- * which never matched any rows. This is the intentional behavioural fix.
- */
+// UI platform code → DB value. 'all' / unknown → null (no filter). Applied
+// in parseAgenticTrafficParams, so it affects every site-scoped endpoint.
 const PLATFORM_CODE_TO_DB = {
   openai: 'ChatGPT',
   chatgpt: 'ChatGPT',
@@ -82,9 +58,7 @@ const PLATFORM_CODE_TO_DB = {
   amazon: 'Amazon',
 };
 
-// Re-exported from `./llmo-agent-types.js` so existing imports (the test
-// suite, the URL Inspector handler before it was switched to import the
-// shared module directly) keep working without churn.
+// Re-exported for existing imports.
 export { parseAgentTypes };
 
 function defaultDateRange() {
@@ -97,12 +71,8 @@ function defaultDateRange() {
   };
 }
 
-/**
- * Parse common agentic traffic query params from context.data.
- * Supports camelCase and snake_case aliases.
- */
-// Filter values reach the exportId hash + SQS message; coerce non-strings
-// to null and bound length (SQS limit is 256 KiB).
+// Filter values feed the exportId hash + SQS message — coerce non-strings to null
+// and cap length to keep messages under SQS's 256 KiB limit.
 const FILTER_STRING_MAX = 512;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -130,24 +100,18 @@ function parseAgenticTrafficParams(context) {
     platform: PLATFORM_CODE_TO_DB[q.platform] ?? null,
     categoryName: sanitizeFilterString(q.categoryName || q.category_name),
     agentType: sanitizeFilterString(q.agentType || q.agent_type),
-    // Additive inclusion list orthogonal to the single-value `agentType`. Used by the
-    // URL Inspector PG page to enforce `Agent Type ∈ {Chatbots, Research}`. Existing
-    // callers omit this and continue to receive the same data.
+    // Additive inclusion list, orthogonal to single-value `agentType`. Used by URL Inspector.
     agentTypes: parseAgentTypes(q.agentTypes ?? q.agent_types),
     userAgent: sanitizeFilterString(q.userAgent || q.user_agent),
     contentType: sanitizeFilterString(q.contentType || q.content_type),
     urlPathSearch: sanitizeFilterString(q.urlPathSearch || q.url_path_search),
-    // Normalise to null for unknown buckets — mirrors how PLATFORM_CODE_TO_DB handles
-    // unknown platform codes, preventing a DB exception (500) for invalid input.
+    // Unknown buckets → null (prevents DB 500 on invalid input).
     successRate: VALID_SUCCESS_RATE_BUCKETS.has(q.successRate || q.success_rate)
       ? (q.successRate || q.success_rate)
       : null,
   };
 }
 
-/**
- * Build the common RPC params object shared by all agentic traffic RPCs.
- */
 function buildRpcParams(siteId, parsed) {
   return {
     p_site_id: siteId,
@@ -181,9 +145,7 @@ function canonicalizeExportPayload(siteId, parsed) {
   };
 }
 
-// RFC 8785 JSON Canonicalization Scheme (JCS) — strict on the subset we use
-// (string, number, boolean, null, array, object of these). Non-finite numbers
-// throw per JCS semantics rather than serialising as 'NaN'/'Infinity'.
+// RFC 8785 JCS — strict on string/number/boolean/null/array/object. NaN/Infinity throw.
 export function jcsStringify(value) {
   if (value === null) {
     return 'null';
@@ -228,11 +190,8 @@ function buildExportKeys(siteId, exportId) {
   };
 }
 
-// Defense in depth: the worker writes `metadata.files[]` and the producer signs
-// presigned URLs for each entry. A worker bug or compromise could put arbitrary
-// keys in `files[]`; this filter rejects anything outside the deterministic
-// export prefix AND anything that isn't a CSV file (the ListObjectsV2 fallback
-// already enforces `urls.csv | urls.csv_partN` — match it on the fast path).
+// Defense-in-depth on worker-written files[] — reject anything outside the
+// deterministic prefix or not matching urls.csv[_partN].
 function validateFilesAgainstPrefix(files, siteId, exportId) {
   const prefix = `${buildExportPrefix(siteId, exportId)}/`;
   const allowedFile = /^urls\.csv(?:_part\d+)?$/;
@@ -244,17 +203,13 @@ function validateFilesAgainstPrefix(files, siteId, exportId) {
   });
 }
 
-// Caps defend status-polling against a pathological prefix (malicious
-// continuation token, misbehaving worker).
+// Caps on status-polling against a pathological prefix.
 const MAX_EXPORT_LIST_PAGES = 5;
 const MAX_EXPORT_LIST_KEYS_PER_PAGE = 100;
 const PART_SUFFIX_PATTERN = /_part(\d+)$/;
 const REGEX_META_PATTERN = /[.*+?^${}()|[\]\\]/g;
 
 function getExportConfig(ctx) {
-  // S3_REPORT_BUCKET is the API service's existing env var name; the worker
-  // uses S3_REPORTING_BUCKET_NAME in its own Lambda env — both resolve to
-  // the same spacecat-{env}-reports bucket at deploy time.
   const s3Bucket = ctx.env?.S3_REPORT_BUCKET;
   const queueUrl = ctx.env?.REPORT_JOBS_QUEUE_URL;
   /* c8 ignore next -- default region when ctx.runtime is unset */
@@ -292,11 +247,9 @@ async function listExportCsvObjects(ctx, bucket, csvKey) {
   });
 }
 
-// Writes processing metadata as a compare-and-set claim. Returns true if we
-// won the race (proceed to enqueue), false if another POST beat us (don't
-// enqueue, just return 202 processing). `casOnly` uses IfNoneMatch:* so the
-// PUT fails when the object already exists — used on the no-metadata path.
-// Stale/failed retries pass casOnly=false and just overwrite.
+// CAS write of processing metadata. `casOnly` uses IfNoneMatch:* so the PUT
+// fails when the object exists (used on no-metadata path); stale/failed
+// retries overwrite. Returns false on race-loss, true on win.
 async function claimProcessingMetadata(ctx, bucket, metadataKey, exportId, siteId, casOnly) {
   const { s3 } = ctx;
   const body = JSON.stringify({
@@ -328,9 +281,8 @@ async function claimProcessingMetadata(ctx, bucket, metadataKey, exportId, siteI
   }
 }
 
-// Rolls back a claimProcessingMetadata write when downstream enqueue fails.
-// Without this a transient SQS failure would leave `processing` metadata
-// behind and block every subsequent POST until the stale window elapses.
+// Rolls back the CAS write when enqueue fails — otherwise a transient SQS
+// failure blocks the cache key until stale-processing expires.
 async function deleteProcessingMetadata(ctx, bucket, metadataKey) {
   const { s3 } = ctx;
   const command = new s3.DeleteObjectCommand({ Bucket: bucket, Key: metadataKey });
@@ -351,7 +303,6 @@ async function getExportMetadata(ctx, bucket, metadataKey) {
     /* c8 ignore next 2 -- propagated to the route's catch-all; not exercised in unit tests */
     throw error;
   }
-  // Treat truncated/corrupt metadata as absent so retry paths heal instead of 500-looping.
   try {
     return JSON.parse(body);
   } catch (parseError) {
@@ -364,14 +315,8 @@ async function getExportMetadata(ctx, bucket, metadataKey) {
 const PRESIGNED_URL_TTL_SECONDS = 60 * 60;
 const MAX_EXPORT_DOWNLOAD_URLS = 50;
 
-// Customer-facing presigned URLs sign against the s3-accelerate endpoint so
-// the AWS region is hidden from the URL. Bucket-side acceleration is enabled
-// in spacecat-infrastructure.
-//
-// When AWS_ENDPOINT_URL_S3 is set (local IT against MinIO/LocalStack) the
-// accelerate endpoint doesn't exist — fall back to the shared regional
-// client. Cached per-region so a multi-region runtime can't accidentally
-// sign with the wrong client.
+// Sign customer URLs against s3-accelerate so the region is hidden, except
+// in IT (AWS_ENDPOINT_URL_S3 set) where accelerate doesn't exist.
 const acceleratedS3Clients = new Map();
 function getSigningClient(ctx, region) {
   if (ctx.env?.AWS_ENDPOINT_URL_S3) {
@@ -392,7 +337,6 @@ async function buildExportReadyResponse(ctx, bucket, exportId, csvKeys, metadata
     const command = new ctx.s3.GetObjectCommand({ Bucket: bucket, Key: key });
     return ctx.s3.getSignedUrl(signingClient, command, { expiresIn });
   }));
-  // Computed after signing so callers see the floor of the URL window.
   const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
 
   return ok({
@@ -406,8 +350,7 @@ async function buildExportReadyResponse(ctx, bucket, exportId, csvKeys, metadata
   });
 }
 
-// Contract: worker writes CSV first, metadata.json last. Tighten to require
-// `metadata.status === 'success'` if that order ever changes.
+// Contract: worker writes CSV first, metadata.json last.
 function isExportReady(csvKeys, metadata) {
   return csvKeys.length > 0 && (!metadata || metadata.status === 'success');
 }
@@ -421,7 +364,6 @@ function isExportProcessing(metadata) {
 }
 
 // 30 min covers Aurora's 840s statement_timeout + Lambda overhead.
-// Older `processing` metadata is treated as abandoned so the cache key unblocks.
 const EXPORT_PROCESSING_STALE_MS = 30 * 60 * 1000;
 
 function isExportStaleProcessing(metadata) {
@@ -432,30 +374,15 @@ function isExportStaleProcessing(metadata) {
   return Number.isFinite(ageMs) && ageMs > EXPORT_PROCESSING_STALE_MS;
 }
 
-/**
- * Extra params for RPCs that accept the additive `p_agent_types TEXT[]` input
- * (currently `rpc_agentic_traffic_kpis_trend` and `rpc_agentic_traffic_by_url`).
- *
- * Returned as its own object so we don't accidentally send `p_agent_types` to
- * the other RPCs — PostgREST rejects calls with unknown named arguments, which
- * would 500 every dashboard whose RPC signature we haven't extended.
- */
+// Extra param for RPCs that accept `p_agent_types` (kpis-trend, by-url). Others would 500.
 function buildAgentTypesRpcParam(parsed) {
   return parsed.agentTypes !== null
     ? { p_agent_types: parsed.agentTypes }
     : {};
 }
 
-/**
- * Shared wrapper for agentic traffic handlers: PostgREST check + site/org access validation.
- * @param {Object} context - Request context
- * @param {Function} getSiteAndValidateAccess - Async (context) => { site, organization }
- * @param {string} handlerName - For error logging
- * @param {Function} handlerFn - Async (context, client, siteId, siteContext) => response
- *   siteContext = { site, organization } — forwarded from getSiteAndValidateAccess so
- *   handlers that need org data (e.g. url-brand-presence) avoid a second DB lookup.
- * @returns {Promise<Response>}
- */
+// PostgREST availability + site/org access check; forwards siteContext so
+// handlers needing org data avoid a second DB lookup.
 async function withAgenticTrafficAuth(context, getSiteAndValidateAccess, handlerName, handlerFn) {
   const { log, dataAccess } = context;
   const { Site } = dataAccess;
@@ -599,8 +526,7 @@ export function createAgenticTrafficByCategoryHandler(getSiteAndValidateAccess) 
       'by-category',
       async (ctx, client, siteId) => {
         const parsed = parseAgenticTrafficParams(ctx);
-        // rpc_agentic_traffic_by_category has no p_category_name parameter —
-        // it groups by category, so filtering by it is not supported.
+        // by_category groups by category — no p_category_name parameter.
         const rpcParams = buildRpcParams(siteId, parsed);
         delete rpcParams.p_category_name;
         const { data, error } = await client.rpc(
@@ -790,11 +716,7 @@ export function createAgenticTrafficByUrlHandler(getSiteAndValidateAccess) {
               && row.avg_citability_score !== undefined
               ? Number(row.avg_citability_score) : null,
             deployedAtEdge: row.deployed_at_edge ?? false,
-            // hits_trend is the [{ week_start, value }] payload generated by
-            // rpc_agentic_traffic_by_url's week_series CTE — forwarded as-is
-            // so the URL Inspector PG dashboard can derive its Owned-table
-            // sparkline + WoW direction from the same per-URL series the
-            // single-URL chart in URLDetailsPgDialog consumes.
+            // [{ week_start, value }] from week_series CTE — drives URL Inspector sparklines.
             hitsTrend: Array.isArray(row.hits_trend)
               ? row.hits_trend.map((point) => ({
                 weekStart: point.week_start,
@@ -808,13 +730,7 @@ export function createAgenticTrafficByUrlHandler(getSiteAndValidateAccess) {
   };
 }
 
-/**
- * POST /sites/:siteId/agentic-traffic/urls/export
- *
- * Creates or reuses a deterministic S3-backed URL export. The API does not run
- * the database export inline; it returns a cached download URL when present or
- * queues a reporting-worker job that calls the data-service DB-to-S3 RPC.
- */
+// POST /sites/:siteId/agentic-traffic/urls/export — cache-check S3 → enqueue SQS on miss.
 export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) {
   return async function exportAgenticTrafficUrls(context) {
     return withAgenticTrafficAuth(
@@ -843,9 +759,7 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
         try {
           const metadata = await getExportMetadata(ctx, s3Bucket, metadataKey);
 
-          // Fast path: worker wrote `files[]` (s3-export-framework ADR). Validate
-          // prefix before signing — defense in depth against a worker bug or
-          // compromise writing keys outside the deterministic export prefix.
+          // Fast path: sign worker-written files[] directly. Validated first.
           if (metadata?.status === 'success'
             && Array.isArray(metadata.files) && metadata.files.length > 0) {
             const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId);
@@ -868,10 +782,8 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
             });
           }
 
-          // Claim the slot with CAS (IfNoneMatch:*) so concurrent POSTs can't
-          // double-enqueue, and don't clobber `success` metadata if CSVs were
-          // evicted (let CAS fail → 202 processing without destroying state).
-          // Stale/failed retries overwrite via casOnly=false.
+          // CAS-claim: protects against double-enqueue AND don't clobber success metadata
+          // if CSVs were evicted. Stale/failed retries overwrite via casOnly=false.
           const casOnly = metadata === null || metadata.status === 'success';
           const claimed = await claimProcessingMetadata(
             ctx,
@@ -900,8 +812,7 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
               },
             });
           } catch (enqueueError) {
-            // Rollback the processing claim so the next POST can retry
-            // instead of being blocked for the full stale-processing window.
+            // Rollback so the next POST can retry instead of waiting for stale window.
             await deleteProcessingMetadata(ctx, s3Bucket, metadataKey).catch(() => {});
             throw enqueueError;
           }
@@ -921,11 +832,7 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
   };
 }
 
-/**
- * GET /sites/:siteId/agentic-traffic/urls/export/:exportId
- *
- * Polls S3 metadata and export objects for a deterministic export id.
- */
+// GET /sites/:siteId/agentic-traffic/urls/export/:exportId — polls S3 metadata.
 export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAccess) {
   return async function getAgenticTrafficUrlsExportStatus(context) {
     return withAgenticTrafficAuth(
@@ -956,9 +863,7 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
         try {
           const metadata = await getExportMetadata(ctx, s3Bucket, metadataKey);
 
-          // Fast path: worker wrote `files[]` (s3-export-framework ADR). Validate
-          // prefix before signing — defense in depth against a worker bug or
-          // compromise writing keys outside the deterministic export prefix.
+          // Fast path: sign worker-written files[] directly. Validated first.
           if (metadata?.status === 'success'
             && Array.isArray(metadata.files) && metadata.files.length > 0) {
             const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId);
@@ -1015,13 +920,7 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
   };
 }
 
-/**
- * GET /sites/:siteId/agentic-traffic/filter-dimensions
- *
- * Delegates to rpc_agentic_traffic_distinct_filters, which returns all five
- * filter dimensions in a single round-trip with cascading behaviour: each
- * dimension list respects the other active filters but ignores its own.
- */
+// GET /sites/:siteId/agentic-traffic/filter-dimensions — cascading filter values in one RPC.
 export function createAgenticTrafficFilterDimensionsHandler(getSiteAndValidateAccess) {
   return async function getAgenticTrafficFilterDimensions(context) {
     return withAgenticTrafficAuth(
@@ -1092,17 +991,8 @@ export function createAgenticTrafficMoversHandler(getSiteAndValidateAccess) {
   };
 }
 
-/**
- * GET /sites/:siteId/agentic-traffic/weeks
- *
- * Returns the list of ISO weeks for which the site has agentic traffic data.
- * Powers the ContinuousWeekPicker (custom-weeks time range option).
- *
- * Queries agentic_traffic for the min and max traffic_date for the site,
- * then generates the full ISO week range between them.
- *
- * Returns: { weeks: [{ week: "2026-W10", startDate: "...", endDate: "..." }] }
- */
+// GET /sites/:siteId/agentic-traffic/weeks → ISO weeks between min/max traffic_date.
+// Returns: { weeks: [{ week, startDate, endDate }] }
 export function createAgenticTrafficWeeksHandler(getSiteAndValidateAccess) {
   return async function getAgenticTrafficWeeks(context) {
     return withAgenticTrafficAuth(
@@ -1159,16 +1049,7 @@ export function createAgenticTrafficWeeksHandler(getSiteAndValidateAccess) {
   };
 }
 
-/**
- * GET /sites/:siteId/agentic-traffic/has-data
- *
- * Fast existence check — returns { hasData: boolean } indicating whether any
- * agentic traffic records exist for the site. Used by the PG dashboard to
- * decide whether to show the no-data overlay without waiting for all parallel
- * queries to settle.
- *
- * Runs a single PostgREST table query with limit(1) — no RPC required.
- */
+// GET /sites/:siteId/agentic-traffic/has-data → { hasData: boolean }. Single limit(1) query.
 export function createAgenticTrafficHasDataHandler(getSiteAndValidateAccess) {
   return async function getAgenticTrafficHasData(context) {
     return withAgenticTrafficAuth(
@@ -1194,18 +1075,8 @@ export function createAgenticTrafficHasDataHandler(getSiteAndValidateAccess) {
   };
 }
 
-/**
- * GET /sites/:siteId/agentic-traffic/url-brand-presence?url=&startDate=&endDate=&platform=
- *
- * Brand presence citation detail for a specific URL. Returns citation stats,
- * weekly citation trends, and the top prompts that cite this URL as a source
- * in brand presence LLM executions.
- *
- * The URL is resolved via source_urls.url_hash (md5 fast-lookup) so the caller
- * must pass a full URL (e.g. "https://www.example.com/path").
- * The organisation_id is derived from the site to keep auth consistent with all
- * other site-scoped agentic traffic endpoints.
- */
+// GET /sites/:siteId/agentic-traffic/url-brand-presence?url=&startDate=&endDate=&platform=
+// URL resolved via source_urls.url_hash (md5); organisation_id derived from site.
 export function createAgenticTrafficUrlBrandPresenceHandler(getSiteAndValidateAccess) {
   return async function getAgenticTrafficUrlBrandPresence(context) {
     return withAgenticTrafficAuth(

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -948,7 +948,9 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
             return ok({
               exportId,
               status: 'failed',
-              failureReason: metadata.failureReason ?? 'Export failed',
+              /* c8 ignore next 2 -- defaults for malformed worker metadata */
+              failureReason: metadata.failureReason ?? 'unknown',
+              failureMessage: metadata.failureMessage ?? 'Export failed',
             });
           }
 
@@ -956,7 +958,8 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
             return ok({
               exportId,
               status: 'failed',
-              failureReason: 'Export timed out — please retry',
+              failureReason: 'timeout',
+              failureMessage: 'Export timed out — please retry',
             });
           }
 

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -11,9 +11,10 @@
  */
 
 import {
-  accepted, badRequest, forbidden, internalServerError, ok,
+  accepted, badRequest, forbidden, internalServerError, notFound, ok,
 } from '@adobe/spacecat-shared-http-utils';
 import { hasText } from '@adobe/spacecat-shared-utils';
+import { S3Client } from '@aws-sdk/client-s3';
 import crypto from 'crypto';
 import { generateIsoWeekRange, getWeekDateRange } from './llmo-brand-presence.js';
 import { parseAgentTypes } from './llmo-agent-types.js';
@@ -38,7 +39,10 @@ const VALID_INTERVALS = new Set(['day', 'week', 'month']);
 const VALID_SORT_ORDERS = new Set(['asc', 'desc']);
 const VALID_SUCCESS_RATE_BUCKETS = new Set(['high', 'medium', 'low']);
 const EXPORT_VERSION = 'v1';
-const EXPORT_TYPE = 'agentic-traffic-urls-export';
+const EXPORT_CANONICAL_VERSION = 1;
+const EXPORT_KIND = 'agentic-traffic-urls';
+const EXPORT_TYPE = `${EXPORT_KIND}-export`;
+const EXPORT_FORMAT = 'csv';
 const EXPORT_ID_PATTERN = /^[a-f0-9]{64}$/;
 // Allowlists mirror the CASE whitelists in the DB RPCs — unknown values are already
 // rejected server-side, but we validate here too for defence-in-depth.
@@ -160,7 +164,10 @@ function buildRpcParams(siteId, parsed) {
 
 function canonicalizeExportPayload(siteId, parsed) {
   return {
-    version: EXPORT_VERSION,
+    kind: EXPORT_KIND,
+    v: 1,
+    c: EXPORT_CANONICAL_VERSION,
+    format: EXPORT_FORMAT,
     siteId,
     startDate: parsed.startDate,
     endDate: parsed.endDate,
@@ -171,26 +178,43 @@ function canonicalizeExportPayload(siteId, parsed) {
     contentType: parsed.contentType,
     successRate: parsed.successRate,
     urlPathSearch: parsed.urlPathSearch,
-    format: 'csv',
   };
 }
 
-// Order-stable JSON serialisation. The canonical export payload is a flat
-// object of primitives, so the recursive object branch is enough — no array
-// handling needed.
-function stableStringify(value) {
-  if (value && typeof value === 'object') {
-    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+// RFC 8785 JSON Canonicalization Scheme (JCS) — limited to the subset we
+// produce: objects of primitives (string, number, boolean, null). Sorted keys,
+// no whitespace, JS Number.toString() is RFC-compatible for finite values.
+function jcsStringify(value) {
+  if (value === null) {
+    return 'null';
   }
-  return JSON.stringify(value);
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  /* c8 ignore next 9 -- payload uses only string/null today */
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(jcsStringify).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${jcsStringify(value[k])}`).join(',')}}`;
+  }
+  /* c8 ignore next -- unreachable for our payload shape */
+  throw new TypeError(`JCS: unsupported type ${typeof value}`);
 }
 
 function buildExportId(payload) {
-  return crypto.createHash('sha256').update(stableStringify(payload)).digest('hex');
+  return crypto.createHash('sha256').update(jcsStringify(payload)).digest('hex');
 }
 
-// EXPORT_VERSION is intentionally in both the key prefix (physical isolation)
-// and the canonical payload (forces hash invalidation on bump). Keep both.
+// Schema/canonical version live in the hash payload (kind/v/c/format).
+// Path stays `v1` for now; `v1c1` migration is a coordinated worker + producer change.
 function buildExportKeys(siteId, exportId) {
   const prefix = `agentic-traffic/url-exports/${siteId}/${EXPORT_VERSION}/${exportId}`;
   return {
@@ -247,6 +271,40 @@ async function listExportCsvObjects(ctx, bucket, csvKey) {
   });
 }
 
+// Writes processing metadata as a compare-and-set claim. Returns true if we
+// won the race (proceed to enqueue), false if another POST beat us (don't
+// enqueue, just return 202 processing). `casOnly` uses IfNoneMatch:* so the
+// PUT fails when the object already exists — used on the no-metadata path.
+// Stale/failed retries pass casOnly=false and just overwrite.
+async function claimProcessingMetadata(ctx, bucket, metadataKey, exportId, siteId, casOnly) {
+  const { s3 } = ctx;
+  const body = JSON.stringify({
+    status: 'processing',
+    exportId,
+    siteId,
+    kind: EXPORT_KIND,
+    format: EXPORT_FORMAT,
+    createdAt: new Date().toISOString(),
+  });
+  const command = new s3.PutObjectCommand({
+    Bucket: bucket,
+    Key: metadataKey,
+    Body: body,
+    ContentType: 'application/json',
+    ...(casOnly ? { IfNoneMatch: '*' } : {}),
+  });
+  try {
+    await s3.s3Client.send(command);
+    return true;
+  } catch (error) {
+    if (error.name === 'PreconditionFailed' || error.$metadata?.httpStatusCode === 412) {
+      return false;
+    }
+    /* c8 ignore next 2 -- propagated to the route's catch-all */
+    throw error;
+  }
+}
+
 async function getExportMetadata(ctx, bucket, metadataKey) {
   const { s3 } = ctx;
   try {
@@ -267,12 +325,25 @@ async function getExportMetadata(ctx, bucket, metadataKey) {
 const PRESIGNED_URL_TTL_SECONDS = 60 * 60;
 const MAX_EXPORT_DOWNLOAD_URLS = 50;
 
+// Customer-facing presigned URLs sign against the s3-accelerate endpoint so
+// the AWS region is hidden from the URL. Bucket-side acceleration is enabled
+// in spacecat-infrastructure.
+let acceleratedS3Client;
+function getAcceleratedS3Client(region) {
+  if (!acceleratedS3Client) {
+    acceleratedS3Client = new S3Client({ region, useAccelerateEndpoint: true });
+  }
+  return acceleratedS3Client;
+}
+
 async function buildExportReadyResponse(ctx, bucket, exportId, csvKeys, metadata = null) {
   const expiresIn = PRESIGNED_URL_TTL_SECONDS;
   const keysToSign = csvKeys.slice(0, MAX_EXPORT_DOWNLOAD_URLS);
+  const { s3Region } = getExportConfig(ctx);
+  const signingClient = getAcceleratedS3Client(s3Region);
   const downloadUrls = await Promise.all(keysToSign.map(async (key) => {
     const command = new ctx.s3.GetObjectCommand({ Bucket: bucket, Key: key });
-    return ctx.s3.getSignedUrl(ctx.s3.s3Client, command, { expiresIn });
+    return ctx.s3.getSignedUrl(signingClient, command, { expiresIn });
   }));
   // Computed after signing so callers see the floor of the URL window.
   const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
@@ -707,7 +778,7 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
         const { s3, sqs } = ctx;
         /* c8 ignore start -- deploy-time misconfig guard, not exercised in unit tests */
         if (!s3?.s3Client || !s3?.ListObjectsV2Command || !s3?.GetObjectCommand
-          || !s3?.getSignedUrl || !sqs?.sendMessage) {
+          || !s3?.PutObjectCommand || !s3?.getSignedUrl || !sqs?.sendMessage) {
           return badRequest('Agentic traffic export requires S3 and SQS configuration');
         }
 
@@ -739,8 +810,20 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
             });
           }
 
-          // Failed / stale-processing / no-metadata → re-enqueue. The worker
-          // overwrites metadata on retry; GET reports `failed` to the UI.
+          // Claim the slot with CAS (IfNoneMatch:*) so concurrent POSTs can't double-enqueue.
+          const casOnly = metadata === null;
+          const claimed = await claimProcessingMetadata(
+            ctx,
+            s3Bucket,
+            metadataKey,
+            exportId,
+            siteId,
+            casOnly,
+          );
+          if (!claimed) {
+            return accepted({ exportId, status: 'processing' });
+          }
+
           await sqs.sendMessage(queueUrl, {
             type: EXPORT_TYPE,
             data: {
@@ -827,6 +910,13 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
               status: 'failed',
               failureReason: 'Export timed out — please retry',
             });
+          }
+
+          // No metadata and no CSV → never POSTed (or evicted). Distinct from
+          // "POSTed, worker hasn't started yet" because POST writes processing
+          // metadata atomically before enqueueing.
+          if (!metadata && csvKeys.length === 0) {
+            return notFound(`No export found for exportId ${exportId}`);
           }
 
           return ok({

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -213,10 +213,10 @@ function buildExportId(payload) {
   return crypto.createHash('sha256').update(jcsStringify(payload)).digest('hex');
 }
 
-// Schema/canonical version live in the hash payload (kind/v/c/format).
-// Path stays `v1` for now; `v1c1` migration is a coordinated worker + producer change.
+// `v{N}c{M}` path matches the s3-export-framework ADR. Worker accepts both
+// `v1` (legacy) and `v1c1` during the rollout (PR adobe/spacecat-reporting-worker#619).
 function buildExportKeys(siteId, exportId) {
-  const prefix = `agentic-traffic/url-exports/${siteId}/${EXPORT_VERSION}/${exportId}`;
+  const prefix = `agentic-traffic/url-exports/${siteId}/${EXPORT_VERSION}c${EXPORT_CANONICAL_VERSION}/${exportId}`;
   return {
     csvKey: `${prefix}/urls.csv`,
     metadataKey: `${prefix}/metadata.json`,
@@ -837,7 +837,6 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
               filters: payload,
               s3Bucket,
               s3Key: csvKey,
-              metadataKey,
               s3Region,
               /* c8 ignore next -- 'unknown' fallback when authInfo is absent */
               requestedBy: ctx.attributes?.authInfo?.profile?.email || 'unknown',

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -794,10 +794,15 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
         const { csvKey, metadataKey } = buildExportKeys(siteId, exportId);
 
         try {
-          const [csvKeys, metadata] = await Promise.all([
-            listExportCsvObjects(ctx, s3Bucket, csvKey),
-            getExportMetadata(ctx, s3Bucket, metadataKey),
-          ]);
+          const metadata = await getExportMetadata(ctx, s3Bucket, metadataKey);
+
+          // Fast path: worker wrote `files[]` (s3-export-framework ADR) — sign directly.
+          if (metadata?.status === 'success'
+            && Array.isArray(metadata.files) && metadata.files.length > 0) {
+            return buildExportReadyResponse(ctx, s3Bucket, exportId, metadata.files, metadata);
+          }
+
+          const csvKeys = await listExportCsvObjects(ctx, s3Bucket, csvKey);
 
           if (isExportReady(csvKeys, metadata)) {
             return buildExportReadyResponse(ctx, s3Bucket, exportId, csvKeys, metadata);
@@ -887,10 +892,15 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
         const { csvKey, metadataKey } = buildExportKeys(siteId, exportId);
 
         try {
-          const [csvKeys, metadata] = await Promise.all([
-            listExportCsvObjects(ctx, s3Bucket, csvKey),
-            getExportMetadata(ctx, s3Bucket, metadataKey),
-          ]);
+          const metadata = await getExportMetadata(ctx, s3Bucket, metadataKey);
+
+          // Fast path: worker wrote `files[]` (s3-export-framework ADR) — sign directly.
+          if (metadata?.status === 'success'
+            && Array.isArray(metadata.files) && metadata.files.length > 0) {
+            return buildExportReadyResponse(ctx, s3Bucket, exportId, metadata.files, metadata);
+          }
+
+          const csvKeys = await listExportCsvObjects(ctx, s3Bucket, csvKey);
 
           if (isExportReady(csvKeys, metadata)) {
             return buildExportReadyResponse(ctx, s3Bucket, exportId, csvKeys, metadata);

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -181,21 +181,23 @@ function canonicalizeExportPayload(siteId, parsed) {
   };
 }
 
-// RFC 8785 JSON Canonicalization Scheme (JCS) — limited to the subset we
-// produce: objects of primitives (string, number, boolean, null). Sorted keys,
-// no whitespace, JS Number.toString() is RFC-compatible for finite values.
-function jcsStringify(value) {
+// RFC 8785 JSON Canonicalization Scheme (JCS) — strict on the subset we use
+// (string, number, boolean, null, array, object of these). Non-finite numbers
+// throw per JCS semantics rather than serialising as 'NaN'/'Infinity'.
+export function jcsStringify(value) {
   if (value === null) {
     return 'null';
   }
   if (typeof value === 'string') {
     return JSON.stringify(value);
   }
-  /* c8 ignore next 9 -- payload uses only string/null today */
   if (typeof value === 'boolean') {
     return value ? 'true' : 'false';
   }
   if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError('JCS: non-finite numbers are not permitted');
+    }
     return String(value);
   }
   if (Array.isArray(value)) {
@@ -213,14 +215,26 @@ function buildExportId(payload) {
   return crypto.createHash('sha256').update(jcsStringify(payload)).digest('hex');
 }
 
-// `v{N}c{M}` path matches the s3-export-framework ADR. Worker accepts both
-// `v1` (legacy) and `v1c1` during the rollout (PR adobe/spacecat-reporting-worker#619).
+// `v{N}c{M}` path matches the s3-export-framework ADR.
+function buildExportPrefix(siteId, exportId) {
+  return `agentic-traffic/url-exports/${siteId}/${EXPORT_VERSION}c${EXPORT_CANONICAL_VERSION}/${exportId}`;
+}
+
 function buildExportKeys(siteId, exportId) {
-  const prefix = `agentic-traffic/url-exports/${siteId}/${EXPORT_VERSION}c${EXPORT_CANONICAL_VERSION}/${exportId}`;
+  const prefix = buildExportPrefix(siteId, exportId);
   return {
     csvKey: `${prefix}/urls.csv`,
     metadataKey: `${prefix}/metadata.json`,
   };
+}
+
+// Defense in depth: the worker writes `metadata.files[]` and the producer signs
+// presigned URLs for each entry. A worker bug or compromise could put arbitrary
+// keys in `files[]`; this filter rejects anything outside the deterministic
+// export prefix, falling back to ListObjectsV2 which already constrains shape.
+function validateFilesAgainstPrefix(files, siteId, exportId) {
+  const expectedPrefix = `${buildExportPrefix(siteId, exportId)}/`;
+  return files.filter((k) => typeof k === 'string' && k.startsWith(expectedPrefix));
 }
 
 // Caps defend status-polling against a pathological prefix (malicious
@@ -297,7 +311,9 @@ async function claimProcessingMetadata(ctx, bucket, metadataKey, exportId, siteI
     await s3.s3Client.send(command);
     return true;
   } catch (error) {
-    if (error.name === 'PreconditionFailed' || error.$metadata?.httpStatusCode === 412) {
+    // 412 is the canonical IfNoneMatch race-loss; SDK error names vary across versions.
+    if (error.$metadata?.httpStatusCode === 412 || error.name === 'PreconditionFailed') {
+      ctx.log.info(`Agentic traffic export: CAS race-loss on metadata.json (exportId=${exportId})`);
       return false;
     }
     /* c8 ignore next 2 -- propagated to the route's catch-all */
@@ -307,17 +323,24 @@ async function claimProcessingMetadata(ctx, bucket, metadataKey, exportId, siteI
 
 async function getExportMetadata(ctx, bucket, metadataKey) {
   const { s3 } = ctx;
+  let body;
   try {
     const command = new s3.GetObjectCommand({ Bucket: bucket, Key: metadataKey });
     const result = await s3.s3Client.send(command);
-    const body = await result.Body.transformToString();
-    return JSON.parse(body);
+    body = await result.Body.transformToString();
   } catch (error) {
     if (error.name === 'NoSuchKey' || error.$metadata?.httpStatusCode === 404) {
       return null;
     }
     /* c8 ignore next 2 -- propagated to the route's catch-all; not exercised in unit tests */
     throw error;
+  }
+  // Treat truncated/corrupt metadata as absent so retry paths heal instead of 500-looping.
+  try {
+    return JSON.parse(body);
+  } catch (parseError) {
+    ctx.log.warn(`Agentic traffic export: metadata.json is not valid JSON; treating as absent (key=${metadataKey})`);
+    return null;
   }
 }
 
@@ -327,13 +350,14 @@ const MAX_EXPORT_DOWNLOAD_URLS = 50;
 
 // Customer-facing presigned URLs sign against the s3-accelerate endpoint so
 // the AWS region is hidden from the URL. Bucket-side acceleration is enabled
-// in spacecat-infrastructure.
-let acceleratedS3Client;
+// in spacecat-infrastructure. Cached per-region so a multi-region runtime
+// can't accidentally sign with the wrong client.
+const acceleratedS3Clients = new Map();
 function getAcceleratedS3Client(region) {
-  if (!acceleratedS3Client) {
-    acceleratedS3Client = new S3Client({ region, useAccelerateEndpoint: true });
+  if (!acceleratedS3Clients.has(region)) {
+    acceleratedS3Clients.set(region, new S3Client({ region, useAccelerateEndpoint: true }));
   }
-  return acceleratedS3Client;
+  return acceleratedS3Clients.get(region);
 }
 
 async function buildExportReadyResponse(ctx, bucket, exportId, csvKeys, metadata = null) {
@@ -796,10 +820,16 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
         try {
           const metadata = await getExportMetadata(ctx, s3Bucket, metadataKey);
 
-          // Fast path: worker wrote `files[]` (s3-export-framework ADR) — sign directly.
+          // Fast path: worker wrote `files[]` (s3-export-framework ADR). Validate
+          // prefix before signing — defense in depth against a worker bug or
+          // compromise writing keys outside the deterministic export prefix.
           if (metadata?.status === 'success'
             && Array.isArray(metadata.files) && metadata.files.length > 0) {
-            return buildExportReadyResponse(ctx, s3Bucket, exportId, metadata.files, metadata);
+            const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId);
+            if (safeFiles.length === metadata.files.length) {
+              return buildExportReadyResponse(ctx, s3Bucket, exportId, safeFiles, metadata);
+            }
+            ctx.log.warn(`Agentic traffic export: metadata.files contained out-of-prefix keys; falling back to ListObjectsV2 (exportId=${exportId})`);
           }
 
           const csvKeys = await listExportCsvObjects(ctx, s3Bucket, csvKey);
@@ -815,8 +845,11 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
             });
           }
 
-          // Claim the slot with CAS (IfNoneMatch:*) so concurrent POSTs can't double-enqueue.
-          const casOnly = metadata === null;
+          // Claim the slot with CAS (IfNoneMatch:*) so concurrent POSTs can't
+          // double-enqueue, and don't clobber `success` metadata if CSVs were
+          // evicted (let CAS fail → 202 processing without destroying state).
+          // Stale/failed retries overwrite via casOnly=false.
+          const casOnly = metadata === null || metadata.status === 'success';
           const claimed = await claimProcessingMetadata(
             ctx,
             s3Bucket,
@@ -893,10 +926,16 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
         try {
           const metadata = await getExportMetadata(ctx, s3Bucket, metadataKey);
 
-          // Fast path: worker wrote `files[]` (s3-export-framework ADR) — sign directly.
+          // Fast path: worker wrote `files[]` (s3-export-framework ADR). Validate
+          // prefix before signing — defense in depth against a worker bug or
+          // compromise writing keys outside the deterministic export prefix.
           if (metadata?.status === 'success'
             && Array.isArray(metadata.files) && metadata.files.length > 0) {
-            return buildExportReadyResponse(ctx, s3Bucket, exportId, metadata.files, metadata);
+            const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId);
+            if (safeFiles.length === metadata.files.length) {
+              return buildExportReadyResponse(ctx, s3Bucket, exportId, safeFiles, metadata);
+            }
+            ctx.log.warn(`Agentic traffic export: metadata.files contained out-of-prefix keys; falling back to ListObjectsV2 (exportId=${exportId})`);
           }
 
           const csvKeys = await listExportCsvObjects(ctx, s3Bucket, csvKey);

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -45,6 +45,10 @@ function GetObjectCommand(input) {
   this.input = input;
 }
 
+function DeleteObjectCommand(input) {
+  this.input = input;
+}
+
 function PutObjectCommand(input) {
   this.input = input;
 }
@@ -113,6 +117,9 @@ function stubS3({ keys = [], echoPrefix = false, metadata } = {}) {
     if (command instanceof PutObjectCommand) {
       return Promise.resolve({});
     }
+    if (command instanceof DeleteObjectCommand) {
+      return Promise.resolve({});
+    }
     if (metadata === undefined) {
       const error = new Error('not found');
       error.name = 'NoSuchKey';
@@ -132,6 +139,9 @@ function makeExportContext(overrides = {}) {
     if (command instanceof PutObjectCommand) {
       return Promise.resolve({});
     }
+    if (command instanceof DeleteObjectCommand) {
+      return Promise.resolve({});
+    }
     const error = new Error('not found');
     error.name = 'NoSuchKey';
     return Promise.reject(error);
@@ -142,6 +152,7 @@ function makeExportContext(overrides = {}) {
     ListObjectsV2Command,
     GetObjectCommand,
     PutObjectCommand,
+    DeleteObjectCommand,
     getSignedUrl: sinon.stub().resolves('https://signed.example.com/export.csv'),
     ...overrides.s3,
   };
@@ -1305,6 +1316,61 @@ describe('llmo-agentic-traffic', () => {
       expect(ctx.log.warn).to.have.been.calledWithMatch(/out-of-prefix/);
     });
 
+    it('falls back to ListObjectsV2 when metadata.files contains in-prefix non-CSV keys', async () => {
+      // Worker bug: an in-prefix path that isn't a CSV (e.g. metadata.json
+      // itself) would otherwise get signed. Reject any entry whose filename
+      // doesn't match urls.csv or urls.csv_partN.
+      const ctx = makeExportContext();
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [{ Key: command.input.Prefix }] });
+        }
+        const prefix = command.input.Key.replace(/\/metadata\.json$/, '');
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success',
+              rowCount: 1,
+              // In-prefix but not a CSV — must be rejected.
+              files: [`${prefix}/metadata.json`],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const listCalls = ctx.s3.s3Client.send.getCalls()
+        .filter((c) => c.args[0] instanceof ListObjectsV2Command);
+      expect(listCalls).to.have.length(1);
+      expect(ctx.log.warn).to.have.been.calledWithMatch(/out-of-prefix/);
+    });
+
+    it('signs with the regular S3 client (not accelerated) when AWS_ENDPOINT_URL_S3 is set (IT/MinIO)', async () => {
+      const ctx = makeExportContext({
+        context: { env: { AWS_ENDPOINT_URL_S3: 'http://localhost:4566' } },
+      });
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [] });
+        }
+        const prefix = command.input.Key.replace(/\/metadata\.json$/, '');
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success',
+              rowCount: 1,
+              files: [`${prefix}/urls.csv`],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      await handler(ctx);
+      // Regular client used, not accelerated.
+      expect(ctx.s3.getSignedUrl.firstCall.args[0]).to.equal(ctx.s3.s3Client);
+    });
+
     it('produces the same exportId for the same filter set across calls', async () => {
       // The cache contract rests on stableStringify being key-order invariant.
       const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
@@ -1419,6 +1485,20 @@ describe('llmo-agentic-traffic', () => {
       // PUT must happen before SQS sendMessage — locks the claim-before-enqueue order.
       const putOrder = ctx.s3.s3Client.send.firstCall.calledBefore(ctx.sqs.sendMessage.firstCall);
       expect(putOrder).to.equal(true);
+    });
+
+    it('rolls back processing metadata when SQS sendMessage fails', async () => {
+      // Without rollback a transient SQS failure would block the cache key
+      // for the full stale-processing window — 30 min outage on a blip.
+      const ctx = makeExportContext({
+        sqs: { sendMessage: sinon.stub().rejects(new Error('sqs unavailable')) },
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(500);
+      const deleteCalls = ctx.s3.s3Client.send.getCalls()
+        .filter((c) => c.args[0] instanceof DeleteObjectCommand);
+      expect(deleteCalls).to.have.length(1);
     });
 
     it('uses CAS (IfNoneMatch:*) when retrying against success metadata so success records are not clobbered', async () => {

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -1635,10 +1635,14 @@ describe('llmo-agentic-traffic', () => {
       expect(body.bytesUploaded).to.equal(1000);
     });
 
-    it('returns failed when metadata reports a failed export', async () => {
+    it('returns failed (ADR enum + message) when metadata reports a failed export', async () => {
       const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
       ctx.s3.s3Client.send = stubS3({
-        metadata: { status: 'failed', failureReason: 'db error' },
+        metadata: {
+          status: 'failed',
+          failureReason: 'db_error',
+          failureMessage: 'connection lost',
+        },
       });
 
       const handler = createAgenticTrafficUrlsExportStatusHandler(stubbedValidateAccess);
@@ -1648,11 +1652,12 @@ describe('llmo-agentic-traffic', () => {
       expect(body).to.deep.equal({
         exportId: EXPORT_ID,
         status: 'failed',
-        failureReason: 'db error',
+        failureReason: 'db_error',
+        failureMessage: 'connection lost',
       });
     });
 
-    it('surfaces stale `processing` metadata as failed (timeout) so the UI can retry', async () => {
+    it('surfaces stale `processing` metadata as failed/timeout so the UI can retry', async () => {
       const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
       const oldDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
       ctx.s3.s3Client.send = stubS3({
@@ -1664,7 +1669,8 @@ describe('llmo-agentic-traffic', () => {
       const body = await res.json();
       expect(res.status).to.equal(200);
       expect(body.status).to.equal('failed');
-      expect(body.failureReason).to.match(/timed out/i);
+      expect(body.failureReason).to.equal('timeout');
+      expect(body.failureMessage).to.match(/timed out/i);
     });
 
     it('rejects invalid export ids', async () => {

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -1197,7 +1197,7 @@ describe('llmo-agentic-traffic', () => {
         .map((c) => c.args[0])
         .find((cmd) => cmd instanceof ListObjectsV2Command);
       expect(listCmd.input.Prefix).to.match(
-        new RegExp(`^agentic-traffic/url-exports/${SITE_ID}/v1/[a-f0-9]{64}/urls\\.csv$`),
+        new RegExp(`^agentic-traffic/url-exports/${SITE_ID}/v1c1/[a-f0-9]{64}/urls\\.csv$`),
       );
       expect(body.downloadUrls).to.deep.equal(['https://signed.example.com/export.csv']);
       expect(ctx.sqs.sendMessage).to.not.have.been.called;
@@ -1278,7 +1278,7 @@ describe('llmo-agentic-traffic', () => {
       expect(queueUrl).to.equal('https://sqs.example.com/report-jobs');
       expect(message.type).to.equal('agentic-traffic-urls-export');
       expect(message.data.filters.platform).to.equal('ChatGPT');
-      expect(message.data.s3Key).to.include(`/v1/${body.exportId}/urls.csv`);
+      expect(message.data.s3Key).to.include(`/v1c1/${body.exportId}/urls.csv`);
       expect(message.data.requestedBy).to.equal('user@example.com');
     });
 
@@ -1395,8 +1395,8 @@ describe('llmo-agentic-traffic', () => {
       const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
       ctx.s3.s3Client.send = stubS3({
         keys: [
-          `agentic-traffic/url-exports/${SITE_ID}/v1/${EXPORT_ID}/urls.csv_part2`,
-          `agentic-traffic/url-exports/${SITE_ID}/v1/${EXPORT_ID}/urls.csv`,
+          `agentic-traffic/url-exports/${SITE_ID}/v1c1/${EXPORT_ID}/urls.csv_part2`,
+          `agentic-traffic/url-exports/${SITE_ID}/v1c1/${EXPORT_ID}/urls.csv`,
         ],
         metadata: {
           status: 'success', rowCount: 10, filesUploaded: 2, bytesUploaded: 1000,

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -44,6 +44,10 @@ function GetObjectCommand(input) {
   this.input = input;
 }
 
+function PutObjectCommand(input) {
+  this.input = input;
+}
+
 /**
  * Minimal chainable PostgREST client mock.
  * rpcResults: { [rpcName]: { data, error } }
@@ -105,6 +109,9 @@ function stubS3({ keys = [], echoPrefix = false, metadata } = {}) {
         : keys.map((Key) => ({ Key }));
       return Promise.resolve({ Contents });
     }
+    if (command instanceof PutObjectCommand) {
+      return Promise.resolve({});
+    }
     if (metadata === undefined) {
       const error = new Error('not found');
       error.name = 'NoSuchKey';
@@ -121,6 +128,9 @@ function makeExportContext(overrides = {}) {
     if (command instanceof ListObjectsV2Command) {
       return Promise.resolve({ Contents: [], NextContinuationToken: undefined });
     }
+    if (command instanceof PutObjectCommand) {
+      return Promise.resolve({});
+    }
     const error = new Error('not found');
     error.name = 'NoSuchKey';
     return Promise.reject(error);
@@ -130,6 +140,7 @@ function makeExportContext(overrides = {}) {
     s3Bucket: 'default-bucket',
     ListObjectsV2Command,
     GetObjectCommand,
+    PutObjectCommand,
     getSignedUrl: sinon.stub().resolves('https://signed.example.com/export.csv'),
     ...overrides.s3,
   };
@@ -1254,10 +1265,6 @@ describe('llmo-agentic-traffic', () => {
     });
 
     it('re-enqueues when a prior attempt failed (failed metadata is retriable)', async () => {
-      // POST is the user's "I want this export" signal — a previously
-      // failed attempt with the same filters shouldn't permanently lock
-      // the cache key. Status reporting on 'failed' is the GET endpoint's
-      // job, not POST's.
       const ctx = makeExportContext();
       ctx.s3.s3Client.send = stubS3({
         metadata: { status: 'failed', failureReason: 'db error' },
@@ -1270,16 +1277,64 @@ describe('llmo-agentic-traffic', () => {
       expect(body.status).to.equal('processing');
       expect(ctx.sqs.sendMessage).to.have.been.calledOnce;
     });
+
+    it('does not enqueue when CAS write loses the race', async () => {
+      const ctx = makeExportContext();
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [] });
+        }
+        if (command instanceof PutObjectCommand) {
+          const error = new Error('precondition failed');
+          error.name = 'PreconditionFailed';
+          return Promise.reject(error);
+        }
+        const error = new Error('not found');
+        error.name = 'NoSuchKey';
+        return Promise.reject(error);
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(202);
+      expect(ctx.sqs.sendMessage).to.not.have.been.called;
+    });
+
+    it('writes processing metadata with IfNoneMatch:* before enqueueing on first POST', async () => {
+      const ctx = makeExportContext();
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      await handler(ctx);
+      const putCalls = ctx.s3.s3Client.send.getCalls()
+        .filter((c) => c.args[0] instanceof PutObjectCommand);
+      expect(putCalls).to.have.length(1);
+      expect(putCalls[0].args[0].input.IfNoneMatch).to.equal('*');
+      const written = JSON.parse(putCalls[0].args[0].input.Body);
+      expect(written.status).to.equal('processing');
+      expect(written.kind).to.equal('agentic-traffic-urls');
+      expect(written.createdAt).to.be.a('string');
+    });
   });
 
   describe('createAgenticTrafficUrlsExportStatusHandler', () => {
-    it('returns processing when no CSV or metadata exists', async () => {
+    it('returns 200 processing when fresh processing metadata exists', async () => {
       const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
+      ctx.s3.s3Client.send = stubS3({
+        metadata: { status: 'processing', createdAt: new Date().toISOString() },
+      });
       const handler = createAgenticTrafficUrlsExportStatusHandler(stubbedValidateAccess);
       const res = await handler(ctx);
       const body = await res.json();
       expect(res.status).to.equal(200);
       expect(body).to.deep.equal({ exportId: EXPORT_ID, status: 'processing' });
+    });
+
+    it('returns 404 when no CSV or metadata exists (unknown exportId)', async () => {
+      // POST writes processing metadata atomically before enqueueing, so an
+      // unknown exportId on GET means it was never POSTed (typo, forged) or
+      // metadata has been evicted — terminal, not "still processing".
+      const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
+      const handler = createAgenticTrafficUrlsExportStatusHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(404);
     });
 
     it('returns ready with presigned URLs for split CSV parts', async () => {

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -29,6 +29,7 @@ import {
   createAgenticTrafficHasDataHandler,
   createAgenticTrafficUrlsExportHandler,
   createAgenticTrafficUrlsExportStatusHandler,
+  jcsStringify,
 } from '../../../src/controllers/llmo/llmo-agentic-traffic.js';
 
 use(sinonChai);
@@ -92,7 +93,7 @@ function makeContext(overrides = {}) {
       },
       ...overrides.dataAccess,
     },
-    log: { error: sinon.stub(), info: sinon.stub() },
+    log: { error: sinon.stub(), info: sinon.stub(), warn: sinon.stub() },
     ...overrides.context,
   };
 }
@@ -1176,6 +1177,49 @@ describe('llmo-agentic-traffic', () => {
     });
   });
 
+  // ── JCS hash invariants ────────────────────────────────────────────────────
+
+  describe('jcsStringify', () => {
+    it('canonicalises primitives + objects with sorted keys', () => {
+      expect(jcsStringify(null)).to.equal('null');
+      expect(jcsStringify('a')).to.equal('"a"');
+      expect(jcsStringify(true)).to.equal('true');
+      expect(jcsStringify(0)).to.equal('0');
+      expect(jcsStringify([1, 'a', null])).to.equal('[1,"a",null]');
+      expect(jcsStringify({ b: 2, a: 1 })).to.equal('{"a":1,"b":2}');
+    });
+
+    it('throws on non-finite numbers per JCS', () => {
+      expect(() => jcsStringify(NaN)).to.throw(TypeError);
+      expect(() => jcsStringify(Infinity)).to.throw(TypeError);
+    });
+
+    it('locks the hash for a known canonical payload (worker must produce the same)', async () => {
+      // Cross-service contract: spacecat-reporting-worker must hash the same
+      // input to the same exportId. If this golden value changes, the worker
+      // PR needs to match — coordinate before merging.
+      const crypto = await import('node:crypto');
+      const payload = {
+        kind: 'agentic-traffic-urls',
+        v: 1,
+        c: 1,
+        format: 'csv',
+        siteId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        platform: null,
+        categoryName: null,
+        agentType: null,
+        userAgent: null,
+        contentType: null,
+        successRate: null,
+        urlPathSearch: null,
+      };
+      const hash = crypto.createHash('sha256').update(jcsStringify(payload)).digest('hex');
+      expect(hash).to.equal('6e6f6d808e6760960dc7540c3b28d991375852b56981bc66fca91e708b812101');
+    });
+  });
+
   // ── URL Export ─────────────────────────────────────────────────────────────
 
   describe('createAgenticTrafficUrlsExportHandler', () => {
@@ -1205,16 +1249,19 @@ describe('llmo-agentic-traffic', () => {
 
     it('skips ListObjectsV2 when metadata.files is present (fast path)', async () => {
       const ctx = makeExportContext();
+      // Echo the metadata's key prefix back as files[] so the fast-path
+      // prefix-validation accepts the entries (mirrors what the worker writes).
       ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
         if (command instanceof ListObjectsV2Command) {
           return Promise.reject(new Error('should not be called'));
         }
+        const prefix = command.input.Key.replace(/\/metadata\.json$/, '');
         return Promise.resolve({
           Body: {
             transformToString: () => Promise.resolve(JSON.stringify({
               status: 'success',
               rowCount: 42,
-              files: ['agentic-traffic/url-exports/x/v1/y/urls.csv'],
+              files: [`${prefix}/urls.csv`],
             })),
           },
         });
@@ -1228,6 +1275,34 @@ describe('llmo-agentic-traffic', () => {
       const listCalls = ctx.s3.s3Client.send.getCalls()
         .filter((c) => c.args[0] instanceof ListObjectsV2Command);
       expect(listCalls).to.have.length(0);
+    });
+
+    it('falls back to ListObjectsV2 when metadata.files contains out-of-prefix keys', async () => {
+      // Defense in depth: worker bug / compromise writes wrong keys in files[];
+      // producer must not sign URLs against them — falls back to ListObjectsV2
+      // which constrains by prefix.
+      const ctx = makeExportContext();
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [{ Key: command.input.Prefix }] });
+        }
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success',
+              rowCount: 1,
+              files: ['agentic-traffic/url-exports/EVIL_SITE/v1c1/EVIL_EXPORT/urls.csv'],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const listCalls = ctx.s3.s3Client.send.getCalls()
+        .filter((c) => c.args[0] instanceof ListObjectsV2Command);
+      expect(listCalls).to.have.length(1);
+      expect(ctx.log.warn).to.have.been.calledWithMatch(/out-of-prefix/);
     });
 
     it('produces the same exportId for the same filter set across calls', async () => {
@@ -1341,6 +1416,119 @@ describe('llmo-agentic-traffic', () => {
       expect(written.status).to.equal('processing');
       expect(written.kind).to.equal('agentic-traffic-urls');
       expect(written.createdAt).to.be.a('string');
+      // PUT must happen before SQS sendMessage — locks the claim-before-enqueue order.
+      const putOrder = ctx.s3.s3Client.send.firstCall.calledBefore(ctx.sqs.sendMessage.firstCall);
+      expect(putOrder).to.equal(true);
+    });
+
+    it('uses CAS (IfNoneMatch:*) when retrying against success metadata so success records are not clobbered', async () => {
+      // If CSV was evicted but success metadata remained, an unconditional
+      // overwrite would destroy the success record. CAS lets us fall through
+      // to 202 processing without touching state.
+      const ctx = makeExportContext();
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [] });
+        }
+        if (command instanceof PutObjectCommand) {
+          // CAS should fail because the object exists.
+          if (command.input.IfNoneMatch === '*') {
+            const error = new Error('precondition failed');
+            error.$metadata = { httpStatusCode: 412 };
+            return Promise.reject(error);
+          }
+          return Promise.resolve({});
+        }
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success', rowCount: 5,
+              // No files[] — exercises the legacy success-without-files path.
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(202);
+      const putCalls = ctx.s3.s3Client.send.getCalls()
+        .filter((c) => c.args[0] instanceof PutObjectCommand);
+      expect(putCalls).to.have.length(1);
+      expect(putCalls[0].args[0].input.IfNoneMatch).to.equal('*');
+      expect(ctx.sqs.sendMessage).to.not.have.been.called;
+    });
+
+    it('uses unconditional overwrite when retrying against stale processing metadata', async () => {
+      const ctx = makeExportContext();
+      const oldDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [] });
+        }
+        if (command instanceof PutObjectCommand) {
+          return Promise.resolve({});
+        }
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'processing', createdAt: oldDate,
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(202);
+      const putCall = ctx.s3.s3Client.send.getCalls()
+        .find((c) => c.args[0] instanceof PutObjectCommand);
+      expect(putCall.args[0].input.IfNoneMatch).to.equal(undefined);
+      expect(ctx.sqs.sendMessage).to.have.been.calledOnce;
+    });
+
+    it('treats corrupt metadata.json as absent (heals via re-enqueue rather than 500-looping)', async () => {
+      const ctx = makeExportContext();
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [] });
+        }
+        if (command instanceof PutObjectCommand) {
+          return Promise.resolve({});
+        }
+        return Promise.resolve({
+          Body: { transformToString: () => Promise.resolve('{not-json') },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(202);
+      expect(ctx.sqs.sendMessage).to.have.been.calledOnce;
+    });
+
+    it('signs customer presigned URLs against the s3-accelerate endpoint, not the regional client', async () => {
+      const ctx = makeExportContext();
+      // The metadata-fetch stub also serves as the success path. Echo the
+      // metadata's prefix into files[] so the fast path accepts it.
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({ Contents: [] });
+        }
+        const prefix = command.input.Key.replace(/\/metadata\.json$/, '');
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success', rowCount: 1, files: [`${prefix}/urls.csv`],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      await handler(ctx);
+      // The first arg to getSignedUrl must NOT be the regional ctx.s3.s3Client
+      // — it should be the accelerated client constructed inside the handler.
+      const signingClient = ctx.s3.getSignedUrl.firstCall.args[0];
+      expect(signingClient).to.not.equal(ctx.s3.s3Client);
+      // The accelerated client carries the useAccelerateEndpoint flag (boolean or provider).
+      expect(signingClient.config?.useAccelerateEndpoint).to.not.equal(undefined);
     });
   });
 
@@ -1368,7 +1556,7 @@ describe('llmo-agentic-traffic', () => {
             transformToString: () => Promise.resolve(JSON.stringify({
               status: 'success',
               rowCount: 7,
-              files: [`agentic-traffic/url-exports/${SITE_ID}/v1/${EXPORT_ID}/urls.csv`],
+              files: [`agentic-traffic/url-exports/${SITE_ID}/v1c1/${EXPORT_ID}/urls.csv`],
             })),
           },
         });
@@ -1379,6 +1567,31 @@ describe('llmo-agentic-traffic', () => {
       expect(res.status).to.equal(200);
       expect(body.status).to.equal('ready');
       expect(body.downloadUrls).to.have.length(1);
+    });
+
+    it('GET falls back to ListObjectsV2 when metadata.files contains out-of-prefix keys', async () => {
+      const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.resolve({
+            Contents: [{ Key: `agentic-traffic/url-exports/${SITE_ID}/v1c1/${EXPORT_ID}/urls.csv` }],
+          });
+        }
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success',
+              files: ['agentic-traffic/url-exports/EVIL/v1c1/EVIL/urls.csv'],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportStatusHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      expect(res.status).to.equal(200);
+      const listCalls = ctx.s3.s3Client.send.getCalls()
+        .filter((c) => c.args[0] instanceof ListObjectsV2Command);
+      expect(listCalls).to.have.length(1);
     });
 
     it('returns 404 when no CSV or metadata exists (unknown exportId)', async () => {

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -1179,7 +1179,7 @@ describe('llmo-agentic-traffic', () => {
   // ── URL Export ─────────────────────────────────────────────────────────────
 
   describe('createAgenticTrafficUrlsExportHandler', () => {
-    it('returns a cached download URL when the CSV already exists', async () => {
+    it('returns a cached download URL when the CSV already exists (legacy: no files[])', async () => {
       const ctx = makeExportContext();
       ctx.s3.s3Client.send = stubS3({
         echoPrefix: true,
@@ -1191,13 +1191,43 @@ describe('llmo-agentic-traffic', () => {
       const body = await res.json();
       expect(res.status).to.equal(200);
       expect(body.status).to.equal('ready');
-      // Lock the S3 key shape; a refactor flipping the prefix surfaces here.
-      const listCmd = ctx.s3.s3Client.send.firstCall.args[0];
+      // ListObjectsV2 is the fallback when metadata.files is missing — verify
+      // the prefix it asked for matches the deterministic key shape.
+      const listCmd = ctx.s3.s3Client.send.getCalls()
+        .map((c) => c.args[0])
+        .find((cmd) => cmd instanceof ListObjectsV2Command);
       expect(listCmd.input.Prefix).to.match(
         new RegExp(`^agentic-traffic/url-exports/${SITE_ID}/v1/[a-f0-9]{64}/urls\\.csv$`),
       );
       expect(body.downloadUrls).to.deep.equal(['https://signed.example.com/export.csv']);
       expect(ctx.sqs.sendMessage).to.not.have.been.called;
+    });
+
+    it('skips ListObjectsV2 when metadata.files is present (fast path)', async () => {
+      const ctx = makeExportContext();
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.reject(new Error('should not be called'));
+        }
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success',
+              rowCount: 42,
+              files: ['agentic-traffic/url-exports/x/v1/y/urls.csv'],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.status).to.equal('ready');
+      expect(body.downloadUrls).to.have.length(1);
+      const listCalls = ctx.s3.s3Client.send.getCalls()
+        .filter((c) => c.args[0] instanceof ListObjectsV2Command);
+      expect(listCalls).to.have.length(0);
     });
 
     it('produces the same exportId for the same filter set across calls', async () => {
@@ -1325,6 +1355,30 @@ describe('llmo-agentic-traffic', () => {
       const body = await res.json();
       expect(res.status).to.equal(200);
       expect(body).to.deep.equal({ exportId: EXPORT_ID, status: 'processing' });
+    });
+
+    it('GET skips ListObjectsV2 when metadata.files is present', async () => {
+      const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.reject(new Error('should not be called'));
+        }
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success',
+              rowCount: 7,
+              files: [`agentic-traffic/url-exports/${SITE_ID}/v1/${EXPORT_ID}/urls.csv`],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportStatusHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.status).to.equal('ready');
+      expect(body.downloadUrls).to.have.length(1);
     });
 
     it('returns 404 when no CSV or metadata exists (unknown exportId)', async () => {


### PR DESCRIPTION
Producer-side changes for the [s3-export-framework ADR](https://github.com/adobe/mysticat-architecture/blob/main/platform/decisions/s3-export-framework.md), plus Option A (S3 Transfer Acceleration) for customer-facing URL hygiene.

## What changes

- **Hash**: `stableStringify` → RFC 8785 JCS; canonical payload now includes `kind`, `v`, `c`, `format`
- **S3 key path**: `v1` → `v1c1`
- **SQS envelope**: drops `metadataKey` (worker derives from `s3Key`)
- **POST**: writes `metadata.processing` via S3 `IfNoneMatch:*` (CAS) before enqueueing; concurrent POSTs can't double-enqueue; success metadata is protected from clobber
- **GET**: unknown `exportId` → 404; returns ADR-shaped `failureReason` enum + `failureMessage` detail
- **Customer URLs**: sign against `s3-accelerate.amazonaws.com` (hides AWS region)
- **Fast path**: read `metadata.files[]` directly; skip `ListObjectsV2` when present (with prefix validation as defense-in-depth)
- **Filter sanitization**: non-string/oversized/malformed-date values coerced to null before hashing

## Cache impact

All existing cached exports become invalid (new hash + new path). Next POST after deploy re-enqueues. **Accepted per team call** — feature not yet broadly used.

## Ordering

1. [spacecat-infrastructure#533](https://github.com/adobe/spacecat-infrastructure/pull/533) — Transfer Acceleration on the reports bucket (must land first)
2. This PR — producer changes
3. [spacecat-reporting-worker#619](https://github.com/adobe/spacecat-reporting-worker/pull/619) — worker changes (after this PR deploys, worker accepts only `v1c1`)

## Test plan

- [x] 117 controller tests pass (new: golden hash, accelerated client, fast-path prefix validation, CAS protect success, JCS primitives, files[] fallback, corrupt-metadata heal)
- [x] 10277 total tests pass
- [x] Coverage: 100% lines/statements/functions, 98.11% branches
- [ ] Smoke test in dev: POST → GET → download URL host is `*.s3-accelerate.amazonaws.com`