### PR TITLE
feat(auth): add route-scoped legacy API key handler for S2S-exempt endpoints

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,7 @@ import AiVisibilityController from './controllers/ai-visibility.js';
 import SemrushController from './controllers/semrush.js';
 import GitHubWebhookHmacHandler from './support/github-webhook-hmac-handler.js';
 import ApiKeyImsHandler from './support/api-key-ims-handler.js';
+import RouteScopedLegacyApiKeyHandler from './support/route-scoped-legacy-api-key-handler.js';
 
 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -394,10 +395,17 @@ const { WORKSPACE_EXTERNAL } = SLACK_TARGETS;
 //    working without re-introducing a global IMS auth backdoor.
 //  - AdobeImsHandler: legacy global IMS path; kept for routes still on IMS auth
 //    (e.g. Auto-Fix). To be removed once all consumers are JWT-migrated.
-//  - ScopedApiKeyHandler / LegacyApiKeyHandler: standard API-key auth paths.
+//  - ScopedApiKeyHandler: scoped API-key auth for Import-as-a-Service.
+//  - RouteScopedLegacyApiKeyHandler: route-scoped legacy API key handler for
+//    POST /event/fulfillment and POST /slack/channels/invite-by-user-id — the two
+//    admin endpoints whose callers cannot migrate to S2S. Returns null for all
+//    other routes. Must run BEFORE LegacyApiKeyHandler so the scoped handler owns
+//    those two routes explicitly. LegacyApiKeyHandler is kept for now and will be
+//    removed in a follow-up once all other consumers are confirmed migrated.
+//  - LegacyApiKeyHandler: legacy catch-all; to be removed in follow-up.
 // When adding a new path-scoped handler, place it in the same position (after
 // SkipAuthHandler, before the path-agnostic handlers) to preserve early-bail.
-// AUTH_HANDLERS order is enforced by test/auth-handlers.test.js.
+// AUTH_HANDLERS order is enforced by test/auth-handlers-order.test.js.
 const AUTH_HANDLERS = [
   SkipAuthHandler,
   GitHubWebhookHmacHandler,
@@ -405,6 +413,7 @@ const AUTH_HANDLERS = [
   ApiKeyImsHandler,
   AdobeImsHandler,
   ScopedApiKeyHandler,
+  RouteScopedLegacyApiKeyHandler,
   LegacyApiKeyHandler,
 ];
 

--- a/src/support/route-scoped-legacy-api-key-handler.js
+++ b/src/support/route-scoped-legacy-api-key-handler.js
@@ -45,7 +45,7 @@ export default class RouteScopedLegacyApiKeyHandler extends LegacyApiKeyHandler 
     }
     const result = await super.checkAuth(request, context);
     if (result) {
-      this.log('request authenticated via route-scoped legacy API key handler', 'info');
+      this.log(`request authenticated via route-scoped legacy API key handler [${context.pathInfo.route}]`, 'info');
     }
     return result;
   }

--- a/src/support/route-scoped-legacy-api-key-handler.js
+++ b/src/support/route-scoped-legacy-api-key-handler.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { LegacyApiKeyHandler } from '@adobe/spacecat-shared-http-utils';
+
+// Routes whose callers cannot be migrated to S2S auth. Per the decision doc
+// (platform/decisions/route-scoped-legacy-api-key-handler.md), these are the
+// only routes this handler is authorised to authenticate.
+const SCOPED_ROUTES = new Set([
+  'POST /event/fulfillment',
+  'POST /slack/channels/invite-by-user-id',
+]);
+
+/**
+ * Route-scoped legacy API key handler for endpoints that cannot migrate to S2S.
+ *
+ * Per the decision doc (mysticat-architecture
+ * `platform/decisions/route-scoped-legacy-api-key-handler.md`), two admin
+ * endpoints are called by external systems that cannot be provisioned as IMS
+ * S2S consumers: POST /event/fulfillment and POST /slack/channels/invite-by-user-id.
+ * This subclass limits legacy API key auth to exactly those two routes. All other
+ * requests receive null and fall through to the next handler in the chain.
+ *
+ * No constructor override — LegacyApiKeyHandler sets the handler name to
+ * 'legacyApiKey', so authInfo.getType() returns 'legacyApiKey' here too.
+ * Controllers that branch on auth type behave identically regardless of which
+ * handler in the legacy-key family authenticated the request.
+ *
+ * TODO: Once the parent LegacyApiKeyHandler is removed from AUTH_HANDLERS
+ * (planned follow-up), delete that removal note from src/index.js.
+ */
+export default class RouteScopedLegacyApiKeyHandler extends LegacyApiKeyHandler {
+  async checkAuth(request, context) {
+    if (!SCOPED_ROUTES.has(context?.pathInfo?.route)) {
+      return null;
+    }
+    const result = await super.checkAuth(request, context);
+    if (result) {
+      this.log('request authenticated via route-scoped legacy API key handler', 'info');
+    }
+    return result;
+  }
+}

--- a/test/auth-handlers-order.test.js
+++ b/test/auth-handlers-order.test.js
@@ -73,4 +73,22 @@ describe('src/index.js authHandlers order contract', () => {
       'ApiKeyImsHandler must come before AdobeImsHandler',
     );
   });
+
+  it('places RouteScopedLegacyApiKeyHandler before LegacyApiKeyHandler', () => {
+    // The scoped handler explicitly owns POST /event/fulfillment and
+    // POST /slack/channels/invite-by-user-id. It must run before the catch-all
+    // LegacyApiKeyHandler so those routes are matched by the scoped handler
+    // rather than falling through to the parent. Both handlers remain in the
+    // chain until the follow-up cleanup removes LegacyApiKeyHandler.
+    const order = parseAuthHandlersOrder();
+    const scopedIdx = order.indexOf('RouteScopedLegacyApiKeyHandler');
+    const legacyIdx = order.indexOf('LegacyApiKeyHandler');
+
+    expect(scopedIdx).to.be.greaterThan(-1, 'RouteScopedLegacyApiKeyHandler must be in AUTH_HANDLERS');
+    expect(legacyIdx).to.be.greaterThan(-1, 'LegacyApiKeyHandler must be in AUTH_HANDLERS');
+    expect(scopedIdx).to.be.lessThan(
+      legacyIdx,
+      'RouteScopedLegacyApiKeyHandler must come before LegacyApiKeyHandler',
+    );
+  });
 });

--- a/test/support/route-scoped-legacy-api-key-handler.test.js
+++ b/test/support/route-scoped-legacy-api-key-handler.test.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import sinon from 'sinon';
+
+use(sinonChai);
+
+/**
+ * RouteScopedLegacyApiKeyHandler extends LegacyApiKeyHandler from
+ * @adobe/spacecat-shared-http-utils. esmock replaces the imported
+ * LegacyApiKeyHandler with a minimal stub so we exercise only the
+ * route-scoping logic in isolation.
+ */
+async function loadHandler({ superCheckAuthStub } = {}) {
+  return (await esmock(
+    '../../src/support/route-scoped-legacy-api-key-handler.js',
+    {
+      '@adobe/spacecat-shared-http-utils': {
+        LegacyApiKeyHandler: class StubLegacyApiKeyHandler {
+          constructor(log) {
+            this.name = 'legacyApiKey';
+            this.log = (message, level) => log?.[level || 'info']?.(`[${this.name}] ${message}`);
+          }
+
+          // eslint-disable-next-line class-methods-use-this
+          checkAuth(...args) {
+            return superCheckAuthStub(...args);
+          }
+        },
+      },
+    },
+  )).default;
+}
+
+describe('RouteScopedLegacyApiKeyHandler', () => {
+  let superCheckAuthStub;
+  let HandlerClass;
+  let handler;
+  let logStubs;
+
+  beforeEach(async () => {
+    superCheckAuthStub = sinon.stub().resolves('SUPER_RESULT');
+    HandlerClass = await loadHandler({ superCheckAuthStub });
+    logStubs = {
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+    };
+    handler = new HandlerClass(logStubs);
+  });
+
+  // --- scoped routes: must delegate to parent ---
+
+  it('delegates to LegacyApiKeyHandler.checkAuth for POST /event/fulfillment', async () => {
+    const req = {};
+    const ctx = { pathInfo: { route: 'POST /event/fulfillment' } };
+    const result = await handler.checkAuth(req, ctx);
+    expect(result).to.equal('SUPER_RESULT');
+    expect(superCheckAuthStub).to.have.been.calledOnceWith(req, ctx);
+  });
+
+  it('delegates to LegacyApiKeyHandler.checkAuth for POST /slack/channels/invite-by-user-id', async () => {
+    const req = {};
+    const ctx = { pathInfo: { route: 'POST /slack/channels/invite-by-user-id' } };
+    const result = await handler.checkAuth(req, ctx);
+    expect(result).to.equal('SUPER_RESULT');
+    expect(superCheckAuthStub).to.have.been.calledOnceWith(req, ctx);
+  });
+
+  // --- success logging ---
+
+  it('emits an info log when auth succeeds on POST /event/fulfillment', async () => {
+    superCheckAuthStub.resolves({ getType: () => 'legacyApiKey' });
+    await handler.checkAuth({}, { pathInfo: { route: 'POST /event/fulfillment' } });
+    expect(logStubs.info).to.have.been.calledOnceWithExactly(
+      '[legacyApiKey] request authenticated via route-scoped legacy API key handler',
+    );
+  });
+
+  it('emits an info log when auth succeeds on POST /slack/channels/invite-by-user-id', async () => {
+    superCheckAuthStub.resolves({ getType: () => 'legacyApiKey' });
+    await handler.checkAuth({}, { pathInfo: { route: 'POST /slack/channels/invite-by-user-id' } });
+    expect(logStubs.info).to.have.been.calledOnceWithExactly(
+      '[legacyApiKey] request authenticated via route-scoped legacy API key handler',
+    );
+  });
+
+  it('does NOT emit the success log when super.checkAuth returns null (auth failed)', async () => {
+    superCheckAuthStub.resolves(null);
+    await handler.checkAuth({}, { pathInfo: { route: 'POST /event/fulfillment' } });
+    expect(logStubs.info).to.not.have.been.called;
+  });
+
+  // --- out-of-scope routes: must return null without calling super ---
+
+  it('returns null without calling super for GET /trigger', async () => {
+    const ctx = { pathInfo: { route: 'GET /trigger' } };
+    const result = await handler.checkAuth({}, ctx);
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('returns null without calling super for POST /sites', async () => {
+    const ctx = { pathInfo: { route: 'POST /sites' } };
+    const result = await handler.checkAuth({}, ctx);
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('returns null without calling super for GET /sites', async () => {
+    const ctx = { pathInfo: { route: 'GET /sites' } };
+    const result = await handler.checkAuth({}, ctx);
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('returns null without calling super for POST /tools/api-keys', async () => {
+    const ctx = { pathInfo: { route: 'POST /tools/api-keys' } };
+    const result = await handler.checkAuth({}, ctx);
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('returns null for GET /event/fulfillment (wrong method, same path)', async () => {
+    const ctx = { pathInfo: { route: 'GET /event/fulfillment' } };
+    const result = await handler.checkAuth({}, ctx);
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('returns null for GET /slack/channels/invite-by-user-id (wrong method)', async () => {
+    const ctx = { pathInfo: { route: 'GET /slack/channels/invite-by-user-id' } };
+    const result = await handler.checkAuth({}, ctx);
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  // --- edge cases ---
+
+  it('returns null when context.pathInfo is missing', async () => {
+    const result = await handler.checkAuth({}, {});
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('returns null when context is undefined', async () => {
+    const result = await handler.checkAuth({});
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('returns null when route is undefined', async () => {
+    const ctx = { pathInfo: { route: undefined } };
+    const result = await handler.checkAuth({}, ctx);
+    expect(result).to.equal(null);
+    expect(superCheckAuthStub).to.not.have.been.called;
+  });
+});

--- a/test/support/route-scoped-legacy-api-key-handler.test.js
+++ b/test/support/route-scoped-legacy-api-key-handler.test.js
@@ -86,7 +86,7 @@ describe('RouteScopedLegacyApiKeyHandler', () => {
     superCheckAuthStub.resolves({ getType: () => 'legacyApiKey' });
     await handler.checkAuth({}, { pathInfo: { route: 'POST /event/fulfillment' } });
     expect(logStubs.info).to.have.been.calledOnceWithExactly(
-      '[legacyApiKey] request authenticated via route-scoped legacy API key handler',
+      '[legacyApiKey] request authenticated via route-scoped legacy API key handler [POST /event/fulfillment]',
     );
   });
 
@@ -94,7 +94,7 @@ describe('RouteScopedLegacyApiKeyHandler', () => {
     superCheckAuthStub.resolves({ getType: () => 'legacyApiKey' });
     await handler.checkAuth({}, { pathInfo: { route: 'POST /slack/channels/invite-by-user-id' } });
     expect(logStubs.info).to.have.been.calledOnceWithExactly(
-      '[legacyApiKey] request authenticated via route-scoped legacy API key handler',
+      '[legacyApiKey] request authenticated via route-scoped legacy API key handler [POST /slack/channels/invite-by-user-id]',
     );
   });
 
@@ -167,5 +167,11 @@ describe('RouteScopedLegacyApiKeyHandler', () => {
     const result = await handler.checkAuth({}, ctx);
     expect(result).to.equal(null);
     expect(superCheckAuthStub).to.not.have.been.called;
+  });
+
+  it('propagates exceptions from super.checkAuth without catching', async () => {
+    superCheckAuthStub.rejects(new Error('key validation failed'));
+    const ctx = { pathInfo: { route: 'POST /event/fulfillment' } };
+    await expect(handler.checkAuth({}, ctx)).to.be.rejectedWith('key validation failed');
   });
 });


### PR DESCRIPTION
## Summary

Two admin endpoints — `POST /event/fulfillment` and `POST /slack/channels/invite-by-user-id` — are called by external systems that cannot be provisioned as IMS S2S consumers. This PR adds a route-scoped subclass of `LegacyApiKeyHandler` that limits legacy API key auth to exactly those two routes, following the same pattern as `ApiKeyImsHandler` from the IMS-to-JWT migration.

**The parent `LegacyApiKeyHandler` is intentionally kept in `AUTH_HANDLERS` for now.** Removal is a planned follow-up once all other consumers are confirmed migrated to S2S.

## Changes

### `src/support/route-scoped-legacy-api-key-handler.js` (new)
- Subclasses `LegacyApiKeyHandler`; inherits the `'legacyApiKey'` handler name so `authInfo.getType()` is unchanged downstream
- `SCOPED_ROUTES` set contains only the two exempt routes
- Returns `null` immediately for any other route; delegates to `super.checkAuth()` for the two scoped routes
- Emits an info log on success as an operational signal (mirrors `ApiKeyImsHandler` pattern)

### `src/index.js`
- Import added for `RouteScopedLegacyApiKeyHandler`
- Handler inserted into `AUTH_HANDLERS` immediately before `LegacyApiKeyHandler`
- Comment updated to document both handlers and the planned removal of the parent

### `test/support/route-scoped-legacy-api-key-handler.test.js` (new)
- 14 tests: both scoped routes delegate to super, success log emitted, null result suppresses log, all out-of-scope routes return null (including wrong-method variants for the two scoped paths), edge cases (missing context, undefined route)

### `test/auth-handlers-order.test.js`
- New contract test asserts `RouteScopedLegacyApiKeyHandler` appears before `LegacyApiKeyHandler` in the parsed `AUTH_HANDLERS` array

## Decision doc

[adobe/mysticat-architecture#86](https://github.com/adobe/mysticat-architecture/pull/86) — `platform/decisions/route-scoped-legacy-api-key-handler.md`

## Test plan
- [ ] `test/support/route-scoped-legacy-api-key-handler.test.js` — 14 unit tests, all passing
- [ ] `test/auth-handlers-order.test.js` — order contract test passes (3 tests total)
- [ ] Verify `POST /event/fulfillment` and `POST /slack/channels/invite-by-user-id` authenticate with `ADMIN_API_KEY` in a dev environment
- [ ] Verify other routes (e.g. `GET /sites`) are unaffected by the new handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
