### PR TITLE
feat: proxy endpoint for url inspector preview | LLMO-434

### DIFF
--- a/src/controllers/proxy.js
+++ b/src/controllers/proxy.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { badRequest } from '@adobe/spacecat-shared-http-utils';
+
+// Block requests to private/loopback/metadata addresses to prevent SSRF
+const BLOCKED_HOST_RE = /^(localhost$|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.)/;
+
+function ProxyController() {
+  const getPreview = async (context) => {
+    const rawUrl = new URL(context.request.url).searchParams.get('url');
+
+    if (!rawUrl) {
+      return badRequest('url query parameter is required');
+    }
+
+    let targetUrl;
+    try {
+      targetUrl = new URL(rawUrl);
+    } catch {
+      return badRequest('Invalid URL');
+    }
+
+    if (targetUrl.protocol !== 'http:' && targetUrl.protocol !== 'https:') {
+      return badRequest('Only http and https URLs are supported');
+    }
+
+    if (BLOCKED_HOST_RE.test(targetUrl.hostname)) {
+      return badRequest('URL hostname is not allowed');
+    }
+
+    let upstream;
+    try {
+      upstream = await fetch(targetUrl.toString(), {
+        redirect: 'follow',
+        signal: AbortSignal.timeout(10000),
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; SpaceCat/1.0)' },
+      });
+    } catch {
+      return new Response('Failed to fetch URL', { status: 502 });
+    }
+
+    const contentType = upstream.headers.get('content-type') || '';
+    if (!contentType.includes('text/html')) {
+      return new Response('URL does not return HTML', { status: 415 });
+    }
+
+    const html = await upstream.text();
+    const baseTag = `<base href="${targetUrl.href}">`;
+    const patched = /<head/i.test(html)
+      ? html.replace(/(<head[^>]*>)/i, `$1${baseTag}`)
+      : `${baseTag}${html}`;
+
+    return new Response(patched, {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  };
+
+  return { getPreview };
+}
+
+export default ProxyController;

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,7 @@ import AiVisibilityController from './controllers/ai-visibility.js';
 import AgenticCategoriesController from './controllers/agentic-categories.js';
 import AgenticPageTypesController from './controllers/agentic-page-types.js';
 import SerenityController from './controllers/serenity.js';
+import ProxyController from './controllers/proxy.js';
 import GitHubWebhookHmacHandler from './support/github-webhook-hmac-handler.js';
 import ApiKeyImsHandler from './support/api-key-ims-handler.js';
 import RouteScopedLegacyApiKeyHandler from './support/route-scoped-legacy-api-key-handler.js';
@@ -278,6 +279,7 @@ async function run(request, context) {
     const agenticCategoriesController = AgenticCategoriesController();
     const agenticPageTypesController = AgenticPageTypesController();
     const serenityController = SerenityController(context, log, context.env);
+    const proxyController = ProxyController();
 
     const routeHandlers = getRouteHandlers(
       auditsController,
@@ -337,6 +339,7 @@ async function run(request, context) {
       agenticCategoriesController,
       agenticPageTypesController,
       serenityController,
+      proxyController,
     );
 
     const routeMatch = matchPath(method, suffix, routeHandlers);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -103,6 +103,7 @@ function isStaticRoute(routePattern) {
  * @param {Object} agenticCategoriesController - Agentic URL category rules controller.
  * @param {Object} agenticPageTypesController - Agentic URL page-type rules controller.
  * @param {Object} serenityController - Serenity API controller (prompts + markets).
+ * @param {Object} proxyController - URL proxy controller for client-side previews.
  * @return {{staticRoutes: {}, dynamicRoutes: {}}} - An object with static and dynamic routes.
  */
 export default function getRouteHandlers(
@@ -163,6 +164,7 @@ export default function getRouteHandlers(
   agenticCategoriesController,
   agenticPageTypesController,
   serenityController,
+  proxyController,
 ) {
   const staticRoutes = {};
   const dynamicRoutes = {};
@@ -398,6 +400,7 @@ export default function getRouteHandlers(
     'POST /tools/api-keys': apiKeyController.createApiKey,
     'DELETE /tools/api-keys/:id': apiKeyController.deleteApiKey,
     'GET /tools/api-keys': apiKeyController.getApiKeys,
+    'GET /tools/proxy': proxyController.getPreview,
     'GET /monitoring/drs-bp-pg-audit': drsBpPgAuditController.getProjectionAudit,
     'POST /tools/import/jobs': importController.createImportJob,
     'GET /tools/import/jobs/:jobId': importController.getImportJobStatus,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -178,6 +178,8 @@ export const INTERNAL_ROUTES = [
   'POST /tools/api-keys',
   'DELETE /tools/api-keys/:id',
   'GET /tools/api-keys',
+  // URL preview proxy - UI-only utility for iframe rendering; not for S2S consumers
+  'GET /tools/proxy',
   // Insights orchestration - admin-only via hasAdminAccess(); not for S2S consumers
   'POST /ephemeral-run/batch',
   'GET /ephemeral-run/batch/:batchId/status',

--- a/test/controllers/proxy.test.js
+++ b/test/controllers/proxy.test.js
@@ -48,6 +48,13 @@ describe('Proxy Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('returns 400 for a malformed url', async () => {
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=not-a-valid-url'),
+      );
+      expect(response.status).to.equal(400);
+    });
+
     it('returns 400 for a non-http/https scheme', async () => {
       const response = await proxyController.getPreview(
         makeContext('https://api.example.com/tools/proxy?url=ftp%3A%2F%2Fevil.com'),

--- a/test/controllers/proxy.test.js
+++ b/test/controllers/proxy.test.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ProxyController from '../../src/controllers/proxy.js';
+
+function makeContext(url) {
+  return { request: { url } };
+}
+
+function mockFetchHtml(html, contentType = 'text/html; charset=utf-8') {
+  return sinon.stub(globalThis, 'fetch').resolves(
+    new Response(html, { status: 200, headers: { 'Content-Type': contentType } }),
+  );
+}
+
+describe('Proxy Controller', () => {
+  let proxyController;
+  let fetchStub;
+
+  before(() => {
+    proxyController = ProxyController();
+  });
+
+  afterEach(() => {
+    if (fetchStub) {
+      fetchStub.restore();
+      fetchStub = null;
+    }
+  });
+
+  describe('getPreview', () => {
+    it('returns 400 when url param is missing', async () => {
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy'),
+      );
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 for a non-http/https scheme', async () => {
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=ftp%3A%2F%2Fevil.com'),
+      );
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 for localhost', async () => {
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=http%3A%2F%2Flocalhost%2Fsecret'),
+      );
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 for AWS metadata IP', async () => {
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=http%3A%2F%2F169.254.169.254%2Flatest%2Fmeta-data%2F'),
+      );
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 for private 10.x IP', async () => {
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=http%3A%2F%2F10.0.0.1%2Fsecret'),
+      );
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 415 when upstream returns non-HTML content-type', async () => {
+      fetchStub = sinon.stub(globalThis, 'fetch').resolves(
+        new Response('{"data":1}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      );
+
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=https%3A%2F%2Fexample.com%2Fpage'),
+      );
+      expect(response.status).to.equal(415);
+    });
+
+    it('returns 502 when upstream fetch throws', async () => {
+      fetchStub = sinon.stub(globalThis, 'fetch').rejects(new Error('connection refused'));
+
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=https%3A%2F%2Funreachable.example.com%2F'),
+      );
+      expect(response.status).to.equal(502);
+    });
+
+    it('returns proxied HTML with injected base tag after <head>', async () => {
+      fetchStub = mockFetchHtml('<html><head><title>Test</title></head><body>hello</body></html>');
+
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=https%3A%2F%2Fexample.com%2Farticle'),
+      );
+
+      expect(response.status).to.equal(200);
+      const body = await response.text();
+      expect(body).to.include('<base href="https://example.com/article">');
+      expect(body).to.include('<title>Test</title>');
+    });
+
+    it('prepends base tag when no <head> element is present', async () => {
+      fetchStub = mockFetchHtml('<body>fragment</body>');
+
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=https%3A%2F%2Fexample.com%2Ffragment'),
+      );
+
+      expect(response.status).to.equal(200);
+      const body = await response.text();
+      expect(body).to.match(/^<base href="https:\/\/example\.com\/fragment">/);
+    });
+
+    it('sets Content-Type to text/html', async () => {
+      fetchStub = mockFetchHtml('<html><head></head><body></body></html>');
+
+      const response = await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=https%3A%2F%2Fexample.com%2F'),
+      );
+
+      expect(response.headers.get('content-type')).to.include('text/html');
+    });
+
+    it('follows redirects and fetches the target URL', async () => {
+      fetchStub = mockFetchHtml('<html><head></head><body>redirected</body></html>');
+
+      await proxyController.getPreview(
+        makeContext('https://api.example.com/tools/proxy?url=https%3A%2F%2Fexample.com%2Fredirect'),
+      );
+
+      const [calledUrl, calledOpts] = fetchStub.firstCall.args;
+      expect(calledUrl).to.equal('https://example.com/redirect');
+      expect(calledOpts.redirect).to.equal('follow');
+    });
+  });
+});

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -534,6 +534,10 @@ describe('getRouteHandlers', () => {
     remove: sinon.stub(),
   };
 
+  const mockProxyController = {
+    getPreview: sinon.stub(),
+  };
+
   it('segregates static and dynamic routes', () => {
     const { staticRoutes, dynamicRoutes } = getRouteHandlers(
       mockAuditsController,
@@ -593,6 +597,7 @@ describe('getRouteHandlers', () => {
       mockAgenticCategoriesController,
       mockAgenticPageTypesController,
       mockSerenityController,
+      mockProxyController,
     );
 
     expect(staticRoutes).to.have.all.keys(
@@ -622,6 +627,7 @@ describe('getRouteHandlers', () => {
       'POST /slack/channels/invite-by-user-id',
       'POST /tools/api-keys',
       'GET /tools/api-keys',
+      'GET /tools/proxy',
       'GET /monitoring/drs-bp-pg-audit',
       'POST /tools/import/jobs',
       'POST /tools/scrape/jobs',
@@ -689,6 +695,7 @@ describe('getRouteHandlers', () => {
     expect(staticRoutes['GET /trigger']).to.equal(mockTrigger);
     expect(staticRoutes['POST /tools/api-keys']).to.equal(mockApiKeyController.createApiKey);
     expect(staticRoutes['GET /tools/api-keys']).to.equal(mockApiKeyController.getApiKeys);
+    expect(staticRoutes['GET /tools/proxy']).to.equal(mockProxyController.getPreview);
     expect(staticRoutes['GET /monitoring/drs-bp-pg-audit']).to.equal(mockDrsBpPgAuditController.getProjectionAudit);
     expect(staticRoutes['POST /consent-banner']).to.equal(mockConsentBannerController.takeScreenshots);
     expect(staticRoutes['POST /tools/scrape/jobs']).to.equal(mockScrapeJobController.createScrapeJob);


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/LLMO-434

### Proxy endpoint

#### New controller

**File**
- `src/controllers/proxy.js`

Added a `GET /tools/proxy?url=<encoded-url>` endpoint that:

- Validates the target URL:
  - Only allows `http` and `https` schemes.
  - Blocks `localhost`.
  - Blocks private IP ranges.
  - Blocks the AWS metadata endpoint.
- Fetches the upstream page with a 10-second timeout.
- Verifies the response content type is HTML.
- Injects a `<base href="...">` tag:
  - Inserts immediately after `<head>` when present.
  - Prepends it to the document when no `<head>` tag exists.
- Returns the patched HTML response.

No additional Lambda was required; the endpoint runs within the existing Lambda.

#### Route registration

**Files**
- `src/routes/index.js`
- `src/index.js`

Wired the proxy controller into the application using the same registration pattern as the existing controllers.

#### Tests

**File**
- `test/controllers/proxy.test.js`

Added 11 tests covering:

- URL validation
- SSRF protection
- Upstream error handling
- HTML `<base>` tag injection
- Redirect handling