### PR TITLE
fix(sites): deep-merge config.llmo on PATCH to preserve siblings

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -734,6 +734,16 @@ function SitesController(ctx, log, env) {
           ...requestBody.config.auditTargetURLs,
         };
       }
+      // Deep-merge `llmo` so a partial llmo patch (e.g. { brand } from a lossy
+      // list-DTO round-trip) does not wipe sibling fields like cdnBucketConfig,
+      // questions, cdnlogsFilter, etc. Callers wanting to remove an llmo field
+      // must use the dedicated partial endpoints (e.g. /llmo/cdn-bucket-config).
+      if (requestBody.config?.llmo && existingConfig?.llmo) {
+        merged.llmo = {
+          ...existingConfig.llmo,
+          ...requestBody.config.llmo,
+        };
+      }
       const auditTargetURLsResult = auditTargetURLsPatchGuard(
         merged,
         site.getBaseURL(),

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -3600,6 +3600,46 @@ describe('Sites Controller', () => {
     expect(mergedConfig.handlers).to.deep.equal({ 'meta-tags': { excludedURLs: [] } });
   });
 
+  it('deep-merges llmo sub-keys so a partial llmo patch preserves siblings like cdnBucketConfig', async () => {
+    const site = sites[0];
+    const existingConfig = Config({
+      llmo: {
+        dataFolder: '/data',
+        brand: 'Test',
+        detectedCdn: 'byocdn-akamai',
+        cdnBucketConfig: { cdnProvider: 'akamai', bucketName: 'tui-cdn-logs', region: 'us-east-1' },
+        tags: ['opportunitiesReviewed'],
+      },
+    });
+    site.getConfig = sandbox.stub().returns(existingConfig);
+    site.setConfig = sandbox.stub();
+    site.save = sandbox.stub().resolves(site);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: {
+          llmo: {
+            dataFolder: '/data',
+            brand: 'Test',
+            detectedCdn: 'byocdn-other',
+            tags: ['opportunitiesReviewed'],
+          },
+        },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(200);
+    const mergedConfig = site.setConfig.firstCall.args[0];
+    expect(mergedConfig.llmo.detectedCdn).to.equal('byocdn-other');
+    expect(mergedConfig.llmo.cdnBucketConfig).to.deep.equal({
+      cdnProvider: 'akamai',
+      bucketName: 'tui-cdn-logs',
+      region: 'us-east-1',
+    });
+  });
+
   describe('auditTargetURLs validation', () => {
     it('returns bad request when manual URL hostname does not match site base URL', async () => {
       const site = sites[0];


### PR DESCRIPTION
## Summary
- PATCH `/sites/:siteId` previously did a top-level-only spread of `config`. A partial `llmo` body — e.g. the backoffice "Edit Site" dialog sending `{ tags, brand, dataFolder, detectedCdn }` — wholesale replaced the server's `llmo` object and deleted siblings like `cdnBucketConfig`, `questions`, and `cdnlogsFilter`.
- Mirror the existing `auditTargetURLs` deep-merge for `llmo` so partial patches preserve untouched fields. Callers wanting to remove an llmo field must use the dedicated partial endpoints (e.g. `/llmo/cdn-bucket-config`).

## Root cause
1. **Lossy list DTO** — `ConfigDto.toListJSON` only emits `{ dataFolder, brand, tags, customerIntent, detectedCdn }` under `llmo`. Clients fetching sites via `GET /sites` never see `cdnBucketConfig` etc.
2. **Shallow PATCH merge** — `updateSite` at `sites.js` did `merged = { ...existingConfig, ...requestBody.config }` (top-level only). Only `auditTargetURLs` had a deep-merge special case.

Result: backoffice "Edit Site" → list-DTO → spread into PATCH body → server replaces full `llmo` with the stripped 4-key version. Observed for `tui.com`, `tui.co.uk`, `repsol.com` on 2026-05-21 (Fastly access logs confirm `x-client-type: sites-optimizer-backoffice`).

## Fix
Add a deep-merge branch for `llmo` in `updateSite`, parallel to the existing `auditTargetURLs` handling.

## Test plan
- [x] New regression test (`deep-merges llmo sub-keys so a partial llmo patch preserves siblings like cdnBucketConfig`) reproduces the exact TUI scenario and asserts `cdnBucketConfig` survives.
- [x] All 280 existing `sites.test.js` tests still pass.
- [x] Lint clean.
- [ ] Manual verification post-deploy: re-PATCH a test site via backoffice and confirm `cdnBucketConfig` is preserved.

## Follow-ups (separate PRs)
- Recovery script to re-populate `cdnBucketConfig` for affected sites via `PATCH /sites/:siteId/llmo/cdn-bucket-config`.
- Backoffice (`experience-success-studio-backoffice`): fetch single-site full DTO on dialog open and send only edited fields in the PATCH body.
- Consider rejecting top-level `config.llmo` on PATCH in a future release once callers migrate to partial endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)