### PR TITLE
feat: add POST /prompts/check endpoint for batch existence check | LLMO-5156

### DIFF
--- a/docs/openapi/prompts-v2-api.yaml
+++ b/docs/openapi/prompts-v2-api.yaml
@@ -373,6 +373,7 @@ v2-prompts-by-brand-check:
                   properties:
                     text:
                       type: string
+                      maxLength: 2000
                       description: Prompt text to look up
                     region:
                       type: string

--- a/docs/openapi/prompts-v2-api.yaml
+++ b/docs/openapi/prompts-v2-api.yaml
@@ -322,3 +322,84 @@ v2-prompts-by-brand-bulk-delete:
         description: PostgREST unavailable
       '500':
         $ref: './responses.yaml#/500'
+
+v2-prompts-by-brand-check:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID, config id, or brand name)
+      schema:
+        type: string
+  post:
+    tags:
+      - customer-config
+    summary: Batch prompt existence check
+    description: |
+      Given a list of {text, region} pairs, returns the subset that already
+      exist in the prompts table for the given brand with status active,
+      deleted, or ignored. Used by the UI to filter suggestion panels without
+      fetching all paginated prompt pages client-side. Max 500 pairs per request.
+      Region values are normalized to lowercase 2-char codes before comparison.
+    operationId: checkPromptsByBrand
+    security:
+      - ims_key: [ ]
+      - api_key: [ ]
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - prompts
+            properties:
+              prompts:
+                type: array
+                minItems: 1
+                maxItems: 500
+                items:
+                  type: object
+                  required:
+                    - text
+                    - region
+                  properties:
+                    text:
+                      type: string
+                      description: Prompt text to look up
+                    region:
+                      type: string
+                      description: Region code (e.g. "US", "gb"). Normalized to lowercase 2-char before comparison.
+    responses:
+      '200':
+        description: Existence check completed
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                results:
+                  type: array
+                  description: Subset of the input pairs that already exist in the DB
+                  items:
+                    type: object
+                    properties:
+                      text:
+                        type: string
+                      region:
+                        type: string
+      '400':
+        $ref: './responses.yaml#/400'
+      '404':
+        description: Organization or brand not found
+      '503':
+        description: PostgREST unavailable
+      '500':
+        $ref: './responses.yaml#/500'

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -629,8 +629,8 @@ function BrandsController(ctx, log, env) {
       if (prompts.length > 500) {
         return badRequest('Maximum 500 prompt pairs per request');
       }
-      if (prompts.some((p) => !p.text || !p.region)) {
-        return badRequest('Each prompt must have "text" and "region"');
+      if (prompts.some((p) => !p || typeof p !== 'object' || !p.text || !p.region || p.text.length > 2000)) {
+        return badRequest('Each prompt must have "text" (max 2000 chars) and "region"');
       }
 
       const organization = await getOrganizationOrNotFound(spaceCatId);
@@ -656,7 +656,7 @@ function BrandsController(ctx, log, env) {
       const results = await checkPromptsExist({ brandUuid, prompts, postgrestClient });
       return ok({ results });
     } catch (error) {
-      log.error(`Error checking prompts existence for brand ${brandId}:`, error);
+      log.error('Error checking prompts existence', { brandId, error });
       return createErrorResponse(error);
     }
   };

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -40,6 +40,7 @@ import {
   updatePromptById,
   deletePromptById,
   bulkDeletePrompts,
+  checkPromptsExist,
   resolveBrandUuid,
 } from '../support/prompts-storage.js';
 import {
@@ -600,6 +601,62 @@ function BrandsController(ctx, log, env) {
       return ok(result);
     } catch (error) {
       log.error(`Error bulk deleting prompts for brand ${brandId}:`, error);
+      return createErrorResponse(error);
+    }
+  };
+
+  // ── Prompt existence check (v2) ──
+
+  const checkPromptsByBrand = async (context) => {
+    const { spaceCatId, brandId } = context.params || {};
+    const body = context.data || {};
+
+    try {
+      if (!hasText(spaceCatId)) {
+        return badRequest('Organization ID required');
+      }
+      if (!isValidUUID(spaceCatId)) {
+        return badRequest('Organization ID must be a valid UUID');
+      }
+      if (!hasText(brandId)) {
+        return badRequest('Brand ID required');
+      }
+
+      const { prompts } = body;
+      if (!Array.isArray(prompts) || prompts.length === 0) {
+        return badRequest('"prompts" array required (min 1)');
+      }
+      if (prompts.length > 500) {
+        return badRequest('Maximum 500 prompt pairs per request');
+      }
+      if (prompts.some((p) => !p.text || !p.region)) {
+        return badRequest('Each prompt must have "text" and "region"');
+      }
+
+      const organization = await getOrganizationOrNotFound(spaceCatId);
+      if (organization.status) {
+        return organization;
+      }
+      if (!await accessControlUtil.hasAccess(organization)) {
+        return forbidden('User does not have access to this organization');
+      }
+
+      const unavailable = requirePostgrestForV2Config(context);
+      if (unavailable) {
+        return unavailable;
+      }
+
+      const { postgrestClient } = context.dataAccess.services;
+
+      const brandUuid = await resolveBrandUuid(spaceCatId, brandId, postgrestClient);
+      if (!brandUuid) {
+        return notFound(`Brand not found: ${brandId}`);
+      }
+
+      const results = await checkPromptsExist({ brandUuid, prompts, postgrestClient });
+      return ok({ results });
+    } catch (error) {
+      log.error(`Error checking prompts existence for brand ${brandId}:`, error);
       return createErrorResponse(error);
     }
   };
@@ -1392,6 +1449,7 @@ function BrandsController(ctx, log, env) {
     updatePromptByBrandAndId,
     deletePromptByBrandAndId,
     bulkDeletePromptsByBrand,
+    checkPromptsByBrand,
     triggerConfigSync,
   };
 }

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -629,7 +629,7 @@ function BrandsController(ctx, log, env) {
       if (prompts.length > 500) {
         return badRequest('Maximum 500 prompt pairs per request');
       }
-      if (prompts.some((p) => !p || typeof p !== 'object' || !p.text || !p.region || p.text.length > 2000)) {
+      if (prompts.some((p) => !p || typeof p !== 'object' || !p.text?.trim() || !p.region?.trim() || p.text.length > 2000)) {
         return badRequest('Each prompt must have "text" (max 2000 chars) and "region"');
       }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -218,6 +218,7 @@ export default function getRouteHandlers(
     'PATCH /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId': brandsController.updatePromptByBrandAndId,
     'DELETE /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId': brandsController.deletePromptByBrandAndId,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/delete': brandsController.bulkDeletePromptsByBrand,
+    'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/check': brandsController.checkPromptsByBrand,
     'POST /v2/orgs/:spaceCatId/sites/:siteId/sync-config': brandsController.triggerConfigSync,
     'GET /v2/orgs/:spaceCatId/sites/:siteId/brand': brandsController.getBrandForOrgSite,
     'GET /organizations/:organizationId/projects': organizationsController.getProjectsByOrganizationId,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -262,6 +262,7 @@ const routeRequiredCapabilities = {
   'PATCH /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId': 'organization:write',
   'DELETE /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/delete': 'organization:write',
+  'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/check': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'organization:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'organization:write',
   'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:promptId': 'organization:write',

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -798,3 +798,20 @@ export async function bulkDeletePrompts({
     failures,
   };
 }
+
+export async function checkPromptsExist({ brandUuid, prompts, postgrestClient }) {
+  if (!postgrestClient?.rpc) {
+    throw new Error('PostgREST client is required');
+  }
+
+  const { data, error } = await postgrestClient.rpc('rpc_check_prompts_exist', {
+    p_brand_id: brandUuid,
+    p_prompts: prompts,
+  });
+
+  if (error) {
+    throw new Error(`checkPromptsExist RPC failed: ${error.message}`);
+  }
+
+  return data ?? [];
+}

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -1758,6 +1758,243 @@ describe('Brands Controller', () => {
     });
   });
 
+  describe('checkPromptsByBrand', () => {
+    const BRAND_UUID = 'd1111111-1111-4111-b111-111111111111';
+    const VALID_PROMPTS = [
+      { text: 'What are generative credits?', region: 'gb' },
+      { text: 'How do I cancel?', region: 'us' },
+    ];
+
+    beforeEach(() => {
+      mockDataAccess.services.postgrestClient = {
+        from: sandbox.stub().callsFake((table) => {
+          const chain = {
+            select: sandbox.stub().returnsThis(),
+            eq: sandbox.stub().returnsThis(),
+            neq: sandbox.stub().returnsThis(),
+            order: sandbox.stub().returnsThis(),
+            range: sandbox.stub().resolves({ data: [], error: null, count: 0 }),
+            maybeSingle: sandbox.stub().callsFake(() => {
+              if (table === 'brands') {
+                return Promise.resolve({ data: { id: BRAND_UUID }, error: null });
+              }
+              if (table === 'llmo_customer_config') {
+                return Promise.resolve({
+                  data: { config: { customer: { brands: [] } } },
+                  error: null,
+                });
+              }
+              return Promise.resolve({ data: null, error: null });
+            }),
+          };
+          return chain;
+        }),
+        rpc: sandbox.stub().resolves({ data: [VALID_PROMPTS[0]], error: null }),
+      };
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+    });
+
+    it('returns 400 when params is undefined', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: undefined,
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when spaceCatId is missing', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { brandId: BRAND_UUID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when spaceCatId is not a valid UUID', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: 'not-a-uuid', brandId: BRAND_UUID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when brandId is missing', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when prompts is missing', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: {},
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('prompts');
+    });
+
+    it('returns 400 when prompts is empty', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when prompts exceeds 500', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: Array.from({ length: 501 }, (_, i) => ({ text: `p${i}`, region: 'us' })) },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when a prompt is missing region', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [{ text: 'some prompt' }] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when a prompt is missing text', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [{ region: 'us' }] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 404 when organization is not found', async () => {
+      mockDataAccess.Organization.findById.resolves(null);
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns 503 when postgrestClient is not available', async () => {
+      mockDataAccess.services.postgrestClient = null;
+
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(503);
+    });
+
+    it('returns 404 when brand is not found', async () => {
+      mockDataAccess.services.postgrestClient.from = sandbox.stub().callsFake((table) => {
+        const chain = {
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          neq: sandbox.stub().returnsThis(),
+          ilike: sandbox.stub().returnsThis(),
+          order: sandbox.stub().returnsThis(),
+          range: sandbox.stub().resolves({ data: [], error: null, count: 0 }),
+          maybeSingle: sandbox.stub().callsFake(() => {
+            if (table === 'brands') {
+              return Promise.resolve({ data: null, error: null });
+            }
+            if (table === 'llmo_customer_config') {
+              return Promise.resolve({
+                data: { config: { customer: { brands: [] } } },
+                error: null,
+              });
+            }
+            return Promise.resolve({ data: null, error: null });
+          }),
+        };
+        return chain;
+      });
+
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: 'nonexistent' },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns 403 when user lacks access', async () => {
+      const authContextUser = {
+        attributes: {
+          authInfo: new AuthInfo()
+            .withType('jwt')
+            .withScopes([{ name: 'user' }])
+            .withProfile({ is_admin: false })
+            .withAuthenticated(true),
+        },
+      };
+      const unauthorizedController = BrandsController({
+        dataAccess: mockDataAccess,
+        pathInfo: { headers: { 'x-product': 'llmo' } },
+        ...authContextUser,
+      }, loggerStub, mockEnv);
+
+      const response = await unauthorizedController.checkPromptsByBrand({
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(403);
+    });
+
+    it('returns 200 with matching results on happy path', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(200);
+      const body = await response.json();
+      expect(body).to.have.property('results').that.is.an('array');
+      expect(body.results).to.deep.equal([VALID_PROMPTS[0]]);
+    });
+
+    it('returns 500 when storage throws', async () => {
+      mockDataAccess.services.postgrestClient.rpc = sandbox.stub().rejects(new Error('DB error'));
+
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: VALID_PROMPTS },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(500);
+    });
+  });
+
   describe('listBrandsForOrg', () => {
     beforeEach(() => {
       mockDataAccess.services.postgrestClient = {

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -1886,6 +1886,26 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('returns 400 when a prompt item is null', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [null] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when prompt text exceeds 2000 chars', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [{ text: 'x'.repeat(2001), region: 'us' }] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
     it('returns 404 when organization is not found', async () => {
       mockDataAccess.Organization.findById.resolves(null);
       brandsController = BrandsController(context, loggerStub, mockEnv);

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -1896,6 +1896,26 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('returns 400 when prompt text is whitespace only', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [{ text: '   ', region: 'us' }] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when prompt region is whitespace only', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [{ text: 'some prompt', region: '   ' }] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
     it('returns 400 when prompt text exceeds 2000 chars', async () => {
       const response = await brandsController.checkPromptsByBrand({
         ...context,
@@ -1904,6 +1924,26 @@ describe('Brands Controller', () => {
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(400);
+    });
+
+    it('accepts exactly 500 prompts', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: Array.from({ length: 500 }, (_, i) => ({ text: `p${i}`, region: 'us' })) },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(200);
+    });
+
+    it('accepts prompt text of exactly 2000 chars', async () => {
+      const response = await brandsController.checkPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { prompts: [{ text: 'x'.repeat(2000), region: 'us' }] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(200);
     });
 
     it('returns 404 when organization is not found', async () => {
@@ -2002,8 +2042,9 @@ describe('Brands Controller', () => {
       expect(body.results).to.deep.equal([VALID_PROMPTS[0]]);
     });
 
-    it('returns 500 when storage throws', async () => {
-      mockDataAccess.services.postgrestClient.rpc = sandbox.stub().rejects(new Error('DB error'));
+    it('returns 500 when storage throws and logs structured error', async () => {
+      const dbError = new Error('DB error');
+      mockDataAccess.services.postgrestClient.rpc = sandbox.stub().rejects(dbError);
 
       const response = await brandsController.checkPromptsByBrand({
         ...context,
@@ -2012,6 +2053,10 @@ describe('Brands Controller', () => {
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(500);
+      expect(loggerStub.error).to.have.been.calledWith('Error checking prompts existence', {
+        brandId: BRAND_UUID,
+        error: dbError,
+      });
     });
   });
 

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -167,6 +167,7 @@ describe('getRouteHandlers', () => {
     updatePromptByBrandAndId: sinon.stub(),
     deletePromptByBrandAndId: sinon.stub(),
     bulkDeletePromptsByBrand: sinon.stub(),
+    checkPromptsByBrand: sinon.stub(),
     triggerConfigSync: sinon.stub(),
   };
 
@@ -738,6 +739,7 @@ describe('getRouteHandlers', () => {
       'PATCH /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId',
       'DELETE /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/delete',
+      'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/check',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-delete',

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -24,6 +24,7 @@ import {
   updatePromptById,
   deletePromptById,
   bulkDeletePrompts,
+  checkPromptsExist,
 } from '../../src/support/prompts-storage.js';
 
 use(chaiAsPromised);
@@ -2017,6 +2018,59 @@ describe('prompts-storage', () => {
       expect(result.metadata.total).to.equal(2);
       expect(result.metadata.success).to.equal(1);
       expect(result.metadata.failure).to.equal(1);
+    });
+  });
+
+  describe('checkPromptsExist', () => {
+    const PROMPTS = [
+      { text: 'What are generative credits?', region: 'gb' },
+      { text: 'should not exist', region: 'tw' },
+    ];
+
+    it('throws when postgrestClient has no rpc', async () => {
+      await expect(
+        checkPromptsExist({
+          brandUuid: BRAND_UUID,
+          prompts: PROMPTS,
+          postgrestClient: null,
+        }),
+      ).to.be.rejectedWith('PostgREST client is required');
+    });
+
+    it('returns empty array when RPC returns null data', async () => {
+      const client = { rpc: sandbox.stub().resolves({ data: null, error: null }) };
+      const result = await checkPromptsExist({
+        brandUuid: BRAND_UUID,
+        prompts: PROMPTS,
+        postgrestClient: client,
+      });
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns matching pairs on success', async () => {
+      const expected = [{ text: 'What are generative credits?', region: 'gb' }];
+      const client = { rpc: sandbox.stub().resolves({ data: expected, error: null }) };
+      const result = await checkPromptsExist({
+        brandUuid: BRAND_UUID,
+        prompts: PROMPTS,
+        postgrestClient: client,
+      });
+      expect(result).to.deep.equal(expected);
+      const [rpcName, rpcArgs] = client.rpc.firstCall.args;
+      expect(rpcName).to.equal('rpc_check_prompts_exist');
+      expect(rpcArgs.p_brand_id).to.equal(BRAND_UUID);
+      expect(rpcArgs.p_prompts).to.deep.equal(PROMPTS);
+    });
+
+    it('throws when RPC returns an error', async () => {
+      const client = { rpc: sandbox.stub().resolves({ data: null, error: { message: 'DB error' } }) };
+      await expect(
+        checkPromptsExist({
+          brandUuid: BRAND_UUID,
+          prompts: PROMPTS,
+          postgrestClient: client,
+        }),
+      ).to.be.rejectedWith('checkPromptsExist RPC failed: DB error');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `checkPromptsExist` storage function in `prompts-storage.js` that calls the new `rpc_check_prompts_exist` PostgREST RPC
- Adds `checkPromptsByBrand` controller handler with full validation (org access, brand resolution, 500-item cap per request)
- Wires up `POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/check` route with `organization:read` capability

## Related issue
https://jira.corp.adobe.com/browse/LLMO-5156

## Context

Part of a fix for a brandalf UI bug where prompt suggestions weren't being filtered for prompts on page 2+ of the configured-prompts table. The UI sends all suggestion `{text, region}` pairs to this endpoint and receives back only the ones that already exist (status `active`/`deleted`/`ignored`), so it can accurately hide them without paginating everything client-side.

**Depends on:** `mysticat-data-service` PR with the `rpc_check_prompts_exist` migration.

## Test plan

- [ ] Happy path: returns matching `{text, region}` pairs
- [ ] Empty/missing `prompts` body → 400
- [ ] >500 pairs → 400
- [ ] Brand not found → 404
- [ ] Org access check enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)