### PR TITLE
feat(s2s): expose auto-fix endpoint to S2S consumers via fixEntity:create

### DIFF
--- a/docs/openapi/site-opportunities.yaml
+++ b/docs/openapi/site-opportunities.yaml
@@ -873,6 +873,11 @@ site-opportunity-suggestions-auto-fix:
       is true (for assess or assess-urls), the worker runs only checks that do not require
       AEM CS access and does not need a valid promise token; when omitted or false, behavior
       is unchanged (full assessment with AEM when possible).
+
+      **S2S access:** S2S consumers registered with the `fixEntity:create` capability may
+      call this endpoint. The `auto_fix` IMS user-profile scope check is bypassed for S2S
+      callers; all other validations (site ownership, opportunity lookup, handler enablement)
+      apply unchanged.
     tags:
       - opportunity-suggestions
     requestBody:

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1056,7 +1056,12 @@ function SuggestionsController(ctx, sqs, env) {
     }
 
     const s2sResult = await accessControlUtil.hasS2SCapability(CAP_FIX_ENTITY_CREATE);
-    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site, 'auto_fix')) {
+    if (s2sResult.allowed) {
+      ctx.log?.info(`[acl] S2S auto-fix granted - clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId}`);
+    } else if (!await accessControlUtil.hasAccess(site, 'auto_fix')) {
+      if (s2sResult.reason !== 'not-s2s') {
+        ctx.log?.info(`[acl] Denied PATCH auto-fix - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'}`);
+      }
       return forbidden('User does not belong to the organization or does not have sufficient permissions');
     }
 

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -47,6 +47,7 @@ import {
   isViewAsTrialRequest,
 } from '../support/utils.js';
 import AccessControlUtil from '../support/access-control-util.js';
+import { CAP_FIX_ENTITY_CREATE } from '../routes/capability-constants.js';
 import { grantSuggestionsForOpportunity } from '../support/grant-suggestions-handler.js';
 import { createAtomicStrategy, deleteAtomicStrategy } from '../support/atomic-strategy-helper.js';
 
@@ -1054,7 +1055,8 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
-    if (!await accessControlUtil.hasAccess(site, 'auto_fix')) {
+    const s2sResult = await accessControlUtil.hasS2SCapability(CAP_FIX_ENTITY_CREATE);
+    if (!s2sResult.allowed && !await accessControlUtil.hasAccess(site, 'auto_fix')) {
       return forbidden('User does not belong to the organization or does not have sufficient permissions');
     }
 

--- a/src/routes/capability-constants.js
+++ b/src/routes/capability-constants.js
@@ -23,3 +23,5 @@ export const CAP_SITE_READ_ALL = 'site:readAll';
 export const CAP_ORG_READ_ALL = 'organization:readAll';
 
 export const CAP_SITE_CREATE = 'site:create';
+
+export const CAP_FIX_ENTITY_CREATE = 'fixEntity:create';

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -10,7 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import { CAP_ORG_READ_ALL, CAP_SITE_CREATE, CAP_SITE_READ_ALL } from './capability-constants.js';
+import {
+  CAP_FIX_ENTITY_CREATE,
+  CAP_ORG_READ_ALL,
+  CAP_SITE_CREATE,
+  CAP_SITE_READ_ALL,
+} from './capability-constants.js';
 
 /**
  * Routes that are intentionally excluded from S2S consumer access.
@@ -38,9 +43,7 @@ export const INTERNAL_ROUTES = [
   // GitHub App webhook - authenticated by HMAC-SHA256 signature, not S2S JWT
   'POST /webhooks/github',
 
-  // Suggestion edge ops (auto-fix, edge-deploy, etc.): not yet required by S2S
-  // TODO: Add these back in when we have a S2S consumer that needs them
-  'PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/auto-fix',
+  // Suggestion edge ops (edge-deploy, etc.): not yet required by S2S
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-deploy',
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-rollback',
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions/edge-preview',
@@ -387,6 +390,7 @@ const routeRequiredCapabilities = {
   'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/fixes': 'fixEntity:read',
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions': 'suggestion:write',
   'PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/status': 'suggestion:write',
+  'PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/auto-fix': CAP_FIX_ENTITY_CREATE,
   'PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'suggestion:write',
   'DELETE /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'suggestion:write',
 

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -6197,6 +6197,8 @@ describe('Suggestions Controller', () => {
 
       sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability')
         .resolves({ allowed: true, reason: 'granted', clientId: 'svc-autofix', consumerId: 'consumer-1' });
+      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess')
+        .rejects(new Error('hasAccess must not be called when S2S capability is granted'));
 
       const response = await suggestionsControllerWithMock.autofixSuggestions({
         params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
@@ -6205,6 +6207,7 @@ describe('Suggestions Controller', () => {
       });
 
       expect(response.status).to.equal(207);
+      expect(hasAccessStub).to.not.have.been.called;
     });
 
     it('returns forbidden for S2S consumer missing fixEntity:create when user lacks auto_fix access', async () => {
@@ -6219,7 +6222,7 @@ describe('Suggestions Controller', () => {
 
       sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability')
         .resolves({ allowed: false, reason: 'missing-capability', clientId: 'svc-autofix', consumerId: 'consumer-1' });
-      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').returns(false);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
 
       const response = await suggestionsController.autofixSuggestions({
         params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
@@ -6229,6 +6232,37 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(403);
       const body = await response.json();
       expect(body).to.have.property('message', 'User does not belong to the organization or does not have sufficient permissions');
+    });
+
+    it('allows non-S2S user with auto_fix access even when S2S capability is absent', async () => {
+      const testSite = {
+        id: SITE_ID,
+        getImsOrgId: () => 'test-org-id',
+        getDeliveryType: () => 'aem_edge',
+        getId: () => SITE_ID,
+        getBaseURL: () => 'https://test.com',
+      };
+      mockSuggestionDataAccess.Site.findById.resolves(testSite);
+      mockSuggestionDataAccess.Opportunity.findById.resolves({
+        getSiteId: () => SITE_ID,
+        getType: () => 'broken-backlinks',
+      });
+      mockSuggestionDataAccess.Configuration.findLatest.resolves({
+        isHandlerEnabledForSite: () => true,
+      });
+      mockSuggestion.allByOpportunityId.resolves([]);
+
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability')
+        .resolves({ allowed: false, reason: 'not-s2s' });
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+      });
+
+      expect(response.status).to.equal(207);
     });
   });
 

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -6176,6 +6176,60 @@ describe('Suggestions Controller', () => {
         'auto_fix',
       );
     });
+
+    it('allows S2S consumer with fixEntity:create capability to autofix (bypasses auto_fix profile)', async () => {
+      const testSite = {
+        id: SITE_ID,
+        getImsOrgId: () => 'test-org-id',
+        getDeliveryType: () => 'aem_edge',
+        getId: () => SITE_ID,
+        getBaseURL: () => 'https://test.com',
+      };
+      mockSuggestionDataAccess.Site.findById.resolves(testSite);
+      mockSuggestionDataAccess.Opportunity.findById.resolves({
+        getSiteId: () => SITE_ID,
+        getType: () => 'broken-backlinks',
+      });
+      mockSuggestionDataAccess.Configuration.findLatest.resolves({
+        isHandlerEnabledForSite: () => true,
+      });
+      mockSuggestion.allByOpportunityId.resolves([]);
+
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability')
+        .resolves({ allowed: true, reason: 'granted', clientId: 'svc-autofix', consumerId: 'consumer-1' });
+
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+      });
+
+      expect(response.status).to.equal(207);
+    });
+
+    it('returns forbidden for S2S consumer missing fixEntity:create when user lacks auto_fix access', async () => {
+      const testSite = {
+        id: SITE_ID,
+        getImsOrgId: () => 'test-org-id',
+        getDeliveryType: () => 'aem_edge',
+        getId: () => SITE_ID,
+        getBaseURL: () => 'https://test.com',
+      };
+      mockSuggestionDataAccess.Site.findById.resolves(testSite);
+
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability')
+        .resolves({ allowed: false, reason: 'missing-capability', clientId: 'svc-autofix', consumerId: 'consumer-1' });
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').returns(false);
+
+      const response = await suggestionsController.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+      });
+
+      expect(response.status).to.equal(403);
+      const body = await response.json();
+      expect(body).to.have.property('message', 'User does not belong to the organization or does not have sufficient permissions');
+    });
   });
 
   describe('deploySuggestionToEdge (Experiment Async Flow)', () => {

--- a/test/it/shared/tests/suggestions.js
+++ b/test/it/shared/tests/suggestions.js
@@ -438,5 +438,32 @@ export default function suggestionTests(getHttpClient, resetData) {
         expect(res.status).to.equal(404);
       });
     });
+
+    // ── S2S auto-fix access control ──
+
+    describe('PATCH .../suggestions/auto-fix (S2S capability gate)', () => {
+      before(() => resetData());
+
+      it('s2sConsumerReadOnly: returns 403 — lacks fixEntity:create capability (Layer 1)', async () => {
+        // s2sConsumerReadOnly holds site:read + site:write but not fixEntity:create.
+        // The s2sAuthWrapper rejects at Layer 1 before the controller is reached.
+        const http = getHttpClient();
+        const res = await http.s2sConsumerReadOnly.patch(
+          `${BASE}/auto-fix`,
+          { suggestionIds: [SUGG_1_ID] },
+        );
+        expect(res.status).to.equal(403);
+      });
+
+      it('s2sConsumerReadAll: returns 403 — lacks fixEntity:create capability (Layer 1)', async () => {
+        // s2sConsumerReadAll holds site:readAll + organization:readAll but not fixEntity:create.
+        const http = getHttpClient();
+        const res = await http.s2sConsumerReadAll.patch(
+          `${BASE}/auto-fix`,
+          { suggestionIds: [SUGG_1_ID] },
+        );
+        expect(res.status).to.equal(403);
+      });
+    });
   });
 }

--- a/test/routes/capability-constants.test.js
+++ b/test/routes/capability-constants.test.js
@@ -74,6 +74,7 @@ describe('capability-constants drift coverage', () => {
     const controllerFiles = [
       join(projectRoot, 'src/controllers/sites.js'),
       join(projectRoot, 'src/controllers/organizations.js'),
+      join(projectRoot, 'src/controllers/suggestions.js'),
     ];
     const controllerSource = controllerFiles
       .map((file) => readFileSync(file, 'utf8'))


### PR DESCRIPTION
## Summary

- Moves `PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/auto-fix` out of `INTERNAL_ROUTES` and maps it to the new `fixEntity:create` capability in `required-capabilities.js`
- Adds `CAP_FIX_ENTITY_CREATE = 'fixEntity:create'` to `capability-constants.js` as the single source of truth
- In `autofixSuggestions` controller, adds a Layer 2 `hasS2SCapability(CAP_FIX_ENTITY_CREATE)` check before the existing `hasAccess(site, 'auto_fix')` check — S2S consumers with this capability bypass the IMS user profile gate; non-S2S callers are unaffected

## Root cause

S2S consumers calling `PATCH /suggestions/auto-fix` were getting 403 because the endpoint was in `INTERNAL_ROUTES` (blocked at Layer 1), and even when reached, `hasAccess(site, 'auto_fix')` checks for an IMS user scope that service accounts structurally cannot hold.

## Test plan

- [ ] All existing `auto-fix suggestions` tests pass unchanged (non-S2S path unaffected)
- [ ] New test: S2S consumer with `fixEntity:create` → 207 (bypasses profile check)
- [ ] New test: S2S consumer without `fixEntity:create` + no `auto_fix` access → 403
- [ ] `required-capabilities.test.js`: disjointness invariant passes, route coverage passes
- [ ] `capability-constants.test.js`: Layer 2 call-site check passes (suggestions.js added to scan)
- [ ] Register the S2S consumer with `fixEntity:create` capability via the standard S2S admin process

🤖 Generated with [Claude Code](https://claude.com/claude-code)