### PR TITLE
chore: bump @adobe/spacecat-shared-tokowaka-client to 1.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
         "@adobe/spacecat-shared-tier-client": "1.5.1",
-        "@adobe/spacecat-shared-tokowaka-client": "1.18.1",
+        "@adobe/spacecat-shared-tokowaka-client": "1.19.0",
         "@adobe/spacecat-shared-utils": "1.115.4",
         "@adobe/spacecat-shared-vault-secrets": "1.3.5",
         "@aws-sdk/client-s3": "3.1045.0",
@@ -9420,9 +9420,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.18.1.tgz",
-      "integrity": "sha512-bECrTJ2Hu7jghX5sanrHbDKXP4oos0Ot0Y+GxS3p+w3cRdaf4W1NwpE5NdyQqSOVs1QbNL2ik2ZI4p5mCxIACg==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.19.0.tgz",
+      "integrity": "sha512-OyF/y5QtocL5Y+cpaf0cZVRsXeU/9xtSI6fodt1HWUGXZKDP4suRhfNJiTjc6ej5sV9Oxqgzev1rTpTZK38n7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",
     "@adobe/spacecat-shared-tier-client": "1.5.1",
-    "@adobe/spacecat-shared-tokowaka-client": "1.18.1",
+    "@adobe/spacecat-shared-tokowaka-client": "1.19.0",
     "@adobe/spacecat-shared-utils": "1.115.4",
     "@adobe/spacecat-shared-vault-secrets": "1.3.5",
     "@aws-sdk/client-s3": "3.1045.0",


### PR DESCRIPTION
## Summary
- Bumps `@adobe/spacecat-shared-tokowaka-client` from `1.18.1` to `1.19.0`
- Updates `package-lock.json` accordingly

## Test plan
- [ ] CI passes (unit tests, lint, bundle build)