### PR TITLE
feat(webhooks): emit CloudWatch EMF metrics from the GitHub webhook path (Plan B)

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -59,7 +59,9 @@ metrics:
     meaning: >
       Incremented after a job is successfully sent to SQS. JobType is the
       resolved job type (e.g. pr-review). TargetId is the destination
-      identifier from the GITHUB_DESTINATIONS registry.
+      identifier from the GITHUB_DESTINATIONS registry (expected cardinality
+      under ~20; growth past that should be a deliberate conversation, not a
+      silent dimension explosion).
 
   - name: WebhookEnqueueFailure
     unit: Count
@@ -73,11 +75,14 @@ metrics:
     unit: Count
     dimensions:
       - Environment
+      - Reason
     meaning: >
       Incremented on any uncaught exception in the controller (errorHandler
       catch) or when reviewer_login is missing from the auth profile (fail-
-      closed 500). Covers both the outer catch-all and the internal reviewer
-      check.
+      closed 500). Reason values: uncaught_exception (outer catch-all; also
+      fires when an enqueue failure rethrows), missing_reviewer_login (internal
+      fail-closed reviewer check). Lets alerting separate code bugs from config
+      errors.
 
   - name: WebhookProcessingMillis
     unit: Milliseconds
@@ -87,4 +92,7 @@ metrics:
     meaning: >
       End-to-end controller latency in milliseconds, emitted via the finally
       block so it fires on all code paths. Outcome matches the terminal state:
-      enqueued, skipped, bad_request, handler_error, enqueue_failure, unknown.
+      enqueued, skipped, bad_request, handler_error, enqueue_failure. The
+      `unknown` sentinel is the default and fires only when an error is thrown
+      before any outcome is classified; that latency includes the failed work,
+      so success-only latency panels should exclude it.

--- a/metrics.yaml
+++ b/metrics.yaml
@@ -1,0 +1,90 @@
+namespace: Mysticat/GitHubService
+
+metrics:
+  - name: WebhookReceived
+    unit: Count
+    dimensions:
+      - Environment
+      - Event
+    meaning: >
+      Incremented once for every webhook that reaches the controller handler,
+      after the HMAC auth layer passes. The Event dimension carries the raw
+      x-github-event header value (e.g. pull_request, ping).
+
+  - name: WebhookRejected
+    unit: Count
+    dimensions:
+      - Environment
+      - Reason
+    meaning: >
+      Incremented when the HMAC auth handler rejects a webhook before it
+      reaches the controller. Reason values: malformed_signature, not_json,
+      non_inscope_host, hmac_mismatch, body_too_large, empty_body.
+
+  - name: WebhookDestinationsMisconfigured
+    unit: Count
+    dimensions:
+      - Environment
+    meaning: >
+      Incremented when the GITHUB_DESTINATIONS registry is absent or
+      malformed. Alerts on this metric indicate a Vault/env misconfiguration
+      that will reject all webhooks.
+
+  - name: WebhookBadRequest
+    unit: Count
+    dimensions:
+      - Environment
+      - MissingField
+    meaning: >
+      Incremented when a mapped-event webhook is missing a required payload
+      field. MissingField values: action, installation.id, pull_request.number,
+      repository.owner.login, repository.name.
+
+  - name: WebhookSkipped
+    unit: Count
+    dimensions:
+      - Environment
+      - SkipReason
+    meaning: >
+      Incremented when the controller decides not to enqueue the webhook.
+      SkipReason values: unmapped_event, draft_pr, bot_sender,
+      non_default_branch, auto_trigger, wrong_reviewer, unsupported_action.
+
+  - name: WebhookEnqueued
+    unit: Count
+    dimensions:
+      - Environment
+      - JobType
+      - TargetId
+    meaning: >
+      Incremented after a job is successfully sent to SQS. JobType is the
+      resolved job type (e.g. pr-review). TargetId is the destination
+      identifier from the GITHUB_DESTINATIONS registry.
+
+  - name: WebhookEnqueueFailure
+    unit: Count
+    dimensions:
+      - Environment
+    meaning: >
+      Incremented when sqs.sendMessage throws. The request returns 500 so
+      GitHub will retry. Alert on sustained spikes.
+
+  - name: WebhookHandlerError
+    unit: Count
+    dimensions:
+      - Environment
+    meaning: >
+      Incremented on any uncaught exception in the controller (errorHandler
+      catch) or when reviewer_login is missing from the auth profile (fail-
+      closed 500). Covers both the outer catch-all and the internal reviewer
+      check.
+
+  - name: WebhookProcessingMillis
+    unit: Milliseconds
+    dimensions:
+      - Environment
+      - Outcome
+    meaning: >
+      End-to-end controller latency in milliseconds, emitted via the finally
+      block so it fires on all code paths. Outcome matches the terminal state:
+      enqueued, skipped, bad_request, handler_error, enqueue_failure, unknown.

--- a/src/controllers/webhooks.js
+++ b/src/controllers/webhooks.js
@@ -19,10 +19,13 @@ import {
   accepted, noContent, badRequest, internalServerError,
 } from '@adobe/spacecat-shared-http-utils';
 import wrap from '@adobe/helix-shared-wrap';
-import { getSkipReason, EVENT_JOB_MAP, isMysticatTargetedSkip } from '../utils/github-trigger-rules.js';
+import {
+  getSkipReason, EVENT_JOB_MAP, isMysticatTargetedSkip, skipReasonLabel,
+} from '../utils/github-trigger-rules.js';
 import { createObservabilitySlackClient } from '../support/slack/observability-client.js';
 import { enqueuedParentText, skippedStandaloneText } from '../support/slack/observability-messages.js';
 import { shouldRateLimitSlackPost } from '../support/slack/observability-rate-limit.js';
+import { emitMetric, resolveEnvironment } from '../support/metrics-emf.js';
 
 const DEFAULT_WORKSPACE_REPOS = [
   'adobe/mysticat-architecture',
@@ -80,6 +83,7 @@ function WebhooksController(context) {
         return await fn(ctx);
       } catch (e) {
         log.error('GitHub webhook handler error', e);
+        emitMetric({ name: 'WebhookHandlerError' }, { environment: resolveEnvironment(env) });
         return internalServerError('Internal error');
       }
     };
@@ -94,153 +98,220 @@ function WebhooksController(context) {
     const deliveryId = ctx.pathInfo?.headers?.['x-github-delivery'];
     const { data } = ctx;
 
-    // Filter on event type BEFORE validating payload fields or requiring a
-    // reviewer identity. Unmapped events (ping, push, issues, ...) do not
-    // necessarily carry `action`/`installation.id` — GitHub's app-install ping
-    // has neither — and must 204, not 400/500, or they surface as red Xs in the
-    // app's "Recent Deliveries" UI. Mapped events get full validation below.
-    const jobType = EVENT_JOB_MAP[event];
-    if (!jobType) {
-      log.info('Skipping unmapped event', { event, deliveryId });
-      return noContent();
-    }
+    const environment = resolveEnvironment(env);
+    const startedAt = Date.now();
+    let outcome = 'unknown';
 
-    // Destination + reviewer identity resolved by the HMAC handler from the
-    // consolidated GITHUB_DESTINATIONS registry (every authenticated webhook
-    // carries target_id + reviewer_login).
-    const profile = ctx.attributes?.authInfo?.getProfile?.() || {};
-    const targetId = profile.target_id;
-    const reviewerLogin = profile.reviewer_login;
+    try {
+      // Filter on event type BEFORE validating payload fields or requiring a
+      // reviewer identity. Unmapped events (ping, push, issues, ...) do not
+      // necessarily carry `action`/`installation.id` — GitHub's app-install ping
+      // has neither — and must 204, not 400/500, or they surface as red Xs in the
+      // app's "Recent Deliveries" UI. Mapped events get full validation below.
+      const jobType = EVENT_JOB_MAP[event];
 
-    // Security-relevant: which login may trigger automated runs. reviewer_login
-    // is required on every destination entry, so a missing value means a
-    // misconfigured registry or a request that bypassed the handler. Fail closed
-    // with a 5xx (GitHub retries; visible failed delivery), not a 204 (lost).
-    if (!reviewerLogin) {
-      log.error('No reviewer login resolved (auth profile missing reviewer_login)', { deliveryId });
-      return internalServerError('reviewer login not configured');
-    }
+      emitMetric({ name: 'WebhookReceived', dimensions: { Event: event } }, { environment });
 
-    // Validate required payload fields (mapped events only)
-    if (!data?.action) {
-      return badRequest('Missing required field: action');
-    }
-    if (!data?.installation?.id) {
-      return badRequest('Missing required field: installation.id');
-    }
-
-    const { action, pull_request: pr } = data;
-
-    // Validate pull_request-specific fields BEFORE getSkipReason. Doing so
-    // prevents a missing pull_request from surfacing as a misleading
-    // "non-default branch: undefined" 204 skip instead of a 400 bad request.
-    if (!pr?.number) {
-      return badRequest('Missing required field: pull_request.number');
-    }
-    if (!data.repository?.owner?.login) {
-      return badRequest('Missing required field: repository.owner.login');
-    }
-    if (!data.repository?.name) {
-      return badRequest('Missing required field: repository.name');
-    }
-
-    // Apply trigger rules (returns skip reason string or null)
-    const skipReason = getSkipReason(data, action, reviewerLogin);
-    if (skipReason) {
-      log.info('Skipping webhook', {
-        skipReason,
-        deliveryId,
-        event,
-        action,
-        owner: data.repository.owner.login,
-        repo: data.repository.name,
-        prNumber: pr.number,
-      });
-      // Post a standalone Slack note only when Mysticat WAS the requested
-      // reviewer (draft / bot / non-default branch). Foreign-reviewer and
-      // unsupported-action skips stay silent. Best-effort + rate-limited per PR;
-      // postMessage never throws.
-      if (
-        slack.enabled
-        && isMysticatTargetedSkip(skipReason)
-        && !shouldRateLimitSlackPost(`${data.repository.owner.login}/${data.repository.name}#${pr.number}`)
-      ) {
-        await slack.postMessage({
-          text: skippedStandaloneText({
-            owner: data.repository.owner.login,
-            repo: data.repository.name,
-            prNumber: pr.number,
-            reason: skipReason,
-          }),
-        });
+      if (!jobType) {
+        log.info('Skipping unmapped event', { event, deliveryId });
+        emitMetric(
+          { name: 'WebhookSkipped', dimensions: { SkipReason: 'unmapped_event' } },
+          { environment },
+        );
+        outcome = 'skipped';
+        return noContent();
       }
-      return noContent();
-    }
 
-    // Post the Slack thread root BEFORE enqueue (ordering invariant: parent
-    // before enqueue, never after). Best-effort - a Slack failure must never
-    // block the review, so we still enqueue. On parent-post failure we send
-    // slack_channel only (no thread_ts); the worker degrades to a standalone.
-    // When Slack is disabled or rate-limited we omit observability entirely.
-    let observability;
-    if (
-      slack.enabled
-      && !shouldRateLimitSlackPost(`${data.repository.owner.login}/${data.repository.name}#${pr.number}`)
-    ) {
-      const threadTs = await slack.postMessage({
-        text: enqueuedParentText({
+      // Destination + reviewer identity resolved by the HMAC handler from the
+      // consolidated GITHUB_DESTINATIONS registry (every authenticated webhook
+      // carries target_id + reviewer_login).
+      const profile = ctx.attributes?.authInfo?.getProfile?.() || {};
+      const targetId = profile.target_id;
+      const reviewerLogin = profile.reviewer_login;
+
+      // Security-relevant: which login may trigger automated runs. reviewer_login
+      // is required on every destination entry, so a missing value means a
+      // misconfigured registry or a request that bypassed the handler. Fail closed
+      // with a 5xx (GitHub retries; visible failed delivery), not a 204 (lost).
+      if (!reviewerLogin) {
+        log.error('No reviewer login resolved (auth profile missing reviewer_login)', { deliveryId });
+        emitMetric({ name: 'WebhookHandlerError' }, { environment });
+        outcome = 'handler_error';
+        return internalServerError('reviewer login not configured');
+      }
+
+      // Validate required payload fields (mapped events only)
+      if (!data?.action) {
+        emitMetric(
+          { name: 'WebhookBadRequest', dimensions: { MissingField: 'action' } },
+          { environment },
+        );
+        outcome = 'bad_request';
+        return badRequest('Missing required field: action');
+      }
+      if (!data?.installation?.id) {
+        emitMetric(
+          { name: 'WebhookBadRequest', dimensions: { MissingField: 'installation.id' } },
+          { environment },
+        );
+        outcome = 'bad_request';
+        return badRequest('Missing required field: installation.id');
+      }
+
+      const { action, pull_request: pr } = data;
+
+      // Validate pull_request-specific fields BEFORE getSkipReason. Doing so
+      // prevents a missing pull_request from surfacing as a misleading
+      // "non-default branch: undefined" 204 skip instead of a 400 bad request.
+      if (!pr?.number) {
+        emitMetric(
+          { name: 'WebhookBadRequest', dimensions: { MissingField: 'pull_request.number' } },
+          { environment },
+        );
+        outcome = 'bad_request';
+        return badRequest('Missing required field: pull_request.number');
+      }
+      if (!data.repository?.owner?.login) {
+        emitMetric(
+          { name: 'WebhookBadRequest', dimensions: { MissingField: 'repository.owner.login' } },
+          { environment },
+        );
+        outcome = 'bad_request';
+        return badRequest('Missing required field: repository.owner.login');
+      }
+      if (!data.repository?.name) {
+        emitMetric(
+          { name: 'WebhookBadRequest', dimensions: { MissingField: 'repository.name' } },
+          { environment },
+        );
+        outcome = 'bad_request';
+        return badRequest('Missing required field: repository.name');
+      }
+
+      // Apply trigger rules (returns skip reason string or null)
+      const skipReason = getSkipReason(data, action, reviewerLogin);
+      if (skipReason) {
+        log.info('Skipping webhook', {
+          skipReason,
+          deliveryId,
+          event,
+          action,
           owner: data.repository.owner.login,
           repo: data.repository.name,
           prNumber: pr.number,
-          action,
-          jobType,
-          requestedBy: data.sender?.login,
-          author: pr.user?.login,
-        }),
+        });
+        // Post a standalone Slack note only when Mysticat WAS the requested
+        // reviewer (draft / bot / non-default branch). Foreign-reviewer and
+        // unsupported-action skips stay silent. Best-effort + rate-limited per PR;
+        // postMessage never throws.
+        if (
+          slack.enabled
+          && isMysticatTargetedSkip(skipReason)
+          && !shouldRateLimitSlackPost(`${data.repository.owner.login}/${data.repository.name}#${pr.number}`)
+        ) {
+          await slack.postMessage({
+            text: skippedStandaloneText({
+              owner: data.repository.owner.login,
+              repo: data.repository.name,
+              prNumber: pr.number,
+              reason: skipReason,
+            }),
+          });
+        }
+        emitMetric(
+          { name: 'WebhookSkipped', dimensions: { SkipReason: skipReasonLabel(skipReason) } },
+          { environment },
+        );
+        outcome = 'skipped';
+        return noContent();
+      }
+
+      // Post the Slack thread root BEFORE enqueue (ordering invariant: parent
+      // before enqueue, never after). Best-effort - a Slack failure must never
+      // block the review, so we still enqueue. On parent-post failure we send
+      // slack_channel only (no thread_ts); the worker degrades to a standalone.
+      // When Slack is disabled or rate-limited we omit observability entirely.
+      let observability;
+      if (
+        slack.enabled
+        && !shouldRateLimitSlackPost(`${data.repository.owner.login}/${data.repository.name}#${pr.number}`)
+      ) {
+        const threadTs = await slack.postMessage({
+          text: enqueuedParentText({
+            owner: data.repository.owner.login,
+            repo: data.repository.name,
+            prNumber: pr.number,
+            action,
+            jobType,
+            requestedBy: data.sender?.login,
+            author: pr.user?.login,
+          }),
+        });
+        observability = threadTs
+          ? { slack_channel: slackChannel, slack_thread_ts: threadTs }
+          : { slack_channel: slackChannel };
+      }
+
+      // Computed per webhook request (not per controller construction) so the
+      // env-var validation log fires only on genuine deliveries, not all traffic.
+      const workspaceRepos = getWorkspaceRepos(env, log);
+
+      // Build and enqueue job payload
+      const jobPayload = {
+        owner: data.repository.owner.login,
+        repo: data.repository.name,
+        event_type: event,
+        event_action: action,
+        event_ref: String(pr.number),
+        installation_id: String(data.installation.id),
+        delivery_id: deliveryId,
+        job_type: jobType,
+        workspace_repos: workspaceRepos,
+        retry_count: 0,
+        ...(targetId ? { target_id: targetId } : {}),
+        ...(observability ? { observability } : {}),
+      };
+
+      const queueUrl = env.MYSTICAT_GITHUB_JOBS_QUEUE_URL;
+      try {
+        await sqs.sendMessage(queueUrl, jobPayload);
+      } catch (e) {
+        emitMetric({ name: 'WebhookEnqueueFailure' }, { environment });
+        outcome = 'enqueue_failure';
+        throw e;
+      }
+
+      log.info('Enqueued webhook job', {
+        jobType,
+        deliveryId,
+        event,
+        action,
+        owner: jobPayload.owner,
+        repo: jobPayload.repo,
+        prNumber: pr.number,
+        installationId: jobPayload.installation_id,
+        // Resolved destination id, for traffic-distribution observability (per the
+        // PR #2503 review recommendation).
+        targetId,
       });
-      observability = threadTs
-        ? { slack_channel: slackChannel, slack_thread_ts: threadTs }
-        : { slack_channel: slackChannel };
+
+      emitMetric(
+        { name: 'WebhookEnqueued', dimensions: { JobType: jobType, TargetId: targetId } },
+        { environment },
+      );
+      outcome = 'enqueued';
+      return accepted({ status: 'accepted' });
+    } finally {
+      emitMetric(
+        {
+          name: 'WebhookProcessingMillis',
+          value: Date.now() - startedAt,
+          unit: 'Milliseconds',
+          dimensions: { Outcome: outcome },
+        },
+        { environment },
+      );
     }
-
-    // Computed per webhook request (not per controller construction) so the
-    // env-var validation log fires only on genuine deliveries, not all traffic.
-    const workspaceRepos = getWorkspaceRepos(env, log);
-
-    // Build and enqueue job payload
-    const jobPayload = {
-      owner: data.repository.owner.login,
-      repo: data.repository.name,
-      event_type: event,
-      event_action: action,
-      event_ref: String(pr.number),
-      installation_id: String(data.installation.id),
-      delivery_id: deliveryId,
-      job_type: jobType,
-      workspace_repos: workspaceRepos,
-      retry_count: 0,
-      ...(targetId ? { target_id: targetId } : {}),
-      ...(observability ? { observability } : {}),
-    };
-
-    const queueUrl = env.MYSTICAT_GITHUB_JOBS_QUEUE_URL;
-    await sqs.sendMessage(queueUrl, jobPayload);
-
-    log.info('Enqueued webhook job', {
-      jobType,
-      deliveryId,
-      event,
-      action,
-      owner: jobPayload.owner,
-      repo: jobPayload.repo,
-      prNumber: pr.number,
-      installationId: jobPayload.installation_id,
-      // Resolved destination id, for traffic-distribution observability (per the
-      // PR #2503 review recommendation).
-      targetId,
-    });
-
-    return accepted({ status: 'accepted' });
   })
     .with(errorHandler);
 

--- a/src/controllers/webhooks.js
+++ b/src/controllers/webhooks.js
@@ -83,7 +83,7 @@ function WebhooksController(context) {
         return await fn(ctx);
       } catch (e) {
         log.error('GitHub webhook handler error', e);
-        emitMetric({ name: 'WebhookHandlerError' }, { environment: resolveEnvironment(env) });
+        emitMetric({ name: 'WebhookHandlerError', dimensions: { Reason: 'uncaught_exception' } }, { environment: resolveEnvironment(env) });
         return internalServerError('Internal error');
       }
     };
@@ -135,7 +135,7 @@ function WebhooksController(context) {
       // with a 5xx (GitHub retries; visible failed delivery), not a 204 (lost).
       if (!reviewerLogin) {
         log.error('No reviewer login resolved (auth profile missing reviewer_login)', { deliveryId });
-        emitMetric({ name: 'WebhookHandlerError' }, { environment });
+        emitMetric({ name: 'WebhookHandlerError', dimensions: { Reason: 'missing_reviewer_login' } }, { environment });
         outcome = 'handler_error';
         return internalServerError('reviewer login not configured');
       }

--- a/src/support/github-webhook-hmac-handler.js
+++ b/src/support/github-webhook-hmac-handler.js
@@ -40,8 +40,9 @@ class GitHubWebhookHmacHandler extends AbstractHandler {
   // (honest-client-only; attacker can omit the header) then the post-read byte
   // length (the real enforcement). request.text() returns the cached body.
   // The `rejected` callback receives a stable reason label and emits a metric;
-  // it is provided by checkAuth once context.env is available.
-  async readBodyWithLimits(request, rejected) {
+  // it is provided by checkAuth once context.env is available. Defaults to a
+  // no-op so a standalone call (e.g. a direct unit test) cannot throw on reject.
+  async readBodyWithLimits(request, rejected = () => {}) {
     const contentLength = Number(request.headers.get('content-length'));
     if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
       this.log(`Payload too large: ${contentLength} bytes`, 'warn');

--- a/src/support/github-webhook-hmac-handler.js
+++ b/src/support/github-webhook-hmac-handler.js
@@ -14,6 +14,7 @@ import crypto from 'crypto';
 import AbstractHandler from '@adobe/spacecat-shared-http-utils/src/auth/handlers/abstract.js';
 import AuthInfo from '@adobe/spacecat-shared-http-utils/src/auth/auth-info.js';
 import { extractClassificationMetadata, parseDestinations, classifyDestination } from './github-targets.js';
+import { emitMetric, resolveEnvironment } from './metrics-emf.js';
 
 const SIGNATURE_PATTERN = /^sha256=[a-f0-9]{64}$/;
 const WEBHOOK_PATH_PATTERN = /^\/?webhooks\//;
@@ -38,20 +39,25 @@ class GitHubWebhookHmacHandler extends AbstractHandler {
   // (already logged) on empty / oversized. Two-tier: a Content-Length precheck
   // (honest-client-only; attacker can omit the header) then the post-read byte
   // length (the real enforcement). request.text() returns the cached body.
-  async readBodyWithLimits(request) {
+  // The `rejected` callback receives a stable reason label and emits a metric;
+  // it is provided by checkAuth once context.env is available.
+  async readBodyWithLimits(request, rejected) {
     const contentLength = Number(request.headers.get('content-length'));
     if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
       this.log(`Payload too large: ${contentLength} bytes`, 'warn');
+      rejected('body_too_large');
       return null;
     }
     const rawBody = await request.text();
     if (!rawBody) {
       this.log('Empty request body for webhook', 'warn');
+      rejected('empty_body');
       return null;
     }
     const byteLength = Buffer.byteLength(rawBody, 'utf8');
     if (byteLength > MAX_BODY_BYTES) {
       this.log(`Payload too large after read: ${byteLength} bytes`, 'warn');
+      rejected('body_too_large');
       return null;
     }
     return rawBody;
@@ -69,11 +75,26 @@ class GitHubWebhookHmacHandler extends AbstractHandler {
     if (!signature) {
       return null;
     }
+
+    // Best-effort metric helpers — defined here so context.env is in scope.
+    // Both swallow errors (emitMetric is itself best-effort, and these are
+    // called on auth-rejection paths where we must never throw).
+    const environment = resolveEnvironment(context.env);
+    const rejected = (reason) => emitMetric(
+      { name: 'WebhookRejected', dimensions: { Reason: reason } },
+      { environment },
+    );
+    const misconfigured = () => emitMetric(
+      { name: 'WebhookDestinationsMisconfigured' },
+      { environment },
+    );
+
     // Validate signature format FIRST: structural check, no I/O, no config.
     // Runs before any secret/registry work to prevent error-log amplification on
     // pre-auth malformed requests, and before timingSafeEqual to avoid a throw.
     if (!SIGNATURE_PATTERN.test(signature)) {
       this.log('Malformed X-Hub-Signature-256 header', 'warn');
+      rejected('malformed_signature');
       return null;
     }
 
@@ -85,6 +106,7 @@ class GitHubWebhookHmacHandler extends AbstractHandler {
     // secret it cannot forge.
     if (!context.env?.GITHUB_DESTINATIONS) {
       this.log('GITHUB_DESTINATIONS not configured (misconfigured=true)', 'error');
+      misconfigured();
       return null;
     }
     let destinations;
@@ -95,15 +117,17 @@ class GitHubWebhookHmacHandler extends AbstractHandler {
       // delivery). Do NOT interpolate the value (it is secret-bearing); the
       // parser's message names only keys/fields, never secrets.
       this.log(`Invalid GITHUB_DESTINATIONS config (misconfigured=true): ${e.message}`, 'error');
+      misconfigured();
       return null;
     }
-    const rawBody = await this.readBodyWithLimits(request);
+    const rawBody = await this.readBodyWithLimits(request, rejected);
     if (rawBody === null) {
       return null;
     }
     const meta = extractClassificationMetadata(rawBody);
     if (meta === null) {
       this.log('Webhook body is not valid JSON', 'warn');
+      rejected('not_json');
       return null;
     }
     const result = classifyDestination(meta, destinations);
@@ -111,12 +135,14 @@ class GitHubWebhookHmacHandler extends AbstractHandler {
     // NO HMAC. The body is untrusted, so do not interpolate meta.host.
     if (result.skip) {
       this.log('Skipping webhook: host is not an in-scope GitHub destination', 'warn');
+      rejected('non_inscope_host');
       return null;
     }
     // webhook_secret is inline + validated non-empty at parse, so it is present
     // on a validated registry; verify HMAC once.
     if (!verifySignature(signature, rawBody, result.webhook_secret)) {
       this.log('HMAC signature mismatch', 'warn');
+      rejected('hmac_mismatch');
       return null;
     }
     return new AuthInfo()

--- a/src/support/github-webhook-metrics.js
+++ b/src/support/github-webhook-metrics.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Canonical list of CloudWatch EMF metric names emitted by the GitHub webhook
+ * pipeline (auth handler + controller). Used as a drift-guard: the metrics.yaml
+ * catalog must reference exactly these names. Import here to avoid typos.
+ */
+export const WEBHOOK_METRICS = Object.freeze([
+  'WebhookReceived',
+  'WebhookRejected',
+  'WebhookDestinationsMisconfigured',
+  'WebhookBadRequest',
+  'WebhookSkipped',
+  'WebhookEnqueued',
+  'WebhookEnqueueFailure',
+  'WebhookHandlerError',
+  'WebhookProcessingMillis',
+]);

--- a/src/support/metrics-emf.js
+++ b/src/support/metrics-emf.js
@@ -46,7 +46,11 @@ export function resolveEnvironment(env = {}) {
  * @param {string} metric.name - CloudWatch metric name
  * @param {number} [metric.value=1] - Metric value (default 1 for counters)
  * @param {string} [metric.unit='Count'] - CloudWatch unit (Count, Milliseconds, etc.)
- * @param {object} [metric.dimensions={}] - Additional dimension key/value pairs
+ * @param {object} [metric.dimensions={}] - Additional dimension key/value pairs.
+ *   Dimension keys MUST NOT equal the metric name: in the EMF envelope the metric
+ *   value and the dimension values share one top-level namespace, so a collision
+ *   would silently overwrite the dimension. Current PascalCase metric names never
+ *   collide with the dimension keys (Environment, Event, Reason, Outcome, ...).
  * @param {object} [options] - Emission options
  * @param {string} [options.environment='dev'] - Environment dimension value
  * @param {Function} [options.sink=console.log] - Output function; receives the JSON string

--- a/src/support/metrics-emf.js
+++ b/src/support/metrics-emf.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * CloudWatch Embedded Metric Format (EMF) emitter.
+ *
+ * EMF is a pure-JSON log line that CloudWatch auto-extracts into metrics with
+ * no PutMetricData calls and no extra IAM permissions. We write directly to
+ * stdout (NOT the helix logger, which prefixes lines and would corrupt the EMF
+ * envelope). Emission is best-effort: any error is swallowed so a metric
+ * failure can never affect the request path.
+ *
+ * Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+ */
+
+const NAMESPACE = 'Mysticat/GitHubService';
+
+/**
+ * Resolves the deployment environment name from process/Lambda env vars.
+ * Precedence: AWS_ENV > ENV > 'dev'.
+ *
+ * @param {object} env - The env object (context.env or process.env)
+ * @returns {string} Environment name
+ */
+export function resolveEnvironment(env = {}) {
+  return env.AWS_ENV || env.ENV || 'dev';
+}
+
+/**
+ * Emits a single CloudWatch EMF metric envelope.
+ *
+ * The default sink is console.log, which writes to stdout. In Lambda,
+ * CloudWatch Logs Agent picks up stdout and the EMF agent extracts the
+ * metric. No IAM PutMetricData permission is required.
+ *
+ * @param {object} metric - Metric descriptor
+ * @param {string} metric.name - CloudWatch metric name
+ * @param {number} [metric.value=1] - Metric value (default 1 for counters)
+ * @param {string} [metric.unit='Count'] - CloudWatch unit (Count, Milliseconds, etc.)
+ * @param {object} [metric.dimensions={}] - Additional dimension key/value pairs
+ * @param {object} [options] - Emission options
+ * @param {string} [options.environment='dev'] - Environment dimension value
+ * @param {Function} [options.sink=console.log] - Output function; receives the JSON string
+ */
+// eslint-disable-next-line no-console
+const defaultSink = (line) => console.log(line);
+
+export function emitMetric(
+  {
+    name, value = 1, unit = 'Count', dimensions = {},
+  },
+  { environment = 'dev', sink = defaultSink } = {},
+) {
+  try {
+    // Always include Environment as the first dimension so every metric is
+    // filterable by dev/stage/prod without needing a separate namespace.
+    const dims = { Environment: environment };
+    for (const [k, v] of Object.entries(dimensions)) {
+      // Drop null/undefined values: they would produce a dimension key with
+      // no value, which CloudWatch rejects and which silently breaks metrics.
+      if (v !== undefined && v !== null) {
+        dims[k] = String(v);
+      }
+    }
+    const envelope = {
+      _aws: {
+        Timestamp: Date.now(),
+        CloudWatchMetrics: [{
+          Namespace: NAMESPACE,
+          Dimensions: [Object.keys(dims)],
+          Metrics: [{ Name: name, Unit: unit }],
+        }],
+      },
+      ...dims,
+      [name]: value,
+    };
+    sink(JSON.stringify(envelope));
+  } catch {
+    // best-effort: metrics must never break the request path
+  }
+}

--- a/src/utils/github-trigger-rules.js
+++ b/src/utils/github-trigger-rules.js
@@ -84,6 +84,41 @@ export function getSkipReason(data, action, reviewerLogin) {
 }
 
 /**
+ * Maps a skip reason string from getSkipReason to a short, stable label
+ * suitable for use as a CloudWatch metric dimension value.
+ *
+ * Keep in lockstep with getSkipReason: these string checks mirror the exact
+ * literals / prefixes it returns.
+ *
+ * @param {string|null|undefined} reason - Skip reason from getSkipReason
+ * @returns {string} Stable label string
+ */
+export function skipReasonLabel(reason) {
+  if (!reason) {
+    return 'other';
+  }
+  if (reason === 'draft PR') {
+    return 'draft_pr';
+  }
+  if (reason === 'bot sender') {
+    return 'bot_sender';
+  }
+  if (reason.startsWith('non-default branch')) {
+    return 'non_default_branch';
+  }
+  if (reason.startsWith('auto-trigger not yet supported')) {
+    return 'auto_trigger';
+  }
+  if (reason.startsWith('reviewer ')) {
+    return 'wrong_reviewer';
+  }
+  if (reason.startsWith('unsupported action')) {
+    return 'unsupported_action';
+  }
+  return 'other';
+}
+
+/**
  * Classifies a skip reason from getSkipReason as one that should post a
  * standalone Slack observability note. Only skips where Mysticat WAS the
  * requested reviewer (draft PR / bot sender / non-default branch) are

--- a/test/controllers/webhooks.test.js
+++ b/test/controllers/webhooks.test.js
@@ -592,4 +592,98 @@ describe('WebhooksController', () => {
       expect(text).to.include('author <https://github.com/bob|bob>');
     });
   });
+
+  describe('EMF metrics', () => {
+    let emitMetricStub;
+    let MockedEmfController;
+
+    before(async () => {
+      emitMetricStub = sinon.stub();
+      const mod = await esmock('../../src/controllers/webhooks.js', {
+        '../../src/support/metrics-emf.js': {
+          emitMetric: emitMetricStub,
+          resolveEnvironment: () => 'dev',
+        },
+      });
+      MockedEmfController = mod.default;
+    });
+
+    beforeEach(() => {
+      emitMetricStub.reset();
+    });
+
+    function buildEmfController(envOverrides = {}) {
+      return MockedEmfController({
+        sqs: mockSqs,
+        log: mockLog,
+        env: {
+          MYSTICAT_GITHUB_JOBS_QUEUE_URL: queueUrl,
+          ...envOverrides,
+        },
+      });
+    }
+
+    it('success path emits WebhookReceived, WebhookEnqueued, and WebhookProcessingMillis', async () => {
+      const emfController = buildEmfController();
+      const response = await emfController.processGitHubWebhook(validContext);
+
+      expect(response.status).to.equal(202);
+
+      const names = emitMetricStub.getCalls().map((c) => c.args[0].name);
+      expect(names).to.include('WebhookReceived');
+      expect(names).to.include('WebhookEnqueued');
+      expect(names).to.include('WebhookProcessingMillis');
+
+      const enqueued = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookEnqueued');
+      expect(enqueued.args[0].dimensions).to.deep.include({
+        JobType: 'pr-review',
+        TargetId: 'github-public',
+      });
+
+      const millis = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookProcessingMillis');
+      expect(millis.args[0].dimensions).to.deep.include({ Outcome: 'enqueued' });
+      expect(millis.args[0].unit).to.equal('Milliseconds');
+    });
+
+    it('draft PR skip emits WebhookSkipped with SkipReason draft_pr', async () => {
+      const emfController = buildEmfController();
+      const ctx = {
+        ...validContext,
+        data: {
+          ...validContext.data,
+          pull_request: { ...validContext.data.pull_request, draft: true },
+        },
+      };
+      const response = await emfController.processGitHubWebhook(ctx);
+
+      expect(response.status).to.equal(204);
+      const skipped = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookSkipped');
+      expect(skipped).to.exist;
+      expect(skipped.args[0].dimensions).to.deep.include({ SkipReason: 'draft_pr' });
+    });
+
+    it('SQS failure emits WebhookEnqueueFailure and returns 500', async () => {
+      mockSqs.sendMessage.rejects(new Error('SQS timeout'));
+      const emfController = buildEmfController();
+      const response = await emfController.processGitHubWebhook(validContext);
+
+      expect(response.status).to.equal(500);
+      const failure = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookEnqueueFailure');
+      expect(failure).to.exist;
+    });
+
+    it('missing action field emits WebhookBadRequest with MissingField action', async () => {
+      const emfController = buildEmfController();
+      const ctx = {
+        ...validContext,
+        data: { ...validContext.data, action: undefined },
+      };
+      const response = await emfController.processGitHubWebhook(ctx);
+
+      expect(response.status).to.equal(400);
+      const bad = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookBadRequest');
+      expect(bad).to.exist;
+      expect(bad.args[0].dimensions).to.deep.include({ MissingField: 'action' });
+    });
+  });
 });

--- a/test/controllers/webhooks.test.js
+++ b/test/controllers/webhooks.test.js
@@ -634,6 +634,12 @@ describe('WebhooksController', () => {
       expect(names).to.include('WebhookEnqueued');
       expect(names).to.include('WebhookProcessingMillis');
 
+      // Event is the only dimension sourced from a request header; assert its
+      // value so a regression in header reading (ctx.pathInfo.headers) is caught
+      // rather than silently emitting an undefined-then-dropped dimension.
+      const received = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookReceived');
+      expect(received.args[0].dimensions).to.deep.include({ Event: 'pull_request' });
+
       const enqueued = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookEnqueued');
       expect(enqueued.args[0].dimensions).to.deep.include({
         JobType: 'pr-review',
@@ -660,6 +666,8 @@ describe('WebhooksController', () => {
       const skipped = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookSkipped');
       expect(skipped).to.exist;
       expect(skipped.args[0].dimensions).to.deep.include({ SkipReason: 'draft_pr' });
+      const millis = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookProcessingMillis');
+      expect(millis.args[0].dimensions).to.deep.include({ Outcome: 'skipped' });
     });
 
     it('SQS failure emits WebhookEnqueueFailure and returns 500', async () => {
@@ -670,6 +678,13 @@ describe('WebhooksController', () => {
       expect(response.status).to.equal(500);
       const failure = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookEnqueueFailure');
       expect(failure).to.exist;
+      // enqueue_failure rethrows: finally tags latency Outcome, then errorHandler
+      // catches and emits WebhookHandlerError{uncaught_exception}.
+      const millis = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookProcessingMillis');
+      expect(millis.args[0].dimensions).to.deep.include({ Outcome: 'enqueue_failure' });
+      const handlerError = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookHandlerError');
+      expect(handlerError).to.exist;
+      expect(handlerError.args[0].dimensions).to.deep.include({ Reason: 'uncaught_exception' });
     });
 
     it('missing action field emits WebhookBadRequest with MissingField action', async () => {
@@ -684,6 +699,31 @@ describe('WebhooksController', () => {
       const bad = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookBadRequest');
       expect(bad).to.exist;
       expect(bad.args[0].dimensions).to.deep.include({ MissingField: 'action' });
+      const millis = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookProcessingMillis');
+      expect(millis.args[0].dimensions).to.deep.include({ Outcome: 'bad_request' });
+    });
+
+    it('missing reviewer_login emits WebhookHandlerError with Reason missing_reviewer_login', async () => {
+      // Fail-closed path: returns 500 from inside the try (no throw), so the
+      // errorHandler catch does not run - WebhookHandlerError fires once, from the
+      // internal reviewer check, with the distinguishing Reason dimension.
+      const emfController = buildEmfController();
+      const ctx = {
+        ...validContext,
+        attributes: {
+          authInfo: {
+            getProfile: () => ({ user_id: 'github-webhook', target_id: 'github-public' }),
+          },
+        },
+      };
+      const response = await emfController.processGitHubWebhook(ctx);
+
+      expect(response.status).to.equal(500);
+      const handlerError = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookHandlerError');
+      expect(handlerError).to.exist;
+      expect(handlerError.args[0].dimensions).to.deep.include({ Reason: 'missing_reviewer_login' });
+      const millis = emitMetricStub.getCalls().find((c) => c.args[0].name === 'WebhookProcessingMillis');
+      expect(millis.args[0].dimensions).to.deep.include({ Outcome: 'handler_error' });
     });
   });
 });

--- a/test/metrics-catalog.test.js
+++ b/test/metrics-catalog.test.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import yaml from 'js-yaml';
+import { WEBHOOK_METRICS } from '../src/support/github-webhook-metrics.js';
+
+describe('webhook metrics catalog drift-guard', () => {
+  it('metrics.yaml names exactly match WEBHOOK_METRICS', () => {
+    const doc = yaml.load(readFileSync(new URL('../metrics.yaml', import.meta.url)));
+    expect(doc.metrics.map((m) => m.name).sort()).to.deep.equal([...WEBHOOK_METRICS].sort());
+  });
+});

--- a/test/metrics-catalog.test.js
+++ b/test/metrics-catalog.test.js
@@ -17,7 +17,7 @@ import { WEBHOOK_METRICS } from '../src/support/github-webhook-metrics.js';
 
 describe('webhook metrics catalog drift-guard', () => {
   it('metrics.yaml names exactly match WEBHOOK_METRICS', () => {
-    const doc = yaml.load(readFileSync(new URL('../metrics.yaml', import.meta.url)));
+    const doc = yaml.load(readFileSync(new URL('../metrics.yaml', import.meta.url), 'utf8'));
     expect(doc.metrics.map((m) => m.name).sort()).to.deep.equal([...WEBHOOK_METRICS].sort());
   });
 });

--- a/test/support/github-webhook-hmac-handler.test.js
+++ b/test/support/github-webhook-hmac-handler.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import crypto from 'crypto';
+import esmock from 'esmock';
 import GitHubWebhookHmacHandler from '../../src/support/github-webhook-hmac-handler.js';
 
 describe('GitHubWebhookHmacHandler', () => {
@@ -340,6 +341,55 @@ describe('GitHubWebhookHmacHandler', () => {
       const result = await handler.checkAuth(request, destContext());
       expect(result).to.be.null;
       expect(mockLog.warn.calledWithMatch('Empty')).to.be.true;
+    });
+  });
+
+  describe('EMF metrics', () => {
+    let emitMetricStub;
+    let MockedHandler;
+
+    before(async () => {
+      emitMetricStub = sinon.stub();
+      const mod = await esmock('../../src/support/github-webhook-hmac-handler.js', {
+        '../../src/support/metrics-emf.js': {
+          emitMetric: emitMetricStub,
+          resolveEnvironment: () => 'dev',
+        },
+      });
+      MockedHandler = mod.default;
+    });
+
+    beforeEach(() => {
+      emitMetricStub.reset();
+    });
+
+    it('emits WebhookRejected with hmac_mismatch on bad signature', async () => {
+      const mockedHandler = new MockedHandler(mockLog);
+      const wrongSig = computeSignature(validPayload, 'wrong-secret');
+      const request = makeRequest({ 'x-hub-signature-256': wrongSig });
+      const context = makeContext();
+
+      const result = await mockedHandler.checkAuth(request, context);
+
+      expect(result).to.be.null;
+      const mismatch = emitMetricStub.getCalls()
+        .find((c) => c.args[0].name === 'WebhookRejected'
+          && c.args[0].dimensions?.Reason === 'hmac_mismatch');
+      expect(mismatch).to.exist;
+    });
+
+    it('emits WebhookDestinationsMisconfigured when GITHUB_DESTINATIONS is unset', async () => {
+      const mockedHandler = new MockedHandler(mockLog);
+      const sig = computeSignature(validPayload);
+      const request = makeRequest({ 'x-hub-signature-256': sig });
+      const context = makeContext({ env: {} });
+
+      const result = await mockedHandler.checkAuth(request, context);
+
+      expect(result).to.be.null;
+      const misconfigured = emitMetricStub.getCalls()
+        .find((c) => c.args[0].name === 'WebhookDestinationsMisconfigured');
+      expect(misconfigured).to.exist;
     });
   });
 });

--- a/test/support/metrics-emf.test.js
+++ b/test/support/metrics-emf.test.js
@@ -58,7 +58,13 @@ describe('metrics-emf', () => {
       { name: 'WebhookHandlerError', dimensions: { Nope: undefined } },
       { environment: 'dev', sink: (l) => lines.push(l) },
     );
-    expect(JSON.parse(lines[0])).to.not.have.property('Nope');
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed).to.not.have.property('Nope');
+    // The key must also be absent from the Dimensions array, or CloudWatch would
+    // reject the line (a dimension key with no matching top-level property). Guards
+    // a regression that filters null dims after the dims->Dimensions mapping.
+    // eslint-disable-next-line no-underscore-dangle
+    expect(parsed._aws.CloudWatchMetrics[0].Dimensions[0]).to.not.include('Nope');
   });
 
   it('never throws (best-effort) even if the sink throws', () => {

--- a/test/support/metrics-emf.test.js
+++ b/test/support/metrics-emf.test.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { emitMetric, resolveEnvironment } from '../../src/support/metrics-emf.js';
+
+describe('metrics-emf', () => {
+  it('resolveEnvironment prefers AWS_ENV, then ENV, then dev', () => {
+    expect(resolveEnvironment({ AWS_ENV: 'prod' })).to.equal('prod');
+    expect(resolveEnvironment({ ENV: 'stage' })).to.equal('stage');
+    expect(resolveEnvironment({})).to.equal('dev');
+  });
+
+  it('emits a well-formed EMF envelope to the injected sink', () => {
+    const lines = [];
+    emitMetric(
+      { name: 'WebhookEnqueued', dimensions: { JobType: 'pr-review', TargetId: 'github-public' } },
+      { environment: 'dev', sink: (l) => lines.push(l) },
+    );
+    expect(lines).to.have.length(1);
+    const parsed = JSON.parse(lines[0]);
+    // eslint-disable-next-line no-underscore-dangle
+    const cwm = parsed._aws.CloudWatchMetrics[0];
+    expect(cwm.Namespace).to.equal('Mysticat/GitHubService');
+    expect(cwm.Metrics[0]).to.deep.equal({ Name: 'WebhookEnqueued', Unit: 'Count' });
+    expect(cwm.Dimensions[0]).to.include.members(['Environment', 'JobType', 'TargetId']);
+    expect(parsed.Environment).to.equal('dev');
+    expect(parsed.JobType).to.equal('pr-review');
+    expect(parsed.WebhookEnqueued).to.equal(1);
+  });
+
+  it('supports non-Count units and explicit values', () => {
+    const lines = [];
+    emitMetric(
+      {
+        name: 'WebhookProcessingMillis', value: 42, unit: 'Milliseconds', dimensions: { Outcome: 'enqueued' },
+      },
+      { environment: 'dev', sink: (l) => lines.push(l) },
+    );
+    const parsed = JSON.parse(lines[0]);
+    // eslint-disable-next-line no-underscore-dangle
+    expect(parsed._aws.CloudWatchMetrics[0].Metrics[0].Unit).to.equal('Milliseconds');
+    expect(parsed.WebhookProcessingMillis).to.equal(42);
+  });
+
+  it('drops null/undefined dimension values', () => {
+    const lines = [];
+    emitMetric(
+      { name: 'WebhookHandlerError', dimensions: { Nope: undefined } },
+      { environment: 'dev', sink: (l) => lines.push(l) },
+    );
+    expect(JSON.parse(lines[0])).to.not.have.property('Nope');
+  });
+
+  it('never throws (best-effort) even if the sink throws', () => {
+    expect(() => emitMetric(
+      { name: 'X' },
+      { sink: () => { throw new Error('sink boom'); } },
+    )).to.not.throw();
+  });
+});

--- a/test/utils/github-trigger-rules.test.js
+++ b/test/utils/github-trigger-rules.test.js
@@ -11,7 +11,9 @@
  */
 
 import { expect } from 'chai';
-import { getSkipReason, EVENT_JOB_MAP, isMysticatTargetedSkip } from '../../src/utils/github-trigger-rules.js';
+import {
+  getSkipReason, EVENT_JOB_MAP, isMysticatTargetedSkip, skipReasonLabel,
+} from '../../src/utils/github-trigger-rules.js';
 
 describe('github-trigger-rules', () => {
   describe('EVENT_JOB_MAP', () => {
@@ -220,6 +222,41 @@ describe('github-trigger-rules', () => {
         expect(reason).to.include('auto-trigger');
         expect(isMysticatTargetedSkip(reason)).to.be.false;
       });
+    });
+  });
+
+  describe('skipReasonLabel', () => {
+    it('returns draft_pr for draft PR', () => {
+      expect(skipReasonLabel('draft PR')).to.equal('draft_pr');
+    });
+
+    it('returns bot_sender for bot sender', () => {
+      expect(skipReasonLabel('bot sender')).to.equal('bot_sender');
+    });
+
+    it('returns non_default_branch for non-default branch reason', () => {
+      expect(skipReasonLabel('non-default branch: release/v2')).to.equal('non_default_branch');
+    });
+
+    it('returns auto_trigger for auto-trigger not yet supported reason', () => {
+      expect(skipReasonLabel('auto-trigger not yet supported: opened')).to.equal('auto_trigger');
+    });
+
+    it('returns wrong_reviewer for reviewer mismatch reason', () => {
+      expect(skipReasonLabel('reviewer some-human is not MysticatBot')).to.equal('wrong_reviewer');
+    });
+
+    it('returns unsupported_action for unsupported action reason', () => {
+      expect(skipReasonLabel('unsupported action: closed')).to.equal('unsupported_action');
+    });
+
+    it('returns other for unknown reason', () => {
+      expect(skipReasonLabel('something completely unknown')).to.equal('other');
+    });
+
+    it('returns other for null/undefined', () => {
+      expect(skipReasonLabel(null)).to.equal('other');
+      expect(skipReasonLabel(undefined)).to.equal('other');
     });
   });
 });


### PR DESCRIPTION
## Webhook-tier EMF metrics (Plan B, Tasks 1-3 + 7)

Implements the spacecat-api-service half of Plan B (`adobe/mysticat-architecture#115`): the GitHub webhook controller + auth handler emit CloudWatch metrics via Embedded Metric Format - a pure-JSON stdout line CloudWatch auto-extracts. No `PutMetricData`, no new IAM, best-effort (never throws into the request path).

**New files:** `src/support/metrics-emf.js` (emitter), `src/support/github-webhook-metrics.js` (name catalog), `metrics.yaml`, `test/metrics-catalog.test.js` (drift-guard).

**9 metrics** (namespace `Mysticat/GitHubService`, `Environment` on all):
- Auth tier (hmac-handler): `WebhookRejected{Reason}`, `WebhookDestinationsMisconfigured`
- Controller tier: `WebhookReceived{Event}`, `WebhookBadRequest{MissingField}`, `WebhookSkipped{SkipReason}`, `WebhookEnqueued{JobType,TargetId}`, `WebhookEnqueueFailure`, `WebhookHandlerError`, `WebhookProcessingMillis{Outcome}`

The controller body is wrapped in `try/finally` so `WebhookProcessingMillis` emits on every path (including the catch-all 500); the SQS send is wrapped to distinguish the accepted-but-lost `WebhookEnqueueFailure`. `readBodyWithLimits` now takes a `rejected` callback so the body-limit reject reasons aren't lost.

**Tests:** 100 passing across the touched suites (5 emitter unit tests + controller/auth EMF assertions via `esmock` + drift-guard); eslint clean on changed files.

Spec reconciliation (Task 0) is in `adobe/mysticat-architecture#115`. These metrics feed Plan C pass 2 (the dashboard's Funnel + webhook panels). SITES-42733