### PR TITLE
feat(onboarding): T3 · Semrush workspace check + project fan-out + 200/207 (LLMO-5203/5204/5205)

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -1318,6 +1318,15 @@ llmo-onboard:
         $ref: './responses.yaml#/401'
       '403':
         $ref: './responses.yaml#/403'
+      '404':
+        description: |
+          The org is in the Semrush cohort (`SERENITY_SITE_ALLOWLIST`) but has no
+          Semrush workspace bound. An operator must run
+          `PATCH /organizations/:spaceCatId` with `{ semrushWorkspaceId: ... }`
+          before retrying onboarding. No Adobe-side state is created in this case.
+        headers:
+          X-Error:
+            $ref: './headers.yaml#/xError'
       '500':
         $ref: './responses.yaml#/500'
     security: []

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -1272,6 +1272,11 @@ llmo-onboard:
           Partial success — LLMO onboarding completed but one or more Semrush project
           provisioning steps failed. Successfully created projects are not rolled back.
           Re-invoking with the same `markets[]` is safe (already-created slices are skipped).
+
+          The body carries the same onboarding fields as the 200 response (message,
+          domain, brandName, imsOrgId, organizationId, siteId, status, …) in addition
+          to the `requested`/`succeeded`/`failed` arrays below. Only cohort
+          (`SERENITY_SITE_ALLOWLIST`) onboardings can return 207; all others return 200.
         content:
           application/json:
             schema:

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1261,6 +1261,34 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
     // Create or find organization
     const organization = await createOrFindOrganization(imsOrgId, context, say);
 
+    // M1 cohort gate (LLMO-5201) + M5 fail-fast workspace check (LLMO-5203).
+    // Resolved here, right after the org exists and BEFORE any other Adobe-side
+    // state (site, entitlement, audits, brand) is created. Per the orchestration
+    // design (LLMO-5007 §M5), a missing Semrush workspace must fail fast so the
+    // operator can bind one via PATCH /organizations/:id and retry cleanly with
+    // nothing left behind. Only the org is needed for this check; the brand-keyed
+    // fan-out (M6–M8) runs later, once the brand row exists. `serenityEnabled` is
+    // reused there to avoid evaluating the allowlist twice.
+    const serenityEnabled = isSerenityOnboardingEnabled(
+      organization.getId(),
+      imsOrgId,
+      env,
+    );
+    if (serenityEnabled && !organization.getSemrushWorkspaceId?.()) {
+      const spaceCatId = organization.getId();
+      const workspaceError = new Error(
+        `Semrush workspace not bound to org ${spaceCatId}. `
+        + `Run PATCH /organizations/${spaceCatId} with { semrushWorkspaceId: ... } `
+        + 'then retry onboarding.',
+      );
+      // Surfaced as HTTP 404 by the controller (matches the AIO Proxy convention,
+      // LLMO-5007 §M5). `preflight` tells the cleanup handler below there is no
+      // Adobe-side state to roll back — this throw precedes site creation.
+      workspaceError.status = 404;
+      workspaceError.preflight = true;
+      throw workspaceError;
+    }
+
     // Create site BEFORE resolving the onboarding mode. createOrFindSite may
     // re-parent an existing site into the destination org; resolveLlmoOnboardingMode
     // reads Site.allByOrganizationId, so the re-parent has to be persisted first
@@ -1394,9 +1422,10 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
         log.warn(`Failed to create initial brand in normalized table: ${brandError.message}`);
       }
 
-      if (isSerenityOnboardingEnabled(organization.getId(), imsOrgId, env)) {
-        // M5–M8: Semrush provisioning path (cohort gate — LLMO-5007).
-        // T3a (workspace check), T3b (fan-out), T3c (readiness validation)
+      if (serenityEnabled) {
+        // M6–M8: Semrush provisioning path (cohort gate — LLMO-5007).
+        // Workspace presence was already validated at M5 (fail-fast, above).
+        // T3b (fan-out — LLMO-5204) and T3c (readiness validation — LLMO-5205)
         // will be implemented here.
         log.info(`Serenity onboarding enabled for org ${organization.getId()} — ${markets?.length ?? 0} market(s) to provision (LLMO-5007)`);
       }
@@ -1488,6 +1517,13 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       message: 'LLMO onboarding completed successfully',
     };
   } catch (error) {
+    // Pre-flight failures (e.g. the M5 missing-workspace 404) throw before any
+    // Adobe-side state is created — there is nothing to clean up, so propagate
+    // directly and let the caller map the status.
+    if (error.preflight) {
+      throw error;
+    }
+
     log.error(`Error during LLMO onboarding: ${error.message}. Attempting cleanup.`);
 
     // Attempt cleanup

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1241,9 +1241,11 @@ export async function enqueueLlmoOnboardingPublish(context, site, dataFolder) {
  */
 function extractImsBearer(context) {
   // The Semrush gateway only understands IMS user tokens; anything else
-  // (scoped API key, S2S JWT) cannot be forwarded.
+  // (scoped API key, S2S JWT, or an auth object we can't classify) must not be
+  // forwarded. Stricter than the proxy's `requireImsBearer` on purpose: require
+  // a recognisable IMS auth type rather than letting an unknown shape through.
   const authInfo = context?.attributes?.authInfo;
-  if (authInfo?.getType && authInfo.getType() !== 'ims') {
+  if (!authInfo?.getType || authInfo.getType() !== 'ims') {
     return null;
   }
   const header = context?.pathInfo?.headers?.authorization;
@@ -1352,6 +1354,10 @@ export async function performSerenityFanOut(context, {
     }
 
     // 201 = newly created; 409 = slice already exists (idempotent success).
+    // Note the 201/409 asymmetry: a 201 echoes `semrushLocationId`, a 409 only
+    // returns the conflicting `semrushProjectId` (no location). That's fine —
+    // M8 (`reconcileSerenityProjects`) reads the authoritative location back from
+    // the DB, so this fan-out entry is provisional and superseded there.
     if (outcome.status === 201 || outcome.status === 409) {
       succeeded.push({
         market,
@@ -1424,6 +1430,11 @@ export async function reconcileSerenityProjects(context, { brandId, fanOut }) {
   const succeeded = [];
   const failed = [];
   requested.forEach(({ market, language }) => {
+    // `resolveLocation` returns null for an unknown market, in which case no DB
+    // slice can match and the tuple is treated as failed. This is consistent
+    // with M7: the proxy also rejects such a tuple (`unknownMarket`), so it
+    // never wrote a row. Unreachable given the `^[A-Z]{2}$` + proxy validation,
+    // but guarded so a bad code degrades to a failure, not a thrown lookup.
     const location = resolveLocation(market);
     const lang = String(language).toLowerCase();
     const row = location ? rowBySlice.get(`${location.locationId}::${lang}`) : undefined;
@@ -1652,9 +1663,12 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
         // workspace presence above. T3b fans out one project per market tuple;
         // T3c (LLMO-5205) will shape the 200/207 response from the result.
         log.info(`Serenity onboarding enabled for org ${organization.getId()} — ${markets?.length ?? 0} market(s) to provision (LLMO-5007)`);
+        // A failed M4 brand upsert leaves `upsertedBrand` undefined; the fan-out
+        // detects the missing brand id and fails every tuple cleanly.
+        const brandId = upsertedBrand?.id ?? null;
         // M7: fan out one Semrush project per (market, language) tuple.
         const fanOut = await performSerenityFanOut(context, {
-          brandId: upsertedBrand?.id,
+          brandId,
           workspaceId: organization.getSemrushWorkspaceId(),
           brandName,
           baseURL,
@@ -1662,7 +1676,7 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
         });
         // M8: read back the authoritative DB state and shape the final outcome.
         serenityProvisioning = await reconcileSerenityProjects(context, {
-          brandId: upsertedBrand?.id,
+          brandId,
           fanOut,
         });
         log.info(`Serenity provisioning for org ${organization.getId()}: ${serenityProvisioning.succeeded.length} of ${serenityProvisioning.requested.length} project(s) live, ${serenityProvisioning.failed.length} failed (LLMO-5007)`);

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -15,7 +15,9 @@ import { createFrom } from '@adobe/spacecat-helix-content-sdk';
 import { Octokit } from '@octokit/rest';
 import { Entitlement as EntitlementModel } from '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js';
 import TierClient from '@adobe/spacecat-shared-tier-client';
-import { composeBaseURL, tracingFetch as fetch, isNonEmptyArray } from '@adobe/spacecat-shared-utils';
+import {
+  composeBaseURL, tracingFetch as fetch, isNonEmptyArray, hasText,
+} from '@adobe/spacecat-shared-utils';
 import SeoClient from '@adobe/mysticat-shared-seo-client';
 import DrsClient from '@adobe/spacecat-shared-drs-client';
 import { parse as parseDomain } from 'tldts';
@@ -36,6 +38,8 @@ import {
 import { upsertFeatureFlag } from '../../support/feature-flags-storage.js';
 import { detectCdnForDomain } from '../../support/cdn-detection.js';
 import { upsertBrand } from '../../support/brands-storage.js';
+import { handleCreateProject } from '../../support/serenity/handlers/projects.js';
+import { createSerenityTransport } from '../../support/serenity/rest-transport.js';
 
 // LLMO Constants
 const LLMO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.LLMO;
@@ -1227,6 +1231,150 @@ export async function enqueueLlmoOnboardingPublish(context, site, dataFolder) {
 }
 
 /**
+ * Extracts the IMS user bearer token from the request context, mirroring the
+ * Serenity controller's `requireImsBearer` but non-throwing — the fan-out is
+ * best-effort, so a missing/incompatible token is recorded as a per-tuple
+ * failure rather than aborting onboarding.
+ *
+ * @param {object} context - The request context.
+ * @returns {string|null} The bearer token, or null when absent / non-IMS auth.
+ */
+function extractImsBearer(context) {
+  // The Semrush gateway only understands IMS user tokens; anything else
+  // (scoped API key, S2S JWT) cannot be forwarded.
+  const authInfo = context?.attributes?.authInfo;
+  if (authInfo?.getType && authInfo.getType() !== 'ims') {
+    return null;
+  }
+  const header = context?.pathInfo?.headers?.authorization;
+  if (!hasText(header) || !header.startsWith('Bearer ')) {
+    return null;
+  }
+  return header.substring('Bearer '.length);
+}
+
+/**
+ * M7 (LLMO-5204): fan out one Semrush project per (market, language) tuple by
+ * calling the already-shipped AIO Proxy handler (`handleCreateProject`)
+ * in-process, once per tuple, sequentially.
+ *
+ * Best-effort per LLMO-5007 §M7: a per-tuple failure is collected, not thrown,
+ * and does not abort the remaining tuples — there is no retry and no rollback.
+ * A 409 (slice already exists) counts as success so re-invoking onboarding with
+ * the same `markets[]` is idempotent (the proxy 409-dedupes via `findBySlice`).
+ *
+ * Returns `{ requested, succeeded, failed }`; the authoritative read-back and
+ * 200/207 response shaping happen in M8 (LLMO-5205, T3c).
+ *
+ * @param {object} context - The request context (env, log, dataAccess, auth).
+ * @param {object} args
+ * @param {string} args.brandId - The brand UUID (from M4 `upsertBrand`).
+ * @param {string} args.workspaceId - The org's Semrush workspace ID (M5-validated).
+ * @param {string} args.brandName - The brand name from the onboard request.
+ * @param {string} args.baseURL - The site base URL; its hostname is sent as `brandDomain`.
+ * @param {Array<{market: string, language: string}>} [args.markets] - Tuples to provision.
+ * @returns {Promise<{requested: object[], succeeded: object[], failed: object[]}>}
+ */
+export async function performSerenityFanOut(context, {
+  brandId, workspaceId, brandName, baseURL, markets,
+}) {
+  const { env, log } = context;
+  const requested = (Array.isArray(markets) ? markets : [])
+    .map(({ market, language }) => ({ market, language }));
+  const succeeded = [];
+  const failed = [];
+
+  if (requested.length === 0) {
+    return { requested, succeeded, failed };
+  }
+
+  const failAll = (status, error) => {
+    requested.forEach(({ market, language }) => failed.push({
+      market, language, status, error,
+    }));
+    return { requested, succeeded, failed };
+  };
+
+  // The brand row is M4's responsibility; if it failed to write we have no
+  // slice key to provision against. Surface, don't throw.
+  if (!hasText(brandId)) {
+    log.warn(`Serenity fan-out: brand row missing — cannot provision ${requested.length} market(s)`);
+    return failAll(500, 'brandNotCreated');
+  }
+
+  const imsToken = extractImsBearer(context);
+  if (!imsToken) {
+    log.warn(`Serenity fan-out: no IMS bearer on the onboarding request — cannot provision ${requested.length} market(s) for brand ${brandId}`);
+    return failAll(401, 'missingImsBearer');
+  }
+
+  let transport;
+  try {
+    transport = createSerenityTransport({ env, imsToken });
+  } catch (transportError) {
+    log.error(`Serenity fan-out: failed to build Semrush transport: ${transportError.message}`);
+    return failAll(transportError.status || 502, 'transportUnavailable');
+  }
+
+  const brandSlug = generateBrandId(brandName.trim());
+  const brandDomain = new URL(baseURL).hostname;
+
+  for (const { market, language } of requested) {
+    const body = {
+      name: `${brandSlug} · ${market} · ${language}`,
+      market,
+      language,
+      brandDomain,
+      brandNames: [brandName.trim()],
+      projectType: 'ai',
+    };
+
+    let outcome;
+    try {
+      // Sequential by design (prototype): one upstream create+publish at a time.
+      // eslint-disable-next-line no-await-in-loop
+      outcome = await handleCreateProject(
+        transport,
+        context.dataAccess,
+        brandId,
+        workspaceId,
+        body,
+        log,
+      );
+    } catch (e) {
+      // SerenityTransportError (upstream non-2xx) or an unexpected throw —
+      // record and continue with the next tuple.
+      failed.push({
+        market, language, status: e.status || 502, error: e.message,
+      });
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    // 201 = newly created; 409 = slice already exists (idempotent success).
+    if (outcome.status === 201 || outcome.status === 409) {
+      succeeded.push({
+        market,
+        language,
+        semrushProjectId: outcome.body?.semrushProjectId,
+        ...(outcome.body?.semrushLocationId !== undefined
+          ? { semrushLocationId: outcome.body.semrushLocationId }
+          : {}),
+      });
+    } else {
+      failed.push({
+        market,
+        language,
+        status: outcome.status,
+        error: outcome.body?.error || 'unknownError',
+      });
+    }
+  }
+
+  return { requested, succeeded, failed };
+}
+
+/**
  * Complete LLMO onboarding process.
  * @param {object} params - Onboarding parameters
  * @param {string} [params.domain] - The domain name (alternative to baseURL)
@@ -1255,6 +1403,8 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
 
   let site;
   let detectedCdn = null;
+  // M7 fan-out result (LLMO-5204); consumed by the M8 response shaping (LLMO-5205).
+  let serenityProvisioning = null;
   try {
     log.info(`Starting LLMO onboarding for IMS org ${imsOrgId}, baseURL ${baseURL}, brand ${brandName}`);
 
@@ -1404,8 +1554,9 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       // Use baseURL (matches sites.base_url) so syncBrandSites can link the brand
       // to the site. overrideBaseURL may differ (e.g., www.blick.ch vs blick.ch)
       // and would fail the exact-match lookup against the sites table.
+      let upsertedBrand;
       try {
-        await upsertBrand({
+        upsertedBrand = await upsertBrand({
           organizationId: organization.getId(),
           brand: {
             name: brandName.trim(),
@@ -1423,11 +1574,18 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       }
 
       if (serenityEnabled) {
-        // M6–M8: Semrush provisioning path (cohort gate — LLMO-5007).
-        // Workspace presence was already validated at M5 (fail-fast, above).
-        // T3b (fan-out — LLMO-5204) and T3c (readiness validation — LLMO-5205)
-        // will be implemented here.
+        // M6–M8 (LLMO-5007): Semrush provisioning path. M5 already validated the
+        // workspace presence above. T3b fans out one project per market tuple;
+        // T3c (LLMO-5205) will shape the 200/207 response from the result.
         log.info(`Serenity onboarding enabled for org ${organization.getId()} — ${markets?.length ?? 0} market(s) to provision (LLMO-5007)`);
+        serenityProvisioning = await performSerenityFanOut(context, {
+          brandId: upsertedBrand?.id,
+          workspaceId: organization.getSemrushWorkspaceId(),
+          brandName,
+          baseURL,
+          markets,
+        });
+        log.info(`Serenity fan-out for org ${organization.getId()}: ${serenityProvisioning.succeeded.length} of ${serenityProvisioning.requested.length} project(s) provisioned, ${serenityProvisioning.failed.length} failed (LLMO-5007)`);
       }
 
       // Trigger Brandalf immediately after the v2 config exists so downstream
@@ -1515,6 +1673,9 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       dataFolder,
       detectedCdn,
       message: 'LLMO onboarding completed successfully',
+      // M7 fan-out outcome for the cohort; absent for non-serenity onboardings.
+      // M8 (LLMO-5205) shapes this into the 200/207 response.
+      ...(serenityProvisioning ? { serenity: serenityProvisioning } : {}),
     };
   } catch (error) {
     // Pre-flight failures (e.g. the M5 missing-workspace 404) throw before any

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -38,7 +38,7 @@ import {
 import { upsertFeatureFlag } from '../../support/feature-flags-storage.js';
 import { detectCdnForDomain } from '../../support/cdn-detection.js';
 import { upsertBrand } from '../../support/brands-storage.js';
-import { handleCreateProject } from '../../support/serenity/handlers/projects.js';
+import { handleCreateProject, resolveLocation } from '../../support/serenity/handlers/projects.js';
 import { createSerenityTransport } from '../../support/serenity/rest-transport.js';
 
 // LLMO Constants
@@ -1375,6 +1375,80 @@ export async function performSerenityFanOut(context, {
 }
 
 /**
+ * M8 (LLMO-5205): validate cohort readiness by reading back the authoritative
+ * DB state after the M7 fan-out and shaping the final per-tuple outcome.
+ *
+ * Reads `BrandSemrushProject.allByBrandId(brandId)` and asserts one row exists
+ * per requested `(market, language)` tuple — rather than trusting the fan-out's
+ * own responses, which also catches the rare case where the proxy returned 201
+ * but the row insert failed silently (LLMO-5007 §M8). A requested tuple with a
+ * matching row is `succeeded`; one without is `failed`, enriched with the
+ * fan-out's status/error when available (otherwise `projectRowMissing`).
+ *
+ * Successful tuples are never rolled back. The caller maps a non-empty `failed`
+ * to HTTP 207.
+ *
+ * @param {object} context - The request context (log, dataAccess).
+ * @param {object} args
+ * @param {string} args.brandId - The brand UUID.
+ * @param {object} args.fanOut - The M7 result `{ requested, succeeded, failed }`.
+ * @returns {Promise<{requested: object[], succeeded: object[], failed: object[]}>}
+ */
+export async function reconcileSerenityProjects(context, { brandId, fanOut }) {
+  const { log, dataAccess } = context;
+  const { requested } = fanOut;
+
+  // Nothing requested, or no brand to key the read-back on — the fan-out result
+  // is already authoritative (it short-circuited for these cases).
+  if (requested.length === 0 || !hasText(brandId)) {
+    return fanOut;
+  }
+
+  let rows;
+  try {
+    rows = await dataAccess.BrandSemrushProject.allByBrandId(brandId) || [];
+  } catch (e) {
+    // If the read-back itself fails we cannot improve on the fan-out result;
+    // surface it as-is rather than masking a partial success as total failure.
+    log.error(`Serenity M8: read-back failed for brand ${brandId}: ${e.message}`);
+    return fanOut;
+  }
+
+  const rowBySlice = new Map();
+  rows.forEach((row) => {
+    rowBySlice.set(`${row.getSemrushLocationId()}::${row.getLanguage()}`, row);
+  });
+  const failureByTuple = new Map();
+  fanOut.failed.forEach((f) => failureByTuple.set(`${f.market}::${f.language}`, f));
+
+  const succeeded = [];
+  const failed = [];
+  requested.forEach(({ market, language }) => {
+    const location = resolveLocation(market);
+    const lang = String(language).toLowerCase();
+    const row = location ? rowBySlice.get(`${location.locationId}::${lang}`) : undefined;
+    if (row) {
+      succeeded.push({
+        market,
+        language,
+        semrushProjectId: row.getSemrushProjectId(),
+        semrushLocationId: row.getSemrushLocationId(),
+      });
+    } else {
+      const prior = failureByTuple.get(`${market}::${language}`);
+      failed.push({
+        market,
+        language,
+        status: prior?.status ?? 500,
+        error: prior?.error ?? 'projectRowMissing',
+      });
+    }
+  });
+
+  return { requested, succeeded, failed };
+}
+
+/**
  * Complete LLMO onboarding process.
  * @param {object} params - Onboarding parameters
  * @param {string} [params.domain] - The domain name (alternative to baseURL)
@@ -1578,14 +1652,20 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
         // workspace presence above. T3b fans out one project per market tuple;
         // T3c (LLMO-5205) will shape the 200/207 response from the result.
         log.info(`Serenity onboarding enabled for org ${organization.getId()} — ${markets?.length ?? 0} market(s) to provision (LLMO-5007)`);
-        serenityProvisioning = await performSerenityFanOut(context, {
+        // M7: fan out one Semrush project per (market, language) tuple.
+        const fanOut = await performSerenityFanOut(context, {
           brandId: upsertedBrand?.id,
           workspaceId: organization.getSemrushWorkspaceId(),
           brandName,
           baseURL,
           markets,
         });
-        log.info(`Serenity fan-out for org ${organization.getId()}: ${serenityProvisioning.succeeded.length} of ${serenityProvisioning.requested.length} project(s) provisioned, ${serenityProvisioning.failed.length} failed (LLMO-5007)`);
+        // M8: read back the authoritative DB state and shape the final outcome.
+        serenityProvisioning = await reconcileSerenityProjects(context, {
+          brandId: upsertedBrand?.id,
+          fanOut,
+        });
+        log.info(`Serenity provisioning for org ${organization.getId()}: ${serenityProvisioning.succeeded.length} of ${serenityProvisioning.requested.length} project(s) live, ${serenityProvisioning.failed.length} failed (LLMO-5007)`);
       }
 
       // Trigger Brandalf immediately after the v2 config exists so downstream

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1082,6 +1082,11 @@ function LlmoController(ctx) {
       });
     } catch (error) {
       log.error(`Error during LLMO onboarding: ${error.message}`);
+      // M5 (LLMO-5203): a missing Semrush workspace fails fast with a 404 and an
+      // operator-actionable message; everything else stays a 400.
+      if (error.status === 404) {
+        return notFound(error.message);
+      }
       return badRequest(cleanupHeaderValue(error.message));
     }
   };

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1065,7 +1065,7 @@ function LlmoController(ctx) {
 
       log.info(`LLMO onboarding completed successfully for domain ${domain}`);
 
-      return ok({
+      const responseBody = {
         message: result.message,
         domain,
         brandName,
@@ -1079,7 +1079,23 @@ function LlmoController(ctx) {
         createdAt: new Date().toISOString(),
         brandProfileExecutionName,
         ...(region ? { region } : {}),
-      });
+      };
+
+      // M8 (LLMO-5205): for cohort onboardings, surface the per-tuple Semrush
+      // provisioning outcome. A non-empty `failed` is a partial success → 207
+      // Multi-Status; successful tuples are never rolled back. Re-invoking with
+      // the same markets[] is safe (the proxy 409-dedupes already-created slices).
+      if (result.serenity) {
+        const { requested, succeeded, failed } = result.serenity;
+        const serenityBody = {
+          ...responseBody, requested, succeeded, failed,
+        };
+        return failed.length > 0
+          ? createResponse(serenityBody, 207)
+          : ok(serenityBody);
+      }
+
+      return ok(responseBody);
     } catch (error) {
       log.error(`Error during LLMO onboarding: ${error.message}`);
       // M5 (LLMO-5203): a missing Semrush workspace fails fast with a 404 and an

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -3837,6 +3837,133 @@ describe('LLMO Onboarding Functions', () => {
     });
   });
 
+  describe('reconcileSerenityProjects (LLMO-5205)', () => {
+    // resolveLocation: US → 2840, DE → 2276 (2000 + ISO 3166-1 numeric).
+    const dbRow = (locationId, language, projectId) => ({
+      getSemrushLocationId: () => locationId,
+      getLanguage: () => language,
+      getSemrushProjectId: () => projectId,
+    });
+
+    const makeContext = (rows, { throws = false } = {}) => ({
+      log: { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() },
+      dataAccess: {
+        BrandSemrushProject: {
+          allByBrandId: throws
+            ? sinon.stub().rejects(new Error('db down'))
+            : sinon.stub().resolves(rows),
+        },
+      },
+    });
+
+    const loadReconcile = async () => {
+      const mod = await esmock('../../../src/controllers/llmo/llmo-onboarding.js', {});
+      return mod.reconcileSerenityProjects;
+    };
+
+    it('returns the fan-out result unchanged when nothing was requested', async () => {
+      const reconcileSerenityProjects = await loadReconcile();
+      const fanOut = { requested: [], succeeded: [], failed: [] };
+      const ctx = makeContext([]);
+      const res = await reconcileSerenityProjects(ctx, { brandId: 'b1', fanOut });
+      expect(res).to.deep.equal(fanOut);
+      expect(ctx.dataAccess.BrandSemrushProject.allByBrandId).to.not.have.been.called;
+    });
+
+    it('returns the fan-out result unchanged when the brand id is missing', async () => {
+      const reconcileSerenityProjects = await loadReconcile();
+      const fanOut = {
+        requested: [{ market: 'US', language: 'en' }],
+        succeeded: [],
+        failed: [{
+          market: 'US', language: 'en', status: 500, error: 'brandNotCreated',
+        }],
+      };
+      const ctx = makeContext([]);
+      const res = await reconcileSerenityProjects(ctx, { brandId: undefined, fanOut });
+      expect(res).to.deep.equal(fanOut);
+      expect(ctx.dataAccess.BrandSemrushProject.allByBrandId).to.not.have.been.called;
+    });
+
+    it('marks every requested tuple with a DB row as succeeded', async () => {
+      const reconcileSerenityProjects = await loadReconcile();
+      const fanOut = {
+        requested: [{ market: 'US', language: 'en' }, { market: 'DE', language: 'de' }],
+        succeeded: [],
+        failed: [],
+      };
+      const ctx = makeContext([dbRow(2840, 'en', 'p-us'), dbRow(2276, 'de', 'p-de')]);
+      const res = await reconcileSerenityProjects(ctx, { brandId: 'b1', fanOut });
+      expect(res.failed).to.be.empty;
+      expect(res.succeeded).to.deep.equal([
+        {
+          market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+        },
+        {
+          market: 'DE', language: 'de', semrushProjectId: 'p-de', semrushLocationId: 2276,
+        },
+      ]);
+    });
+
+    it('marks a tuple with no DB row as failed, enriched with the fan-out error', async () => {
+      const reconcileSerenityProjects = await loadReconcile();
+      const fanOut = {
+        requested: [{ market: 'US', language: 'en' }, { market: 'DE', language: 'de' }],
+        succeeded: [],
+        failed: [{
+          market: 'DE', language: 'de', status: 502, error: 'semrushUpstreamError',
+        }],
+      };
+      const ctx = makeContext([dbRow(2840, 'en', 'p-us')]); // DE row missing
+      const res = await reconcileSerenityProjects(ctx, { brandId: 'b1', fanOut });
+      expect(res.succeeded).to.deep.equal([
+        {
+          market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+        },
+      ]);
+      expect(res.failed).to.deep.equal([
+        {
+          market: 'DE', language: 'de', status: 502, error: 'semrushUpstreamError',
+        },
+      ]);
+    });
+
+    it('flags a silently-missing row as projectRowMissing even when the fan-out reported success', async () => {
+      const reconcileSerenityProjects = await loadReconcile();
+      const fanOut = {
+        requested: [{ market: 'US', language: 'en' }],
+        // Fan-out thought it succeeded, but the row never landed (201-but-no-insert).
+        succeeded: [{
+          market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+        }],
+        failed: [],
+      };
+      const ctx = makeContext([]); // authoritative read-back: no rows
+      const res = await reconcileSerenityProjects(ctx, { brandId: 'b1', fanOut });
+      expect(res.succeeded).to.be.empty;
+      expect(res.failed).to.deep.equal([
+        {
+          market: 'US', language: 'en', status: 500, error: 'projectRowMissing',
+        },
+      ]);
+    });
+
+    it('falls back to the fan-out result when the read-back throws', async () => {
+      const reconcileSerenityProjects = await loadReconcile();
+      const fanOut = {
+        requested: [{ market: 'US', language: 'en' }],
+        succeeded: [{
+          market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+        }],
+        failed: [],
+      };
+      const ctx = makeContext([], { throws: true });
+      const res = await reconcileSerenityProjects(ctx, { brandId: 'b1', fanOut });
+      expect(res).to.deep.equal(fanOut);
+      expect(ctx.log.error).to.have.been.called;
+    });
+  });
+
   describe('buildInitialCustomerConfigV2', () => {
     it('builds a single active brand config for onboarding', async () => {
       const { buildInitialCustomerConfigV2 } = await esmock('../../../src/controllers/llmo/llmo-onboarding.js', {});

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -3428,6 +3428,8 @@ describe('LLMO Onboarding Functions', () => {
       const mockOrganization = {
         getId: sinon.stub().returns('org-serenity-cohort'),
         getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+        // M5 (LLMO-5203): workspace is bound, so onboarding proceeds into M6–M8.
+        getSemrushWorkspaceId: sinon.stub().returns('semrush-ws-123'),
       };
       const mockSite = {
         getId: sinon.stub().returns('site123'),
@@ -3503,6 +3505,67 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockLog.info).to.have.been.calledWith(
         sinon.match(/Serenity onboarding enabled for org org-serenity-cohort/),
       );
+    });
+
+    it('should fail fast with a 404 when an allowlisted org has no Semrush workspace bound (LLMO-5203)', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org-serenity-cohort'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+        // M5 (LLMO-5203): no workspace bound — onboarding must fail fast.
+        getSemrushWorkspaceId: sinon.stub().returns(null),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves({ getId: sinon.stub().returns('site123') });
+
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+
+      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: { ...mockEnv, [SERENITY_SITE_ALLOWLIST]: 'org-serenity-cohort' },
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      let thrown;
+      try {
+        await performLlmoOnboardingWithMocks({ domain: 'example.com', brandName: 'Test Brand', imsOrgId: 'ABC123@AdobeOrg' }, context);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown, 'expected performLlmoOnboarding to throw').to.exist;
+      expect(thrown.status).to.equal(404);
+      expect(thrown.preflight).to.be.true;
+      expect(thrown.message).to.match(/Semrush workspace not bound to org org-serenity-cohort/);
+      // Fail-fast: nothing downstream of the org lookup should have run.
+      expect(mockDataAccess.Site.create).to.not.have.been.called;
     });
 
     it('should skip serenity provisioning when org is not in SERENITY_SITE_ALLOWLIST', async () => {

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -3650,6 +3650,193 @@ describe('LLMO Onboarding Functions', () => {
     });
   });
 
+  describe('performSerenityFanOut (LLMO-5204)', () => {
+    let log;
+    let createTransportStub;
+
+    const baseArgs = {
+      brandId: 'brand-uuid-1',
+      workspaceId: 'ws-1',
+      brandName: 'Example Brand',
+      baseURL: 'https://example.com',
+      markets: [{ market: 'US', language: 'en' }, { market: 'DE', language: 'de' }],
+    };
+
+    const makeContext = (overrides = {}) => ({
+      env: { SEMRUSH_PROJECTS_BASE_URL: 'https://sr.example.com' },
+      log,
+      dataAccess: { BrandSemrushProject: {} },
+      attributes: { authInfo: { getType: () => 'ims' } },
+      pathInfo: { headers: { authorization: 'Bearer ims-token' } },
+      ...overrides,
+    });
+
+    const loadFanOut = async (handleCreateProjectStub) => {
+      const mod = await esmock('../../../src/controllers/llmo/llmo-onboarding.js', {
+        '../../../src/support/serenity/handlers/projects.js': {
+          handleCreateProject: handleCreateProjectStub,
+        },
+        '../../../src/support/serenity/rest-transport.js': {
+          createSerenityTransport: createTransportStub,
+        },
+      });
+      return mod.performSerenityFanOut;
+    };
+
+    beforeEach(() => {
+      log = {
+        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+      };
+      createTransportStub = sinon.stub().returns({ id: 'transport' });
+    });
+
+    it('returns an empty result and makes no calls when markets is absent', async () => {
+      const hcp = sinon.stub();
+      const performSerenityFanOut = await loadFanOut(hcp);
+      const res = await performSerenityFanOut(makeContext(), { ...baseArgs, markets: undefined });
+      expect(res).to.deep.equal({ requested: [], succeeded: [], failed: [] });
+      expect(hcp).to.not.have.been.called;
+      expect(createTransportStub).to.not.have.been.called;
+    });
+
+    it('creates one project per tuple and collects successes (201)', async () => {
+      const hcp = sinon.stub();
+      hcp.onCall(0).resolves({ status: 201, body: { semrushProjectId: 'p-us', semrushLocationId: 2840 } });
+      hcp.onCall(1).resolves({ status: 201, body: { semrushProjectId: 'p-de', semrushLocationId: 2276 } });
+      const performSerenityFanOut = await loadFanOut(hcp);
+
+      const res = await performSerenityFanOut(makeContext(), baseArgs);
+
+      expect(res.requested).to.deep.equal([
+        { market: 'US', language: 'en' }, { market: 'DE', language: 'de' },
+      ]);
+      expect(res.succeeded).to.deep.equal([
+        {
+          market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+        },
+        {
+          market: 'DE', language: 'de', semrushProjectId: 'p-de', semrushLocationId: 2276,
+        },
+      ]);
+      expect(res.failed).to.be.empty;
+      expect(hcp).to.have.been.calledTwice;
+
+      // Body contract enforced by the proxy's validateCreateBody.
+      const [, , brandIdArg, wsArg, body] = hcp.firstCall.args;
+      expect(brandIdArg).to.equal('brand-uuid-1');
+      expect(wsArg).to.equal('ws-1');
+      expect(body.name).to.equal('example-brand · US · en');
+      expect(body.market).to.equal('US');
+      expect(body.language).to.equal('en');
+      expect(body.brandDomain).to.equal('example.com');
+      expect(body.brandNames).to.deep.equal(['Example Brand']);
+      expect(body.projectType).to.equal('ai');
+    });
+
+    it('treats 409 (slice already exists) as an idempotent success', async () => {
+      const hcp = sinon.stub().resolves({ status: 409, body: { semrushProjectId: 'p-existing' } });
+      const performSerenityFanOut = await loadFanOut(hcp);
+      const res = await performSerenityFanOut(
+        makeContext(),
+        { ...baseArgs, markets: [{ market: 'US', language: 'en' }] },
+      );
+      expect(res.succeeded).to.deep.equal([
+        { market: 'US', language: 'en', semrushProjectId: 'p-existing' },
+      ]);
+      expect(res.failed).to.be.empty;
+    });
+
+    it('collects per-tuple failures without aborting the remaining tuples', async () => {
+      const hcp = sinon.stub();
+      hcp.onCall(0).resolves({ status: 502, body: { error: 'semrushUpstreamError' } });
+      hcp.onCall(1).resolves({ status: 201, body: { semrushProjectId: 'p-de', semrushLocationId: 2276 } });
+      const performSerenityFanOut = await loadFanOut(hcp);
+
+      const res = await performSerenityFanOut(makeContext(), baseArgs);
+
+      expect(hcp).to.have.been.calledTwice;
+      expect(res.failed).to.deep.equal([
+        {
+          market: 'US', language: 'en', status: 502, error: 'semrushUpstreamError',
+        },
+      ]);
+      expect(res.succeeded).to.deep.equal([
+        {
+          market: 'DE', language: 'de', semrushProjectId: 'p-de', semrushLocationId: 2276,
+        },
+      ]);
+    });
+
+    it('records a thrown transport error as a failure and continues', async () => {
+      const hcp = sinon.stub();
+      const err = new Error('upstream 503');
+      err.status = 502;
+      hcp.onCall(0).rejects(err);
+      hcp.onCall(1).resolves({ status: 201, body: { semrushProjectId: 'p-de', semrushLocationId: 2276 } });
+      const performSerenityFanOut = await loadFanOut(hcp);
+
+      const res = await performSerenityFanOut(makeContext(), baseArgs);
+
+      expect(res.failed).to.deep.equal([
+        {
+          market: 'US', language: 'en', status: 502, error: 'upstream 503',
+        },
+      ]);
+      expect(res.succeeded).to.have.length(1);
+    });
+
+    it('fails all tuples when no IMS bearer is present', async () => {
+      const hcp = sinon.stub();
+      const performSerenityFanOut = await loadFanOut(hcp);
+      const res = await performSerenityFanOut(
+        makeContext({ pathInfo: { headers: {} } }),
+        baseArgs,
+      );
+      expect(hcp).to.not.have.been.called;
+      expect(createTransportStub).to.not.have.been.called;
+      expect(res.succeeded).to.be.empty;
+      expect(res.failed).to.deep.equal([
+        { market: 'US', language: 'en', status: 401, error: 'missingImsBearer' },
+        { market: 'DE', language: 'de', status: 401, error: 'missingImsBearer' },
+      ]);
+    });
+
+    it('fails all tuples when the caller did not authenticate with IMS', async () => {
+      const hcp = sinon.stub();
+      const performSerenityFanOut = await loadFanOut(hcp);
+      const res = await performSerenityFanOut(
+        makeContext({ attributes: { authInfo: { getType: () => 'jwt' } } }),
+        baseArgs,
+      );
+      expect(hcp).to.not.have.been.called;
+      expect(res.failed.map((f) => f.error)).to.deep.equal(['missingImsBearer', 'missingImsBearer']);
+    });
+
+    it('fails all tuples when the brand row is missing', async () => {
+      const hcp = sinon.stub();
+      const performSerenityFanOut = await loadFanOut(hcp);
+      const res = await performSerenityFanOut(makeContext(), { ...baseArgs, brandId: undefined });
+      expect(hcp).to.not.have.been.called;
+      expect(res.failed.map((f) => f.error)).to.deep.equal(['brandNotCreated', 'brandNotCreated']);
+    });
+
+    it('fails all tuples when the Semrush transport cannot be built', async () => {
+      const hcp = sinon.stub();
+      const tErr = new Error('SEMRUSH_PROJECTS_BASE_URL is not set');
+      tErr.status = 503;
+      createTransportStub.throws(tErr);
+      const performSerenityFanOut = await loadFanOut(hcp);
+
+      const res = await performSerenityFanOut(makeContext(), baseArgs);
+
+      expect(hcp).to.not.have.been.called;
+      expect(res.failed).to.deep.equal([
+        { market: 'US', language: 'en', status: 503, error: 'transportUnavailable' },
+        { market: 'DE', language: 'de', status: 503, error: 'transportUnavailable' },
+      ]);
+    });
+  });
+
   describe('buildInitialCustomerConfigV2', () => {
     it('builds a single active brand config for onboarding', async () => {
       const { buildInitialCustomerConfigV2 } = await esmock('../../../src/controllers/llmo/llmo-onboarding.js', {});

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -3796,8 +3796,12 @@ describe('LLMO Onboarding Functions', () => {
       expect(createTransportStub).to.not.have.been.called;
       expect(res.succeeded).to.be.empty;
       expect(res.failed).to.deep.equal([
-        { market: 'US', language: 'en', status: 401, error: 'missingImsBearer' },
-        { market: 'DE', language: 'de', status: 401, error: 'missingImsBearer' },
+        {
+          market: 'US', language: 'en', status: 401, error: 'missingImsBearer',
+        },
+        {
+          market: 'DE', language: 'de', status: 401, error: 'missingImsBearer',
+        },
       ]);
     });
 
@@ -3831,8 +3835,12 @@ describe('LLMO Onboarding Functions', () => {
 
       expect(hcp).to.not.have.been.called;
       expect(res.failed).to.deep.equal([
-        { market: 'US', language: 'en', status: 503, error: 'transportUnavailable' },
-        { market: 'DE', language: 'de', status: 503, error: 'transportUnavailable' },
+        {
+          market: 'US', language: 'en', status: 503, error: 'transportUnavailable',
+        },
+        {
+          market: 'DE', language: 'de', status: 503, error: 'transportUnavailable',
+        },
       ]);
     });
   });

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -3564,8 +3564,10 @@ describe('LLMO Onboarding Functions', () => {
       expect(thrown.status).to.equal(404);
       expect(thrown.preflight).to.be.true;
       expect(thrown.message).to.match(/Semrush workspace not bound to org org-serenity-cohort/);
-      // Fail-fast: nothing downstream of the org lookup should have run.
+      // Fail-fast: nothing downstream of the org lookup should have run —
+      // neither site creation nor any later config/audit step.
       expect(mockDataAccess.Site.create).to.not.have.been.called;
+      expect(mockDataAccess.Configuration.findLatest).to.not.have.been.called;
     });
 
     it('should skip serenity provisioning when org is not in SERENITY_SITE_ALLOWLIST', async () => {
@@ -3816,6 +3818,19 @@ describe('LLMO Onboarding Functions', () => {
       expect(res.failed.map((f) => f.error)).to.deep.equal(['missingImsBearer', 'missingImsBearer']);
     });
 
+    it('fails all tuples when the auth object cannot be classified as IMS (no getType)', async () => {
+      const hcp = sinon.stub();
+      const performSerenityFanOut = await loadFanOut(hcp);
+      // Unrecognisable auth shape (no getType) — must not forward the token.
+      const res = await performSerenityFanOut(
+        makeContext({ attributes: { authInfo: {} } }),
+        baseArgs,
+      );
+      expect(hcp).to.not.have.been.called;
+      expect(createTransportStub).to.not.have.been.called;
+      expect(res.failed.map((f) => f.error)).to.deep.equal(['missingImsBearer', 'missingImsBearer']);
+    });
+
     it('fails all tuples when the brand row is missing', async () => {
       const hcp = sinon.stub();
       const performSerenityFanOut = await loadFanOut(hcp);
@@ -3969,6 +3984,26 @@ describe('LLMO Onboarding Functions', () => {
       const res = await reconcileSerenityProjects(ctx, { brandId: 'b1', fanOut });
       expect(res).to.deep.equal(fanOut);
       expect(ctx.log.error).to.have.been.called;
+    });
+
+    it('fails an unknown market code (resolveLocation null) without throwing', async () => {
+      const reconcileSerenityProjects = await loadReconcile();
+      const fanOut = {
+        requested: [{ market: 'ZZ', language: 'en' }],
+        succeeded: [],
+        failed: [{
+          market: 'ZZ', language: 'en', status: 400, error: 'unknownMarket',
+        }],
+      };
+      // A row keyed to a real location must NOT be matched to the unknown 'ZZ' tuple.
+      const ctx = makeContext([dbRow(2840, 'en', 'p-us')]);
+      const res = await reconcileSerenityProjects(ctx, { brandId: 'b1', fanOut });
+      expect(res.succeeded).to.be.empty;
+      expect(res.failed).to.deep.equal([
+        {
+          market: 'ZZ', language: 'en', status: 400, error: 'unknownMarket',
+        },
+      ]);
     });
   });
 

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -3733,6 +3733,21 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       expect(performLlmoOnboardingStub.firstCall.args[0]).to.not.have.property('markets');
     });
+
+    it('should return 404 when performLlmoOnboarding reports a missing Semrush workspace (LLMO-5203)', async () => {
+      const workspaceError = new Error(
+        'Semrush workspace not bound to org org-1. Run PATCH /organizations/org-1 with { semrushWorkspaceId: ... } then retry onboarding.',
+      );
+      workspaceError.status = 404;
+      const failingStub = sinon.stub().rejects(workspaceError);
+      const ctrl = await makeOnboardController(failingStub);
+
+      const result = await ctrl.onboardCustomer(onboardingContext);
+
+      expect(result.status).to.equal(404);
+      const body = await result.json();
+      expect(body.message).to.match(/Semrush workspace not bound to org org-1/);
+    });
   });
 
   describe('offboardCustomer', () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -3748,6 +3748,67 @@ describe('LlmoController', () => {
       const body = await result.json();
       expect(body.message).to.match(/Semrush workspace not bound to org org-1/);
     });
+
+    it('should return 207 when some Semrush projects failed to provision (LLMO-5205)', async () => {
+      const stub = sinon.stub().resolves({
+        siteId: 'new-site-id',
+        organizationId: 'new-org-id',
+        baseURL: 'https://example.com',
+        dataFolder: 'dev/example-com',
+        message: 'LLMO onboarding completed successfully',
+        serenity: {
+          requested: [{ market: 'US', language: 'en' }, { market: 'DE', language: 'de' }],
+          succeeded: [{
+            market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+          }],
+          failed: [{
+            market: 'DE', language: 'de', status: 502, error: 'semrushUpstreamError',
+          }],
+        },
+      });
+      const ctrl = await makeOnboardController(stub);
+
+      const result = await ctrl.onboardCustomer(onboardingContext);
+
+      expect(result.status).to.equal(207);
+      const body = await result.json();
+      // Carries the standard onboarding fields plus the per-tuple arrays.
+      expect(body.siteId).to.equal('new-site-id');
+      expect(body.status).to.equal('completed');
+      expect(body.requested).to.have.length(2);
+      expect(body.succeeded).to.deep.equal([{
+        market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+      }]);
+      expect(body.failed).to.deep.equal([{
+        market: 'DE', language: 'de', status: 502, error: 'semrushUpstreamError',
+      }]);
+    });
+
+    it('should return 200 with the provisioning arrays when all Semrush projects succeeded (LLMO-5205)', async () => {
+      const stub = sinon.stub().resolves({
+        siteId: 'new-site-id',
+        organizationId: 'new-org-id',
+        baseURL: 'https://example.com',
+        dataFolder: 'dev/example-com',
+        message: 'LLMO onboarding completed successfully',
+        serenity: {
+          requested: [{ market: 'US', language: 'en' }],
+          succeeded: [{
+            market: 'US', language: 'en', semrushProjectId: 'p-us', semrushLocationId: 2840,
+          }],
+          failed: [],
+        },
+      });
+      const ctrl = await makeOnboardController(stub);
+
+      const result = await ctrl.onboardCustomer(onboardingContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.failed).to.deep.equal([]);
+      expect(body.succeeded).to.have.length(1);
+      expect(body.status).to.equal('completed');
+    });
   });
 
   describe('offboardCustomer', () => {


### PR DESCRIPTION
## Summary

Implements the full **T3** chain of the Semrush onboarding orchestrator (epic [LLMO-5007](https://jira.corp.adobe.com/browse/LLMO-5007)) inside `performLlmoOnboarding`, gated by the `SERENITY_SITE_ALLOWLIST` cohort gate:

| Step | Ticket | What |
|---|---|---|
| **M5** | [T3a / LLMO-5203](https://jira.corp.adobe.com/browse/LLMO-5203) | Fail fast (404) on missing Semrush workspace |
| **M7** | [T3b / LLMO-5204](https://jira.corp.adobe.com/browse/LLMO-5204) | Fan out one Semrush project per `(market, language)` tuple |
| **M8** | [T3c / LLMO-5205](https://jira.corp.adobe.com/browse/LLMO-5205) | Read back DB state, shape 200/207 response |

> ⚠️ **Stacked PR.** Base is `feat/LLMO-5201-5202-cohort-gate-markets` (PR #2513), not `main`. Merge/rebase after #2513 lands.

---

### M5 — fail fast on missing workspace (LLMO-5203)
Cohort org with no `semrushWorkspaceId` → **404** + operator-actionable message. **Hoisted** to right after `createOrFindOrganization` (before any site/brand state) so a 404 leaves nothing behind and "retry onboarding" works — per the design doc §M5 rationale. 404 not 412; no rollback. Implemented via a `status:404`/`preflight:true` throw mapped to `notFound` in the controller; cleanup `catch` skips rollback for pre-flight throws.

### M7 — fan out per market tuple (LLMO-5204)
`performSerenityFanOut` calls the shipped AIO Proxy handler `handleCreateProject` **in-process**, sequentially, one tuple at a time. Best-effort (§M7): per-tuple failures are collected, never abort the rest; **409 = idempotent success**. Keyed by the brand UUID (captured from `upsertBrand`) + the M5-validated workspace; the IMS bearer is forwarded to Semrush. Missing/non-IMS bearer, missing brand row, or unbuildable transport → recorded as per-tuple failures, not an onboarding failure.

### M8 — read back + shape 200/207 (LLMO-5205)
`reconcileSerenityProjects` reads `BrandSemrushProject.allByBrandId(brandId)` as the **authoritative** source — not the fan-out's own responses — so it also catches the "proxy returned 201 but the row insert failed silently" case. A requested tuple with a matching DB row is `succeeded`; one without is `failed` (enriched with the fan-out's status/error, else `projectRowMissing`). The controller returns **200** when all tuples are present, **207 Multi-Status** when any failed; both carry the standard onboarding fields plus `requested`/`succeeded`/`failed`. Successful tuples are never rolled back; re-invoking with the same `markets[]` is safe (proxy 409-dedupes).

## Tests
- **M5:** fail-fast (404, `preflight`, no `Site.create`); controller 404 mapping; existing allowlist test binds a workspace.
- **M7:** 9 unit tests for `performSerenityFanOut` (201 + body contract, 409 idempotency, partial failure, thrown transport error, no bearer, non-IMS auth, missing brand, transport-build failure, empty markets).
- **M8:** 6 unit tests for `reconcileSerenityProjects` (empty/no-brand short-circuit, all-present, missing tuple enriched from fan-out error, silently-missing row → `projectRowMissing`, read-back throws → fallback) + 2 controller tests (207 on partial failure, 200 when all succeed).
- `llmo-api.yaml`: 404 documented; 207 clarified to mirror the 200 body + arrays.

> **Note:** the suite was **not** run locally — this checkout can't `npm ci` here (needs Node 24; only Node 26 available, plus an unfetchable private git dep). Files pass `node --check`, OpenAPI YAML parses, no `max-len` issues. CI / a Node-24 env must run `npm test` + `npm run docs:lint`.

## Heads-up for @luis6156
Hoists the `serenityEnabled` cohort-gate evaluation to the M1/M2 position (matches T1/5201's "at the top" wording; PR #2513 placed it after `upsertBrand`). The M6–M8 block reuses the same boolean — reconcile between branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)