### PR TITLE
feat(llmo): include paid tier in CDN opt-in notification email

### DIFF
--- a/src/controllers/llmo/cdn-opt-in-notification.js
+++ b/src/controllers/llmo/cdn-opt-in-notification.js
@@ -25,10 +25,17 @@
  * - BYOCDN sites: customer-facing onboarding email (header shows To/cc with customer + org).
  * - Adobe-managed sites: internal coordination email (header instructs LLMO team to reply-all
  *   and loop in CSE / Commerce team).
+ * - Post Office template `llmo_cdn_opt_in_notification` should use templateData:
+ *   `isPaidTier` (boolean), `customerTier` (e.g. PAID, FREE_TRIAL), `tierKnown` (boolean).
+ *   Tier is loaded from org LLMO entitlement (DB); no separate entitlement API call.
  */
+
+import { Entitlement as EntitlementModel } from '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js';
 
 import { sendEmail } from '../../support/email-service.js';
 import { CDN_TYPES, CDN_DISPLAY_NAMES } from './llmo-utils.js';
+
+const LLMO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.LLMO;
 
 const OPT_IN_NOTIFICATION_TEMPLATE = 'llmo_cdn_opt_in_notification';
 const EXCLUDED_MEMBER_STATUSES = new Set(['BLOCKED', 'DELETED']);
@@ -112,6 +119,43 @@ async function getOrgMembersCsv(context, orgId) {
 }
 
 /**
+ * Resolves LLMO entitlement tier for the org (same source as GET /organizations/{id}/entitlements).
+ * @returns {{ customerTier: string, isPaidTier: boolean, tierKnown: boolean }}
+ */
+async function getCustomerTierInfo(context, orgId) {
+  const unknown = { customerTier: '', isPaidTier: false, tierKnown: false };
+  if (!orgId) {
+    return unknown;
+  }
+
+  const entitlementModel = context?.dataAccess?.Entitlement;
+  if (!entitlementModel?.findByOrganizationIdAndProductCode) {
+    return unknown;
+  }
+
+  try {
+    const entitlement = await entitlementModel.findByOrganizationIdAndProductCode(
+      orgId,
+      LLMO_PRODUCT_CODE,
+    );
+    const tier = entitlement?.getTier?.() || '';
+    if (!tier) {
+      return unknown;
+    }
+    return {
+      customerTier: tier,
+      isPaidTier: tier === EntitlementModel.TIERS.PAID,
+      tierKnown: true,
+    };
+  } catch (error) {
+    context?.log?.warn?.(
+      `[cdn-opt-in-notification] Failed to fetch LLMO entitlement for org=${orgId}: ${error.message}`,
+    );
+    return unknown;
+  }
+}
+
+/**
  * @param {Object} context - Request context with env, log, dataAccess.
  * @param {Object} params
  * @param {string} params.siteId
@@ -145,7 +189,10 @@ export async function notifyOptInIfNeeded(context, params) {
     const adobeManaged = Boolean(cdnEntry?.adobeManaged);
     const commerceManaged = Boolean(cdnEntry?.commerceManaged);
     const replyAllTeam = cdnEntry?.replyAllTeam || '';
-    const orgMembers = await getOrgMembersCsv(context, orgId);
+    const [orgMembers, tierInfo] = await Promise.all([
+      getOrgMembersCsv(context, orgId),
+      getCustomerTierInfo(context, orgId),
+    ]);
 
     if (!cdnKnown) {
       log.warn(`[cdn-opt-in-notification] Unknown CDN type for site=${siteId} — sending notification without CDN-specific guidance (cdnType="${cdnType ?? ''}")`);
@@ -161,9 +208,15 @@ export async function notifyOptInIfNeeded(context, params) {
       adobeManaged,
       commerceManaged,
       replyAllTeam,
+      customerTier: tierInfo.customerTier,
+      isPaidTier: tierInfo.isPaidTier,
+      tierKnown: tierInfo.tierKnown,
     };
 
-    log.info(`[cdn-opt-in-notification] Sending ${OPT_IN_NOTIFICATION_TEMPLATE} for site=${siteId} cdnType=${cdnType} cdnKnown=${cdnKnown}`);
+    log.info(
+      `[cdn-opt-in-notification] Sending ${OPT_IN_NOTIFICATION_TEMPLATE} for site=${siteId} `
+      + `cdnType=${cdnType} cdnKnown=${cdnKnown} tierKnown=${tierInfo.tierKnown} isPaidTier=${tierInfo.isPaidTier}`,
+    );
 
     const result = await sendEmail(context, {
       recipients,

--- a/test/controllers/llmo/cdn-opt-in-notification.test.js
+++ b/test/controllers/llmo/cdn-opt-in-notification.test.js
@@ -10,12 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
+import { Entitlement as EntitlementModel } from '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js';
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
 
 use(sinonChai);
+
+const LLMO_PRODUCT_CODE = EntitlementModel.PRODUCT_CODES.LLMO;
 
 describe('cdn-opt-in-notification', () => {
   let notifyOptInIfNeeded;
@@ -55,6 +58,9 @@ describe('cdn-opt-in-notification', () => {
         TrialUser: {
           allByOrganizationId: sinon.stub().resolves([]),
         },
+        Entitlement: {
+          findByOrganizationIdAndProductCode: sinon.stub().resolves(null),
+        },
       },
     };
   });
@@ -90,6 +96,74 @@ describe('cdn-opt-in-notification', () => {
       expect(opts.templateData.adobeManaged).to.be.false;
       expect(opts.templateData.commerceManaged).to.be.false;
       expect(opts.templateData.replyAllTeam).to.equal('');
+      expect(opts.templateData.customerTier).to.equal('');
+      expect(opts.templateData.isPaidTier).to.be.false;
+      expect(opts.templateData.tierKnown).to.be.false;
+      const findEntitlement = mockContext.dataAccess.Entitlement
+        .findByOrganizationIdAndProductCode;
+      expect(findEntitlement).to.have.been.calledWith('org-uuid-456', LLMO_PRODUCT_CODE);
+    });
+
+    it('passes isPaidTier=true and customerTier=PAID when org has paid LLMO entitlement', async () => {
+      mockContext.dataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves({
+        getTier: () => EntitlementModel.TIERS.PAID,
+      });
+
+      await notifyOptInIfNeeded(mockContext, baseParams);
+
+      const { templateData } = sendEmailStub.firstCall.args[1];
+      expect(templateData.customerTier).to.equal('PAID');
+      expect(templateData.isPaidTier).to.be.true;
+      expect(templateData.tierKnown).to.be.true;
+    });
+
+    it('passes isPaidTier=false and customerTier=FREE_TRIAL for trial entitlement', async () => {
+      mockContext.dataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves({
+        getTier: () => EntitlementModel.TIERS.FREE_TRIAL,
+      });
+
+      await notifyOptInIfNeeded(mockContext, baseParams);
+
+      const { templateData } = sendEmailStub.firstCall.args[1];
+      expect(templateData.customerTier).to.equal('FREE_TRIAL');
+      expect(templateData.isPaidTier).to.be.false;
+      expect(templateData.tierKnown).to.be.true;
+    });
+
+    it('keeps sending with tierKnown=false when no LLMO entitlement exists', async () => {
+      mockContext.dataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
+
+      const result = await notifyOptInIfNeeded(mockContext, baseParams);
+
+      expect(result.sent).to.be.true;
+      const { templateData } = sendEmailStub.firstCall.args[1];
+      expect(templateData.customerTier).to.equal('');
+      expect(templateData.isPaidTier).to.be.false;
+      expect(templateData.tierKnown).to.be.false;
+    });
+
+    it('keeps sending when entitlement lookup fails', async () => {
+      mockContext.dataAccess.Entitlement.findByOrganizationIdAndProductCode.rejects(new Error('db unavailable'));
+
+      const result = await notifyOptInIfNeeded(mockContext, baseParams);
+
+      expect(result.sent).to.be.true;
+      const { templateData } = sendEmailStub.firstCall.args[1];
+      expect(templateData.tierKnown).to.be.false;
+      expect(templateData.isPaidTier).to.be.false;
+      expect(mockContext.log.warn).to.have.been.calledWith(
+        sinon.match(/Failed to fetch LLMO entitlement/),
+      );
+    });
+
+    it('keeps sending with unknown tier when Entitlement model is unavailable', async () => {
+      delete mockContext.dataAccess.Entitlement;
+
+      const result = await notifyOptInIfNeeded(mockContext, baseParams);
+
+      expect(result.sent).to.be.true;
+      const { templateData } = sendEmailStub.firstCall.args[1];
+      expect(templateData.tierKnown).to.be.false;
     });
 
     it('adds organization members as comma-separated emails', async () => {
@@ -169,13 +243,18 @@ describe('cdn-opt-in-notification', () => {
     });
 
     it('keeps sending with empty org members when TrialUser model is unavailable', async () => {
-      mockContext.dataAccess = {};
+      mockContext.dataAccess = {
+        Entitlement: {
+          findByOrganizationIdAndProductCode: sinon.stub().resolves(null),
+        },
+      };
 
       const result = await notifyOptInIfNeeded(mockContext, baseParams);
 
       expect(result.sent).to.be.true;
       const { templateData } = sendEmailStub.firstCall.args[1];
       expect(templateData.orgMembers).to.equal('');
+      expect(templateData.tierKnown).to.be.false;
     });
 
     it('formats org members when trial users expose plain status/emailId fields', async () => {
@@ -366,6 +445,8 @@ describe('cdn-opt-in-notification', () => {
       expect(templateData.adobeManaged).to.be.false;
       expect(templateData.replyAllTeam).to.equal('');
       expect(templateData.orgMembers).to.equal('');
+      expect(templateData.tierKnown).to.be.false;
+      expect(templateData.isPaidTier).to.be.false;
       expect(mockContext.log.warn).to.have.been.calledWithMatch(
         /Unknown CDN type for site=/,
       );
@@ -379,6 +460,7 @@ describe('cdn-opt-in-notification', () => {
       const { templateData } = sendEmailStub.firstCall.args[1];
       expect(templateData.siteBaseURL).to.equal('');
       expect(templateData.orgMembers).to.equal('');
+      expect(templateData.tierKnown).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Summary

- Loads org LLMO entitlement from the database when sending the first edge opt-in notification (`llmo_cdn_opt_in_notification`).
- Adds `isPaidTier`, `customerTier`, and `tierKnown` to Post Office `templateData` (same source of truth as `GET /organizations/{id}/entitlements`).
- Runs entitlement lookup in parallel with org members fetch; failures are logged and do not block the email.

## Post Office follow-up

Update the `llmo_cdn_opt_in_notification` template top notes to use `isPaidTier` (paid) vs `tierKnown` + not paid (free/trial). Backend change alone does not change email copy until the template is updated.

## Test plan

- [x] `npx mocha test/controllers/llmo/cdn-opt-in-notification.test.js` (31 passing)
- [ ] After deploy: trigger first edge opt-in on a paid vs free-trial org and verify log line includes `tierKnown` / `isPaidTier`
- [ ] After Post Office template update: confirm top notes in received email


Made with [Cursor](https://cursor.com)