### PR TITLE
fix: force download on agentic traffic export URLs | LLMO-4888

### DIFF
--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -769,7 +769,11 @@ export function createAgenticTrafficUrlsExportHandler(getSiteAndValidateAccess) 
           // Fast path: sign worker-written files[] directly. Validated first.
           if (metadata?.status === 'success'
             && Array.isArray(metadata.files) && metadata.files.length > 0) {
-            const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId);
+            const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId)
+              .sort((a, b) => {
+                const partNum = (k) => Number(k.match(PART_SUFFIX_PATTERN)?.[1] ?? 0);
+                return partNum(a) - partNum(b);
+              });
             if (safeFiles.length === metadata.files.length) {
               return buildExportReadyResponse(ctx, s3Bucket, exportId, safeFiles, metadata);
             }
@@ -873,7 +877,11 @@ export function createAgenticTrafficUrlsExportStatusHandler(getSiteAndValidateAc
           // Fast path: sign worker-written files[] directly. Validated first.
           if (metadata?.status === 'success'
             && Array.isArray(metadata.files) && metadata.files.length > 0) {
-            const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId);
+            const safeFiles = validateFilesAgainstPrefix(metadata.files, siteId, exportId)
+              .sort((a, b) => {
+                const partNum = (k) => Number(k.match(PART_SUFFIX_PATTERN)?.[1] ?? 0);
+                return partNum(a) - partNum(b);
+              });
             if (safeFiles.length === metadata.files.length) {
               return buildExportReadyResponse(ctx, s3Bucket, exportId, safeFiles, metadata);
             }

--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -333,8 +333,15 @@ async function buildExportReadyResponse(ctx, bucket, exportId, csvKeys, metadata
   const keysToSign = csvKeys.slice(0, MAX_EXPORT_DOWNLOAD_URLS);
   const { s3Region } = getExportConfig(ctx);
   const signingClient = getSigningClient(ctx, s3Region);
-  const downloadUrls = await Promise.all(keysToSign.map(async (key) => {
-    const command = new ctx.s3.GetObjectCommand({ Bucket: bucket, Key: key });
+  const downloadUrls = await Promise.all(keysToSign.map(async (key, i) => {
+    const partSuffix = keysToSign.length > 1 ? `_part${i + 1}` : '';
+    const filename = `urls${partSuffix}.csv`;
+    const command = new ctx.s3.GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      ResponseContentDisposition: `attachment; filename="${filename}"`,
+      ResponseContentType: 'text/csv; charset=utf-8',
+    });
     return ctx.s3.getSignedUrl(signingClient, command, { expiresIn });
   }));
   const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -1291,6 +1291,40 @@ describe('llmo-agentic-traffic', () => {
       expect(listCalls).to.have.length(0);
     });
 
+    it('sorts metadata.files by part number in fast path (out-of-order worker writes)', async () => {
+      const ctx = makeExportContext();
+      ctx.s3.getSignedUrl = sinon.stub()
+        .onFirstCall()
+        .resolves('https://signed.example.com/part1')
+        .onSecondCall()
+        .resolves('https://signed.example.com/part2');
+      ctx.s3.s3Client.send = sinon.stub().callsFake((command) => {
+        if (command instanceof ListObjectsV2Command) {
+          return Promise.reject(new Error('should not be called'));
+        }
+        const prefix = command.input.Key.replace(/\/metadata\.json$/, '');
+        return Promise.resolve({
+          Body: {
+            transformToString: () => Promise.resolve(JSON.stringify({
+              status: 'success',
+              rowCount: 20,
+              // Worker wrote part2 before part1 — fast path must sort before signing.
+              files: [`${prefix}/urls.csv_part2`, `${prefix}/urls.csv_part1`],
+            })),
+          },
+        });
+      });
+      const handler = createAgenticTrafficUrlsExportHandler(stubbedValidateAccess);
+      const res = await handler(ctx);
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.status).to.equal('ready');
+      const calls = ctx.s3.getSignedUrl.getCalls();
+      // After sorting, part1 key must be signed first.
+      expect(calls[0].args[1].input).to.include({ ResponseContentDisposition: 'attachment; filename="urls_part1.csv"' });
+      expect(calls[1].args[1].input).to.include({ ResponseContentDisposition: 'attachment; filename="urls_part2.csv"' });
+    });
+
     it('falls back to ListObjectsV2 when metadata.files contains out-of-prefix keys', async () => {
       // Defense in depth: worker bug / compromise writes wrong keys in files[];
       // producer must not sign URLs against them — falls back to ListObjectsV2

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -1283,6 +1283,9 @@ describe('llmo-agentic-traffic', () => {
       expect(res.status).to.equal(200);
       expect(body.status).to.equal('ready');
       expect(body.downloadUrls).to.have.length(1);
+      const [, cmd] = ctx.s3.getSignedUrl.firstCall.args;
+      expect(cmd.input.ResponseContentDisposition).to.equal('attachment; filename="urls.csv"');
+      expect(cmd.input.ResponseContentType).to.equal('text/csv; charset=utf-8');
       const listCalls = ctx.s3.s3Client.send.getCalls()
         .filter((c) => c.args[0] instanceof ListObjectsV2Command);
       expect(listCalls).to.have.length(0);
@@ -1713,6 +1716,15 @@ describe('llmo-agentic-traffic', () => {
       expect(body.rowCount).to.equal(10);
       expect(body.filesUploaded).to.equal(2);
       expect(body.bytesUploaded).to.equal(1000);
+      const getSignedUrlCalls = ctx.s3.getSignedUrl.getCalls();
+      expect(getSignedUrlCalls[0].args[1].input).to.include({
+        ResponseContentDisposition: 'attachment; filename="urls_part1.csv"',
+        ResponseContentType: 'text/csv; charset=utf-8',
+      });
+      expect(getSignedUrlCalls[1].args[1].input).to.include({
+        ResponseContentDisposition: 'attachment; filename="urls_part2.csv"',
+        ResponseContentType: 'text/csv; charset=utf-8',
+      });
     });
 
     it('returns failed (ADR enum + message) when metadata reports a failed export', async () => {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] Related issue linked below (LLMO-4888)
- [x] Fix commit includes the issue reference for release notes

If the PR is changing the API specification:
- N/A — no API contract change; presigned URL generation is internal.

If the PR is changing the API implementation or an entity exposed through the API:
- N/A — `ResponseContentDisposition` / `ResponseContentType` are `Response*` override parameters baked into the presigned URL query string. The stored S3 object is unchanged.

## Related Issues

LLMO-4888: https://jira.corp.adobe.com/browse/LLMO-4888

Chrome opens agentic traffic export CSVs inline as text instead of downloading them. Firefox and Safari handle it correctly. Root cause: presigned S3 URLs for `spacecat-prod-reports` (no CORS) lacked `Content-Disposition: attachment`, so Chrome renders the response inline.

Adds `ResponseContentDisposition: 'attachment; filename="urls.csv"'` and `ResponseContentType: 'text/csv; charset=utf-8'` to `GetObjectCommand` in `buildExportReadyResponse`. For multi-part exports the filename becomes `urls_part1.csv`, `urls_part2.csv`, etc. No import changes needed — these are first-class `GetObjectCommand` options.

Thanks for contributing!