### PR TITLE
feat(slack): add 'run cdn reports bulk publish' command

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -20,6 +20,7 @@ import martechImpact from './commands/martech-impact.js';
 import runAudit from './commands/run-audit.js';
 import runImport from './commands/run-import.js';
 import runGlobalImport from './commands/run-global-import.js';
+import runCdnReportsBulkPublish from './commands/run-cdn-reports-bulk-publish.js';
 import runInternalReport from './commands/run-internal-report.js';
 import runReport from './commands/run-report.js';
 import runScrape from './commands/run-scrape.js';
@@ -74,6 +75,7 @@ export default (context) => [
   runAudit(context),
   runImport(context),
   runGlobalImport(context),
+  runCdnReportsBulkPublish(context),
   runInternalReport(context),
   runReport(context),
   runScrape(context),

--- a/src/support/slack/commands/run-cdn-reports-bulk-publish.js
+++ b/src/support/slack/commands/run-cdn-reports-bulk-publish.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* c8 ignore start */
+import BaseCommand from './base.js';
+import { postErrorMessage } from '../../../utils/slack/base.js';
+import { sendAuditMessage } from '../../utils.js';
+
+const PHRASES = ['run cdn reports bulk publish'];
+const AUDIT_TYPE = 'cdn-reports-bulk-publish';
+
+function runCdnReportsBulkPublishCommand(context) {
+  const { log, sqs, env } = context;
+
+  const baseCommand = BaseCommand({
+    id: 'run-cdn-reports-bulk-publish',
+    name: 'Run CDN Reports Bulk Publish',
+    description: 'Manually trigger the cross-site cdn-reports-bulk-publish audit. '
+      + 'Submits one bulk preview + publish to admin.hlx.page covering every site '
+      + 'with cdn-logs-report enabled.',
+    phrases: PHRASES,
+    usageText: PHRASES[0],
+  });
+
+  const handleExecution = async (_args, slackContext) => {
+    const { say } = slackContext;
+    try {
+      await sendAuditMessage(
+        sqs,
+        env.AUDIT_JOBS_QUEUE_URL,
+        AUDIT_TYPE,
+        {
+          slackContext: {
+            channelId: slackContext.channelId,
+            threadTs: slackContext.threadTs,
+          },
+        },
+      );
+      await say(`:adobe-run: Triggered *${AUDIT_TYPE}*`);
+    } catch (error) {
+      log.error(`Error triggering ${AUDIT_TYPE}: ${error.message}`);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+}
+
+export default runCdnReportsBulkPublishCommand;
+/* c8 ignore end */


### PR DESCRIPTION
## Summary

Adds a Slack command for triggering the cross-site `cdn-reports-bulk-publish` audit added in [spacecat-audit-worker#2534](https://github.com/adobe/spacecat-audit-worker/pull/2534).

```
@spacecat run cdn reports bulk publish
```

## Why

The `cdn-reports-bulk-publish` audit is registered as a plain HANDLERS entry (no `AuditBuilder`) because it operates across all sites and doesn't need a trigger siteId. The existing `run audit` Slack command can't trigger it because it enforces:

1. A valid `{site}` argument
2. `isHandlerEnabledForSite(auditType, site)` — would require enabling the type per-site in Configuration
3. `handler.productCodes` configured — would require a one-time Configuration update

A dedicated Slack command sidesteps all three, since none of those gates are meaningful for a system-wide manual safety-net.

## Scope

Intentionally narrow: just this one audit type. The audit itself is a temporary safety net for the SKYSI-79147 issue (per-site `cdn-logs-report` audits fire-and-forgetting bulk publish to admin.hlx.page on slow days). If we end up with more system-wide handlers later, this can be generalised then.

## Changes

`src/support/slack/commands/run-cdn-reports-bulk-publish.js` (new, ~50 lines, wrapped in `/* c8 ignore */` matching the `run-global-import` pattern) — sends `{ type: 'cdn-reports-bulk-publish', auditContext: { slackContext } }` to the audit-jobs queue. No siteId.

`src/support/slack/commands.js` — register the command.

## Test plan

- [x] `npx eslint` on the touched files — clean
- [ ] Deploy to dev; in Slack: `@spacecat run cdn reports bulk publish` — confirm the audit-worker dispatcher receives the message and Coralogix shows `REPORT_UPLOADER: Starting bulk publish for N files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)