### PR TITLE
feat: per-target reviewer login (web tier)

### DIFF
--- a/src/controllers/webhooks.js
+++ b/src/controllers/webhooks.js
@@ -100,6 +100,9 @@ function WebhooksController(context) {
     const profile = ctx.attributes?.authInfo?.getProfile?.() || {};
     const targetId = profile.target_id;
     const appSlug = profile.app_slug || env.GITHUB_APP_SLUG;
+    // Per-target reviewer-gate identity. Set for non-default targets by the HMAC
+    // handler; the default/legacy path falls back to the global env knob.
+    const reviewerLogin = profile.reviewer_login || env.GITHUB_REVIEWER_LOGIN;
 
     // Security-relevant: which bot can trigger automated runs. In registry mode
     // this comes from the target's appSlug; in legacy mode from env. A missing
@@ -145,7 +148,7 @@ function WebhooksController(context) {
     }
 
     // Apply trigger rules (returns skip reason string or null)
-    const skipReason = getSkipReason(data, action, env, appSlug);
+    const skipReason = getSkipReason(data, action, env, appSlug, reviewerLogin);
     if (skipReason) {
       log.info('Skipping webhook', {
         skipReason,

--- a/src/support/github-targets.js
+++ b/src/support/github-targets.js
@@ -75,6 +75,23 @@ export function parseTargets(env) {
     if (isDefault && i !== parsed.length - 1) {
       throw new Error(`GITHUB_TARGETS default entry "${t.id}" must be last`);
     }
+    // reviewerLogin is the trigger-gate identity (the user we react to as the
+    // requested reviewer). REQUIRED on non-default (enterprise-matched) entries
+    // so a destination missing its reviewer fails loudly at config-load rather
+    // than silently falling back to the global GITHUB_REVIEWER_LOGIN (wrong for
+    // that destination). OPTIONAL on the default entry, which keeps the global
+    // fallback. When present, accept plain users (MysticatBot), EMU users
+    // (handle_shortcode), and App bots (slug[bot]).
+    if (!isDefault && (typeof t.reviewerLogin !== 'string' || !t.reviewerLogin.trim())) {
+      throw new Error(`GITHUB_TARGETS["${t.id}"] is missing a string "reviewerLogin" (required for non-default targets)`);
+    }
+    if (t.reviewerLogin !== undefined) {
+      if (typeof t.reviewerLogin !== 'string'
+        || t.reviewerLogin.length > 64
+        || !/^[A-Za-z0-9][A-Za-z0-9_-]*(\[bot\])?$/.test(t.reviewerLogin)) {
+        throw new Error(`GITHUB_TARGETS["${t.id}"].reviewerLogin must match ^[A-Za-z0-9][A-Za-z0-9_-]*(\\[bot\\])?$ and be at most 64 chars`);
+      }
+    }
   });
   const defaults = parsed.filter((t) => t.match?.default === true);
   if (defaults.length !== 1) {

--- a/src/support/github-webhook-hmac-handler.js
+++ b/src/support/github-webhook-hmac-handler.js
@@ -141,7 +141,14 @@ class GitHubWebhookHmacHandler extends AbstractHandler {
     }
     return new AuthInfo()
       .withAuthenticated(true)
-      .withProfile({ user_id: 'github-webhook', target_id: result.id, app_slug: result.appSlug })
+      .withProfile({
+        user_id: 'github-webhook',
+        target_id: result.id,
+        app_slug: result.appSlug,
+        // Per-target reviewer-gate identity (undefined on the default entry,
+        // which falls back to env.GITHUB_REVIEWER_LOGIN in the controller).
+        reviewer_login: result.reviewerLogin,
+      })
       .withType('github_webhook');
   }
 }

--- a/src/utils/github-trigger-rules.js
+++ b/src/utils/github-trigger-rules.js
@@ -27,9 +27,18 @@ export const EVENT_JOB_MAP = {
  * @param {string} action - The event action (e.g. 'review_requested', 'labeled')
  * @param {object} env - Environment variables
  * @param {string} [appSlug] - Allowed-bot slug; defaults to env.GITHUB_APP_SLUG
+ * @param {string} [reviewerLogin] - Per-target reviewer login; defaults to
+ *   env.GITHUB_REVIEWER_LOGIN. The requested reviewer must equal this (or
+ *   `${appSlug}[bot]` when both are unset) for review_requested to proceed.
  * @returns {string|null} Skip reason or null
  */
-export function getSkipReason(data, action, env, appSlug = env.GITHUB_APP_SLUG) {
+export function getSkipReason(
+  data,
+  action,
+  env,
+  appSlug = env.GITHUB_APP_SLUG,
+  reviewerLogin = env.GITHUB_REVIEWER_LOGIN,
+) {
   const pr = data.pull_request;
   // appSlug is resolved by the caller: the per-target appSlug in registry mode,
   // else env.GITHUB_APP_SLUG (the default). Used to form the expected bot
@@ -46,7 +55,7 @@ export function getSkipReason(data, action, env, appSlug = env.GITHUB_APP_SLUG) 
   // rather than a GitHub App bot.
   if (action === 'review_requested') {
     const reviewer = data.requested_reviewer?.login;
-    const expectedReviewer = env.GITHUB_REVIEWER_LOGIN?.trim() || `${appSlug}[bot]`;
+    const expectedReviewer = reviewerLogin?.trim() || `${appSlug}[bot]`;
     if (reviewer !== expectedReviewer) {
       return `reviewer ${reviewer} is not ${expectedReviewer}`;
     }

--- a/test/controllers/webhooks.test.js
+++ b/test/controllers/webhooks.test.js
@@ -400,6 +400,48 @@ describe('WebhooksController', () => {
       expect(mockSqs.sendMessage.calledOnce).to.be.true;
     });
 
+    it('uses the per-target reviewer_login from the profile to gate the trigger', async () => {
+      // Profile pins reviewer_login=emu_reviewer; requested reviewer matches ->
+      // enqueue (not skip), even though env.GITHUB_REVIEWER_LOGIN is unset and
+      // app_slug would otherwise expect mysticat-bot[bot].
+      const ctx = ghecAuthContext();
+      ctx.attributes.authInfo.getProfile = () => ({
+        user_id: 'github-webhook', target_id: 'ghec', app_slug: 'mysticat-bot', reviewer_login: 'emu_reviewer',
+      });
+      ctx.data = { ...ctx.data, requested_reviewer: { login: 'emu_reviewer' } };
+
+      const response = await controller.processGitHubWebhook(ctx);
+
+      expect(response.status).to.equal(202);
+      expect(mockSqs.sendMessage.calledOnce).to.be.true;
+    });
+
+    it('skips when the requested reviewer does not match the per-target reviewer_login', async () => {
+      const ctx = ghecAuthContext();
+      ctx.attributes.authInfo.getProfile = () => ({
+        user_id: 'github-webhook', target_id: 'ghec', app_slug: 'mysticat-bot', reviewer_login: 'emu_reviewer',
+      });
+      ctx.data = { ...ctx.data, requested_reviewer: { login: 'someone-else' } };
+
+      const response = await controller.processGitHubWebhook(ctx);
+
+      expect(response.status).to.equal(204);
+      expect(mockSqs.sendMessage.called).to.be.false;
+    });
+
+    it('falls back to env.GITHUB_REVIEWER_LOGIN when the profile has no reviewer_login (legacy)', async () => {
+      controller = buildController({ GITHUB_REVIEWER_LOGIN: 'MysticatBot' });
+      const ctx = {
+        ...validContext,
+        data: { ...validContext.data, requested_reviewer: { login: 'MysticatBot' } },
+      };
+
+      const response = await controller.processGitHubWebhook(ctx);
+
+      expect(response.status).to.equal(202);
+      expect(mockSqs.sendMessage.calledOnce).to.be.true;
+    });
+
     it('omits target_id when no auth profile target_id is present (legacy)', async () => {
       const response = await controller.processGitHubWebhook(validContext);
       expect(response.status).to.equal(202);

--- a/test/support/github-targets.test.js
+++ b/test/support/github-targets.test.js
@@ -15,7 +15,7 @@ import { parseTargets, classify, extractClassificationMetadata } from '../../src
 
 const VALID_TARGETS = JSON.stringify([
   {
-    id: 'ghec', match: { enterpriseSlug: ['adobe-prd'] }, appSlug: 'mysticat-bot', webhookSecretEnvVar: 'GITHUB_WEBHOOK_SECRET_GHEC',
+    id: 'ghec', match: { enterpriseSlug: ['adobe-prd'] }, appSlug: 'mysticat-bot', reviewerLogin: 'emu_reviewer', webhookSecretEnvVar: 'GITHUB_WEBHOOK_SECRET_GHEC',
   },
   {
     id: 'github-public', match: { default: true }, appSlug: 'mysticat-bot', webhookSecretEnvVar: 'GITHUB_WEBHOOK_SECRET',
@@ -46,7 +46,7 @@ describe('github-targets parseTargets', () => {
   it('throws on duplicate ids', () => {
     const dup = JSON.stringify([
       {
-        id: 'x', match: { enterpriseSlug: ['a'] }, appSlug: 's', webhookSecretEnvVar: 'V',
+        id: 'x', match: { enterpriseSlug: ['a'] }, appSlug: 's', reviewerLogin: 'r', webhookSecretEnvVar: 'V',
       },
       {
         id: 'x', match: { default: true }, appSlug: 's', webhookSecretEnvVar: 'W',
@@ -83,7 +83,7 @@ describe('github-targets parseTargets', () => {
 
   it('throws when there is not exactly one default', () => {
     const noDefault = JSON.stringify([{
-      id: 'ghec', match: { enterpriseSlug: ['a'] }, appSlug: 's', webhookSecretEnvVar: 'V',
+      id: 'ghec', match: { enterpriseSlug: ['a'] }, appSlug: 's', reviewerLogin: 'r', webhookSecretEnvVar: 'V',
     }]);
     expect(() => parseTargets({ GITHUB_TARGETS: noDefault })).to.throw('exactly one');
   });
@@ -119,6 +119,52 @@ describe('github-targets parseTargets', () => {
       id: 'GitHub_Public', match: { default: true }, appSlug: 's', webhookSecretEnvVar: 'V',
     }]);
     expect(() => parseTargets({ GITHUB_TARGETS: bad })).to.throw('target_id');
+  });
+});
+
+describe('github-targets parseTargets reviewerLogin', () => {
+  const withReviewer = (reviewerLogin) => JSON.stringify([
+    {
+      id: 'ghec', match: { enterpriseSlug: ['adobe-prd'] }, appSlug: 'mysticat-bot', reviewerLogin, webhookSecretEnvVar: 'GITHUB_WEBHOOK_SECRET_GHEC',
+    },
+    {
+      id: 'github-public', match: { default: true }, appSlug: 'mysticat-bot', webhookSecretEnvVar: 'GITHUB_WEBHOOK_SECRET',
+    },
+  ]);
+
+  it('parses reviewerLogin on a non-default entry', () => {
+    const targets = parseTargets({ GITHUB_TARGETS: withReviewer('emu_reviewer') });
+    expect(targets[0].reviewerLogin).to.equal('emu_reviewer');
+  });
+
+  it('accepts a slug[bot] reviewerLogin', () => {
+    const targets = parseTargets({ GITHUB_TARGETS: withReviewer('some-app[bot]') });
+    expect(targets[0].reviewerLogin).to.equal('some-app[bot]');
+  });
+
+  it('allows the default entry to omit reviewerLogin', () => {
+    const targets = parseTargets({ GITHUB_TARGETS: withReviewer('emu_reviewer') });
+    expect(targets[1].reviewerLogin).to.be.undefined;
+  });
+
+  it('throws when a non-default entry omits reviewerLogin', () => {
+    const noReviewer = JSON.stringify([
+      {
+        id: 'ghec', match: { enterpriseSlug: ['adobe-prd'] }, appSlug: 's', webhookSecretEnvVar: 'V',
+      },
+      {
+        id: 'github-public', match: { default: true }, appSlug: 's', webhookSecretEnvVar: 'W',
+      },
+    ]);
+    expect(() => parseTargets({ GITHUB_TARGETS: noReviewer })).to.throw('reviewerLogin');
+  });
+
+  it('throws when reviewerLogin has an invalid charset', () => {
+    expect(() => parseTargets({ GITHUB_TARGETS: withReviewer('bad login!') })).to.throw('reviewerLogin');
+  });
+
+  it('throws when reviewerLogin exceeds 64 chars', () => {
+    expect(() => parseTargets({ GITHUB_TARGETS: withReviewer('a'.repeat(65)) })).to.throw('reviewerLogin');
   });
 });
 

--- a/test/support/github-webhook-hmac-handler.test.js
+++ b/test/support/github-webhook-hmac-handler.test.js
@@ -67,6 +67,16 @@ describe('GitHubWebhookHmacHandler', () => {
     expect(result.authenticated).to.be.true;
   });
 
+  it('attaches no reviewer_login in legacy mode (no GITHUB_TARGETS)', async () => {
+    const sig = computeSignature(validPayload);
+    const request = makeRequest({ 'x-hub-signature-256': sig });
+    const context = makeContext();
+
+    const result = await handler.checkAuth(request, context);
+
+    expect(result.getProfile().reviewer_login).to.be.undefined;
+  });
+
   it('accepts webhook path without leading slash', async () => {
     const sig = computeSignature(validPayload);
     const request = makeRequest({ 'x-hub-signature-256': sig });
@@ -235,6 +245,7 @@ describe('GitHubWebhookHmacHandler', () => {
         id: 'ghec',
         match: { enterpriseSlug: ['adobe-prd'] },
         appSlug: 'mysticat-bot',
+        reviewerLogin: 'emu_reviewer',
         webhookSecretEnvVar: 'GITHUB_WEBHOOK_SECRET_GHEC',
       },
       {
@@ -283,6 +294,18 @@ describe('GitHubWebhookHmacHandler', () => {
       const result = await handler.checkAuth(request, registryContext());
       expect(result).to.not.be.null;
       expect(result.getProfile().target_id).to.equal('ghec');
+    });
+
+    it('attaches reviewer_login from the matched ghec target to the profile', async () => {
+      const request = makeRequest({ 'x-hub-signature-256': computeSignature(ghecBody, ghecSecret) }, ghecBody);
+      const result = await handler.checkAuth(request, registryContext());
+      expect(result.getProfile().reviewer_login).to.equal('emu_reviewer');
+    });
+
+    it('attaches no reviewer_login for the default (github-public) target', async () => {
+      const request = makeRequest({ 'x-hub-signature-256': computeSignature(publicBody, secret) }, publicBody);
+      const result = await handler.checkAuth(request, registryContext());
+      expect(result.getProfile().reviewer_login).to.be.undefined;
     });
 
     it('rejects a GHEC body signed with the github-public secret (wrong secret)', async () => {

--- a/test/utils/github-trigger-rules.test.js
+++ b/test/utils/github-trigger-rules.test.js
@@ -102,6 +102,41 @@ describe('github-trigger-rules', () => {
       });
     });
 
+    describe('per-target reviewerLogin (5th arg)', () => {
+      const baseReq = {
+        pull_request: { draft: false, base: { ref: 'main' } },
+        repository: { default_branch: 'main' },
+        sender: { type: 'User' },
+        action: 'review_requested',
+      };
+
+      it('returns null when the requested reviewer equals the 5th-arg reviewerLogin', () => {
+        const env = { GITHUB_APP_SLUG: 'mysticat-bot', GITHUB_REVIEWER_LOGIN: 'MysticatBot' };
+        const data = { ...baseReq, requested_reviewer: { login: 'emu_reviewer' } };
+        expect(getSkipReason(data, 'review_requested', env, 'mysticat-bot', 'emu_reviewer')).to.be.null;
+      });
+
+      it('returns the "is not" skip when the requested reviewer differs from the 5th-arg reviewerLogin', () => {
+        const env = { GITHUB_APP_SLUG: 'mysticat-bot', GITHUB_REVIEWER_LOGIN: 'MysticatBot' };
+        const data = { ...baseReq, requested_reviewer: { login: 'MysticatBot' } };
+        const reason = getSkipReason(data, 'review_requested', env, 'mysticat-bot', 'emu_reviewer');
+        expect(reason).to.include('MysticatBot');
+        expect(reason).to.include('emu_reviewer');
+      });
+
+      it('defaults to env.GITHUB_REVIEWER_LOGIN when the 5th arg is omitted (back-compat)', () => {
+        const env = { GITHUB_APP_SLUG: 'mysticat-bot', GITHUB_REVIEWER_LOGIN: 'MysticatBot' };
+        const data = { ...baseReq, requested_reviewer: { login: 'MysticatBot' } };
+        expect(getSkipReason(data, 'review_requested', env)).to.be.null;
+      });
+
+      it('falls back to appSlug[bot] when both the 5th arg and env are unset', () => {
+        const env = { GITHUB_APP_SLUG: 'mysticat-bot' };
+        const data = { ...baseReq, requested_reviewer: { login: 'mysticat-bot[bot]' } };
+        expect(getSkipReason(data, 'review_requested', env, 'mysticat-bot', undefined)).to.be.null;
+      });
+    });
+
     describe('labeled trigger (disabled)', () => {
       // Labeled triggers were disabled because GitHub does not count
       // label-triggered reviews toward branch protection / merge


### PR DESCRIPTION
## Summary

Implements the **web-tier half** of per-target reviewer login, per the plan in #2515 and the spec [`per-target-reviewer-login.md`](https://github.com/adobe/mysticat-architecture/blob/main/platform/decisions/per-target-reviewer-login.md) (adobe/mysticat-architecture#101; extends #94 / #2503). Companion worker PR: adobe/mysticat-github-service#33.

Threads a per-destination `reviewerLogin` from the `GITHUB_TARGETS` registry through the HMAC auth profile into the `getSkipReason` trigger gate, so a destination like `ghec` reacts to its own reviewer account instead of the global `MysticatBot`. Additive and backward-compatible.

- **`parseTargets`** (`github-targets.js`): validates a `reviewerLogin` per entry - **required** on non-`default` (enterprise-matched) entries (throws at config-parse), **optional** on the `default` catch-all; charset `^[A-Za-z0-9][A-Za-z0-9_-]*(\[bot\])?$`, max 64.
- **`github-webhook-hmac-handler.js`**: attaches the matched target's `reviewerLogin` to the post-HMAC auth profile as `reviewer_login`; legacy/no-match paths attach nothing.
- **`getSkipReason`** (`github-trigger-rules.js`): new 5th param `reviewerLogin = env.GITHUB_REVIEWER_LOGIN`; `expectedReviewer = reviewerLogin?.trim() || ${appSlug}[bot]`. `isMysticatTargetedSkip` unchanged; 3/4-arg callers unaffected.
- **`webhooks.js`**: resolves `profile.reviewer_login || env.GITHUB_REVIEWER_LOGIN` and passes it as the 5th arg.

TDD, one commit per task:
```
179c72b0 feat(github-targets): validate per-target reviewerLogin (required for non-default)
36df15e9 feat(github-webhook): attach per-target reviewer_login to auth profile
4dd62b75 feat(github-trigger-rules): add per-target reviewerLogin 5th arg to getSkipReason
b792c83f feat(webhooks): resolve per-target reviewer_login and pass to getSkipReason
```

## Test plan
- [x] `npm test` → **11030 passing**, 0 failing. New cases across `parseTargets` (required/optional/charset/length), HMAC profile (carries / legacy-omits), `getSkipReason` (5-arg match / mismatch / back-compat default / `[bot]` tail), controller (per-target gate / mismatch-skip / legacy-fallback).
- [x] `npm run lint` clean.
- [x] Independent spec-compliance + code-quality review: clean (all requirements met, nothing extra; existing `appSlug` test still green via the unchanged default path).

## Notes
- Three small adaptations vs the plan, all reviewed: the `dup`/`noDefault` fixtures gained a `reviewerLogin` (their first non-`default` entry now hits the new check before the duplicate-id/exactly-one check), and two lint fixes (multi-line signature for `max-len`; a test-description string for `no-template-curly-in-string`). No assertions weakened.
- **Deploy/config:** `github-public` (the `default` entry) omits `reviewerLogin` and falls back to `env.GITHUB_REVIEWER_LOGIN` per env. As the per-env reviewer model rolls out, dev's `GITHUB_REVIEWER_LOGIN` should be `MysticatBot-Dev` and prod's `MysticatBot`. `ghec` supplies its own `reviewerLogin` at cutover.