### PR TITLE
fix(routes): validate :jobId as UUID before reaching controllers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -346,6 +346,9 @@ async function run(request, context) {
       if (params.executionId && !isValidUUID(params.executionId)) {
         return badRequest('Execution Id is invalid. Please provide a valid UUID.');
       }
+      if (params.jobId && !isValidUUIDV4(params.jobId)) {
+        return badRequest('Job Id is invalid. Please provide a valid UUID.');
+      }
       context.params = params;
       context.request = request;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -346,6 +346,17 @@ describe('Index Tests', () => {
     expect(resp.headers.plain()['x-error']).to.equal('Job Id is invalid. Please provide a valid UUID.');
   });
 
+  it('rejects bare /tools/scrape/jobs/by-base-url misroute with invalid jobId', async () => {
+    context.pathInfo.suffix = '/tools/scrape/jobs/by-base-url';
+
+    request = new Request(`${baseUrl}/tools/scrape/jobs/by-base-url`, { headers: { 'x-api-key': apiKey } });
+
+    const resp = await main(request, context);
+
+    expect(resp.status).to.equal(400);
+    expect(resp.headers.plain()['x-error']).to.equal('Job Id is invalid. Please provide a valid UUID.');
+  });
+
   it('rejects bare /tools/import/jobs/by-date-range misroute with invalid jobId', async () => {
     context.pathInfo.suffix = '/tools/import/jobs/by-date-range';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -335,6 +335,28 @@ describe('Index Tests', () => {
     expect(resp.headers.plain()['x-error']).to.equal('Execution Id is invalid. Please provide a valid UUID.');
   });
 
+  it('rejects bare /tools/scrape/jobs/by-url misroute with invalid jobId', async () => {
+    context.pathInfo.suffix = '/tools/scrape/jobs/by-url';
+
+    request = new Request(`${baseUrl}/tools/scrape/jobs/by-url`, { headers: { 'x-api-key': apiKey } });
+
+    const resp = await main(request, context);
+
+    expect(resp.status).to.equal(400);
+    expect(resp.headers.plain()['x-error']).to.equal('Job Id is invalid. Please provide a valid UUID.');
+  });
+
+  it('rejects bare /tools/import/jobs/by-date-range misroute with invalid jobId', async () => {
+    context.pathInfo.suffix = '/tools/import/jobs/by-date-range';
+
+    request = new Request(`${baseUrl}/tools/import/jobs/by-date-range`, { headers: { 'x-api-key': apiKey } });
+
+    const resp = await main(request, context);
+
+    expect(resp.status).to.equal(400);
+    expect(resp.headers.plain()['x-error']).to.equal('Job Id is invalid. Please provide a valid UUID.');
+  });
+
   it('handles dynamic route errors', async () => {
     context.pathInfo.suffix = '/sites/e730ec12-4325-4bdd-ac71-0f4aa5b18cff';
 


### PR DESCRIPTION
## Summary

Adds UUID v4 validation on `params.jobId` in `src/index.js`, mirroring the existing pattern for `:siteId`, `:organizationId`, `:plgOnboardingId`, `:onboardingId`, `:spaceCatId`, `:brandId`, and `:executionId`.

## Problem

The route matcher (`src/utils/route-utils.js:56-95`) is **first-match-wins with no specificity scoring** and enforces strict segment-count equality. `GET /tools/scrape/jobs/:jobId` (`src/routes/index.js:386`) is registered before the static-prefix routes (`by-url`, `by-base-url`, `by-date-range`), so a bare `GET /tools/scrape/jobs/by-url/` (4 segments, missing required `:url`) gets captured by `:jobId` with `jobId="by-url"` and routed to `getScrapeJobStatus()` instead of the by-url handler.

Same misroute class exists on `/tools/import/jobs/by-date-range/` (`src/routes/index.js:377` sits after `:jobId` at line 372).

## Evidence

- **1,224 ERROR-level log entries in 7 days** (`/aws/lambda/spacecat-services--api-service` prod), all `Failed to fetch scrape job status for jobId: by-url, message: Job ID is required`.
- Surfaced during the [SITES-43989](https://jira.corp.adobe.com/browse/SITES-43989) Sev1 investigation as scrape-API error noise that masked the real signal.
- Verified the caller path in the IMS-auth log line: `Checking authentication with IMS for product ASO at route GET /tools/scrape/jobs/by-url/`.

## Why UUID validation (not route reordering)

The ticket suggested reordering static-prefix routes above `:jobId`, citing the `/consumers/by-client-id/:clientId` precedent. That fix doesn't apply here:

- The matcher enforces strict segment-count equality (`route-utils.js:69`), so `:jobId` (4 segments) and `by-url/:url` (5 segments) never collide for well-formed requests. The misroute only fires for the bare 4-segment prefix, for which no static route exists to "win" reordering.
- The `/consumers/` precedent is stylistic — those routes have different segment counts (2 vs 3) and can't collide regardless of order.

UUID validation matches the documented convention in `CLAUDE.md` ("UUID parameters are validated in `src/index.js` using `isValidUUIDV4()` before reaching controllers") and protects `:jobId` across all five endpoint families that share the parameter: scrape, import, preflight, beta preflight, site detection, consent-banner.

## Follow-up

The root cause (first-match-wins matcher with no specificity scoring) remains and is mentioned in the ticket as an "Optional follow-up (M)" — worth filing as a separate ticket but out of scope here.

## Related Issues

- Fixes [SITES-45112](https://jira.corp.adobe.com/browse/SITES-45112)
- Related: [SITES-43989](https://jira.corp.adobe.com/browse/SITES-43989) (Sev1 that surfaced this), [SITES-45110](https://jira.corp.adobe.com/browse/SITES-45110) (upstream producer fix)

## Test plan

- [x] Two new tests in `test/index.test.js` covering the scrape misroute and the import sibling case — both return 400 with `Job Id is invalid. Please provide a valid UUID.`
- [x] Watched both tests fail (RED) before adding the validation; confirmed failure reasons matched expected misroute behavior.
- [x] Full `npm test` suite green: 10,299 passing.
- [x] `npm run lint` clean (pre-existing warnings in unrelated files unchanged).