### PR TITLE
fix(prompts): transform flat intent_* RPC fields into nested intents object

### DIFF
--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -832,15 +832,10 @@ export async function getPromptStats({ organizationId, brandUuid, postgrestClien
     throw new Error(`getPromptStats RPC failed: ${error.message}`);
   }
 
-  const row = Array.isArray(data) && data.length > 0 ? data[0] : (data ?? {});
-  const intents = Object.fromEntries(INTENT_VALUES.map((k) => [k, 0]));
-  if (row.intents && typeof row.intents === 'object') {
-    for (const [k, v] of Object.entries(row.intents)) {
-      if (INTENT_VALUES.includes(k)) {
-        intents[k] = Number(v) || 0;
-      }
-    }
-  }
+  const row = Array.isArray(data) ? (data[0] ?? {}) : (data ?? {});
+  const intents = Object.fromEntries(
+    INTENT_VALUES.map((k) => [k, Number(row[`intent_${k}`]) || 0]),
+  );
 
   return {
     branded: Number(row.branded) || 0,

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -2062,17 +2062,16 @@ describe('Brands Controller', () => {
 
   describe('getPromptStatsByBrand', () => {
     const BRAND_UUID = 'd1111111-1111-4111-b111-111111111111';
-    const STATS_RESPONSE = {
+    // RPC returns flat intent_* fields; the storage layer transforms them to nested intents
+    const STATS_RPC_ROW = {
       branded: 42,
       unbranded: 1208,
-      intents: {
-        informational: 410,
-        instructional: 180,
-        comparative: 95,
-        transactional: 250,
-        planning: 60,
-        delegation: 15,
-      },
+      intent_informational: 410,
+      intent_instructional: 180,
+      intent_comparative: 95,
+      intent_transactional: 250,
+      intent_planning: 60,
+      intent_delegation: 15,
     };
 
     beforeEach(() => {
@@ -2087,7 +2086,7 @@ describe('Brands Controller', () => {
             return Promise.resolve({ data: null, error: null });
           }),
         })),
-        rpc: sandbox.stub().resolves({ data: STATS_RESPONSE, error: null }),
+        rpc: sandbox.stub().resolves({ data: STATS_RPC_ROW, error: null }),
       };
       brandsController = BrandsController(context, loggerStub, mockEnv);
     });
@@ -2185,7 +2184,7 @@ describe('Brands Controller', () => {
       const body = await response.json();
       expect(body).to.have.property('branded', 42);
       expect(body).to.have.property('unbranded', 1208);
-      expect(body).to.have.property('intents').that.includes({ informational: 410, delegation: 15 });
+      expect(body.intents).to.deep.include({ informational: 410, delegation: 15 });
     });
 
     it('returns 500 when storage throws and logs the error', async () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -2116,8 +2116,34 @@ describe('prompts-storage', () => {
       expect(result).to.deep.equal({ branded: 0, unbranded: 0, intents: ALL_ZERO_INTENTS });
     });
 
-    it('returns correct counts from a single-object RPC response', async () => {
+    it('returns all-zero shape when RPC returns an empty array', async () => {
+      const client = { rpc: sandbox.stub().resolves({ data: [], error: null }) };
+      const result = await getPromptStats({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        postgrestClient: client,
+      });
+      expect(result).to.deep.equal({ branded: 0, unbranded: 0, intents: ALL_ZERO_INTENTS });
+    });
+
+    it('transforms flat intent_* RPC fields into nested intents object', async () => {
       const row = {
+        branded: 42,
+        unbranded: 1208,
+        intent_informational: 410,
+        intent_instructional: 180,
+        intent_comparative: 95,
+        intent_transactional: 250,
+        intent_planning: 60,
+        intent_delegation: 15,
+      };
+      const client = { rpc: sandbox.stub().resolves({ data: row, error: null }) };
+      const result = await getPromptStats({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        postgrestClient: client,
+      });
+      expect(result).to.deep.equal({
         branded: 42,
         unbranded: 1208,
         intents: {
@@ -2128,22 +2154,31 @@ describe('prompts-storage', () => {
           planning: 60,
           delegation: 15,
         },
-      };
-      const client = { rpc: sandbox.stub().resolves({ data: row, error: null }) };
-      const result = await getPromptStats({
-        organizationId: ORG_ID,
-        brandUuid: BRAND_UUID,
-        postgrestClient: client,
       });
-      expect(result).to.deep.equal({ branded: 42, unbranded: 1208, intents: row.intents });
       const [rpcName, rpcArgs] = client.rpc.firstCall.args;
       expect(rpcName).to.equal('rpc_brand_prompt_stats');
       expect(rpcArgs.p_organization_id).to.equal(ORG_ID);
       expect(rpcArgs.p_brand_id).to.equal(BRAND_UUID);
     });
 
-    it('returns correct counts from an array RPC response', async () => {
+    it('transforms flat intent_* fields from an array RPC response', async () => {
       const row = {
+        branded: 5,
+        unbranded: 10,
+        intent_informational: 3,
+        intent_instructional: 2,
+        intent_comparative: 0,
+        intent_transactional: 0,
+        intent_planning: 0,
+        intent_delegation: 0,
+      };
+      const client = { rpc: sandbox.stub().resolves({ data: [row], error: null }) };
+      const result = await getPromptStats({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        postgrestClient: client,
+      });
+      expect(result).to.deep.equal({
         branded: 5,
         unbranded: 10,
         intents: {
@@ -2154,17 +2189,10 @@ describe('prompts-storage', () => {
           planning: 0,
           delegation: 0,
         },
-      };
-      const client = { rpc: sandbox.stub().resolves({ data: [row], error: null }) };
-      const result = await getPromptStats({
-        organizationId: ORG_ID,
-        brandUuid: BRAND_UUID,
-        postgrestClient: client,
       });
-      expect(result).to.deep.equal({ branded: 5, unbranded: 10, intents: row.intents });
     });
 
-    it('defaults all intent keys to 0 when intents field is absent', async () => {
+    it('defaults all intent keys to 0 when intent fields are absent', async () => {
       const client = {
         rpc: sandbox.stub().resolves({ data: { branded: 3, unbranded: 7 }, error: null }),
       };
@@ -2176,13 +2204,14 @@ describe('prompts-storage', () => {
       expect(result).to.deep.equal({ branded: 3, unbranded: 7, intents: ALL_ZERO_INTENTS });
     });
 
-    it('filters out unknown intent keys returned by the RPC', async () => {
+    it('ignores unknown intent_* fields from the RPC', async () => {
       const client = {
         rpc: sandbox.stub().resolves({
           data: {
             branded: 1,
             unbranded: 1,
-            intents: { informational: 5, unknown_future_intent: 99 },
+            intent_informational: 5,
+            intent_unknown_future: 99,
           },
           error: null,
         }),
@@ -2192,8 +2221,25 @@ describe('prompts-storage', () => {
         brandUuid: BRAND_UUID,
         postgrestClient: client,
       });
-      expect(result.intents).to.not.have.property('unknown_future_intent');
+      expect(result.intents).to.not.have.property('unknown_future');
       expect(result.intents.informational).to.equal(5);
+    });
+
+    it('correctly coerces stringified bigint values returned by PostgREST', async () => {
+      const client = {
+        rpc: sandbox.stub().resolves({
+          data: { branded: '42', unbranded: '1208', intent_informational: '410' },
+          error: null,
+        }),
+      };
+      const result = await getPromptStats({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        postgrestClient: client,
+      });
+      expect(result.branded).to.equal(42);
+      expect(result.unbranded).to.equal(1208);
+      expect(result.intents.informational).to.equal(410);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up fix to #2528. The `rpc_brand_prompt_stats` RPC returns flat `intent_informational`, `intent_instructional` etc. fields, but the endpoint was returning them as-is instead of transforming into the spec's nested `intents` shape.

**Before:**
```json
{ "branded": 2129, "unbranded": 57029, "intent_informational": 0, ... }
```

**After:**
```json
{
  "branded": 2129,
  "unbranded": 57029,
  "intents": { "informational": 0, "instructional": 0, ... }
}
```

Also updates tests to mock the actual RPC flat-field shape and assert the correct nested output.

## Test plan

- [x] Unit tests pass locally (360 passing)
- [x] Lint clean

Generated with [Claude Code](https://claude.com/claude-code)