### PR TITLE
fix(fixes): load suggestions in getAllForOpportunity without fixCreatedDate (SITES-45274)

### DIFF
--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -145,6 +145,18 @@ export class FixesController {
       return res;
     }
 
+    // SITES-45274: attach suggestions to each fix entity so FixDto.toJSON
+    // includes them in the response. Without this, the UI's DeployedViewTable
+    // renders 0 rows (it iterates fixEntity.suggestions) even though the tab
+    // counter correctly counts the fix entities.
+    // The fixCreatedDate path above (lines 112-126) already does this via
+    // getAllFixesWithSuggestionByCreatedAt; this path was missing it.
+    await Promise.all(fixEntities.map(async (fixEntity) => {
+      const suggestions = await fixEntity.getSuggestions();
+      // eslint-disable-next-line no-underscore-dangle,no-param-reassign
+      fixEntity._suggestions = suggestions;
+    }));
+
     fixes = fixEntities.map((fix) => FixDto.toJSON(fix));
     return ok(fixes);
   }


### PR DESCRIPTION
## Summary

- **Deployed tab shows count=2 but only renders 1 row** — the initial fetch path (`getAllForOpportunity` without `fixCreatedDate`) returns fix entities WITHOUT suggestions attached. The UI renders rows by iterating `fixEntity.suggestions`, so missing suggestions = missing rows.

**Tracking:** [SITES-45274](https://jira.corp.adobe.com/browse/SITES-45274)

## Root cause

`src/controllers/fixes.js:99-149` has two code paths:

| Path | When | Loads suggestions? |
|---|---|---|
| WITH `fixCreatedDate` (lines 111-136) | User clicks a date group | **YES** — `getAllFixesWithSuggestionByCreatedAt` + attaches `_suggestions` |
| WITHOUT `fixCreatedDate` (lines 139-149) | Initial load (count + overview) | **NO** — `allByOpportunityId` only |

`FixDto.toJSON` (line 56-61) only includes `suggestions` when `fix._suggestions` is truthy. The UI's `DeployedViewTable.tsx:98` renders via `fixEntity.suggestions.forEach()` — no suggestions = 0 rows, but the fix entity still counts toward the tab badge.

## Fix

Added `getSuggestions()` loading to the no-filter path (line 139), matching the existing pattern in the `fixCreatedDate` path.

## Test plan

- [ ] CI tests
- [ ] Verify on Maurice Blackburn prod: Deployed tab count matches rendered rows
- [ ] Verify on JLR prod: backfilled FixEntities render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)