### PR TITLE
feat: classify gapKind per topic/prompt | LLMO-4959

### DIFF
--- a/src/support/ai-visibility/grpc-utils.js
+++ b/src/support/ai-visibility/grpc-utils.js
@@ -598,6 +598,69 @@ export function parseGapKindEnumList(sp) {
   return result.length ? result : [1];
 }
 
+/**
+ * Classify a topic or prompt entry by its mention gap between the target brand and
+ * its competitors. Returns one of GAP_KIND enum names (string): 'MISSING' | 'WEAK'
+ * | 'SHARED' | 'STRONG' | 'UNIQUE'. Mirrors the proto enum semantics defined in
+ * `semrush.services.ai_seo.common.v1.GAP_KIND.ENUM`:
+ *   - MISSING : target has 0 mentions AND every competitor has > 0
+ *   - UNIQUE  : target has > 0 mentions AND every competitor has 0
+ *   - WEAK    : target < min(competitor mentions)
+ *   - STRONG  : target > max(competitor mentions)
+ *   - SHARED  : otherwise (between the two extremes, or mixed-zero edge cases)
+ *
+ * `entry.gapMentions` is expected to be `[{ brand: { domain }, mentions }, ...]`
+ * and typically includes the target brand itself — we exclude it by domain match.
+ * If no competitor entries are found, returns 'SHARED' as a neutral fallback.
+ */
+export function classifyGapKind(entry, targetDomain) {
+  const target = typeof targetDomain === 'string' ? targetDomain.trim().toLowerCase() : '';
+  const gapMentions = Array.isArray(entry?.gapMentions) ? entry.gapMentions : [];
+
+  // Topics expose `mentions` at the top level; prompts don't and require lookup
+  // inside `gapMentions` by brand domain. Prefer the explicit field when present.
+  const targetMentions = entry?.mentions != null
+    ? num(entry.mentions)
+    : num(gapMentions.find((m) => {
+      const d = m?.brand?.domain;
+      return typeof d === 'string' && d.toLowerCase() === target;
+    })?.mentions);
+
+  const competitorMentions = gapMentions
+    .filter((m) => {
+      const d = m?.brand?.domain;
+      return typeof d === 'string' && d.toLowerCase() !== target;
+    })
+    .map((m) => num(m?.mentions));
+
+  if (competitorMentions.length === 0) {
+    return 'SHARED';
+  }
+
+  const allCompetitorsZero = competitorMentions.every((m) => m === 0);
+  const everyCompetitorPositive = competitorMentions.every((m) => m > 0);
+
+  if (targetMentions === 0) {
+    return everyCompetitorPositive ? 'MISSING' : 'SHARED';
+  }
+
+  if (allCompetitorsZero) {
+    return 'UNIQUE';
+  }
+
+  const minCompetitor = Math.min(...competitorMentions);
+  if (targetMentions < minCompetitor) {
+    return 'WEAK';
+  }
+
+  const maxCompetitor = Math.max(...competitorMentions);
+  if (targetMentions > maxCompetitor) {
+    return 'STRONG';
+  }
+
+  return 'SHARED';
+}
+
 export function coerceProtoCommonGapKind(kind) {
   if (kind == null) {
     return null;

--- a/src/support/ai-visibility/grpc-utils.js
+++ b/src/support/ai-visibility/grpc-utils.js
@@ -603,7 +603,7 @@ export function parseGapKindEnumList(sp) {
  * its competitors. Returns one of GAP_KIND enum names (string): 'MISSING' | 'WEAK'
  * | 'SHARED' | 'STRONG' | 'UNIQUE'. Mirrors the proto enum semantics defined in
  * `semrush.services.ai_seo.common.v1.GAP_KIND.ENUM`:
- *   - MISSING : target has 0 mentions AND every competitor has > 0
+ *   - MISSING : target has 0 mentions AND at least one competitor has > 0
  *   - UNIQUE  : target has > 0 mentions AND every competitor has 0
  *   - WEAK    : target < min(competitor mentions)
  *   - STRONG  : target > max(competitor mentions)
@@ -637,17 +637,14 @@ export function classifyGapKind(entry, targetDomain) {
     return 'SHARED';
   }
 
-  const allCompetitorsZero = competitorMentions.every((m) => m === 0);
-  const anyCompetitorPositive = competitorMentions.some((m) => m > 0);
-
   if (targetMentions === 0) {
     // Empirically the upstream gRPC service treats MISSING as "target = 0 AND at
     // least one competitor > 0" — the strict reading ("every competitor > 0")
     // would produce a far smaller bucket than the totals returned by the service.
-    return anyCompetitorPositive ? 'MISSING' : 'SHARED';
+    return competitorMentions.some((m) => m > 0) ? 'MISSING' : 'SHARED';
   }
 
-  if (allCompetitorsZero) {
+  if (competitorMentions.every((m) => m === 0)) {
     return 'UNIQUE';
   }
 

--- a/src/support/ai-visibility/grpc-utils.js
+++ b/src/support/ai-visibility/grpc-utils.js
@@ -638,10 +638,13 @@ export function classifyGapKind(entry, targetDomain) {
   }
 
   const allCompetitorsZero = competitorMentions.every((m) => m === 0);
-  const everyCompetitorPositive = competitorMentions.every((m) => m > 0);
+  const anyCompetitorPositive = competitorMentions.some((m) => m > 0);
 
   if (targetMentions === 0) {
-    return everyCompetitorPositive ? 'MISSING' : 'SHARED';
+    // Empirically the upstream gRPC service treats MISSING as "target = 0 AND at
+    // least one competitor > 0" — the strict reading ("every competitor > 0")
+    // would produce a far smaller bucket than the totals returned by the service.
+    return anyCompetitorPositive ? 'MISSING' : 'SHARED';
   }
 
   if (allCompetitorsZero) {

--- a/src/support/ai-visibility/handlers/v1/prompt/gap-prompts.js
+++ b/src/support/ai-visibility/handlers/v1/prompt/gap-prompts.js
@@ -31,6 +31,7 @@ import {
   brandTarget,
   parseCompetitorDomainsList,
   responseFromGrpcError,
+  classifyGapKind,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -108,10 +109,17 @@ export async function handleGapPrompts(sp, clients) {
       toJson(GapPromptsTotalsResponseSchema, totalsMessage, PROTO_TO_JSON)
     );
 
+    // Same rationale as the gap-topics handler: the proto response does not
+    // include per-prompt gapKind, so classify here from `gapMentions`.
+    const enrichedPrompts = (promptsJson.prompts ?? []).map((prompt) => ({
+      ...prompt,
+      gapKind: classifyGapKind(prompt, domain),
+    }));
+
     return {
       status: 200,
       body: {
-        data: promptsJson.prompts ?? [],
+        data: enrichedPrompts,
         totals: totalsJson.totals ?? [],
       },
     };

--- a/src/support/ai-visibility/handlers/v1/prompt/gap-prompts.js
+++ b/src/support/ai-visibility/handlers/v1/prompt/gap-prompts.js
@@ -39,6 +39,15 @@ import {
 /* c8 ignore start */
 export async function handleGapPrompts(sp, clients) {
   const domain = sp.get('domain');
+  if (!domain) {
+    return {
+      status: 400,
+      body: {
+        error: 'invalid_request',
+        message: 'domain is required',
+      },
+    };
+  }
   const competitorDomains = parseCompetitorDomainsList(sp);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;

--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
@@ -34,6 +34,7 @@ import {
   buildRangeExpr,
   escapeQlString,
   isValidVolume,
+  classifyGapKind,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -141,10 +142,18 @@ export async function handleGapTopics(sp, clients) {
       toJson(GapTopicsTotalsResponseSchema, totalsMessage, PROTO_TO_JSON)
     );
 
+    // The gRPC response shape does not surface per-topic gapKind, so classify
+    // each row here using the proto-defined GAP_KIND semantics. This keeps the
+    // server-side filter and the UI badges in sync.
+    const enrichedTopics = (topicsJson.topics ?? []).map((topic) => ({
+      ...topic,
+      gapKind: classifyGapKind(topic, domain),
+    }));
+
     return {
       status: 200,
       body: {
-        data: topicsJson.topics ?? [],
+        data: enrichedTopics,
         totals: totalsJson.totals ?? [],
       },
     };

--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
@@ -71,6 +71,15 @@ function buildGapTopicsMetricFilterQl(sp) {
 
 export async function handleGapTopics(sp, clients) {
   const domain = sp.get('domain');
+  if (!domain) {
+    return {
+      status: 400,
+      body: {
+        error: 'invalid_request',
+        message: 'domain is required',
+      },
+    };
+  }
   const competitorDomains = parseCompetitorDomainsList(sp);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;

--- a/test/support/ai-visibility/grpc-utils.test.js
+++ b/test/support/ai-visibility/grpc-utils.test.js
@@ -55,6 +55,7 @@ import {
   voTotalCountForSourceCategory,
   parseCompetitorDomainsList,
   parseGapKindEnumList,
+  classifyGapKind,
   coerceProtoCommonGapKind,
   aggregateGapPromptsTotalFromTotals,
   resolveTopicIdsDimensionFilter,
@@ -1192,6 +1193,147 @@ describe('grpc-utils', () => {
       ]);
       expect(result.brands[0].brandName).to.equal('a b');
       expect(result.brands[0].count).to.equal(10);
+    });
+  });
+
+  describe('classifyGapKind', () => {
+    const target = 'example.com';
+
+    function entry(targetMentions, competitorMentionsList) {
+      return {
+        mentions: targetMentions,
+        gapMentions: competitorMentionsList.map((m) => ({
+          brand: { domain: m.domain },
+          mentions: m.mentions,
+        })),
+      };
+    }
+
+    it('returns SHARED when no competitor entries', () => {
+      expect(classifyGapKind({ mentions: 5, gapMentions: [] }, target)).to.equal('SHARED');
+    });
+
+    it('returns SHARED when gapMentions is absent', () => {
+      expect(classifyGapKind({ mentions: 5 }, target)).to.equal('SHARED');
+    });
+
+    it('returns SHARED when entry is nullish', () => {
+      expect(classifyGapKind(null, target)).to.equal('SHARED');
+    });
+
+    it('returns MISSING when target=0 and at least one competitor>0', () => {
+      const e = entry(0, [
+        { domain: 'comp1.com', mentions: 10 },
+        { domain: 'comp2.com', mentions: 0 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('MISSING');
+    });
+
+    it('returns SHARED when target=0 and all competitors=0', () => {
+      const e = entry(0, [
+        { domain: 'comp1.com', mentions: 0 },
+        { domain: 'comp2.com', mentions: 0 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('SHARED');
+    });
+
+    it('returns UNIQUE when target>0 and all competitors=0', () => {
+      const e = entry(5, [
+        { domain: 'comp1.com', mentions: 0 },
+        { domain: 'comp2.com', mentions: 0 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('UNIQUE');
+    });
+
+    it('returns WEAK when target < min(competitor mentions)', () => {
+      const e = entry(2, [
+        { domain: 'comp1.com', mentions: 5 },
+        { domain: 'comp2.com', mentions: 8 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('WEAK');
+    });
+
+    it('returns STRONG when target > max(competitor mentions)', () => {
+      const e = entry(20, [
+        { domain: 'comp1.com', mentions: 5 },
+        { domain: 'comp2.com', mentions: 8 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('STRONG');
+    });
+
+    it('returns SHARED when target is between min and max competitor mentions', () => {
+      const e = entry(6, [
+        { domain: 'comp1.com', mentions: 5 },
+        { domain: 'comp2.com', mentions: 8 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('SHARED');
+    });
+
+    it('returns SHARED when target equals min competitor mentions', () => {
+      const e = entry(5, [
+        { domain: 'comp1.com', mentions: 5 },
+        { domain: 'comp2.com', mentions: 8 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('SHARED');
+    });
+
+    it('returns SHARED when target equals max competitor mentions', () => {
+      const e = entry(8, [
+        { domain: 'comp1.com', mentions: 5 },
+        { domain: 'comp2.com', mentions: 8 },
+      ]);
+      expect(classifyGapKind(e, target)).to.equal('SHARED');
+    });
+
+    it('excludes the target brand domain from competitor list', () => {
+      // target is in gapMentions but should be excluded from competitor calc
+      const e = {
+        mentions: 3,
+        gapMentions: [
+          { brand: { domain: 'example.com' }, mentions: 3 },
+          { brand: { domain: 'comp.com' }, mentions: 10 },
+        ],
+      };
+      // target(3) < min(comp)(10) → WEAK
+      expect(classifyGapKind(e, target)).to.equal('WEAK');
+    });
+
+    it('is case-insensitive for domain matching', () => {
+      const e = {
+        mentions: 3,
+        gapMentions: [
+          { brand: { domain: 'EXAMPLE.COM' }, mentions: 3 },
+          { brand: { domain: 'comp.com' }, mentions: 10 },
+        ],
+      };
+      expect(classifyGapKind(e, 'example.com')).to.equal('WEAK');
+    });
+
+    it('falls back to gapMentions lookup when entry.mentions is absent', () => {
+      // No top-level mentions field; target domain is in gapMentions
+      const e = {
+        gapMentions: [
+          { brand: { domain: 'example.com' }, mentions: 3 },
+          { brand: { domain: 'comp.com' }, mentions: 10 },
+        ],
+      };
+      // target found in gapMentions with 3; comp has 10 → WEAK
+      expect(classifyGapKind(e, target)).to.equal('WEAK');
+    });
+
+    it('treats missing target in gapMentions as 0 mentions when no top-level field', () => {
+      const e = {
+        gapMentions: [
+          { brand: { domain: 'comp.com' }, mentions: 10 },
+        ],
+      };
+      // target not found → 0 mentions; comp > 0 → MISSING
+      expect(classifyGapKind(e, target)).to.equal('MISSING');
+    });
+
+    it('returns SHARED when only one competitor and target equals it', () => {
+      const e = entry(5, [{ domain: 'comp.com', mentions: 5 }]);
+      expect(classifyGapKind(e, target)).to.equal('SHARED');
     });
   });
 });


### PR DESCRIPTION
## Description

The proto response from the gRPC gap-topics / gap-prompts services does not expose the per-row GAP_KIND, so every row arrived at the UI without a kind field and badges defaulted to WEAK regardless of the active filter. Compute the kind here from `mentions` and `gapMentions` using the proto enum semantics (MISSING / WEAK / SHARED / STRONG / UNIQUE) so the server-side filter and the UI badge column stay in sync.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-4959