### PR TITLE
feat(serenity): denormalize semrushLocationName + local-dev env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,44 @@ USER_API_KEY=api_key_for_user_requests
 ADMIN_API_KEY=api_key_for_admin_requests
 
 # ── IMS client (eagerly initialized, dummy values are fine) ───────────────────
-IMS_HOST=https://dummy-ims.example.com
+# IMS_HOST is just the hostname — NO scheme. ImsClient builds URLs as
+# `https://${IMS_HOST}${endpoint}`, so a value like `https://ims-...`
+# yields `https://https://ims-.../...` and fails with `ENOTFOUND https`.
+# Real value for stage: `ims-na1-stg1.adobelogin.com` (sourced from Vault in prod).
+IMS_HOST=dummy-ims.example.com
 IMS_CLIENT_ID=dummy-client-id
 IMS_CLIENT_CODE=dummy-client-code
 IMS_CLIENT_SECRET=dummy-client-secret
+
+# ── Auth handler config (REQUIRED for any authenticated request) ──────────────
+# Without these, JwtHandler / AdobeImsHandler return null on every request and
+# the auth chain 401s with a generic "Unauthorized". Both are Vault-backed in
+# prod (dx_mysticat/<env>/api-service); fetch values for local dev with:
+#   vault kv get -field=AUTH_PUBLIC_KEY_B64 dx_mysticat/dev/api-service
+#   vault kv get -field=AUTH_HANDLER_IMS    dx_mysticat/dev/api-service
+# Uncomment + paste the values to use real elmo IMS / JWT tokens locally.
+# AUTH_PUBLIC_KEY_B64=
+# AUTH_HANDLER_IMS={"name":"ims-na1-stg1","discovery":{"jwks_uri":"https://ims-na1-stg1.adobelogin.com/ims/keys"}}
+
+# ── Local CORS (needed for elmo at https://localhost:3000) ────────────────────
+# `localCORSWrapper` is a no-op unless ENABLE_CORS=true. CORS_ALLOWED_ORIGINS is
+# a comma-separated list — must include the elmo dev URL exactly (including
+# scheme + port).
+# ENABLE_CORS=true
+# CORS_ALLOWED_ORIGINS=https://localhost:3000
+
+# ── LLMO Helix API (sheets API, used by /sites/:id/llmo/sources/*) ────────────
+# Bearer token for hlx.live admin operations against the LLMO data folder.
+# Vault-backed in prod; controllers throw an explicit error if unset:
+#   vault kv get -field=LLMO_HLX_API_KEY dx_mysticat/dev/api-service
+# LLMO_HLX_API_KEY=
+
+# ── Tokowaka site-config bucket (edge-routing for /sites/* /suggestions/*) ────
+# S3 bucket name read by @adobe/spacecat-shared-tokowaka-client at construction
+# time. Missing it throws "TOKOWAKA_SITE_CONFIG_BUCKET is required" on any
+# request that goes through edge-routing-utils, suggestions, sites, or llmo.
+#   vault kv get -field=TOKOWAKA_SITE_CONFIG_BUCKET dx_mysticat/dev/api-service
+# TOKOWAKA_SITE_CONFIG_BUCKET=
 
 # ── Slack client (eagerly initialized) ────────────────────────────────────────
 SLACK_TOKEN_WORKSPACE_EXTERNAL_ELEVATED=xoxb-dummy-token

--- a/src/support/serenity/handlers/projects.js
+++ b/src/support/serenity/handlers/projects.js
@@ -11,7 +11,7 @@
  */
 
 import { hasText } from '@adobe/spacecat-shared-utils';
-import { iso31661Alpha2ToNumeric } from 'iso-3166';
+import { iso31661Alpha2ToNumeric, iso31661NumericToAlpha2 } from 'iso-3166';
 
 const LANGUAGE_CACHE_TTL_MS = 60 * 60 * 1000;
 const LANGUAGE_TAG_REGEX = /^[a-z]{2,3}(-[a-z]{2,4})?$/;
@@ -81,6 +81,27 @@ export function resolveLocation(market) {
     locationId: 2000 + Number(numeric),
     locationName: ENGLISH_REGION_NAMES.of(alpha2),
   };
+}
+
+/**
+ * Reverse of `resolveLocation`: maps a Semrush `location_id` back to an
+ * English country name (e.g. 2840 → "United States"). Returns null for
+ * unknown / non-country location ids. Used by `handleListProjects` to
+ * denormalize a human-readable market label onto each row so the elmo UI
+ * doesn't have to keep a numeric → ISO → name table client-side.
+ */
+function locationNameFromId(locationId) {
+  if (!Number.isInteger(locationId) || locationId < 2000 || locationId >= 3000) {
+    return null;
+  }
+  // Pad to 3 digits with leading zeros — iso-3166's numeric keys are strings
+  // like '004', '036', '840'. Without padding, '36' (AU) and '4' (AF) miss.
+  const numeric = String(locationId - 2000).padStart(3, '0');
+  const alpha2 = iso31661NumericToAlpha2[numeric];
+  if (!alpha2) {
+    return null;
+  }
+  return ENGLISH_REGION_NAMES.of(alpha2) || null;
 }
 
 /**
@@ -252,10 +273,12 @@ export async function handleListProjects(transport, dataAccess, brandId, workspa
     items: filtered.map((row) => {
       const projectId = row.getSemrushProjectId();
       const live = liveByProjectId.get(projectId) || {};
+      const locationId = row.getSemrushLocationId();
       return {
         brandId,
         semrushProjectId: projectId,
-        semrushLocationId: row.getSemrushLocationId(),
+        semrushLocationId: locationId,
+        semrushLocationName: locationNameFromId(locationId),
         language: row.getLanguage(),
         name: live.name ?? null,
         domain: live.domain ?? null,

--- a/test/support/serenity/handlers/projects.test.js
+++ b/test/support/serenity/handlers/projects.test.js
@@ -114,6 +114,27 @@ describe('semrush projects handler', () => {
       });
     });
 
+    it('denormalizes semrushLocationName from semrushLocationId for known countries', async () => {
+      // Three rows covering: 2-digit ISO numeric needing zero-pad (AU=036 → 2036),
+      // 3-digit numeric (US=840 → 2840 / FR=250 → 2250), and one numeric that
+      // doesn't map to a country at all (unknown id → null, never raw integer).
+      const projects = [
+        makeProject({ semrushProjectId: 'p-au', semrushLocationId: 2036, language: 'en' }),
+        makeProject({ semrushProjectId: 'p-us', semrushLocationId: 2840, language: 'en' }),
+        makeProject({ semrushProjectId: 'p-fr', semrushLocationId: 2250, language: 'fr' }),
+        makeProject({ semrushProjectId: 'p-x', semrushLocationId: 2999, language: 'en' }),
+      ];
+      const transport = { listWorkspaceProjects: sinon.stub().resolves({ items: [] }) };
+      const result = await handleListProjects(transport, makeDataAccess({ projects }), BRAND, WORKSPACE, {});
+      const byId = Object.fromEntries(result.items.map((p) => [p.semrushProjectId, p.semrushLocationName]));
+      expect(byId).to.deep.equal({
+        'p-au': 'Australia',
+        'p-us': 'United States',
+        'p-fr': 'France',
+        'p-x': null,
+      });
+    });
+
     it('returns rows without enrichment when upstream transport fails — marks enrichment:failed', async () => {
       const projects = [
         makeProject({


### PR DESCRIPTION
## Summary

Follow-up to #2467 (Semrush AIO REST proxy). Two independent changes, both surfaced while validating the proxy end-to-end against the elmo UI:

- **`handleListProjects` now denormalizes `semrushLocationName`** onto each row (e.g. `2840 → "United States"`). The UI was previously falling back to displaying the raw Semrush `location_id` integer in the Market combobox because the controller only returned the numeric id. Reverse-lookup uses the existing `iso31661NumericToAlpha2` table + `Intl.DisplayNames` — no new deps. Includes a zero-pad fix for 2-digit ISO numerics like `036` (Australia).
- **`.env.example` expanded** with the local-dev requirements that today's session uncovered as undocumented or actively misleading:
  - `IMS_HOST` corrected from `https://dummy-ims.example.com` to the bare hostname `dummy-ims.example.com`. `ImsClient` prepends `https://` internally, so a scheme-prefixed value yields `https://https://.../ims/profile/v1` → `getaddrinfo ENOTFOUND https`.
  - `AUTH_PUBLIC_KEY_B64` + `AUTH_HANDLER_IMS` documented as commented stubs with `vault kv get` commands — without these the entire auth chain silently 401s.
  - `ENABLE_CORS` + `CORS_ALLOWED_ORIGINS` documented for elmo at `https://localhost:3000`.
  - `LLMO_HLX_API_KEY` and `TOKOWAKA_SITE_CONFIG_BUCKET` documented (used by `/sites/:id/llmo/sources/*` and any controller through `tokowakaClient`).

Paired with elmo PR adobe/project-elmo-ui#1815 which switches `/serenity/*` calls to send the raw IMS bearer.

## Test plan

- [x] `npx mocha test/support/serenity/handlers/projects.test.js test/controllers/serenity.test.js` — 109/109 passing, includes new denormalization test (2-digit/3-digit ISO numerics + out-of-range locationId)
- [x] `npm run lint` — exit 0
- [x] Local E2E verified: `curl /v2/orgs/:org/brands/:brand/serenity/projects` returns rows with `semrushLocationName` populated (`"United States"`, `"Australia"`, `"France"`)
- [x] No public API contract regressions — response shape gains one field; existing fields unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)