### PR TITLE
feat(llmo): switch agentic-traffic export to v1c1 path and drop metadataKey

### DIFF
--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -213,10 +213,10 @@ function buildExportId(payload) {
   return crypto.createHash('sha256').update(jcsStringify(payload)).digest('hex');
 }
 
-// Schema/canonical version live in the hash payload (kind/v/c/format).
-// Path stays `v1` for now; `v1c1` migration is a coordinated worker + producer change.
+// `v{N}c{M}` path matches the s3-export-framework ADR. Worker accepts both
+// `v1` (legacy) and `v1c1` during the rollout (PR adobe/spacecat-reporting-worker#619).
 function buildExportKeys(siteId, exportId) {
-  const prefix = `agentic-traffic/url-exports/${siteId}/${EXPORT_VERSION}/${exportId}`;
+  const prefix = `agentic-traffic/url-exports/${siteId}/${EXPORT_VERSION}c${EXPORT_CANONICAL_VERSION}/${exportId}`;
   return {
     csvKey: `${prefix}/urls.csv`,
     metadataKey: `${prefix}/metadata.json`,
@@ -832,7 +832,6 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
               filters: payload,
               s3Bucket,
               s3Key: csvKey,
-              metadataKey,
               s3Region,
               /* c8 ignore next -- 'unknown' fallback when authInfo is absent */
               requestedBy: ctx.attributes?.authInfo?.profile?.email || 'unknown',

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -1194,7 +1194,7 @@ describe('llmo-agentic-traffic', () => {
       // Lock the S3 key shape; a refactor flipping the prefix surfaces here.
       const listCmd = ctx.s3.s3Client.send.firstCall.args[0];
       expect(listCmd.input.Prefix).to.match(
-        new RegExp(`^agentic-traffic/url-exports/${SITE_ID}/v1/[a-f0-9]{64}/urls\\.csv$`),
+        new RegExp(`^agentic-traffic/url-exports/${SITE_ID}/v1c1/[a-f0-9]{64}/urls\\.csv$`),
       );
       expect(body.downloadUrls).to.deep.equal(['https://signed.example.com/export.csv']);
       expect(ctx.sqs.sendMessage).to.not.have.been.called;
@@ -1248,7 +1248,7 @@ describe('llmo-agentic-traffic', () => {
       expect(queueUrl).to.equal('https://sqs.example.com/report-jobs');
       expect(message.type).to.equal('agentic-traffic-urls-export');
       expect(message.data.filters.platform).to.equal('ChatGPT');
-      expect(message.data.s3Key).to.include(`/v1/${body.exportId}/urls.csv`);
+      expect(message.data.s3Key).to.include(`/v1c1/${body.exportId}/urls.csv`);
       expect(message.data.requestedBy).to.equal('user@example.com');
     });
 
@@ -1341,8 +1341,8 @@ describe('llmo-agentic-traffic', () => {
       const ctx = makeExportContext({ params: { exportId: EXPORT_ID } });
       ctx.s3.s3Client.send = stubS3({
         keys: [
-          `agentic-traffic/url-exports/${SITE_ID}/v1/${EXPORT_ID}/urls.csv_part2`,
-          `agentic-traffic/url-exports/${SITE_ID}/v1/${EXPORT_ID}/urls.csv`,
+          `agentic-traffic/url-exports/${SITE_ID}/v1c1/${EXPORT_ID}/urls.csv_part2`,
+          `agentic-traffic/url-exports/${SITE_ID}/v1c1/${EXPORT_ID}/urls.csv`,
         ],
         metadata: {
           status: 'success', rowCount: 10, filesUploaded: 2, bytesUploaded: 1000,


### PR DESCRIPTION
## Summary

Completes the producer-side migration to the [s3-export-framework ADR](https://github.com/adobe/mysticat-architecture/blob/main/platform/decisions/s3-export-framework.md). Two changes:

- **S3 key path** `agentic-traffic/url-exports/{siteId}/v1c1/{exportId}/...` (was `/v1/`). The `c{M}` segment is the canonicalization version, separate from the column-schema version (`v{N}`). Future canonicalization changes bump `c` without bumping `v`.
- **SQS envelope** no longer includes `metadataKey` — derived from `s3Key` on the worker side.

## Dependency

**Requires [adobe/spacecat-reporting-worker#619](https://github.com/adobe/spacecat-reporting-worker/pull/619)** to land and deploy first. That PR teaches the worker to accept both `v1` and `v1c1` paths and to derive `metadataKey` when absent.

## Base branch

Stacked on `feat/agentic-traffic-export-adr-alignment` (PR [#2441](https://github.com/adobe/spacecat-api-service/pull/2441)) for review clarity. Will retarget to `main` once #2441 merges.

## Once deployed

The old `v1` path becomes dead code on the worker side and can be removed in a future cleanup.

## Test plan

- [x] 106 controller tests pass (existing tests adjusted for new path; no new tests needed — `buildExportKeys` change is fully exercised by current cache-hit + queue tests)
- [x] Coverage on `llmo-agentic-traffic.js`: 100% lines/statements/functions, 97.97% branches
- [ ] After both worker + this PR deploy: smoke test in dev that the new exportId hashes against `v1c1` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)