### PR TITLE
fix: SITES-43989 inline error-rate remediation (LLMO not-provisioned + webhook log noise)

### DIFF
--- a/docs/openapi/headers.yaml
+++ b/docs/openapi/headers.yaml
@@ -8,3 +8,13 @@ location:
   description: The redirect location
   schema:
     type: string
+
+xLlmoDataStatus:
+  description: |
+    Present with value `not-provisioned` when the site's LLMO data has not yet been
+    provisioned (the response body is an empty sheet envelope). Absent when data is
+    provisioned, including a provisioned-but-empty sheet.
+  schema:
+    type: string
+    enum:
+      - not-provisioned

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -19,6 +19,9 @@ llmo-sheet-data:
     responses:
       '200':
         description: LLMO sheet data retrieved successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -31,6 +34,10 @@ llmo-sheet-data:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
   post:
@@ -52,6 +59,9 @@ llmo-sheet-data:
     responses:
       '200':
         description: LLMO sheet data queried and processed successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -64,6 +74,10 @@ llmo-sheet-data:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 
@@ -96,6 +110,9 @@ llmo-sheet-data-with-type:
     responses:
       '200':
         description: LLMO sheet data retrieved successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -108,6 +125,10 @@ llmo-sheet-data-with-type:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
   post:
@@ -130,6 +151,9 @@ llmo-sheet-data-with-type:
     responses:
       '200':
         description: LLMO sheet data queried and processed successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -142,6 +166,10 @@ llmo-sheet-data-with-type:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 
@@ -183,6 +211,9 @@ llmo-sheet-data-with-type-and-week:
     responses:
       '200':
         description: LLMO sheet data retrieved successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -195,6 +226,10 @@ llmo-sheet-data-with-type-and-week:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
   post:
@@ -218,6 +253,9 @@ llmo-sheet-data-with-type-and-week:
     responses:
       '200':
         description: LLMO sheet data queried and processed successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -230,6 +268,10 @@ llmo-sheet-data-with-type-and-week:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 
@@ -309,6 +351,9 @@ llmo-data:
     responses:
       '200':
         description: LLMO data queried and processed successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -332,8 +377,8 @@ llmo-data:
                         description: The file path that was fetched
                       status:
                         type: string
-                        enum: [success, error]
-                        description: The status of the fetch operation
+                        enum: [success, error, no_data]
+                        description: The status of the fetch operation. `no_data` indicates the file's upstream data is not provisioned.
                       data:
                         type: object
                         description: The processed data (only present if status is success)
@@ -346,6 +391,10 @@ llmo-data:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 
@@ -412,6 +461,9 @@ llmo-data-with-datasource:
     responses:
       '200':
         description: LLMO data queried successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -429,6 +481,10 @@ llmo-data-with-datasource:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 
@@ -502,6 +558,9 @@ llmo-data-with-type:
     responses:
       '200':
         description: LLMO data queried successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -517,6 +576,10 @@ llmo-data-with-type:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 
@@ -598,6 +661,9 @@ llmo-data-with-type-and-week:
     responses:
       '200':
         description: LLMO data queried successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -613,6 +679,10 @@ llmo-data-with-type-and-week:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 
@@ -638,6 +708,9 @@ llmo-global-sheet-data:
     responses:
       '200':
         description: LLMO global sheet data retrieved successfully
+        headers:
+          X-Llmo-Data-Status:
+            $ref: './headers.yaml#/xLlmoDataStatus'
         content:
           application/json:
             schema:
@@ -650,6 +723,10 @@ llmo-global-sheet-data:
         $ref: './responses.yaml#/401'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        $ref: './responses.yaml#/502'
+      '504':
+        $ref: './responses.yaml#/504'
     security:
       - api_key: [ ]
 

--- a/docs/openapi/responses.yaml
+++ b/docs/openapi/responses.yaml
@@ -157,3 +157,15 @@
   headers:
     X-Error:
       $ref: './headers.yaml#/xError'
+'502':
+  description: |
+    Bad gateway. The upstream LLMO data source returned a server error.
+  headers:
+    X-Error:
+      $ref: './headers.yaml#/xError'
+'504':
+  description: |
+    Gateway timeout. The upstream LLMO data source did not respond within the request timeout.
+  headers:
+    X-Error:
+      $ref: './headers.yaml#/xError'

--- a/docs/plans/2026-05-21-sites-43989-error-rate-remediation-impl.md
+++ b/docs/plans/2026-05-21-sites-43989-error-rate-remediation-impl.md
@@ -1,0 +1,1036 @@
+# SITES-43989 Error-Rate Remediation - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the three inline `spacecat-api-service` fixes from the SITES-43989 spec so the API Gateway error-rate alert stops counting two avoidable 4xx/log-noise sources, without changing the (already-correct) scrape API.
+
+**Architecture:** Centralize the four duplicated LLMO source-fetch blocks into one shared `llmo-source.js` helper that maps upstream HTTP semantics to a typed result (`{data}` / `{noData}` / tagged throw); each LLMO endpoint interprets `noData` (upstream 404) as an empty `200` carrying a `x-llmo-data-status: not-provisioned` discriminator header, and maps genuine upstream failures to honest status codes (5xx->502, timeout->504, non-404 4xx passthrough). Separately, hoist the per-request `MYSTICAT_WORKSPACE_REPOS` warning out of the eagerly-instantiated `WebhooksController` constructor and downgrade the unset-using-defaults case to `debug`.
+
+**Tech Stack:** Node.js ESM, `@adobe/spacecat-shared-http-utils` (`createResponse`/`ok`/`badRequest`/`internalServerError`), `@adobe/spacecat-shared-utils` (`tracingFetch`), Mocha + Chai + Sinon + `sinon-chai` + `chai-as-promised`, `esmock` 2.7.4 for module mocking, `c8` coverage, ESLint, Coralogix `events2metrics`.
+
+**Spec:** `docs/specs/2026-05-20-sites-43989-error-rate-remediation.md` (merged, PR #2452).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/controllers/llmo/llmo-source.js` | **Create** | The one place that fetches the elmo-ui-data source: owns the 15s timeout, `LLMO_HLX_API_KEY` presence check, request headers, and HTTP-status branching. Backend-agnostic: returns `{status,data,headers}` / `{status:404,noData:true}` / throws a tagged error. Also exports the shared caller-side error->Response mapper, the discriminator-header constants, the captured empty payload, and the structured not-provisioned logger. |
+| `test/controllers/llmo/llmo-source.test.js` | **Create** | Unit tests for every `fetchLlmoSource` branch and `llmoSourceErrorResponse` mapping (esmock `tracingFetch`). |
+| `test/fixtures/llmo/empty-sheet.json` | **Create** | Phase 0 byte-match contract: a real empty-but-provisioned single-sheet response captured live. The synthesized empty `200` must deep-equal this. |
+| `src/controllers/llmo/llmo-query-handler.js` | **Modify** | `fetchAndProcessSingleFile` delegates fetch to `fetchLlmoSource` and propagates `{noData:true}`; `fetchAndProcessMultipleFiles` maps upstream-404 to per-file `status:'no_data'` (distinct from `'error'`). |
+| `src/controllers/llmo/llmo.js` | **Modify** | `getLlmoSheetData`, `queryLlmoSheetData`, `getLlmoGlobalSheetData`, `queryFiles` call the helper, return the empty-200+header on `noData`, and map source errors via `llmoSourceErrorResponse` in their catch. |
+| `src/controllers/webhooks.js` | **Modify** | Move `getWorkspaceRepos(env, log)` from the `WebhooksController` constructor into `processGitHubWebhook`; downgrade the unset->defaults branch from `warn` to `debug`. |
+| `test/controllers/llmo/llmo.test.js` | **Modify** | Add the 3rd-arg global esmock mock for `tracingFetch` so the transitively-imported helper is stubbed; update the handful of behavior-changed assertions (404, missing-key, exact-header match) and add the new not-provisioned / 502 / 504 / passthrough tests. |
+| `test/controllers/llmo/llmo-query-handler.test.js` | **Modify** | Move the `tracingFetch` mock to the 3rd-arg global slot; add the multi-file `no_data` test. |
+| `test/controllers/webhooks.test.js` | **Modify** | Add `debug` to the mock logger; assert the constructor emits no warn and unset->defaults no longer warns; keep present-but-invalid warning. |
+| `docs/openapi/**` (LLMO paths) | **Modify** | Document the `x-llmo-data-status` response header and the new status codes (200-empty, 502, 504) for the four LLMO read endpoints. |
+
+---
+
+## Phasing and ordering
+
+The spec splits the work into **Phase 0 (pin contracts)** and **Phase 1 (implement)**. Fix 1 (webhooks) is fully independent of Phase 0 and goes first as a warm-up. Phase 0 (Tasks 2-4) must complete before the Fix-2 implementation tasks (5-8) because the empty-200 byte-match contract and the timeout go/no-go decision are inputs to that code and its tests.
+
+```
+Task 1  (Fix 1, independent)
+Task 2  (Phase 0: capture fixtures)        ─┐
+Task 3  (Phase 0: 15s payload audit)        │ all three precede Tasks 5-8
+Task 4  (Phase 0: events2metrics + log lvl) ─┘
+Task 5  (Fix 2: helper)         -> Task 6 (query-handler) -> Task 7 (queryFiles) -> Task 8 (3 sheet endpoints)
+Task 9  (docs)
+Task 10 (full verification + PR)
+```
+
+**Error-mapping policy implemented by `llmoSourceErrorResponse` (the plan's concrete reading of the spec matrix - confirm in PR):**
+
+| Upstream condition | Tag on thrown error | Response |
+|--------------------|---------------------|----------|
+| 404 (not provisioned) | (not thrown; `{noData:true}` returned) | `200` empty + `x-llmo-data-status: not-provisioned` |
+| 5xx | `upstreamStatus >= 500` | `502` |
+| timeout / abort | `isTimeout` | `504` |
+| non-404 4xx (incl 401/403) | `400 <= upstreamStatus < 500` | passthrough (same 4xx) |
+| missing `LLMO_HLX_API_KEY` | `isConfigError` | `500` (server misconfig) |
+| network / parse / other | (untagged) | `400` (existing fallback, unchanged) |
+
+---
+
+## Task 1: Fix 1 - hoist + reclassify the `MYSTICAT_WORKSPACE_REPOS` warning
+
+**Files:**
+- Modify: `src/controllers/webhooks.js:68-70` (constructor) and `:200-213` (`processGitHubWebhook` payload build) and `:38-42` (`getWorkspaceRepos` unset branch)
+- Test: `test/controllers/webhooks.test.js:63-72` (logger), `:253-308` (env-var tests)
+
+- [ ] **Step 1: Add a `debug` stub to the mock logger**
+
+In `test/controllers/webhooks.test.js`, the `beforeEach` builds `mockLog` with only `info`/`warn`/`error`. Add `debug`:
+
+```js
+    mockLog = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    };
+```
+
+- [ ] **Step 2: Rewrite the two unset-path tests + add a constructor-purity test (failing)**
+
+Replace the existing `it('logs warning and uses defaults when MYSTICAT_WORKSPACE_REPOS is not set', ...)` (currently at `:267-274`) with these three tests:
+
+```js
+  it('does not warn at construction (constructor is side-effect-free)', () => {
+    // beforeEach already built a controller without the env var set.
+    const constructWarn = mockLog.warn.getCalls()
+      .find((c) => c.args[0].includes('MYSTICAT_WORKSPACE_REPOS'));
+    expect(constructWarn).to.be.undefined;
+  });
+
+  it('uses defaults at debug (not warn) when MYSTICAT_WORKSPACE_REPOS is not set', async () => {
+    await controller.processGitHubWebhook(validContext);
+
+    const [, payload] = mockSqs.sendMessage.firstCall.args;
+    expect(payload.workspace_repos).to.deep.equal([
+      'adobe/mysticat-architecture',
+      'adobe/mysticat-ai-native-guidelines',
+      'Adobe-AEM-Sites/aem-sites-architecture',
+    ]);
+    const notSetWarn = mockLog.warn.getCalls()
+      .find((c) => c.args[0].includes('not set'));
+    expect(notSetWarn, 'unset path must not warn').to.be.undefined;
+    const notSetDebug = mockLog.debug.getCalls()
+      .find((c) => c.args[0].includes('MYSTICAT_WORKSPACE_REPOS not set'));
+    expect(notSetDebug, 'unset path should debug-log').to.not.be.undefined;
+  });
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `npx mocha test/controllers/webhooks.test.js -g "construction|debug"`
+Expected: FAIL - `mockLog.debug` is currently never called for the unset branch (still `warn`), and the constructor still warns.
+
+- [ ] **Step 4: Move the call out of the constructor (implementation)**
+
+In `src/controllers/webhooks.js`, delete the constructor call at `:70`:
+
+```js
+function WebhooksController(context) {
+  const { sqs, log, env } = context;
+  const slackChannel = env.MYSTICAT_OBSERVABILITY_SLACK_CHANNEL;
+```
+
+(remove the line `const workspaceRepos = getWorkspaceRepos(env, log);`). Then, inside `processGitHubWebhook`, compute it once per request right before the job payload is built (immediately above the `const jobPayload = {` block at `:201`):
+
+```js
+    // Computed per webhook request (not per controller construction) so the
+    // env-var validation log fires only on genuine deliveries, not all traffic.
+    const workspaceRepos = getWorkspaceRepos(env, log);
+
+    // Build and enqueue job payload
+    const jobPayload = {
+```
+
+- [ ] **Step 5: Downgrade the unset->defaults branch to `debug`**
+
+In `getWorkspaceRepos` (`src/controllers/webhooks.js:38-43`), change the unset branch from `log.warn` to `log.debug`. Leave the present-but-invalid branches (`:54-58` invalid entries, `:59-64` no-valid-entries fallback) as `log.warn` - those are the genuinely actionable cases.
+
+```js
+  const raw = env.MYSTICAT_WORKSPACE_REPOS;
+  if (!raw) {
+    log.debug('MYSTICAT_WORKSPACE_REPOS not set, using built-in defaults', {
+      defaults: DEFAULT_WORKSPACE_REPOS,
+    });
+    return DEFAULT_WORKSPACE_REPOS;
+  }
+```
+
+- [ ] **Step 6: Run the full webhooks suite + lint**
+
+Run: `npx mocha test/controllers/webhooks.test.js`
+Expected: PASS (all, including the still-valid `:276` invalid-entries and `:292` only-invalid warning tests - they call `processGitHubWebhook`, which now computes `getWorkspaceRepos`).
+Run: `npm run lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/controllers/webhooks.js test/controllers/webhooks.test.js
+git commit -m "fix: emit MYSTICAT_WORKSPACE_REPOS warning per-request, not per-controller (SITES-43989)"
+```
+
+---
+
+## Task 2: Phase 0 - capture the empty-response byte-match fixture
+
+> **Requires** a real `LLMO_HLX_API_KEY` (Vault `dx_mysticat/{dev}/api-service`) and network egress to `main--project-elmo-ui-data--adobe.aem.live`. If running as an unauthenticated agent, **stop and hand this task to a human / a session with the key** - it cannot be faked, and it is the contract the Fix-2 tests assert against.
+
+**Files:**
+- Create: `test/fixtures/llmo/empty-sheet.json`
+
+- [ ] **Step 1: Identify a provisioned-but-empty single sheet**
+
+Find a `dataFolder` whose query-index is published but whose sheet has zero rows (e.g. a freshly-onboarded LLMO site, or a known-empty sheet). Record the folder + sheet used in the PR description. If none exists, capture the smallest real sheet and empty its `data` array by hand, noting the deviation in the PR.
+
+- [ ] **Step 2: Capture the empty single-sheet envelope**
+
+```bash
+curl -sS -H "Authorization: token $LLMO_HLX_API_KEY" \
+  "https://main--project-elmo-ui-data--adobe.aem.live/<known-empty-folder>/<sheet>.json" \
+  | tee test/fixtures/llmo/empty-sheet.json
+```
+
+Expected: a 200 JSON envelope shaped like (confirm exact keys/order from the live capture - **use the captured bytes verbatim**, do not hand-write):
+
+```json
+{ "total": 0, "offset": 0, "limit": 0, "data": [], ":type": "sheet" }
+```
+
+- [ ] **Step 3: Record the multi-sheet and not-provisioned shapes (documentation only)**
+
+For the PR description (not committed as load-bearing fixtures), also capture:
+- a multi-sheet empty envelope (`:type: multi-sheet`), to confirm the single-sheet shape is the right default to synthesize, and
+- the literal 404 body for a non-provisioned folder, to confirm the helper's `status === 404` branch is the correct trigger.
+
+Paste both into the PR. **Decision recorded in this plan:** single-file `noData` synthesizes the single-sheet empty shape (`empty-sheet.json`) regardless of whether the eventual sheet would have been multi-sheet, because a 404 folder gives no shape hint and the `x-llmo-data-status` header - not the body - is the machine discriminator. Flag this for reviewer confirmation.
+
+- [ ] **Step 4: Commit the fixture**
+
+```bash
+git add test/fixtures/llmo/empty-sheet.json
+git commit -m "test: pin empty LLMO sheet envelope fixture for SITES-43989 not-provisioned contract"
+```
+
+---
+
+## Task 3: Phase 0 - validate the 15s timeout against real payloads
+
+> The three sheet endpoints have **no** timeout today; the helper adds the query-handler's 15s `AbortController` to all four. This task confirms no legitimate sheet read exceeds 15s before that becomes a hard abort.
+
+**Files:** none (investigation; record findings in the PR).
+
+- [ ] **Step 1: Enumerate the largest known sheet reads in dev**
+
+Pick the largest `dataFolder`/sheet combinations in use (e.g. agentic-traffic, referral-traffic, brand-presence weekly). Use the SpaceCat dev base URL with an admin key, or curl the source directly with `LLMO_HLX_API_KEY`.
+
+- [ ] **Step 2: Time them**
+
+```bash
+for u in "<folder-a>/<sheet>.json?limit=1000000" "<folder-b>/<sheet>.json?limit=1000000"; do
+  curl -sS -o /dev/null -w "%{time_total}s  %{http_code}  $u\n" \
+    -H "Authorization: token $LLMO_HLX_API_KEY" \
+    "https://main--project-elmo-ui-data--adobe.aem.live/$u"
+done
+```
+
+Expected: all well under `15.000s`.
+
+- [ ] **Step 3: Go/no-go**
+
+If any legitimate read approaches 15s, **stop and discuss** before adopting the timeout on the sheet endpoints (raise the constant, or scope the timeout to the cached-query path only). Record the max observed time and the go/no-go in the PR. Default assumption: GO (proceed with 15s).
+
+---
+
+## Task 4: Phase 0 - events2metrics rule + confirm log-level ingestion
+
+**Files:** none in this repo (Coralogix config via MCP/UI; record the rule definition in the PR).
+
+- [ ] **Step 1: Confirm whether `debug` logs reach Coralogix ingestion**
+
+Run a known-good control query for a recent `debug` line from `spacecat-services-dev` api-service (filter by `$l.applicationname`, `$l.subsystemname`, `$d.inv.functionName`). If `debug` is dropped at ingestion, the structured not-provisioned line must be emitted at `info` instead. Record the decision; it sets the log level used in Task 5 Step 7 / Tasks 7-8.
+
+- [ ] **Step 2: Author the `events2metrics` rule**
+
+Create a Coralogix `events2metrics` rule keyed on `event == 'llmo_data_not_provisioned'` producing a per-site counter (label: `siteId`). This is the durable signal for post-merge verification, independent of raw-log retention. Record the rule JSON in the PR.
+
+- [ ] **Step 3: Validation**
+
+Confirm the rule validates (dry-run/preview) and that the metric name is documented in the PR for the post-merge verification queries.
+
+---
+
+## Task 5: Fix 2 - create `llmo-source.js` + unit tests
+
+**Files:**
+- Create: `src/controllers/llmo/llmo-source.js`
+- Create: `test/controllers/llmo/llmo-source.test.js`
+
+- [ ] **Step 1: Write the helper unit tests first (failing)**
+
+Create `test/controllers/llmo/llmo-source.test.js`. Mirror `llmo-query-handler.test.js`'s esmock-of-`tracingFetch` pattern:
+
+```js
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+const TEST_URL = 'https://main--project-elmo-ui-data--adobe.aem.live/folder/sheet.json';
+
+const mockResponse = (data, ok = true, status = 200, statusText = 'OK') => ({
+  ok,
+  status,
+  statusText,
+  json: sinon.stub().resolves(data),
+  headers: new Map([['content-type', 'application/json']]),
+});
+
+describe('llmo-source', () => {
+  let fetchLlmoSource;
+  let llmoSourceErrorResponse;
+  let tracingFetchStub;
+  let context;
+
+  beforeEach(async () => {
+    tracingFetchStub = sinon.stub();
+    context = {
+      log: {
+        info: sinon.stub(), error: sinon.stub(), warn: sinon.stub(), debug: sinon.stub(),
+      },
+      env: { LLMO_HLX_API_KEY: 'test-key' },
+    };
+    const mod = await esmock('../../../src/controllers/llmo/llmo-source.js', {
+      '@adobe/spacecat-shared-utils': {
+        SPACECAT_USER_AGENT: 'test-ua',
+        tracingFetch: tracingFetchStub,
+      },
+    });
+    fetchLlmoSource = mod.fetchLlmoSource;
+    llmoSourceErrorResponse = mod.llmoSourceErrorResponse;
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('returns parsed data + headers on 2xx', async () => {
+    tracingFetchStub.resolves(mockResponse({ rows: [1, 2] }));
+    const result = await fetchLlmoSource(context, TEST_URL);
+    expect(result.status).to.equal(200);
+    expect(result.data).to.deep.equal({ rows: [1, 2] });
+    expect(result.headers).to.be.an('object');
+    expect(result.noData).to.be.undefined;
+  });
+
+  it('returns {status:404, noData:true} on upstream 404 (no throw)', async () => {
+    tracingFetchStub.resolves(mockResponse(null, false, 404, 'Not Found'));
+    const result = await fetchLlmoSource(context, TEST_URL);
+    expect(result).to.deep.equal({ status: 404, noData: true });
+  });
+
+  it('sends the Authorization/User-Agent/Accept-Encoding headers and an abort signal', async () => {
+    tracingFetchStub.resolves(mockResponse({}));
+    await fetchLlmoSource(context, TEST_URL);
+    const [url, opts] = tracingFetchStub.getCall(0).args;
+    expect(url).to.equal(TEST_URL);
+    expect(opts.headers.Authorization).to.equal('token test-key');
+    expect(opts.headers['User-Agent']).to.equal('test-ua');
+    expect(opts.headers['Accept-Encoding']).to.equal('br');
+    expect(opts.signal).to.exist;
+  });
+
+  it('throws with upstreamStatus on non-404 non-OK (5xx)', async () => {
+    tracingFetchStub.resolves(mockResponse(null, false, 500, 'Internal Server Error'));
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.upstreamStatus).to.equal(500);
+      expect(err.message).to.include('External API returned 500');
+    }
+  });
+
+  it('throws with upstreamStatus on non-404 4xx (e.g. 401)', async () => {
+    tracingFetchStub.resolves(mockResponse(null, false, 401, 'Unauthorized'));
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.upstreamStatus).to.equal(401);
+    }
+  });
+
+  it('throws isTimeout on AbortError', async () => {
+    const abort = new Error('aborted');
+    abort.name = 'AbortError';
+    tracingFetchStub.rejects(abort);
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.isTimeout).to.equal(true);
+      expect(err.message).to.include('Request timeout');
+    }
+  });
+
+  it('throws isConfigError when LLMO_HLX_API_KEY is missing (no fetch)', async () => {
+    context.env.LLMO_HLX_API_KEY = undefined;
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.isConfigError).to.equal(true);
+      expect(tracingFetchStub).to.not.have.been.called;
+    }
+  });
+
+  describe('llmoSourceErrorResponse', () => {
+    it('maps isTimeout -> 504', () => {
+      const e = new Error('Request timeout after 15000ms'); e.isTimeout = true;
+      expect(llmoSourceErrorResponse(e).status).to.equal(504);
+    });
+    it('maps 5xx -> 502', () => {
+      const e = new Error('External API returned 503'); e.upstreamStatus = 503;
+      expect(llmoSourceErrorResponse(e).status).to.equal(502);
+    });
+    it('passes through non-404 4xx', () => {
+      const e = new Error('External API returned 401'); e.upstreamStatus = 401;
+      expect(llmoSourceErrorResponse(e).status).to.equal(401);
+    });
+    it('maps isConfigError -> 500', () => {
+      const e = new Error('LLMO_HLX_API_KEY environment variable is not configured'); e.isConfigError = true;
+      expect(llmoSourceErrorResponse(e).status).to.equal(500);
+    });
+    it('returns null for untagged errors (caller keeps its 400 fallback)', () => {
+      expect(llmoSourceErrorResponse(new Error('Network error'))).to.equal(null);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx mocha test/controllers/llmo/llmo-source.test.js`
+Expected: FAIL - module `llmo-source.js` does not exist.
+
+- [ ] **Step 3: Implement `llmo-source.js`**
+
+Create `src/controllers/llmo/llmo-source.js`. The empty payload constant is the Phase 0 (Task 2) capture - **replace the body below with the verbatim contents of `test/fixtures/llmo/empty-sheet.json`** before committing:
+
+```js
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { SPACECAT_USER_AGENT, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { createResponse, internalServerError } from '@adobe/spacecat-shared-http-utils';
+
+const TIMEOUT_MS = 15000;
+
+// Discriminator header so clients can tell "provisioned-but-empty" (absent)
+// from "not provisioned yet" (present), while the body stays byte-identical
+// to a genuinely-empty sheet for backwards compatibility.
+export const NOT_PROVISIONED_HEADER = 'x-llmo-data-status';
+export const NOT_PROVISIONED_VALUE = 'not-provisioned';
+
+// Captured live from elmo-ui-data (SITES-43989 Phase 0, Task 2).
+// MUST byte-match test/fixtures/llmo/empty-sheet.json.
+export const EMPTY_SHEET_PAYLOAD = {
+  total: 0, offset: 0, limit: 0, data: [], ':type': 'sheet',
+};
+
+/**
+ * Fetch a single elmo-ui-data source URL with a 15s timeout and the LLMO key.
+ * Backend-agnostic about meaning: it reports HTTP semantics only.
+ *  - 2xx          -> { status, data: <parsed json>, headers }
+ *  - 404          -> { status: 404, noData: true }            (no throw)
+ *  - other non-OK -> throws Error with `upstreamStatus`
+ *  - abort/timeout-> throws Error with `isTimeout = true`
+ *  - missing key  -> throws Error with `isConfigError = true` (before any fetch)
+ */
+export const fetchLlmoSource = async (context, url) => {
+  const { log, env } = context;
+
+  if (!env.LLMO_HLX_API_KEY) {
+    const err = new Error('LLMO_HLX_API_KEY environment variable is not configured');
+    err.isConfigError = true;
+    throw err;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `token ${env.LLMO_HLX_API_KEY}`,
+        'User-Agent': SPACECAT_USER_AGENT,
+        'Accept-Encoding': 'br',
+      },
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (response.status === 404) {
+      return { status: 404, noData: true };
+    }
+
+    if (!response.ok) {
+      log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
+      const err = new Error(`External API returned ${response.status}: ${response.statusText}`);
+      err.upstreamStatus = response.status;
+      throw err;
+    }
+
+    const data = await response.json();
+    return {
+      status: response.status,
+      data,
+      headers: response.headers ? Object.fromEntries(response.headers.entries()) : {},
+    };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error.name === 'AbortError') {
+      const timeoutErr = new Error(`Request timeout after ${TIMEOUT_MS}ms`);
+      timeoutErr.isTimeout = true;
+      throw timeoutErr;
+    }
+    throw error;
+  }
+};
+
+/**
+ * Maps a fetchLlmoSource error to an honest HTTP response, or null if the
+ * error is not a recognized source failure (caller keeps its own 400 fallback).
+ */
+export const llmoSourceErrorResponse = (error) => {
+  if (error.isConfigError) {
+    return internalServerError(error.message);
+  }
+  if (error.isTimeout) {
+    return createResponse({ message: error.message }, 504);
+  }
+  if (typeof error.upstreamStatus === 'number') {
+    if (error.upstreamStatus >= 500) {
+      return createResponse({ message: error.message }, 502);
+    }
+    return createResponse({ message: error.message }, error.upstreamStatus);
+  }
+  return null;
+};
+
+/** Structured, queryable not-provisioned signal (events2metrics key). */
+export const logNotProvisioned = (log, siteId, dataFolder) => {
+  // Level decided in Phase 0 Task 4 (debug if it reaches ingestion, else info).
+  log.debug('llmo_data_not_provisioned', { event: 'llmo_data_not_provisioned', siteId, dataFolder });
+};
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run: `npx mocha test/controllers/llmo/llmo-source.test.js`
+Expected: PASS (all branch + mapper tests).
+
+- [ ] **Step 5: Assert the constant byte-matches the fixture (add one test)**
+
+Append to `test/controllers/llmo/llmo-source.test.js` (top-level `describe`):
+
+```js
+  it('EMPTY_SHEET_PAYLOAD byte-matches the captured fixture', async () => {
+    const { readFileSync } = await import('fs');
+    const { fileURLToPath } = await import('url');
+    const { dirname, join } = await import('path');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const fixture = JSON.parse(readFileSync(
+      join(here, '../../fixtures/llmo/empty-sheet.json'), 'utf-8',
+    ));
+    const mod = await esmock('../../../src/controllers/llmo/llmo-source.js', {});
+    expect(mod.EMPTY_SHEET_PAYLOAD).to.deep.equal(fixture);
+  });
+```
+
+Run: `npx mocha test/controllers/llmo/llmo-source.test.js`
+Expected: PASS. If it fails, the constant in Step 3 does not match the Task 2 capture - fix the constant to the captured bytes.
+
+- [ ] **Step 6: Lint**
+
+Run: `npm run lint`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/controllers/llmo/llmo-source.js test/controllers/llmo/llmo-source.test.js
+git commit -m "feat: add shared llmo-source fetch helper with 404->noData semantics (SITES-43989)"
+```
+
+---
+
+## Task 6: Fix 2 - refactor `llmo-query-handler.js` onto the helper
+
+**Files:**
+- Modify: `src/controllers/llmo/llmo-query-handler.js:77-155` (`fetchAndProcessSingleFile`), `:186-224` (`fetchAndProcessMultipleFiles`)
+- Test: `test/controllers/llmo/llmo-query-handler.test.js:90-94` (esmock slot), add multi-file `no_data` test near `:661`
+
+- [ ] **Step 1: Move the `tracingFetch` mock to the global esmock slot (so it reaches the helper)**
+
+In `test/controllers/llmo/llmo-query-handler.test.js`, the current `esmock(path, { '@adobe/spacecat-shared-utils': {...} })` (`:90-94`) mocks the handler's direct import. After the refactor, the fetch happens inside `llmo-source.js` (a separate module), so move that mock to the **3rd** (global) argument:
+
+```js
+    const module = await esmock(
+      '../../../src/controllers/llmo/llmo-query-handler.js',
+      {},
+      {
+        '@adobe/spacecat-shared-utils': {
+          SPACECAT_USER_AGENT: 'test-user-agent',
+          tracingFetch: tracingFetchStub,
+        },
+      },
+    );
+```
+
+- [ ] **Step 2: Add the multi-file `no_data` test (failing) and run**
+
+Next to the existing `it('should handle file fetch errors in multi-file mode', ...)` (`:661`), add:
+
+```js
+    it('reports status no_data for an upstream-404 file in multi-file mode', async () => {
+      tracingFetchStub.onFirstCall().resolves(createMockResponse({ ':type': 'sheet', data: [] }));
+      tracingFetchStub.onSecondCall().resolves(createMockResponse(null, false, 404));
+      mockContext.data = { file: ['a.json', 'b.json'] };
+      delete mockContext.params.dataSource;
+
+      const result = await queryLlmoFiles(mockContext, mockLlmoConfig);
+
+      expect(result.data[0].status).to.equal('success');
+      expect(result.data[1].status).to.equal('no_data');
+      expect(result.data[1].error).to.be.undefined;
+    });
+```
+
+Run: `npx mocha test/controllers/llmo/llmo-query-handler.test.js -g "no_data"`
+Expected: FAIL - today a 404 throws -> caught as `status:'error'`.
+
+- [ ] **Step 3: Refactor `fetchAndProcessSingleFile` to use the helper**
+
+Replace the body of `fetchAndProcessSingleFile` (`:77-155`) below the URL construction. Remove the local `AbortController`, the `LLMO_HLX_API_KEY` check, the `fetch(...)`, the `!response.ok` throw, and the `AbortError` mapping (all now inside `fetchLlmoSource`). Keep the URL building and `processData`:
+
+```js
+import { fetchLlmoSource } from './llmo-source.js';
+// ... (keep existing imports; SPACECAT_USER_AGENT / tracingFetch no longer needed here
+//      unless used elsewhere in the file - remove if now unused to satisfy lint)
+
+const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryParams) => {
+  const { log } = context;
+  const { sheet } = context.data;
+
+  const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${llmoConfig.dataFolder}/${filePath}`);
+  const limit = queryParams.limit ? parseInt(queryParams.limit, 10) : 10000000;
+  const offset = queryParams.offset ? parseInt(queryParams.offset, 10) : 0;
+  url.searchParams.set('limit', limit.toString());
+  url.searchParams.set('offset', offset.toString());
+  if (sheet) {
+    url.searchParams.set('sheet', sheet);
+  }
+
+  const urlAsString = url.toString();
+  log.info(`Fetching single file with path: ${urlAsString}`);
+
+  const result = await fetchLlmoSource(context, urlAsString);
+  if (result.noData) {
+    return { noData: true };
+  }
+
+  const processedData = processData(result.data, queryParams);
+  return { data: processedData, headers: result.headers };
+};
+```
+
+- [ ] **Step 4: Map `noData` to `status:'no_data'` in `fetchAndProcessMultipleFiles`**
+
+In the per-file callback (`:198-218`):
+
+```js
+    async (filePath) => {
+      try {
+        const single = await fetchAndProcessSingleFile(context, llmoConfig, filePath, queryParams);
+        if (single.noData) {
+          return { path: filePath, status: 'no_data' };
+        }
+        return { path: filePath, status: 'success', data: single.data };
+      } catch (error) {
+        log.debug(`Error fetching and processing file ${filePath}: ${error.message}`);
+        return { path: filePath, status: 'error', error: error.message };
+      }
+    },
+```
+
+- [ ] **Step 5: Run the query-handler suite**
+
+Run: `npx mocha test/controllers/llmo/llmo-query-handler.test.js`
+Expected: PASS, including the pre-existing 500/timeout/missing-key tests (`:183`, `:194`, `:215`) - their thrown messages are unchanged - and the new `no_data` test. The single-file "should return files data" test still sees `{ data, headers }` for a 200.
+
+- [ ] **Step 6: Lint + commit**
+
+Run: `npm run lint`
+
+```bash
+git add src/controllers/llmo/llmo-query-handler.js test/controllers/llmo/llmo-query-handler.test.js
+git commit -m "refactor: route llmo-query-handler single-file fetch through llmo-source; 404->no_data (SITES-43989)"
+```
+
+---
+
+## Task 7: Fix 2 - wire the `queryFiles` controller's `noData` -> empty 200
+
+**Files:**
+- Modify: `src/controllers/llmo/llmo.js:1129-1148` (`queryFiles`)
+- Test: `test/controllers/llmo/llmo.test.js:3650-3748` (`queryFiles` describe)
+
+- [ ] **Step 1: Add the not-provisioned test (failing)**
+
+In the `queryFiles` describe (`:3650`), the existing `createControllerWithCacheStub` stubs `queryLlmoFiles`. Add a test that stubs it to the new single-file `noData` shape:
+
+```js
+    it('returns empty 200 with not-provisioned header when single-file query reports noData', async () => {
+      const queryLlmoFilesStub = sinon.stub().resolves({ noData: true });
+      const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-query-handler.js': {
+          queryLlmoFiles: queryLlmoFilesStub,
+        },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        ...getCommonMocks(),
+      });
+      const cacheController = LlmoControllerWithCache(mockContext);
+
+      const result = await cacheController.queryFiles(mockContext);
+
+      expect(result.status).to.equal(200);
+      expect(result.headers.get('x-llmo-data-status')).to.equal('not-provisioned');
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        total: 0, offset: 0, limit: 0, data: [], ':type': 'sheet',
+      });
+    });
+```
+
+Run: `npx mocha test/controllers/llmo/llmo.test.js -g "queryFiles.*not-provisioned"`
+Expected: FAIL - `queryFiles` currently destructures `{ data, headers }` and returns `cachedOk(undefined, undefined)`.
+
+- [ ] **Step 2: Implement the `noData` branch**
+
+Edit `queryFiles` (`:1142-1143`):
+
+```js
+      const { llmoConfig } = siteValidation;
+      const queryResult = await queryLlmoFiles(context, llmoConfig);
+      if (queryResult.noData) {
+        logNotProvisioned(log, siteId, llmoConfig.dataFolder);
+        return cachedOk(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
+      }
+      return cachedOk(queryResult.data, queryResult.headers);
+```
+
+Add the import at the top of `llmo.js` (with the other `./llmo-*` imports):
+
+```js
+import {
+  fetchLlmoSource,
+  llmoSourceErrorResponse,
+  logNotProvisioned,
+  EMPTY_SHEET_PAYLOAD,
+  NOT_PROVISIONED_HEADER,
+  NOT_PROVISIONED_VALUE,
+} from './llmo-source.js';
+```
+
+(Note: `fetchLlmoSource` and `llmoSourceErrorResponse` are used in Task 8; importing them now is fine but will trip `no-unused-vars` until Task 8 - if running tasks strictly one-at-a-time, import only `logNotProvisioned`, `EMPTY_SHEET_PAYLOAD`, `NOT_PROVISIONED_HEADER`, `NOT_PROVISIONED_VALUE` here and add the other two in Task 8.)
+
+- [ ] **Step 3: Run + confirm existing queryFiles tests still pass**
+
+Run: `npx mocha test/controllers/llmo/llmo.test.js -g "queryFiles"`
+Expected: PASS - new test green; existing success/error/403/404 tests unchanged (`queryLlmoFiles` returning `{data,headers}` still hits the `cachedOk(queryResult.data, queryResult.headers)` path).
+
+- [ ] **Step 4: Lint + commit**
+
+Run: `npm run lint`
+
+```bash
+git add src/controllers/llmo/llmo.js test/controllers/llmo/llmo.test.js
+git commit -m "feat: queryFiles returns empty 200 + not-provisioned header on upstream 404 (SITES-43989)"
+```
+
+---
+
+## Task 8: Fix 2 - migrate the three sheet endpoints onto the helper
+
+**Files:**
+- Modify: `src/controllers/llmo/llmo.js` - `getLlmoSheetData` (`:188-253`), `queryLlmoSheetData` (`:257-427`), `getLlmoGlobalSheetData` (`:430-485`)
+- Test: `test/controllers/llmo/llmo.test.js:222` (shared esmock - add global slot), `:710-1015` (`getLlmoSheetData`), `:1016-1083` (`getLlmoGlobalSheetData`), `:1084+` (`queryLlmoSheetData`)
+
+- [ ] **Step 1: Add the global `tracingFetch` mock to the shared esmock call**
+
+The main controller is esmocked once at `:222`. Add the **3rd** argument so the transitively-imported `llmo-source.js` gets the same `tracingFetchStub`, and keep `SPACECAT_USER_AGENT` aligned so header assertions still match:
+
+```js
+    LlmoController = await esmock('../../../src/controllers/llmo/llmo.js', {
+      // ... existing 2nd-arg mocks unchanged ...
+    }, {
+      '@adobe/spacecat-shared-utils': {
+        SPACECAT_USER_AGENT: TEST_USER_AGENT,
+        tracingFetch: (...args) => tracingFetchStub(...args),
+      },
+    });
+```
+
+(The existing 2nd-arg `@adobe/spacecat-shared-utils` mock stays; it still serves `llmo.js`'s own non-sheet `tracingFetch` callers. esmock partial-merges, so the other real exports are preserved - verified: probe + `suggestions.test.js:5581` precedent.)
+
+- [ ] **Step 2: Relax the two exact-object header assertions (they gain a `signal`)**
+
+`getLlmoSheetData` "should proxy data ... successfully" (`:722`) asserts an exact options object. The helper now also passes `signal`. Change to a partial match:
+
+```js
+      expect(tracingFetchStub).to.have.been.calledWith(testUrl, sinon.match({
+        headers: {
+          Authorization: `token ${TEST_API_KEY}`,
+          'User-Agent': TEST_USER_AGENT,
+          'Accept-Encoding': 'br',
+        },
+      }));
+```
+
+- [ ] **Step 3: Replace the missing-key + 404 behavior tests (failing)**
+
+Replace "should use fallback API key when env.LLMO_HLX_API_KEY is undefined" (`:782-796`) - the helper no longer forwards a bogus token; a missing key throws `isConfigError` -> 500, and fetch is not called:
+
+```js
+    it('returns 500 and does not call the source when LLMO_HLX_API_KEY is undefined', async () => {
+      mockContext.env.LLMO_HLX_API_KEY = undefined;
+
+      const result = await controller.getLlmoSheetData(mockContext);
+
+      expect(result.status).to.equal(500);
+      expect(tracingFetchStub).to.not.have.been.called;
+    });
+```
+
+Replace "should handle external API errors" (`:798-807`, which stubbed a 404 -> 400) with the not-provisioned behavior plus the genuine-failure mappings:
+
+```js
+    it('returns empty 200 + not-provisioned header on upstream 404', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 404));
+
+      const result = await controller.getLlmoSheetData(mockContext);
+
+      expect(result.status).to.equal(200);
+      expect(result.headers.get('x-llmo-data-status')).to.equal('not-provisioned');
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        total: 0, offset: 0, limit: 0, data: [], ':type': 'sheet',
+      });
+      expect(mockLog.error).to.not.have.been.called;
+    });
+
+    it('maps upstream 5xx to 502', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 503, 'Service Unavailable'));
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(502);
+    });
+
+    it('maps timeout/abort to 504', async () => {
+      const abort = new Error('aborted'); abort.name = 'AbortError';
+      tracingFetchStub.rejects(abort);
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(504);
+    });
+
+    it('passes through a non-404 4xx (e.g. 401)', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 401, 'Unauthorized'));
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(401);
+    });
+```
+
+The "should handle network errors" test (`:809`) stays as-is: an untagged `Error('Network error')` -> `llmoSourceErrorResponse` returns `null` -> existing `badRequest(400)` fallback.
+
+Run: `npx mocha test/controllers/llmo/llmo.test.js -g "getLlmoSheetData"`
+Expected: FAIL on the new not-provisioned/502/504/401/500 tests (endpoint not yet refactored).
+
+- [ ] **Step 4: Refactor `getLlmoSheetData`**
+
+Replace the fetch/throw block (`:228-252`) - from `const response = await fetch(...)` through the `catch`:
+
+```js
+      // Fetch via the shared helper (owns timeout, key check, headers, status branching)
+      const result = await fetchLlmoSource(context, url.toString());
+      if (result.noData) {
+        logNotProvisioned(log, siteId, llmoConfig.dataFolder);
+        return cachedOk(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
+      }
+      return cachedOk(result.data, { ...result.headers });
+    } catch (error) {
+      log.error(`Error proxying data for siteId: ${siteId}, error: ${error.message}`);
+      const mapped = llmoSourceErrorResponse(error);
+      if (mapped) {
+        return mapped;
+      }
+      return badRequest(cleanupHeaderValue(error.message));
+    }
+```
+
+(Remove the now-dead URL `Authorization`/`fetch`/`!response.ok`/`response.json()` lines that the helper replaces. `llmoConfig` is already in scope from `siteValidation`.)
+
+- [ ] **Step 5: Refactor `queryLlmoSheetData` and `getLlmoGlobalSheetData` identically**
+
+`queryLlmoSheetData` (`:330-426`): replace the `const response = await fetch(...)` + `!response.ok` throw (`:332-343`) with `const result = await fetchLlmoSource(context, url.toString());` then a `noData` guard returning the empty-200+header **before** the post-processing block, and let `let data = result.data;` feed the existing sheets/mapping/inclusion/filter/exclusion/group pipeline. Pass `result.headers` to the final `ok(...)`. In the `catch` (`:422-425`), insert the `llmoSourceErrorResponse(error)` mapping before the `badRequest` fallback:
+
+```js
+      const result = await fetchLlmoSource(context, url.toString());
+      if (result.noData) {
+        logNotProvisioned(log, siteId, llmoConfig.dataFolder);
+        return ok(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
+      }
+      let data = result.data;
+      const responseHeaders = result.headers;
+      // ... existing sheets/mapping/inclusion/filter/exclusion/group pipeline unchanged ...
+      return ok(data, { ...responseHeaders });
+    } catch (error) {
+      const errorTime = Date.now();
+      log.error(`Error proxying data for siteId: ${siteId}, error: ${error.message} - elapsed: ${errorTime - methodStartTime}ms`);
+      const mapped = llmoSourceErrorResponse(error);
+      if (mapped) {
+        return mapped;
+      }
+      return badRequest(cleanupHeaderValue(error.message));
+    }
+```
+
+`getLlmoGlobalSheetData` (`:459-484`): same shape as `getLlmoSheetData` (it uses `cachedOk`). On `noData`, log with the `llmo-global` folder context (use the `sheetURL`/`configName` for the log; `dataFolder` is not site-specific here - pass `'llmo-global'`):
+
+```js
+      const result = await fetchLlmoSource(context, url.toString());
+      if (result.noData) {
+        logNotProvisioned(log, siteId, 'llmo-global');
+        return cachedOk(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
+      }
+      log.info(`Successfully proxied global data for siteId: ${siteId}, sheetURL: ${sheetURL}`);
+      return cachedOk(result.data, { ...result.headers });
+    } catch (error) {
+      log.error(`Error proxying global data for siteId: ${siteId}, error: ${error.message}`);
+      const mapped = llmoSourceErrorResponse(error);
+      if (mapped) {
+        return mapped;
+      }
+      return badRequest(cleanupHeaderValue(error.message));
+    }
+```
+
+- [ ] **Step 6: Mirror the behavior tests for the other two endpoints**
+
+In the `getLlmoGlobalSheetData` (`:1016`) and `queryLlmoSheetData` (`:1084`) describes, find each block's equivalent of the "external API errors" (404->400) test and replace it with the not-provisioned 200+header assertion (use `EXTERNAL_API_BASE_URL/llmo-global/...` for the global testUrl). Add a 5xx->502 and an abort->504 test to each, copying the `getLlmoSheetData` versions from Step 3 with the endpoint's own controller method. For `queryLlmoSheetData`, the empty-200 body assertion is the same `EMPTY_SHEET_PAYLOAD` deep-equal. Show the full test bodies (do not abbreviate) so each describe is self-contained.
+
+- [ ] **Step 7: Run the full LLMO controller suite**
+
+Run: `npx mocha test/controllers/llmo/llmo.test.js`
+Expected: PASS. The bulk of URL-construction tests are unchanged (the controller still builds the same URL and `tracingFetchStub` is still called with it via the global mock). If any URL test fails because it asserted an exact options object, relax it to `sinon.match.object` (same fix as Step 2).
+
+- [ ] **Step 8: Lint + commit**
+
+Run: `npm run lint`
+
+```bash
+git add src/controllers/llmo/llmo.js test/controllers/llmo/llmo.test.js
+git commit -m "feat: LLMO sheet endpoints return empty 200 on not-provisioned, map upstream failures honestly (SITES-43989)"
+```
+
+---
+
+## Task 9: Documentation - OpenAPI for the four LLMO read endpoints
+
+**Files:**
+- Modify: the LLMO path definitions under `docs/openapi/` (the sheet-data, global-sheet-data, and cached-query operations).
+
+- [ ] **Step 1: Locate the LLMO endpoint definitions**
+
+Run: `grep -rln "sheet-data\|global-sheet-data\|llmo/data" docs/openapi/`
+
+- [ ] **Step 2: Document the new response contract**
+
+For each of the four read operations, add/adjust:
+- a `200` response that may carry the optional response header `x-llmo-data-status` with enum value `not-provisioned` (description: "present when the site's LLMO data is not yet provisioned; body is an empty sheet envelope"),
+- `502` (upstream source failure) and `504` (upstream timeout) responses,
+- note that a non-404 upstream 4xx is passed through.
+
+Follow the existing header/response YAML style in the file (match an existing `headers:`/`responses:` block).
+
+- [ ] **Step 3: Validate docs**
+
+Run: `npm run docs:lint`
+Expected: clean. (If the repo also builds the bundled spec, run that build and confirm no errors.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/openapi
+git commit -m "docs: document x-llmo-data-status header and 200-empty/502/504 for LLMO read endpoints (SITES-43989)"
+```
+
+---
+
+## Task 10: Final verification + PR
+
+- [ ] **Step 1: Full test suite + coverage + lint**
+
+Run: `npm test`
+Expected: PASS with coverage gates met. If coverage drops on `llmo-source.js`, add the missing branch test to `llmo-source.test.js`.
+
+- [ ] **Step 2: Confirm Fix 3 is intentionally untouched**
+
+Run: `git diff --stat origin/main -- src/controllers/scrapeJob.js`
+Expected: **empty** (no change). The spec deliberately leaves the scrape API as-is; if a diff appears, revert it.
+
+- [ ] **Step 3: Sanity-grep the behavior changes are isolated to LLMO + webhooks**
+
+Run: `git diff --stat origin/main -- src/`
+Expected: only `src/controllers/llmo/llmo.js`, `src/controllers/llmo/llmo-source.js`, `src/controllers/llmo/llmo-query-handler.js`, `src/controllers/webhooks.js`.
+
+- [ ] **Step 4: Open the PR**
+
+Push the branch and open a PR titled `fix: SITES-43989 inline error-rate remediation (LLMO not-provisioned + webhook log noise)`. In the body: link the spec and SITES-43989; paste the Phase 0 captures (empty fixture provenance, the 15s payload timings, the events2metrics rule JSON, and the debug-vs-info log-level decision); call out the two flagged decisions for reviewer confirmation (missing-key -> 500; single-sheet empty shape synthesized for all single-file noData). Use a Conventional Commit title so semantic-release picks it up.
+
+- [ ] **Step 5: Post-merge verification (after deploy, ~24h)**
+
+Re-run the SITES-43989 Coralogix queries: `MYSTICAT_WORKSPACE_REPOS not set` warn rate -> ~0; LLMO not-provisioned 400s gone (confirm via the new `llmo_data_not_provisioned` events2metrics counter); overall API Gateway 4xx+5xx below the SKYSI-76262 threshold with margin.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Fix 1 (hoist + reclassify warn) -> Task 1. ✓
+- Phase 0 (fixtures, 15s audit, events2metrics + log level) -> Tasks 2-4. ✓
+- Fix 2 shared helper + 4 endpoints, 404->empty200+header, 5xx->502, timeout->504, 4xx passthrough, multi-file `no_data` -> Tasks 5-8. ✓
+- Fetch unification (15s + key check applied to the 3 sheet endpoints) -> helper in Task 5, adopted in Tasks 6/8; go/no-go in Task 3. ✓
+- Discriminator header + structured log + events2metrics -> constants/logger in Task 5, emitted in Tasks 7/8, rule in Task 4. ✓
+- Fix 3 (no change) -> asserted in Task 10 Step 2. ✓
+- Docs (response headers/examples change) -> Task 9. ✓
+- Rollback -> revert the helper's 404 branch (covered by isolating HTTP semantics in `llmo-source.js`). ✓
+- Post-merge verification -> Task 10 Step 5. ✓
+
+**Placeholder scan:** The only deferred value is `EMPTY_SHEET_PAYLOAD` / `empty-sheet.json`, which is a genuine live-capture output of Task 2 (not a placeholder); the expected Helix shape is shown and a byte-match test (Task 5 Step 5) enforces it. OpenAPI file paths are resolved by a `grep` step rather than hard-coded because the exact path layout is unverified. Task 8 Step 6 says "show full test bodies" rather than repeating three near-identical blocks inline - the executor must write them out, not abbreviate.
+
+**Type/name consistency:** `fetchLlmoSource(context, url)`, `llmoSourceErrorResponse(error)`, `logNotProvisioned(log, siteId, dataFolder)`, `EMPTY_SHEET_PAYLOAD`, `NOT_PROVISIONED_HEADER`/`NOT_PROVISIONED_VALUE` are defined once in Task 5 and used with the same signatures in Tasks 6-8. The single-file `noData` contract is `{ noData: true }` (Task 5/6) and consumed identically in Tasks 6/7. Multi-file uses `status: 'no_data'` (Task 6) and is asserted with that exact string (Task 6 Step 2).
+
+**Open confirmations (carry into the PR):** (1) missing-key -> 500 vs 400; (2) synthesizing the single-sheet empty shape for all single-file `noData`; (3) Phase 0 Task 3 go/no-go on the 15s timeout for the sheet endpoints.

--- a/src/controllers/llmo/llmo-query-handler.js
+++ b/src/controllers/llmo/llmo-query-handler.js
@@ -10,13 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import { SPACECAT_USER_AGENT, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 import {
   applyFilters,
   applyInclusions,
   applySort,
   LLMO_SHEETDATA_SOURCE_URL,
 } from './llmo-utils.js';
+import { fetchLlmoSource } from './llmo-source.js';
 
 const processData = (data, queryParams) => {
   let processedData = data;
@@ -75,7 +75,7 @@ const processData = (data, queryParams) => {
 };
 
 const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryParams) => {
-  const { log, env } = context;
+  const { log } = context;
   const { sheet } = context.data;
 
   const url = new URL(`${LLMO_SHEETDATA_SOURCE_URL}/${llmoConfig.dataFolder}/${filePath}`);
@@ -95,63 +95,13 @@ const fetchAndProcessSingleFile = async (context, llmoConfig, filePath, queryPar
   const urlAsString = url.toString();
   log.info(`Fetching single file with path: ${urlAsString}`);
 
-  // Create an AbortController with a 15-second timeout
-  // to prevent large data fetches keeping the Lambda running for too long
-  const TIMEOUT_MS = 15000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS); // 15 seconds
-
-  // Validate API key exists before making the request
-  if (!env.LLMO_HLX_API_KEY) {
-    clearTimeout(timeoutId);
-    throw new Error('LLMO_HLX_API_KEY environment variable is not configured');
+  const result = await fetchLlmoSource(context, urlAsString);
+  if (result.noData) {
+    return { noData: true };
   }
 
-  // Start timing the source fetch
-  const sourceFetchStartTime = Date.now();
-
-  try {
-    // Fetch data from the external endpoint using the dataFolder from config
-    const response = await fetch(url.toString(), {
-      headers: {
-        Authorization: `token ${env.LLMO_HLX_API_KEY}`,
-        'User-Agent': SPACECAT_USER_AGENT,
-        'Accept-Encoding': 'br',
-      },
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
-      throw new Error(`External API returned ${response.status}: ${response.statusText}`);
-    }
-
-    // Get the raw response data
-    const rawData = await response.json();
-    const fetchTime = Date.now() - sourceFetchStartTime;
-
-    log.info(`✓ Fetch from HELIX ${filePath}: ${fetchTime}ms`);
-
-    // Process the data with all query parameters
-    const processStartTime = Date.now();
-    const processedData = processData(rawData, queryParams);
-    const processTime = Date.now() - processStartTime;
-
-    log.info(`✓ Data processing completed in ${processTime}ms`);
-
-    return {
-      data: processedData,
-      headers: response.headers ? Object.fromEntries(response.headers.entries()) : {},
-    };
-  } catch (error) {
-    clearTimeout(timeoutId);
-    if (error.name === 'AbortError') {
-      log.debug(`Request timeout after ${TIMEOUT_MS}ms for file: ${filePath}`);
-      throw new Error(`Request timeout after ${TIMEOUT_MS}ms`);
-    }
-    throw error;
-  }
+  const processedData = processData(result.data, queryParams);
+  return { data: processedData, headers: result.headers };
 };
 
 /**
@@ -197,17 +147,16 @@ const fetchAndProcessMultipleFiles = async (context, llmoConfig, files, queryPar
     files,
     async (filePath) => {
       try {
-        const { data } = await fetchAndProcessSingleFile(
+        const single = await fetchAndProcessSingleFile(
           context,
           llmoConfig,
           filePath,
           queryParams,
         );
-        return {
-          path: filePath,
-          status: 'success',
-          data,
-        };
+        if (single.noData) {
+          return { path: filePath, status: 'no_data' };
+        }
+        return { path: filePath, status: 'success', data: single.data };
       } catch (error) {
         log.debug(`Error fetching and processing file ${filePath}: ${error.message}`);
         return {

--- a/src/controllers/llmo/llmo-source.js
+++ b/src/controllers/llmo/llmo-source.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { SPACECAT_USER_AGENT, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { createResponse, internalServerError } from '@adobe/spacecat-shared-http-utils';
+
+const TIMEOUT_MS = 15000;
+
+// Discriminator header so clients can tell "provisioned-but-empty" (header
+// absent) from "not provisioned yet" (header present), while the body stays a
+// valid empty sheet envelope.
+export const NOT_PROVISIONED_HEADER = 'x-llmo-data-status';
+export const NOT_PROVISIONED_VALUE = 'not-provisioned';
+
+// Captured live from elmo-ui-data (SITES-43989 Phase 0). MUST deep-equal
+// test/fixtures/llmo/empty-sheet.json. A real provisioned-empty sheet also
+// carries a sheet-specific `columns` array; not-provisioned has no schema, so
+// we omit it and rely on NOT_PROVISIONED_HEADER as the discriminator.
+export const EMPTY_SHEET_PAYLOAD = {
+  total: 0,
+  offset: 0,
+  limit: 0,
+  data: [],
+  ':type': 'sheet',
+};
+
+/**
+ * Fetch a single elmo-ui-data source URL with a 15s timeout and the LLMO key.
+ * Reports HTTP semantics only (backend-agnostic):
+ *  - 2xx          -> { status, data: <parsed json>, headers }
+ *  - 404          -> { status: 404, noData: true }            (no throw)
+ *  - other non-OK -> throws Error with `upstreamStatus`
+ *  - abort/timeout-> throws Error with `isTimeout = true`
+ *  - missing key  -> throws Error with `isConfigError = true` (before any fetch)
+ */
+export const fetchLlmoSource = async (context, url) => {
+  const { log, env } = context;
+
+  if (!env.LLMO_HLX_API_KEY) {
+    const err = new Error('LLMO_HLX_API_KEY environment variable is not configured');
+    err.isConfigError = true;
+    throw err;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `token ${env.LLMO_HLX_API_KEY}`,
+        'User-Agent': SPACECAT_USER_AGENT,
+        'Accept-Encoding': 'br',
+      },
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (response.status === 404) {
+      return { status: 404, noData: true };
+    }
+
+    if (!response.ok) {
+      log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
+      const err = new Error(`External API returned ${response.status}: ${response.statusText}`);
+      err.upstreamStatus = response.status;
+      throw err;
+    }
+
+    const data = await response.json();
+    return {
+      status: response.status,
+      data,
+      headers: response.headers ? Object.fromEntries(response.headers.entries()) : {},
+    };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error.name === 'AbortError') {
+      const timeoutErr = new Error(`Request timeout after ${TIMEOUT_MS}ms`);
+      timeoutErr.isTimeout = true;
+      throw timeoutErr;
+    }
+    throw error;
+  }
+};
+
+/**
+ * Maps a fetchLlmoSource error to an honest HTTP response, or null if the error
+ * is not a recognized source failure (caller keeps its own 400 fallback).
+ */
+export const llmoSourceErrorResponse = (error) => {
+  if (error.isConfigError) {
+    return internalServerError(error.message);
+  }
+  if (error.isTimeout) {
+    return createResponse({ message: error.message }, 504);
+  }
+  if (typeof error.upstreamStatus === 'number') {
+    if (error.upstreamStatus >= 500) {
+      return createResponse({ message: error.message }, 502);
+    }
+    return createResponse({ message: error.message }, error.upstreamStatus);
+  }
+  return null;
+};
+
+/**
+ * Structured, queryable not-provisioned signal. Emitted at `info` (NOT debug):
+ * prod suppresses debug, and the Coralogix events2metrics rule keyed on
+ * `event=llmo_data_not_provisioned` must see this line (SITES-43989 Phase 0).
+ */
+export const logNotProvisioned = (log, siteId, dataFolder) => {
+  log.info('llmo_data_not_provisioned', { event: 'llmo_data_not_provisioned', siteId, dataFolder });
+};

--- a/src/controllers/llmo/llmo-source.js
+++ b/src/controllers/llmo/llmo-source.js
@@ -64,19 +64,25 @@ export const fetchLlmoSource = async (context, url) => {
       },
       signal: controller.signal,
     });
-    clearTimeout(timeoutId);
 
     if (response.status === 404) {
+      // Drain the unread body so the underlying connection can be reused; undici
+      // pins the socket until the body is consumed/cancelled, which matters on
+      // the high-frequency not-provisioned path.
+      await response.body?.cancel?.();
       return { status: 404, noData: true };
     }
 
     if (!response.ok) {
       log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
+      await response.body?.cancel?.();
       const err = new Error(`External API returned ${response.status}: ${response.statusText}`);
       err.upstreamStatus = response.status;
       throw err;
     }
 
+    // Timer stays armed through the body read so TIMEOUT_MS bounds fetch+read
+    // end-to-end (an abort mid-read surfaces as AbortError below).
     const data = await response.json();
     return {
       status: response.status,
@@ -84,13 +90,14 @@ export const fetchLlmoSource = async (context, url) => {
       headers: response.headers ? Object.fromEntries(response.headers.entries()) : {},
     };
   } catch (error) {
-    clearTimeout(timeoutId);
     if (error.name === 'AbortError') {
       const timeoutErr = new Error(`Request timeout after ${TIMEOUT_MS}ms`);
       timeoutErr.isTimeout = true;
       throw timeoutErr;
     }
     throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
 };
 

--- a/src/controllers/llmo/llmo-source.js
+++ b/src/controllers/llmo/llmo-source.js
@@ -12,6 +12,7 @@
 
 import { SPACECAT_USER_AGENT, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 import { createResponse, internalServerError } from '@adobe/spacecat-shared-http-utils';
+import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 
 const TIMEOUT_MS = 15000;
 
@@ -99,16 +100,20 @@ export const fetchLlmoSource = async (context, url) => {
  */
 export const llmoSourceErrorResponse = (error) => {
   if (error.isConfigError) {
-    return internalServerError(error.message);
+    // internalServerError() sets the standard x-error header itself.
+    return internalServerError(cleanupHeaderValue(error.message));
   }
   if (error.isTimeout) {
-    return createResponse({ message: error.message }, 504);
+    const message = cleanupHeaderValue(error.message);
+    return createResponse({ message }, 504, { 'x-error': message });
   }
   if (typeof error.upstreamStatus === 'number') {
-    if (error.upstreamStatus >= 500) {
-      return createResponse({ message: error.message }, 502);
-    }
-    return createResponse({ message: error.message }, error.upstreamStatus);
+    // upstream 5xx -> 502; non-404 4xx -> passthrough. createResponse (unlike
+    // badRequest/internalServerError) does not set the x-error header, so set it
+    // explicitly to keep the error contract (and responses.yaml) consistent.
+    const message = cleanupHeaderValue(error.message);
+    const status = error.upstreamStatus >= 500 ? 502 : error.upstreamStatus;
+    return createResponse({ message }, status, { 'x-error': message });
   }
   return null;
 };

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -16,8 +16,6 @@ import {
   unauthorized,
 } from '@adobe/spacecat-shared-http-utils';
 import {
-  SPACECAT_USER_AGENT,
-  tracingFetch as fetch,
   hasText,
   isObject,
   isValidUUID,
@@ -70,6 +68,8 @@ import {
 } from './llmo-onboarding.js';
 import { queryLlmoFiles } from './llmo-query-handler.js';
 import {
+  fetchLlmoSource,
+  llmoSourceErrorResponse,
   logNotProvisioned,
   EMPTY_SHEET_PAYLOAD,
   NOT_PROVISIONED_HEADER,
@@ -196,7 +196,6 @@ function LlmoController(ctx) {
     const {
       siteId, dataSource, sheetType, week,
     } = context.params;
-    const { env } = context;
     try {
       const siteValidation = await getSiteAndValidateLlmo(context);
       if (siteValidation.status) {
@@ -232,28 +231,18 @@ function LlmoController(ctx) {
       }
 
       // Fetch data from the external endpoint using the dataFolder from config
-      const response = await fetch(url.toString(), {
-        headers: {
-          Authorization: `token ${env.LLMO_HLX_API_KEY || 'hlx_api_key_missing'}`,
-          'User-Agent': SPACECAT_USER_AGENT,
-          'Accept-Encoding': 'br',
-        },
-      });
-
-      if (!response.ok) {
-        log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
-        throw new Error(`External API returned ${response.status}: ${response.statusText}`);
+      const result = await fetchLlmoSource(context, url.toString());
+      if (result.noData) {
+        logNotProvisioned(log, siteId, llmoConfig.dataFolder);
+        return cachedOk(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
       }
-
-      // Get the response data
-      const data = await response.json();
-
-      // Return the data, pass through any compression headers from upstream
-      return cachedOk(data, {
-        ...(response.headers ? Object.fromEntries(response.headers.entries()) : {}),
-      });
+      return cachedOk(result.data, { ...result.headers });
     } catch (error) {
       log.error(`Error proxying data for siteId: ${siteId}, error: ${error.message}`);
+      const mapped = llmoSourceErrorResponse(error);
+      if (mapped) {
+        return mapped;
+      }
       return badRequest(cleanupHeaderValue(error.message));
     }
   };
@@ -265,7 +254,6 @@ function LlmoController(ctx) {
     const {
       siteId, dataSource, sheetType, week,
     } = context.params;
-    const { env } = context;
 
     // Start timing for the entire method
     const methodStartTime = Date.now();
@@ -335,21 +323,13 @@ function LlmoController(ctx) {
 
       // Fetch data from the external endpoint using the dataFolder from config
       const fetchStartTime = Date.now();
-      const response = await fetch(url.toString(), {
-        headers: {
-          Authorization: `token ${env.LLMO_HLX_API_KEY || 'hlx_api_key_missing'}`,
-          'User-Agent': SPACECAT_USER_AGENT,
-          'Accept-Encoding': 'br',
-        },
-      });
-
-      if (!response.ok) {
-        log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
-        throw new Error(`External API returned ${response.status}: ${response.statusText}`);
+      const fetchResult = await fetchLlmoSource(context, url.toString());
+      if (fetchResult.noData) {
+        logNotProvisioned(log, siteId, llmoConfig.dataFolder);
+        return ok(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
       }
-
-      // Get the response data
-      let data = await response.json();
+      let { data } = fetchResult;
+      const responseHeaders = fetchResult.headers;
       const fetchEndTime = Date.now();
       const fetchDuration = fetchEndTime - fetchStartTime;
       log.info(`External API fetch completed - elapsed: ${fetchEndTime - methodStartTime}ms, duration: ${fetchDuration}ms`);
@@ -422,12 +402,14 @@ function LlmoController(ctx) {
       log.info(`LLMO query completed - total duration: ${totalDuration}ms (fetch: ${fetchDuration}ms, inclusion: ${inclusionDuration}ms, filtering: ${filterDuration}ms, exclusion: ${exclusionDuration}ms, grouping: ${groupingDuration}ms, mapping: ${mappingDuration}ms)`);
 
       // Return the data, pass through any compression headers from upstream
-      return ok(data, {
-        ...(response.headers ? Object.fromEntries(response.headers.entries()) : {}),
-      });
+      return ok(data, { ...responseHeaders });
     } catch (error) {
       const errorTime = Date.now();
       log.error(`Error proxying data for siteId: ${siteId}, error: ${error.message} - elapsed: ${errorTime - methodStartTime}ms`);
+      const mapped = llmoSourceErrorResponse(error);
+      if (mapped) {
+        return mapped;
+      }
       return badRequest(cleanupHeaderValue(error.message));
     }
   };
@@ -436,7 +418,6 @@ function LlmoController(ctx) {
   const getLlmoGlobalSheetData = async (context) => {
     const { log } = context;
     const { siteId, configName } = context.params;
-    const { env } = context;
     try {
       log.info(`validating LLMO global sheet data for siteId: ${siteId}, configName: ${configName}`);
       // Validate LLMO access but don't use the site-specific dataFolder
@@ -463,29 +444,19 @@ function LlmoController(ctx) {
       }
 
       // Fetch data from the external endpoint using the global llmo-global folder
-      const response = await fetch(url.toString(), {
-        headers: {
-          Authorization: `token ${env.LLMO_HLX_API_KEY || 'hlx_api_key_missing'}`,
-          'User-Agent': SPACECAT_USER_AGENT,
-          'Accept-Encoding': 'br',
-        },
-      });
-
-      if (!response.ok) {
-        log.debug(`Failed to fetch data from external endpoint: ${response.status} ${response.statusText}`);
-        throw new Error(`External API returned ${response.status}: ${response.statusText}`);
+      const result = await fetchLlmoSource(context, url.toString());
+      if (result.noData) {
+        logNotProvisioned(log, siteId, 'llmo-global');
+        return cachedOk(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
       }
-
-      // Get the response data
-      const data = await response.json();
-
       log.info(`Successfully proxied global data for siteId: ${siteId}, sheetURL: ${sheetURL}`);
-      // Return the data and let the framework handle the compression
-      return cachedOk(data, {
-        ...(response.headers ? Object.fromEntries(response.headers.entries()) : {}),
-      });
+      return cachedOk(result.data, { ...result.headers });
     } catch (error) {
       log.error(`Error proxying global data for siteId: ${siteId}, error: ${error.message}`);
+      const mapped = llmoSourceErrorResponse(error);
+      if (mapped) {
+        return mapped;
+      }
       return badRequest(cleanupHeaderValue(error.message));
     }
   };

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1124,6 +1124,10 @@ function LlmoController(ctx) {
       return cachedOk(queryResult.data, queryResult.headers);
     } catch (error) {
       log.error(`Error during LLMO cached query for site ${siteId}: ${error.message}`);
+      const mapped = llmoSourceErrorResponse(error);
+      if (mapped) {
+        return mapped;
+      }
       return badRequest(cleanupHeaderValue(error.message));
     }
   };

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -69,6 +69,12 @@ import {
   previewAndPublishQueryIndex,
 } from './llmo-onboarding.js';
 import { queryLlmoFiles } from './llmo-query-handler.js';
+import {
+  logNotProvisioned,
+  EMPTY_SHEET_PAYLOAD,
+  NOT_PROVISIONED_HEADER,
+  NOT_PROVISIONED_VALUE,
+} from './llmo-source.js';
 import { updateModifiedByDetails } from './llmo-config-metadata.js';
 import { notifyOptInIfNeeded } from './cdn-opt-in-notification.js';
 import { handleLlmoRationale } from './llmo-rationale.js';
@@ -1139,8 +1145,12 @@ function LlmoController(ctx) {
         return forbidden(HLX_SHEET_DATA_PG_MIGRATION_FORBIDDEN_MESSAGE);
       }
       const { llmoConfig } = siteValidation;
-      const { data, headers } = await queryLlmoFiles(context, llmoConfig);
-      return cachedOk(data, headers);
+      const queryResult = await queryLlmoFiles(context, llmoConfig);
+      if (queryResult.noData) {
+        logNotProvisioned(log, siteId, llmoConfig.dataFolder);
+        return cachedOk(EMPTY_SHEET_PAYLOAD, { [NOT_PROVISIONED_HEADER]: NOT_PROVISIONED_VALUE });
+      }
+      return cachedOk(queryResult.data, queryResult.headers);
     } catch (error) {
       log.error(`Error during LLMO cached query for site ${siteId}: ${error.message}`);
       return badRequest(cleanupHeaderValue(error.message));

--- a/src/controllers/webhooks.js
+++ b/src/controllers/webhooks.js
@@ -36,7 +36,7 @@ const WORKSPACE_REPO_PATTERN = /^[^/\s]+\/[^/\s]+$/;
 function getWorkspaceRepos(env, log) {
   const raw = env.MYSTICAT_WORKSPACE_REPOS;
   if (!raw) {
-    log.warn('MYSTICAT_WORKSPACE_REPOS not set, using built-in defaults', {
+    log.debug('MYSTICAT_WORKSPACE_REPOS not set, using built-in defaults', {
       defaults: DEFAULT_WORKSPACE_REPOS,
     });
     return DEFAULT_WORKSPACE_REPOS;
@@ -67,7 +67,6 @@ function getWorkspaceRepos(env, log) {
 
 function WebhooksController(context) {
   const { sqs, log, env } = context;
-  const workspaceRepos = getWorkspaceRepos(env, log);
   const slackChannel = env.MYSTICAT_OBSERVABILITY_SLACK_CHANNEL;
   const slack = createObservabilitySlackClient({
     token: env.MYSTICAT_OBSERVABILITY_SLACK_TOKEN,
@@ -196,6 +195,10 @@ function WebhooksController(context) {
         ? { slack_channel: slackChannel, slack_thread_ts: threadTs }
         : { slack_channel: slackChannel };
     }
+
+    // Computed per webhook request (not per controller construction) so the
+    // env-var validation log fires only on genuine deliveries, not all traffic.
+    const workspaceRepos = getWorkspaceRepos(env, log);
 
     // Build and enqueue job payload
     const jobPayload = {

--- a/test/controllers/llmo/llmo-query-handler.test.js
+++ b/test/controllers/llmo/llmo-query-handler.test.js
@@ -61,7 +61,26 @@ describe('llmo-query-handler', () => {
   // Helper to get fetch options from stub
   const getFetchOptions = () => tracingFetchStub.getCall(0).args[1];
 
-  beforeEach(async () => {
+  before(async () => {
+    tracingFetchStub = sinon.stub();
+
+    const module = await esmock(
+      '../../../src/controllers/llmo/llmo-query-handler.js',
+      {},
+      {
+        '@adobe/spacecat-shared-utils': {
+          SPACECAT_USER_AGENT: 'test-user-agent',
+          tracingFetch: tracingFetchStub,
+        },
+      },
+    );
+
+    queryLlmoFiles = module.queryLlmoFiles;
+  });
+
+  beforeEach(() => {
+    tracingFetchStub.reset();
+
     mockLog = {
       info: sinon.stub(),
       error: sinon.stub(),
@@ -84,17 +103,6 @@ describe('llmo-query-handler', () => {
       },
       data: {},
     };
-
-    tracingFetchStub = sinon.stub();
-
-    const module = await esmock('../../../src/controllers/llmo/llmo-query-handler.js', {
-      '@adobe/spacecat-shared-utils': {
-        SPACECAT_USER_AGENT: 'test-user-agent',
-        tracingFetch: tracingFetchStub,
-      },
-    });
-
-    queryLlmoFiles = module.queryLlmoFiles;
   });
 
   afterEach(() => {
@@ -118,9 +126,6 @@ describe('llmo-query-handler', () => {
       expect(result.data).to.deep.equal(filesData);
       expect(result.headers).to.be.an('object');
       expect(tracingFetchStub).to.have.been.calledOnce;
-      expect(mockLog.info).to.have.been.calledWith(
-        sinon.match(/Fetch from HELIX/),
-      );
     });
 
     it('should construct correct URL for single file', async () => {
@@ -199,9 +204,6 @@ describe('llmo-query-handler', () => {
       await expect(
         queryLlmoFiles(mockContext, mockLlmoConfig),
       ).to.be.rejectedWith('Request timeout after 15000ms');
-      expect(mockLog.debug).to.have.been.calledWith(
-        sinon.match(/Request timeout after 15000ms/),
-      );
     });
 
     it('should include Authorization header with API key', async () => {
@@ -679,6 +681,19 @@ describe('llmo-query-handler', () => {
       expect(mockLog.debug).to.have.been.calledWith(
         sinon.match(/Error fetching and processing file file2.json/),
       );
+    });
+
+    it('reports status no_data for an upstream-404 file in multi-file mode', async () => {
+      tracingFetchStub.onFirstCall().resolves(createMockResponse({ ':type': 'sheet', data: [] }));
+      tracingFetchStub.onSecondCall().resolves(createMockResponse(null, false, 404));
+      mockContext.data = { file: ['a.json', 'b.json'] };
+      delete mockContext.params.dataSource;
+
+      const result = await queryLlmoFiles(mockContext, mockLlmoConfig);
+
+      expect(result.data[0].status).to.equal('success');
+      expect(result.data[1].status).to.equal('no_data');
+      expect(result.data[1].error).to.be.undefined;
     });
 
     it('should apply query params to each file in multi-file mode', async () => {

--- a/test/controllers/llmo/llmo-query-handler.test.js
+++ b/test/controllers/llmo/llmo-query-handler.test.js
@@ -61,7 +61,11 @@ describe('llmo-query-handler', () => {
   // Helper to get fetch options from stub
   const getFetchOptions = () => tracingFetchStub.getCall(0).args[1];
 
-  before(async () => {
+  before(async function () {
+    // esmock with a 3rd-arg global mock deep-replaces the spacecat-shared-utils
+    // import tree, which can exceed the default 10s hook timeout on slower CI
+    // runners. Mirrors the 120s before-hook timeout used in llmo.test.js.
+    this.timeout(120000);
     tracingFetchStub = sinon.stub();
 
     const module = await esmock(

--- a/test/controllers/llmo/llmo-query-handler.test.js
+++ b/test/controllers/llmo/llmo-query-handler.test.js
@@ -686,8 +686,8 @@ describe('llmo-query-handler', () => {
     it('reports status no_data for an upstream-404 file in multi-file mode', async () => {
       tracingFetchStub.onFirstCall().resolves(createMockResponse({ ':type': 'sheet', data: [] }));
       tracingFetchStub.onSecondCall().resolves(createMockResponse(null, false, 404));
+      mockContext.params = { siteId: TEST_SITE_ID };
       mockContext.data = { file: ['a.json', 'b.json'] };
-      delete mockContext.params.dataSource;
 
       const result = await queryLlmoFiles(mockContext, mockLlmoConfig);
 

--- a/test/controllers/llmo/llmo-source.test.js
+++ b/test/controllers/llmo/llmo-source.test.js
@@ -36,6 +36,8 @@ describe('llmo-source', () => {
   let fetchLlmoSource;
   let llmoSourceErrorResponse;
   let logNotProvisioned;
+  let NOT_PROVISIONED_HEADER;
+  let NOT_PROVISIONED_VALUE;
   let tracingFetchStub;
   let context;
 
@@ -56,6 +58,8 @@ describe('llmo-source', () => {
     fetchLlmoSource = mod.fetchLlmoSource;
     llmoSourceErrorResponse = mod.llmoSourceErrorResponse;
     logNotProvisioned = mod.logNotProvisioned;
+    NOT_PROVISIONED_HEADER = mod.NOT_PROVISIONED_HEADER;
+    NOT_PROVISIONED_VALUE = mod.NOT_PROVISIONED_VALUE;
   });
 
   afterEach(() => sinon.restore());
@@ -120,6 +124,18 @@ describe('llmo-source', () => {
     }
   });
 
+  it('propagates non-AbortError fetch rejections unchanged', async () => {
+    const netErr = new Error('ECONNREFUSED');
+    tracingFetchStub.rejects(netErr);
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).to.equal(netErr);
+      expect(err.isTimeout).to.be.undefined;
+    }
+  });
+
   it('throws isConfigError when LLMO_HLX_API_KEY is missing (no fetch)', async () => {
     context.env.LLMO_HLX_API_KEY = undefined;
     try {
@@ -173,5 +189,10 @@ describe('llmo-source', () => {
     const fixture = JSON.parse(readFileSync(join(here, '../../fixtures/llmo/empty-sheet.json'), 'utf-8'));
     const mod = await esmock('../../../src/controllers/llmo/llmo-source.js', {});
     expect(mod.EMPTY_SHEET_PAYLOAD).to.deep.equal(fixture);
+  });
+
+  it('exposes the not-provisioned discriminator header constants', () => {
+    expect(NOT_PROVISIONED_HEADER).to.equal('x-llmo-data-status');
+    expect(NOT_PROVISIONED_VALUE).to.equal('not-provisioned');
   });
 });

--- a/test/controllers/llmo/llmo-source.test.js
+++ b/test/controllers/llmo/llmo-source.test.js
@@ -79,6 +79,21 @@ describe('llmo-source', () => {
     expect(result).to.deep.equal({ status: 404, noData: true });
   });
 
+  it('drains the response body on a 404 so the connection can be reused', async () => {
+    const cancel = sinon.stub().resolves();
+    tracingFetchStub.resolves({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: sinon.stub(),
+      headers: new Map(),
+      body: { cancel },
+    });
+    const result = await fetchLlmoSource(context, TEST_URL);
+    expect(result).to.deep.equal({ status: 404, noData: true });
+    expect(cancel).to.have.been.calledOnce;
+  });
+
   it('sends Authorization/User-Agent/Accept-Encoding headers and an abort signal', async () => {
     tracingFetchStub.resolves(mockResponse({}));
     await fetchLlmoSource(context, TEST_URL);

--- a/test/controllers/llmo/llmo-source.test.js
+++ b/test/controllers/llmo/llmo-source.test.js
@@ -148,25 +148,33 @@ describe('llmo-source', () => {
   });
 
   describe('llmoSourceErrorResponse', () => {
-    it('maps isTimeout -> 504', () => {
+    it('maps isTimeout -> 504 with x-error header', () => {
       const e = new Error('Request timeout after 15000ms');
       e.isTimeout = true;
-      expect(llmoSourceErrorResponse(e).status).to.equal(504);
+      const res = llmoSourceErrorResponse(e);
+      expect(res.status).to.equal(504);
+      expect(res.headers.get('x-error')).to.equal('Request timeout after 15000ms');
     });
-    it('maps 5xx -> 502', () => {
+    it('maps 5xx -> 502 with x-error header', () => {
       const e = new Error('External API returned 503');
       e.upstreamStatus = 503;
-      expect(llmoSourceErrorResponse(e).status).to.equal(502);
+      const res = llmoSourceErrorResponse(e);
+      expect(res.status).to.equal(502);
+      expect(res.headers.get('x-error')).to.equal('External API returned 503');
     });
-    it('passes through non-404 4xx', () => {
+    it('passes through non-404 4xx with x-error header', () => {
       const e = new Error('External API returned 401');
       e.upstreamStatus = 401;
-      expect(llmoSourceErrorResponse(e).status).to.equal(401);
+      const res = llmoSourceErrorResponse(e);
+      expect(res.status).to.equal(401);
+      expect(res.headers.get('x-error')).to.equal('External API returned 401');
     });
-    it('maps isConfigError -> 500', () => {
+    it('maps isConfigError -> 500 with x-error header', () => {
       const e = new Error('LLMO_HLX_API_KEY environment variable is not configured');
       e.isConfigError = true;
-      expect(llmoSourceErrorResponse(e).status).to.equal(500);
+      const res = llmoSourceErrorResponse(e);
+      expect(res.status).to.equal(500);
+      expect(res.headers.get('x-error')).to.equal('LLMO_HLX_API_KEY environment variable is not configured');
     });
     it('returns null for untagged errors (caller keeps its 400 fallback)', () => {
       expect(llmoSourceErrorResponse(new Error('Network error'))).to.equal(null);

--- a/test/controllers/llmo/llmo-source.test.js
+++ b/test/controllers/llmo/llmo-source.test.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+const TEST_URL = 'https://main--project-elmo-ui-data--adobe.aem.live/folder/sheet.json';
+
+const mockResponse = (data, ok = true, status = 200, statusText = 'OK') => ({
+  ok,
+  status,
+  statusText,
+  json: sinon.stub().resolves(data),
+  headers: new Map([['content-type', 'application/json']]),
+});
+
+describe('llmo-source', () => {
+  let fetchLlmoSource;
+  let llmoSourceErrorResponse;
+  let logNotProvisioned;
+  let tracingFetchStub;
+  let context;
+
+  beforeEach(async () => {
+    tracingFetchStub = sinon.stub();
+    context = {
+      log: {
+        info: sinon.stub(), error: sinon.stub(), warn: sinon.stub(), debug: sinon.stub(),
+      },
+      env: { LLMO_HLX_API_KEY: 'test-key' },
+    };
+    const mod = await esmock('../../../src/controllers/llmo/llmo-source.js', {
+      '@adobe/spacecat-shared-utils': {
+        SPACECAT_USER_AGENT: 'test-ua',
+        tracingFetch: tracingFetchStub,
+      },
+    });
+    fetchLlmoSource = mod.fetchLlmoSource;
+    llmoSourceErrorResponse = mod.llmoSourceErrorResponse;
+    logNotProvisioned = mod.logNotProvisioned;
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('returns parsed data + headers on 2xx', async () => {
+    tracingFetchStub.resolves(mockResponse({ rows: [1, 2] }));
+    const result = await fetchLlmoSource(context, TEST_URL);
+    expect(result.status).to.equal(200);
+    expect(result.data).to.deep.equal({ rows: [1, 2] });
+    expect(result.headers).to.be.an('object');
+    expect(result.noData).to.be.undefined;
+  });
+
+  it('returns {status:404, noData:true} on upstream 404 (no throw)', async () => {
+    tracingFetchStub.resolves(mockResponse(null, false, 404, 'Not Found'));
+    const result = await fetchLlmoSource(context, TEST_URL);
+    expect(result).to.deep.equal({ status: 404, noData: true });
+  });
+
+  it('sends Authorization/User-Agent/Accept-Encoding headers and an abort signal', async () => {
+    tracingFetchStub.resolves(mockResponse({}));
+    await fetchLlmoSource(context, TEST_URL);
+    const [url, opts] = tracingFetchStub.getCall(0).args;
+    expect(url).to.equal(TEST_URL);
+    expect(opts.headers.Authorization).to.equal('token test-key');
+    expect(opts.headers['User-Agent']).to.equal('test-ua');
+    expect(opts.headers['Accept-Encoding']).to.equal('br');
+    expect(opts.signal).to.exist;
+  });
+
+  it('throws with upstreamStatus on non-404 non-OK (5xx)', async () => {
+    tracingFetchStub.resolves(mockResponse(null, false, 500, 'Internal Server Error'));
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.upstreamStatus).to.equal(500);
+      expect(err.message).to.include('External API returned 500');
+    }
+  });
+
+  it('throws with upstreamStatus on non-404 4xx (e.g. 401)', async () => {
+    tracingFetchStub.resolves(mockResponse(null, false, 401, 'Unauthorized'));
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.upstreamStatus).to.equal(401);
+    }
+  });
+
+  it('throws isTimeout on AbortError', async () => {
+    const abort = new Error('aborted');
+    abort.name = 'AbortError';
+    tracingFetchStub.rejects(abort);
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.isTimeout).to.equal(true);
+      expect(err.message).to.include('Request timeout');
+    }
+  });
+
+  it('throws isConfigError when LLMO_HLX_API_KEY is missing (no fetch)', async () => {
+    context.env.LLMO_HLX_API_KEY = undefined;
+    try {
+      await fetchLlmoSource(context, TEST_URL);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err.isConfigError).to.equal(true);
+      expect(tracingFetchStub).to.not.have.been.called;
+    }
+  });
+
+  describe('llmoSourceErrorResponse', () => {
+    it('maps isTimeout -> 504', () => {
+      const e = new Error('Request timeout after 15000ms');
+      e.isTimeout = true;
+      expect(llmoSourceErrorResponse(e).status).to.equal(504);
+    });
+    it('maps 5xx -> 502', () => {
+      const e = new Error('External API returned 503');
+      e.upstreamStatus = 503;
+      expect(llmoSourceErrorResponse(e).status).to.equal(502);
+    });
+    it('passes through non-404 4xx', () => {
+      const e = new Error('External API returned 401');
+      e.upstreamStatus = 401;
+      expect(llmoSourceErrorResponse(e).status).to.equal(401);
+    });
+    it('maps isConfigError -> 500', () => {
+      const e = new Error('LLMO_HLX_API_KEY environment variable is not configured');
+      e.isConfigError = true;
+      expect(llmoSourceErrorResponse(e).status).to.equal(500);
+    });
+    it('returns null for untagged errors (caller keeps its 400 fallback)', () => {
+      expect(llmoSourceErrorResponse(new Error('Network error'))).to.equal(null);
+    });
+  });
+
+  describe('logNotProvisioned', () => {
+    it('emits a structured info line (not debug)', () => {
+      logNotProvisioned(context.log, 'site-1', 'folder-1');
+      expect(context.log.info).to.have.been.calledWith(
+        'llmo_data_not_provisioned',
+        { event: 'llmo_data_not_provisioned', siteId: 'site-1', dataFolder: 'folder-1' },
+      );
+      expect(context.log.debug).to.not.have.been.called;
+    });
+  });
+
+  it('EMPTY_SHEET_PAYLOAD byte-matches the committed fixture', async () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const fixture = JSON.parse(readFileSync(join(here, '../../fixtures/llmo/empty-sheet.json'), 'utf-8'));
+    const mod = await esmock('../../../src/controllers/llmo/llmo-source.js', {});
+    expect(mod.EMPTY_SHEET_PAYLOAD).to.deep.equal(fixture);
+  });
+});

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -46,10 +46,10 @@ const HLX_PG_MIGRATION_SITE_ID_STAGE = 'c2473d89-e997-458d-a86d-b4096649c12b';
 const HLX_SHEET_TYPE_BRAND_PRESENCE = 'brand-presence';
 const HLX_SHEET_DATA_PG_MIGRATION_FORBIDDEN_MESSAGE = 'Access to HLX sheet data has been blocked for this site due to PG migration';
 
-const createMockResponse = (data, ok = true, status = 200) => ({
+const createMockResponse = (data, ok = true, status = 200, statusText = null) => ({
   ok,
   status,
-  statusText: ok ? 'OK' : 'Not Found',
+  statusText: statusText || (ok ? 'OK' : 'Not Found'),
   json: sinon.stub().resolves(data),
   headers: { entries: sinon.stub().returns([]) },
 });
@@ -355,6 +355,11 @@ describe('LlmoController', () => {
         OPTIMIZE_AT_EDGE_ENABLED_MARKING_TYPE: 'optimize-at-edge-enabled-marking',
         EDGE_OPTIMIZE_MARKING_DELAY_SECONDS: 300,
         LOG_SOURCES,
+      },
+    }, {
+      '@adobe/spacecat-shared-utils': {
+        SPACECAT_USER_AGENT: TEST_USER_AGENT,
+        tracingFetch: (...args) => tracingFetchStub(...args),
       },
     });
 
@@ -724,13 +729,13 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({ data: 'test-data' });
-      expect(tracingFetchStub).to.have.been.calledWith(testUrl, {
+      expect(tracingFetchStub).to.have.been.calledWith(testUrl, sinon.match({
         headers: {
           Authorization: `token ${TEST_API_KEY}`,
           'User-Agent': TEST_USER_AGENT,
           'Accept-Encoding': 'br',
         },
-      });
+      }));
     });
 
     ['limit', 'offset', 'sheet'].forEach((param) => {
@@ -784,31 +789,41 @@ describe('LlmoController', () => {
       });
     });
 
-    it('should use fallback API key when env.LLMO_HLX_API_KEY is undefined', async () => {
-      const mockResponse = createMockResponse({ data: 'test-data' });
-      tracingFetchStub.resolves(mockResponse);
+    it('returns 500 and does not call the source when LLMO_HLX_API_KEY is undefined', async () => {
       mockContext.env.LLMO_HLX_API_KEY = undefined;
-
-      await controller.getLlmoSheetData(mockContext);
-
-      expect(tracingFetchStub).to.have.been.calledWith(testUrl, {
-        headers: {
-          Authorization: 'token hlx_api_key_missing',
-          'User-Agent': TEST_USER_AGENT,
-          'Accept-Encoding': 'br',
-        },
-      });
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(500);
+      expect(tracingFetchStub).to.not.have.been.called;
     });
 
-    it('should handle external API errors', async () => {
-      const mockResponse = createMockResponse(null, false, 404);
-      tracingFetchStub.resolves(mockResponse);
-
+    it('returns empty 200 + not-provisioned header on upstream 404', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 404));
       const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(200);
+      expect(result.headers.get(NOT_PROVISIONED_HEADER)).to.equal(NOT_PROVISIONED_VALUE);
+      const body = await result.json();
+      expect(body).to.deep.equal(EMPTY_SHEET_PAYLOAD);
+      expect(mockLog.error).to.not.have.been.called;
+    });
 
-      expect(result.status).to.equal(400);
-      const responseBody = await result.json();
-      expect(responseBody.message).to.include('External API returned 404');
+    it('maps upstream 5xx to 502', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 503, 'Service Unavailable'));
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(502);
+    });
+
+    it('maps timeout/abort to 504', async () => {
+      const abort = new Error('aborted');
+      abort.name = 'AbortError';
+      tracingFetchStub.rejects(abort);
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(504);
+    });
+
+    it('passes through a non-404 4xx (e.g. 401)', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 401, 'Unauthorized'));
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(401);
     });
 
     it('should handle network errors', async () => {
@@ -1046,26 +1061,41 @@ describe('LlmoController', () => {
       });
     });
 
-    it('should handle external API errors', async () => {
-      const mockResponse = createMockResponse(null, false, 404);
-      tracingFetchStub.resolves(mockResponse);
-
+    it('returns 500 and does not call the source when LLMO_HLX_API_KEY is undefined', async () => {
+      mockContext.env.LLMO_HLX_API_KEY = undefined;
       const result = await controller.getLlmoGlobalSheetData(mockContext);
-
-      expect(result.status).to.equal(400);
+      expect(result.status).to.equal(500);
+      expect(tracingFetchStub).to.not.have.been.called;
     });
 
-    it('should use fallback API key when env.LLMO_HLX_API_KEY is undefined', async () => {
-      tracingFetchStub.resolves(createMockResponse({ data: 'test-data' }));
-      mockContext.env.LLMO_HLX_API_KEY = undefined;
-
+    it('returns empty 200 + not-provisioned header on upstream 404', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 404));
       const result = await controller.getLlmoGlobalSheetData(mockContext);
-
       expect(result.status).to.equal(200);
-      expect(tracingFetchStub).to.have.been.calledWith(
-        sinon.match.string,
-        sinon.match({ headers: sinon.match({ Authorization: 'token hlx_api_key_missing' }) }),
-      );
+      expect(result.headers.get(NOT_PROVISIONED_HEADER)).to.equal(NOT_PROVISIONED_VALUE);
+      const body = await result.json();
+      expect(body).to.deep.equal(EMPTY_SHEET_PAYLOAD);
+      expect(mockLog.error).to.not.have.been.called;
+    });
+
+    it('maps upstream 5xx to 502', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 503, 'Service Unavailable'));
+      const result = await controller.getLlmoGlobalSheetData(mockContext);
+      expect(result.status).to.equal(502);
+    });
+
+    it('maps timeout/abort to 504', async () => {
+      const abort = new Error('aborted');
+      abort.name = 'AbortError';
+      tracingFetchStub.rejects(abort);
+      const result = await controller.getLlmoGlobalSheetData(mockContext);
+      expect(result.status).to.equal(504);
+    });
+
+    it('passes through a non-404 4xx (e.g. 401)', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 401, 'Unauthorized'));
+      const result = await controller.getLlmoGlobalSheetData(mockContext);
+      expect(result.status).to.equal(401);
     });
 
     it('should handle undefined response headers', async () => {
@@ -1445,18 +1475,14 @@ describe('LlmoController', () => {
       expect(responseBody.sheet2.data[0]).to.not.have.property('email');
     });
 
-    it('should log error when external API fails', async () => {
-      const mockResponse = createMockResponse(null, false, 500);
-      mockResponse.statusText = 'Internal Server Error';
+    it('maps upstream 5xx to 502', async () => {
+      const mockResponse = createMockResponse(null, false, 500, 'Internal Server Error');
       tracingFetchStub.resolves(mockResponse);
       mockContext.data = { filters: { status: 'active' } };
 
       const result = await controller.queryLlmoSheetData(mockContext);
 
-      expect(result.status).to.equal(400);
-      expect(mockLog.debug).to.have.been.calledWith(
-        sinon.match(/Failed to fetch data from external endpoint: 500/),
-      );
+      expect(result.status).to.equal(502);
     });
 
     it('should handle missing response headers in queryLlmoSheetData', async () => {
@@ -1471,18 +1497,39 @@ describe('LlmoController', () => {
       expect(await result.json()).to.deep.equal({ ':type': 'sheet', data: [{ id: 1 }] });
     });
 
-    it('should use fallback API key when env.LLMO_HLX_API_KEY is undefined in queryLlmoSheetData', async () => {
-      tracingFetchStub.resolves(createMockResponse({ ':type': 'sheet', data: [] }));
+    it('returns 500 and does not call the source when LLMO_HLX_API_KEY is undefined', async () => {
       mockContext.env.LLMO_HLX_API_KEY = undefined;
       mockContext.data = null;
-
       const result = await controller.queryLlmoSheetData(mockContext);
+      expect(result.status).to.equal(500);
+      expect(tracingFetchStub).to.not.have.been.called;
+    });
 
+    it('returns empty 200 + not-provisioned header on upstream 404', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 404));
+      mockContext.data = null;
+      const result = await controller.queryLlmoSheetData(mockContext);
       expect(result.status).to.equal(200);
-      expect(tracingFetchStub).to.have.been.calledWith(
-        sinon.match.string,
-        sinon.match({ headers: sinon.match({ Authorization: 'token hlx_api_key_missing' }) }),
-      );
+      expect(result.headers.get(NOT_PROVISIONED_HEADER)).to.equal(NOT_PROVISIONED_VALUE);
+      const body = await result.json();
+      expect(body).to.deep.equal(EMPTY_SHEET_PAYLOAD);
+      expect(mockLog.error).to.not.have.been.called;
+    });
+
+    it('maps timeout/abort to 504', async () => {
+      const abort = new Error('aborted');
+      abort.name = 'AbortError';
+      tracingFetchStub.rejects(abort);
+      mockContext.data = null;
+      const result = await controller.queryLlmoSheetData(mockContext);
+      expect(result.status).to.equal(504);
+    });
+
+    it('passes through a non-404 4xx (e.g. 401)', async () => {
+      tracingFetchStub.resolves(createMockResponse(null, false, 401, 'Unauthorized'));
+      mockContext.data = null;
+      const result = await controller.queryLlmoSheetData(mockContext);
+      expect(result.status).to.equal(401);
     });
 
     it('should construct URL without sheetType when not provided', async () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -3789,6 +3789,45 @@ describe('LlmoController', () => {
       );
     });
 
+    it('maps a tagged upstream 5xx from the cached query to 502', async () => {
+      const err = new Error('External API returned 503');
+      err.upstreamStatus = 503;
+      const queryLlmoFilesStub = sinon.stub().rejects(err);
+      const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-query-handler.js': { queryLlmoFiles: queryLlmoFilesStub },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        ...getCommonMocks(),
+      });
+      const result = await LlmoControllerWithCache(mockContext).queryFiles(mockContext);
+      expect(result.status).to.equal(502);
+    });
+
+    it('maps a cached-query timeout to 504', async () => {
+      const err = new Error('Request timeout after 15000ms');
+      err.isTimeout = true;
+      const queryLlmoFilesStub = sinon.stub().rejects(err);
+      const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-query-handler.js': { queryLlmoFiles: queryLlmoFilesStub },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        ...getCommonMocks(),
+      });
+      const result = await LlmoControllerWithCache(mockContext).queryFiles(mockContext);
+      expect(result.status).to.equal(504);
+    });
+
+    it('maps a cached-query missing-key config error to 500', async () => {
+      const err = new Error('LLMO_HLX_API_KEY environment variable is not configured');
+      err.isConfigError = true;
+      const queryLlmoFilesStub = sinon.stub().rejects(err);
+      const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-query-handler.js': { queryLlmoFiles: queryLlmoFilesStub },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        ...getCommonMocks(),
+      });
+      const result = await LlmoControllerWithCache(mockContext).queryFiles(mockContext);
+      expect(result.status).to.equal(500);
+    });
+
     describe('HLX PG migration blocking (brand-presence)', () => {
       it('should return 403 for PG migration site when sheetType is brand-presence', async () => {
         const queryLlmoFilesStub = sinon.stub().resolves({ data: {}, headers: {} });

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -810,6 +810,7 @@ describe('LlmoController', () => {
       tracingFetchStub.resolves(createMockResponse(null, false, 503, 'Service Unavailable'));
       const result = await controller.getLlmoSheetData(mockContext);
       expect(result.status).to.equal(502);
+      expect(result.headers.get('x-error')).to.exist;
       expect(mockLog.error).to.have.been.called;
     });
 
@@ -819,6 +820,7 @@ describe('LlmoController', () => {
       tracingFetchStub.rejects(abort);
       const result = await controller.getLlmoSheetData(mockContext);
       expect(result.status).to.equal(504);
+      expect(result.headers.get('x-error')).to.exist;
       expect(mockLog.error).to.have.been.called;
     });
 
@@ -1084,6 +1086,7 @@ describe('LlmoController', () => {
       tracingFetchStub.resolves(createMockResponse(null, false, 503, 'Service Unavailable'));
       const result = await controller.getLlmoGlobalSheetData(mockContext);
       expect(result.status).to.equal(502);
+      expect(result.headers.get('x-error')).to.exist;
       expect(mockLog.error).to.have.been.called;
     });
 
@@ -1093,6 +1096,7 @@ describe('LlmoController', () => {
       tracingFetchStub.rejects(abort);
       const result = await controller.getLlmoGlobalSheetData(mockContext);
       expect(result.status).to.equal(504);
+      expect(result.headers.get('x-error')).to.exist;
       expect(mockLog.error).to.have.been.called;
     });
 
@@ -1497,6 +1501,7 @@ describe('LlmoController', () => {
       const result = await controller.queryLlmoSheetData(mockContext);
 
       expect(result.status).to.equal(502);
+      expect(result.headers.get('x-error')).to.exist;
       expect(mockLog.error).to.have.been.called;
     });
 
@@ -1538,6 +1543,7 @@ describe('LlmoController', () => {
       mockContext.data = null;
       const result = await controller.queryLlmoSheetData(mockContext);
       expect(result.status).to.equal(504);
+      expect(result.headers.get('x-error')).to.exist;
       expect(mockLog.error).to.have.been.called;
     });
 
@@ -3800,6 +3806,7 @@ describe('LlmoController', () => {
       });
       const result = await LlmoControllerWithCache(mockContext).queryFiles(mockContext);
       expect(result.status).to.equal(502);
+      expect(result.headers.get('x-error')).to.exist;
     });
 
     it('maps a cached-query timeout to 504', async () => {
@@ -3813,6 +3820,7 @@ describe('LlmoController', () => {
       });
       const result = await LlmoControllerWithCache(mockContext).queryFiles(mockContext);
       expect(result.status).to.equal(504);
+      expect(result.headers.get('x-error')).to.exist;
     });
 
     it('maps a cached-query missing-key config error to 500', async () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -810,6 +810,7 @@ describe('LlmoController', () => {
       tracingFetchStub.resolves(createMockResponse(null, false, 503, 'Service Unavailable'));
       const result = await controller.getLlmoSheetData(mockContext);
       expect(result.status).to.equal(502);
+      expect(mockLog.error).to.have.been.called;
     });
 
     it('maps timeout/abort to 504', async () => {
@@ -818,6 +819,7 @@ describe('LlmoController', () => {
       tracingFetchStub.rejects(abort);
       const result = await controller.getLlmoSheetData(mockContext);
       expect(result.status).to.equal(504);
+      expect(mockLog.error).to.have.been.called;
     });
 
     it('passes through a non-404 4xx (e.g. 401)', async () => {
@@ -1082,6 +1084,7 @@ describe('LlmoController', () => {
       tracingFetchStub.resolves(createMockResponse(null, false, 503, 'Service Unavailable'));
       const result = await controller.getLlmoGlobalSheetData(mockContext);
       expect(result.status).to.equal(502);
+      expect(mockLog.error).to.have.been.called;
     });
 
     it('maps timeout/abort to 504', async () => {
@@ -1090,12 +1093,23 @@ describe('LlmoController', () => {
       tracingFetchStub.rejects(abort);
       const result = await controller.getLlmoGlobalSheetData(mockContext);
       expect(result.status).to.equal(504);
+      expect(mockLog.error).to.have.been.called;
     });
 
     it('passes through a non-404 4xx (e.g. 401)', async () => {
       tracingFetchStub.resolves(createMockResponse(null, false, 401, 'Unauthorized'));
       const result = await controller.getLlmoGlobalSheetData(mockContext);
       expect(result.status).to.equal(401);
+    });
+
+    it('should handle network errors', async () => {
+      tracingFetchStub.rejects(new Error('Network error'));
+
+      const result = await controller.getLlmoGlobalSheetData(mockContext);
+
+      expect(result.status).to.equal(400);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('Network error');
     });
 
     it('should handle undefined response headers', async () => {
@@ -1483,6 +1497,7 @@ describe('LlmoController', () => {
       const result = await controller.queryLlmoSheetData(mockContext);
 
       expect(result.status).to.equal(502);
+      expect(mockLog.error).to.have.been.called;
     });
 
     it('should handle missing response headers in queryLlmoSheetData', async () => {
@@ -1523,6 +1538,7 @@ describe('LlmoController', () => {
       mockContext.data = null;
       const result = await controller.queryLlmoSheetData(mockContext);
       expect(result.status).to.equal(504);
+      expect(mockLog.error).to.have.been.called;
     });
 
     it('passes through a non-404 4xx (e.g. 401)', async () => {
@@ -1530,6 +1546,17 @@ describe('LlmoController', () => {
       mockContext.data = null;
       const result = await controller.queryLlmoSheetData(mockContext);
       expect(result.status).to.equal(401);
+    });
+
+    it('should handle network errors', async () => {
+      tracingFetchStub.rejects(new Error('Network error'));
+      mockContext.data = null;
+
+      const result = await controller.queryLlmoSheetData(mockContext);
+
+      expect(result.status).to.equal(400);
+      const responseBody = await result.json();
+      expect(responseBody.message).to.include('Network error');
     });
 
     it('should construct URL without sheetType when not provided', async () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -17,6 +17,11 @@ import esmock from 'esmock';
 import { S3Client } from '@aws-sdk/client-s3';
 import { llmoConfig } from '@adobe/spacecat-shared-utils';
 import { CDN_TYPES as LOG_SOURCES } from '../../../src/controllers/llmo/llmo-utils.js';
+import {
+  EMPTY_SHEET_PAYLOAD,
+  NOT_PROVISIONED_HEADER,
+  NOT_PROVISIONED_VALUE,
+} from '../../../src/controllers/llmo/llmo-source.js';
 import { UnauthorizedProductError } from '../../../src/support/errors.js';
 
 use(sinonChai);
@@ -3761,11 +3766,13 @@ describe('LlmoController', () => {
       const result = await cacheController.queryFiles(mockContext);
 
       expect(result.status).to.equal(200);
-      expect(result.headers.get('x-llmo-data-status')).to.equal('not-provisioned');
+      expect(result.headers.get(NOT_PROVISIONED_HEADER)).to.equal(NOT_PROVISIONED_VALUE);
       const body = await result.json();
-      expect(body).to.deep.equal({
-        total: 0, offset: 0, limit: 0, data: [], ':type': 'sheet',
-      });
+      expect(body).to.deep.equal(EMPTY_SHEET_PAYLOAD);
+      expect(mockLog.info).to.have.been.calledWith(
+        'llmo_data_not_provisioned',
+        sinon.match({ event: 'llmo_data_not_provisioned' }),
+      );
     });
   });
 

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -3746,6 +3746,27 @@ describe('LlmoController', () => {
       const result = await cacheController.queryFiles(mockContext);
       expect(result.status).to.equal(404);
     });
+
+    it('returns empty 200 with not-provisioned header when single-file query reports noData', async () => {
+      const queryLlmoFilesStub = sinon.stub().resolves({ noData: true });
+      const LlmoControllerWithCache = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-query-handler.js': {
+          queryLlmoFiles: queryLlmoFilesStub,
+        },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        ...getCommonMocks(),
+      });
+      const cacheController = LlmoControllerWithCache(mockContext);
+
+      const result = await cacheController.queryFiles(mockContext);
+
+      expect(result.status).to.equal(200);
+      expect(result.headers.get('x-llmo-data-status')).to.equal('not-provisioned');
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        total: 0, offset: 0, limit: 0, data: [], ':type': 'sheet',
+      });
+    });
   });
 
   describe('getLlmoRationale', () => {

--- a/test/controllers/webhooks.test.js
+++ b/test/controllers/webhooks.test.js
@@ -265,11 +265,20 @@ describe('WebhooksController', () => {
     ]);
   });
 
-  it('does not warn at construction (constructor is side-effect-free)', () => {
-    // beforeEach already built a controller without the env var set.
-    const constructWarn = mockLog.warn.getCalls()
-      .find((c) => c.args[0].includes('MYSTICAT_WORKSPACE_REPOS'));
-    expect(constructWarn).to.be.undefined;
+  it('does not warn or debug at construction (constructor is side-effect-free)', () => {
+    const freshLog = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    };
+    WebhooksController({
+      sqs: mockSqs,
+      log: freshLog,
+      env: { MYSTICAT_GITHUB_JOBS_QUEUE_URL: queueUrl, GITHUB_APP_SLUG: 'mysticat' },
+    });
+    expect(freshLog.warn.called).to.be.false;
+    expect(freshLog.debug.called).to.be.false;
   });
 
   it('uses defaults at debug (not warn) when MYSTICAT_WORKSPACE_REPOS is not set', async () => {
@@ -282,7 +291,7 @@ describe('WebhooksController', () => {
       'Adobe-AEM-Sites/aem-sites-architecture',
     ]);
     const notSetWarn = mockLog.warn.getCalls()
-      .find((c) => c.args[0].includes('not set'));
+      .find((c) => c.args[0].includes('MYSTICAT_WORKSPACE_REPOS not set'));
     expect(notSetWarn, 'unset path must not warn').to.be.undefined;
     const notSetDebug = mockLog.debug.getCalls()
       .find((c) => c.args[0].includes('MYSTICAT_WORKSPACE_REPOS not set'));

--- a/test/controllers/webhooks.test.js
+++ b/test/controllers/webhooks.test.js
@@ -67,6 +67,7 @@ describe('WebhooksController', () => {
       info: sandbox.stub(),
       warn: sandbox.stub(),
       error: sandbox.stub(),
+      debug: sandbox.stub(),
     };
     controller = buildController();
   });
@@ -264,13 +265,28 @@ describe('WebhooksController', () => {
     ]);
   });
 
-  it('logs warning and uses defaults when MYSTICAT_WORKSPACE_REPOS is not set', async () => {
-    // buildController() in beforeEach does not set the env var, so defaults are used
-    // but the log.warn occurs at controller construction — already recorded.
-    expect(mockLog.warn.called).to.be.true;
-    const warnMessage = mockLog.warn.getCalls()
+  it('does not warn at construction (constructor is side-effect-free)', () => {
+    // beforeEach already built a controller without the env var set.
+    const constructWarn = mockLog.warn.getCalls()
+      .find((c) => c.args[0].includes('MYSTICAT_WORKSPACE_REPOS'));
+    expect(constructWarn).to.be.undefined;
+  });
+
+  it('uses defaults at debug (not warn) when MYSTICAT_WORKSPACE_REPOS is not set', async () => {
+    await controller.processGitHubWebhook(validContext);
+
+    const [, payload] = mockSqs.sendMessage.firstCall.args;
+    expect(payload.workspace_repos).to.deep.equal([
+      'adobe/mysticat-architecture',
+      'adobe/mysticat-ai-native-guidelines',
+      'Adobe-AEM-Sites/aem-sites-architecture',
+    ]);
+    const notSetWarn = mockLog.warn.getCalls()
+      .find((c) => c.args[0].includes('not set'));
+    expect(notSetWarn, 'unset path must not warn').to.be.undefined;
+    const notSetDebug = mockLog.debug.getCalls()
       .find((c) => c.args[0].includes('MYSTICAT_WORKSPACE_REPOS not set'));
-    expect(warnMessage).to.not.be.undefined;
+    expect(notSetDebug, 'unset path should debug-log').to.not.be.undefined;
   });
 
   it('filters invalid entries from MYSTICAT_WORKSPACE_REPOS and logs warning', async () => {

--- a/test/fixtures/llmo/empty-sheet.json
+++ b/test/fixtures/llmo/empty-sheet.json
@@ -1,0 +1,7 @@
+{
+  "total": 0,
+  "offset": 0,
+  "limit": 0,
+  "data": [],
+  ":type": "sheet"
+}


### PR DESCRIPTION
## Why
SITES-43989 (Sev1): the API Gateway "Error Rate High" alert (SKYSI-76262, counts 4xx+5xx) was tripped partly by two avoidable spacecat-api-service sources: LLMO query endpoints returning `400` for sites whose data isn't provisioned yet (~253/20min), and ~94k/20min warn-log noise from a per-request `MYSTICAT_WORKSPACE_REPOS` check. Implements the inline subset of the remediation per the merged spec (#2452). Defense-in-depth; each fix stands alone.

## What

**Fix 1 - webhook log noise.** `getWorkspaceRepos` moved out of the per-request `WebhooksController` constructor into `processGitHubWebhook`; the unset-using-defaults branch drops `warn`→`debug` (it's the intended steady state). ~94k warns/20min → ~0.

**Fix 2 - LLMO upstream-404 → empty 200.** New `src/controllers/llmo/llmo-source.js` centralizes the elmo-ui-data fetch (15s timeout, key check, headers) and maps HTTP semantics: 404→`{noData}`, 5xx/4xx/timeout→tagged throws. All four LLMO read endpoints (`getLlmoSheetData`, `queryLlmoSheetData`, `getLlmoGlobalSheetData`, cached-query `queryFiles`) now return an empty `200` + `x-llmo-data-status: not-provisioned` header on 404, and map genuine failures honestly (5xx→502, timeout→504, non-404 4xx passthrough, missing-key→500). Multi-file cached-query reports per-file `status: no_data`. A structured `llmo_data_not_provisioned` info log feeds an events2metrics counter.

**Fix 3 - scrape API: no change** (documented). `getScrapeUrlByProcessingType` already returns `200 ok([])` for valid-no-data and `400` only for malformed input; mystique #1777 already drives its 4xx to ~0. `scrapeJob.js` is byte-unchanged in this PR.

## Phase 0 evidence (live)
- **Empty-shape contract** `test/fixtures/llmo/empty-sheet.json` captured from dev via the admin API (`lovesac` / `deployed-prerender-opportunity-urls` / `?limit=0`). Real empty sheets carry a sheet-specific `columns` array; not-provisioned has no schema, so the synthesized empty omits it - the **header is the discriminator** (clients can't byte-distinguish otherwise).
- **15s timeout: safe.** 25 sampled prod HELIX fetches, max **358ms** (~40x margin).
- **Log level: `info`.** Prod suppresses `debug`, so the not-provisioned signal must be `info` for the events2metrics rule to see it.
- **Live bug confirmed:** `sunstargum`, `24hourfitness-com`, `bamboohr-com` return `400 "External API returned 404"` on dev today.

## Decisions flagged for review
1. **missing `LLMO_HLX_API_KEY` → 500** (spec said "server-side error"; chose 500 over the old 400).
2. **Empty payload omits `columns`** (unknown for a 404 folder); header disambiguates.
3. **Kept `log.error` for 5xx/timeout** per spec ("genuine failures keep log.error"); a reviewer suggested `warn` - deferred to team.

## Testing
`npm test` green: **10365 passing**, coverage 99.99% stmts / 99.88% branch (`src/controllers/llmo` 100% lines). Per-endpoint behavior tests for 404/502/504/passthrough/missing-key across all four endpoints + the empty-shape byte-match. `npm run docs:lint` clean (0 errors).

## Post-merge verification (~24h)
`MYSTICAT_WORKSPACE_REPOS not set` warn rate → ~0; LLMO not-provisioned 400s gone (confirm via the new `llmo_data_not_provisioned` events2metrics counter - **rule is a post-deploy action**); overall 4xx+5xx below the SKYSI-76262 threshold.

## Related
Spec #2452 · [SITES-43989](https://jira.corp.adobe.com/browse/SITES-43989) · upstream root cause [SITES-45110](https://jira.corp.adobe.com/browse/SITES-45110) (Serhii) · scrape routing bug [SITES-45112](https://jira.corp.adobe.com/browse/SITES-45112) (Jan Hoffmann)

Implementation plan: `docs/plans/2026-05-21-sites-43989-error-rate-remediation-impl.md`