### PR TITLE
feat(s2s): expose GET /sites/:siteId/user-activities to S2S consumers via trialUser:read

### DIFF
--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -135,8 +135,7 @@ export const INTERNAL_ROUTES = [
   'PATCH /plg/records/:plgOnboardingId',
   'DELETE /plg/records/:plgOnboardingId',
 
-  // Tier-specific - user activities, trial users, user details: end-user/admin flows only
-  'GET /sites/:siteId/user-activities',
+  // Tier-specific - user activities (POST only), trial users, user details: end-user/admin flows
   'POST /sites/:siteId/user-activities',
   'GET /organizations/:organizationId/trial-users',
   'GET /admin/users/:userId',
@@ -588,6 +587,9 @@ const routeRequiredCapabilities = {
   'GET /llmo/ai-visibility/v1/prompt/brand-prompts': 'report:read',
   'GET /llmo/ai-visibility/v1/prompt/gap-prompts': 'report:read',
   'GET /llmo/ai-visibility/v1/prompt/prompt-response': 'report:read',
+
+  // User Activities
+  'GET /sites/:siteId/user-activities': 'trialUser:read',
 
   // Site Enrollments
   'GET /sites/:siteId/site-enrollments': 'siteEnrollment:read',


### PR DESCRIPTION
## Summary

- Moves `GET /sites/:siteId/user-activities` from `INTERNAL_ROUTES` to `routeRequiredCapabilities` with capability `trialUser:read`
- `POST /sites/:siteId/user-activities` remains in `INTERNAL_ROUTES` as it is the trial-user self-service activity creation flow, not intended for S2S consumers
- All existing unit tests and capability partition tests pass (2443 passing)

## Test plan

- [x] `npx mocha test/routes/required-capabilities.test.js` — all 2443 tests pass, including the disjointness invariant and route coverage assertions
- [x] `npx mocha test/controllers/user-activities.test.js test/s2s-auth-integration.test.js` — all 54 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)