### PR TITLE
fix(ci): add exit:true to mocha config to fix it-postgres timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "mocha": {
     "require": "test/setup-env.js",
     "recursive": "true",
+    "exit": true,
     "reporter": "mocha-multi-reporters",
     "reporter-options": "configFile=.mocha-multi.json"
   },


### PR DESCRIPTION
## Summary

- The `ci / it-postgres` job was hitting the 15-minute wall even though all 499 tests pass in ~3 minutes
- After tests complete, mocha hangs on open handles: the `@adobe/fetch` HTTP agent used by the data-access layer for PostgREST requests holds sockets alive after the PostgREST container stops, keeping the Node.js event loop from emptying
- `test/it/postgres/.mocharc.postgres.yml` already had `exit: true`, but the CI command (hardcoded in the `mysticat-ci` reusable workflow as `npx mocha --require test/it/postgres/harness.js --timeout 30000 ...`) passes no `--config` flag — so that file is never loaded
- Mocha reads `package.json`'s `mocha` section instead; adding `exit: true` there ensures the CI invocation picks it up

## Evidence

From the timed-out run (CI job `78015006847`, branch `feat-LLMO-4959-topic-opps-gap`):
- Tests finish at `05:44:47Z` (`499 passing (3m)`)
- Process killed at `05:56:04Z` (`The operation was canceled`)
- `Terminate orphan process: pid (2578) (npm exec mocha)` confirms mocha is the hanging process

## Test plan
- [ ] Confirm `ci / it-postgres` completes in under 5 minutes on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)