### PR TITLE
fix(configuration): allow S2S consumers with configuration:read to read configurations

### DIFF
--- a/src/controllers/configuration.js
+++ b/src/controllers/configuration.js
@@ -27,6 +27,7 @@ import { checkConfiguration } from '@adobe/spacecat-shared-data-access';
 
 import { ConfigurationDto } from '../dto/configuration.js';
 import AccessControlUtil from '../support/access-control-util.js';
+import { CAP_CONFIGURATION_READ } from '../routes/capability-constants.js';
 
 function ConfigurationController(ctx) {
   if (!isNonEmptyObject(ctx)) {
@@ -52,13 +53,40 @@ function ConfigurationController(ctx) {
   };
 
   /**
+   * Authorizes a configuration read. Full and read-only admins pass as before.
+   * Additionally, an S2S consumer holding the `configuration:read` capability is
+   * allowed — the capability is also enforced at Layer 1 by `s2sAuthWrapper`, so
+   * this re-check (a fresh consumer fetch via `hasS2SCapability`) is the Layer-2
+   * guard that mirrors the readAll pattern in the sites/organizations controllers.
+   * @param {UniversalContext} context - Request context.
+   * @param {string} route - Route label used in structured logs.
+   * @returns {Promise<Response|null>} A `forbidden` response when denied, else null.
+   */
+  const authorizeConfigRead = async (context, route) => {
+    const requestId = context?.invocation?.id || 'unknown';
+    const isAdmin = accessControlUtil.hasAdminReadAccess();
+    const s2sResult = isAdmin
+      ? { allowed: false, reason: 'admin-bypass' }
+      : await accessControlUtil.hasS2SCapability(CAP_CONFIGURATION_READ);
+    if (!isAdmin && !s2sResult.allowed) {
+      log.info(`[acl] Denied ${route} - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} requestId=${requestId}`);
+      return forbidden('Only admins can view configurations');
+    }
+    if (s2sResult.allowed) {
+      log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_CONFIGURATION_READ} requestId=${requestId}`);
+    }
+    return null;
+  };
+
+  /**
    * Retrieves the configuration identified by the given version.
    * @param {UniversalContext} context - Context of the request.
    * @return {Promise<Response>} Configuration response.
    */
   const getByVersion = async (context) => {
-    if (!accessControlUtil.hasAdminReadAccess()) {
-      return forbidden('Only admins can view configurations');
+    const denied = await authorizeConfigRead(context, 'GET /configurations/:version');
+    if (denied) {
+      return denied;
     }
     const configurationVersion = context.params?.version;
 
@@ -76,11 +104,13 @@ function ConfigurationController(ctx) {
 
   /**
    * Retrieves the latest configuration with schema validation.
+   * @param {UniversalContext} context - Context of the request.
    * @return {Promise<Response>} Configuration response.
    */
-  const getLatest = async () => {
-    if (!accessControlUtil.hasAdminReadAccess()) {
-      return forbidden('Only admins can view configurations');
+  const getLatest = async (context) => {
+    const denied = await authorizeConfigRead(context, 'GET /configurations/latest');
+    if (denied) {
+      return denied;
     }
     const configuration = await Configuration.findLatest();
     if (!configuration) {

--- a/src/routes/capability-constants.js
+++ b/src/routes/capability-constants.js
@@ -22,6 +22,8 @@
 export const CAP_SITE_READ_ALL = 'site:readAll';
 export const CAP_ORG_READ_ALL = 'organization:readAll';
 
+export const CAP_CONFIGURATION_READ = 'configuration:read';
+
 export const CAP_SITE_CREATE = 'site:create';
 
 export const CAP_FIX_ENTITY_CREATE = 'fixEntity:create';

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -11,6 +11,7 @@
  */
 
 import {
+  CAP_CONFIGURATION_READ,
   CAP_FIX_ENTITY_CREATE,
   CAP_ORG_READ_ALL,
   CAP_SITE_CREATE,
@@ -223,10 +224,10 @@ const routeRequiredCapabilities = {
   'GET /consent-banner/:jobId': 'organization:read',
 
   // Configuration
-  'GET /configurations/latest': 'configuration:read',
+  'GET /configurations/latest': CAP_CONFIGURATION_READ,
   'PATCH /configurations/latest': 'configuration:write',
   'POST /configurations/:version/restore': 'configuration:write',
-  'GET /configurations/:version': 'configuration:read',
+  'GET /configurations/:version': CAP_CONFIGURATION_READ,
   'POST /configurations/audits': 'configuration:write',
   'DELETE /configurations/audits/:auditType': 'configuration:write',
   'PUT /configurations/latest/queues': 'configuration:write',

--- a/test/controllers/configurations.test.js
+++ b/test/controllers/configurations.test.js
@@ -318,6 +318,84 @@ describe('Configurations Controller', () => {
     expect(error).to.have.property('message', 'Only admins can view configurations');
   });
 
+  describe('configuration read - S2S configuration:read capability', () => {
+    const makeS2SConsumer = ({
+      clientId = 'svc-cfg', imsOrgId = 'AAA111111111111111111111@AdobeOrg',
+    } = {}) => ({ getClientId: () => clientId, getImsOrgId: () => imsOrgId });
+
+    const makeFreshConsumer = ({
+      id = 'consumer-cfg-1',
+      capabilities = ['configuration:read'],
+      status = 'ACTIVE',
+      revoked = false,
+    } = {}) => ({
+      getId: () => id,
+      getCapabilities: () => capabilities,
+      getStatus: () => status,
+      isRevoked: () => revoked,
+    });
+
+    beforeEach(() => {
+      // Non-admin caller so the S2S capability path (not the admin bypass) runs.
+      context.attributes.authInfo.withProfile({ is_admin: false });
+      context.s2sConsumer = makeS2SConsumer();
+      context.invocation = { id: 'req-cfg-1' };
+      mockDataAccess.Consumer = { findByClientIdAndImsOrgId: sandbox.stub() };
+    });
+
+    it('grants getLatest to an S2S consumer holding configuration:read', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:read'] }));
+
+      const result = await configurationsController.getLatest(context);
+
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Consumer.findByClientIdAndImsOrgId).to.have.been.calledOnce;
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /\[s2s\] GET \/configurations\/latest granted clientId=svc-cfg consumerId=consumer-cfg-1 capability=configuration:read requestId=req-cfg-1/,
+      );
+    });
+
+    it('grants getByVersion to an S2S consumer holding configuration:read', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:read'] }));
+
+      const result = await configurationsController.getByVersion({
+        params: { version: '1' },
+        invocation: { id: 'req-cfg-1' },
+      });
+
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Consumer.findByClientIdAndImsOrgId).to.have.been.calledOnce;
+    });
+
+    it('denies an S2S consumer lacking configuration:read', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['site:read'] }));
+
+      const result = await configurationsController.getLatest(context);
+      const error = await result.json();
+
+      expect(result.status).to.equal(403);
+      expect(error).to.have.property('message', 'Only admins can view configurations');
+      expect(mockDataAccess.Configuration.findLatest).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /\[acl\] Denied GET \/configurations\/latest - reason=missing-capability clientId=svc-cfg consumerId=consumer-cfg-1/,
+      );
+    });
+
+    it('denies a revoked S2S consumer', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ revoked: true }));
+
+      const result = await configurationsController.getLatest(context);
+
+      expect(result.status).to.equal(403);
+      expect(mockDataAccess.Configuration.findLatest).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWithMatch(/reason=revoked/);
+    });
+  });
+
   it('returns not found when a configuration is not found by version', async () => {
     mockDataAccess.Configuration.findByVersion.resolves(null);
 

--- a/test/controllers/configurations.test.js
+++ b/test/controllers/configurations.test.js
@@ -360,10 +360,8 @@ describe('Configurations Controller', () => {
       mockDataAccess.Consumer.findByClientIdAndImsOrgId
         .resolves(makeFreshConsumer({ capabilities: ['configuration:read'] }));
 
-      const result = await configurationsController.getByVersion({
-        params: { version: '1' },
-        invocation: { id: 'req-cfg-1' },
-      });
+      context.params = { version: '1' };
+      const result = await configurationsController.getByVersion(context);
 
       expect(result.status).to.equal(200);
       expect(mockDataAccess.Consumer.findByClientIdAndImsOrgId).to.have.been.calledOnce;
@@ -396,6 +394,17 @@ describe('Configurations Controller', () => {
       expect(result.status).to.equal(403);
       expect(mockDataAccess.Configuration.findLatest).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWithMatch(/reason=revoked/);
+    });
+
+    it('logs requestId=unknown when the invocation id is missing', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['site:read'] }));
+      delete context.invocation;
+
+      const result = await configurationsController.getLatest(context);
+
+      expect(result.status).to.equal(403);
+      expect(context.log.info).to.have.been.calledWithMatch(/requestId=unknown/);
     });
   });
 

--- a/test/controllers/configurations.test.js
+++ b/test/controllers/configurations.test.js
@@ -367,6 +367,9 @@ describe('Configurations Controller', () => {
 
       expect(result.status).to.equal(200);
       expect(mockDataAccess.Consumer.findByClientIdAndImsOrgId).to.have.been.calledOnce;
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /\[s2s\] GET \/configurations\/:version granted clientId=svc-cfg consumerId=consumer-cfg-1 capability=configuration:read requestId=req-cfg-1/,
+      );
     });
 
     it('denies an S2S consumer lacking configuration:read', async () => {

--- a/test/routes/capability-constants.test.js
+++ b/test/routes/capability-constants.test.js
@@ -66,6 +66,18 @@ describe('capability-constants drift coverage', () => {
     });
   });
 
+  it('every exported CAP_ constant is used by at least one route in routeRequiredCapabilities', () => {
+    // Generalizes the readAll coverage to all capability constants (e.g. configuration:read):
+    // an exported constant that no route requires is dead and should be removed or wired up.
+    const usedCaps = new Set(Object.values(routeRequiredCapabilities));
+    ALL_CAP_CONSTANTS.forEach((cap) => {
+      expect(usedCaps.has(cap)).to.equal(
+        true,
+        `Constant "${cap}" is exported but no route in required-capabilities.js requires it. Either map a route to it or remove the constant.`,
+      );
+    });
+  });
+
   it('every readAll constant has an actual hasS2SCapability(CONST) call site (Layer 2 opt-in)', () => {
     // Tighter assertion than "is the constant imported": there must be an actual
     // hasS2SCapability(...) invocation against the constant (or its literal value).
@@ -92,7 +104,7 @@ describe('capability-constants drift coverage', () => {
       const hasCallSite = callByName.test(controllerSource) || callByLiteral.test(controllerSource);
       expect(hasCallSite).to.equal(
         true,
-        `Constant ${name} ("${value}") has no hasS2SCapability(...) call site in sites.js / organizations.js. Without the Layer 2 check the endpoint stays admin-only - this is a silent denial of intended access.`,
+        `Constant ${name} ("${value}") has no hasS2SCapability(...) call site in any scanned controller (sites.js / organizations.js / suggestions.js / configuration.js). Without the Layer 2 check the endpoint stays admin-only - this is a silent denial of intended access.`,
       );
     });
   });

--- a/test/routes/capability-constants.test.js
+++ b/test/routes/capability-constants.test.js
@@ -78,7 +78,7 @@ describe('capability-constants drift coverage', () => {
     });
   });
 
-  it('every readAll constant has an actual hasS2SCapability(CONST) call site (Layer 2 opt-in)', () => {
+  it('every CAP_ constant with an S2S opt-in has an actual hasS2SCapability(CONST) call site (Layer 2 opt-in)', () => {
     // Tighter assertion than "is the constant imported": there must be an actual
     // hasS2SCapability(...) invocation against the constant (or its literal value).
     // An import alone could rot if the call site is removed but the import is kept,

--- a/test/routes/capability-constants.test.js
+++ b/test/routes/capability-constants.test.js
@@ -75,6 +75,7 @@ describe('capability-constants drift coverage', () => {
       join(projectRoot, 'src/controllers/sites.js'),
       join(projectRoot, 'src/controllers/organizations.js'),
       join(projectRoot, 'src/controllers/suggestions.js'),
+      join(projectRoot, 'src/controllers/configuration.js'),
     ];
     const controllerSource = controllerFiles
       .map((file) => readFileSync(file, 'utf8'))


### PR DESCRIPTION
## Problem

`GET /configurations/latest` and `GET /configurations/:version` are gated solely by `accessControlUtil.hasAdminReadAccess()` in the controller. For IMS/S2S tokens that only passes when the token carries the `admin` scope. So an S2S consumer that holds the route's **declared** `configuration:read` capability still gets:

```
403 {"message":"Only admins can view configurations"}
```

The route already declares `configuration:read` in `required-capabilities.js` and `s2sAuthWrapper` (Layer 1) enforces it — but the controller's admin gate (Layer 2) is independent of that capability, so the capability grant is effectively dead for these read routes. The two layers are inconsistent.

Legacy api-key auth bypassed the admin gate (api-key is neither IMS nor JWT, so `hasAdminAccess()` returns `true`). So this was invisible until the **api-key → S2S migration** (api-key deprecation + S2S enablement): once a consumer authenticates with an S2S Bearer instead of the api-key, it loses the admin-equivalent treatment and hits the long-standing admin gate.

### Impact
This silently broke the Adobe LLMO **Data Retrieval Service** schedule-sync, which calls `GET /configurations/latest` to read brand-presence handler→site assignments. With both legacy auths dead for it (api-key 401, S2S 403), no new schedules were reconciled for ~11 days — new customer onboardings got no data-retrieval / brand-presence schedule. The DRS S2S consumer was registered with `configuration:read` in its access request (SITES-43722), but the controller admin gate ignored it.

Verified in prod (3-way auth test against both `llmo` and `spacecat` hosts):

| Auth | Result |
|---|---|
| legacy x-api-key | 401 (deprecated) |
| platform (internal-org) S2S Bearer | 403 `Only admins can view configurations` |
| org-scoped S2S Bearer | 403 `Only admins can view configurations` |

## Fix

Add a Layer-2 `hasS2SCapability('configuration:read')` opt-in on both read endpoints, mirroring the established readAll pattern in the `sites` / `organizations` controllers, via a shared `authorizeConfigRead` helper:

- Full and read-only admins pass exactly as before (admin bypass).
- Otherwise, an S2S consumer holding `configuration:read` is allowed (fresh consumer re-fetch via `hasS2SCapability`, consistent with the other controllers' Layer-2 re-check).
- The denial message (`Only admins can view configurations`) and all write-endpoint gating are **unchanged**.
- Introduces `CAP_CONFIGURATION_READ` as the single-source-of-truth constant shared by `required-capabilities.js` (Layer 1) and the controller (Layer 2), and wires it into the existing drift coverage.

Write endpoints (`PATCH/POST/PUT/DELETE /configurations/...`) remain admin-only — only the two `configuration:read` GET routes change.

## Tests

- New cases in `test/controllers/configurations.test.js`: S2S consumer with `configuration:read` is granted on `getLatest` and `getByVersion`; denied when missing the capability or revoked (with the `[acl]`/`[s2s]` log assertions).
- Existing admin / read-only-admin / non-admin denial tests pass unchanged.
- `test/routes/capability-constants.test.js` updated to include `configuration.js` as a known `hasS2SCapability` call site.
- Full suite green locally (`2598 passing`), lint clean.

## Context

Root-cause analysis and the prod evidence are tracked in LLMO-5341. This is the durable, least-privilege fix (honor the declared capability) rather than granting the DRS consumer a full `admin` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)