### PR TITLE
feat(bot-blocker): forward scraperConfig.headers to detectBotBlocker probe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@adobe/spacecat-shared-slack-client": "1.6.7",
         "@adobe/spacecat-shared-tier-client": "1.5.1",
         "@adobe/spacecat-shared-tokowaka-client": "1.19.0",
-        "@adobe/spacecat-shared-utils": "1.116.6",
+        "@adobe/spacecat-shared-utils": "1.117.0",
         "@adobe/spacecat-shared-vault-secrets": "1.3.5",
         "@aws-sdk/client-s3": "3.1045.0",
         "@aws-sdk/client-secrets-manager": "3.1045.0",
@@ -10441,9 +10441,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.116.6",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.116.6.tgz",
-      "integrity": "sha512-yPohm6sZrLCnkinD6jgtYGMdFoJYy+fHM+MUkCXUzlVVgG+Rw0mpVjzGeZC+xH8hBUQ5gPYoUSP5fKHcaIT1Uw==",
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.117.0.tgz",
+      "integrity": "sha512-oQU+1pYaGHE9mbA432lEuNXAfF8QaqN0RnM6ox9lxovIhVmRy5kCDwbI+Vm8gLnRP//tD+QqCWFUafZlpBsjjw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@adobe/spacecat-shared-slack-client": "1.6.7",
     "@adobe/spacecat-shared-tier-client": "1.5.1",
     "@adobe/spacecat-shared-tokowaka-client": "1.19.0",
-    "@adobe/spacecat-shared-utils": "1.116.6",
+    "@adobe/spacecat-shared-utils": "1.117.0",
     "@adobe/spacecat-shared-vault-secrets": "1.3.5",
     "@aws-sdk/client-s3": "3.1045.0",
     "@aws-sdk/client-secrets-manager": "3.1045.0",

--- a/src/controllers/bot-blocker.js
+++ b/src/controllers/bot-blocker.js
@@ -72,10 +72,18 @@ function BotBlockerController(ctx, log) {
         return internalServerError('Site has no baseURL configured');
       }
 
-      log.debug(`Checking bot blocker for site ${siteId} with baseURL: ${baseURL}`);
+      // Mirror what the real scraper sends so the probe is a faithful predictor
+      // of scrape success. Without this, sites that allowlist scraper traffic via
+      // a custom header (e.g. Akamai Bot Manager requiring `Accept-Language`)
+      // probe as blocked even though scrapes succeed.
+      // Defensive `?.` chain matches spacecat-scrape-job-manager — older
+      // `@adobe/spacecat-shared-data-access` versions without `getScraperConfig`
+      // silently fall back to `{}`, preserving today's behavior.
+      const customHeaders = site.getConfig()?.getScraperConfig?.()?.headers || {};
 
-      // Call the bot blocker detection function
-      const result = await detectBotBlocker({ baseUrl: baseURL });
+      log.debug(`Checking bot blocker for site ${siteId} with baseURL: ${baseURL}, customHeaders: ${Object.keys(customHeaders).join(',') || 'none'}`);
+
+      const result = await detectBotBlocker({ baseUrl: baseURL, headers: customHeaders });
 
       log.debug(`Bot blocker check completed for site ${siteId}: crawlable=${result.crawlable}, type=${result.type}, confidence=${result.confidence}`);
 

--- a/test/controllers/bot-blocker.test.js
+++ b/test/controllers/bot-blocker.test.js
@@ -31,6 +31,12 @@ describe('Bot Blocker Controller', () => {
     debug: sandbox.stub(),
   };
 
+  // Default: site has a config but no scraperConfig.headers. Individual tests
+  // can override `siteConfig.getScraperConfig` to exercise the passthrough.
+  const siteConfig = {
+    getScraperConfig: sandbox.stub().returns(undefined),
+  };
+
   const mockSite = {
     getId: () => siteId,
     getBaseURL: () => baseURL,
@@ -39,6 +45,7 @@ describe('Bot Blocker Controller', () => {
       getId: () => 'org-123',
       getImsOrgId: () => 'imsOrg123@AdobeOrg',
     }),
+    getConfig: () => siteConfig,
   };
 
   const mockDataAccess = {
@@ -89,6 +96,7 @@ describe('Bot Blocker Controller', () => {
     // Reset stubs
     mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
     mockAccessControlUtil.hasAccess = sandbox.stub().resolves(true);
+    siteConfig.getScraperConfig = sandbox.stub().returns(undefined);
     detectBotBlockerStub.reset();
     isValidUUIDStub.resetBehavior();
     isValidUUIDStub.returns(true); // Default to valid UUID
@@ -179,8 +187,8 @@ describe('Bot Blocker Controller', () => {
       expect(response.status).to.equal(200);
       const result = await response.json();
       expect(result).to.deep.equal(botBlockerResult);
-      expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL });
-      expect(loggerStub.debug).to.have.been.calledWith(`Checking bot blocker for site ${siteId} with baseURL: ${baseURL}`);
+      expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL, headers: {} });
+      expect(loggerStub.debug).to.have.been.calledWith(`Checking bot blocker for site ${siteId} with baseURL: ${baseURL}, customHeaders: none`);
       expect(loggerStub.debug).to.have.been.calledWith(`Bot blocker check completed for site ${siteId}: crawlable=true, type=none, confidence=1`);
     });
 
@@ -201,8 +209,45 @@ describe('Bot Blocker Controller', () => {
       expect(response.status).to.equal(200);
       const result = await response.json();
       expect(result).to.deep.equal(botBlockerResult);
-      expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL });
+      expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL, headers: {} });
       expect(loggerStub.debug).to.have.been.calledWith(`Bot blocker check completed for site ${siteId}: crawlable=false, type=cloudflare, confidence=0.99`);
+    });
+
+    it('passes scraperConfig.headers through so the probe mirrors the scraper', async () => {
+      // Without this passthrough the probe sees a false-positive block on sites
+      // whose WAF (e.g. Akamai Bot Manager) allowlists scraper traffic via a
+      // required header like `Accept-Language`.
+      const customHeaders = { 'Accept-Language': 'en-US' };
+      siteConfig.getScraperConfig = sandbox.stub().returns({ headers: customHeaders });
+      detectBotBlockerStub.resolves({ crawlable: true, type: 'none', confidence: 1.0 });
+
+      const response = await botBlockerController.checkBotBlocker({ params: { siteId } });
+
+      expect(response.status).to.equal(200);
+      expect(detectBotBlockerStub).to.have.been.calledWith({
+        baseUrl: baseURL,
+        headers: customHeaders,
+      });
+      expect(loggerStub.debug).to.have.been.calledWith(
+        `Checking bot blocker for site ${siteId} with baseURL: ${baseURL}, customHeaders: Accept-Language`,
+      );
+    });
+
+    it('falls back to empty headers when site lacks getScraperConfig (old data-access)', async () => {
+      // Older @adobe/spacecat-shared-data-access versions don't define
+      // getScraperConfig on the Config object. The defensive `?.()` chain must
+      // silently return {} so the probe still runs.
+      const oldSiteConfig = {}; // no getScraperConfig
+      mockDataAccess.Site.findById = sandbox.stub().resolves({
+        ...mockSite,
+        getConfig: () => oldSiteConfig,
+      });
+      detectBotBlockerStub.resolves({ crawlable: true, type: 'none', confidence: 1.0 });
+
+      const response = await botBlockerController.checkBotBlocker({ params: { siteId } });
+
+      expect(response.status).to.equal(200);
+      expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL, headers: {} });
     });
 
     it('returns internal server error when detectBotBlocker throws an error', async () => {

--- a/test/controllers/bot-blocker.test.js
+++ b/test/controllers/bot-blocker.test.js
@@ -250,6 +250,34 @@ describe('Bot Blocker Controller', () => {
       expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL, headers: {} });
     });
 
+    it('falls back to empty headers when getConfig() returns null', async () => {
+      // Defensive `?.` on getConfig() must short-circuit cleanly if a site
+      // ever surfaces a null Config object (e.g. partially-initialized site).
+      mockDataAccess.Site.findById = sandbox.stub().resolves({
+        ...mockSite,
+        getConfig: () => null,
+      });
+      detectBotBlockerStub.resolves({ crawlable: true, type: 'none', confidence: 1.0 });
+
+      const response = await botBlockerController.checkBotBlocker({ params: { siteId } });
+
+      expect(response.status).to.equal(200);
+      expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL, headers: {} });
+    });
+
+    it('falls back to empty headers when scraperConfig has no headers key', async () => {
+      // Sites may persist scraperConfig with other future fields (e.g. timeout)
+      // but no headers property. The `|| {}` fallback must catch the
+      // `undefined` headers and pass an empty object to the probe.
+      siteConfig.getScraperConfig = sandbox.stub().returns({ timeout: 5000 });
+      detectBotBlockerStub.resolves({ crawlable: true, type: 'none', confidence: 1.0 });
+
+      const response = await botBlockerController.checkBotBlocker({ params: { siteId } });
+
+      expect(response.status).to.equal(200);
+      expect(detectBotBlockerStub).to.have.been.calledWith({ baseUrl: baseURL, headers: {} });
+    });
+
     it('returns internal server error when detectBotBlocker throws an error', async () => {
       const error = new Error('Network error');
       detectBotBlockerStub.rejects(error);


### PR DESCRIPTION
## Summary
The `/sites/:siteId/bot-blocker` controller now reads `site.getConfig()?.getScraperConfig?.()?.headers` and forwards them to `detectBotBlocker`. The probe now mirrors what the real scraper sends, so sites whose WAF allowlists scraper traffic via a custom header (e.g. Akamai Bot Manager requiring `Accept-Language`) report `crawlable: true` correctly.

Defensive `?.` chain matches the pattern in [spacecat-scrape-job-manager#183](https://github.com/adobe/spacecat-scrape-job-manager/pull/183) — older `@adobe/spacecat-shared-data-access` versions without `getScraperConfig` silently fall back to `{}`, preserving today's behavior for sites without custom headers.

Depends on `@adobe/spacecat-shared-utils@1.117.0` ([adobe/spacecat-shared#1650](https://github.com/adobe/spacecat-shared/pull/1650)) which added the optional `headers` param to `detectBotBlocker`.

## Related Issues
- LLMO-4975 — careinsurance.com "Unlock Opportunities" card stuck in error state even though scrapes succeed after `scraperConfig.headers` allowlist

## Test plan
- [x] 2 new unit tests: scraperConfig.headers passthrough + old data-access fallback
- [x] Existing 9 tests updated for new call signature
- [x] All 11 controller tests pass
- [x] ESLint clean
- [x] `npm run docs:lint` validates

## Verification after merge
1. Hit `GET /sites/{careHealthSiteId}/bot-blocker` directly — should return `crawlable: true`
2. Refresh `llmo.now/.../brands-management?...&brandTab=cdn` in elmo UI — "Unlock Opportunities" card flips from Error → green
3. Spot-check 1-2 sites *without* `scraperConfig.headers` to confirm no regression