### PR TITLE
docs: exclude internal plans/specs from Jekyll Pages build; fix Vault secret note

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,11 @@
+# Jekyll configuration for the published GitHub Pages docs site (source: ./docs).
+#
+# Internal implementation plans and specs live under docs/ per the workspace
+# information hierarchy, but they are working documents - not part of the public
+# API reference - and they embed code samples whose JSDoc object-type syntax is
+# misread by Jekyll's Liquid parser as an unterminated variable, which fails the
+# build. Exclude them so the site builds cleanly and internal docs stay off the
+# public site.
+exclude:
+  - plans
+  - specs

--- a/docs/plans/2026-05-27-multi-github-destination-web.md
+++ b/docs/plans/2026-05-27-multi-github-destination-web.md
@@ -809,7 +809,7 @@ This plan is the web half of **migration step 1** plus the **step-2 registry cut
 | `GITHUB_TARGETS` | No (JSON registry) | All envs | Step 2 (registry cutover) |
 | `GITHUB_WEBHOOK_SECRET_GHEC` | **Yes** | Envs serving GHEC | GHEC cutover only |
 
-`GITHUB_WEBHOOK_SECRET` and `GITHUB_APP_SLUG` are unchanged. All of these are injected through the existing secret store via `npm run deploy-secrets` (`hedy --aws-update-secrets --params-file=secrets/secrets.env`, the same store that already provides `GITHUB_WEBHOOK_SECRET` / `GITHUB_APP_SLUG`). `GITHUB_TARGETS` is non-secret but rides the same channel.
+`GITHUB_WEBHOOK_SECRET` and `GITHUB_APP_SLUG` are unchanged. This service loads its runtime config from HashiCorp Vault (`dx_mysticat/{env}/api-service`, KV v2) at Lambda cold start via the `vaultSecrets` middleware (`src/index.js`), which merges it into `context.env` - the same store that already provides `GITHUB_WEBHOOK_SECRET` / `GITHUB_APP_SLUG`. Add `GITHUB_WEBHOOK_SECRET_GHEC` and the (non-secret) `GITHUB_TARGETS` to that same path with `vault kv patch -mount=dx_mysticat {env}/api-service ...`; a patch takes effect on the next cold start (within ~1 min on warm containers via the Vault metadata recheck) - no redeploy. (The `deploy-secrets` npm script writes to AWS Secrets Manager from a `secrets/` file that is absent from the repo and the CI pipeline; it is not how this service's secrets are managed.)
 
 ### Rollout sequence
 
@@ -818,8 +818,8 @@ This plan is the web half of **migration step 1** plus the **step-2 registry cut
    ```json
    [{ "id": "github-public", "match": { "default": true }, "appSlug": "mysticat", "webhookSecretEnvVar": "GITHUB_WEBHOOK_SECRET" }]
    ```
-   (Use the env's real `GITHUB_APP_SLUG` value as `appSlug` - e.g. `mysticat-bot-dev` in dev.) Deploy / update secrets. **Validation:** trigger a dev PR review; confirm the SQS message now carries `target_id: "github-public"`; confirm the review still posts (worker resolves `targets["github-public"]`); watch the **skip-and-log rate and per-target auth-failure rate** (ADR success metric) - both flat.
-3. **GHEC cutover (gated, separate change).** Preconditions (ADR): the EMU enterprise slug is known; the `ghec` app + PAT + webhook secret are provisioned (worker Vault `targets["ghec"]` added; `GITHUB_WEBHOOK_SECRET_GHEC` set). Insert the `ghec` rule **ahead of** the catch-all:
+   (Use the env's real `GITHUB_APP_SLUG` value as `appSlug` - e.g. `mysticat-bot-dev` in dev.) Apply with `vault kv patch -mount=dx_mysticat {env}/api-service GITHUB_TARGETS='...'` (effective on the next cold start; no redeploy). **Validation:** trigger a dev PR review; confirm the SQS message now carries `target_id: "github-public"`; confirm the review still posts (worker resolves `targets["github-public"]`); watch the **skip-and-log rate and per-target auth-failure rate** (ADR success metric) - both flat.
+3. **GHEC cutover (gated, separate change).** Preconditions (ADR): the EMU enterprise slug is known; the `ghec` app + PAT + webhook secret are provisioned (worker Vault `targets["ghec"]` added; `GITHUB_WEBHOOK_SECRET_GHEC` added to Vault `dx_mysticat/{env}/api-service`). Insert the `ghec` rule **ahead of** the catch-all:
    ```json
    [
      { "id": "ghec", "match": { "enterpriseSlug": ["<EMU-enterprise-slug>"] }, "appSlug": "mysticat-bot", "webhookSecretEnvVar": "GITHUB_WEBHOOK_SECRET_GHEC" },

--- a/src/support/github-targets.js
+++ b/src/support/github-targets.js
@@ -14,7 +14,7 @@
 // inbound webhook to a destination ("target") from the SIGNED body, so the
 // worker can select per-destination credentials by a non-secret target_id.
 // Secrets are NOT in this registry: webhookSecretEnvVar names the env var that
-// carries the secret (injected from the deploy secret store).
+// carries the secret (loaded at runtime from Vault into context.env).
 
 /**
  * Parse + validate the GITHUB_TARGETS env var.


### PR DESCRIPTION
## Summary
Follow-up to #2503. Two doc fixes:

1. **Un-break the docs-site build.** #2503 merged `docs/plans/2026-05-27-multi-github-destination-web.md`, whose embedded JSDoc object type (`@returns {{host: ...}|null}`) is parsed by Jekyll's Liquid engine as an unterminated `{{ }}` variable. That threw a `Liquid::SyntaxError` and failed the `pages build and deployment` run on `main` (commit `ef66b617`). This workflow only runs on push to `main`, not on PRs, so neither CI nor review caught it pre-merge.

   Fix: add `docs/_config.yml` excluding `plans/` and `specs/`. These are internal working docs, not the public API reference. This un-breaks the build, keeps internal plans/specs off the public docs site, and clears a pre-existing (non-fatal) Liquid warning in `plans/2026-05-21-slack-observability-web-tier.md`.

2. **Correct the secret-store guidance.** The plan doc and a `github-targets.js` comment claimed webhook secrets are injected via the `deploy-secrets` npm script. That script writes to AWS Secrets Manager from a `secrets/` file absent from the repo and CI. This service actually loads runtime config from HashiCorp Vault (`dx_mysticat/{env}/api-service`, KV v2) at cold start via the `vaultSecrets` middleware (`src/index.js`). Corrected so the runbook points operators at `vault kv patch`.

## Validation
- Ran the CI action image locally (`ghcr.io/actions/jekyll-build-pages:v1.0.13`): `_config.yml` loads and the `Liquid::SyntaxError` is gone. A fully green local build is blocked only by the `jekyll-github-metadata` plugin's GitHub-API auth (no network/token in the sandbox), which real CI provides - so the definitive gate is the post-merge `pages build and deployment` run.
- No functional code change (the only `src/` edit is a one-line comment).