### PR TITLE
feat(auth): remove catch-all LegacyApiKeyHandler; S2S is the replacement (SITES-34224)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ const hasAccess = await accessControlUtil.hasAccess(
 1. JWT with scopes
 2. Adobe IMS
 3. Scoped API Key (fine-grained permissions)
-4. Legacy API Key (backward compatibility)
+4. Route-Scoped Legacy API Key (`POST /event/fulfillment` and `POST /slack/channels/invite-by-user-id` only — frozen list, SITES-34224)
 
 ### Queue-Based Async Pattern
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ import {
   notFound,
   authWrapper,
   enrichPathInfo,
-  LegacyApiKeyHandler,
   ScopedApiKeyHandler,
   AdobeImsHandler,
   JwtHandler,
@@ -383,7 +382,7 @@ const { WORKSPACE_EXTERNAL } = SLACK_TARGETS;
 
 // Wrapper execution order (helix-shared-wrap: last .with() = outermost = runs first):
 // 1. s2sAuthWrapper — intercepts S2S JWT bearer tokens, passes through non-S2S to authWrapper
-// 2. authWrapper — handles JWT, IMS, scoped API key, legacy API key
+// 2. authWrapper — handles JWT, IMS, scoped API key, route-scoped legacy API key
 // 3. readOnlyAdminWrapper — enforces read-only access for read-only admin tokens (see
 //    adobe/spacecat-shared#1469); routes not present in routeCapabilities default to deny
 //    (fail-closed), so unmapped routes are blocked for read-only admins
@@ -395,7 +394,8 @@ const { WORKSPACE_EXTERNAL } = SLACK_TARGETS;
 //    BEFORE path-agnostic handlers so a webhook request does not reach JwtHandler
 //    / AdobeImsHandler and fail with a misleading 401 on a missing JWT.
 //  - JwtHandler: tried first for token-bearing requests (JWT path is the target
-//    end-state for all consumers).
+//    end-state for all consumers). S2S consumers use s2sAuthWrapper; all new
+//    service integrations must onboard via S2S (SITES-34224).
 //  - ApiKeyImsHandler: route-scoped IMS handler (/tools/api-keys/*) for IaaS-only
 //    orgs that cannot acquire a JWT session token. Returns null for other paths,
 //    falling through to AdobeImsHandler. Once Auto-Fix (ASO-607) migrates and
@@ -404,13 +404,12 @@ const { WORKSPACE_EXTERNAL } = SLACK_TARGETS;
 //  - AdobeImsHandler: legacy global IMS path; kept for routes still on IMS auth
 //    (e.g. Auto-Fix). To be removed once all consumers are JWT-migrated.
 //  - ScopedApiKeyHandler: scoped API-key auth for Import-as-a-Service.
-//  - RouteScopedLegacyApiKeyHandler: route-scoped legacy API key handler for
-//    POST /event/fulfillment and POST /slack/channels/invite-by-user-id — the two
-//    admin endpoints whose callers cannot migrate to S2S. Returns null for all
-//    other routes. Must run BEFORE LegacyApiKeyHandler so the scoped handler owns
-//    those two routes explicitly. LegacyApiKeyHandler is kept for now and will be
-//    removed in a follow-up once all other consumers are confirmed migrated.
-//  - LegacyApiKeyHandler: legacy catch-all; to be removed in follow-up.
+//  - RouteScopedLegacyApiKeyHandler: the only remaining legacy-key surface. Owns
+//    exactly two routes whose external callers cannot be onboarded as IMS S2S
+//    consumers: POST /event/fulfillment (external fulfillment webhook) and
+//    POST /slack/channels/invite-by-user-id (external Slack integration).
+//    Returns null for every other path. The list is frozen — no new routes will
+//    be added; every new service integration must use S2S (SITES-34224).
 // When adding a new path-scoped handler, place it in the same position (after
 // SkipAuthHandler, before the path-agnostic handlers) to preserve early-bail.
 // AUTH_HANDLERS order is enforced by test/auth-handlers-order.test.js.
@@ -422,7 +421,6 @@ const AUTH_HANDLERS = [
   AdobeImsHandler,
   ScopedApiKeyHandler,
   RouteScopedLegacyApiKeyHandler,
-  LegacyApiKeyHandler,
 ];
 
 const wrappedMain = wrap(run)

--- a/src/support/route-scoped-legacy-api-key-handler.js
+++ b/src/support/route-scoped-legacy-api-key-handler.js
@@ -46,11 +46,7 @@ function isScopedRoute(method, suffix) {
  *
  * No constructor override — LegacyApiKeyHandler sets the handler name to
  * 'legacyApiKey', so authInfo.getType() returns 'legacyApiKey' here too.
- * Controllers that branch on auth type behave identically regardless of which
- * handler in the legacy-key family authenticated the request.
- *
- * TODO: Once the parent LegacyApiKeyHandler is removed from AUTH_HANDLERS
- * (planned follow-up), delete that removal note from src/index.js.
+ * Controllers that branch on auth type behave identically.
  */
 export default class RouteScopedLegacyApiKeyHandler extends LegacyApiKeyHandler {
   async checkAuth(request, context) {

--- a/src/support/route-scoped-legacy-api-key-handler.js
+++ b/src/support/route-scoped-legacy-api-key-handler.js
@@ -44,9 +44,9 @@ function isScopedRoute(method, suffix) {
  * sub-paths (e.g. POST /event/fulfillment/xxxx). All other requests receive null
  * and fall through to the next handler in the chain.
  *
- * No constructor override — LegacyApiKeyHandler sets the handler name to
- * 'legacyApiKey', so authInfo.getType() returns 'legacyApiKey' here too.
- * Controllers that branch on auth type behave identically.
+ * No constructor override — the parent class `LegacyApiKeyHandler` sets the
+ * handler name to 'legacyApiKey', so authInfo.getType() returns 'legacyApiKey'
+ * here too. Controllers that branch on auth type behave identically.
  */
 export default class RouteScopedLegacyApiKeyHandler extends LegacyApiKeyHandler {
   async checkAuth(request, context) {

--- a/test/auth-handlers-order.test.js
+++ b/test/auth-handlers-order.test.js
@@ -48,7 +48,7 @@ describe('src/index.js authHandlers order contract', () => {
 
     // Path-agnostic handlers must come after the path-scoped HMAC handler so
     // webhook requests do not reach them and fail with a misleading 401.
-    ['JwtHandler', 'AdobeImsHandler', 'ScopedApiKeyHandler', 'LegacyApiKeyHandler'].forEach((name) => {
+    ['JwtHandler', 'AdobeImsHandler', 'ScopedApiKeyHandler'].forEach((name) => {
       const idx = order.indexOf(name);
       expect(idx).to.be.greaterThan(-1, `${name} must be in AUTH_HANDLERS`);
       expect(ghIdx).to.be.lessThan(idx, `GitHubWebhookHmacHandler must come before ${name}`);
@@ -74,21 +74,17 @@ describe('src/index.js authHandlers order contract', () => {
     );
   });
 
-  it('places RouteScopedLegacyApiKeyHandler before LegacyApiKeyHandler', () => {
-    // The scoped handler explicitly owns POST /event/fulfillment and
-    // POST /slack/channels/invite-by-user-id. It must run before the catch-all
-    // LegacyApiKeyHandler so those routes are matched by the scoped handler
-    // rather than falling through to the parent. Both handlers remain in the
-    // chain until the follow-up cleanup removes LegacyApiKeyHandler.
+  it('contains RouteScopedLegacyApiKeyHandler but NOT the catch-all LegacyApiKeyHandler', () => {
+    // The catch-all LegacyApiKeyHandler has been removed (SITES-34224). All new
+    // service integrations must use S2S. The only remaining legacy-key surface is
+    // RouteScopedLegacyApiKeyHandler, which is locked to exactly two routes
+    // (POST /event/fulfillment and POST /slack/channels/invite-by-user-id) whose
+    // callers cannot be migrated to IMS S2S. The list is frozen.
     const order = parseAuthHandlersOrder();
     const scopedIdx = order.indexOf('RouteScopedLegacyApiKeyHandler');
     const legacyIdx = order.indexOf('LegacyApiKeyHandler');
 
-    expect(scopedIdx).to.be.greaterThan(-1, 'RouteScopedLegacyApiKeyHandler must be in AUTH_HANDLERS');
-    expect(legacyIdx).to.be.greaterThan(-1, 'LegacyApiKeyHandler must be in AUTH_HANDLERS');
-    expect(scopedIdx).to.be.lessThan(
-      legacyIdx,
-      'RouteScopedLegacyApiKeyHandler must come before LegacyApiKeyHandler',
-    );
+    expect(scopedIdx).to.be.greaterThan(-1, 'RouteScopedLegacyApiKeyHandler must remain in AUTH_HANDLERS');
+    expect(legacyIdx).to.equal(-1, 'LegacyApiKeyHandler must NOT be in AUTH_HANDLERS (removed: SITES-34224)');
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,6 +21,7 @@ import AccessControlUtil from '../src/support/access-control-util.js';
 use(sinonChai);
 
 const s2sAuthWrapperStub = (fn) => fn;
+const authWrapperStub = (fn) => fn;
 
 const tokowakaTestShim = {
   default: class TokowakaClientStub {
@@ -51,6 +52,7 @@ const { main } = await esmock(
   {
     '@adobe/spacecat-shared-http-utils': {
       s2sAuthWrapper: s2sAuthWrapperStub,
+      authWrapper: authWrapperStub,
     },
   },
   {


### PR DESCRIPTION
## Summary

Removes the catch-all `LegacyApiKeyHandler` from `AUTH_HANDLERS` in `src/index.js`. S2S authentication is now the supported path for all service integrations.

**What changes:**
- `LegacyApiKeyHandler` removed from the `AUTH_HANDLERS` array and import
- `RouteScopedLegacyApiKeyHandler` remains — it is locked to exactly two routes whose external callers cannot be onboarded as IMS S2S consumers:
  - `POST /event/fulfillment` (external fulfillment webhook, e.g. SFDC/commerce provisioning)
  - `POST /slack/channels/invite-by-user-id` (external Slack integration)
  - This list is **frozen** — no new routes will be added; every new service must use S2S
- `auth-handlers-order.test.js` updated: test now asserts `LegacyApiKeyHandler` is **absent** from `AUTH_HANDLERS` (regression guard so it cannot be re-added accidentally)
- Stale TODO comment removed from `route-scoped-legacy-api-key-handler.js`

**Why now:** SITES-34224 tracks removal of legacy API key auth as a security requirement. S2S is fully operational and is the replacement for all consumers. The `RouteScopedLegacyApiKeyHandler` decision is documented in `platform/decisions/route-scoped-legacy-api-key-handler.md`.

## Related
- Security ticket: https://jira.corp.adobe.com/browse/SITES-34224
- Decision doc: `mysticat-architecture/platform/decisions/route-scoped-legacy-api-key-handler.md`
- Companion PR: `adobe/spacecat-auth-service` feat/remove-legacy-api-key-handler

## Test plan
- [ ] `auth-handlers-order.test.js` — asserts `LegacyApiKeyHandler` absent, `RouteScopedLegacyApiKeyHandler` present
- [ ] `route-scoped-legacy-api-key-handler.test.js` — existing tests unchanged (scoped handler behaviour is identical)
- [ ] `POST /event/fulfillment` and `POST /slack/channels/invite-by-user-id` still authenticate via legacy API key through the scoped handler
- [ ] All other routes reject legacy API key requests (no handler in chain accepts them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)