### PR TITLE
docs: correct Preflight TTL mechanism in ADR 002

### DIFF
--- a/docs/decisions/002-preflight-api-rest-redesign.md
+++ b/docs/decisions/002-preflight-api-rest-redesign.md
@@ -302,11 +302,11 @@ polling, result storage). The `asyncJobId` is never exposed to API consumers.
 immediately creates the `Preflight` entity with `asyncJobId` as the FK. This ordering ensures
 the execution primitive exists before the domain record that references it.
 
-**TTL** is configured on the `Preflight` table/collection at the same 7-day window as
-`AsyncJob`. The TTL column approach matches the `async_jobs` mechanism — verify the exact
-column name in `mysticat-data-service` before writing the migration. Given the 1-to-1
-relationship, the two records expire together: when the `AsyncJob` TTLs, the associated
-`Preflight` record is also obsolete.
+**Expiry** is handled implicitly via the `ON DELETE CASCADE` on `async_job_id`. When the
+backing `AsyncJob` is cleaned up, its associated `Preflight` row is deleted with it. There
+is no separate TTL column on `preflights` — the `withRecordExpiry` SchemaBuilder helper is
+a DynamoDB-era mechanism marked `postgrestIgnore` in the v3 PostgreSQL layer and does not
+write to the database.
 
 `createdBy` is derived from the caller's IMS profile at job creation time: `email` is
 `profile.email` (the IMS user identifier); `displayName` is composed from


### PR DESCRIPTION
Corrects the TTL/expiry description in ADR 002 to reflect the actual implementation.

`withRecordExpiry` is a DynamoDB-era SchemaBuilder helper marked `postgrestIgnore` in the v3 PostgreSQL layer - it never writes to the database. The `preflights` table has no `record_expires_at` column. Cleanup is handled by `ON DELETE CASCADE` on `async_job_id`.

Companion to:
- mysticat-data-service PR: https://github.com/adobe/mysticat-data-service/pull/622
- spacecat-shared PR: https://github.com/adobe/spacecat-shared/pull/1622

Generated with Claude Code