### PR TITLE
fix: resolveTopicUuid and resolveCategoryUuid accept UUID input directly

### DIFF
--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -55,11 +55,11 @@ export async function resolveBrandUuid(organizationId, brandId, postgrestClient)
 }
 
 /**
- * Resolves category business key (or UUID) to categories.id (uuid).
- * If categoryId is already a valid UUID it is returned directly — the UI
- * derives category identifiers from category.id (UUID PK) in prompt responses,
- * so bypassing the business-key lookup avoids a spurious miss and ensures the
- * filter is never silently skipped.
+ * Resolves category business key or UUID to categories.id (uuid).
+ * When categoryId is a UUID it is looked up by primary key scoped to the
+ * organization (consistent with resolveBrandUuid) — this validates org
+ * ownership rather than blindly trusting the caller-supplied UUID.
+ * When categoryId is a business key it is looked up by category_id as before.
  *
  * @param {string} organizationId - SpaceCat organization UUID
  * @param {string} categoryId - Business key or UUID
@@ -70,24 +70,20 @@ export async function resolveCategoryUuid(organizationId, categoryId, postgrestC
   if (!hasText(categoryId) || !postgrestClient?.from) {
     return null;
   }
-  if (isValidUUID(categoryId)) {
-    return categoryId;
-  }
-  const { data, error } = await postgrestClient
-    .from('categories')
-    .select('id')
-    .eq('organization_id', organizationId)
-    .eq('category_id', categoryId)
-    .maybeSingle();
+  const query = postgrestClient.from('categories').select('id').eq('organization_id', organizationId);
+  const { data, error } = await (isValidUUID(categoryId)
+    ? query.eq('id', categoryId)
+    : query.eq('category_id', categoryId)
+  ).maybeSingle();
   return !error && data?.id ? data.id : null;
 }
 
 /**
- * Resolves topic business key (or UUID) to topics.id (uuid).
- * If topicId is already a valid UUID it is returned directly — the UI
- * derives topic identifiers from topic.id (UUID PK) in prompt responses,
- * so bypassing the business-key lookup avoids a spurious miss and ensures the
- * filter is never silently skipped.
+ * Resolves topic business key or UUID to topics.id (uuid).
+ * When topicId is a UUID it is looked up by primary key scoped to the
+ * organization (consistent with resolveBrandUuid) — this validates org
+ * ownership rather than blindly trusting the caller-supplied UUID.
+ * When topicId is a business key it is looked up by topic_id as before.
  *
  * @param {string} organizationId - SpaceCat organization UUID
  * @param {string} topicId - Business key or UUID
@@ -98,15 +94,11 @@ export async function resolveTopicUuid(organizationId, topicId, postgrestClient)
   if (!hasText(topicId) || !postgrestClient?.from) {
     return null;
   }
-  if (isValidUUID(topicId)) {
-    return topicId;
-  }
-  const { data, error } = await postgrestClient
-    .from('topics')
-    .select('id')
-    .eq('organization_id', organizationId)
-    .eq('topic_id', topicId)
-    .maybeSingle();
+  const query = postgrestClient.from('topics').select('id').eq('organization_id', organizationId);
+  const { data, error } = await (isValidUUID(topicId)
+    ? query.eq('id', topicId)
+    : query.eq('topic_id', topicId)
+  ).maybeSingle();
   return !error && data?.id ? data.id : null;
 }
 

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -55,16 +55,23 @@ export async function resolveBrandUuid(organizationId, brandId, postgrestClient)
 }
 
 /**
- * Resolves category business key to categories.id (uuid).
+ * Resolves category business key (or UUID) to categories.id (uuid).
+ * If categoryId is already a valid UUID it is returned directly — the UI
+ * derives category identifiers from category.id (UUID PK) in prompt responses,
+ * so bypassing the business-key lookup avoids a spurious miss and ensures the
+ * filter is never silently skipped.
  *
  * @param {string} organizationId - SpaceCat organization UUID
- * @param {string} categoryId - Business key (e.g. "photoshop-photo-editing")
+ * @param {string} categoryId - Business key or UUID
  * @param {object} postgrestClient - PostgREST client
  * @returns {Promise<string|null>} categories.id (uuid) or null
  */
 export async function resolveCategoryUuid(organizationId, categoryId, postgrestClient) {
   if (!hasText(categoryId) || !postgrestClient?.from) {
     return null;
+  }
+  if (isValidUUID(categoryId)) {
+    return categoryId;
   }
   const { data, error } = await postgrestClient
     .from('categories')
@@ -76,16 +83,23 @@ export async function resolveCategoryUuid(organizationId, categoryId, postgrestC
 }
 
 /**
- * Resolves topic business key to topics.id (uuid).
+ * Resolves topic business key (or UUID) to topics.id (uuid).
+ * If topicId is already a valid UUID it is returned directly — the UI
+ * derives topic identifiers from topic.id (UUID PK) in prompt responses,
+ * so bypassing the business-key lookup avoids a spurious miss and ensures the
+ * filter is never silently skipped.
  *
  * @param {string} organizationId - SpaceCat organization UUID
- * @param {string} topicId - Business key
+ * @param {string} topicId - Business key or UUID
  * @param {object} postgrestClient - PostgREST client
  * @returns {Promise<string|null>} topics.id (uuid) or null
  */
 export async function resolveTopicUuid(organizationId, topicId, postgrestClient) {
   if (!hasText(topicId) || !postgrestClient?.from) {
     return null;
+  }
+  if (isValidUUID(topicId)) {
+    return topicId;
   }
   const { data, error } = await postgrestClient
     .from('topics')

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -114,10 +114,18 @@ describe('prompts-storage', () => {
       expect(result).to.be.null;
     });
 
-    it('returns category id when found', async () => {
+    it('returns category id when found by business key', async () => {
       const client = { from: () => makeChain({ data: { id: 'cat-uuid' }, error: null }) };
       const result = await resolveCategoryUuid(ORG_ID, 'cat-1', client);
       expect(result).to.equal('cat-uuid');
+    });
+
+    it('returns uuid directly without a DB lookup when categoryId is already a valid UUID', async () => {
+      const uuid = 'a1111111-1111-4111-b111-111111111111';
+      const client = { from: sandbox.stub().throws(new Error('should not query DB')) };
+      const result = await resolveCategoryUuid(ORG_ID, uuid, client);
+      expect(result).to.equal(uuid);
+      expect(client.from.called).to.be.false;
     });
   });
 
@@ -127,7 +135,7 @@ describe('prompts-storage', () => {
       expect(result).to.be.null;
     });
 
-    it('returns topic id when found', async () => {
+    it('returns topic id when found by business key', async () => {
       const client = { from: () => makeChain({ data: { id: 'topic-uuid' }, error: null }) };
       const result = await resolveTopicUuid(ORG_ID, 'topic-1', client);
       expect(result).to.equal('topic-uuid');
@@ -137,6 +145,14 @@ describe('prompts-storage', () => {
       const client = { from: () => makeChain({ data: null, error: null }) };
       const result = await resolveTopicUuid(ORG_ID, 'nonexistent', client);
       expect(result).to.be.null;
+    });
+
+    it('returns uuid directly without a DB lookup when topicId is already a valid UUID', async () => {
+      const uuid = 'b2222222-2222-4222-b222-222222222222';
+      const client = { from: sandbox.stub().throws(new Error('should not query DB')) };
+      const result = await resolveTopicUuid(ORG_ID, uuid, client);
+      expect(result).to.equal(uuid);
+      expect(client.from.called).to.be.false;
     });
   });
 

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -120,12 +120,18 @@ describe('prompts-storage', () => {
       expect(result).to.equal('cat-uuid');
     });
 
-    it('returns uuid directly without a DB lookup when categoryId is already a valid UUID', async () => {
+    it('resolves by primary key scoped to org when categoryId is a valid UUID', async () => {
       const uuid = 'a1111111-1111-4111-b111-111111111111';
-      const client = { from: sandbox.stub().throws(new Error('should not query DB')) };
+      const client = { from: () => makeChain({ data: { id: uuid }, error: null }) };
       const result = await resolveCategoryUuid(ORG_ID, uuid, client);
       expect(result).to.equal(uuid);
-      expect(client.from.called).to.be.false;
+    });
+
+    it('returns null when UUID does not belong to the organization', async () => {
+      const uuid = 'a1111111-1111-4111-b111-111111111111';
+      const client = { from: () => makeChain({ data: null, error: null }) };
+      const result = await resolveCategoryUuid(ORG_ID, uuid, client);
+      expect(result).to.be.null;
     });
   });
 
@@ -147,12 +153,18 @@ describe('prompts-storage', () => {
       expect(result).to.be.null;
     });
 
-    it('returns uuid directly without a DB lookup when topicId is already a valid UUID', async () => {
+    it('resolves by primary key scoped to org when topicId is a valid UUID', async () => {
       const uuid = 'b2222222-2222-4222-b222-222222222222';
-      const client = { from: sandbox.stub().throws(new Error('should not query DB')) };
+      const client = { from: () => makeChain({ data: { id: uuid }, error: null }) };
       const result = await resolveTopicUuid(ORG_ID, uuid, client);
       expect(result).to.equal(uuid);
-      expect(client.from.called).to.be.false;
+    });
+
+    it('returns null when UUID does not belong to the organization', async () => {
+      const uuid = 'b2222222-2222-4222-b222-222222222222';
+      const client = { from: () => makeChain({ data: null, error: null }) };
+      const result = await resolveTopicUuid(ORG_ID, uuid, client);
+      expect(result).to.be.null;
     });
   });
 


### PR DESCRIPTION
## Summary

- `resolveTopicUuid` and `resolveCategoryUuid` now handle UUID inputs by doing an org-scoped primary-key lookup (`WHERE id = ? AND organization_id = ?`), consistent with the existing `resolveBrandUuid` pattern
- Business-key inputs (slugs, names) continue to use the existing `topic_id` / `category_id` column lookup unchanged
- Adds unit tests covering the UUID path (found and not-found) for both functions

## Root cause

When a user deletes a topic from the Prompts Management page, the UI passes the topic's UUID PK (sourced from `prompt.topic.id` in list responses) as the `topicId` filter param on `GET .../prompts`.

`resolveTopicUuid` treated every input as a business key and queried `WHERE topic_id = ?`. The lookup returned `null`, the `topic_id` filter on the prompts query was silently skipped, and **all prompts for the brand** were returned instead of just the topic's prompts. With a chunk size of 500 (exceeding the API's 100-prompt hard limit), this caused a `Maximum 100 prompt IDs per request` error on every topic delete.


## Test plan
- Make sure the branch is deployed and run UI locally points to dev
- Try deleting a topic and open the network tab to check the payload from delete api call
- Verify that the number of prompts in the payload is correct based on the topic you delete
