### PR TITLE
feat(webhooks): log resolved targetId on the enqueue log

### DIFF
--- a/src/controllers/webhooks.js
+++ b/src/controllers/webhooks.js
@@ -235,6 +235,10 @@ function WebhooksController(context) {
       repo: jobPayload.repo,
       prNumber: pr.number,
       installationId: jobPayload.installation_id,
+      // Classification outcome, for traffic-distribution observability (per the
+      // PR #2503 review recommendation). 'legacy' = GITHUB_TARGETS unset, so the
+      // worker resolves its flat keys; otherwise the resolved destination id.
+      targetId: targetId || 'legacy',
     });
 
     return accepted({ status: 'accepted' });

--- a/test/controllers/webhooks.test.js
+++ b/test/controllers/webhooks.test.js
@@ -384,6 +384,13 @@ describe('WebhooksController', () => {
       expect(payload.target_id).to.equal('ghec');
     });
 
+    it('logs the resolved target id on the enqueue log', async () => {
+      await controller.processGitHubWebhook(ghecAuthContext());
+      const enqueueLog = mockLog.info.getCalls().find((c) => c.args[0] === 'Enqueued webhook job');
+      expect(enqueueLog, 'expected an "Enqueued webhook job" info log').to.exist;
+      expect(enqueueLog.args[1]).to.include({ targetId: 'ghec' });
+    });
+
     it('uses the per-target app_slug for the reviewer check (mysticat-bot[bot])', async () => {
       // env.GITHUB_APP_SLUG is 'mysticat', but the profile app_slug is
       // 'mysticat-bot'; the requested reviewer mysticat-bot[bot] must match and
@@ -398,6 +405,13 @@ describe('WebhooksController', () => {
       expect(response.status).to.equal(202);
       const [, payload] = mockSqs.sendMessage.firstCall.args;
       expect(payload).to.not.have.property('target_id');
+    });
+
+    it('logs targetId "legacy" on the enqueue log when no target_id is present', async () => {
+      await controller.processGitHubWebhook(validContext);
+      const enqueueLog = mockLog.info.getCalls().find((c) => c.args[0] === 'Enqueued webhook job');
+      expect(enqueueLog, 'expected an "Enqueued webhook job" info log').to.exist;
+      expect(enqueueLog.args[1]).to.include({ targetId: 'legacy' });
     });
   });
 


### PR DESCRIPTION
## Summary
Observability follow-up to #2503. Adds `targetId` (the resolved destination, or `'legacy'` when `GITHUB_TARGETS` is unset) to the "Enqueued webhook job" info log.

Neither the web tier nor (in our Coralogix) the Python worker logs the resolved `target_id` today, so the classification outcome is only inferable from timing - this is the gap hit while validating the dev cutover. This makes it directly observable, so the upcoming GHEC cutover can be verified from logs. Implements the observability recommendation from the #2503 review.

## Test plan
- [x] `mocha test/controllers/webhooks.test.js` -> 30 passing; two new cases assert the resolved id (`ghec`) and the `legacy` fallback on the enqueue log.
- [x] eslint clean. No behavior change beyond the added log field; `target_id` on the SQS payload is unchanged.