### PR TITLE
chore(release): bump @adobe/spacecat-shared-utils to 1.116.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@adobe/spacecat-shared-slack-client": "1.6.7",
         "@adobe/spacecat-shared-tier-client": "1.5.1",
         "@adobe/spacecat-shared-tokowaka-client": "1.19.0",
-        "@adobe/spacecat-shared-utils": "1.115.4",
+        "@adobe/spacecat-shared-utils": "1.116.6",
         "@adobe/spacecat-shared-vault-secrets": "1.3.5",
         "@aws-sdk/client-s3": "3.1045.0",
         "@aws-sdk/client-secrets-manager": "3.1045.0",
@@ -10441,18 +10441,18 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.115.4",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.115.4.tgz",
-      "integrity": "sha512-wVliP5D+81uz+1KXnIGDUPv0dwwchZH8X2gRLCeEpamoZp0rt03xJJyisG8+8UYPTDWsKEnWZ+DpvYCdVyI3Ew==",
+      "version": "1.116.6",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.116.6.tgz",
+      "integrity": "sha512-yPohm6sZrLCnkinD6jgtYGMdFoJYy+fHM+MUkCXUzlVVgG+Rw0mpVjzGeZC+xH8hBUQ5gPYoUSP5fKHcaIT1Uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
-        "@aws-sdk/client-s3": "3.1045.0",
-        "@aws-sdk/client-sqs": "3.1045.0",
+        "@aws-sdk/client-s3": "3.1057.0",
+        "@aws-sdk/client-sqs": "3.1057.0",
         "@json2csv/plainjs": "7.0.6",
         "aws-xray-sdk": "3.12.0",
         "cheerio": "1.2.0",
-        "date-fns": "4.1.0",
+        "date-fns": "4.4.0",
         "franc-min": "6.2.0",
         "ipaddr.js": "^2.2.0",
         "iso-639-3": "3.0.1",
@@ -10464,6 +10464,70 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-s3": {
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1057.0.tgz",
+      "integrity": "sha512-4MV5+ph7WSLEqStKYdWf2EIHIvLpPzV8xN98jWSVJfUpp5j7T8dyN3AROPPsKWvCme8hbx1ybCjtK76ALCZUYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.47",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.17",
+        "@aws-sdk/middleware-expect-continue": "^3.972.14",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.23",
+        "@aws-sdk/middleware-location-constraint": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.44",
+        "@aws-sdk/middleware-ssec": "^3.972.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-sqs": {
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1057.0.tgz",
+      "integrity": "sha512-Qaxt1azI1PwClNkQzt/7N10rTdvC8oBleBxZ3yZWswXgMD/EcZ5sMim925uD75YXgzLwLnxKzF7c4mUxNuCqqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.47",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.26",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/types": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
+      "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-utils/node_modules/cheerio": {
@@ -10489,6 +10553,16 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@adobe/spacecat-shared-utils/node_modules/ipaddr.js": {
@@ -13449,16 +13523,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.22.tgz",
-      "integrity": "sha512-DtR3mEiOUJcnEX/QuXmvbJto6xvQzp2ftnHb29c0aQYdmmzbKf0gsu9ovx1i/yy4ZR6m0rttTucS0iiP32dlGA==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.28.tgz",
+      "integrity": "sha512-hr4JLdfsF4nkonLKu7igqP44eNMo78pc5n62H07EvCjCC1s4LH5/tWH+yRZ1Ho4Wv43ZOVQRYtxpU/30TaLOfg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -13466,12 +13538,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
+      "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16874,13 +16946,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
-      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17290,9 +17362,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@adobe/spacecat-shared-slack-client": "1.6.7",
     "@adobe/spacecat-shared-tier-client": "1.5.1",
     "@adobe/spacecat-shared-tokowaka-client": "1.19.0",
-    "@adobe/spacecat-shared-utils": "1.115.4",
+    "@adobe/spacecat-shared-utils": "1.116.6",
     "@adobe/spacecat-shared-vault-secrets": "1.3.5",
     "@aws-sdk/client-s3": "3.1045.0",
     "@aws-sdk/client-secrets-manager": "3.1045.0",


### PR DESCRIPTION
## Summary

- Bumps `@adobe/spacecat-shared-utils` from `1.115.4` to `1.116.6`
- `@adobe/spacecat-shared-tokowaka-client` is already at `1.19.0` (landed in #2552)

## Changes

- `package.json`: `@adobe/spacecat-shared-utils` `1.115.4` → `1.116.6`

Notable in `1.116.6`: tightens the `/press.*hold/` and `/click.*hold/` regexes in `detectBotBlocker` to require adjacent words, preventing false-positive bot-block detections on normal page content (e.g. athenahealth.com). See adobe/spacecat-shared#1649.

## Test plan

- [ ] CI passes
- [ ] No regression in bot-blocker detection