### PR TITLE
Feat/llmo 5142 geo experiments s2s access

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -2081,9 +2081,10 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:read.
-    // The Layer 1 s2sAuthWrapper has already verified the route capability; this Layer 2
-    // re-fetches the consumer to defend against a stale/tampered context.
+    // S2S consumers (e.g. project-elmo-ui server flow) bypass org-membership when granted
+    // geoExperiment:read. The Layer 1 s2sAuthWrapper has already verified the route
+    // capability; this Layer 2 re-fetches the consumer to defend against a stale/tampered
+    // context. End-user (IMS/JWT) callers continue through hasAccess(site).
     const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:read');
     if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
@@ -2112,7 +2113,8 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:read.
+    // S2S consumers bypass org-membership when granted geoExperiment:read. See
+    // listGeoExperiments above for the full rationale.
     const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:read');
     if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
@@ -2170,9 +2172,7 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:write.
-    const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:write');
-    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
+    if (!await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
     }
 
@@ -2232,9 +2232,7 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:write.
-    const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:write');
-    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
+    if (!await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
     }
 

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -2081,7 +2081,11 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    if (!await accessControlUtil.hasAccess(site)) {
+    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:read.
+    // The Layer 1 s2sAuthWrapper has already verified the route capability; this Layer 2
+    // re-fetches the consumer to defend against a stale/tampered context.
+    const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:read');
+    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
     }
 
@@ -2108,7 +2112,9 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    if (!await accessControlUtil.hasAccess(site)) {
+    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:read.
+    const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:read');
+    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
     }
 
@@ -2164,7 +2170,9 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    if (!await accessControlUtil.hasAccess(site)) {
+    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:write.
+    const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:write');
+    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
     }
 
@@ -2224,7 +2232,9 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    if (!await accessControlUtil.hasAccess(site)) {
+    // S2S consumers (e.g. Mystique) bypass org-membership when granted geoExperiment:write.
+    const s2sResult = await accessControlUtil.hasS2SCapability('geoExperiment:write');
+    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not have access to this site');
     }
 

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -46,12 +46,6 @@ export const INTERNAL_ROUTES = [
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-preview',
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-live-preview',
 
-  // Geo experiment — list and detail endpoints (detail includes prompts) used by DRS/UI
-  'GET /sites/:siteId/geo-experiments',
-  'GET /sites/:siteId/geo-experiments/:geoExperimentId',
-  'PATCH /sites/:siteId/geo-experiments/:geoExperimentId',
-  'DELETE /sites/:siteId/geo-experiments/:geoExperimentId',
-
   // Slack - event subscriptions and commands use Slack's signature verification
   'GET /slack/events',
   'POST /slack/events',
@@ -386,6 +380,14 @@ const routeRequiredCapabilities = {
   'PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/status': 'suggestion:write',
   'PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'suggestion:write',
   'DELETE /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'suggestion:write',
+
+  // Geo experiments — used by Mystique (S2S) to poll/manage experiments initiated by edge-deploy.
+  // Scoped to a dedicated `geoExperiment` entity (not `experiment`) to avoid silently broadening
+  // the regular experiments capability. See LLMO-5142.
+  'GET /sites/:siteId/geo-experiments': 'geoExperiment:read',
+  'GET /sites/:siteId/geo-experiments/:geoExperimentId': 'geoExperiment:read',
+  'PATCH /sites/:siteId/geo-experiments/:geoExperimentId': 'geoExperiment:write',
+  'DELETE /sites/:siteId/geo-experiments/:geoExperimentId': 'geoExperiment:write',
 
   // Traffic
   'GET /sites/:siteId/traffic/paid': 'site:read',

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -46,6 +46,13 @@ export const INTERNAL_ROUTES = [
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-preview',
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-live-preview',
 
+  // Geo experiment mutations: admin-tooling only today (postman/curl via admin x-api-key).
+  // GET variants moved to routeRequiredCapabilities for project-elmo-ui's S2S read flow.
+  // Re-add to routeRequiredCapabilities (with geoExperiment:write) when a concrete S2S
+  // consumer needs to mutate experiments — keep affirmative-act principle. See LLMO-5142.
+  'PATCH /sites/:siteId/geo-experiments/:geoExperimentId',
+  'DELETE /sites/:siteId/geo-experiments/:geoExperimentId',
+
   // Slack - event subscriptions and commands use Slack's signature verification
   'GET /slack/events',
   'POST /slack/events',
@@ -381,13 +388,12 @@ const routeRequiredCapabilities = {
   'PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'suggestion:write',
   'DELETE /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'suggestion:write',
 
-  // Geo experiments — used by Mystique (S2S) to poll/manage experiments initiated by edge-deploy.
-  // Scoped to a dedicated `geoExperiment` entity (not `experiment`) to avoid silently broadening
-  // the regular experiments capability. See LLMO-5142.
+  // Geo experiments — list + detail reads exposed for project-elmo-ui S2S flow (commerce
+  // deploy & measure tab). Scoped to a dedicated `geoExperiment` entity (not `experiment`)
+  // to avoid silently broadening the regular experiments capability. PATCH/DELETE remain
+  // internal — admin-tooling only today, see INTERNAL_ROUTES. See LLMO-5142.
   'GET /sites/:siteId/geo-experiments': 'geoExperiment:read',
   'GET /sites/:siteId/geo-experiments/:geoExperimentId': 'geoExperiment:read',
-  'PATCH /sites/:siteId/geo-experiments/:geoExperimentId': 'geoExperiment:write',
-  'DELETE /sites/:siteId/geo-experiments/:geoExperimentId': 'geoExperiment:write',
 
   // Traffic
   'GET /sites/:siteId/traffic/paid': 'site:read',

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -8404,7 +8404,7 @@ describe('Suggestions Controller', () => {
       AccessControlUtil.prototype.hasAccess.restore();
       const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
       const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
-        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
+        allowed: true, reason: 'granted', clientId: 's2s-client', consumerId: 'c1',
       });
       mockSuggestionDataAccess.GeoExperiment.allBySiteId = sandbox.stub().resolves({
         data: [],
@@ -8558,7 +8558,7 @@ describe('Suggestions Controller', () => {
       AccessControlUtil.prototype.hasAccess.restore();
       const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
       const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
-        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
+        allowed: true, reason: 'granted', clientId: 's2s-client', consumerId: 'c1',
       });
       context.s3.s3Client.send.rejects(new Error('no prompts'));
       const response = await suggestionsController.getGeoExperiment({
@@ -8731,22 +8731,6 @@ describe('Suggestions Controller', () => {
         data: { name: 'New Name' },
       });
       expect(response.status).to.equal(403);
-    });
-
-    it('allows S2S consumer with geoExperiment:write when org access is missing', async () => {
-      AccessControlUtil.prototype.hasAccess.restore();
-      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
-      const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
-        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
-      });
-      const response = await suggestionsController.patchGeoExperiment({
-        ...context,
-        params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
-        data: { name: 'Updated by mystique' },
-      });
-      expect(response.status).to.equal(200);
-      expect(s2sStub).to.have.been.calledWith('geoExperiment:write');
-      expect(hasAccessStub).to.not.have.been.called;
     });
 
     it('returns 404 when GeoExperiment not found', async () => {
@@ -8929,22 +8913,6 @@ describe('Suggestions Controller', () => {
         params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
       });
       expect(response.status).to.equal(403);
-    });
-
-    it('allows S2S consumer with geoExperiment:write when org access is missing', async () => {
-      AccessControlUtil.prototype.hasAccess.restore();
-      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
-      const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
-        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
-      });
-      const response = await suggestionsController.deleteGeoExperiment({
-        ...context,
-        params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
-      });
-      expect(response.status).to.equal(204);
-      expect(s2sStub).to.have.been.calledWith('geoExperiment:write');
-      expect(hasAccessStub).to.not.have.been.called;
-      expect(mockGeoExperiment.remove).to.have.been.calledOnce;
     });
 
     it('returns 404 when GeoExperiment not found', async () => {

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -8400,6 +8400,25 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(403);
     });
 
+    it('allows S2S consumer with geoExperiment:read when org access is missing', async () => {
+      AccessControlUtil.prototype.hasAccess.restore();
+      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
+      const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
+        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
+      });
+      mockSuggestionDataAccess.GeoExperiment.allBySiteId = sandbox.stub().resolves({
+        data: [],
+        cursor: null,
+      });
+      const response = await suggestionsController.listGeoExperiments({
+        ...context,
+        params: { siteId: SITE_ID },
+      });
+      expect(response.status).to.equal(200);
+      expect(s2sStub).to.have.been.calledWith('geoExperiment:read');
+      expect(hasAccessStub).to.not.have.been.called;
+    });
+
     it('returns list of experiments without prompts', async () => {
       const makeExp = (id, name, status, phase) => ({
         getId: () => id,
@@ -8533,6 +8552,22 @@ describe('Suggestions Controller', () => {
         params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
       });
       expect(response.status).to.equal(403);
+    });
+
+    it('allows S2S consumer with geoExperiment:read when org access is missing', async () => {
+      AccessControlUtil.prototype.hasAccess.restore();
+      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
+      const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
+        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
+      });
+      context.s3.s3Client.send.rejects(new Error('no prompts'));
+      const response = await suggestionsController.getGeoExperiment({
+        ...context,
+        params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
+      });
+      expect(response.status).to.equal(200);
+      expect(s2sStub).to.have.been.calledWith('geoExperiment:read');
+      expect(hasAccessStub).to.not.have.been.called;
     });
 
     it('returns notFound when GeoExperiment is missing', async () => {
@@ -8696,6 +8731,22 @@ describe('Suggestions Controller', () => {
         data: { name: 'New Name' },
       });
       expect(response.status).to.equal(403);
+    });
+
+    it('allows S2S consumer with geoExperiment:write when org access is missing', async () => {
+      AccessControlUtil.prototype.hasAccess.restore();
+      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
+      const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
+        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
+      });
+      const response = await suggestionsController.patchGeoExperiment({
+        ...context,
+        params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
+        data: { name: 'Updated by mystique' },
+      });
+      expect(response.status).to.equal(200);
+      expect(s2sStub).to.have.been.calledWith('geoExperiment:write');
+      expect(hasAccessStub).to.not.have.been.called;
     });
 
     it('returns 404 when GeoExperiment not found', async () => {
@@ -8878,6 +8929,22 @@ describe('Suggestions Controller', () => {
         params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
       });
       expect(response.status).to.equal(403);
+    });
+
+    it('allows S2S consumer with geoExperiment:write when org access is missing', async () => {
+      AccessControlUtil.prototype.hasAccess.restore();
+      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
+      const s2sStub = sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({
+        allowed: true, reason: 'granted', clientId: 'mystique', consumerId: 'c1',
+      });
+      const response = await suggestionsController.deleteGeoExperiment({
+        ...context,
+        params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
+      });
+      expect(response.status).to.equal(204);
+      expect(s2sStub).to.have.been.calledWith('geoExperiment:write');
+      expect(hasAccessStub).to.not.have.been.called;
+      expect(mockGeoExperiment.remove).to.have.been.calledOnce;
     });
 
     it('returns 404 when GeoExperiment not found', async () => {


### PR DESCRIPTION
## Summary

Expose the two read-only geo-experiment endpoints to S2S consumers behind a
dedicated `geoExperiment:read` capability, so `project-elmo-ui`'s Commerce
Deploy & Measure flow can list and poll experiments it initiated via
`edge-deploy`. PATCH/DELETE remain internal — no S2S consumer needs them
today, and we want to follow the repo's "opening to S2S is an affirmative
act" principle (see `docs/s2s/READALL_CAPABILITY_DESIGN.md`).

Ref: [LLMO-5142](https://jira.corp.adobe.com/browse/LLMO-5142)

## Problem

Today the four `/sites/:siteId/geo-experiments` routes are in `INTERNAL_ROUTES`,
which means the Layer-1 `s2sAuthWrapper` rejects every S2S JWT at the gate.
That blocks `project-elmo-ui`'s server-side polling flow with a 403, even
though the consumer is fully trusted and only needs to read.

## What changed

- **`src/routes/required-capabilities.js`**
  - Move `GET /sites/:siteId/geo-experiments` and
    `GET /sites/:siteId/geo-experiments/:geoExperimentId` out of
    `INTERNAL_ROUTES` into `routeRequiredCapabilities` behind
    `geoExperiment:read`.
  - Use a dedicated `geoExperiment` entity (not the existing `experiment`
    scope) so we don't silently broaden any capability granted for the
    regular experiments API.
  - PATCH/DELETE stay in `INTERNAL_ROUTES` with an updated rationale
    comment.
- **`src/controllers/suggestions.js`**
  - `listGeoExperiments` and `getGeoExperiment` gain a Layer-2
    `accessControlUtil.hasS2SCapability('geoExperiment:read')` check
    that bypasses `hasAccess(site)` for granted S2S consumers.
  - End-user (IMS/JWT) callers continue through the existing
    `hasAccess(site)` org-membership gate — unchanged behaviour.
  - Pattern matches the existing dual-gate approach in `sites.js` and
    `organizations.js`.
- **`test/controllers/suggestions.test.js`**
  - Two new test cases (one per handler) asserting that an S2S consumer
    with `geoExperiment:read` succeeds when org-membership is missing,
    and that `hasAccess` is not called on that path.

## Why narrow to GET only

Verified across the workspace that the only S2S-flavoured caller is
`project-elmo-ui`'s Commerce Deploy & Measure tab, which only calls the
list + detail GETs. No caller (mystique, spacecat workers, drs-client,
llmo-usage-report-node) uses PATCH/DELETE via S2S. PATCH/DELETE today are
admin-tooling only (postman/curl via admin `x-api-key`, per the original
author's note in `INTERNAL_ROUTES`). We can add `geoExperiment:write` later
when a concrete S2S consumer proves the need.

## Out of scope (filed separately)

- DRS `POST /schedules` returns `422 "Could not resolve spacecat_org_id from
  site_id: <UUID>"` for some sites, which blocks end-to-end testing of the
  Deploy & Measure flow regardless of this PR. Tracked in
  [LLMO-5268](https://jira.corp.adobe.com/browse/LLMO-5268), related family
  to LLMO-5150. Not addressed here.

## Operational follow-up (post-merge)

The `geoExperiment:read` capability must be granted on the relevant S2S
Consumer record before `project-elmo-ui`'s server-side flow can succeed
end-to-end. See `docs/s2s/S2S_ADMIN_GUIDE.md` for the registration /
capability-grant procedure.

## Test plan

- [x] `npm run test` — full suite passes locally (incl. the 2 new cases)
- [x] `npm run lint` — clean
- [ ] Reviewer: confirm the dedicated `geoExperiment:*` capability naming is
      preferred over re-using `experiment:*`
- [ ] Reviewer: confirm the "GET-only first, add `:write` later" framing
      aligns with the `READALL_CAPABILITY_DESIGN.md` principle
- [ ] Post-merge: grant `geoExperiment:read` to the project-elmo-ui Consumer
      record in dev → smoke-test against a site whose DRS mapping is intact
      (e.g. main `frescopa.coffee`, not `frescopa-dba`) to avoid the
      unrelated LLMO-5268 422


