### PR TITLE
fix(fixes): filter by executedAt date instead of junction table in date query

### DIFF
--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -120,7 +120,7 @@ export class FixesController {
         .getAllFixesWithSuggestionsByOpportunityId(opportunityId);
 
       const fixEntitiesWithSuggestions = allFixesWithSuggestions.filter(({ fixEntity }) => {
-        const ts = fixEntity.getExecutedAt() || fixEntity.getCreatedAt();
+        const ts = fixEntity.getExecutedAt() ?? fixEntity.getCreatedAt();
         return ts && new Date(ts).toISOString().split('T')[0] === fixCreatedDate;
       });
 

--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -109,8 +109,20 @@ export class FixesController {
     let fixes = [];
 
     if (hasText(fixCreatedDate)) {
-      const fixEntitiesWithSuggestions = await this.#FixEntity
-        .getAllFixesWithSuggestionByCreatedAt(opportunityId, fixCreatedDate);
+      // Fetch all fixes with suggestions then filter in-memory by
+      // executedAt ?? createdAt date. The previous approach used the junction
+      // table (getAllFixesWithSuggestionByCreatedAt) which stores the date at
+      // fix-creation time when executedAt is still null. Once the deploy
+      // completes and executedAt is updated, the junction date no longer
+      // matches the UI accordion key (which uses executedAt), causing the
+      // accordion to show empty even though fixes exist.
+      const allFixesWithSuggestions = await this.#FixEntity
+        .getAllFixesWithSuggestionsByOpportunityId(opportunityId);
+
+      const fixEntitiesWithSuggestions = allFixesWithSuggestions.filter(({ fixEntity }) => {
+        const ts = fixEntity.getExecutedAt() || fixEntity.getCreatedAt();
+        return ts && new Date(ts).toISOString().split('T')[0] === fixCreatedDate;
+      });
 
       if (fixEntitiesWithSuggestions.length === 0) {
         return ok([]);

--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -121,7 +121,8 @@ export class FixesController {
 
       const fixEntitiesWithSuggestions = allFixesWithSuggestions.filter(({ fixEntity }) => {
         const ts = fixEntity.getExecutedAt() ?? fixEntity.getCreatedAt();
-        return ts && new Date(ts).toISOString().split('T')[0] === fixCreatedDate;
+        const d = ts ? new Date(ts) : null;
+        return d && !Number.isNaN(d.getTime()) && d.toISOString().split('T')[0] === fixCreatedDate;
       });
 
       if (fixEntitiesWithSuggestions.length === 0) {

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -452,6 +452,25 @@ describe('Fixes Controller', () => {
         const result = await response.json();
         expect(result).to.deep.equal([]);
       });
+
+      it('skips fix with malformed timestamp instead of throwing', async () => {
+        const fixEntity = await fixEntityCollection.create({
+          type: Suggestion.TYPES.CONTENT_UPDATE,
+          opportunityId,
+        });
+        sandbox.stub(fixEntity, 'getExecutedAt').returns('not-a-valid-date');
+        sandbox.stub(fixEntity, 'getCreatedAt').returns('also-garbage');
+
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([{ fixEntity, suggestions: [] }]);
+
+        // Should return 200 and skip the malformed fix rather than 500
+        const response = await fixesController.getAllForOpportunity(requestContext);
+        expect(response).includes({ status: 200 });
+        const result = await response.json();
+        expect(result).to.deep.equal([]);
+      });
     });
   });
 

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -94,6 +94,7 @@ describe('Fixes Controller', () => {
     sandbox.stub(fixEntityCollection, 'findById');
     sandbox.stub(fixEntityCollection, 'setSuggestionsForFixEntity');
     sandbox.stub(fixEntityCollection, 'getAllFixesWithSuggestionByCreatedAt');
+    sandbox.stub(fixEntityCollection, 'getAllFixesWithSuggestionsByOpportunityId');
     sandbox.stub(fixEntityCollection, 'updateByKeys');
     sandbox.stub(fixEntityCollection, 'getSuggestionsByFixEntityId');
     sandbox.stub(suggestionCollection, 'bulkUpdateStatus');
@@ -198,13 +199,18 @@ describe('Fixes Controller', () => {
     });
 
     describe('with fixEntityCreatedDate parameter', () => {
-      const fixEntityCreatedDate = '2025-05-19T01:23:45.678Z';
+      // YYYY-MM-DD date string — matches what the UI accordion key uses
+      const fixCreatedDateStr = '2025-05-19';
+      // A timestamp on that UTC date — simulates executedAt being set after creation
+      const executedAtOnDate = '2025-05-19T14:30:00.000Z';
+      // A timestamp on a DIFFERENT date — should NOT be returned for the above key
+      const executedAtOtherDate = '2025-05-18T22:00:00.000Z';
 
       beforeEach(() => {
-        requestContext.data = { fixCreatedDate: fixEntityCreatedDate };
+        requestContext.data = { fixCreatedDate: fixCreatedDateStr };
       });
 
-      it('can get all fixes with suggestions by created date', async () => {
+      it('can get all fixes with suggestions by created date (filters by executedAt)', async () => {
         const suggestion1 = await suggestionCollection.create({
           opportunityId,
           type: Suggestion.TYPES.CONTENT_UPDATE,
@@ -218,17 +224,12 @@ describe('Fixes Controller', () => {
           type: Suggestion.TYPES.CONTENT_UPDATE,
           opportunityId,
           changeDetails: { arbitrary: 'value 1' },
-          createdAt: fixEntityCreatedDate,
+          executedAt: executedAtOnDate,
         });
 
-        fixEntityCollection.getAllFixesWithSuggestionByCreatedAt
-          .withArgs(opportunityId, fixEntityCreatedDate)
-          .resolves([
-            {
-              fixEntity,
-              suggestions: [suggestion1, suggestion2],
-            },
-          ]);
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([{ fixEntity, suggestions: [suggestion1, suggestion2] }]);
 
         const response = await fixesController.getAllForOpportunity(requestContext);
 
@@ -245,9 +246,35 @@ describe('Fixes Controller', () => {
         expect(result[0].suggestions[1].id).to.equal(suggestion2.getId());
       });
 
+      it('filters out fixes whose executedAt ?? createdAt does not match the date', async () => {
+        const fixOnDate = await fixEntityCollection.create({
+          type: Suggestion.TYPES.CONTENT_UPDATE,
+          opportunityId,
+          executedAt: executedAtOnDate,
+        });
+        const fixOtherDate = await fixEntityCollection.create({
+          type: Suggestion.TYPES.REDIRECT_UPDATE,
+          opportunityId,
+          executedAt: executedAtOtherDate,
+        });
+
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([
+            { fixEntity: fixOnDate, suggestions: [] },
+            { fixEntity: fixOtherDate, suggestions: [] },
+          ]);
+
+        const response = await fixesController.getAllForOpportunity(requestContext);
+        expect(response).includes({ status: 200 });
+        const result = await response.json();
+        expect(result).to.have.lengthOf(1);
+        expect(result[0].id).to.equal(fixOnDate.getId());
+      });
+
       it('returns empty array when no fixes found for the given created date', async () => {
-        fixEntityCollection.getAllFixesWithSuggestionByCreatedAt
-          .withArgs(opportunityId, fixEntityCreatedDate)
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
           .resolves([]);
 
         const response = await fixesController.getAllForOpportunity(requestContext);
@@ -261,11 +288,11 @@ describe('Fixes Controller', () => {
         const fixEntity = await fixEntityCollection.create({
           type: Suggestion.TYPES.CONTENT_UPDATE,
           opportunityId: 'wrong-opportunity-id',
-          createdAt: fixEntityCreatedDate,
+          executedAt: executedAtOnDate,
         });
 
-        fixEntityCollection.getAllFixesWithSuggestionByCreatedAt
-          .withArgs(opportunityId, fixEntityCreatedDate)
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
           .resolves([
             {
               fixEntity,
@@ -284,17 +311,12 @@ describe('Fixes Controller', () => {
         const fixEntity = await fixEntityCollection.create({
           type: Suggestion.TYPES.CONTENT_UPDATE,
           opportunityId,
-          createdAt: fixEntityCreatedDate,
+          executedAt: executedAtOnDate,
         });
 
-        fixEntityCollection.getAllFixesWithSuggestionByCreatedAt
-          .withArgs(opportunityId, fixEntityCreatedDate)
-          .resolves([
-            {
-              fixEntity,
-              suggestions: [],
-            },
-          ]);
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([{ fixEntity, suggestions: [] }]);
 
         opportunityGetStub.callsFake((data) => ({
           go: async () => ({ data: { ...data, siteId: 'wrong-site-id' } }),
@@ -325,27 +347,21 @@ describe('Fixes Controller', () => {
           type: Suggestion.TYPES.CONTENT_UPDATE,
           opportunityId,
           changeDetails: { arbitrary: 'value 1' },
-          createdAt: fixEntityCreatedDate,
+          executedAt: executedAtOnDate,
         });
 
         const fixEntity2 = await fixEntityCollection.create({
           type: Suggestion.TYPES.REDIRECT_UPDATE,
           opportunityId,
           changeDetails: { arbitrary: 'value 2' },
-          createdAt: fixEntityCreatedDate,
+          executedAt: executedAtOnDate,
         });
 
-        fixEntityCollection.getAllFixesWithSuggestionByCreatedAt
-          .withArgs(opportunityId, fixEntityCreatedDate)
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
           .resolves([
-            {
-              fixEntity: fixEntity1,
-              suggestions: [suggestion1, suggestion2],
-            },
-            {
-              fixEntity: fixEntity2,
-              suggestions: [suggestion3],
-            },
+            { fixEntity: fixEntity1, suggestions: [suggestion1, suggestion2] },
+            { fixEntity: fixEntity2, suggestions: [suggestion3] },
           ]);
 
         const response = await fixesController.getAllForOpportunity(requestContext);
@@ -374,17 +390,12 @@ describe('Fixes Controller', () => {
           type: Suggestion.TYPES.CONTENT_UPDATE,
           opportunityId,
           changeDetails: { arbitrary: 'value 1' },
-          createdAt: fixEntityCreatedDate,
+          executedAt: executedAtOnDate,
         });
 
-        fixEntityCollection.getAllFixesWithSuggestionByCreatedAt
-          .withArgs(opportunityId, fixEntityCreatedDate)
-          .resolves([
-            {
-              fixEntity,
-              suggestions: [],
-            },
-          ]);
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([{ fixEntity, suggestions: [] }]);
 
         const response = await fixesController.getAllForOpportunity(requestContext);
 

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -93,7 +93,6 @@ describe('Fixes Controller', () => {
     sandbox.stub(fixEntityCollection, 'allByOpportunityIdAndStatus');
     sandbox.stub(fixEntityCollection, 'findById');
     sandbox.stub(fixEntityCollection, 'setSuggestionsForFixEntity');
-    sandbox.stub(fixEntityCollection, 'getAllFixesWithSuggestionByCreatedAt');
     sandbox.stub(fixEntityCollection, 'getAllFixesWithSuggestionsByOpportunityId');
     sandbox.stub(fixEntityCollection, 'updateByKeys');
     sandbox.stub(fixEntityCollection, 'getSuggestionsByFixEntityId');
@@ -408,6 +407,50 @@ describe('Fixes Controller', () => {
           type: Suggestion.TYPES.CONTENT_UPDATE,
         });
         expect(result[0].suggestions).to.have.lengthOf(0);
+      });
+
+      // Regression guard: the original bug manifested when executedAt is null
+      // at fix-creation time. The junction table was populated with createdAt,
+      // but once executedAt was set the key no longer matched. The filter must
+      // use executedAt ?? createdAt so newly-created fixes (executedAt=null)
+      // still match on createdAt.
+      it('returns fix when executedAt is null but createdAt matches the requested date', async () => {
+        const fixEntity = await fixEntityCollection.create({
+          type: Suggestion.TYPES.CONTENT_UPDATE,
+          opportunityId,
+        });
+        // Simulate executedAt=null (not yet deployed) with createdAt on target date
+        sandbox.stub(fixEntity, 'getExecutedAt').returns(null);
+        sandbox.stub(fixEntity, 'getCreatedAt').returns(executedAtOnDate);
+
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([{ fixEntity, suggestions: [] }]);
+
+        const response = await fixesController.getAllForOpportunity(requestContext);
+        expect(response).includes({ status: 200 });
+        const result = await response.json();
+        expect(result).to.have.lengthOf(1);
+        expect(result[0].id).to.equal(fixEntity.getId());
+      });
+
+      it('filters out fix when executedAt is null and createdAt does not match the requested date', async () => {
+        const fixEntity = await fixEntityCollection.create({
+          type: Suggestion.TYPES.CONTENT_UPDATE,
+          opportunityId,
+        });
+        // Simulate executedAt=null with createdAt on a DIFFERENT date
+        sandbox.stub(fixEntity, 'getExecutedAt').returns(null);
+        sandbox.stub(fixEntity, 'getCreatedAt').returns(executedAtOtherDate);
+
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([{ fixEntity, suggestions: [] }]);
+
+        const response = await fixesController.getAllForOpportunity(requestContext);
+        expect(response).includes({ status: 200 });
+        const result = await response.json();
+        expect(result).to.deep.equal([]);
       });
     });
   });


### PR DESCRIPTION
The previous implementation used getAllFixesWithSuggestionByCreatedAt which queries the junction table by fixEntityCreatedDate. This date is stored at fix-creation time when executedAt is null, so it always equals createdAt. Once the deploy completes and executedAt is set to a later date, the junction date no longer matches the UI accordion key (which uses executedAt ?? createdAt), causing the accordion to show empty even though the fixes exist and appear in the deployed count.

Fix: fetch all fixes via getAllFixesWithSuggestionsByOpportunityId then filter in-memory by executedAt ?? createdAt date. This matches the exact same logic the UI uses to assign fixes to accordion date buckets.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
