### PR TITLE
fix: bump spacecat shared data access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@adobe/spacecat-shared-athena-client": "1.9.12",
         "@adobe/spacecat-shared-brand-client": "1.1.42",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "3.71.1",
+        "@adobe/spacecat-shared-data-access": "3.71.2",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
         "@adobe/spacecat-shared-drs-client": "1.7.2",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
@@ -3342,9 +3342,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.71.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.71.1.tgz",
-      "integrity": "sha512-jOeon2A7gMlhBMTEq3SonB8IddLuNF+9giPbUSOGrR7X8UUsDQ+E6gdZ/Rq/lJwxQhDLf24RZo7kwyYFdiVM9w==",
+      "version": "3.71.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.71.2.tgz",
+      "integrity": "sha512-QYTC2QcvhRK6cpO7hIYDVofwNGCbGYAfjEnwmT3oS7Yozx7TOpt4Rw9XXMH8vK9Qd9phl6jaG1TDcmINKRg1ow==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@adobe/spacecat-shared-athena-client": "1.9.12",
     "@adobe/spacecat-shared-brand-client": "1.1.42",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "3.71.1",
+    "@adobe/spacecat-shared-data-access": "3.71.2",
     "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
     "@adobe/spacecat-shared-drs-client": "1.7.2",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",


### PR DESCRIPTION
 ### Problem
  
  GET /api/ci/sites/{siteId}/opportunities/{opportunityId}/fixes was throwing:

  this[#FixEntity].getAllFixesWithSuggestionsByOpportunityId is not a function

  on stage/CI/RV environments. The fixes controller calls getAllFixesWithSuggestionsByOpportunityId, which was added to spacecat-shared-data-access in 3.71.2 (spacecat-shared PR #1619), but
  api-service was still pinned to 3.71.1.

  Fix

  Bump @adobe/spacecat-shared-data-access from 3.71.1 to 3.71.2.
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
