### PR TITLE
docs: add release-caused-outage runbook + orchestration skill

### DIFF
--- a/.claude/skills/release-outage-response/SKILL.md
+++ b/.claude/skills/release-outage-response/SKILL.md
@@ -44,6 +44,8 @@ what order*; the runbook tells you *how*.
 - Establish: is it **broad** (all/most requests) or scoped to one endpoint/tenant?
   If scoped, **stop** — this skill is for release-wide outages; diagnose that
   endpoint instead.
+- Optionally confirm black-box with the auth-free health check (runbook Step 1) — a
+  load-time failure fails even `/_status_check/healthcheck.json`.
 - Capture the **exact error** and the **first-occurrence timestamp**.
 
 ### Phase 2 — Correlate with the most recent release
@@ -103,11 +105,14 @@ Follow runbook Step 5 exactly. Key points the runbook details:
 - Watch the Coralogix error rate fall to zero **on the new deploy**, not just on
   the revert merge.
 - Confirm CI ran on the revert commit and the deploy job completed; check the
-  Lambda `LastModified` updated.
+  Lambda `LastModified` updated and the health check returns `200` (runbook Step 6).
 - Do not declare the incident resolved until errors stop on the redeployed code.
 
 ### Phase 7 — Follow-up
 
+- Close the loop in `#aem-sites-optimizer-engineering` and file the post-mortem
+  (JIRA project **SITES**, component **ASO**/**LLMO**; post-mortem as a wiki page) —
+  see runbook Step 7 for links.
 - File a ticket for the **real fix** (re-land the reverted change correctly):
   symptom, root cause, chosen fix; link the revert commit and the original PR;
   `Critical` priority for a full outage, type `Bug`.

--- a/.claude/skills/release-outage-response/SKILL.md
+++ b/.claude/skills/release-outage-response/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: release-outage-response
+description: >-
+  Orchestrates incident response when the spacecat-api-service Lambda is failing
+  broadly after a deploy. Drives a diagnose-first workflow — confirm the outage,
+  correlate it with the most recent release, and verify the suspect build locally
+  — then gates a revert+push to prod main behind explicit human confirmation,
+  and finally confirms recovery and files follow-up. Use when spacecat-api-service
+  is returning widespread 500s shortly after a release; when a Lambda invocation
+  error such as `TypeError: main2 is not a function`, `Cannot find module`, or a
+  module-load `ENOENT` appears; when asked whether a release caused an outage; or
+  when asked to revert / roll back a bad spacecat-api-service release. The manual
+  step-by-step lives in docs/runbooks/release-caused-outage.md.
+---
+
+# Release-Caused Outage Response
+
+LLM-led companion to `docs/runbooks/release-caused-outage.md`. The runbook holds
+the exact commands and the worked example; this skill enforces the **sequence**,
+the **diagnosis discipline**, and the **one hard safety gate**.
+
+**Before starting, read `docs/runbooks/release-caused-outage.md`** — work from its
+commands rather than reconstructing them. This skill tells you *what to do and in
+what order*; the runbook tells you *how*.
+
+## Operating rules
+
+- **Diagnose before reverting.** Do not propose a revert until evidence supports
+  it. Hold at least two hypotheses until one is confirmed (see Phase 2–3).
+- **One hard gate:** never run the revert **or** the push to prod `main` without
+  explicit human confirmation (Phase 4). This is the only irreversible, shared-state
+  action in the flow — treat it as such.
+- **Verify locally first.** A revert is cheap, but a *wrong* revert wastes the one
+  cheap mitigation you have. Prove the suspect build is broken before you touch
+  `main` (Phase 3).
+- **Narrate for an operator under pressure.** State what you found and what you're
+  about to do in plain, skimmable terms — someone is watching this incident.
+
+## Workflow
+
+### Phase 1 — Confirm and frame the outage
+
+- Pull live errors (`npm run logs` / Coralogix `inv.functionName:/spacecat-services/api-service/latest`).
+- Establish: is it **broad** (all/most requests) or scoped to one endpoint/tenant?
+  If scoped, **stop** — this skill is for release-wide outages; diagnose that
+  endpoint instead.
+- Capture the **exact error** and the **first-occurrence timestamp**.
+
+### Phase 2 — Correlate with the most recent release
+
+- `git fetch origin && git log --oneline --format='%h %ci %s' -15 origin/main`.
+- Identify the suspect **feature commit** (the PR merge), not the
+  `chore(release)` commit — the release commit carries no application code.
+- Apply the **timeline caveat** from the runbook: the release-commit timestamp is
+  not the deploy time, and log timezones may mislead. Correlate on the feature
+  commit and the actual Lambda deploy time
+  (`aws lambda get-function … --query 'Configuration.LastModified'`), not on the
+  `chore(release)` timestamp.
+
+### Phase 3 — Verify before reverting (do NOT skip)
+
+Follow runbook Step 3. Any one of these is good evidence; together they're
+conclusive:
+
+- Build the suspect commit locally (`nvm use 24`, `npm ci`, then `npm run build`
+  with the dummy VPC env vars). The `--test-bundle` step loads the artifact, so a
+  load-time break reproduces here.
+- Inspect the deploy zip (`unzip -l dist/…@<version>.zip`) and confirm whether the
+  failing code's expected asset/module is present.
+- Optionally pull and inspect the deployed artifact directly.
+
+State the result explicitly: "confirmed — <cause>" or "not confirmed — staying in
+diagnosis." Do not advance to Phase 4 on an unconfirmed hypothesis.
+
+### Phase 4 — CONFIRMATION GATE (required)
+
+**Stop here and get explicit human sign-off before any `git revert` or
+`git push`.** Present, concisely:
+
+1. The confirmed root cause and the evidence for it.
+2. The exact mitigation: which **feature commit** will be reverted, and that it
+   pushes to prod `main`.
+3. The alternative (roll-forward) and why revert is the call right now.
+
+Then ask plainly, e.g. *"Revert `<sha>` and push to main?"* — and **wait**. Do not
+run the revert or the push until the human answers yes. If they redirect, follow
+that instead. A prior approval does not authorize re-running on a later/different
+commit — re-confirm each time.
+
+### Phase 5 — Revert and push (only after Phase 4 approval)
+
+Follow runbook Step 5 exactly. Key points the runbook details:
+
+- Revert the **feature** commit, not the `chore(release)` commit.
+- Write a commit message documenting symptom + root cause + re-land options.
+- Expect and handle the real gotchas: node 24 via `nvm`, `npm ci` so the
+  pre-commit hook's eslint resolves, **do not** reach for `--no-verify`, and the
+  branch-protection `Bypassed rule violations` notice on push is expected for an
+  admin emergency revert.
+
+### Phase 6 — Confirm recovery
+
+- Watch the Coralogix error rate fall to zero **on the new deploy**, not just on
+  the revert merge.
+- Confirm CI ran on the revert commit and the deploy job completed; check the
+  Lambda `LastModified` updated.
+- Do not declare the incident resolved until errors stop on the redeployed code.
+
+### Phase 7 — Follow-up
+
+- File a ticket for the **real fix** (re-land the reverted change correctly):
+  symptom, root cause, chosen fix; link the revert commit and the original PR;
+  `Critical` priority for a full outage, type `Bug`.
+- Recommend the durable regression guard: a CI bundle-smoke test that imports the
+  built artifact and asserts `typeof main === 'function'` — written in **Node**
+  (the repo's language) as a test / npm script, not bundled in this skill.
+
+## Anti-patterns
+
+- Reverting on a hunch without local verification (Phase 3).
+- Reverting or pushing without the Phase 4 human gate.
+- Reverting the `chore(release)` commit (no code) instead of the feature commit.
+- Using `--no-verify` to get past a failing pre-commit hook — that hook failure is
+  an environment problem (node version / stale deps), not a code problem.
+- Declaring victory on the revert *merge* rather than on the recovered *deploy*.

--- a/.claude/skills/release-outage-response/SKILL.md
+++ b/.claude/skills/release-outage-response/SKILL.md
@@ -112,8 +112,7 @@ Follow runbook Step 5 exactly. Key points the runbook details:
   symptom, root cause, chosen fix; link the revert commit and the original PR;
   `Critical` priority for a full outage, type `Bug`.
 - Recommend the durable regression guard: a CI bundle-smoke test that imports the
-  built artifact and asserts `typeof main === 'function'` — written in **Node**
-  (the repo's language) as a test / npm script, not bundled in this skill.
+  built artifact.
 
 ## Anti-patterns
 

--- a/README.md
+++ b/README.md
@@ -274,3 +274,7 @@ The `multipartFormData` wrapper uses the following optional env variables:
 MULTIPART_FORM_FILE_COUNT_LIMIT=Maximum number of files which can be included in a multipart/form-data request (defaults to 5)
 MULTIPART_FORM_MAX_FILE_SIZE_MB=Maximum file size in MB for a single file in a multipart/form-data request (defaults to 20)
 ```
+
+## Operations & Runbooks
+
+- [Release-caused outage (diagnose → verify → revert)](docs/runbooks/release-caused-outage.md) — what to do when the API starts failing broadly after a deploy, including how to confirm a release is the cause before reverting and the `main is not a function` bundle-failure signature.

--- a/docs/runbooks/release-caused-outage.md
+++ b/docs/runbooks/release-caused-outage.md
@@ -27,6 +27,44 @@ release-wide outage — diagnose that endpoint instead.
 
 ---
 
+## Prerequisites
+
+Check these *before* you need them — discovering missing access at the revert
+(Step 5) is the expensive failure mode.
+
+**Tooling.** `nvm` + node `>=24 <25` (`.nvmrc` pins `24.15.0`) and npm `>=10.9.0`;
+run `nvm use` in the repo to match.
+
+**Access** (read-only is enough for diagnosis):
+
+- **AWS** — an authenticated session for the spacecat **prod** account, region
+  `us-east-1` (your normal `aws sso login` / `AWS_PROFILE` / exported keys). Needs
+  CloudWatch Logs read (`npm run logs`) and `lambda:GetFunction` (deploy-time and
+  artifact checks). The `aws` commands authenticate via your shell's ambient
+  credentials — **nothing is baked into the npm scripts** — so with no active
+  session `npm run logs` just fails with a credentials error.
+- **Coralogix** — account access (Adobe SSO) for the error-stream queries; separate
+  from AWS.
+- **GitHub** — push to `main` with admin/bypass rights (branch protection) for the
+  Step 5 revert. Without bypass, open the revert as a PR and admin-merge (or ask
+  someone who can).
+
+**Build env vars (Step 3 local verify only).** `npm run build` resolves the `hlx`
+block in `package.json`, which interpolates four vars. **Dummy values are fine** —
+`--test-bundle` only builds and loads the artifact; real values matter only for an
+actual deploy (run by CI):
+
+| Env var | Feeds (`package.json` → `hlx`) |
+|---|---|
+| `VPC_SUBNET_1`, `VPC_SUBNET_2` | `awsVpcSubnetIds` |
+| `VPC_SG_ID` | `awsVpcSecurityGroupIds` |
+| `AWS_ACCOUNT_ID` | `awsRole!important` (role ARN) |
+
+You do **not** need a populated `.env` or `secrets/dev-secrets.json` — those are for
+the local dev server (`npm start`), which this flow never runs.
+
+---
+
 ## TL;DR fast path
 
 ```bash
@@ -69,6 +107,16 @@ inv.functionName:/spacecat-services/api-service/latest AND level:error
 
 Capture two facts: **what the error is** and **when it first occurred**. You need
 the first-occurrence timestamp for Step 2.
+
+You can also confirm the outage black-box, with **no credentials** — a load-time
+failure takes down even the unauthenticated health check (`helixStatus` runs before
+auth):
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  https://spacecat.experiencecloud.live/_status_check/healthcheck.json
+# broad outage: 5xx / error  ·  healthy: 200
+```
 
 ---
 
@@ -173,9 +221,10 @@ real fix and a regression test.
 
 ## Step 5 — Revert and push
 
-> **Communicate first.** Post in the incident channel _(TODO: name it, e.g.
-> `#spacecat-incidents`)_ that you're mitigating with a revert of `<sha>`, so
-> responders aren't duplicating work.
+> **Communicate first.** Post in
+> [`#aem-sites-optimizer-engineering`](https://adobe.enterprise.slack.com/archives/C05A45JBP9N)
+> that you're mitigating with a revert of `<sha>`, so responders aren't duplicating
+> work.
 
 Revert the **feature commit**, not the release commit:
 
@@ -240,6 +289,9 @@ cuts a new patch version, and the shared CI deploys it.
   job — https://github.com/adobe/spacecat-api-service/actions
 - **Lambda deploy time:** `aws lambda get-function --function-name
   spacecat-services--api-service --query 'Configuration.LastModified'` should update.
+- **Health check:** `curl -sS -o /dev/null -w '%{http_code}\n' https://spacecat.experiencecloud.live/_status_check/healthcheck.json`
+  returns `200` — the unauthenticated `helixStatus` endpoint fails too during a
+  load-time outage, so a `200` on the new deploy is a real recovery signal.
 
 Don't declare the incident over until you've seen the error rate drop on the *new*
 deploy, not just the revert merge.
@@ -250,16 +302,20 @@ deploy, not just the revert merge.
 
 Once recovery is confirmed (Step 6):
 
-- **Close the loop in the incident channel** _(TODO: name it)_ — post that the
-  revert deployed and the error rate is back to baseline, with the recovered-deploy
-  timestamp. Update the status page if one exists _(TODO: link)_.
-- **File the post-mortem** _(TODO: SLA, e.g. within 48h)_ using the team template
-  _(TODO: link to post-mortem template)_. Capture the timeline, the root cause, and
-  the **detection gap** — this class of failure is invisible until a cold-start
-  invocation, so note how the regression guard below would have caught it.
-- **File the real-fix ticket** to re-land the reverted change correctly: symptom,
-  root cause, chosen fix; link the revert commit and the original PR. Priority
-  `Critical` for a full outage; type `Bug`.
+- **Close the loop** in
+  [`#aem-sites-optimizer-engineering`](https://adobe.enterprise.slack.com/archives/C05A45JBP9N)
+  — post that the revert deployed and the error rate is back to baseline, with the
+  recovered-deploy timestamp. (No status page to update.)
+- **File the post-mortem.** Track it with a JIRA in project **SITES** (component
+  **ASO** or **LLMO**, as applicable); write the post-mortem itself as a wiki page
+  under [AEM Sites Optimizer Post Mortems](https://wiki.corp.adobe.com/spaces/AEMSites/pages/3484809541/AEM+Sites+Optimizer+Post+Mortems)
+  (no fixed template — follow the existing pages there). Capture the timeline, the
+  root cause, and the **detection gap** — this class of failure is invisible until a
+  cold-start invocation, so note how the regression guard below would have caught it.
+- **File the real-fix ticket** in JIRA project **SITES** (component **ASO** or
+  **LLMO**) to re-land the reverted change correctly: symptom, root cause, chosen
+  fix; link the revert commit and the original PR. Priority `Critical` for a full
+  outage; type `Bug`.
 - **Add a regression guard.** The repo already ships a bundle test —
   `npm run test:bundle` resolves the artifact path from `npm pkg get version`
   dynamically (no hard-coded version) and runs `test/index.test.js` against the

--- a/docs/runbooks/release-caused-outage.md
+++ b/docs/runbooks/release-caused-outage.md
@@ -1,5 +1,7 @@
 # Runbook: Release-Caused Outage (diagnose → verify → revert)
 
+**Last validated:** 2026-05-21 (v1.508.0 incident).
+
 How to respond when `spacecat-api-service` starts failing broadly shortly after a
 deploy. The goal is to **confirm the release is the cause before reverting**, then
 mitigate safely and hand off a real fix.
@@ -171,6 +173,10 @@ real fix and a regression test.
 
 ## Step 5 — Revert and push
 
+> **Communicate first.** Post in the incident channel _(TODO: name it, e.g.
+> `#spacecat-incidents`)_ that you're mitigating with a revert of `<sha>`, so
+> responders aren't duplicating work.
+
 Revert the **feature commit**, not the release commit:
 
 ```bash
@@ -240,23 +246,28 @@ deploy, not just the revert merge.
 
 ---
 
-## Step 7 — Follow-up
+## Step 7 — Follow-up & post-incident
 
-- File a ticket for the **real fix** (re-land the reverted change correctly). Include
-  the symptom, root cause, and chosen fix; link the revert commit and the original
-  PR. Priority `Critical` if it was a full outage; type `Bug`.
-- Add a **regression guard**. For bundle/module-load failures the cheap, durable one
-  is a CI smoke test that loads the built artifact and asserts the handler is
-  callable:
+Once recovery is confirmed (Step 6):
 
-  ```js
-  const mod = await import('../dist/spacecat-services/api-service@<version>-bundle.mjs');
-  assert(typeof mod.main === 'function');
-  ```
-
-  More generally: if `npm run build`'s `--test-bundle` step is currently advisory,
-  make it blocking in CI — it already loads the artifact and would catch this class
-  of failure pre-merge.
+- **Close the loop in the incident channel** _(TODO: name it)_ — post that the
+  revert deployed and the error rate is back to baseline, with the recovered-deploy
+  timestamp. Update the status page if one exists _(TODO: link)_.
+- **File the post-mortem** _(TODO: SLA, e.g. within 48h)_ using the team template
+  _(TODO: link to post-mortem template)_. Capture the timeline, the root cause, and
+  the **detection gap** — this class of failure is invisible until a cold-start
+  invocation, so note how the regression guard below would have caught it.
+- **File the real-fix ticket** to re-land the reverted change correctly: symptom,
+  root cause, chosen fix; link the revert commit and the original PR. Priority
+  `Critical` for a full outage; type `Bug`.
+- **Add a regression guard.** The repo already ships a bundle test —
+  `npm run test:bundle` resolves the artifact path from `npm pkg get version`
+  dynamically (no hard-coded version) and runs `test/index.test.js` against the
+  built bundle. Ensure that test asserts the handler is callable
+  (`typeof main === 'function'`) and that it runs as a **blocking** CI gate, not
+  advisory. `npm run build`'s `--test-bundle` step also loads the artifact at build
+  time and would catch this pre-merge — confirm it fails the build rather than
+  warning.
 
 ---
 
@@ -297,12 +308,18 @@ const locationsData = JSON.parse(readFileSync(LOCATIONS_JSON_PATH, 'utf8'));  //
 `locations.json` was not in `package.json`'s `hlx.static`, so the bundler never
 shipped it. Load-time ENOENT → `main` undefined → `main2 is not a function`.
 
-**The three fixes** (prefer the first — it removes the runtime FS read entirely):
+**Fix — recommended:** inline the data as a JS module (`export const LOCATIONS =
+[...]`) and `import` it. This removes the runtime `readFileSync` entirely, so the
+bundler includes the data via normal import resolution and **this failure mode
+cannot recur**. Prefer this for the re-land.
 
-1. Inline the data as a JS module (`export const LOCATIONS = [...]`) and `import` it.
-2. Add the file to `hlx.static` in `package.json`.
-3. Use a JSON import attribute: `import x from './data/x.json' with { type: 'json' }`
-   (requires relaxing the eslint parser config that currently rejects it).
+Alternatives (they work, but keep the fragile read):
+
+- Add the file to `hlx.static` in `package.json`. Matches the existing allow-list
+  pattern, but preserves the load-time `readFileSync` — the next data file that
+  forgets the allow-list hits the same trap.
+- Use a JSON import attribute: `import x from './data/x.json' with { type: 'json' }`
+  (requires relaxing the eslint parser config that currently rejects it).
 
 ---
 
@@ -312,12 +329,25 @@ shipped it. Load-time ENOENT → `main` undefined → `main2 is not a function`.
   `dist/spacecat-services/api-service@<version>-bundle.mjs` and a `.zip`. The
   `--test-bundle` step loads + invokes the artifact, so a load-time break fails the
   build.
+- **Bundle test:** `npm run test:bundle` runs `test/index.test.js` against an
+  already-built bundle, resolving the artifact path from `npm pkg get version` (so it
+  never hard-codes a version). Distinct role from `build`: `build` produces +
+  validates the bundle; `test:bundle` runs the test suite against an existing one.
+  Use it as the CI regression gate (Step 7).
 - **Deploy (prod):** `npm run deploy` → `hedy -v --deploy
   --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest`. Run by CI, not by
   hand, in normal operation.
-- **Static assets:** `package.json` → `hlx.static` is an allow-list of non-JS files
-  copied into the bundle. **Anything read from disk at runtime must be listed here**
-  (or, better, imported so the bundler includes it automatically).
+- **Static assets:** `hlx.static` is an allow-list of non-JS files copied into the
+  bundle. It lives in `package.json` under the `hlx` key (not a separate
+  `helix-deploy.yaml`). **Anything read from disk at runtime must be listed here**
+  (or, better, imported so the bundler includes it automatically). Concrete shape:
+
+  ```jsonc
+  // package.json
+  "hlx": {
+    "static": ["static/onboard/profiles.json"]
+  }
+  ```
 - **Lambda function name:** `spacecat-services--api-service` (CloudWatch) /
   `/spacecat-services/api-service/latest` (Coralogix `inv.functionName`).
 - **Node:** `engines` pins `>=24 <25`. Match it locally with `nvm use 24`.

--- a/docs/runbooks/release-caused-outage.md
+++ b/docs/runbooks/release-caused-outage.md
@@ -1,0 +1,356 @@
+# Runbook: Release-Caused Outage (diagnose → verify → revert)
+
+How to respond when `spacecat-api-service` starts failing broadly shortly after a
+deploy. The goal is to **confirm the release is the cause before reverting**, then
+mitigate safely and hand off a real fix.
+
+This runbook was written from the 2026-05-21 incident (commit
+[`882dbab5`](https://github.com/adobe/spacecat-api-service/commit/882dbab5),
+released as v1.508.0) where every Lambda invocation failed with
+`TypeError: main2 is not a function`. That incident is used as the worked example
+throughout. See [§ The `main is not a function` signature](#appendix-a-the-main-is-not-a-function-signature)
+for that specific failure mode.
+
+---
+
+## When to use this
+
+- The API is returning broad `500`s (not a single endpoint, not a single tenant).
+- It started **shortly after a release/deploy**.
+- Error looks like a startup/handler-load failure rather than business logic
+  (e.g. `is not a function`, `Cannot find module`, `ENOENT … at module load`).
+
+If the failure is scoped to one endpoint or one customer, this is probably *not* a
+release-wide outage — diagnose that endpoint instead.
+
+---
+
+## TL;DR fast path
+
+```bash
+cd spacecat-api-service
+
+# 1. Find the most recent release + the feature commit it shipped
+git fetch origin && git log --oneline -10 origin/main
+
+# 2. VERIFY locally that the suspect build is broken (don't skip — see Step 3)
+git checkout <release-sha>
+nvm use 24 && npm ci
+VPC_SUBNET_1=x VPC_SUBNET_2=x VPC_SG_ID=x AWS_ACCOUNT_ID=0 npm run build   # --test-bundle loads the artifact
+unzip -l dist/spacecat-services/api-service@<version>.zip                  # is the expected asset present?
+
+# 3. Revert the FEATURE commit (not the release commit) and push
+git checkout main && git pull --ff-only origin main
+git revert --no-commit <feature-sha>
+git commit            # write a message documenting the cause (see Step 5)
+git push origin main
+
+# 4. Watch recovery in Coralogix / CloudWatch (Step 6)
+```
+
+---
+
+## Step 1 — Confirm the outage and its scope
+
+Pull the live error stream and confirm it's broad:
+
+```bash
+npm run logs        # aws logs tail /aws/lambda/spacecat-services--api-service
+```
+
+In Coralogix, scope to the function and look at the error rate and first
+occurrence:
+
+```
+inv.functionName:/spacecat-services/api-service/latest AND level:error
+```
+
+Capture two facts: **what the error is** and **when it first occurred**. You need
+the first-occurrence timestamp for Step 2.
+
+---
+
+## Step 2 — Correlate with the most recent release
+
+```bash
+git fetch origin
+git log --oneline --format='%h %ci %s' -15 origin/main
+```
+
+Releases on this repo are cut by `semantic-release`, so `main` has two kinds of
+commit:
+
+- **Release commits** — `chore(release): X.Y.Z [skip ci]`, authored by
+  `semantic-release-bot`. These only bump `package.json`, `package-lock.json`, and
+  `CHANGELOG.md`. **They contain no application code.**
+- **Feature/fix commits** — the actual PR merges. This is what can break prod.
+
+Find the release that lines up with the outage, then identify the **feature
+commit(s) between it and the previous release**:
+
+```bash
+git log --oneline <previous-release-sha>..<suspect-release-sha>
+```
+
+> ⚠️ **Timeline caveat.** The release-commit timestamp is **not** the deploy time.
+> In the 2026-05-21 incident the feature merge was at 16:07 ET, the first error at
+> 16:08 ET, and the `chore(release)` commit at 16:23 ET — i.e. errors started
+> *before* the release commit existed. Deploy is driven by the shared
+> `adobe/mysticat-ci` workflow, not by the release commit you see in `git log`, and
+> log timestamps may be in a different timezone than you assume. **Correlate on the
+> feature commit and the deploy, not on the release-commit timestamp.** When in
+> doubt, check the Lambda's actual deploy time:
+>
+> ```bash
+> aws lambda get-function --function-name spacecat-services--api-service \
+>   --query 'Configuration.LastModified'
+> ```
+
+The thing you revert is the **feature commit**, because that's where the code is.
+The release commit on its own is harmless.
+
+---
+
+## Step 3 — Verify before you revert
+
+A revert during an outage is low-risk, but a *wrong* revert wastes the one cheap
+mitigation you have. Spend 2–3 minutes proving the suspect build is actually
+broken. Any one of these is good evidence; together they're conclusive.
+
+### 3a. Build the suspect commit locally
+
+```bash
+git checkout <suspect-release-sha>
+nvm use 24                 # repo requires node >=24 <25 — see gotchas
+npm ci
+# build needs VPC params that only exist in the deploy env; dummy values are fine
+VPC_SUBNET_1=subnet-dummy VPC_SUBNET_2=subnet-dummy VPC_SG_ID=sg-dummy \
+  AWS_ACCOUNT_ID=000000000000 npm run build
+```
+
+`npm run build` runs `hedy -v --test-bundle`, which **loads and invokes the bundled
+artifact** as part of validation. If the bundle is broken at module-load time, the
+build itself fails here with the same error prod is throwing — that's your
+confirmation. (This is also the check that *would have caught the bug in CI* if the
+build step weren't being skipped/passed; note it for the follow-up.)
+
+### 3b. Inspect the deploy artifact
+
+The zip in `dist/` is exactly what gets uploaded to Lambda:
+
+```bash
+unzip -l dist/spacecat-services/api-service@<version>.zip
+```
+
+Confirm the artifact contains what the failing code expects (a static asset, a
+module, etc.). In the worked example the zip had 5 files and the
+`locations.json` the handler read at load time was simply not among them.
+
+### 3c. (Optional) inspect the deployed Lambda directly
+
+```bash
+aws lambda get-function --function-name spacecat-services--api-service \
+  --query 'Code.Location' --output text | xargs curl -s -o /tmp/lambda.zip
+unzip -l /tmp/lambda.zip | grep -i <expected-file>
+```
+
+---
+
+## Step 4 — Decide: revert vs roll-forward
+
+| Situation | Action |
+|---|---|
+| Active outage, cause confirmed | **Revert.** Fastest restore to known-good. |
+| Cause confirmed, fix is trivial *and* the PR owner is online | Roll-forward is acceptable, but only if it lands as fast as a revert. |
+| Cause not confirmed | Stay in diagnosis. Do **not** revert speculatively. |
+
+Default during an outage is **revert**. Roll-forward later, in a normal PR, with the
+real fix and a regression test.
+
+---
+
+## Step 5 — Revert and push
+
+Revert the **feature commit**, not the release commit:
+
+```bash
+git checkout main && git pull --ff-only origin main
+git revert --no-commit <feature-sha>
+```
+
+Write a commit message that documents the cause so the next person isn't
+re-diagnosing from scratch. Include: the symptom, the root cause, and the
+re-land options. Example from the worked incident:
+
+```
+Revert "feat(...): ... (#NNNN)"
+
+This reverts commit <sha>.
+
+Reverting due to production outage. After the vX.Y.Z deploy, every Lambda
+invocation failed with `TypeError: main2 is not a function at lambdaAdapter`.
+
+Root cause: <one paragraph>.
+
+Re-land options:
+- <option 1>
+- <option 2>
+```
+
+```bash
+git commit          # paste the message above
+git push origin main
+```
+
+### Gotchas you will hit (all real, from the worked incident)
+
+- **Node version.** The repo requires node `>=24 <25`. If your shell is on an older
+  node, `npm ci` fails with `EBADENGINE`. Fix: `nvm use 24` (install with
+  `nvm install 24` if missing). The pre-commit hook also runs under your active
+  node, so keep 24 active for the commit too.
+- **Pre-commit hook needs deps installed.** `husky` + `lint-staged` run `eslint` on
+  commit. If `node_modules` is stale you'll see `Cannot find package
+  '@eslint/config-helpers'` or similar. Fix: `npm ci`. **Do not** reach for
+  `--no-verify` — the hook failure is an environment problem, not a code problem,
+  and bypassing it skips the lint that protects main.
+- **Which commit.** Reverting the `chore(release)` commit does nothing useful — it
+  only un-bumps the version. Revert the feature commit.
+- **Branch protection.** `main` requires PRs + status checks. A direct push from an
+  account with admin will go through but report `Bypassed rule violations`. That's
+  expected for an emergency revert; CI still runs on the pushed commit. If you don't
+  have bypass rights, open the revert as a PR and use admin-merge / ask someone who
+  does.
+
+After the push, `semantic-release` treats the revert as a release-worthy change,
+cuts a new patch version, and the shared CI deploys it.
+
+---
+
+## Step 6 — Confirm recovery
+
+- **Coralogix:** `inv.functionName:/spacecat-services/api-service/latest AND level:error`
+  — error rate should fall to zero a couple of minutes after the new deploy lands.
+- **GitHub Actions:** watch the CI run on your revert commit, then the release/deploy
+  job — https://github.com/adobe/spacecat-api-service/actions
+- **Lambda deploy time:** `aws lambda get-function --function-name
+  spacecat-services--api-service --query 'Configuration.LastModified'` should update.
+
+Don't declare the incident over until you've seen the error rate drop on the *new*
+deploy, not just the revert merge.
+
+---
+
+## Step 7 — Follow-up
+
+- File a ticket for the **real fix** (re-land the reverted change correctly). Include
+  the symptom, root cause, and chosen fix; link the revert commit and the original
+  PR. Priority `Critical` if it was a full outage; type `Bug`.
+- Add a **regression guard**. For bundle/module-load failures the cheap, durable one
+  is a CI smoke test that loads the built artifact and asserts the handler is
+  callable:
+
+  ```js
+  const mod = await import('../dist/spacecat-services/api-service@<version>-bundle.mjs');
+  assert(typeof mod.main === 'function');
+  ```
+
+  More generally: if `npm run build`'s `--test-bundle` step is currently advisory,
+  make it blocking in CI — it already loads the artifact and would catch this class
+  of failure pre-merge.
+
+---
+
+## Appendix A — The `main is not a function` signature
+
+```
+TypeError: main2 is not a function
+    at lambdaAdapter (file:///var/task/index.js:NNNNNN:NN)
+```
+
+**What it means.** `helix-deploy` wraps your exported `main` from `src/index.js` in
+a generated `lambdaAdapter`. The bundler often renames the import (`main` → `main2`).
+If `main` is `undefined` at invocation time, the adapter throws this `TypeError`.
+
+**Why `main` would be undefined.** `src/index.js` exports `main` as the *last*
+statement (a `wrap(run).with(...)` chain). If **anything throws while the module is
+loading** — a failed `import`, a top-level `readFileSync` that ENOENTs, a circular
+import resolving to `undefined` — execution never reaches the `export const main`,
+so `main` is never defined. Every invocation then fails identically, because it's a
+load-time failure, not a per-request one.
+
+**Why tests can pass while prod burns.** Unit tests import modules from **source**,
+where `import.meta.url` resolves to the real source path and sibling files (JSON,
+data) exist on disk. The **bundle** is a different layout: only code reachable through
+`import` is included, plus whatever is declared in `hlx.static`. A module that does
+`readFileSync(<path relative to import.meta.url>)` at load time works from source and
+fails in the bundle.
+
+**The worked-example cause (2026-05-21).**
+`src/support/semrush/handlers/projects.js` did, at module top level:
+
+```js
+const LOCATIONS_JSON_PATH = resolvePath(dirname(fileURLToPath(import.meta.url)),
+  '..', 'data', 'locations.json');
+const locationsData = JSON.parse(readFileSync(LOCATIONS_JSON_PATH, 'utf8'));  // ENOENT in the bundle
+```
+
+`locations.json` was not in `package.json`'s `hlx.static`, so the bundler never
+shipped it. Load-time ENOENT → `main` undefined → `main2 is not a function`.
+
+**The three fixes** (prefer the first — it removes the runtime FS read entirely):
+
+1. Inline the data as a JS module (`export const LOCATIONS = [...]`) and `import` it.
+2. Add the file to `hlx.static` in `package.json`.
+3. Use a JSON import attribute: `import x from './data/x.json' with { type: 'json' }`
+   (requires relaxing the eslint parser config that currently rejects it).
+
+---
+
+## Appendix B — helix-deploy bundling reference
+
+- **Build:** `npm run build` → `hedy -v --test-bundle`. Produces
+  `dist/spacecat-services/api-service@<version>-bundle.mjs` and a `.zip`. The
+  `--test-bundle` step loads + invokes the artifact, so a load-time break fails the
+  build.
+- **Deploy (prod):** `npm run deploy` → `hedy -v --deploy
+  --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest`. Run by CI, not by
+  hand, in normal operation.
+- **Static assets:** `package.json` → `hlx.static` is an allow-list of non-JS files
+  copied into the bundle. **Anything read from disk at runtime must be listed here**
+  (or, better, imported so the bundler includes it automatically).
+- **Lambda function name:** `spacecat-services--api-service` (CloudWatch) /
+  `/spacecat-services/api-service/latest` (Coralogix `inv.functionName`).
+- **Node:** `engines` pins `>=24 <25`. Match it locally with `nvm use 24`.
+
+---
+
+## Command quick-reference
+
+```bash
+# logs / live errors
+npm run logs
+aws logs tail /aws/lambda/spacecat-services--api-service --follow
+
+# correlate release with outage
+git fetch origin && git log --oneline --format='%h %ci %s' -15 origin/main
+git log --oneline <prev-release>..<suspect-release>
+
+# verify a suspect build locally
+git checkout <sha> && nvm use 24 && npm ci
+VPC_SUBNET_1=x VPC_SUBNET_2=x VPC_SG_ID=x AWS_ACCOUNT_ID=0 npm run build
+unzip -l dist/spacecat-services/api-service@<version>.zip
+
+# inspect the deployed artifact
+aws lambda get-function --function-name spacecat-services--api-service \
+  --query 'Code.Location' --output text | xargs curl -s -o /tmp/lambda.zip
+unzip -l /tmp/lambda.zip
+
+# revert + push
+git checkout main && git pull --ff-only origin main
+git revert --no-commit <feature-sha>
+git commit && git push origin main
+
+# confirm deploy landed
+aws lambda get-function --function-name spacecat-services--api-service \
+  --query 'Configuration.LastModified'
+```


### PR DESCRIPTION
## Summary

Adds an operations runbook and a companion Claude Code skill for responding to a
release-caused outage of the `spacecat-api-service` Lambda — the scenario where a
deploy makes every invocation fail at startup (e.g. `TypeError: main2 is not a
function`).

Two ways to run the same playbook:

- **Manual** — [`docs/runbooks/release-caused-outage.md`](docs/runbooks/release-caused-outage.md):
  a step-by-step runbook (triage → correlate the release → verify locally →
  revert → confirm recovery → follow-up) with copy-pasteable commands.
- **LLM-led** — `.claude/skills/release-outage-response/`: a skill that drives an
  agent through the same phases, enforcing diagnose-before-revert discipline and a
  hard **human-confirmation gate** before any revert/push to prod `main`.

## What's included

- `docs/runbooks/release-caused-outage.md` — the runbook, with a deep-dive appendix
  on the `main is not a function` bundle-failure signature: a recurring
  helix-deploy gotcha where a file read from disk at module load isn't shipped in
  the bundle (not declared in `hlx.static`), so the `main` export never initializes.
- `.claude/skills/release-outage-response/SKILL.md` — the orchestration skill. It
  delegates the actual commands to the runbook and adds the sequencing + safety
  gates.
- `README.md` — new "Operations & Runbooks" section linking to the runbook.

## Motivation

Distilled from the 2026-05-21 v1.508.0 incident: commit 882dbab5 (#2456) read a
JSON asset at module load that wasn't included in the Lambda bundle, so every
invocation failed with `main2 is not a function`. Reverted in 873eddb9. The runbook
captures how that was diagnosed — and how to confirm a release is the cause *before*
reverting — so the next responder doesn't start from scratch.

## Notes

- Docs + skill only; no runtime code changed (`docs:`, so no version bump).
- The recommended durable fix — a CI bundle-smoke test asserting
  `typeof main === 'function'` on the built artifact — is called out as follow-up,
  not included here.

## Test plan

- [x] Skill passes the skill validator (frontmatter + structure)
- [x] Runbook commands verified against current `main` (`hlx.static`, `npm` scripts,
      node `engines`, deploy-zip path)
- [x] README → runbook relative link resolves; GitHub references use real commit
      SHAs / PR #2456
- [x] N/A — no code paths exercised; no unit/IT impact