### PR TITLE
feat(trigger): add rum-config-refresh audit type to /trigger endpoint

### DIFF
--- a/docs/openapi/trigger-api.yaml
+++ b/docs/openapi/trigger-api.yaml
@@ -22,6 +22,9 @@ trigger:
         - lhs-desktop
         - lhs-mobile
 
+      Note: additional internal audit types (e.g. rum-config-refresh) are supported but intentionally
+      omitted from this list — they are not part of the public API surface.
+
       The URL can be either a site ID or a base URL depending on the audit type.
     operationId: triggerAudit
     responses:

--- a/src/controllers/trigger.js
+++ b/src/controllers/trigger.js
@@ -19,6 +19,7 @@ import canonical from './trigger/canonical.js';
 import sitemap from './trigger/sitemap.js';
 import backlinks from './trigger/backlinks.js';
 import organictraffic from './trigger/organictraffic.js';
+import rumConfigRefresh from './trigger/rum-config-refresh.js';
 
 const AUDITS = {
   apex,
@@ -27,6 +28,7 @@ const AUDITS = {
   sitemap,
   'broken-backlinks': backlinks,
   'organic-traffic': organictraffic,
+  'rum-config-refresh': rumConfigRefresh,
 };
 
 /**

--- a/src/controllers/trigger/rum-config-refresh.js
+++ b/src/controllers/trigger/rum-config-refresh.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { triggerFromData } from './common/trigger.js';
+
+export default async function triggerAudit(context) {
+  const { type, url } = context.data;
+
+  return triggerFromData(context, { url, auditTypes: [type], deliveryType: 'ALL' });
+}

--- a/src/controllers/trigger/rum-config-refresh.js
+++ b/src/controllers/trigger/rum-config-refresh.js
@@ -12,7 +12,7 @@
 
 import { triggerFromData } from './common/trigger.js';
 
-export default async function triggerAudit(context) {
+export default async function trigger(context) {
   const { type, url } = context.data;
 
   return triggerFromData(context, { url, auditTypes: [type], deliveryType: 'ALL' });

--- a/test/controllers/trigger/rum-config-refresh.test.js
+++ b/test/controllers/trigger/rum-config-refresh.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import sinon from 'sinon';
+import { use, expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import rumConfigRefresh from '../../../src/controllers/trigger/rum-config-refresh.js';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+const sandbox = sinon.createSandbox();
+
+describe('rum-config-refresh handler', () => {
+  let context;
+  let dataAccessMock;
+  let sqsMock;
+  let sites;
+
+  beforeEach(() => {
+    const configuration = {
+      isHandlerEnabledForSite: sandbox.stub(),
+    };
+
+    sites = [
+      { getId: () => 'site1', baseURL: 'https://site1.com' },
+      { getId: () => 'site2', baseURL: 'https://site2.com' },
+    ];
+
+    configuration.isHandlerEnabledForSite.withArgs('rum-config-refresh', sites[0]).returns(false);
+    configuration.isHandlerEnabledForSite.withArgs('rum-config-refresh', sites[1]).returns(true);
+
+    dataAccessMock = {
+      Configuration: {
+        findLatest: sandbox.stub().resolves(configuration),
+      },
+      Site: {
+        all: sandbox.stub().resolves(sites),
+        findByBaseURL: sandbox.stub().resolves(sites[1]),
+      },
+    };
+
+    sqsMock = {
+      sendMessage: sandbox.stub().resolves(),
+    };
+
+    context = {
+      log: console,
+      dataAccess: dataAccessMock,
+      sqs: sqsMock,
+      env: { AUDIT_JOBS_QUEUE_URL: 'https://sqs-queue-url.com' },
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('triggers rum-config-refresh audit for all enabled sites', async () => {
+    context.data = { type: 'rum-config-refresh', url: 'ALL' };
+
+    const response = await rumConfigRefresh(context);
+    const result = await response.json();
+
+    expect(dataAccessMock.Site.all.calledOnce).to.be.true;
+    expect(sqsMock.sendMessage.callCount).to.equal(1);
+    expect(result.message[0]).to.equal('Triggered rum-config-refresh audit for site2');
+  });
+
+  it('triggers rum-config-refresh audit for a single site', async () => {
+    context.data = { type: 'rum-config-refresh', url: 'https://site2.com' };
+
+    const response = await rumConfigRefresh(context);
+    const result = await response.json();
+
+    expect(dataAccessMock.Site.findByBaseURL.calledOnce).to.be.true;
+    expect(sqsMock.sendMessage.callCount).to.equal(1);
+    expect(result.message[0]).to.equal('Triggered rum-config-refresh audit for site2');
+  });
+
+  it('returns not found when site does not exist', async () => {
+    dataAccessMock.Site.findByBaseURL.resolves(null);
+    context.data = { type: 'rum-config-refresh', url: 'https://unknown.com' };
+
+    const response = await rumConfigRefresh(context);
+
+    expect(response.status).to.equal(404);
+  });
+
+  it('returns message when no site is enabled for the audit type', async () => {
+    const configuration = { isHandlerEnabledForSite: sandbox.stub().returns(false) };
+    dataAccessMock.Configuration.findLatest.resolves(configuration);
+    context.data = { type: 'rum-config-refresh', url: 'ALL' };
+
+    const response = await rumConfigRefresh(context);
+    const result = await response.json();
+
+    expect(sqsMock.sendMessage.callCount).to.equal(0);
+    expect(result.message[0]).to.equal('No site is enabled for rum-config-refresh audit type');
+  });
+});


### PR DESCRIPTION
rum-config-refresh was not wired into the trigger controller, making it impossible to queue the audit via the HTTP API. Adds the handler and registers it in the AUDITS map so GET /trigger?type=rum-config-refresh&url=<url> sends an SQS message to the audit worker for all delivery types.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
