### PR TITLE
fix: allow read-only admins through resolveSite admin gates

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -104,7 +104,7 @@ export async function resolveOrgDefaultSite(org, productCode, context, ctx, acce
     }
 
     const isVisibleTier = CUSTOMER_VISIBLE_TIERS.includes(entitlement.getTier());
-    if (!isVisibleTier && !accessControlUtil.hasAdminAccess()) {
+    if (!isVisibleTier && !accessControlUtil.hasAdminReadAccess()) {
       return null;
     }
 
@@ -1318,13 +1318,13 @@ function SitesController(ctx, log, env) {
       }
 
       if (!CUSTOMER_VISIBLE_TIERS.includes(entitlement.getTier())) {
-        if (!callerIsInternal && !accessControlUtil.hasAdminAccess()) {
+        if (!callerIsInternal && !accessControlUtil.hasAdminReadAccess()) {
           return resolveFailure('No site found for the provided parameters', 'aso_pre_onboard', failureDetails);
         }
         log.info(`[resolveSite] Internal or admin caller (callerImsOrg=${callerImsOrg}): skipping tier check (tier=${entitlement.getTier()})`, failureDetails);
       }
 
-      if (enrolledSite && (accessControlUtil.hasAdminAccess()
+      if (enrolledSite && (accessControlUtil.hasAdminReadAccess()
         || CUSTOMER_VISIBLE_TIERS.includes(entitlement.getTier()))) {
         return ok({ data: await buildResolveData(org, enrolledSite, context) });
       }

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -4966,7 +4966,7 @@ describe('Sites Controller', () => {
     });
 
     it('should return 200 via imsOrg path when non-admin has visible entitlement and enrolled site', async () => {
-      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(false);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(false);
       context.data = { imsOrg: testOrganizations[2].getImsOrgId() };
       mockDataAccess.Organization.findByImsOrgId.resolves(testOrganizations[2]);
       mockTierClientStub.getFirstEnrollment.resolves({
@@ -5250,7 +5250,7 @@ describe('Sites Controller', () => {
     });
 
     it('should return 404 with aso_pre_onboard for PRE_ONBOARD-tier site via organizationId path for non-admin', async () => {
-      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(false);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(false);
       context.data = { organizationId: testOrganizations[0].getId() };
       mockDataAccess.Organization.findById.resolves(testOrganizations[0]);
 
@@ -5272,7 +5272,7 @@ describe('Sites Controller', () => {
     });
 
     it('should return 200 for PRE_ONBOARD-tier site via organizationId path for admin', async () => {
-      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(true);
       context.data = { organizationId: testOrganizations[0].getId() };
       mockDataAccess.Organization.findById.resolves(testOrganizations[0]);
 
@@ -5295,7 +5295,7 @@ describe('Sites Controller', () => {
     });
 
     it('should return 404 for PRE_ONBOARD-tier site via imsOrg path for non-admin', async () => {
-      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(false);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(false);
       context.data = { imsOrg: testOrganizations[2].getImsOrgId() };
       mockDataAccess.Organization.findByImsOrgId.resolves(testOrganizations[2]);
 
@@ -5319,7 +5319,7 @@ describe('Sites Controller', () => {
     });
 
     it('should return 200 for PRE_ONBOARD-tier site via imsOrg path for admin', async () => {
-      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(true);
       context.data = { imsOrg: testOrganizations[2].getImsOrgId() };
       mockDataAccess.Organization.findByImsOrgId.resolves(testOrganizations[2]);
 
@@ -5345,7 +5345,7 @@ describe('Sites Controller', () => {
     });
 
     it('should return 404 with no_entitlement_for_product for admin when organizationId path has no entitlement', async () => {
-      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(true);
       context.data = { organizationId: testOrganizations[0].getId() };
       mockDataAccess.Organization.findById.resolves(testOrganizations[0]);
 
@@ -5364,7 +5364,7 @@ describe('Sites Controller', () => {
     });
 
     it('should return 404 for admin when imsOrg path has no enrolled site', async () => {
-      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(true);
       context.data = { imsOrg: testOrganizations[2].getImsOrgId() };
       mockDataAccess.Organization.findByImsOrgId.resolves(testOrganizations[2]);
 
@@ -5449,7 +5449,7 @@ describe('Sites Controller', () => {
       beforeEach(() => {
         [org] = testOrganizations;
         mockCtx = { dataAccess: mockDataAccess, log: { warn: sandbox.stub() } };
-        mockAccessControlUtil = { hasAdminAccess: sandbox.stub().returns(false) };
+        mockAccessControlUtil = { hasAdminReadAccess: sandbox.stub().returns(false) };
         sandbox.stub(org, 'getConfig').returns(makeConfigWithDefault(SITE_IDS[0]));
         mockDataAccess.Site.findById.resolves(testSites[0]);
         mockTierClientStub.getAllEnrollment.resolves({
@@ -5510,7 +5510,7 @@ describe('Sites Controller', () => {
       });
 
       it('returns data when the configured site is on a non-customer-visible tier for admin', async () => {
-        mockAccessControlUtil.hasAdminAccess.returns(true);
+        mockAccessControlUtil.hasAdminReadAccess.returns(true);
         mockTierClientStub.getAllEnrollment.resolves({
           entitlement: { getTier: () => 'PRE_ONBOARD' },
           enrollments: [{ getId: () => 'enrollment-1' }],
@@ -5697,7 +5697,7 @@ describe('Sites Controller', () => {
       it('internal caller accessing CUSTOMER site (admin) with PRE_ONBOARD + not enrolled → 404 site_not_enrolled', async () => {
         // Caller-based check: bypass fires even when the site lives in a customer org.
         // PRE_ONBOARD tier check skipped for internal caller; no enrollment → site_not_enrolled.
-        sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+        sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(true);
         context.data = {
           siteId: SITE_IDS[1],
           imsOrg: CUSTOMER_ORG_IMS_ID,
@@ -5718,7 +5718,7 @@ describe('Sites Controller', () => {
       });
 
       it('internal caller accessing CUSTOMER site (admin) with PRE_ONBOARD + enrolled → 200', async () => {
-        sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+        sandbox.stub(AccessControlUtil.prototype, 'hasAdminReadAccess').returns(true);
         context.data = {
           siteId: SITE_IDS[1],
           imsOrg: CUSTOMER_ORG_IMS_ID,


### PR DESCRIPTION
Replace hasAdminAccess() with hasAdminReadAccess() in the resolveSite flow (and its resolveOrgDefaultSite helper) so read-only admin tokens
- which readOnlyAdminWrapper already permits for GET requests - can also bypass tier and enrollment restrictions when resolving sites. This aligns resolveSite with other read paths (getAll, getAllByOrganization) that already use hasAdminReadAccess. Write paths (e.g. createSite) remain on hasAdminAccess. Tests updated accordingly.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
