### PR TITLE
feat: daily granularity for sentiment-overview endpoint | LLMO-5307

### DIFF
--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -1655,8 +1655,111 @@ export function aggregateSentimentByWeek(rows) {
 }
 
 /**
+ * Aggregates execution rows into per-calendar-day sentiment percentages.
+ * Mirrors aggregateSentimentByWeek but buckets by execution_date instead of ISO week.
+ * Dedup key, first-seen semantics, and percentage math are identical.
+ *
+ * @param {Array<{execution_date: string, sentiment: string|null, prompt: string|null,
+ *   region_code: string|null, topics: string|null}>} rows
+ * @returns {Array<Object>} dailyTrends sorted by date ascending
+ * @internal Exported for testing
+ */
+export function aggregateSentimentByDay(rows) {
+  const dayMap = new Map();
+
+  rows.forEach((row) => {
+    const date = row.execution_date;
+    if (!dayMap.has(date)) {
+      const { week, weekNumber, year } = toISOWeek(date);
+      dayMap.set(date, {
+        date,
+        week,
+        weekNumber,
+        year,
+        positive: 0,
+        neutral: 0,
+        negative: 0,
+        totalPrompts: 0,
+        promptsWithSentiment: 0,
+        seenKeys: new Set(),
+      });
+    }
+    const entry = dayMap.get(date);
+
+    const key = buildPromptKey(row);
+    if (entry.seenKeys.has(key)) {
+      return;
+    }
+    entry.seenKeys.add(key);
+
+    entry.totalPrompts += 1;
+
+    const sentiment = (row.sentiment || '').toLowerCase().trim();
+    if (sentiment === 'positive') {
+      entry.positive += 1;
+      entry.promptsWithSentiment += 1;
+    } else if (sentiment === 'neutral') {
+      entry.neutral += 1;
+      entry.promptsWithSentiment += 1;
+    } else if (sentiment === 'negative') {
+      entry.negative += 1;
+      entry.promptsWithSentiment += 1;
+    }
+  });
+
+  return [...dayMap.values()]
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .map((entry) => {
+      const total = entry.promptsWithSentiment;
+      const positivePct = total > 0 ? Math.round((entry.positive / total) * 100) : 0;
+      const negativePct = total > 0 ? Math.round((entry.negative / total) * 100) : 0;
+      const neutralPct = total > 0 ? 100 - positivePct - negativePct : 0;
+
+      return {
+        date: entry.date,
+        week: entry.week,
+        weekNumber: entry.weekNumber,
+        year: entry.year,
+        sentiment: [
+          { name: 'Positive', value: positivePct, color: SENTIMENT_COLORS.positive },
+          { name: 'Neutral', value: neutralPct, color: SENTIMENT_COLORS.neutral },
+          { name: 'Negative', value: negativePct, color: SENTIMENT_COLORS.negative },
+        ],
+        totalPrompts: entry.totalPrompts,
+        promptsWithSentiment: entry.promptsWithSentiment,
+        mentions: 0,
+        citations: 0,
+        visibilityScore: 0,
+        competitors: [],
+      };
+    });
+}
+
+const SENTIMENT_DAILY_MAX_DAYS = 90;
+
+function mapRpcRowToSentimentTrend(row) {
+  return {
+    week: row.week_str,
+    weekNumber: row.week_number,
+    year: row.year,
+    sentiment: [
+      { name: 'Positive', value: row.positive_pct, color: SENTIMENT_COLORS.positive },
+      { name: 'Neutral', value: row.neutral_pct, color: SENTIMENT_COLORS.neutral },
+      { name: 'Negative', value: row.negative_pct, color: SENTIMENT_COLORS.negative },
+    ],
+    totalPrompts: row.total_prompts,
+    promptsWithSentiment: row.prompts_with_sentiment,
+    mentions: 0,
+    citations: 0,
+    visibilityScore: 0,
+    competitors: [],
+  };
+}
+
+/**
  * Creates the getSentimentOverview handler.
- * Returns per-week sentiment counts (positive, neutral, negative) and prompt metrics.
+ * Returns per-week or per-day sentiment counts and prompt metrics.
+ * Pass granularity=day for daily buckets (max 90-day range); default is weekly.
  * @param {Function} getOrgAndValidateAccess - Async (context) => { organization }
  */
 export function createSentimentOverviewHandler(getOrgAndValidateAccess) {
@@ -1671,12 +1774,27 @@ export function createSentimentOverviewHandler(getOrgAndValidateAccess) {
       const organizationId = spaceCatId;
       const filterByBrandId = brandId && brandId !== 'all' ? brandId : null;
 
+      const granularity = ((ctx.data?.granularity) || 'week').toLowerCase();
+      if (granularity !== 'week' && granularity !== 'day') {
+        return badRequest("granularity must be 'week' or 'day'");
+      }
+
       if (brandPresenceRpcRejectsMultiCategoryOrRegion(params)) {
         return badRequest(MULTI_CATEGORY_REGION_RPC_UNSUPPORTED);
       }
 
       const startDate = params.startDate || defaults.startDate;
       const endDate = params.endDate || defaults.endDate;
+
+      if (granularity === 'day') {
+        const days = Math.round(
+          (new Date(`${endDate}T00:00:00Z`) - new Date(`${startDate}T00:00:00Z`)) / MS_PER_DAY,
+        ) + 1;
+        if (days > SENTIMENT_DAILY_MAX_DAYS) {
+          return badRequest('Date range too large for daily granularity (max 90 days)');
+        }
+      }
+
       const model = resolveModelFromRequest(params.model);
 
       if (shouldApplyFilter(params.siteId)) {
@@ -1702,6 +1820,7 @@ export function createSentimentOverviewHandler(getOrgAndValidateAccess) {
         p_region_code: params.regionCodesList?.[0] ?? null,
         p_origin: shouldApplyFilter(params.origin) ? params.origin : null,
         p_topic_ids: params.topicIds?.length > 0 ? params.topicIds : null,
+        p_granularity: granularity,
       });
 
       if (error) {
@@ -1709,23 +1828,16 @@ export function createSentimentOverviewHandler(getOrgAndValidateAccess) {
         return badRequest(error.message);
       }
 
-      const weeklyTrends = (data || []).map((row) => ({
-        week: row.week_str,
-        weekNumber: row.week_number,
-        year: row.year,
-        sentiment: [
-          { name: 'Positive', value: row.positive_pct, color: SENTIMENT_COLORS.positive },
-          { name: 'Neutral', value: row.neutral_pct, color: SENTIMENT_COLORS.neutral },
-          { name: 'Negative', value: row.negative_pct, color: SENTIMENT_COLORS.negative },
-        ],
-        totalPrompts: row.total_prompts,
-        promptsWithSentiment: row.prompts_with_sentiment,
-        mentions: 0,
-        citations: 0,
-        visibilityScore: 0,
-        competitors: [],
-      }));
-      return cachedOk({ weeklyTrends });
+      if (granularity === 'day') {
+        const dailyTrends = (data || []).map((row) => ({
+          date: row.date_str,
+          ...mapRpcRowToSentimentTrend(row),
+        }));
+        return cachedOk({ granularity: 'day', dailyTrends, weeklyTrends: [] });
+      }
+
+      const weeklyTrends = (data || []).map(mapRpcRowToSentimentTrend);
+      return cachedOk({ granularity: 'week', weeklyTrends, dailyTrends: [] });
     },
   );
 }

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -22,6 +22,7 @@ import {
   promptIdForDetailResponse,
   topicLabelForDetailResponse,
   aggregateDetailSources,
+  aggregateSentimentByDay,
   aggregateSentimentByWeek,
   aggregateTopicData,
   aggregateWeeklyDetailStats,
@@ -2508,6 +2509,141 @@ describe('llmo-brand-presence', () => {
     });
   });
 
+  describe('aggregateSentimentByDay', () => {
+    it('returns empty array for empty input', () => {
+      expect(aggregateSentimentByDay([])).to.deep.equal([]);
+    });
+
+    it('deduplicates same prompt key within a day', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-01', sentiment: 'negative', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].totalPrompts).to.equal(1);
+      expect(result[0].promptsWithSentiment).to.equal(1);
+    });
+
+    it('produces two buckets for same prompt on two different days', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-02', sentiment: 'negative', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].date).to.equal('2026-06-01');
+      expect(result[1].date).to.equal('2026-06-02');
+    });
+
+    it('first-seen wins for brands/all multi-brand dedup within a day', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-01', sentiment: 'negative', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+
+      expect(result[0].totalPrompts).to.equal(1);
+      const sentimentMap = {};
+      result[0].sentiment.forEach((s) => {
+        sentimentMap[s.name] = s.value;
+      });
+      expect(sentimentMap.Positive).to.equal(100);
+    });
+
+    it('percentages sum to 100', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-01', sentiment: 'negative', prompt: 'p2', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-01', sentiment: 'neutral', prompt: 'p3', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+      const total = result[0].sentiment.reduce((sum, s) => sum + s.value, 0);
+
+      expect(total).to.equal(100);
+    });
+
+    it('empty/unknown sentiment increments totalPrompts but not promptsWithSentiment', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-01', sentiment: null, prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p2', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+
+      expect(result[0].totalPrompts).to.equal(2);
+      expect(result[0].promptsWithSentiment).to.equal(1);
+    });
+
+    it('sorts ascending by date', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-03', sentiment: 'positive', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p2', region_code: 'US', topics: 't1',
+        },
+        {
+          execution_date: '2026-06-02', sentiment: 'positive', prompt: 'p3', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+
+      expect(result.map((r) => r.date)).to.deep.equal(['2026-06-01', '2026-06-02', '2026-06-03']);
+    });
+
+    it('populates week/weekNumber/year from execution_date', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+
+      expect(result[0].date).to.equal('2026-06-01');
+      expect(result[0].week).to.equal('2026-W23');
+      expect(result[0].weekNumber).to.equal(23);
+      expect(result[0].year).to.equal(2026);
+    });
+
+    it('includes color hex codes in sentiment entries', () => {
+      const rows = [
+        {
+          execution_date: '2026-06-01', sentiment: 'positive', prompt: 'p1', region_code: 'US', topics: 't1',
+        },
+      ];
+      const result = aggregateSentimentByDay(rows);
+      const colors = result[0].sentiment.map((s) => s.color);
+
+      expect(colors).to.include('#047857');
+      expect(colors).to.include('#4B5563');
+      expect(colors).to.include('#B91C1C');
+    });
+  });
+
   describe('createSentimentOverviewHandler', () => {
     const RPC_NAME = 'rpc_brand_presence_sentiment_overview';
 
@@ -2873,6 +3009,134 @@ describe('llmo-brand-presence', () => {
       expect(result.status).to.equal(400);
       const body = await result.json();
       expect(body.message).to.equal('Multiple categoryIds or regionCodes are not supported for this endpoint.');
+    });
+
+    it('default missing granularity returns weeklyTrends and empty dailyTrends', async () => {
+      mockContext.dataAccess.Site.postgrestService = createChainableMock(
+        { data: [], error: null },
+        null,
+        makeRpcResult([makeRpcRow()]),
+      );
+
+      const handler = createSentimentOverviewHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.granularity).to.equal('week');
+      expect(body.weeklyTrends).to.have.lengthOf(1);
+      expect(body.dailyTrends).to.deep.equal([]);
+    });
+
+    it('granularity=week returns weeklyTrends and empty dailyTrends', async () => {
+      mockContext.data = { granularity: 'week' };
+      mockContext.dataAccess.Site.postgrestService = createChainableMock(
+        { data: [], error: null },
+        null,
+        makeRpcResult([makeRpcRow()]),
+      );
+
+      const handler = createSentimentOverviewHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+      const body = await result.json();
+
+      expect(body.granularity).to.equal('week');
+      expect(body.weeklyTrends).to.have.lengthOf(1);
+      expect(body.dailyTrends).to.deep.equal([]);
+    });
+
+    it('granularity=day calls RPC with p_granularity day and returns dailyTrends', async () => {
+      const dayRow = {
+        week_str: '2026-W23',
+        week_number: 23,
+        year: 2026,
+        date_str: '2026-06-01',
+        total_prompts: 10,
+        prompts_with_sentiment: 8,
+        positive_pct: 50,
+        neutral_pct: 25,
+        negative_pct: 25,
+      };
+      const chainMock = createChainableMock(
+        { data: [], error: null },
+        null,
+        { data: [dayRow], error: null },
+      );
+      mockContext.data = {
+        granularity: 'day',
+        startDate: '2026-05-06',
+        endDate: '2026-06-02',
+      };
+      mockContext.dataAccess.Site.postgrestService = chainMock;
+
+      const handler = createSentimentOverviewHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
+      expect(chainMock.rpc).to.have.been.calledWith(
+        RPC_NAME,
+        sinon.match({ p_granularity: 'day' }),
+      );
+      const body = await result.json();
+      expect(body.granularity).to.equal('day');
+      expect(body.weeklyTrends).to.deep.equal([]);
+      expect(body.dailyTrends).to.have.lengthOf(1);
+      const [trend] = body.dailyTrends;
+      expect(trend.date).to.equal('2026-06-01');
+      expect(trend.week).to.equal('2026-W23');
+      expect(trend.weekNumber).to.equal(23);
+      expect(trend.year).to.equal(2026);
+      expect(trend.totalPrompts).to.equal(10);
+      expect(trend.sentiment).to.deep.equal([
+        { name: 'Positive', value: 50, color: '#047857' },
+        { name: 'Neutral', value: 25, color: '#4B5563' },
+        { name: 'Negative', value: 25, color: '#B91C1C' },
+      ]);
+    });
+
+    it('granularity=day with invalid value returns 400', async () => {
+      mockContext.data = { granularity: 'month' };
+      mockContext.dataAccess.Site.postgrestService = createChainableMock();
+      const handler = createSentimentOverviewHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(400);
+      const body = await result.json();
+      expect(body.message).to.equal("granularity must be 'week' or 'day'");
+    });
+
+    it('granularity=day with range > 90 days returns 400', async () => {
+      mockContext.data = {
+        granularity: 'day',
+        startDate: '2026-01-01',
+        endDate: '2026-04-15',
+      };
+      mockContext.dataAccess.Site.postgrestService = createChainableMock(
+        { data: [], error: null },
+      );
+      const handler = createSentimentOverviewHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(400);
+      const body = await result.json();
+      expect(body.message).to.equal('Date range too large for daily granularity (max 90 days)');
+    });
+
+    it('granularity=day with exactly 90-day range succeeds', async () => {
+      mockContext.data = {
+        granularity: 'day',
+        startDate: '2026-03-06',
+        endDate: '2026-06-03',
+      };
+      mockContext.dataAccess.Site.postgrestService = createChainableMock(
+        { data: [], error: null },
+        null,
+        makeRpcResult([]),
+      );
+      const handler = createSentimentOverviewHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      expect(result.status).to.equal(200);
     });
   });
 


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/LLMO-5307

## Summary

Adds `granularity=day` query parameter to
`GET /org/:spaceCatId/brands/{all|:brandId}/brand-presence/sentiment-overview`.

- **Backward compatible** — omitting `granularity` or passing `week` produces the existing
  `weeklyTrends` response unchanged (now also includes `granularity: "week"` and
  `dailyTrends: []`)
- `granularity=day` returns one bucket per calendar date in `dailyTrends`; each entry
  carries `date` (YYYY-MM-DD), `week` (ISO week string), and the same sentiment/prompt
  shape as weekly
- 90-day range cap enforced for daily granularity; invalid values return 400
- Passes `p_granularity` to the RPC (requires the mysticat-data-service migration deployed first)
- Adds `aggregateSentimentByDay` as a JS reference implementation and test oracle
  (same dedup and percentage rules as `aggregateSentimentByWeek`)

## Files changed

| File | Change |
|------|--------|
| `src/controllers/llmo/llmo-brand-presence.js` | `aggregateSentimentByDay`, updated `createSentimentOverviewHandler` |
| `test/controllers/llmo/llmo-brand-presence.test.js` | 9 aggregator tests + 6 handler tests for daily path |

## Test plan

- [ ] `npm test` passes (11 k+ tests, no regressions)
- [ ] Weekly request (no `granularity` param) → response shape unchanged, `weeklyTrends` populated
- [ ] `granularity=day` with 28-day range → `dailyTrends` array, one entry per date
- [ ] `granularity=day` with 91-day range → 400 `Date range too large for daily granularity (max 90 days)`
- [ ] `granularity=month` → 400 `granularity must be 'week' or 'day'`

## Deploy order

1. mysticat-data-service (RPC migration) — deploy first
2. This PR
3. project-elmo-ui (pass `granularity=day` for daily-prompt sites) — separate PR