### PR TITLE
ci: adopt upstream bundle-build gate (remove repo-local job)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   ci:
-    needs: bundle-build
     uses: adobe/mysticat-ci/.github/workflows/service-ci.yaml@v2
     with:
       service-name: api-service
@@ -21,42 +20,5 @@ jobs:
       docs-lint: true
       it-postgres: true
       vpc-enabled: true
+      bundle-build: true
     secrets: inherit
-
-  bundle-build:
-    # Runs `npm run build` (= `hedy -v --test-bundle`), which bundles the Lambda
-    # artifact, creates the deploy zip, AND invokes the bundled `lambda()`
-    # against a synthetic healthcheck event. Exits non-zero on any non-2xx
-    # response — including the "TypeError: main2 is not a function" /
-    # "ENOENT … data/locations.json" class of bundling failures that take down
-    # cold starts in production but never surface in source-based unit tests.
-    #
-    # Mysticat-ci's reusable build job runs lint + test + coverage only, never
-    # `npm run build`, so this gap is what allowed SITES-45260 to escape to
-    # prod. Until the equivalent step is added to mysticat-ci, this repo-local
-    # job is the gate.
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node & NPM
-        uses: adobe/mysticat-ci/.github/actions/setup-node-npm@v1
-        env:
-          MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN: ${{ secrets.MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN }}
-
-      - name: Build production bundle (catches module-load failures)
-        env:
-          # hedy substitutes these into hlx.* fields at build time. They are
-          # deploy-time concerns only — dummy values keep the build hermetic
-          # and unblock the check on PRs that don't have access to
-          # environment-scoped secrets.
-          VPC_SUBNET_1: subnet-00000000000000000
-          VPC_SUBNET_2: subnet-00000000000000000
-          VPC_SG_ID: sg-00000000000000000
-          AWS_ACCOUNT_ID: '000000000000'
-        run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,13 +63,11 @@ History: SITES-45260 — `handlers/projects.js` read `data/locations.json` synch
 - **If you must keep a file as a non-JS asset**, declare its repo-relative path in `package.json` under `hlx.static` so `helix-deploy` copies it into the Lambda zip. Do NOT compute its runtime path from `import.meta.url` — read it from the Lambda task root (`process.env.LAMBDA_TASK_ROOT` or a known absolute path inside the zip).
 - **JSON import attributes** (`import x from './x.json' with { type: 'json' }`) are blocked by the repo's eslint parser today; don't try to work around the lint rule. Use the JS-module pattern instead.
 
-### CI gate (`bundle-build: true` input on the reusable workflow)
+### CI gate
 
-The bundle-build gate is provided by the upstream `adobe/mysticat-ci` reusable workflow, enabled via `bundle-build: true` in `.github/workflows/ci.yaml`'s `with:` block. It runs as the `Build Lambda bundle (smoke check)` step inside the reusable workflow's `build` job (same runner as lint+test+coverage — no extra checkout/`npm ci`).
+The bundle is validated in CI by the `bundle-build: true` input on the `adobe/mysticat-ci` reusable workflow (`.github/workflows/ci.yaml`) — it runs `npm run build` (`hedy -v --test-bundle`) and invokes the bundled `lambda()` against a healthcheck, catching the module-load failures that source-only lint+test+coverage miss (SITES-45260). The gate lives upstream; don't re-add a repo-local `bundle-build` job.
 
-The step runs `npm run build` (`hedy -v --test-bundle`) on every push/PR: it bundles, zips, imports the bundled `main`, and invokes `lambda()` against a healthcheck event — exits non-zero on any non-2xx response. This is the load-bearing catch for module-load failures in the bundled artifact that the source-only lint+test+coverage checks miss (they would have missed SITES-45260). There is no repo-local `bundle-build` job — do not re-introduce one; the gate lives upstream behind the `bundle-build: true` input.
-
-If you change anything that touches the bundle layer (new asset, new dependency that uses FS at boot, change to `hlx.static`, new top-level side-effect), run `npm run build` locally before pushing — the CI gate will catch it, but it's faster to know on your laptop.
+If you touch the bundle layer (new asset, a dependency that uses FS at boot, `hlx.static` changes, new top-level side-effects), run `npm run build` locally before pushing — faster than waiting on CI.
 
 ## Architecture Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,11 @@ History: SITES-45260 — `handlers/projects.js` read `data/locations.json` synch
 - **If you must keep a file as a non-JS asset**, declare its repo-relative path in `package.json` under `hlx.static` so `helix-deploy` copies it into the Lambda zip. Do NOT compute its runtime path from `import.meta.url` — read it from the Lambda task root (`process.env.LAMBDA_TASK_ROOT` or a known absolute path inside the zip).
 - **JSON import attributes** (`import x from './x.json' with { type: 'json' }`) are blocked by the repo's eslint parser today; don't try to work around the lint rule. Use the JS-module pattern instead.
 
-### CI gate (`.github/workflows/ci.yaml::bundle-build`)
+### CI gate (`bundle-build: true` input on the reusable workflow)
 
-`npm run build` runs `hedy -v --test-bundle` on every push/PR. It bundles, zips, imports the bundled `main`, and invokes `lambda()` against a healthcheck event — exits non-zero on any non-2xx response. This is the load-bearing catch for module-load failures in the bundled artifact (the mysticat-ci reusable workflow only runs lint+test+coverage, which is source-only and would have missed SITES-45260).
+The bundle-build gate is provided by the upstream `adobe/mysticat-ci` reusable workflow, enabled via `bundle-build: true` in `.github/workflows/ci.yaml`'s `with:` block. It runs as the `Build Lambda bundle (smoke check)` step inside the reusable workflow's `build` job (same runner as lint+test+coverage — no extra checkout/`npm ci`).
+
+The step runs `npm run build` (`hedy -v --test-bundle`) on every push/PR: it bundles, zips, imports the bundled `main`, and invokes `lambda()` against a healthcheck event — exits non-zero on any non-2xx response. This is the load-bearing catch for module-load failures in the bundled artifact that the source-only lint+test+coverage checks miss (they would have missed SITES-45260). There is no repo-local `bundle-build` job — do not re-introduce one; the gate lives upstream behind the `bundle-build: true` input.
 
 If you change anything that touches the bundle layer (new asset, new dependency that uses FS at boot, change to `hlx.static`, new top-level side-effect), run `npm run build` locally before pushing — the CI gate will catch it, but it's faster to know on your laptop.
 


### PR DESCRIPTION
## Summary

Switches `spacecat-api-service` from its repo-local `bundle-build` job to the upstream gate now provided by `adobe/mysticat-ci@v2.2.0` via the new `bundle-build: true` input on `service-ci.yaml`.

Two changes to `.github/workflows/ci.yaml`:

- Add `bundle-build: true` to the `with:` block of the `ci:` job.
- Remove the repo-local `bundle-build` job and the `ci: needs: bundle-build` dependency. The upstream gate replaces it as a step inside the reusable workflow's `build` job — runs on the same runner as lint/test, no extra `npm ci` cost.

## Why

The repo-local job was introduced in adobe/spacecat-api-service#2466 as the immediate fix for [SITES-45260](https://jira.corp.adobe.com/browse/SITES-45260) — the semrush AIO proxy that crashed every cold start because `data/locations.json` was read at module load via `readFileSync(import.meta.url)` but never copied into the deploy zip. The recommendation to lift the gate upstream is now implemented by adobe/mysticat-ci#17.

This PR is the api-service half of the Phase 2 rollout documented at https://github.com/adobe/mysticat-ci/pull/17#issuecomment-4563972002. The other nine spacecat Lambda services are being opted in via parallel PRs.

## What stays

- `CLAUDE.md` `## Lambda Bundle Constraints` section. Documents contributor-facing rules for AI agents and new contributors (no `readFileSync(import.meta.url)`, prefer JS-module imports for static data, etc.). These remain load-bearing even with the gate moved upstream.
- `src/support/semrush/data/locations.js` — the actual SITES-45260 fix, unrelated to CI.

## Verification

- [ ] CI run on this PR completes.
- [ ] New step `Build Lambda bundle (smoke check)` appears in the `build` job log of the reusable workflow.
- [ ] Step exits 0.
- [ ] The standalone `bundle-build` check is no longer in the PR check list.

## Cross-references

- adobe/mysticat-ci#17 — upstream lift PR
- [adobe/mysticat-ci@v2.2.0](https://github.com/adobe/mysticat-ci/releases/tag/v2.2.0) — release that ships the new input
- adobe/spacecat-api-service#2466 — original repo-local gate (SITES-45260)

🤖 Generated with [Claude Code](https://claude.com/claude-code)