### PR TITLE
fix(auth): use context.log in auth handler subclasses for per-request logging

### DIFF
--- a/src/support/api-key-ims-handler.js
+++ b/src/support/api-key-ims-handler.js
@@ -77,7 +77,7 @@ export default class ApiKeyImsHandler extends AdobeImsHandler {
       // claim for exactly this reason). Normalising to trial_email (the real
       // address) would create a format mismatch that makes existing keys
       // invisible on GET and breaks cross-path consistency (ASO-607).
-      this.log('api-key request authenticated via scoped IMS handler - JWT migration pending', 'info');
+      context.log.info('[ims] api-key request authenticated via scoped IMS handler - JWT migration pending');
     }
     return result;
   }

--- a/src/support/route-scoped-legacy-api-key-handler.js
+++ b/src/support/route-scoped-legacy-api-key-handler.js
@@ -45,7 +45,7 @@ export default class RouteScopedLegacyApiKeyHandler extends LegacyApiKeyHandler 
     }
     const result = await super.checkAuth(request, context);
     if (result) {
-      this.log(`request authenticated via route-scoped legacy API key handler [${context.pathInfo.route}]`, 'info');
+      context.log.info(`[legacyApiKey] request authenticated via route-scoped legacy API key handler [${context.pathInfo.route}]`);
     }
     return result;
   }

--- a/test/support/api-key-ims-handler.test.js
+++ b/test/support/api-key-ims-handler.test.js
@@ -69,7 +69,7 @@ describe('ApiKeyImsHandler', () => {
 
   it('delegates to AdobeImsHandler.checkAuth for /tools/api-keys', async () => {
     const req = {};
-    const ctx = { pathInfo: { suffix: '/tools/api-keys' } };
+    const ctx = { pathInfo: { suffix: '/tools/api-keys' }, log: logStubs };
     const result = await handler.checkAuth(req, ctx);
     expect(result).to.equal('SUPER_RESULT');
     expect(superCheckAuthStub).to.have.been.calledOnceWith(req, ctx);
@@ -77,7 +77,7 @@ describe('ApiKeyImsHandler', () => {
 
   it('delegates to AdobeImsHandler.checkAuth for /tools/api-keys/<id>', async () => {
     const req = {};
-    const ctx = { pathInfo: { suffix: '/tools/api-keys/abc-123' } };
+    const ctx = { pathInfo: { suffix: '/tools/api-keys/abc-123' }, log: logStubs };
     const result = await handler.checkAuth(req, ctx);
     expect(result).to.equal('SUPER_RESULT');
     expect(superCheckAuthStub).to.have.been.calledOnce;
@@ -85,7 +85,7 @@ describe('ApiKeyImsHandler', () => {
 
   it('emits an info log when the scoped IMS auth succeeds (migration signal)', async () => {
     superCheckAuthStub.resolves({ getProfile: () => null });
-    await handler.checkAuth({}, { pathInfo: { suffix: '/tools/api-keys' } });
+    await handler.checkAuth({}, { pathInfo: { suffix: '/tools/api-keys' }, log: logStubs });
     expect(logStubs.info).to.have.been.calledOnceWithExactly(
       '[ims] api-key request authenticated via scoped IMS handler - JWT migration pending',
     );
@@ -97,14 +97,14 @@ describe('ApiKeyImsHandler', () => {
     // never the real address — so we must not overwrite profile.email here.
     const profile = { email: 'ABC123@AdobeID', trial_email: 'real@adobe.com' };
     superCheckAuthStub.resolves({ getProfile: () => profile });
-    await handler.checkAuth({}, { pathInfo: { suffix: '/tools/api-keys' } });
+    await handler.checkAuth({}, { pathInfo: { suffix: '/tools/api-keys' }, log: logStubs });
     expect(profile.email).to.equal('ABC123@AdobeID');
   });
 
   it('leaves profile.email unchanged when trial_email is absent', async () => {
     const profile = { email: 'ABC123@AdobeID' };
     superCheckAuthStub.resolves({ getProfile: () => profile });
-    await handler.checkAuth({}, { pathInfo: { suffix: '/tools/api-keys' } });
+    await handler.checkAuth({}, { pathInfo: { suffix: '/tools/api-keys' }, log: logStubs });
     expect(profile.email).to.equal('ABC123@AdobeID');
   });
 

--- a/test/support/route-scoped-legacy-api-key-handler.test.js
+++ b/test/support/route-scoped-legacy-api-key-handler.test.js
@@ -66,7 +66,7 @@ describe('RouteScopedLegacyApiKeyHandler', () => {
 
   it('delegates to LegacyApiKeyHandler.checkAuth for POST /event/fulfillment', async () => {
     const req = {};
-    const ctx = { pathInfo: { route: 'POST /event/fulfillment' } };
+    const ctx = { pathInfo: { route: 'POST /event/fulfillment' }, log: logStubs };
     const result = await handler.checkAuth(req, ctx);
     expect(result).to.equal('SUPER_RESULT');
     expect(superCheckAuthStub).to.have.been.calledOnceWith(req, ctx);
@@ -74,7 +74,7 @@ describe('RouteScopedLegacyApiKeyHandler', () => {
 
   it('delegates to LegacyApiKeyHandler.checkAuth for POST /slack/channels/invite-by-user-id', async () => {
     const req = {};
-    const ctx = { pathInfo: { route: 'POST /slack/channels/invite-by-user-id' } };
+    const ctx = { pathInfo: { route: 'POST /slack/channels/invite-by-user-id' }, log: logStubs };
     const result = await handler.checkAuth(req, ctx);
     expect(result).to.equal('SUPER_RESULT');
     expect(superCheckAuthStub).to.have.been.calledOnceWith(req, ctx);
@@ -84,7 +84,7 @@ describe('RouteScopedLegacyApiKeyHandler', () => {
 
   it('emits an info log when auth succeeds on POST /event/fulfillment', async () => {
     superCheckAuthStub.resolves({ getType: () => 'legacyApiKey' });
-    await handler.checkAuth({}, { pathInfo: { route: 'POST /event/fulfillment' } });
+    await handler.checkAuth({}, { pathInfo: { route: 'POST /event/fulfillment' }, log: logStubs });
     expect(logStubs.info).to.have.been.calledOnceWithExactly(
       '[legacyApiKey] request authenticated via route-scoped legacy API key handler [POST /event/fulfillment]',
     );
@@ -92,7 +92,7 @@ describe('RouteScopedLegacyApiKeyHandler', () => {
 
   it('emits an info log when auth succeeds on POST /slack/channels/invite-by-user-id', async () => {
     superCheckAuthStub.resolves({ getType: () => 'legacyApiKey' });
-    await handler.checkAuth({}, { pathInfo: { route: 'POST /slack/channels/invite-by-user-id' } });
+    await handler.checkAuth({}, { pathInfo: { route: 'POST /slack/channels/invite-by-user-id' }, log: logStubs });
     expect(logStubs.info).to.have.been.calledOnceWithExactly(
       '[legacyApiKey] request authenticated via route-scoped legacy API key handler [POST /slack/channels/invite-by-user-id]',
     );


### PR DESCRIPTION


this.log() in AbstractHandler uses the logger captured at handler construction time (first request), causing all subsequent requests to log with a stale context. Switch to context.log in ApiKeyImsHandler and RouteScopedLegacyApiKeyHandler so the per-request logger is used.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
