### PR TITLE
chore(it): diagnostic — dump open handles after IT teardown (DO NOT MERGE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "semantic-release": "^25.0.3",
         "sinon": "22.0.0",
         "sinon-chai": "4.0.1",
+        "why-is-node-running": "3.2.2",
         "yaml": "2.8.4"
       },
       "engines": {
@@ -704,7 +705,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -11131,7 +11131,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -14143,8 +14142,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -14168,7 +14166,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -15105,7 +15102,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -15403,7 +15399,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -15610,7 +15605,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -15775,7 +15769,6 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -17744,7 +17737,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -17992,7 +17984,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -18040,7 +18031,6 @@
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18506,7 +18496,6 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -19169,7 +19158,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -21364,7 +21352,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -25303,7 +25290,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -26358,7 +26344,6 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -28940,7 +28925,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -29467,7 +29451,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -30655,7 +30638,6 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30666,7 +30648,6 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -31421,7 +31402,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -32787,7 +32767,6 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -33794,7 +33773,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -34395,6 +34373,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-3.2.2.tgz",
+      "integrity": "sha512-NKUzAelcoCXhXL4dJzKIwXeR8iEVqsA0Lq6Vnd0UXvgaKbzVo4ZTHROF2Jidrv+SgxOQ03fMinnNhzZATxOD3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=20.11"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -34547,7 +34538,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -34833,7 +34823,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -34843,7 +34832,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "semantic-release": "^25.0.3",
     "sinon": "22.0.0",
     "sinon-chai": "4.0.1",
+    "why-is-node-running": "3.2.2",
     "yaml": "2.8.4"
   },
   "overrides": {

--- a/test/it/postgres/harness.js
+++ b/test/it/postgres/harness.js
@@ -58,21 +58,59 @@ export const mochaHooks = {
     await stopServer();
     await stopPostgres();
 
-    // DIAGNOSTIC (do not merge): if the Node event loop is still alive 5s after
-    // teardown completes, dump active handles via why-is-node-running and
-    // force-exit so the CI job ends quickly instead of hitting the 15-min
-    // step timeout. This is a temporary probe to identify the leaked handle
-    // that intermittently causes ci/it-postgres cancellations on main.
-    setTimeout(async () => {
-      console.log('\n=== why-is-node-running: handles still keeping the loop alive ===');
-      try {
-        const mod = await import('why-is-node-running');
-        (mod.default || mod)();
-      } catch (err) {
-        console.error('why-is-node-running failed to load:', err);
+    // DIAGNOSTIC (do not merge): identify the intermittent handle that
+    // sometimes keeps mocha from exiting after IT teardown and causes the
+    // ci/it-postgres job to hit the 15-min step timeout. Dump active handles
+    // immediately, then every 5s, force-exit at 60s. Also list child-process
+    // tree state so we can tell whether the hang is in Node (unclosed handle)
+    // or outside Node (orphaned helper / npm exec wrapper).
+    let wirn = null;
+    try {
+      const mod = await import('why-is-node-running');
+      wirn = mod.default || mod;
+    } catch (err) {
+      console.error('why-is-node-running load failed:', err);
+    }
+
+    const dump = (label) => {
+      console.log(`\n=== handle dump [${label}] ===`);
+      const handles = process.getActiveResourcesInfo
+        ? process.getActiveResourcesInfo()
+        : [];
+      console.log('process.getActiveResourcesInfo():', JSON.stringify(handles));
+      if (wirn) {
+        try {
+          wirn(process.stderr);
+        } catch (err) {
+          console.error('wirn failed:', err);
+        }
       }
-      console.log('=== end handle dump — force-exiting ===');
-      process.exit(0);
-    }, 5000).unref();
+      console.log(`=== end dump [${label}] ===`);
+    };
+
+    // Snapshot child processes (Linux only — CI is ubuntu-latest).
+    try {
+      const { execSync } = await import('child_process');
+      const psOut = execSync('ps -eo pid,ppid,stat,comm,args --no-headers 2>/dev/null | head -200', { encoding: 'utf8' });
+      console.log('\n=== ps snapshot (post-teardown) ===');
+      console.log(psOut);
+      console.log('=== end ps snapshot ===');
+    } catch (err) {
+      console.error('ps snapshot failed:', err.message);
+    }
+
+    dump('t=0 immediately after teardown');
+
+    let elapsed = 0;
+    const interval = setInterval(() => {
+      elapsed += 5;
+      dump(`t=${elapsed}s`);
+      if (elapsed >= 60) {
+        clearInterval(interval);
+        console.log('=== diagnostic timeout reached — force-exiting ===');
+        process.exit(0);
+      }
+    }, 5000);
+    interval.unref();
   },
 };

--- a/test/it/postgres/harness.js
+++ b/test/it/postgres/harness.js
@@ -57,5 +57,22 @@ export const mochaHooks = {
     this.timeout(HARNESS_HOOK_TIMEOUT_MS);
     await stopServer();
     await stopPostgres();
+
+    // DIAGNOSTIC (do not merge): if the Node event loop is still alive 5s after
+    // teardown completes, dump active handles via why-is-node-running and
+    // force-exit so the CI job ends quickly instead of hitting the 15-min
+    // step timeout. This is a temporary probe to identify the leaked handle
+    // that intermittently causes ci/it-postgres cancellations on main.
+    setTimeout(async () => {
+      console.log('\n=== why-is-node-running: handles still keeping the loop alive ===');
+      try {
+        const mod = await import('why-is-node-running');
+        (mod.default || mod)();
+      } catch (err) {
+        console.error('why-is-node-running failed to load:', err);
+      }
+      console.log('=== end handle dump — force-exiting ===');
+      process.exit(0);
+    }, 5000).unref();
   },
 };

--- a/test/it/postgres/harness.js
+++ b/test/it/postgres/harness.js
@@ -20,6 +20,12 @@
  * before all test files, and tears both down after all test files complete.
  */
 
+// DIAGNOSTIC: import why-is-node-running FIRST so its async_hooks listener is
+// active before any other module creates a handle. Lazy-importing it later
+// means it misses everything created before its import — which is why
+// previous diagnostic runs only ever attributed handles to our own console.log.
+import wirn from 'why-is-node-running';
+
 import { initAuth, createAllTokens } from '../shared/auth.js';
 import { buildEnv } from '../env.js';
 import { startServer, stopServer } from '../server.js';
@@ -64,27 +70,16 @@ export const mochaHooks = {
     // immediately, then every 5s, force-exit at 60s. Also list child-process
     // tree state so we can tell whether the hang is in Node (unclosed handle)
     // or outside Node (orphaned helper / npm exec wrapper).
-    let wirn = null;
-    try {
-      const mod = await import('why-is-node-running');
-      wirn = mod.default || mod;
-    } catch (err) {
-      console.error('why-is-node-running load failed:', err);
-    }
-
     const dump = (label) => {
       console.log(`\n=== handle dump [${label}] ===`);
       const handles = process.getActiveResourcesInfo
         ? process.getActiveResourcesInfo()
         : [];
       console.log('process.getActiveResourcesInfo():', JSON.stringify(handles));
-      if (wirn) {
-        try {
-          // wirn() expects a logger object with .error(); default is console.
-          wirn();
-        } catch (err) {
-          console.error('wirn failed:', err);
-        }
+      try {
+        wirn();
+      } catch (err) {
+        console.error('wirn failed:', err);
       }
       // Extra context for diagnosing PipeWrap handles (stdio).
       /* eslint-disable no-underscore-dangle */

--- a/test/it/postgres/harness.js
+++ b/test/it/postgres/harness.js
@@ -80,11 +80,34 @@ export const mochaHooks = {
       console.log('process.getActiveResourcesInfo():', JSON.stringify(handles));
       if (wirn) {
         try {
-          wirn(process.stderr);
+          // wirn() expects a logger object with .error(); default is console.
+          wirn();
         } catch (err) {
           console.error('wirn failed:', err);
         }
       }
+      // Extra context for diagnosing PipeWrap handles (stdio).
+      /* eslint-disable no-underscore-dangle */
+      const refed = (s) => !!s._handle?.hasRef?.();
+      const stdioInfo = {
+        stdin: {
+          isTTY: process.stdin.isTTY,
+          readable: process.stdin.readable,
+          refed: refed(process.stdin),
+        },
+        stdout: {
+          isTTY: process.stdout.isTTY,
+          writable: process.stdout.writable,
+          refed: refed(process.stdout),
+        },
+        stderr: {
+          isTTY: process.stderr.isTTY,
+          writable: process.stderr.writable,
+          refed: refed(process.stderr),
+        },
+      };
+      /* eslint-enable no-underscore-dangle */
+      console.log('stdio info:', JSON.stringify(stdioInfo));
       console.log(`=== end dump [${label}] ===`);
     };
 


### PR DESCRIPTION
## Purpose

Diagnostic-only probe to identify which handle is keeping the Node event loop alive after the PostgreSQL integration suite finishes, which intermittently causes \`ci/it-postgres\` to hit the ~15-minute step timeout and get cancelled on \`main\` (e.g. runs [26282298612](https://github.com/adobe/spacecat-api-service/actions/runs/26282298612), [26229325483](https://github.com/adobe/spacecat-api-service/actions/runs/26229325483), [26216823004](https://github.com/adobe/spacecat-api-service/actions/runs/26216823004)).

In every cancelled run, the log shows \`491 passing\` and successful container teardown, then ~11 minutes of silence with orphan \`npm exec mocha\` reported at cleanup. Mocha doesn't exit because something is holding the loop open.

## What this PR does

In \`test/it/postgres/harness.js\` \`afterAll\`, after the existing teardown:

1. Waits 5s for the loop to drain on its own.
2. If still alive, calls \`why-is-node-running\` to dump active handles with file:line.
3. \`process.exit(0)\` so the job ends in ~3 min instead of timing out at 15.

\`why-is-node-running\` added as a dev dependency.

## Expected outcome

CI logs will name the leaked handle. Hypothesis: the module-scope \`http.Agent({ keepAlive: true })\` inside \`@adobe/spacecat-shared-data-access\`'s \`@adobe/fetch\` context. Verified or refuted by the dump.

## After this PR

Close as not-for-merge. Open the real fix:
- Export \`resetDataAccessConnections\` from \`@adobe/spacecat-shared-data-access\` (calls \`fetchContext.reset()\`).
- Call it from the IT \`afterAll\` before \`stopPostgres()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)