### PR TITLE
feat(agentic-rules): customer-edit endpoints for URL classification rules (LLMO-5037)

### DIFF
--- a/docs/openapi/agentic-rules-api.yaml
+++ b/docs/openapi/agentic-rules-api.yaml
@@ -52,7 +52,7 @@ agentic-categories-list:
           schema:
             $ref: '#/AgenticRuleCreateRequest'
     responses:
-      '200':
+      '201':
         description: Rule created
         content:
           application/json:
@@ -185,7 +185,7 @@ agentic-page-types-list:
           schema:
             $ref: '#/AgenticRuleCreateRequest'
     responses:
-      '200':
+      '201':
         description: Rule created
         content:
           application/json:

--- a/docs/openapi/agentic-rules-api.yaml
+++ b/docs/openapi/agentic-rules-api.yaml
@@ -1,0 +1,359 @@
+# Customer-edit endpoints for auto-derived URL classification rules.
+# Two parallel dimensions (categories + page-types) sharing one shape:
+#   - `agentic_url_category_rules`
+#   - `agentic_url_page_type_rules`
+# Customers paste sample URLs; the server computes a matching regex via
+# the regex-from-urls 4-strategy ladder (common-prefix → universal-token
+# → disjoint-cover → literal-fallback). See src/support/regex-from-urls.js.
+
+# ───────────────────────────── categories ─────────────────────────────
+
+agentic-categories-list:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - site
+      - agentic rules
+    summary: List URL category rules for a site
+    description: Returns auto-derived + customer-edited URL category rules.
+    operationId: listAgenticCategories
+    responses:
+      '200':
+        description: List of category rules
+        content:
+          application/json:
+            schema:
+              $ref: '#/AgenticRuleListResponse'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404-site-not-found-with-id' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+  post:
+    tags:
+      - site
+      - agentic rules
+    summary: Create a URL category rule from sample URLs
+    description: |
+      Computes a matching regex from the supplied sample URLs and persists
+      it with `source='human'`. Returns 409 if a sample URL already belongs
+      to another active rule on the same site, if the rule name collides
+      with an existing active rule, or if the site already has the maximum of
+      20 active category rules.
+    operationId: createAgenticCategory
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/AgenticRuleCreateRequest'
+    responses:
+      '200':
+        description: Rule created
+        content:
+          application/json:
+            schema:
+              $ref: '#/AgenticRule'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404-site-not-found-with-id' }
+      '409': { $ref: '#/AgenticRuleConflictResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+
+agentic-categories-one:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+    - name: name
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Rule name (unique per site).
+  patch:
+    tags:
+      - site
+      - agentic rules
+    summary: Edit a URL category rule
+    description: |
+      Edit `name`, `urls`, or `newRegex`. Any customer edit marks the rule
+      `source='human'`; `updated_at` is bumped automatically. Returns 409 if
+      a supplied sample URL already belongs to a different active rule.
+    operationId: updateAgenticCategory
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/AgenticRuleUpdateRequest'
+    responses:
+      '200':
+        description: Rule updated
+        content:
+          application/json:
+            schema:
+              $ref: '#/AgenticRule'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404' }
+      '409': { $ref: '#/AgenticRuleConflictResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+  delete:
+    tags:
+      - site
+      - agentic rules
+    summary: Delete a URL category rule
+    description: |
+      Soft delete — flips the rule's `status` to `deleted` and stamps
+      `updated_by`, retaining the row for audit. The deleted name becomes
+      free to re-create. Runtime classification and the list endpoint only
+      return active rules.
+    operationId: deleteAgenticCategory
+    responses:
+      '200':
+        description: Rule deleted
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deleted: { type: boolean }
+                name: { type: string }
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+
+# ───────────────────────────── page-types ─────────────────────────────
+# Identical shape to categories — re-uses the same schemas.
+
+agentic-page-types-list:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - site
+      - agentic rules
+    summary: List URL page-type rules for a site
+    operationId: listAgenticPageTypes
+    responses:
+      '200':
+        description: List of page-type rules
+        content:
+          application/json:
+            schema:
+              $ref: '#/AgenticRuleListResponse'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404-site-not-found-with-id' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+  post:
+    tags:
+      - site
+      - agentic rules
+    summary: Create a URL page-type rule from sample URLs
+    description: |
+      Computes a matching regex from the supplied sample URLs and persists
+      it with `source='human'`. Returns 409 if a sample URL already belongs
+      to another active rule on the same site, if the rule name collides
+      with an existing active rule, or if the site already has the maximum of
+      20 active page-type rules.
+    operationId: createAgenticPageType
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/AgenticRuleCreateRequest'
+    responses:
+      '200':
+        description: Rule created
+        content:
+          application/json:
+            schema:
+              $ref: '#/AgenticRule'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404-site-not-found-with-id' }
+      '409': { $ref: '#/AgenticRuleConflictResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+
+agentic-page-types-one:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+    - name: name
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Rule name (unique per site).
+  patch:
+    tags:
+      - site
+      - agentic rules
+    summary: Edit a URL page-type rule
+    description: |
+      Edit `name`, `urls`, or `newRegex`. Any customer edit marks the rule
+      `source='human'`; `updated_at` is bumped automatically. Returns 409 if
+      a supplied sample URL already belongs to a different active rule.
+    operationId: updateAgenticPageType
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/AgenticRuleUpdateRequest'
+    responses:
+      '200':
+        description: Rule updated
+        content:
+          application/json:
+            schema:
+              $ref: '#/AgenticRule'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404' }
+      '409': { $ref: '#/AgenticRuleConflictResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+  delete:
+    tags:
+      - site
+      - agentic rules
+    summary: Delete a URL page-type rule
+    description: |
+      Soft delete — flips the rule's `status` to `deleted` and stamps
+      `updated_by`, retaining the row for audit. The deleted name becomes
+      free to re-create. Runtime classification and the list endpoint only
+      return active rules.
+    operationId: deleteAgenticPageType
+    responses:
+      '200':
+        description: Rule deleted
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deleted: { type: boolean }
+                name: { type: string }
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '404': { $ref: './responses.yaml#/404' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - ims_key: [ ]
+      - scoped_api_key: [ ]
+
+# ─────────────────────────────── schemas ──────────────────────────────
+
+AgenticRule:
+  type: object
+  description: |
+    A single URL classification rule. The same shape is used for both
+    categories and page-types.
+  properties:
+    id: { type: string, format: uuid }
+    siteId: { type: string, format: uuid }
+    name: { type: string }
+    regex: { type: string }
+    sortOrder: { type: [integer, 'null'] }
+    source:
+      type: string
+      enum: [ai, human]
+      description: Provenance — `ai` (audit-worker auto-derivation) or `human` (customer create, edit, or confirm).
+    sampleUrls:
+      type: array
+      items: { type: string }
+      description: Representative URLs that define the rule (hard cap 50, each ≤ 2048 chars).
+    derivationMethod:
+      type: [string, 'null']
+      enum: [llm, common-prefix, universal-token, disjoint-cover, literal-fallback, customer, null]
+      description: How the regex was produced. `llm` for auto-derived; customer-edit API writes `customer` (or a regex-from-urls strategy). NULL for legacy rules.
+    createdAt:
+      type: string
+      format: date-time
+    updatedAt:
+      type: string
+      format: date-time
+    createdBy:
+      type: [string, 'null']
+      description: Identifier of the user or system that first created the rule. Set once on create and never modified.
+    updatedBy:
+      type: [string, 'null']
+      description: Identifier of the user or system that last wrote the rule. Rewritten on every edit.
+
+AgenticRuleListResponse:
+  type: object
+  description: |
+    List of active rules. v1 has no cursor pagination; the result is capped at
+    1000 rules per site (well above expected cardinality). A truncated response
+    is logged server-side.
+  properties:
+    items:
+      type: array
+      items: { $ref: '#/AgenticRule' }
+
+AgenticRuleConflictResponse:
+  description: |
+    Conflict — the rule name already exists for an active rule on the site, a
+    supplied sample URL already belongs to another active rule, or the site has
+    reached the maximum of 20 active rules for this dimension.
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          message: { type: string }
+
+AgenticRuleCreateRequest:
+  type: object
+  required: [name, urls]
+  properties:
+    name: { type: string, maxLength: 200 }
+    urls:
+      type: array
+      minItems: 1
+      maxItems: 50
+      items: { type: string, maxLength: 2048 }
+
+AgenticRuleUpdateRequest:
+  type: object
+  description: |
+    All fields are optional. Provide either `urls` (regex re-derived) or
+    `newRegex` (advanced — verbatim, validated for compile + length cap).
+  properties:
+    newName: { type: string, maxLength: 200 }
+    urls:
+      type: array
+      minItems: 1
+      maxItems: 50
+      items: { type: string, maxLength: 2048 }
+    newRegex: { type: string }

--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -310,6 +310,14 @@ paths:
     $ref: './url-store-api.yaml#/url-store-get'
   /sites/{siteId}/url-store/delete:
     $ref: './url-store-api.yaml#/url-store-delete'
+  /sites/{siteId}/agentic-categories:
+    $ref: './agentic-rules-api.yaml#/agentic-categories-list'
+  /sites/{siteId}/agentic-categories/{name}:
+    $ref: './agentic-rules-api.yaml#/agentic-categories-one'
+  /sites/{siteId}/agentic-page-types:
+    $ref: './agentic-rules-api.yaml#/agentic-page-types-list'
+  /sites/{siteId}/agentic-page-types/{name}:
+    $ref: './agentic-rules-api.yaml#/agentic-page-types-one'
   /sites/{siteId}/traffic/paid:
     $ref: './site-paid.yaml#/site-traffic-paid-top-pages'
   /sites/{siteId}/traffic/paid/url-page-type:

--- a/src/controllers/agentic-categories.js
+++ b/src/controllers/agentic-categories.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createRulesController } from './agentic-rules-factory.js';
+
+/**
+ * Customer-edit endpoints for auto-derived URL category rules
+ * (`agentic_url_category_rules`).
+ */
+export default function AgenticCategoriesController() {
+  return createRulesController({
+    tableName: 'agentic_url_category_rules',
+    dimensionLabel: 'category',
+  });
+}

--- a/src/controllers/agentic-page-types.js
+++ b/src/controllers/agentic-page-types.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createRulesController } from './agentic-rules-factory.js';
+
+/**
+ * Customer-edit endpoints for auto-derived URL page-type rules
+ * (`agentic_url_page_type_rules`).
+ */
+export default function AgenticPageTypesController() {
+  return createRulesController({
+    tableName: 'agentic_url_page_type_rules',
+    dimensionLabel: 'page type',
+  });
+}

--- a/src/controllers/agentic-rules-factory.js
+++ b/src/controllers/agentic-rules-factory.js
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  badRequest, createResponse, forbidden, internalServerError, notFound, ok,
+} from '@adobe/spacecat-shared-http-utils';
+import {
+  hasText, isArray, isNonEmptyObject, isValidUUID,
+} from '@adobe/spacecat-shared-utils';
+
+import AccessControlUtil from '../support/access-control-util.js';
+import { AgenticRuleDto } from '../dto/agentic-rule.js';
+import { regexFromUrls, validateUserRegex } from '../support/regex-from-urls.js';
+
+/**
+ * Factory for site-scoped customer-edit endpoints over an auto-derived URL
+ * classification table. Both `agentic_url_category_rules` and
+ * `agentic_url_page_type_rules` share the same shape; controllers diverge
+ * only by table name and human-readable label.
+ *
+ * Source semantics (DB CHECK allows only `ai` | `human`).
+ * `derivation_method`: NULL or one of `llm`, `common-prefix`, `universal-token`,
+ * `disjoint-cover`, `literal-fallback`, `customer`.
+ */
+
+const SOURCE_HUMAN = 'human';
+const DERIVATION_CUSTOMER = 'customer';
+const STATUS_ACTIVE = 'active';
+const STATUS_DELETED = 'deleted';
+
+// Input ceilings mirror the OpenAPI contract; enforced server-side.
+const MAX_SAMPLE_URLS = 50;
+const MAX_URL_LEN = 2048;
+const MAX_NAME_LEN = 200;
+// Hard ceiling on total active rules per site+dimension (auto + customer).
+// Enforced on the create endpoint only; the DB itself is uncapped.
+const MAX_ACTIVE_RULES_PER_SITE = 20;
+// Defensive cap on the active-rule scans (list + cross-rule dedup).
+const MAX_ACTIVE_RULES_SCAN = 1000;
+
+function isValidUrlListBody(urls) {
+  return isArray(urls)
+    && urls.length > 0
+    && urls.length <= MAX_SAMPLE_URLS
+    && urls.every((u) => hasText(u) && u.length <= MAX_URL_LEN);
+}
+
+const URL_LIST_ERROR = `urls must be a non-empty array of at most ${MAX_SAMPLE_URLS} strings, each at most ${MAX_URL_LEN} characters`;
+
+// The router stores path segments raw (route-utils.js leaves them URL-encoded),
+// so a rule name with spaces/special chars arrives as e.g. 'Blog%20Posts'.
+// Decode it before querying by name, or PATCH/DELETE can never match the row.
+function decodeRuleName(context) {
+  const raw = context.params?.name;
+  if (!hasText(raw)) {
+    return { error: badRequest('rule name is required') };
+  }
+  try {
+    return { name: decodeURIComponent(raw) };
+  } catch {
+    return { error: badRequest('rule name is not valid') };
+  }
+}
+
+// Identity from the IMS Bearer token. authorize() gates on hasAccess(), so the
+// 'system' fallback should be unreachable — warn if it fires.
+function getUserIdentifier(context) {
+  const authInfo = context.attributes?.authInfo;
+  const profile = authInfo?.getProfile?.();
+  const identity = profile?.email || profile?.name;
+  if (!identity) {
+    context.log?.warn?.('agentic-rule mutation has no authenticated user identity; attributing to "system"');
+    return 'system';
+  }
+  return identity;
+}
+
+// Normalize a URL/path for cross-rule dedup: trim, drop a trailing slash,
+// lowercase. Comparison only — the stored sample_urls keep their original form.
+function normalizeUrl(url) {
+  return String(url).trim().replace(/\/+$/, '').toLowerCase();
+}
+
+/**
+ * Scan the site+dimension's active rules: returns the cross-rule sample-URL
+ * conflict (if any) and the active rule count (for the per-site cap).
+ * Note: this is a read-then-write check — two concurrent writers can still
+ * race past it. Acceptable for v1 (low write rate); revisit with a DB
+ * constraint if it becomes a real problem.
+ */
+async function findSampleUrlConflict(client, tableName, siteId, urls, excludeName) {
+  const { data, error } = await client
+    .from(tableName)
+    .select('name,sample_urls')
+    .eq('site_id', siteId)
+    .eq('status', STATUS_ACTIVE)
+    .limit(MAX_ACTIVE_RULES_SCAN);
+  if (error) {
+    return { error };
+  }
+  // rules serves both purposes: dedup (the owners map) and the per-site cap
+  // (rules.length below).
+  const rules = data || [];
+  const owners = new Map();
+  rules.forEach((rule) => {
+    if (rule.name === excludeName) {
+      return;
+    }
+    (rule.sample_urls || []).forEach((u) => owners.set(normalizeUrl(u), rule.name));
+  });
+  const conflict = urls
+    .map((u) => ({ url: u, owner: owners.get(normalizeUrl(u)) }))
+    .find((c) => c.owner);
+  return { conflict, ruleCount: rules.length };
+}
+
+/**
+ * Create a rules controller bound to a specific table.
+ * @param {object} params
+ * @param {string} params.tableName - PostgREST table name.
+ * @param {string} params.dimensionLabel - Human-readable label, e.g. 'category'.
+ * @returns {object} Object with method handlers.
+ */
+export function createRulesController({ tableName, dimensionLabel }) {
+  if (!hasText(tableName) || !hasText(dimensionLabel)) {
+    throw new Error('tableName and dimensionLabel are required');
+  }
+
+  async function authorize(context) {
+    const { siteId } = context.params || {};
+    if (!isValidUUID(siteId)) {
+      return { error: badRequest('Site ID required') };
+    }
+    if (!isNonEmptyObject(context.dataAccess)) {
+      return { error: internalServerError('Data access not available') };
+    }
+    const client = context.dataAccess.services?.postgrestClient;
+    if (!client?.from) {
+      return { error: internalServerError('PostgREST client is not available') };
+    }
+    const { Site } = context.dataAccess;
+    const site = await Site.findById(siteId);
+    if (!site) {
+      return { error: notFound('Site not found') };
+    }
+    const ac = AccessControlUtil.fromContext(context);
+    if (!await ac.hasAccess(site)) {
+      return { error: forbidden(`Only users belonging to the organization can manage ${dimensionLabel} rules`) };
+    }
+    return { siteId, client };
+  }
+
+  function logAndFail(context, err, action) {
+    /* c8 ignore next -- err.message is always populated by callers */
+    const msg = err?.message || 'unknown error';
+    context.log?.error?.(`Failed to ${action} ${dimensionLabel} rule (code=${err?.code ?? 'n/a'}): ${msg}`);
+    // PostgREST surfaces the Postgres unique-violation SQLSTATE (23505) when a
+    // rule name collides with the UNIQUE (site_id, name) constraint. Map it to a
+    // 409 with an actionable message instead of an opaque 500.
+    if (err?.code === '23505') {
+      return createResponse(
+        { message: `A ${dimensionLabel} rule with that name already exists` },
+        409,
+      );
+    }
+    return internalServerError(`Failed to ${action} ${dimensionLabel} rule`);
+  }
+
+  /** GET /sites/:siteId/agentic-{dimension} */
+  async function list(context) {
+    const auth = await authorize(context);
+    if (auth.error) {
+      return auth.error;
+    }
+    const { siteId, client } = auth;
+    // v1 has no cursor; bound the scan so it can't return unbounded rows.
+    const { data, error } = await client
+      .from(tableName)
+      .select('*')
+      .eq('site_id', siteId)
+      .eq('status', STATUS_ACTIVE)
+      .limit(MAX_ACTIVE_RULES_SCAN)
+      .order('sort_order', { ascending: true });
+    if (error) {
+      return logAndFail(context, error, 'list');
+    }
+    const items = (data || []).map(AgenticRuleDto.toJSON);
+    // No cursor in v1: warn if we hit the cap so silent truncation is visible.
+    if (items.length === MAX_ACTIVE_RULES_SCAN) {
+      context.log?.warn?.(`${dimensionLabel} rule list truncated at ${MAX_ACTIVE_RULES_SCAN} for site ${siteId}`);
+    }
+    return ok({ items });
+  }
+
+  /** POST /sites/:siteId/agentic-{dimension} */
+  async function create(context) {
+    const auth = await authorize(context);
+    if (auth.error) {
+      return auth.error;
+    }
+    const { siteId, client } = auth;
+    const body = context.data || {};
+    // Trim so whitespace can't create "invisible" name conflicts.
+    const name = hasText(body.name) ? body.name.trim() : '';
+    if (!name) {
+      return badRequest('name is required');
+    }
+    if (name.length > MAX_NAME_LEN) {
+      return badRequest(`name must be at most ${MAX_NAME_LEN} characters`);
+    }
+    if (!isValidUrlListBody(body.urls)) {
+      return badRequest(URL_LIST_ERROR);
+    }
+    let derived;
+    try {
+      derived = regexFromUrls(body.urls);
+    } catch (err) {
+      return badRequest(err.message);
+    }
+    context.log?.info?.(`regexFromUrls result: method=${derived.method} regex=${derived.regex} evidence=${derived.evidence}`);
+
+    const dedup = await findSampleUrlConflict(client, tableName, siteId, body.urls);
+    if (dedup.error) {
+      return logAndFail(context, dedup.error, 'create');
+    }
+    if (dedup.ruleCount >= MAX_ACTIVE_RULES_PER_SITE) {
+      return createResponse(
+        { message: `Site has reached the maximum of ${MAX_ACTIVE_RULES_PER_SITE} active ${dimensionLabel} rules` },
+        409,
+      );
+    }
+    if (dedup.conflict) {
+      return createResponse(
+        { message: `URL "${dedup.conflict.url}" already belongs to ${dimensionLabel} rule "${dedup.conflict.owner}"` },
+        409,
+      );
+    }
+
+    const identity = getUserIdentifier(context);
+    const row = {
+      site_id: siteId,
+      name,
+      regex: derived.regex,
+      source: SOURCE_HUMAN,
+      sample_urls: body.urls,
+      derivation_method: DERIVATION_CUSTOMER,
+      // created_by is set once here; update()/remove() only touch updated_by so
+      // the original author survives later edits by a different user.
+      created_by: identity,
+      updated_by: identity,
+    };
+    const { data, error } = await client
+      .from(tableName)
+      .insert(row)
+      .select()
+      .maybeSingle();
+    if (error) {
+      return logAndFail(context, error, 'create');
+    }
+    // maybeSingle() resolves to null (no error) when the INSERT returns zero rows
+    // — e.g. an RLS filter excludes the row. Do not report success in that case.
+    if (!data) {
+      return internalServerError(`Failed to create ${dimensionLabel} rule`);
+    }
+    return ok(AgenticRuleDto.toJSON(data));
+  }
+
+  /**
+   * PATCH /sites/:siteId/agentic-{dimension}/:name
+   * Body may include `newName`, `urls`, `newRegex`.
+   */
+  async function update(context) {
+    const auth = await authorize(context);
+    if (auth.error) {
+      return auth.error;
+    }
+    const { siteId, client } = auth;
+    const decoded = decodeRuleName(context);
+    if (decoded.error) {
+      return decoded.error;
+    }
+    const { name } = decoded;
+    const body = context.data || {};
+    const hasNewName = body.newName !== undefined;
+    const hasUrls = body.urls !== undefined;
+    const hasNewRegex = body.newRegex !== undefined;
+    if (hasUrls && hasNewRegex) {
+      return badRequest('provide either urls or newRegex, not both');
+    }
+    // Reject an empty patch. Without this, a PATCH {} would silently set only
+    // source='human' — laundering an ai rule's provenance with no content change.
+    if (!hasNewName && !hasUrls && !hasNewRegex) {
+      return badRequest('at least one of newName, urls, or newRegex is required');
+    }
+    const newName = hasNewName && hasText(body.newName) ? body.newName.trim() : '';
+    if (hasNewName && !newName) {
+      return badRequest('newName must be a non-empty string');
+    }
+    if (hasNewName && newName.length > MAX_NAME_LEN) {
+      return badRequest(`newName must be at most ${MAX_NAME_LEN} characters`);
+    }
+
+    const fetched = await client
+      .from(tableName)
+      .select('*')
+      .eq('site_id', siteId)
+      .eq('name', name)
+      .eq('status', STATUS_ACTIVE)
+      .maybeSingle();
+    if (fetched.error) {
+      return logAndFail(context, fetched.error, 'update');
+    }
+    if (!fetched.data) {
+      return notFound(`${dimensionLabel} rule not found`);
+    }
+
+    const patch = { source: SOURCE_HUMAN, updated_by: getUserIdentifier(context) };
+    if (hasNewName) {
+      patch.name = newName;
+    }
+    if (hasUrls) {
+      if (!isValidUrlListBody(body.urls)) {
+        return badRequest(URL_LIST_ERROR);
+      }
+      const dedup = await findSampleUrlConflict(client, tableName, siteId, body.urls, name);
+      if (dedup.error) {
+        return logAndFail(context, dedup.error, 'update');
+      }
+      if (dedup.conflict) {
+        return createResponse(
+          { message: `URL "${dedup.conflict.url}" already belongs to ${dimensionLabel} rule "${dedup.conflict.owner}"` },
+          409,
+        );
+      }
+      try {
+        const derived = regexFromUrls(body.urls);
+        context.log?.info?.(`regexFromUrls result: method=${derived.method} regex=${derived.regex} evidence=${derived.evidence}`);
+        patch.regex = derived.regex;
+        patch.sample_urls = body.urls;
+        patch.derivation_method = DERIVATION_CUSTOMER;
+      } catch (err) {
+        return badRequest(err.message);
+      }
+    }
+    if (hasNewRegex) {
+      try {
+        patch.regex = validateUserRegex(body.newRegex);
+        patch.derivation_method = DERIVATION_CUSTOMER;
+      } catch (err) {
+        return badRequest(err.message);
+      }
+    }
+
+    const { data, error } = await client
+      .from(tableName)
+      .update(patch)
+      .eq('site_id', siteId)
+      .eq('name', name)
+      .eq('status', STATUS_ACTIVE)
+      .select()
+      .maybeSingle();
+    if (error) {
+      return logAndFail(context, error, 'update');
+    }
+    if (!data) {
+      return notFound(`${dimensionLabel} rule not found`);
+    }
+    return ok(AgenticRuleDto.toJSON(data));
+  }
+
+  /**
+   * DELETE /sites/:siteId/agentic-{dimension}/:name
+   * Soft delete: flip status to 'deleted' and stamp who, retaining the row for
+   * audit. The active-rows partial unique index lets the name be re-created.
+   */
+  async function remove(context) {
+    const auth = await authorize(context);
+    if (auth.error) {
+      return auth.error;
+    }
+    const { siteId, client } = auth;
+    const decoded = decodeRuleName(context);
+    if (decoded.error) {
+      return decoded.error;
+    }
+    const { name } = decoded;
+    const { data, error } = await client
+      .from(tableName)
+      .update({ status: STATUS_DELETED, updated_by: getUserIdentifier(context) })
+      .eq('site_id', siteId)
+      .eq('name', name)
+      .eq('status', STATUS_ACTIVE)
+      .select()
+      .maybeSingle();
+    if (error) {
+      return logAndFail(context, error, 'delete');
+    }
+    if (!data) {
+      return notFound(`${dimensionLabel} rule not found`);
+    }
+    return ok({ deleted: true, name });
+  }
+
+  return {
+    list, create, update, remove,
+  };
+}
+
+export default createRulesController;

--- a/src/controllers/agentic-rules-factory.js
+++ b/src/controllers/agentic-rules-factory.js
@@ -11,7 +11,7 @@
  */
 
 import {
-  badRequest, createResponse, forbidden, internalServerError, notFound, ok,
+  badRequest, created, createResponse, forbidden, internalServerError, notFound, ok,
 } from '@adobe/spacecat-shared-http-utils';
 import {
   hasText, isArray, isNonEmptyObject, isValidUUID,
@@ -19,7 +19,7 @@ import {
 
 import AccessControlUtil from '../support/access-control-util.js';
 import { AgenticRuleDto } from '../dto/agentic-rule.js';
-import { regexFromUrls, validateUserRegex } from '../support/regex-from-urls.js';
+import { regexFromUrls, validateUserRegex, toComparablePath } from '../support/regex-from-urls.js';
 
 /**
  * Factory for site-scoped customer-edit endpoints over an auto-derived URL
@@ -84,11 +84,12 @@ function getUserIdentifier(context) {
   return identity;
 }
 
-// Normalize a URL/path for cross-rule dedup: trim, drop a trailing slash,
-// lowercase. Comparison only — the stored sample_urls keep their original form.
-function normalizeUrl(url) {
-  return String(url).trim().replace(/\/+$/, '').toLowerCase();
-}
+// Normalize for cross-rule dedup through the SAME extract→strip-locale pipeline
+// derivation uses, so two URLs that derive the same regex are detected as a
+// conflict regardless of scheme/host/locale/extension (e.g. "/products/a",
+// "https://x/products/a", "/en-us/products/a" all collapse to one key).
+// Comparison only — the stored sample_urls keep their original form.
+const normalizeUrl = toComparablePath;
 
 /**
  * Scan the site+dimension's active rules: returns the cross-rule sample-URL
@@ -135,7 +136,11 @@ export function createRulesController({ tableName, dimensionLabel }) {
     throw new Error('tableName and dimensionLabel are required');
   }
 
-  async function authorize(context) {
+  // `requireAdmin` gates mutations (create/update/delete) behind the LLMO-admin
+  // claim, matching every sibling LLMO customer-edit endpoint; reads only need
+  // org membership. hasAccess() must precede isLLMOAdministrator() so the
+  // delegation-aware check works (see llmo.js convention).
+  async function authorize(context, { requireAdmin = false } = {}) {
     const { siteId } = context.params || {};
     if (!isValidUUID(siteId)) {
       return { error: badRequest('Site ID required') };
@@ -155,6 +160,9 @@ export function createRulesController({ tableName, dimensionLabel }) {
     const ac = AccessControlUtil.fromContext(context);
     if (!await ac.hasAccess(site)) {
       return { error: forbidden(`Only users belonging to the organization can manage ${dimensionLabel} rules`) };
+    }
+    if (requireAdmin && !ac.isLLMOAdministrator()) {
+      return { error: forbidden(`Only LLMO administrators can modify ${dimensionLabel} rules`) };
     }
     return { siteId, client };
   }
@@ -203,7 +211,7 @@ export function createRulesController({ tableName, dimensionLabel }) {
 
   /** POST /sites/:siteId/agentic-{dimension} */
   async function create(context) {
-    const auth = await authorize(context);
+    const auth = await authorize(context, { requireAdmin: true });
     if (auth.error) {
       return auth.error;
     }
@@ -271,7 +279,7 @@ export function createRulesController({ tableName, dimensionLabel }) {
     if (!data) {
       return internalServerError(`Failed to create ${dimensionLabel} rule`);
     }
-    return ok(AgenticRuleDto.toJSON(data));
+    return created(AgenticRuleDto.toJSON(data));
   }
 
   /**
@@ -279,7 +287,7 @@ export function createRulesController({ tableName, dimensionLabel }) {
    * Body may include `newName`, `urls`, `newRegex`.
    */
   async function update(context) {
-    const auth = await authorize(context);
+    const auth = await authorize(context, { requireAdmin: true });
     if (auth.error) {
       return auth.error;
     }
@@ -383,7 +391,7 @@ export function createRulesController({ tableName, dimensionLabel }) {
    * audit. The active-rows partial unique index lets the name be re-created.
    */
   async function remove(context) {
-    const auth = await authorize(context);
+    const auth = await authorize(context, { requireAdmin: true });
     if (auth.error) {
       return auth.error;
     }

--- a/src/dto/agentic-rule.js
+++ b/src/dto/agentic-rule.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * DTO for `agentic_url_category_rules` / `agentic_url_page_type_rules` PostgREST
+ * rows. Both tables share the same shape, so a single DTO serves both dimensions.
+ * Transforms snake_case DB columns into the camelCase API contract — never expose
+ * raw database rows.
+ */
+export const AgenticRuleDto = {
+  /**
+   * @param {object} row - Snake_case row from PostgREST.
+   * @returns {object} camelCase API representation.
+   */
+  toJSON: (row) => ({
+    id: row.id,
+    siteId: row.site_id,
+    name: row.name,
+    regex: row.regex,
+    sortOrder: row.sort_order,
+    source: row.source,
+    sampleUrls: row.sample_urls ?? [],
+    derivationMethod: row.derivation_method ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    createdBy: row.created_by ?? null,
+    updatedBy: row.updated_by ?? null,
+  }),
+};
+
+export default AgenticRuleDto;

--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,8 @@ import PageRelationshipsController from './controllers/page-relationships.js';
 import PlgOnboardingController from './controllers/plg/plg-onboarding.js';
 import WebhooksController from './controllers/webhooks.js';
 import AiVisibilityController from './controllers/ai-visibility.js';
+import AgenticCategoriesController from './controllers/agentic-categories.js';
+import AgenticPageTypesController from './controllers/agentic-page-types.js';
 import SerenityController from './controllers/serenity.js';
 import GitHubWebhookHmacHandler from './support/github-webhook-hmac-handler.js';
 import ApiKeyImsHandler from './support/api-key-ims-handler.js';
@@ -273,6 +275,8 @@ async function run(request, context) {
     const drsBpPgAuditController = DrsBpPgAuditController(context);
     const webhooksController = WebhooksController(context);
     const aiVisibilityController = AiVisibilityController(context, log, context.env);
+    const agenticCategoriesController = AgenticCategoriesController();
+    const agenticPageTypesController = AgenticPageTypesController();
     const serenityController = SerenityController(context, log, context.env);
 
     const routeHandlers = getRouteHandlers(
@@ -330,6 +334,8 @@ async function run(request, context) {
       webhooksController,
       aiVisibilityController,
       fanoutReportController,
+      agenticCategoriesController,
+      agenticPageTypesController,
       serenityController,
     );
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -100,6 +100,8 @@ function isStaticRoute(routePattern) {
  * @param {Object} webhooksController - GitHub webhook handler controller.
  * @param {Object} aiVisibilityController - AI Visibility (Semrush) controller.
  * @param {Object} fanoutReportController - Query Fan-Out report controller.
+ * @param {Object} agenticCategoriesController - Agentic URL category rules controller.
+ * @param {Object} agenticPageTypesController - Agentic URL page-type rules controller.
  * @param {Object} serenityController - Serenity API controller (prompts + markets).
  * @return {{staticRoutes: {}, dynamicRoutes: {}}} - An object with static and dynamic routes.
  */
@@ -158,6 +160,8 @@ export default function getRouteHandlers(
   webhooksController,
   aiVisibilityController,
   fanoutReportController,
+  agenticCategoriesController,
+  agenticPageTypesController,
   serenityController,
 ) {
   const staticRoutes = {};
@@ -264,6 +268,16 @@ export default function getRouteHandlers(
     'POST /sites/:siteId/url-store': urlStoreController.addUrls,
     'PATCH /sites/:siteId/url-store': urlStoreController.updateUrls,
     'POST /sites/:siteId/url-store/delete': urlStoreController.deleteUrls,
+
+    // Agentic URL classification rules (precede :auditType for static-segment match)
+    'GET /sites/:siteId/agentic-categories': agenticCategoriesController.list,
+    'POST /sites/:siteId/agentic-categories': agenticCategoriesController.create,
+    'PATCH /sites/:siteId/agentic-categories/:name': agenticCategoriesController.update,
+    'DELETE /sites/:siteId/agentic-categories/:name': agenticCategoriesController.remove,
+    'GET /sites/:siteId/agentic-page-types': agenticPageTypesController.list,
+    'POST /sites/:siteId/agentic-page-types': agenticPageTypesController.create,
+    'PATCH /sites/:siteId/agentic-page-types/:name': agenticPageTypesController.update,
+    'DELETE /sites/:siteId/agentic-page-types/:name': agenticPageTypesController.remove,
 
     'PATCH /sites/:siteId/:auditType': auditsController.patchAuditForSite,
     'GET /sites/:siteId/latest-audit/:auditType': auditsController.getLatestForSite,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -362,6 +362,16 @@ const routeRequiredCapabilities = {
   'PATCH /sites/:siteId/url-store': 'site:write',
   'POST /sites/:siteId/url-store/delete': 'site:write',
 
+  // Agentic URL classification rules
+  'GET /sites/:siteId/agentic-categories': 'site:read',
+  'POST /sites/:siteId/agentic-categories': 'site:write',
+  'PATCH /sites/:siteId/agentic-categories/:name': 'site:write',
+  'DELETE /sites/:siteId/agentic-categories/:name': 'site:write',
+  'GET /sites/:siteId/agentic-page-types': 'site:read',
+  'POST /sites/:siteId/agentic-page-types': 'site:write',
+  'PATCH /sites/:siteId/agentic-page-types/:name': 'site:write',
+  'DELETE /sites/:siteId/agentic-page-types/:name': 'site:write',
+
   'PATCH /sites/:siteId/:auditType': 'audit:write',
   'GET /sites/:siteId/latest-audit/:auditType': 'audit:read',
   'GET /sites/:siteId/experiments': 'experiment:read',

--- a/src/support/regex-from-urls.js
+++ b/src/support/regex-from-urls.js
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Derives a URL classification regex from a small set of sample URLs.
+ *
+ * The ladder runs in order — first strategy whose regex matches every input wins:
+ *   1. Common prefix   — longest shared path prefix, snapped to a segment boundary.
+ *   2. Universal token — single whole-segment keyword present in every URL.
+ *   3. Disjoint cover  — one token per URL joined with anchored alternation.
+ *   4. Literal fallback — escaped, alternated full paths.
+ *
+ * Each strategy returns `{ regex, method, evidence }`.
+ */
+
+// Minimum segment length to qualify as a token. 3 so short but real category
+// segments ("mac", "faq", "art", "tax") tokenize instead of dropping to literal
+// fallback; the segment-boundary anchor (/|\.|$) keeps short tokens precise.
+// (2-char segments stay out: they're indistinguishable from locale codes.)
+const MIN_TOKEN_LEN = 3;
+
+// API-side guard: keeps DB rows small and bounds backtracking risk.
+const MAX_REGEX_LEN = 512;
+
+const CASE_INSENSITIVE_PREFIX = '(?i)';
+
+// Start of a path-anchored rule, tolerant of how the matched `url` is stored:
+// an optional leading slash and an optional locale segment (with or without its
+// own leading slash). Matches all of: "/products", "products", "/en/products",
+// "en/products". CDN-log url columns are inconsistent about the leading slash
+// across sites, and existing auto-rules are anchored to the no-slash form — so
+// rules must work either way without a global url normalization.
+const PATH_START = '^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?';
+
+// Start of a token: string-start or a slash, so "/docs", "en/docs", and a
+// first-segment "docs/…" all match.
+const SEG_START = '(?:^|/)';
+
+// Locale-segment pattern: /en, /en-us/, /de_de/, etc. (just the locale, nothing more).
+const LOCALE_ONLY_RE = /^\/[a-z]{2}([-_][a-z]{2})?\/?\s*$/i;
+
+/** True when a bare segment token is locale-only (e.g. "en", "en-us"). */
+function isLocaleToken(token) {
+  return LOCALE_ONLY_RE.test(`/${token}`);
+}
+
+// A leading locale segment to strip before deriving (/en, /en-gb, /zh-hans …),
+// only when followed by another segment so a real 2-letter segment at the end
+// is left alone.
+const LEADING_LOCALE_RE = /^\/[a-z]{2}(-[a-z]{2,4})?(?=\/)/i;
+
+/** Drop a leading locale segment so the derived rule generalises across locales. */
+function stripLeadingLocale(path) {
+  return path.replace(LEADING_LOCALE_RE, '');
+}
+
+// Trailing server-page / markup extension (e.g. /loyalty/redeem.mi, /foo.aspx).
+// Stripped before deriving so it neither becomes a token nor breaks the
+// common-prefix segment-boundary snap; the (/|\.|$) boundary still matches the
+// extension at runtime, so the rule keeps matching the real .mi/.html URLs.
+const PAGE_EXT_RE = /\.(?:mi|aspx?|jspx?|do|cfm|php|s?html?|phtml)$/i;
+
+/** Drop a trailing server-page extension so it doesn't pollute derivation. */
+function stripPageExtension(path) {
+  return path.replace(PAGE_EXT_RE, '');
+}
+
+/**
+ * Extract the URL path from a URL string. Falls back to the raw input
+ * if URL parsing fails so customers can pass bare paths ("/products/foo").
+ */
+function extractPath(raw) {
+  if (raw.startsWith('/')) {
+    return raw;
+  }
+  try {
+    const u = new URL(raw);
+    return u.pathname || '/';
+  } catch {
+    return raw;
+  }
+}
+
+/** Escape a string for safe inclusion inside a regex literal. */
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Compile-test a `(?i)`-prefixed regex against the JS engine (i flag).
+ */
+function isCompilable(regex) {
+  try {
+    // eslint-disable-next-line no-new
+    new RegExp(regex.replace(/^\(\?i\)/, ''), 'i');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Test whether a (?i)-prefixed regex matches every path.
+ */
+function matchesAll(regex, paths) {
+  // Ladder only calls matchesAll after isCompilable passes, so the source is safe.
+  const compiled = new RegExp(regex.replace(/^\(\?i\)/, ''), 'i');
+  return paths.every((p) => compiled.test(p));
+}
+
+/**
+ * Strategy 1: Longest common prefix, snapped to a path-segment boundary.
+ * Rejects a locale-only prefix (e.g. /en-us/) to prevent over-broad rules.
+ */
+function tryCommonPrefix(paths) {
+  // Case-insensitive char comparison; keep the casing from the first input.
+  // regexFromUrls guarantees a non-empty paths array before any strategy runs.
+  let prefix = paths[0];
+  for (let i = 1; i < paths.length; i += 1) {
+    const p = paths[i];
+    let j = 0;
+    while (
+      j < prefix.length
+      && j < p.length
+      && prefix[j].toLowerCase() === p[j].toLowerCase()
+    ) {
+      j += 1;
+    }
+    prefix = prefix.slice(0, j);
+    if (prefix.length === 0) {
+      break;
+    }
+  }
+
+  // Require non-trivial prefix (bare "/" is not useful).
+  if (prefix.length <= 1) {
+    return null;
+  }
+
+  // Snap to segment boundary: keep only if every input has end-of-string or
+  // "/" immediately after the prefix; otherwise trim back to the last "/".
+  const onBoundary = paths.every((p) => {
+    const next = p[prefix.length];
+    return next === undefined || next === '/';
+  });
+  if (!onBoundary) {
+    const lastSlash = prefix.lastIndexOf('/');
+    if (lastSlash <= 0) {
+      return null; // no segment boundary to trim to
+    }
+    prefix = prefix.slice(0, lastSlash + 1); // keep trailing slash
+  }
+
+  // Reject a locale-only prefix (e.g. /en-us/, /de/) — matches entire site.
+  if (LOCALE_ONLY_RE.test(prefix)) {
+    return null;
+  }
+
+  // A prefix that ends mid-segment (no trailing "/") must be bounded so it
+  // can't match a longer sibling: "^/products/foo" would otherwise also match
+  // "/products/foobar". A "/"-terminated prefix is already segment-bounded.
+  const boundary = prefix.endsWith('/') ? '' : '(/|\\.|$)';
+  const prefixNoLead = prefix.replace(/^\//, '');
+  const regex = `${CASE_INSENSITIVE_PREFIX}${PATH_START}${escapeRegex(prefixNoLead)}${boundary}`;
+  return {
+    regex,
+    method: 'common-prefix',
+    core: prefixNoLead,
+    evidence: `All ${paths.length} URLs share prefix ${prefix}`,
+  };
+}
+
+/**
+ * Split a path into whole slash-delimited segments (lowercased, extension-stripped).
+ * Only segments >= MIN_TOKEN_LEN qualify.
+ * "/products/photoshop.html" → ["products", "photoshop"]
+ */
+function segmentsOf(path) {
+  const segs = path.toLowerCase().split('/').filter(Boolean);
+  return segs
+    // Strip a trailing file extension only on the LAST segment, and only when
+    // it looks like a real extension (".html", ".json"). A dotted middle
+    // segment ("node.js") or a version ("v1.2") must keep its dot.
+    .map((seg, i) => (i === segs.length - 1 ? seg.replace(/\.[a-z0-9]{1,5}$/, '') : seg))
+    .filter((seg) => seg.length >= MIN_TOKEN_LEN);
+}
+
+/**
+ * Strategy 2: A single token that appears as a complete segment in every URL.
+ * Emits `(?i)/<token>(/|\\.|$)` to avoid substring matches.
+ */
+function tryUniversalToken(paths) {
+  const segSets = paths.map(segmentsOf);
+  const candidates = segSets[0];
+
+  // Prefer the longest universal token. Drop locale-only tokens (e.g. "en-us")
+  // so the common-prefix locale guard can't be sidestepped here.
+  const universal = candidates
+    .filter((t) => segSets.every((s) => s.includes(t)))
+    .filter((t) => !isLocaleToken(t))
+    .sort((a, b) => b.length - a.length);
+
+  if (universal.length === 0) {
+    return null;
+  }
+  const token = universal[0];
+  const regex = `${CASE_INSENSITIVE_PREFIX}${SEG_START}${escapeRegex(token)}(/|\\.|$)`;
+  return {
+    regex,
+    method: 'universal-token',
+    core: token,
+    evidence: `All ${paths.length} URLs contain the segment "${token}"`,
+  };
+}
+
+/**
+ * Strategy 3: One distinct segment-token per URL, joined with anchored alternation.
+ * Emits `(?i)/(token1|token2)(/|\\.|$)` to prevent substring collisions.
+ */
+function tryDisjointCover(paths) {
+  const tokens = [];
+  for (const path of paths) {
+    // Exclude locale-only tokens so a per-URL pick can't yield a whole-locale rule.
+    const segs = segmentsOf(path).filter((t) => !isLocaleToken(t));
+    if (segs.length === 0) {
+      return null;
+    }
+    // Add the most distinctive (longest) segment — product/category names like
+    // "customer-journey-analytics" beat short generic containers ("docs",
+    // "browse"), so the rule captures meaning instead of the container. Skip if a
+    // token we already picked is a whole segment of this path: its `(/|\.|$)`
+    // boundary already matches here (e.g. "travel-insurance" covers
+    // "/travel-insurance/uk-..."), so a redundant alternative would be wasteful.
+    if (!segs.some((s) => tokens.includes(s))) {
+      const best = segs.slice().sort((a, b) => b.length - a.length)[0];
+      tokens.push(best);
+    }
+  }
+  const alts = tokens.map(escapeRegex).join('|');
+  const regex = `${CASE_INSENSITIVE_PREFIX}${SEG_START}(${alts})(/|\\.|$)`;
+  return {
+    regex,
+    method: 'disjoint-cover',
+    evidence: `Per-URL keywords: ${tokens.join(', ')}`,
+  };
+}
+
+/**
+ * Strategy 4: Escape every path and alternate verbatim. Never generalises.
+ */
+function literalFallback(paths) {
+  // Drop the leading slash before escaping so PATH_START (which tolerates an
+  // optional leading slash + locale) governs the start, matching the path with
+  // or without a leading slash and with or without a locale prefix.
+  const escaped = paths.map((p) => escapeRegex(p.replace(/^\//, '')));
+  const regex = `${CASE_INSENSITIVE_PREFIX}${PATH_START}(${escaped.join('|')})(/|\\.|$)`;
+  return {
+    regex,
+    method: 'literal-fallback',
+    evidence: `Exact match against ${paths.length} URL(s)`,
+  };
+}
+
+/**
+ * Compute a regex matching every URL using the 4-strategy ladder.
+ *
+ * @param {string[]} urls - Sample URLs (or paths) supplied by the customer.
+ * @returns {{regex: string, method: string, evidence: string}}
+ * @throws {Error} - When urls is missing/empty/non-array, when entries are
+ *   non-string, or when no strategy can produce a compilable regex under MAX_REGEX_LEN.
+ */
+export function regexFromUrls(urls) {
+  if (!Array.isArray(urls) || urls.length === 0) {
+    throw new Error('urls must be a non-empty array');
+  }
+  if (urls.some((u) => typeof u !== 'string' || u.trim().length === 0)) {
+    throw new Error('every url must be a non-empty string');
+  }
+
+  const paths = urls
+    .map((u) => stripPageExtension(extractPath(u.trim())))
+    .filter((p) => p.length > 0);
+  /* c8 ignore next 3 -- non-empty strings always yield a path */
+  if (paths.length === 0) {
+    throw new Error('urls did not yield any extractable paths');
+  }
+
+  // Derive from locale-stripped paths so the rule generalises across locales.
+  // Anchored rules still tolerate a leading locale (OPTIONAL_LOCALE_PREFIX);
+  // literal fallback runs on the original paths so the guaranteed-match escape
+  // hatch always matches verbatim.
+  const generalPaths = paths.map(stripLeadingLocale);
+
+  // common-prefix usually wins, but when it collapses to a short generic
+  // container (e.g. "/solutions/") while a universal token reaches deeper
+  // ("/value-based-care"), the deeper token is more specific — try it first.
+  const cp = tryCommonPrefix(generalPaths);
+  const ut = tryUniversalToken(generalPaths);
+  const preferToken = cp && ut && ut.core.length > cp.core.length;
+
+  const strategies = [
+    () => (preferToken ? ut : cp),
+    () => (preferToken ? cp : ut),
+    () => tryDisjointCover(generalPaths),
+    () => literalFallback(paths),
+  ];
+
+  for (const strategy of strategies) {
+    const result = strategy();
+    const usable = result
+      && result.regex.length <= MAX_REGEX_LEN
+      && isCompilable(result.regex)
+      && matchesAll(result.regex, paths);
+    if (usable) {
+      return result;
+    }
+  }
+
+  // Reachable only when every strategy (incl. literal fallback) exceeds MAX_REGEX_LEN.
+  throw new Error('Failed to derive a regex from the supplied URLs');
+}
+
+/**
+ * Validate a customer-supplied regex string.
+ *
+ * @param {string} regex - Customer-supplied regex (with or without `(?i)`).
+ * @returns {string} - The validated regex (unchanged).
+ * @throws {Error} - On empty input, oversized regex, or compile failure.
+ */
+export function validateUserRegex(regex) {
+  if (typeof regex !== 'string' || regex.length === 0) {
+    throw new Error('regex must be a non-empty string');
+  }
+  // Normalize to case-insensitive so a pasted rule matches the same way derived
+  // rules do (every derived regex carries the (?i) prefix); otherwise validation
+  // (which forces the 'i' flag) would lie about case-sensitive runtime behavior.
+  // Power users who need case-sensitivity can opt out with an inline (?-i).
+  const normalized = regex.startsWith(CASE_INSENSITIVE_PREFIX)
+    ? regex
+    : `${CASE_INSENSITIVE_PREFIX}${regex}`;
+  if (normalized.length > MAX_REGEX_LEN) {
+    throw new Error(`regex exceeds ${MAX_REGEX_LEN} characters`);
+  }
+  if (!isCompilable(normalized)) {
+    throw new Error('regex is not a valid regular expression');
+  }
+  return normalized;
+}
+
+export const REGEX_FROM_URLS_INTERNALS = {
+  MIN_TOKEN_LEN,
+  MAX_REGEX_LEN,
+};

--- a/src/support/regex-from-urls.js
+++ b/src/support/regex-from-urls.js
@@ -28,8 +28,16 @@
 // (2-char segments stay out: they're indistinguishable from locale codes.)
 const MIN_TOKEN_LEN = 3;
 
-// API-side guard: keeps DB rows small and bounds backtracking risk.
+// API-side guard: keeps DB rows small. NOTE: length does NOT bound backtracking —
+// catastrophic patterns are tiny (e.g. "(a+)+$"). ReDoS is screened separately
+// (NESTED_QUANTIFIER_RE) and the evaluation engine is the primary guard.
 const MAX_REGEX_LEN = 512;
+
+// Reject obviously catastrophic backtracking shapes — a group that contains an
+// unbounded quantifier and is itself unbounded-quantified ("(a+)+", "(a*)*",
+// "([a-z]+){2,}"). Stored regex is UNTRUSTED at evaluation time; this is a
+// write-boundary screen (defense-in-depth for any JS consumer). Not exhaustive.
+const NESTED_QUANTIFIER_RE = /\([^()]*(?:[*+]|\{\d+,\d*\})[^()]*\)\s*(?:[*+]|\{\d+,\d*\})/;
 
 const CASE_INSENSITIVE_PREFIX = '(?i)';
 
@@ -88,6 +96,17 @@ function extractPath(raw) {
   } catch {
     return raw;
   }
+}
+
+/**
+ * Canonical path for cross-rule sample-URL comparison: runs the same
+ * extract → strip-extension → strip-locale pipeline as derivation, then folds
+ * case and a trailing slash. So "/products/a", "https://x/products/a", and
+ * "/en-us/products/a/" all compare equal (the regex they derive is identical).
+ */
+export function toComparablePath(url) {
+  const path = stripLeadingLocale(stripPageExtension(extractPath(String(url).trim())));
+  return path.replace(/\/+$/, '').toLowerCase();
 }
 
 /** Escape a string for safe inclusion inside a regex literal. */
@@ -293,6 +312,23 @@ export function regexFromUrls(urls) {
   if (paths.length === 0) {
     throw new Error('urls did not yield any extractable paths');
   }
+  // Root-path samples ("/") are legitimate — a customer classifying the homepage
+  // pastes the plain domain. Emit a PRECISE root/homepage rule (matches "", "/",
+  // "/home", "/index", and the locale-prefixed forms) — NOT a match-everything
+  // rule. Mixing the root with deeper paths in one rule is ambiguous → reject.
+  const isRoot = (p) => p === '/';
+  const rootCount = paths.filter(isRoot).length;
+  if (rootCount === paths.length) {
+    return {
+      regex: `${CASE_INSENSITIVE_PREFIX}^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?(home|index)?$`,
+      method: 'common-prefix',
+      core: '',
+      evidence: 'Site homepage (root path)',
+    };
+  }
+  if (rootCount > 0) {
+    throw new Error('cannot mix the site root with other paths in one rule');
+  }
 
   // Derive from locale-stripped paths so the rule generalises across locales.
   // Anchored rules still tolerate a leading locale (OPTIONAL_LOCALE_PREFIX);
@@ -349,6 +385,9 @@ export function validateUserRegex(regex) {
     : `${CASE_INSENSITIVE_PREFIX}${regex}`;
   if (normalized.length > MAX_REGEX_LEN) {
     throw new Error(`regex exceeds ${MAX_REGEX_LEN} characters`);
+  }
+  if (NESTED_QUANTIFIER_RE.test(normalized)) {
+    throw new Error('regex has nested unbounded quantifiers (catastrophic backtracking risk)');
   }
   if (!isCompilable(normalized)) {
     throw new Error('regex is not a valid regular expression');

--- a/test/controllers/agentic-categories.test.js
+++ b/test/controllers/agentic-categories.test.js
@@ -85,7 +85,10 @@ function buildContext({
   };
 }
 
-function loadController(mockHasAccess = sinon.stub().resolves(true)) {
+function loadController(
+  mockHasAccess = sinon.stub().resolves(true),
+  mockIsAdmin = sinon.stub().returns(true),
+) {
   // Restore prior stub before re-applying to keep tests independent.
   if (AccessControlUtil.fromContext.restore) {
     AccessControlUtil.fromContext.restore();
@@ -93,6 +96,7 @@ function loadController(mockHasAccess = sinon.stub().resolves(true)) {
   sinon.stub(AccessControlUtil, 'fromContext').returns({
     hasAccess: mockHasAccess,
     hasAdminAccess: sinon.stub().returns(false),
+    isLLMOAdministrator: mockIsAdmin,
   });
   return { controller: AgenticCategoriesController(), mockHasAccess };
 }
@@ -156,6 +160,24 @@ describe('AgenticCategoriesController', () => {
     expect(create.status).to.equal(403);
     expect(update.status).to.equal(403);
     expect(remove.status).to.equal(403);
+  });
+
+  it('create/update/remove require LLMO administrator (403 for org member, non-admin)', async () => {
+    // org member (hasAccess true) but NOT an LLMO admin → writes forbidden
+    const { controller } = loadController(sinon.stub().resolves(true), sinon.stub().returns(false));
+    const create = await controller.create(buildContext({ data: { name: 'c', urls: ['/a'] } }));
+    const update = await controller.update(buildContext({ params: { name: 'c' }, data: { urls: ['/a'] } }));
+    const remove = await controller.remove(buildContext({ params: { name: 'c' } }));
+    expect(create.status).to.equal(403);
+    expect(update.status).to.equal(403);
+    expect(remove.status).to.equal(403);
+  });
+
+  it('list does NOT require LLMO administrator (org membership is enough)', async () => {
+    const client = buildClient({ resolveWith: { data: [], error: null } });
+    const { controller } = loadController(sinon.stub().resolves(true), sinon.stub().returns(false));
+    const res = await controller.list(buildContext({ client }));
+    expect(res.status).to.equal(200);
   });
 
   // ───── list ─────
@@ -295,7 +317,7 @@ describe('AgenticCategoriesController', () => {
       client,
       data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
     }));
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(201);
     const body = await res.json();
     expect(body.source).to.equal('human');
   });
@@ -518,6 +540,17 @@ describe('AgenticCategoriesController', () => {
     expect(res.status).to.equal(400);
   });
 
+  it('update returns 400 for a newRegex with catastrophic backtracking (ReDoS)', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'foo', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newRegex: '(a+)+$' },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
   it('update returns 500 on update error', async () => {
     let call = 0;
     const client = {
@@ -675,6 +708,19 @@ describe('AgenticCategoriesController', () => {
     expect(body.message).to.match(/already belongs to category rule "acrobat"/);
   });
 
+  it('create detects a cross-format sample-URL conflict (full URL / locale vs stored path)', async () => {
+    // Stored path is "/products/acrobat/a"; the new samples are the same content
+    // as a full URL and a locale-prefixed path — must still be detected.
+    const client = dedupClient([{ name: 'acrobat', sample_urls: ['/products/acrobat/a'] }]);
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['https://x.com/en-us/products/acrobat/a', '/products/photoshop/x'] },
+    }));
+    expect(res.status).to.equal(409);
+    expect((await res.json()).message).to.match(/already belongs to category rule "acrobat"/);
+  });
+
   it('create returns 409 when the site is at the 20-rule cap', async () => {
     const existing = Array.from({ length: 20 }, (_, i) => ({ name: `c${i}`, sample_urls: [] }));
     const client = dedupClient(existing);
@@ -696,7 +742,7 @@ describe('AgenticCategoriesController', () => {
       client,
       data: { name: 'twentieth', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
     }));
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(201);
   });
 
   it('create stamps both created_by and updated_by from the auth profile', async () => {
@@ -708,7 +754,7 @@ describe('AgenticCategoriesController', () => {
     ctx.attributes.authInfo = { getProfile: () => ({ email: 'editor@adobe.com' }) };
     const { controller } = loadController();
     const res = await controller.create(ctx);
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(201);
     const insertOp = client.capturedOps.find((o) => o.op === 'insert');
     expect(insertOp.args[0].created_by).to.equal('editor@adobe.com');
     expect(insertOp.args[0].updated_by).to.equal('editor@adobe.com');
@@ -721,7 +767,7 @@ describe('AgenticCategoriesController', () => {
       client,
       data: { name: '  photoshop  ', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
     }));
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(201);
     const insertOp = client.capturedOps.find((o) => o.op === 'insert');
     expect(insertOp.args[0].name).to.equal('photoshop');
   });
@@ -735,7 +781,7 @@ describe('AgenticCategoriesController', () => {
     ctx.attributes.authInfo = {};
     const { controller } = loadController();
     const res = await controller.create(ctx);
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(201);
     const insertOp = client.capturedOps.find((o) => o.op === 'insert');
     expect(insertOp.args[0].created_by).to.equal('system');
     expect(ctx.log.warn).to.have.been.called;

--- a/test/controllers/agentic-categories.test.js
+++ b/test/controllers/agentic-categories.test.js
@@ -1,0 +1,836 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import AuthInfo from '@adobe/spacecat-shared-http-utils/src/auth/auth-info.js';
+
+import AgenticCategoriesController from '../../src/controllers/agentic-categories.js';
+import AccessControlUtil from '../../src/support/access-control-util.js';
+
+use(sinonChai);
+
+const SITE_ID = '0178a3f0-1234-7000-8000-000000000001';
+
+// Builds a postgrestClient mock that captures the table name + last
+// resolved value. Tests can override `resolveWith` per-call to simulate
+// success/error/not-found.
+function buildClient({
+  resolveWith = { data: [], error: null },
+  lastResolveByOp = {},
+} = {}) {
+  const ops = [];
+  function chain(initialOp) {
+    // eslint-disable-next-line no-underscore-dangle
+    const c = { _ops: [initialOp] };
+    const tracker = (op) => function track(...args) {
+      // eslint-disable-next-line no-underscore-dangle
+      c._ops.push({ op, args });
+      // operations that resolve the promise
+      if (['maybeSingle', 'single'].includes(op)) {
+        return Promise.resolve(lastResolveByOp[op] ?? resolveWith);
+      }
+      return c;
+    };
+    c.select = tracker('select');
+    c.insert = tracker('insert');
+    c.update = tracker('update');
+    c.delete = tracker('delete');
+    c.eq = tracker('eq');
+    c.limit = tracker('limit');
+    c.order = (...args) => {
+      // eslint-disable-next-line no-underscore-dangle
+      c._ops.push({ op: 'order', args });
+      return Promise.resolve(lastResolveByOp.order ?? resolveWith);
+    };
+    c.maybeSingle = tracker('maybeSingle');
+    c.single = tracker('single');
+    return c;
+  }
+  return {
+    from: (table) => {
+      const c = chain({ op: 'from', table });
+      ops.push(c);
+      return c;
+    },
+    _ops: ops,
+  };
+}
+
+function buildContext({
+  accessControl, client, params = {}, data = {},
+} = {}) {
+  return {
+    params: { siteId: SITE_ID, ...params },
+    data,
+    attributes: {
+      authInfo: new AuthInfo().withType('jwt').withProfile({ user_id: 'u' }).withAuthenticated(true),
+    },
+    dataAccess: {
+      Site: { findById: sinon.stub().resolves({ getId: () => SITE_ID }) },
+      services: { postgrestClient: client || buildClient() },
+    },
+    log: { info: sinon.stub(), error: sinon.stub(), warn: sinon.stub() },
+    _accessControl: accessControl,
+  };
+}
+
+function loadController(mockHasAccess = sinon.stub().resolves(true)) {
+  // Restore prior stub before re-applying to keep tests independent.
+  if (AccessControlUtil.fromContext.restore) {
+    AccessControlUtil.fromContext.restore();
+  }
+  sinon.stub(AccessControlUtil, 'fromContext').returns({
+    hasAccess: mockHasAccess,
+    hasAdminAccess: sinon.stub().returns(false),
+  });
+  return { controller: AgenticCategoriesController(), mockHasAccess };
+}
+
+describe('AgenticCategoriesController', () => {
+  afterEach(() => sinon.restore());
+
+  it('exposes four handlers', async () => {
+    const { controller } = loadController();
+    expect(controller.list).to.be.a('function');
+    expect(controller.create).to.be.a('function');
+    expect(controller.update).to.be.a('function');
+    expect(controller.remove).to.be.a('function');
+  });
+
+  // ───── auth + setup gates ─────
+  it('returns 400 on missing/invalid siteId', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext({ params: { siteId: 'not-a-uuid' } });
+    const res = await controller.list(ctx);
+    expect(res.status).to.equal(400);
+  });
+
+  it('returns 500 when dataAccess is missing', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext();
+    delete ctx.dataAccess;
+    const res = await controller.list(ctx);
+    expect(res.status).to.equal(500);
+  });
+
+  it('returns 500 when postgrestClient is unavailable (server misconfig, not bad input)', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext();
+    ctx.dataAccess.services = {};
+    const res = await controller.list(ctx);
+    expect(res.status).to.equal(500);
+  });
+
+  it('returns 404 when site is missing', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext();
+    ctx.dataAccess.Site.findById = sinon.stub().resolves(null);
+    const res = await controller.list(ctx);
+    expect(res.status).to.equal(404);
+  });
+
+  it('returns 403 when access is denied', async () => {
+    const denied = sinon.stub().resolves(false);
+    const { controller } = loadController(denied);
+    const res = await controller.list(buildContext());
+    expect(res.status).to.equal(403);
+  });
+
+  it('create/update/remove all enforce the auth gate', async () => {
+    const denied = sinon.stub().resolves(false);
+    const { controller } = loadController(denied);
+    const create = await controller.create(buildContext({ data: { name: 'c', urls: ['/a'] } }));
+    const update = await controller.update(buildContext({ params: { name: 'c' }, data: { urls: ['/a'] } }));
+    const remove = await controller.remove(buildContext({ params: { name: 'c' } }));
+    expect(create.status).to.equal(403);
+    expect(update.status).to.equal(403);
+    expect(remove.status).to.equal(403);
+  });
+
+  // ───── list ─────
+  it('list returns rows from PostgREST, mapped to the camelCase DTO', async () => {
+    const client = buildClient({
+      resolveWith: {
+        data: [{
+          id: 'r1',
+          site_id: SITE_ID,
+          name: 'cat-1',
+          regex: '(?i)/cat',
+          sort_order: 2,
+          source: 'human',
+          sample_urls: ['/cat/a'],
+          derivation_method: 'customer',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-02T00:00:00Z',
+          created_by: 'author',
+          updated_by: 'u',
+        }],
+        error: null,
+      },
+    });
+    const { controller } = loadController();
+    const res = await controller.list(buildContext({ client }));
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    // snake_case columns must surface as camelCase, no raw column leak.
+    expect(body.items).to.deep.equal([{
+      id: 'r1',
+      siteId: SITE_ID,
+      name: 'cat-1',
+      regex: '(?i)/cat',
+      sortOrder: 2,
+      source: 'human',
+      sampleUrls: ['/cat/a'],
+      derivationMethod: 'customer',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-02T00:00:00Z',
+      createdBy: 'author',
+      updatedBy: 'u',
+    }]);
+    expect(body.items[0]).to.not.have.any.keys('site_id', 'sample_urls', 'sort_order', 'derivation_method');
+  });
+
+  it('list returns 500 on PostgREST error', async () => {
+    const client = buildClient({ resolveWith: { data: null, error: { message: 'boom' } } });
+    const { controller } = loadController();
+    const res = await controller.list(buildContext({ client }));
+    expect(res.status).to.equal(500);
+  });
+
+  // ───── create ─────
+  it('create returns 400 when name missing', async () => {
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({ data: { urls: ['/a'] } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('create returns 400 when urls missing', async () => {
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({ data: { name: 'x' } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('create returns 400 when regex cannot be derived', async () => {
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({ data: { name: 'x', urls: [42] } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('create returns 400 when regexFromUrls throws (urls exceed the regex length cap)', async () => {
+    // Valid strings (pass isValidUrlListBody) but a 600-char shared segment makes
+    // every derivation strategy exceed MAX_REGEX_LEN, so regexFromUrls throws.
+    const seg = 'a'.repeat(600);
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      data: { name: 'x', urls: [`/${seg}/x`, `/${seg}/y`] },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('create returns 400 when urls exceeds the 50-item cap', async () => {
+    const { controller } = loadController();
+    const urls = Array.from({ length: 51 }, (_, i) => `/p/${i}`);
+    const res = await controller.create(buildContext({ data: { name: 'x', urls } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('create returns 400 when a url exceeds the 2048-char cap', async () => {
+    const { controller } = loadController();
+    const longUrl = `/${'a'.repeat(2048)}`;
+    const res = await controller.create(buildContext({ data: { name: 'x', urls: [longUrl] } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('create returns 400 when name exceeds the 200-char cap', async () => {
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      data: { name: 'a'.repeat(201), urls: ['/products/photoshop/a'] },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('create returns 400 when name is only whitespace', async () => {
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({ data: { name: '   ', urls: ['/a'] } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('list bounds the scan with a limit of 1000', async () => {
+    const client = buildClient({ resolveWith: { data: [], error: null } });
+    const { controller } = loadController();
+    await controller.list(buildContext({ client }));
+    // eslint-disable-next-line no-underscore-dangle
+    const limitOp = client._ops[0]._ops.find((o) => o.op === 'limit');
+    expect(limitOp).to.not.equal(undefined);
+    expect(limitOp.args[0]).to.equal(1000);
+  });
+
+  it('list warns when the result hits the scan cap (silent truncation)', async () => {
+    const rows = Array.from({ length: 1000 }, (_, i) => ({ id: `r${i}`, name: `c${i}` }));
+    const client = buildClient({ resolveWith: { data: rows, error: null } });
+    const ctx = buildContext({ client });
+    const { controller } = loadController();
+    const res = await controller.list(ctx);
+    expect(res.status).to.equal(200);
+    expect(ctx.log.warn).to.have.been.calledWithMatch(/truncated at 1000/);
+  });
+
+  it('create persists with source=human and returns the new row', async () => {
+    const client = buildClient({
+      resolveWith: { data: { name: 'photoshop', source: 'human' }, error: null },
+    });
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.source).to.equal('human');
+  });
+
+  it('create returns 500 on PostgREST insert error', async () => {
+    const client = buildClient({ resolveWith: { data: null, error: { message: 'dup' } } });
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(500);
+  });
+
+  it('create returns 409 on a duplicate-name unique violation (PG 23505)', async () => {
+    const client = buildClient({
+      resolveWith: { data: null, error: { code: '23505', message: 'duplicate key value' } },
+    });
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(409);
+    const body = await res.json();
+    expect(body.message).to.match(/already exists/);
+  });
+
+  it('create returns 500 when the insert returns no row (data null, no error)', async () => {
+    const client = buildClient({ resolveWith: { data: null, error: null } });
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(500);
+  });
+
+  // ───── update ─────
+  it('update returns 400 when name path param missing', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext({ params: { name: '' }, data: { urls: ['/a'] } });
+    const res = await controller.update(ctx);
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 on an empty patch (no newName, urls, or newRegex)', async () => {
+    // Guards against silently flipping source ai→human with no content change.
+    const { controller } = loadController();
+    const ctx = buildContext({ params: { name: 'foo' }, data: {} });
+    const res = await controller.update(ctx);
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when newName is provided but empty', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext({ params: { name: 'foo' }, data: { newName: '' } });
+    const res = await controller.update(ctx);
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when newName exceeds the 200-char cap', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext({ params: { name: 'foo' }, data: { newName: 'a'.repeat(201) } });
+    const res = await controller.update(ctx);
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when urls exceeds the 50-item cap', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'foo', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const urls = Array.from({ length: 51 }, (_, i) => `/p/${i}`);
+    const res = await controller.update(buildContext({
+      client, params: { name: 'foo' }, data: { urls },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when a url exceeds the 2048-char cap', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'foo', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const longUrl = `/${'a'.repeat(2048)}`;
+    const res = await controller.update(buildContext({
+      client, params: { name: 'foo' }, data: { urls: [longUrl] },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when both urls and newRegex supplied', async () => {
+    const { controller } = loadController();
+    const ctx = buildContext({
+      params: { name: 'foo' },
+      data: { urls: ['/a'], newRegex: '^/a' },
+    });
+    const res = await controller.update(ctx);
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 500 when fetch errors', async () => {
+    const client = buildClient({ resolveWith: { data: null, error: { message: 'boom' } } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newName: 'bar' },
+    }));
+    expect(res.status).to.equal(500);
+  });
+
+  it('update returns 404 when rule is missing', async () => {
+    const client = buildClient({ resolveWith: { data: null, error: null } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newName: 'bar' },
+    }));
+    expect(res.status).to.equal(404);
+  });
+
+  it('update marks the rule source=human when previous source was ai', async () => {
+    // Two maybeSingle resolutions: first the SELECT (returns ai row),
+    // second the UPDATE (returns the patched, human-owned row).
+    let call = 0;
+    const client = {
+      from: () => {
+        const c = {};
+        c.select = () => c;
+        c.update = () => c;
+        c.eq = () => c;
+        c.limit = () => c;
+        c.maybeSingle = () => {
+          call += 1;
+          return call === 1
+            ? Promise.resolve({ data: { name: 'foo', source: 'ai' }, error: null })
+            : Promise.resolve({ data: { name: 'foo', source: 'human' }, error: null });
+        };
+        return c;
+      },
+    };
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.source).to.equal('human');
+  });
+
+  it('update accepts newRegex (advanced) and validates it', async () => {
+    let call = 0;
+    const client = {
+      from: () => {
+        const c = {};
+        c.select = () => c;
+        c.update = () => c;
+        c.eq = () => c;
+        c.maybeSingle = () => {
+          call += 1;
+          return call === 1
+            ? Promise.resolve({ data: { name: 'foo', source: 'human' }, error: null })
+            : Promise.resolve({ data: { name: 'foo', regex: '^/x' }, error: null });
+        };
+        return c;
+      },
+    };
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newRegex: '^/x' },
+    }));
+    expect(res.status).to.equal(200);
+  });
+
+  it('update returns 400 when urls list is invalid', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'foo', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { urls: [] },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when urls cannot derive regex', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'foo', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { urls: [42] },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when regexFromUrls throws (urls exceed the regex length cap)', async () => {
+    const seg = 'a'.repeat(600);
+    const client = buildClient({ resolveWith: { data: { name: 'foo', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { urls: [`/${seg}/x`, `/${seg}/y`] },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 400 when newRegex is invalid', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'foo', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newRegex: '' },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('update returns 500 on update error', async () => {
+    let call = 0;
+    const client = {
+      from: () => {
+        const c = {};
+        c.select = () => c;
+        c.update = () => c;
+        c.eq = () => c;
+        c.maybeSingle = () => {
+          call += 1;
+          return call === 1
+            ? Promise.resolve({ data: { name: 'foo', source: 'human' }, error: null })
+            : Promise.resolve({ data: null, error: { message: 'boom' } });
+        };
+        return c;
+      },
+    };
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newName: 'bar' },
+    }));
+    expect(res.status).to.equal(500);
+  });
+
+  it('update returns 404 when update returns no row', async () => {
+    let call = 0;
+    const client = {
+      from: () => {
+        const c = {};
+        c.select = () => c;
+        c.update = () => c;
+        c.eq = () => c;
+        c.maybeSingle = () => {
+          call += 1;
+          return call === 1
+            ? Promise.resolve({ data: { name: 'foo', source: 'human' }, error: null })
+            : Promise.resolve({ data: null, error: null });
+        };
+        return c;
+      },
+    };
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newName: 'bar' },
+    }));
+    expect(res.status).to.equal(404);
+  });
+
+  // ───── remove ─────
+  it('remove returns 400 when name missing', async () => {
+    const { controller } = loadController();
+    const res = await controller.remove(buildContext({ params: { name: '' } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('remove deletes and returns 200', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'foo' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.remove(buildContext({ client, params: { name: 'foo' } }));
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.deleted).to.equal(true);
+    expect(body.name).to.equal('foo');
+  });
+
+  it('remove URL-decodes the name before querying and echoes the decoded name', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'Blog Posts' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.remove(buildContext({ client, params: { name: 'Blog%20Posts' } }));
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.name).to.equal('Blog Posts');
+    // eslint-disable-next-line no-underscore-dangle
+    const nameEq = client._ops[0]._ops.find((o) => o.op === 'eq' && o.args[0] === 'name');
+    expect(nameEq.args[1]).to.equal('Blog Posts');
+  });
+
+  it('remove returns 400 when the name is malformed percent-encoding', async () => {
+    const { controller } = loadController();
+    const res = await controller.remove(buildContext({ params: { name: '%E0%A4%A' } }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('update URL-decodes the name before querying', async () => {
+    const client = buildClient({ resolveWith: { data: { name: 'Blog Posts', source: 'human' }, error: null } });
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'Blog%20Posts' },
+      data: { newName: 'Articles' },
+    }));
+    expect(res.status).to.equal(200);
+    // eslint-disable-next-line no-underscore-dangle
+    const nameEq = client._ops[0]._ops.find((o) => o.op === 'eq' && o.args[0] === 'name');
+    expect(nameEq.args[1]).to.equal('Blog Posts');
+  });
+
+  it('update returns 400 when the name is malformed percent-encoding', async () => {
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      params: { name: '%E0%A4%A' },
+      data: { newName: 'x' },
+    }));
+    expect(res.status).to.equal(400);
+  });
+
+  it('remove returns 404 when row missing', async () => {
+    const client = buildClient({ resolveWith: { data: null, error: null } });
+    const { controller } = loadController();
+    const res = await controller.remove(buildContext({ client, params: { name: 'foo' } }));
+    expect(res.status).to.equal(404);
+  });
+
+  it('remove returns 500 on PostgREST error', async () => {
+    const client = buildClient({ resolveWith: { data: null, error: { message: 'boom' } } });
+    const { controller } = loadController();
+    const res = await controller.remove(buildContext({ client, params: { name: 'foo' } }));
+    expect(res.status).to.equal(500);
+  });
+
+  // ───── sample-URL cross-rule uniqueness ─────
+  // A chain that is thenable (resolves the dedup SELECT to `dedupRows`) and also
+  // exposes maybeSingle (resolves write ops to `single`). Tracks ops for asserts.
+  function dedupClient(dedupRows, single = { data: { name: 'x' }, error: null }, dedupError = null) {
+    const opsLog = [];
+    const c = {};
+    const track = (op) => (...args) => {
+      opsLog.push({ op, args });
+      return c;
+    };
+    c.select = track('select');
+    c.insert = track('insert');
+    c.update = track('update');
+    c.eq = track('eq');
+    c.limit = track('limit');
+    c.maybeSingle = () => Promise.resolve(single);
+    c.then = (resolve) => Promise.resolve({ data: dedupRows, error: dedupError }).then(resolve);
+    return { from: () => c, capturedOps: opsLog };
+  }
+
+  it('create returns 409 when a sample URL already belongs to another rule', async () => {
+    const client = dedupClient([{ name: 'acrobat', sample_urls: ['/products/acrobat/a'] }]);
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      // shares /products/acrobat/a (normalized) with the existing rule
+      data: { name: 'photoshop', urls: ['/products/acrobat/a/', '/products/photoshop/x'] },
+    }));
+    expect(res.status).to.equal(409);
+    const body = await res.json();
+    expect(body.message).to.match(/already belongs to category rule "acrobat"/);
+  });
+
+  it('create returns 409 when the site is at the 20-rule cap', async () => {
+    const existing = Array.from({ length: 20 }, (_, i) => ({ name: `c${i}`, sample_urls: [] }));
+    const client = dedupClient(existing);
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'twentyfirst', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(409);
+    const body = await res.json();
+    expect(body.message).to.match(/maximum of 20 active category rules/);
+  });
+
+  it('create succeeds at 19 existing rules (cap boundary is >= 20)', async () => {
+    const existing = Array.from({ length: 19 }, (_, i) => ({ name: `c${i}`, sample_urls: [] }));
+    const client = dedupClient(existing, { data: { name: 'twentieth' }, error: null });
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'twentieth', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(200);
+  });
+
+  it('create stamps both created_by and updated_by from the auth profile', async () => {
+    const client = dedupClient([], { data: { name: 'photoshop' }, error: null });
+    const ctx = buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    });
+    ctx.attributes.authInfo = { getProfile: () => ({ email: 'editor@adobe.com' }) };
+    const { controller } = loadController();
+    const res = await controller.create(ctx);
+    expect(res.status).to.equal(200);
+    const insertOp = client.capturedOps.find((o) => o.op === 'insert');
+    expect(insertOp.args[0].created_by).to.equal('editor@adobe.com');
+    expect(insertOp.args[0].updated_by).to.equal('editor@adobe.com');
+  });
+
+  it('create trims surrounding whitespace from the name before persisting', async () => {
+    const client = dedupClient([], { data: { name: 'photoshop' }, error: null });
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: '  photoshop  ', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(200);
+    const insertOp = client.capturedOps.find((o) => o.op === 'insert');
+    expect(insertOp.args[0].name).to.equal('photoshop');
+  });
+
+  it('create falls back to "system" identity and warns when no profile', async () => {
+    const client = dedupClient([], { data: { name: 'photoshop' }, error: null });
+    const ctx = buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    });
+    ctx.attributes.authInfo = {};
+    const { controller } = loadController();
+    const res = await controller.create(ctx);
+    expect(res.status).to.equal(200);
+    const insertOp = client.capturedOps.find((o) => o.op === 'insert');
+    expect(insertOp.args[0].created_by).to.equal('system');
+    expect(ctx.log.warn).to.have.been.called;
+  });
+
+  it('update stamps updated_by but never created_by (author survives edits)', async () => {
+    const client = dedupClient([], { data: { name: 'foo', source: 'human' }, error: null });
+    const ctx = buildContext({
+      client,
+      params: { name: 'foo' },
+      data: { newName: 'bar' },
+    });
+    ctx.attributes.authInfo = { getProfile: () => ({ email: 'editor@adobe.com' }) };
+    const { controller } = loadController();
+    const res = await controller.update(ctx);
+    expect(res.status).to.equal(200);
+    const updateOp = client.capturedOps.find((o) => o.op === 'update');
+    expect(updateOp.args[0].updated_by).to.equal('editor@adobe.com');
+    expect(updateOp.args[0]).to.not.have.property('created_by');
+  });
+
+  it('update returns 409 when a sample URL belongs to another rule', async () => {
+    const client = dedupClient(
+      [{ name: 'acrobat', sample_urls: ['/products/acrobat/a'] }],
+      { data: { name: 'photoshop', source: 'human' }, error: null },
+    );
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'photoshop' },
+      data: { urls: ['/products/acrobat/a', '/products/photoshop/x'] },
+    }));
+    expect(res.status).to.equal(409);
+  });
+
+  it('update does not conflict on the rule\'s own existing sample URLs', async () => {
+    // The edited rule already owns these URLs; excluding self must avoid a
+    // false 409 against itself.
+    const client = dedupClient(
+      [{ name: 'photoshop', sample_urls: ['/products/photoshop/a'] }],
+      { data: { name: 'photoshop', source: 'human' }, error: null },
+    );
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'photoshop' },
+      data: { urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(200);
+  });
+
+  it('create returns 500 when the sample-URL lookup errors', async () => {
+    const client = dedupClient([], { data: { name: 'x' }, error: null }, { message: 'boom' });
+    const { controller } = loadController();
+    const res = await controller.create(buildContext({
+      client,
+      data: { name: 'photoshop', urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(500);
+  });
+
+  it('update returns 500 when the sample-URL lookup errors', async () => {
+    const client = dedupClient(
+      [],
+      { data: { name: 'photoshop', source: 'human' }, error: null },
+      { message: 'boom' },
+    );
+    const { controller } = loadController();
+    const res = await controller.update(buildContext({
+      client,
+      params: { name: 'photoshop' },
+      data: { urls: ['/products/photoshop/a', '/products/photoshop/b'] },
+    }));
+    expect(res.status).to.equal(500);
+  });
+
+  // ───── soft delete ─────
+  it('remove soft-deletes via UPDATE status=deleted (never a hard delete)', async () => {
+    const client = dedupClient([], { data: { name: 'foo' }, error: null });
+    const ctx = buildContext({ client, params: { name: 'foo' } });
+    ctx.attributes.authInfo = { getProfile: () => ({ email: 'editor@adobe.com' }) };
+    const { controller } = loadController();
+    const res = await controller.remove(ctx);
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.deleted).to.equal(true);
+    const updateOp = client.capturedOps.find((o) => o.op === 'update');
+    expect(updateOp.args[0]).to.deep.equal({ status: 'deleted', updated_by: 'editor@adobe.com' });
+    expect(client.capturedOps.find((o) => o.op === 'delete')).to.equal(undefined);
+  });
+
+  // ───── factory validation ─────
+  it('factory throws when tableName/dimensionLabel are missing', async () => {
+    const { createRulesController } = await import('../../src/controllers/agentic-rules-factory.js');
+    expect(() => createRulesController({ tableName: '', dimensionLabel: '' })).to.throw();
+    expect(() => createRulesController({ tableName: 'x', dimensionLabel: '' })).to.throw();
+  });
+});

--- a/test/controllers/agentic-page-types.test.js
+++ b/test/controllers/agentic-page-types.test.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import AuthInfo from '@adobe/spacecat-shared-http-utils/src/auth/auth-info.js';
+
+import AgenticPageTypesController from '../../src/controllers/agentic-page-types.js';
+import AccessControlUtil from '../../src/support/access-control-util.js';
+
+use(sinonChai);
+
+// agentic-page-types is a thin wrapper over the same factory used by
+// agentic-categories. Deep behaviour coverage lives in agentic-categories.test.js;
+// here we just verify the wrapper exposes all handlers and routes operations to
+// the page-type table (not the category table).
+
+const SITE_ID = '0178a3f0-1234-7000-8000-000000000001';
+const PAGE_TYPE_TABLE = 'agentic_url_page_type_rules';
+
+function buildClient() {
+  const tablesQueried = [];
+  function chain() {
+    const c = {};
+    c.select = () => c;
+    c.insert = () => c;
+    c.update = () => c;
+    c.delete = () => c;
+    c.eq = () => c;
+    c.limit = () => c;
+    c.order = () => Promise.resolve({ data: [], error: null });
+    c.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    c.single = () => Promise.resolve({ data: null, error: null });
+    return c;
+  }
+  return {
+    from: (table) => {
+      tablesQueried.push(table);
+      return chain();
+    },
+    tablesQueried,
+  };
+}
+
+function buildContext({ client }) {
+  return {
+    params: { siteId: SITE_ID },
+    data: {},
+    attributes: {
+      authInfo: new AuthInfo().withType('jwt').withProfile({ user_id: 'u' }).withAuthenticated(true),
+    },
+    dataAccess: {
+      Site: { findById: sinon.stub().resolves({ getId: () => SITE_ID }) },
+      services: { postgrestClient: client },
+    },
+    log: { info: sinon.stub(), error: sinon.stub(), warn: sinon.stub() },
+  };
+}
+
+function loadController(mockHasAccess = sinon.stub().resolves(true)) {
+  if (AccessControlUtil.fromContext.restore) {
+    AccessControlUtil.fromContext.restore();
+  }
+  sinon.stub(AccessControlUtil, 'fromContext').returns({
+    hasAccess: mockHasAccess,
+    hasAdminAccess: sinon.stub().returns(false),
+  });
+  return AgenticPageTypesController();
+}
+
+describe('AgenticPageTypesController', () => {
+  afterEach(() => sinon.restore());
+
+  it('exposes four handlers', () => {
+    const controller = loadController();
+    expect(controller.list).to.be.a('function');
+    expect(controller.create).to.be.a('function');
+    expect(controller.update).to.be.a('function');
+    expect(controller.remove).to.be.a('function');
+  });
+
+  it('list queries the page-type table', async () => {
+    const client = buildClient();
+    const controller = loadController();
+    const res = await controller.list(buildContext({ client }));
+    expect(res.status).to.equal(200);
+    expect(client.tablesQueried).to.include(PAGE_TYPE_TABLE);
+    expect(client.tablesQueried).to.not.include('agentic_url_category_rules');
+  });
+
+  it('returns 403 when access denied', async () => {
+    const client = buildClient();
+    const controller = loadController(sinon.stub().resolves(false));
+    const res = await controller.list(buildContext({ client }));
+    expect(res.status).to.equal(403);
+    // Auth must short-circuit before any DB query.
+    expect(client.tablesQueried).to.have.length(0);
+  });
+});

--- a/test/controllers/agentic-page-types.test.js
+++ b/test/controllers/agentic-page-types.test.js
@@ -74,6 +74,7 @@ function loadController(mockHasAccess = sinon.stub().resolves(true)) {
   sinon.stub(AccessControlUtil, 'fromContext').returns({
     hasAccess: mockHasAccess,
     hasAdminAccess: sinon.stub().returns(false),
+    isLLMOAdministrator: sinon.stub().returns(true),
   });
   return AgenticPageTypesController();
 }

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -520,6 +520,20 @@ describe('getRouteHandlers', () => {
     listWorkspaceProjects: sinon.stub(),
   };
 
+  const mockAgenticCategoriesController = {
+    list: sinon.stub(),
+    create: sinon.stub(),
+    update: sinon.stub(),
+    remove: sinon.stub(),
+  };
+
+  const mockAgenticPageTypesController = {
+    list: sinon.stub(),
+    create: sinon.stub(),
+    update: sinon.stub(),
+    remove: sinon.stub(),
+  };
+
   it('segregates static and dynamic routes', () => {
     const { staticRoutes, dynamicRoutes } = getRouteHandlers(
       mockAuditsController,
@@ -576,6 +590,8 @@ describe('getRouteHandlers', () => {
       mockWebhooksController,
       mockAiVisibilityController,
       mockFanoutReportController,
+      mockAgenticCategoriesController,
+      mockAgenticPageTypesController,
       mockSerenityController,
     );
 
@@ -1111,6 +1127,14 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/referral-traffic/business-impact',
       'GET /sites/:siteId/referral-traffic/weeks',
       'GET /admin/users/:userId',
+      'GET /sites/:siteId/agentic-categories',
+      'POST /sites/:siteId/agentic-categories',
+      'PATCH /sites/:siteId/agentic-categories/:name',
+      'DELETE /sites/:siteId/agentic-categories/:name',
+      'GET /sites/:siteId/agentic-page-types',
+      'POST /sites/:siteId/agentic-page-types',
+      'PATCH /sites/:siteId/agentic-page-types/:name',
+      'DELETE /sites/:siteId/agentic-page-types/:name',
     ];
     expect(Object.keys(dynamicRoutes)).to.have.members(expectedDynamicRouteKeys);
 

--- a/test/support/regex-from-urls.test.js
+++ b/test/support/regex-from-urls.test.js
@@ -329,6 +329,29 @@ describe('regexFromUrls', () => {
     expect(applyRegex(result.regex, '/ipad/ipad-pro')).to.be.true;
   });
 
+  // ── root / homepage handling ──
+  it('derives a precise homepage rule from the plain domain (not match-everything)', () => {
+    const result = regexFromUrls(['https://x.com']);
+    expect(applyRegex(result.regex, '/')).to.be.true;
+    expect(applyRegex(result.regex, '')).to.be.true;
+    expect(applyRegex(result.regex, '/home')).to.be.true;
+    expect(applyRegex(result.regex, '/en/')).to.be.true;
+    // must NOT match arbitrary pages
+    expect(applyRegex(result.regex, '/products')).to.be.false;
+    expect(applyRegex(result.regex, '/products/photoshop')).to.be.false;
+  });
+
+  it('treats a trailing-slash root the same as the bare domain', () => {
+    const result = regexFromUrls(['https://x.com/']);
+    expect(applyRegex(result.regex, '/')).to.be.true;
+    expect(applyRegex(result.regex, '/anything')).to.be.false;
+  });
+
+  it('rejects mixing the site root with deeper paths in one rule', () => {
+    expect(() => regexFromUrls(['https://x.com/', 'https://x.com/products']))
+      .to.throw(/cannot mix the site root/);
+  });
+
   // ── strategy 4: literal fallback ──
   it('strategy 4: literal fallback when no token is reusable', () => {
     const result = regexFromUrls(['/a/b', '/c/d']);
@@ -463,5 +486,17 @@ describe('validateUserRegex', () => {
 
   it('throws on uncompilable regex', () => {
     expect(() => validateUserRegex('([unclosed')).to.throw(/not a valid/);
+  });
+
+  // ReDoS: reject nested unbounded quantifiers at the write boundary.
+  it('rejects catastrophic-backtracking patterns (nested unbounded quantifiers)', () => {
+    expect(() => validateUserRegex('(a+)+$')).to.throw(/nested unbounded quantifiers/);
+    expect(() => validateUserRegex('(a*)*')).to.throw(/nested unbounded quantifiers/);
+    expect(() => validateUserRegex('([a-z]+){2,}')).to.throw(/nested unbounded quantifiers/);
+  });
+
+  it('allows ordinary customer regexes (no nested quantifiers)', () => {
+    expect(validateUserRegex('^/products/photoshop')).to.equal('(?i)^/products/photoshop');
+    expect(validateUserRegex('/(foo|bar)/')).to.equal('(?i)/(foo|bar)/');
   });
 });

--- a/test/support/regex-from-urls.test.js
+++ b/test/support/regex-from-urls.test.js
@@ -1,0 +1,467 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import {
+  regexFromUrls,
+  validateUserRegex,
+  REGEX_FROM_URLS_INTERNALS,
+} from '../../src/support/regex-from-urls.js';
+
+function applyRegex(regex, path) {
+  return new RegExp(regex.replace(/^\(\?i\)/, ''), 'i').test(path);
+}
+
+describe('regexFromUrls', () => {
+  // ── input validation ──
+  it('throws when urls is not an array', () => {
+    expect(() => regexFromUrls(undefined)).to.throw(/non-empty array/);
+    expect(() => regexFromUrls('not an array')).to.throw(/non-empty array/);
+    expect(() => regexFromUrls(null)).to.throw(/non-empty array/);
+  });
+
+  it('throws on empty array', () => {
+    expect(() => regexFromUrls([])).to.throw(/non-empty array/);
+  });
+
+  it('throws on non-string entries', () => {
+    expect(() => regexFromUrls([123])).to.throw(/non-empty string/);
+    expect(() => regexFromUrls([''])).to.throw(/non-empty string/);
+  });
+
+  it('throws on whitespace-only entries', () => {
+    expect(() => regexFromUrls(['   '])).to.throw(/non-empty string/);
+    expect(() => regexFromUrls(['/ok', '\t'])).to.throw(/non-empty string/);
+  });
+
+  // ── strategy 1: common prefix ──
+  it('strategy 1: derives a common-prefix regex when URLs share a full path segment', () => {
+    const result = regexFromUrls([
+      'https://example.com/products/photoshop/install',
+      'https://example.com/products/photoshop/buy',
+      'https://example.com/products/photoshop/learn',
+    ]);
+    expect(result.method).to.equal('common-prefix');
+    expect(result.regex).to.match(/^\(\?i\)\^/);
+    expect(result.evidence).to.include('share prefix');
+    expect(applyRegex(result.regex, '/products/photoshop/install')).to.be.true;
+    expect(applyRegex(result.regex, '/products/photoshop/anything-else')).to.be.true;
+  });
+
+  // Fix 1: snap to segment boundary — mid-segment prefix must be trimmed.
+  it('Fix 1: trims prefix when it stops mid-segment', () => {
+    const result = regexFromUrls([
+      '/products/payments',
+      '/products/payroll',
+      '/products/photoshop',
+    ]);
+    // Raw prefix would be "/products/p" — must snap back to "/products/"
+    expect(result.method).to.equal('common-prefix');
+    expect(result.regex).to.equal('(?i)^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?products/');
+    expect(applyRegex(result.regex, '/products/payments')).to.be.true;
+    expect(applyRegex(result.regex, '/products/other')).to.be.true;
+    expect(applyRegex(result.regex, '/jp/products/payments')).to.be.true; // localized traffic
+  });
+
+  it('Fix 1: keeps prefix when every input has end-or-slash after it', () => {
+    const result = regexFromUrls([
+      '/products/photoshop',
+      '/products/photoshop/cc',
+      '/products/photoshop/features',
+    ]);
+    // prefix is "/products/photoshop" — after it every input has '' or '/'.
+    // A non-"/"-terminated prefix is bounded with (/|\.|$) so it cannot match a
+    // longer sibling like "/products/photoshopx".
+    expect(result.method).to.equal('common-prefix');
+    expect(result.regex).to.equal('(?i)^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?products/photoshop(/|\\.|$)');
+    expect(applyRegex(result.regex, '/products/photoshop')).to.be.true;
+    expect(applyRegex(result.regex, '/products/photoshop/cc')).to.be.true;
+    expect(applyRegex(result.regex, '/products/photoshopx')).to.be.false;
+  });
+
+  it('strategy 1 → 2 fallback when only "/" is shared', () => {
+    const result = regexFromUrls([
+      'https://example.com/shared/a',
+      'https://example.com/shared/b',
+    ]);
+    expect(['common-prefix', 'universal-token']).to.include(result.method);
+    expect(applyRegex(result.regex, '/shared/a')).to.be.true;
+    expect(applyRegex(result.regex, '/shared/b')).to.be.true;
+  });
+
+  // Fix 3: locale-root prefix rejection.
+  it('Fix 3: rejects a locale-only prefix (/en-us/) and falls through', () => {
+    // These paths span categories — the common prefix is /en-us/ which is locale-only.
+    const result = regexFromUrls([
+      '/en-us/products/foo',
+      '/en-us/support/bar',
+      '/en-us/blog/baz',
+    ]);
+    // Must NOT emit (?i)^/en-us/ — must fall through to a later strategy.
+    expect(result.regex).to.not.equal('(?i)^/en-us/');
+    expect(result.method).to.not.equal('common-prefix');
+  });
+
+  it('Fix 3: accepts a single non-locale segment prefix like /products/', () => {
+    const result = regexFromUrls([
+      '/products/foo',
+      '/products/bar',
+    ]);
+    expect(result.method).to.equal('common-prefix');
+    expect(result.regex).to.equal('(?i)^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?products/');
+  });
+
+  it('Fix 3: accepts /ipos/ (single segment, not a locale)', () => {
+    const result = regexFromUrls([
+      '/ipos/intro',
+      '/ipos/advanced',
+    ]);
+    expect(result.method).to.equal('common-prefix');
+    expect(result.regex).to.equal('(?i)^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?ipos/');
+  });
+
+  // Fix 5: case-insensitive prefix computation.
+  it('Fix 5: computes prefix case-insensitively (mixed-case paths)', () => {
+    const result = regexFromUrls([
+      '/Industries/technology',
+      '/industries/finance',
+    ]);
+    // Should still find /Industries/ or /industries/ as common prefix (case-folded compare).
+    expect(result.method).to.equal('common-prefix');
+    // The prefix from first input's casing should be used, snapped to boundary.
+    expect(result.regex.toLowerCase()).to.include('industries/');
+  });
+
+  // ── strategy 2: universal token ──
+  it('strategy 2: whole-segment token present in every URL', () => {
+    const result = regexFromUrls([
+      'https://example.com/buy/photoshop',
+      'https://example.com/learn/photoshop',
+      'https://example.com/try/photoshop/features',
+    ]);
+    expect(result.method).to.equal('universal-token');
+    expect(result.regex).to.include('photoshop');
+    expect(applyRegex(result.regex, '/buy/photoshop')).to.be.true;
+    expect(applyRegex(result.regex, '/some/photoshop/install')).to.be.true;
+  });
+
+  // Fix 2: .html extension must NOT become a universal token.
+  it('Fix 2: strips .html extension — does not produce (?i)(html)', () => {
+    const result = regexFromUrls([
+      '/campaigns/summer.html',
+      '/campaigns/winter.html',
+      '/campaigns/spring.html',
+    ]);
+    // "html" must not be the token; the common prefix /campaigns/ should win.
+    expect(result.regex).to.not.include('html');
+    // common prefix /campaigns/ should fire
+    expect(result.method).to.equal('common-prefix');
+  });
+
+  // Fix 2: token must be a whole segment, not a substring.
+  it('Fix 2: token is anchored at segment boundaries (not a bare substring match)', () => {
+    const result = regexFromUrls([
+      '/buy/photoshop',
+      '/download/photoshop',
+    ]);
+    expect(result.method).to.equal('universal-token');
+    // regex must anchor: /photoshop(/|.|$) — should NOT match /photoshop-extras
+    expect(applyRegex(result.regex, '/buy/photoshop')).to.be.true;
+    // substring "photoshop" inside "photoshop-extras" should NOT match if anchored
+    // (the segment "photoshop-extras" != "photoshop")
+    expect(applyRegex(result.regex, '/buy/notphotoshop')).to.be.false;
+  });
+
+  // ── strategy 3: disjoint cover ──
+  it('strategy 3: anchored alternation when URLs share neither prefix nor token', () => {
+    const result = regexFromUrls([
+      '/photoshop-pro/install',
+      '/illustrator-tools/setup',
+      '/acrobat-reader/download',
+    ]);
+    expect(result.method).to.equal('disjoint-cover');
+    expect(applyRegex(result.regex, '/photoshop-pro/install')).to.be.true;
+    expect(applyRegex(result.regex, '/illustrator-tools/setup')).to.be.true;
+    expect(applyRegex(result.regex, '/acrobat-reader/download')).to.be.true;
+  });
+
+  // Fix 4: disjoint-cover tokens anchored at segment boundaries.
+  it('Fix 4: disjoint-cover does not match mid-word substring', () => {
+    const result = regexFromUrls([
+      '/contact/us',
+      '/pricing/plans',
+    ]);
+    expect(result.method).to.equal('disjoint-cover');
+    // "contact" token must NOT match "/contactform" (mid-word collision)
+    expect(applyRegex(result.regex, '/contact/us')).to.be.true;
+    expect(applyRegex(result.regex, '/contactform/submit')).to.be.false;
+  });
+
+  // A child URL already covered by a chosen parent token must not add a
+  // redundant alternative: /travel-insurance covers /travel-insurance/uk-...
+  it('collapses child URLs already covered by a parent token', () => {
+    const urls = [
+      '/health-insurance/',
+      '/travel-insurance/',
+      '/travel-insurance/uk-travel-insurance',
+      '/travel-insurance/thailand-travel-insurance',
+    ];
+    const result = regexFromUrls(urls);
+    expect(result.method).to.equal('disjoint-cover');
+    expect(result.regex).to.equal('(?i)(?:^|/)(health-insurance|travel-insurance)(/|\\.|$)');
+    urls.forEach((u) => expect(applyRegex(result.regex, u)).to.be.true);
+  });
+
+  it('prefers distinctive segments over generic containers (no /docs or /browse grab)', () => {
+    // Mixed roots (/docs/<product>, /browse/<product>): the rule must capture the
+    // product segments, not collapse to the shared containers "docs"/"browse".
+    const result = regexFromUrls([
+      '/docs/customer-journey-analytics-learn/tutorials/overview',
+      '/docs/analytics-platform/using/cja-landing',
+      '/browse/customer-journey-analytics',
+    ]);
+    expect(result.method).to.equal('disjoint-cover');
+    expect(result.regex).to.not.match(/docs|browse/);
+    expect(applyRegex(result.regex, '/docs/customer-journey-analytics-learn/x')).to.be.true;
+    expect(applyRegex(result.regex, '/browse/customer-journey-analytics')).to.be.true;
+  });
+
+  it('prefers a deeper universal token over a generic container common-prefix', () => {
+    // Both share only /solutions/ as a prefix, but "value-based-care" is in both.
+    const result = regexFromUrls([
+      '/solutions/athenaone/value-based-care',
+      '/solutions/value-based-care/population-health-management',
+    ]);
+    expect(result.method).to.equal('universal-token');
+    expect(result.regex).to.equal('(?i)(?:^|/)value-based-care(/|\\.|$)');
+    expect(applyRegex(result.regex, '/solutions/athenaone/value-based-care')).to.be.true;
+    // does NOT over-match the whole /solutions/ container
+    expect(applyRegex(result.regex, '/solutions/electronic-health-records')).to.be.false;
+  });
+
+  // ── locale stripping → locale-agnostic rules ──
+  it('strips a leading locale and emits a locale-agnostic rule', () => {
+    const result = regexFromUrls([
+      '/en-gb/basketball/basketballs/fiba-3x3',
+      '/en-gb/basketball/basketballs/evolution',
+      '/en-gb/basketball/nba-shop',
+    ]);
+    expect(result.regex).to.equal('(?i)^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?basketball/');
+    // matches the sample locale AND others — not locked to /en-gb.
+    expect(applyRegex(result.regex, '/en-gb/basketball/nba-shop')).to.be.true;
+    expect(applyRegex(result.regex, '/de/basketball/x')).to.be.true;
+    expect(applyRegex(result.regex, '/basketball/x')).to.be.true;
+  });
+
+  it('derives a locale-agnostic rule from locale-prefixed samples', () => {
+    const result = regexFromUrls([
+      '/en-gb/golf/clubs/woods-hybrids',
+      '/en-gb/golf/complete-golf-club-sets',
+    ]);
+    expect(result.regex).to.equal('(?i)^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?golf/');
+    expect(applyRegex(result.regex, '/fr/golf/anything')).to.be.true;
+    expect(applyRegex(result.regex, '/golf/clubs')).to.be.true;
+  });
+
+  it('anchored rule from non-localized samples still matches localized traffic', () => {
+    // Customer pastes bare /acrobat paths; live traffic is localized (/jp/acrobat).
+    const result = regexFromUrls([
+      '/acrobat',
+      '/acrobat/pdf-reader',
+      '/acrobat/online/pdf-editor',
+    ]);
+    expect(result.method).to.equal('common-prefix');
+    expect(applyRegex(result.regex, '/acrobat')).to.be.true;
+    expect(applyRegex(result.regex, '/jp/acrobat')).to.be.true;
+    expect(applyRegex(result.regex, '/en-gb/acrobat/pdf-reader')).to.be.true;
+    // a non-locale leading segment must NOT be treated as a locale
+    expect(applyRegex(result.regex, '/products/acrobat')).to.be.false;
+  });
+
+  it('rejects a locale-only common prefix (double-locale path /us/en/…)', () => {
+    // After stripping the leading /us, the remaining paths share /en/ — a
+    // locale-only common prefix that must be rejected, not anchored as ^/en/.
+    const result = regexFromUrls([
+      '/us/en/alpha-page',
+      '/us/en/beta-page',
+    ]);
+    expect(result.regex).to.not.match(/\^\/en\//);
+    expect(applyRegex(result.regex, '/us/en/alpha-page')).to.be.true;
+  });
+
+  it('strips a trailing server-page extension before deriving (.mi/.aspx)', () => {
+    // The .mi must not break the boundary snap: result is /loyalty/redeem, not /loyalty/.
+    const result = regexFromUrls(['/loyalty/redeem.mi', '/loyalty/redeem/hotels.mi']);
+    expect(result.method).to.equal('common-prefix');
+    expect(result.regex).to.equal('(?i)^/?(?:[a-z]{2}(?:-[a-z]{2,4})?/)?loyalty/redeem(/|\\.|$)');
+    // still matches the real .mi URLs at runtime via the (/|\.|$) boundary
+    expect(applyRegex(result.regex, '/loyalty/redeem.mi')).to.be.true;
+    expect(applyRegex(result.regex, '/loyalty/redeem/hotels.mi')).to.be.true;
+  });
+
+  it('only strips a TRAILING extension, never a dotted middle segment', () => {
+    const result = regexFromUrls(['/aaa/node.js/docs', '/bbb/node.js/guide']);
+    expect(result.method).to.equal('universal-token');
+    expect(applyRegex(result.regex, '/x/node.js/y')).to.be.true;
+    expect(applyRegex(result.regex, '/x/node/y')).to.be.false;
+  });
+
+  // 3-char segments must tokenize (not drop to literal fallback).
+  it('tokenizes short 3-char segments like "mac"', () => {
+    const result = regexFromUrls([
+      'https://www.apple.com/mac/',
+      'https://www.apple.com/ipad/',
+      'https://www.apple.com/shop/accessories/all',
+    ]);
+    expect(result.method).to.equal('disjoint-cover');
+    expect(result.regex).to.equal('(?i)(?:^|/)(mac|ipad|accessories)(/|\\.|$)');
+    expect(applyRegex(result.regex, '/mac/macbook-air')).to.be.true;
+    expect(applyRegex(result.regex, '/ipad/ipad-pro')).to.be.true;
+  });
+
+  // ── strategy 4: literal fallback ──
+  it('strategy 4: literal fallback when no token is reusable', () => {
+    const result = regexFromUrls(['/a/b', '/c/d']);
+    expect(result.method).to.equal('literal-fallback');
+    expect(applyRegex(result.regex, '/a/b')).to.be.true;
+    expect(applyRegex(result.regex, '/c/d')).to.be.true;
+  });
+
+  // ── over-match tightening ──
+  it('anchors literal fallback at both ends (no substring / prefix match)', () => {
+    const result = regexFromUrls(['/a/b/c', '/d/e/f']);
+    expect(result.method).to.equal('literal-fallback');
+    expect(applyRegex(result.regex, '/a/b/c')).to.be.true;
+    expect(applyRegex(result.regex, '/a/b/c/')).to.be.true; // segment boundary ok
+    expect(applyRegex(result.regex, '/prefix/a/b/c')).to.be.false; // start-anchored
+    expect(applyRegex(result.regex, '/a/b/cX')).to.be.false; // end-bounded
+  });
+
+  it('bounds a single-URL prefix so it does not match longer siblings', () => {
+    const result = regexFromUrls(['/products/foo']);
+    expect(result.method).to.equal('common-prefix');
+    expect(applyRegex(result.regex, '/products/foo')).to.be.true;
+    expect(applyRegex(result.regex, '/products/foo/bar')).to.be.true;
+    expect(applyRegex(result.regex, '/products/foobar')).to.be.false;
+    expect(applyRegex(result.regex, '/products/food')).to.be.false;
+  });
+
+  it('does not emit a locale-only token via the token strategies', () => {
+    // common-prefix /en-us/ is locale-rejected; the token strategies must not
+    // resurrect "en-us" as a universal/disjoint token (whole-locale rule).
+    const result = regexFromUrls(['/en-us/products/x', '/en-us/blog/y']);
+    expect(result.regex).to.not.match(/\(en-us\)|\/en-us\(/);
+    expect(applyRegex(result.regex, '/en-us/random/page')).to.be.false;
+  });
+
+  it('keeps a dotted middle segment instead of truncating it', () => {
+    // "node.js" is a middle segment — the extension strip must not chop it to
+    // "node" (which would over-match "/node/", "/node.exe").
+    const result = regexFromUrls(['/aaa/node.js/docs', '/bbb/node.js/guide']);
+    expect(result.method).to.equal('universal-token');
+    expect(applyRegex(result.regex, '/x/node.js/y')).to.be.true;
+    expect(applyRegex(result.regex, '/x/node/y')).to.be.false;
+  });
+
+  // ── edge cases ──
+  it('handles a single URL (common-prefix)', () => {
+    const result = regexFromUrls(['https://example.com/blog/2026/article']);
+    expect(result.method).to.equal('common-prefix');
+    expect(applyRegex(result.regex, '/blog/2026/article')).to.be.true;
+  });
+
+  it('handles all-identical URLs', () => {
+    const result = regexFromUrls([
+      'https://example.com/products/foo',
+      'https://example.com/products/foo',
+    ]);
+    expect(result.method).to.equal('common-prefix');
+    expect(applyRegex(result.regex, '/products/foo')).to.be.true;
+  });
+
+  it('accepts bare paths (no protocol)', () => {
+    const result = regexFromUrls(['/blog/intro', '/blog/advanced']);
+    expect(result.method).to.equal('common-prefix');
+    expect(applyRegex(result.regex, '/blog/intro')).to.be.true;
+  });
+
+  it('falls back when URL parsing fails (raw input used as path)', () => {
+    const result = regexFromUrls(['photoshop-page', 'photoshop-other']);
+    expect(applyRegex(result.regex, 'photoshop-page')).to.be.true;
+  });
+
+  it('escapes regex metacharacters in literal fallback', () => {
+    // 2-char segments stay below MIN_TOKEN_LEN, so no token forms and the
+    // ladder reaches the literal fallback — where escaping must still apply.
+    const result = regexFromUrls(['/a$', '/c+']);
+    expect(result.method).to.equal('literal-fallback');
+    expect(applyRegex(result.regex, '/a$')).to.be.true;
+    expect(applyRegex(result.regex, '/c+')).to.be.true;
+  });
+
+  it('handles very long URLs without truncation when under the cap', () => {
+    const long = `/p/${'x'.repeat(100)}`;
+    const result = regexFromUrls([long, `/p/${'y'.repeat(100)}`]);
+    expect(applyRegex(result.regex, long)).to.be.true;
+  });
+
+  it('falls through to literal fallback when inputs share no common prefix', () => {
+    // segments are too short (<3) to tokenize and share no prefix → literal fallback.
+    const result = regexFromUrls(['ab', 'cd']);
+    expect(result.method).to.equal('literal-fallback');
+    expect(applyRegex(result.regex, 'ab')).to.be.true;
+    expect(applyRegex(result.regex, 'cd')).to.be.true;
+  });
+
+  it('throws when every strategy exceeds the regex length cap', () => {
+    // A 600-char shared segment blows past MAX_REGEX_LEN (512) for common-prefix,
+    // universal-token, disjoint-cover, and the literal fallback alike — so the
+    // ladder exhausts and regexFromUrls throws.
+    const seg = 'a'.repeat(600);
+    expect(() => regexFromUrls([`/${seg}/x`, `/${seg}/y`]))
+      .to.throw(/Failed to derive a regex/);
+  });
+
+  it('exposes internals for downstream test/tools', () => {
+    expect(REGEX_FROM_URLS_INTERNALS.MIN_TOKEN_LEN).to.equal(3);
+    expect(REGEX_FROM_URLS_INTERNALS.MAX_REGEX_LEN).to.equal(512);
+  });
+});
+
+describe('validateUserRegex', () => {
+  it('normalizes a case-sensitive paste to case-insensitive (prepends (?i))', () => {
+    // Without (?i) the stored regex would run case-sensitive in Athena/JONI
+    // while validation (forced 'i') claimed it matched case-insensitively.
+    expect(validateUserRegex('^/products/')).to.equal('(?i)^/products/');
+    expect(validateUserRegex('/EN/')).to.equal('(?i)/EN/');
+  });
+
+  it('leaves an already case-insensitive paste unchanged', () => {
+    expect(validateUserRegex('(?i)(foo|bar)')).to.equal('(?i)(foo|bar)');
+  });
+
+  it('throws on non-string or empty', () => {
+    expect(() => validateUserRegex(undefined)).to.throw(/non-empty string/);
+    expect(() => validateUserRegex('')).to.throw(/non-empty string/);
+    expect(() => validateUserRegex(42)).to.throw(/non-empty string/);
+  });
+
+  it('throws when over the length cap', () => {
+    const big = 'a'.repeat(513);
+    expect(() => validateUserRegex(big)).to.throw(/exceeds/);
+  });
+
+  it('throws on uncompilable regex', () => {
+    expect(() => validateUserRegex('([unclosed')).to.throw(/not a valid/);
+  });
+});


### PR DESCRIPTION
## Summary

PR 3 of the 3-PR **customer-edit** feature. Adds customer-facing endpoints that let LLMO customers review, add, edit, and delete the auto-derived URL classification rules surfaced by the upstream audit-worker work.

- **8 endpoints** (4 per dimension × categories + page-types) under `/sites/{siteId}/agentic-categories/*` and `/sites/{siteId}/agentic-page-types/*`
- Customers paste **sample URLs**; the server computes the matching regex via `src/support/regex-from-urls.js` (4-strategy ladder). Power users may pass a raw regex instead.
- Direct PostgREST writes — no new RPC
- `AccessControlUtil`-based auth: `site:read` for GET, `site:write` for all mutations
- Responses are mapped through a DTO (`src/dto/agentic-rule.js`) so the API returns **camelCase** (`siteId`, `sortOrder`, `sampleUrls`, `derivationMethod`, `createdAt`, …) regardless of the snake_case DB columns

### Endpoints (per dimension)

| Method | Path | Body | Purpose |
|---|---|---|---|
| `GET` | `/sites/{siteId}/agentic-categories` | — | List rules with metadata |
| `POST` | `/sites/{siteId}/agentic-categories` | `{ name, urls[] }` *(or `{ name, regex }`)* | Create rule (`source='human'`) |
| `PATCH` | `/sites/{siteId}/agentic-categories/{name}` | `{ newName?, urls?, newRegex? }` | Edit; recomputes regex if `urls` given; marks `source='human'` |
| `DELETE` | `/sites/{siteId}/agentic-categories/{name}` | — | Remove rule |

Same shape for `/sites/{siteId}/agentic-page-types/*`.

### `regex-from-urls` strategy ladder
Returns the first strategy whose regex matches **every** input URL, plus an `evidence` string (logged once per create/update). All comparisons and emitted regexes are case-insensitive (`(?i)` prefix), and every strategy is anchored/bounded so a rule can't accidentally match a longer sibling path:
1. **common-prefix** — longest shared prefix, snapped to a segment boundary. A prefix that ends mid-segment (no trailing `/`) is bounded with `(/|\.|$)` so `/products/foo` can't match `/products/foobar`. Locale-only roots (`/en-us/`, `/de/`) are rejected so a rule can't silently match the whole site.
2. **universal-token** — a whole path segment present in every URL; file extension stripped from the last segment only (dotted middle segments like `node.js` and versions like `v1.2` keep their dot), emitted anchored as `/<token>(/|\.|$)`. Locale-only tokens are skipped.
3. **disjoint-cover** — per-URL keyword alternation, anchored `/(a|b|c)(/|\.|$)` (no substring matches). Locale-only tokens skipped here too.
4. **literal-fallback** — escaped full-path alternation, anchored at start **and** bounded at end `^(…)(/|\.|$)` (worst case).

`validateUserRegex` (the raw-regex paste path) normalizes input to case-insensitive `(?i)` so a pasted rule behaves like a derived one; power users who need case-sensitivity can opt out with an inline `(?-i)`. Input is validated for compile + length cap (512 chars).

### Validation & error handling
- Rejects missing / empty / whitespace-only URL entries (trimmed before extraction)
- Empty `PATCH` body (and blank `newName`) → `400`
- Duplicate rule name → `409` (maps PG unique-constraint `23505`)
- Null row from an unexpected PostgREST result → `500` guard
- Oversized or uncompilable regex → `400`

### Data model
- Customer-created → `source='human'`, `derivation_method='customer'`, `sample_urls` = pasted URLs
- Any edit of an auto rule (`source='ai'`) flips it to `source='human'`
- Writes go to `agentic_url_category_rules` / `agentic_url_page_type_rules` (unique on `(site_id, name)`)

### Files
**New**
- `src/controllers/agentic-categories.js` / `agentic-page-types.js` — thin wrappers over a shared factory
- `src/controllers/agentic-rules-factory.js` — `createRulesController({ tableName, dimensionLabel })`: `list`, `create`, `update`, `remove`
- `src/dto/agentic-rule.js` — snake_case row → camelCase response mapper
- `src/support/regex-from-urls.js` — pasted-URLs → regex helper (+ `validateUserRegex`)
- `docs/openapi/agentic-rules-api.yaml` — OpenAPI spec (camelCase schema)
- Tests: `test/controllers/agentic-{categories,page-types}.test.js`, `test/support/regex-from-urls.test.js`

**Modified**
- `src/routes/index.js`, `src/routes/required-capabilities.js`, `src/index.js`, `docs/openapi/api.yaml`, `docs/index.html`, `test/routes/index.test.js`

### Predecessor
Builds on spacecat-audit-worker PR #2539, which derives the candidate rules this PR lets customers edit.

## Validation
- `npm run lint`: clean for all changed files
- `npm test`: **11271 passing**, coverage gate green (`codecov/patch` ✓)
- `npm run docs:lint && docs:build`: API description valid

## Out of scope (follow-ups)
- Structured includes/excludes/contains rule builder (compose regex from declared predicates) — better authoring UX, exclusion as a first-class concept
- Raw-regex paste-path ReDoS hardening (real mitigation is Athena query timeout / tenant isolation, not code) — the derived-regex path is ReDoS-safe by construction

## Related Issues
LLMO-5037
