### PR TITLE
feat(backfill-llmo): simplify cdn-logs-report backfill to per-day DB imports

### DIFF
--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -215,6 +215,10 @@ async function triggerCdnLogsReportBackfill(sqs, configuration, siteId, trafficD
       message,
       undefined,
       {
+        // Stagger the per-day imports so they don't all fire at once. At current
+        // limits the largest delay is small (CDN_LOGS_REPORT_MAX_DAYS * the
+        // per-day step), but the SQS hard cap (900s) is enforced here so the
+        // value stays valid if those knobs are ever increased.
         delaySeconds: Math.min(index * CDN_LOGS_REPORT_DELAY_SECONDS, SQS_MAX_DELAY_SECONDS),
       },
     );
@@ -284,7 +288,9 @@ async function triggerBackfill(
 
     case AUDIT_TYPES.CDN_LOGS_REPORT: {
       // Daily backfill: one date-based import per traffic day (oldest first).
-      // (mode=weekly-db is handled synchronously before triggerBackfill is called.)
+      // mode=weekly-db is handled synchronously and returns before triggerBackfill
+      // is reached, so specificDate.trafficDays is always populated here; the `|| []`
+      // is a defensive no-op guard, never the queued path.
       await triggerCdnLogsReportBackfill(
         sqs,
         configuration,

--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -104,13 +104,24 @@ function isCompletedIsoWeek(weekRange, now = new Date()) {
 }
 
 /**
+ * Strictly parses a non-negative integer argument. Returns NaN for anything that
+ * isn't all digits (e.g. `foo`, `2x`, `2.5`), so operator typos fail loudly
+ * instead of being silently truncated by parseInt.
+ */
+function parseIntArg(raw) {
+  return /^\s*\d+\s*$/.test(String(raw)) ? parseInt(raw, 10) : NaN;
+}
+
+/**
  * Enumerates the UTC traffic days to backfill for cdn-logs-report, oldest first.
  *
  * Backfilling oldest→newest means each completed week's Sunday is imported after
  * its earlier days, so the projector's automatic weekly rollup (which fires when a
  * week's closing Sunday lands) rebuilds the week from a complete set of raw rows.
  *
- * Precedence: date= (single day) > days=M (trailing days) > weeks=N (ISO weeks).
+ * Exactly one range selector may be set: date= (single day), days=M (trailing days),
+ * or weeks=N (ISO weeks). Combining them is rejected so a queued backfill can't be
+ * misread. When none is given, defaults to the last N completed ISO weeks.
  *
  * @returns {{ days: Date[], desc: string }}
  */
@@ -118,8 +129,19 @@ function buildCdnReportTrafficDays(parsed, now = new Date()) {
   const today = startOfUtcDay(now);
   const yesterday = addUtcDays(today, -1);
 
-  // Single explicit traffic day.
   const trafficDate = parseTrafficDate(parsed);
+
+  // Reject ambiguous combinations — only one of date=/days=/weeks= may be set.
+  const selectors = [
+    trafficDate ? 'date' : null,
+    parsed.days !== undefined ? 'days' : null,
+    parsed.weeks !== undefined ? 'weeks' : null,
+  ].filter(Boolean);
+  if (selectors.length > 1) {
+    throw new Error(`Specify only one of date=, days=, or weeks= (got: ${selectors.join(', ')}).`);
+  }
+
+  // Single explicit traffic day.
   if (trafficDate) {
     if (trafficDate.date > yesterday) {
       throw new Error('date must be yesterday (UTC) or earlier.');
@@ -129,7 +151,7 @@ function buildCdnReportTrafficDays(parsed, now = new Date()) {
 
   // Trailing N days ending yesterday.
   if (parsed.days !== undefined) {
-    const n = parseInt(parsed.days, 10);
+    const n = parseIntArg(parsed.days);
     if (Number.isNaN(n) || n < 1) {
       throw new Error('days must be a positive integer.');
     }
@@ -142,9 +164,12 @@ function buildCdnReportTrafficDays(parsed, now = new Date()) {
 
   // Last N completed ISO weeks (default). weeks=0 = current week to date.
   const thisMonday = startOfUtcIsoWeek(now);
-  let weeks = parseInt(parsed.weeks, 10);
-  if (Number.isNaN(weeks)) {
-    weeks = CDN_LOGS_REPORT_DEFAULT_WEEKS;
+  let weeks = CDN_LOGS_REPORT_DEFAULT_WEEKS;
+  if (parsed.weeks !== undefined) {
+    weeks = parseIntArg(parsed.weeks);
+    if (Number.isNaN(weeks)) {
+      throw new Error(`weeks must be an integer between 0 and ${CDN_LOGS_REPORT_MAX_WEEKS} for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`);
+    }
   }
   if (weeks < 0 || weeks > CDN_LOGS_REPORT_MAX_WEEKS) {
     throw new Error(`weeks must be between 0 and ${CDN_LOGS_REPORT_MAX_WEEKS} for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`);

--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -32,7 +32,7 @@ const AUDIT_TYPES = {
   LLMO_REFERRAL_TRAFFIC: 'llmo-referral-traffic',
   LLM_ERROR_PAGES: 'llm-error-pages',
 };
-const CDN_LOGS_ANALYSIS_DELAY_SECONDS = 5;
+const CDN_LOGS_ANALYSIS_DELAY_SECONDS = 30;
 const SQS_MAX_DELAY_SECONDS = 900;
 
 // cdn-logs-report daily backfill knobs

--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -20,6 +20,7 @@ import BaseCommand from './base.js';
 import {
   addUtcDays,
   formatUtcDate,
+  startOfUtcDay,
   startOfUtcIsoWeek,
 } from './status-command-helpers.js';
 
@@ -33,6 +34,12 @@ const AUDIT_TYPES = {
 };
 const CDN_LOGS_ANALYSIS_DELAY_SECONDS = 5;
 const SQS_MAX_DELAY_SECONDS = 900;
+
+// cdn-logs-report daily backfill knobs
+const CDN_LOGS_REPORT_DELAY_SECONDS = 5;
+const CDN_LOGS_REPORT_MAX_WEEKS = 4;
+const CDN_LOGS_REPORT_DEFAULT_WEEKS = 2;
+const CDN_LOGS_REPORT_MAX_DAYS = 31;
 
 function parseArgs(args) {
   const parsed = {};
@@ -48,10 +55,6 @@ function parseArgs(args) {
 }
 
 const pad2 = (n) => String(n).padStart(2, '0');
-
-function isDbBackfillMode(parsed) {
-  return parsed.mode?.toLowerCase() === 'db';
-}
 
 function isWeeklyDbRefreshMode(parsed) {
   return parsed.mode?.toLowerCase() === 'weekly-db';
@@ -100,6 +103,72 @@ function isCompletedIsoWeek(weekRange, now = new Date()) {
   return weekRange.weekEndDate < startOfUtcIsoWeek(now);
 }
 
+/**
+ * Enumerates the UTC traffic days to backfill for cdn-logs-report, oldest first.
+ *
+ * Backfilling oldest→newest means each completed week's Sunday is imported after
+ * its earlier days, so the projector's automatic weekly rollup (which fires when a
+ * week's closing Sunday lands) rebuilds the week from a complete set of raw rows.
+ *
+ * Precedence: date= (single day) > days=M (trailing days) > weeks=N (ISO weeks).
+ *
+ * @returns {{ days: Date[], desc: string }}
+ */
+function buildCdnReportTrafficDays(parsed, now = new Date()) {
+  const today = startOfUtcDay(now);
+  const yesterday = addUtcDays(today, -1);
+
+  // Single explicit traffic day.
+  const trafficDate = parseTrafficDate(parsed);
+  if (trafficDate) {
+    if (trafficDate.date > yesterday) {
+      throw new Error('date must be yesterday (UTC) or earlier.');
+    }
+    return { days: [trafficDate.date], desc: `traffic day ${trafficDate.dateStr}` };
+  }
+
+  // Trailing N days ending yesterday.
+  if (parsed.days !== undefined) {
+    const n = parseInt(parsed.days, 10);
+    if (Number.isNaN(n) || n < 1) {
+      throw new Error('days must be a positive integer.');
+    }
+    if (n > CDN_LOGS_REPORT_MAX_DAYS) {
+      throw new Error(`Max ${CDN_LOGS_REPORT_MAX_DAYS} days for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`);
+    }
+    const days = Array.from({ length: n }, (_, i) => addUtcDays(yesterday, -(n - 1 - i)));
+    return { days, desc: `last ${n} day${n === 1 ? '' : 's'}` };
+  }
+
+  // Last N completed ISO weeks (default). weeks=0 = current week to date.
+  const thisMonday = startOfUtcIsoWeek(now);
+  let weeks = parseInt(parsed.weeks, 10);
+  if (Number.isNaN(weeks)) {
+    weeks = CDN_LOGS_REPORT_DEFAULT_WEEKS;
+  }
+  if (weeks < 0 || weeks > CDN_LOGS_REPORT_MAX_WEEKS) {
+    throw new Error(`weeks must be between 0 and ${CDN_LOGS_REPORT_MAX_WEEKS} for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`);
+  }
+
+  if (weeks === 0) {
+    // Monday of the current (in-progress) ISO week through yesterday.
+    const count = Math.round((yesterday - thisMonday) / 86_400_000) + 1;
+    if (count <= 0) {
+      return { days: [], desc: 'current week to date (no completed days yet)' };
+    }
+    const days = Array.from({ length: count }, (_, i) => addUtcDays(thisMonday, i));
+    return { days, desc: 'current week to date' };
+  }
+
+  const firstMonday = addUtcDays(thisMonday, -7 * weeks);
+  const lastSunday = addUtcDays(thisMonday, -1);
+  const days = Array.from({ length: 7 * weeks }, (_, i) => addUtcDays(firstMonday, i));
+  return {
+    days,
+    desc: `last ${weeks} completed ISO week${weeks === 1 ? '' : 's'} (${formatUtcDate(firstMonday)}..${formatUtcDate(lastSunday)})`,
+  };
+}
+
 async function refreshAgenticWeeklyRollup(context, siteId, weekRange) {
   const postgrestClient = context.dataAccess?.services?.postgrestClient;
   if (!postgrestClient?.rpc) {
@@ -125,6 +194,31 @@ async function refreshAgenticWeeklyRollup(context, siteId, weekRange) {
 
 function sumRowsInserted(rows) {
   return rows.reduce((sum, row) => sum + Number(row.rows_inserted || 0), 0);
+}
+
+/**
+ * Queues one date-based daily import message per traffic day. The worker exports
+ * the day BEFORE auditContext.date, so we send trafficDay + 1 as the reference.
+ */
+async function triggerCdnLogsReportBackfill(sqs, configuration, siteId, trafficDays) {
+  for (const [index, trafficDay] of trafficDays.entries()) {
+    const message = {
+      type: AUDIT_TYPES.CDN_LOGS_REPORT,
+      siteId,
+      auditContext: {
+        date: formatUtcDate(addUtcDays(trafficDay, 1)),
+      },
+    };
+    // eslint-disable-next-line no-await-in-loop
+    await sqs.sendMessage(
+      configuration.getQueues().audits,
+      message,
+      undefined,
+      {
+        delaySeconds: Math.min(index * CDN_LOGS_REPORT_DELAY_SECONDS, SQS_MAX_DELAY_SECONDS),
+      },
+    );
+  }
 }
 
 async function triggerBackfill(
@@ -189,36 +283,14 @@ async function triggerBackfill(
     }
 
     case AUDIT_TYPES.CDN_LOGS_REPORT: {
-      if (specificDate?.date) {
-        const message = {
-          type: auditType,
-          siteId,
-          auditContext: {
-            date: specificDate.date,
-            refreshAgenticDailyExport: true,
-          },
-        };
-        await sqs.sendMessage(configuration.getQueues().audits, message);
-        break;
-      }
-
-      const weeks = timeValue;
-
-      // Determine weekOffset values: [0] for current week, [-1, -2, -3, -4] for previous weeks
-      const weekOffsets = weeks === 0 ? [0] : Array.from({ length: weeks }, (_, i) => -(i + 1));
-
-      for (const weekOffset of weekOffsets) {
-        const message = {
-          type: auditType,
-          siteId,
-          auditContext: {
-            weekOffset,
-            refreshAgenticDailyExport: true,
-          },
-        };
-        // eslint-disable-next-line no-await-in-loop
-        await sqs.sendMessage(configuration.getQueues().audits, message);
-      }
+      // Daily backfill: one date-based import per traffic day (oldest first).
+      // (mode=weekly-db is handled synchronously before triggerBackfill is called.)
+      await triggerCdnLogsReportBackfill(
+        sqs,
+        configuration,
+        siteId,
+        specificDate?.trafficDays || [],
+      );
       break;
     }
 
@@ -274,7 +346,7 @@ function BackfillLlmoCommand(context) {
     name: 'Backfill LLMO',
     description: 'Backfills LLMO audits.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} baseurl={baseURL} audit={auditType} [days={days}|weeks={weeks}]`,
+    usageText: `${PHRASES[0]} baseurl={baseURL} audit={auditType} [days={days}|weeks={weeks}|date={YYYY-MM-DD}]`,
   });
 
   const { dataAccess, log } = context;
@@ -293,10 +365,8 @@ function BackfillLlmoCommand(context) {
         return;
       }
 
-      if (parsed.mode
-        && !isDbBackfillMode(parsed)
-        && !isWeeklyDbRefreshMode(parsed)) {
-        await say(':warning: Unsupported mode. Use mode=db for daily DB imports or mode=weekly-db for weekly DB refresh.');
+      if (parsed.mode && !isWeeklyDbRefreshMode(parsed)) {
+        await say(':warning: Unsupported mode. Use mode=weekly-db for a weekly DB rollup refresh (daily DB import is the default — just pass weeks/days/date).');
         return;
       }
 
@@ -306,12 +376,11 @@ function BackfillLlmoCommand(context) {
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS} days=3\` (last 3 days)`);
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS} year=2024 month=11 day=15 hour=14\` (specific hour)`);
         await say(`• \`backfill-llmo baseurl=all audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS} year=2024 month=11 day=15 hour=14\` (all enabled sites)`);
-        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} weeks=2\``);
-        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} weeks=0\` (current week)`);
-        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} mode=db date=2026-04-27\` (daily DB import for that traffic date)`);
-        await say('• `backfill-llmo baseurl=https://example.com mode=weekly-db date=2026-05-03` (weekly DB refresh for that completed ISO week)');
+        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} weeks=2\` (last 2 completed ISO weeks → DB)`);
+        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} days=10\` (last 10 days → DB)`);
+        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} date=2026-04-27\` (single traffic day → DB)`);
+        await say('• `backfill-llmo baseurl=https://example.com mode=weekly-db date=2026-05-03` (force weekly rollup refresh for that completed ISO week)');
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.LLM_ERROR_PAGES} weeks=2\``);
-        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.LLM_ERROR_PAGES} weeks=0\` (current week)`);
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.LLMO_REFERRAL_TRAFFIC} weeks=2\``);
         return;
       }
@@ -356,67 +425,46 @@ function BackfillLlmoCommand(context) {
           break;
 
         case AUDIT_TYPES.CDN_LOGS_REPORT:
-          if (hasDateInput(parsed) && !isDbBackfillMode(parsed) && !isWeeklyDbRefreshMode(parsed)) {
-            await say(':warning: For cdn-logs-report DB refreshes, use mode=db or mode=weekly-db with date=YYYY-MM-DD.');
-            return;
-          }
-
-          if (isDbBackfillMode(parsed) && !hasDateInput(parsed)) {
-            await say(':warning: mode=db requires date=YYYY-MM-DD for the traffic date.');
-            return;
-          }
-
-          if (isWeeklyDbRefreshMode(parsed) && !hasDateInput(parsed)) {
-            await say(':warning: mode=weekly-db requires date=YYYY-MM-DD within the ISO week to refresh.');
-            return;
-          }
-
-          try {
-            const trafficDate = parseTrafficDate(parsed);
-            if (trafficDate) {
-              if (isWeeklyDbRefreshMode(parsed)) {
-                const weekRange = getIsoWeekRange(trafficDate.date);
-                if (!isCompletedIsoWeek(weekRange)) {
-                  await say(`:warning: mode=weekly-db only supports completed ISO weeks. Week ${weekRange.weekStart}..${weekRange.weekEnd} is not complete yet.`);
-                  return;
-                }
-                specificDate = {
-                  mode: 'weekly-db',
-                  anchorDate: trafficDate.dateStr,
-                  ...weekRange,
-                };
-                timeValue = 1;
-                timeDesc = `weekly DB refresh for ${weekRange.weekStart}..${weekRange.weekEnd} (from ${trafficDate.dateStr})`;
-                break;
+          // Force weekly rollup refresh for one completed ISO week (no data import).
+          if (isWeeklyDbRefreshMode(parsed)) {
+            if (!hasDateInput(parsed)) {
+              await say(':warning: mode=weekly-db requires date=YYYY-MM-DD within the ISO week to refresh.');
+              return;
+            }
+            try {
+              const trafficDate = parseTrafficDate(parsed);
+              const weekRange = getIsoWeekRange(trafficDate.date);
+              if (!isCompletedIsoWeek(weekRange)) {
+                await say(`:warning: mode=weekly-db only supports completed ISO weeks. Week ${weekRange.weekStart}..${weekRange.weekEnd} is not complete yet.`);
+                return;
               }
-              const auditContextDate = formatUtcDate(addUtcDays(trafficDate.date, 1));
               specificDate = {
-                date: auditContextDate,
-                trafficDate: trafficDate.dateStr,
+                mode: 'weekly-db',
+                anchorDate: trafficDate.dateStr,
+                ...weekRange,
               };
               timeValue = 1;
-              timeDesc = `daily DB import for ${trafficDate.dateStr} (audit context date ${auditContextDate})`;
-              break;
+              timeDesc = `weekly DB refresh for ${weekRange.weekStart}..${weekRange.weekEnd} (from ${trafficDate.dateStr})`;
+            } catch (e) {
+              await say(`:warning: ${e.message}`);
+              return;
             }
+            break;
+          }
+
+          // Daily DB backfill: enumerate traffic days (date | days | weeks).
+          try {
+            const { days, desc } = buildCdnReportTrafficDays(parsed);
+            if (days.length === 0) {
+              await say(':warning: No completed traffic days to backfill for the requested range.');
+              return;
+            }
+            specificDate = { trafficDays: days };
+            timeValue = days.length;
+            timeDesc = `${desc} → ${days.length} daily DB import${days.length === 1 ? '' : 's'}`;
           } catch (e) {
             await say(`:warning: ${e.message}`);
             return;
-          }
-
-          timeValue = parseInt(parsed.weeks, 10);
-          if (Number.isNaN(timeValue)) {
-            timeValue = 4;
-          }
-
-          if (timeValue > 4) {
-            await say(`:warning: Max 4 weeks for ${AUDIT_TYPES.CDN_LOGS_REPORT}`);
-            return;
-          }
-
-          if (timeValue === 0) {
-            timeDesc = 'current week only';
-          } else {
-            timeDesc = `${timeValue} previous weeks`;
           }
           break;
 
@@ -505,9 +553,9 @@ function BackfillLlmoCommand(context) {
         );
       }
 
-      const usesWeekOffsets = auditType === AUDIT_TYPES.CDN_LOGS_REPORT
-        || auditType === AUDIT_TYPES.LLM_ERROR_PAGES;
-      const msgsPerSite = usesWeekOffsets && timeValue === 0 ? 1 : timeValue;
+      const msgsPerSite = (auditType === AUDIT_TYPES.LLM_ERROR_PAGES && timeValue === 0)
+        ? 1
+        : timeValue;
       await say(`:white_check_mark: Done! ${sites.length * msgsPerSite} messages queued.`);
     } catch (error) {
       log.error('Error in LLMO backfill:', error);

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -167,7 +167,7 @@ describe('BackfillLlmoCommand', () => {
       expect(sqsStub.sendMessage.callCount).to.equal(2);
     });
 
-    it('adds a 5-second gap between multi-day cdn-logs-analysis messages for the same site', async () => {
+    it('adds a 30-second gap between multi-day cdn-logs-analysis messages for the same site', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
@@ -175,8 +175,8 @@ describe('BackfillLlmoCommand', () => {
 
       expect(sqsStub.sendMessage.callCount).to.equal(3);
       expect(sqsStub.sendMessage.firstCall.args[3]).to.deep.equal({ delaySeconds: 0 });
-      expect(sqsStub.sendMessage.secondCall.args[3]).to.deep.equal({ delaySeconds: 5 });
-      expect(sqsStub.sendMessage.thirdCall.args[3]).to.deep.equal({ delaySeconds: 10 });
+      expect(sqsStub.sendMessage.secondCall.args[3]).to.deep.equal({ delaySeconds: 30 });
+      expect(sqsStub.sendMessage.thirdCall.args[3]).to.deep.equal({ delaySeconds: 60 });
     });
 
     it('sends date-based per-day SQS messages for cdn-logs-report (traffic day + 1), staggered', async () => {

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -90,28 +90,43 @@ describe('BackfillLlmoCommand', () => {
       expect(sqsStub.sendMessage.callCount).to.equal(1);
     });
 
-    it('triggers cdn-logs-report backfill with default weeks', async () => {
+    it('triggers cdn-logs-report daily backfill with default weeks (last 2 completed ISO weeks)', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime()); // Wednesday
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution(['baseurl=https://example.com', `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`], slackContext);
+      clock.restore();
 
-      expect(slackContext.say.called).to.be.true;
-      expect(slackContext.say.firstCall.args[0]).to.include(`:rocket: Triggering ${AUDIT_TYPES.CDN_LOGS_REPORT} for https://example.com (4 previous weeks)...`);
-      expect(sqsStub.sendMessage.called).to.be.true;
-      expect(sqsStub.sendMessage.callCount).to.equal(4);
+      expect(slackContext.say.firstCall.args[0]).to.include(
+        `:rocket: Triggering ${AUDIT_TYPES.CDN_LOGS_REPORT} for https://example.com (last 2 completed ISO weeks (2026-04-20..2026-05-03) → 14 daily DB imports)...`,
+      );
+      expect(sqsStub.sendMessage.callCount).to.equal(14);
     });
 
-    it('triggers cdn-logs-report backfill for current week only when weeks=0', async () => {
+    it('triggers cdn-logs-report daily backfill for current week to date when weeks=0', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime()); // Wednesday
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution(['baseurl=https://example.com', `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`, 'weeks=0'], slackContext);
+      clock.restore();
 
-      expect(slackContext.say.called).to.be.true;
-      expect(slackContext.say.firstCall.args[0]).to.include(`:rocket: Triggering ${AUDIT_TYPES.CDN_LOGS_REPORT} for https://example.com (current week only)...`);
-      expect(sqsStub.sendMessage.called).to.be.true;
-      expect(sqsStub.sendMessage.callCount).to.equal(1);
+      // Mon 2026-05-04 + Tue 2026-05-05 (Wed is "today", still incomplete)
+      expect(slackContext.say.firstCall.args[0]).to.include('current week to date');
+      expect(sqsStub.sendMessage.callCount).to.equal(2);
+    });
+
+    it('warns when weeks=0 has no completed days yet (Monday)', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-04T08:00:00Z').getTime()); // Monday
+      dataAccessStub.Site.findByBaseURL.resolves(siteStub);
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution(['baseurl=https://example.com', `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`, 'weeks=0'], slackContext);
+      clock.restore();
+
+      expect(slackContext.say.calledWith(':warning: No completed traffic days to backfill for the requested range.')).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
     });
 
     it('triggers llmo-referral-traffic backfill with default weeks', async () => {
@@ -164,93 +179,94 @@ describe('BackfillLlmoCommand', () => {
       expect(sqsStub.sendMessage.thirdCall.args[3]).to.deep.equal({ delaySeconds: 10 });
     });
 
-    it('sends correct SQS message structure for cdn-logs-report', async () => {
+    it('sends date-based per-day SQS messages for cdn-logs-report (traffic day + 1), staggered', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime()); // Wednesday
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution(['baseurl=https://example.com', `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`, 'weeks=1'], slackContext);
+      clock.restore();
 
-      expect(sqsStub.sendMessage.called).to.be.true;
-      const [queueUrl, message] = sqsStub.sendMessage.firstCall.args;
+      // 1 ISO week = 7 days (Mon 2026-04-27 .. Sun 2026-05-03)
+      expect(sqsStub.sendMessage.callCount).to.equal(7);
+      const [queueUrl, message, group, opts] = sqsStub.sendMessage.firstCall.args;
       expect(queueUrl).to.equal('test-audits-queue-url');
-      expect(message).to.have.property('type', AUDIT_TYPES.CDN_LOGS_REPORT);
-      expect(message).to.have.property('siteId', 'test-site-id');
-      expect(message).to.have.property('auditContext');
-      expect(message.auditContext).to.have.property('weekOffset', -1);
-      expect(message.auditContext).to.have.property('refreshAgenticDailyExport', true);
+      expect(message).to.deep.equal({
+        type: AUDIT_TYPES.CDN_LOGS_REPORT,
+        siteId: 'test-site-id',
+        // oldest day first: Mon 2026-04-27 traffic → reference date 2026-04-28
+        auditContext: { date: '2026-04-28' },
+      });
+      expect(group).to.equal(undefined);
+      expect(opts).to.deep.equal({ delaySeconds: 0 });
+      expect(sqsStub.sendMessage.secondCall.args[3]).to.deep.equal({ delaySeconds: 5 });
+      expect(sqsStub.sendMessage.thirdCall.args[3]).to.deep.equal({ delaySeconds: 10 });
     });
 
-    it('sends correct SQS message structure for current week (weeks=0)', async () => {
-      dataAccessStub.Site.findByBaseURL.resolves(siteStub);
-      const command = BackfillLlmoCommand(context);
-
-      await command.handleExecution(['baseurl=https://example.com', `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`, 'weeks=0'], slackContext);
-
-      expect(sqsStub.sendMessage.called).to.be.true;
-      const [queueUrl, message] = sqsStub.sendMessage.firstCall.args;
-      expect(queueUrl).to.equal('test-audits-queue-url');
-      expect(message).to.have.property('type', AUDIT_TYPES.CDN_LOGS_REPORT);
-      expect(message).to.have.property('siteId', 'test-site-id');
-      expect(message).to.have.property('auditContext');
-      expect(message.auditContext).to.have.property('weekOffset', 0);
-      expect(message.auditContext).to.have.property('refreshAgenticDailyExport', true);
-    });
-
-    it('sends a cdn-logs-report daily DB import message using traffic date + 1 as auditContext.date', async () => {
+    it('sends a single date-based message for a specific traffic day', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime());
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution([
         'baseurl=https://example.com',
         `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
-        'mode=db',
         'date=2026-04-27',
       ], slackContext);
+      clock.restore();
 
-      expect(slackContext.say.firstCall.args[0]).to.include(
-        `:rocket: Triggering ${AUDIT_TYPES.CDN_LOGS_REPORT} for https://example.com (daily DB import for 2026-04-27 (audit context date 2026-04-28))...`,
-      );
+      expect(slackContext.say.firstCall.args[0]).to.include('traffic day 2026-04-27');
       expect(sqsStub.sendMessage.callCount).to.equal(1);
       const [queueUrl, message] = sqsStub.sendMessage.firstCall.args;
       expect(queueUrl).to.equal('test-audits-queue-url');
       expect(message).to.deep.equal({
         type: AUDIT_TYPES.CDN_LOGS_REPORT,
         siteId: 'test-site-id',
-        auditContext: {
-          date: '2026-04-28',
-          refreshAgenticDailyExport: true,
-        },
+        auditContext: { date: '2026-04-28' },
       });
     });
 
-    it('supports year month day for cdn-logs-report daily DB import', async () => {
+    it('supports year/month/day for a specific traffic day', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime());
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution([
         'baseurl=https://example.com',
         `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
-        'mode=db',
         'year=2026',
         'month=4',
         'day=27',
       ], slackContext);
+      clock.restore();
 
       expect(sqsStub.sendMessage.callCount).to.equal(1);
       const [, message] = sqsStub.sendMessage.firstCall.args;
-      expect(message.auditContext).to.deep.equal({
-        date: '2026-04-28',
-        refreshAgenticDailyExport: true,
-      });
+      expect(message.auditContext).to.deep.equal({ date: '2026-04-28' });
     });
 
-    it('rejects invalid cdn-logs-report daily DB import date', async () => {
+    it('rejects a future traffic day', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime());
+      dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution([
         'baseurl=https://example.com',
         `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
-        'mode=db',
+        'date=2026-05-06',
+      ], slackContext);
+      clock.restore();
+
+      expect(slackContext.say.calledWith(':warning: date must be yesterday (UTC) or earlier.')).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
+    it('rejects an invalid traffic day', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
         'date=2026-04-31',
       ], slackContext);
 
@@ -258,13 +274,12 @@ describe('BackfillLlmoCommand', () => {
       expect(sqsStub.sendMessage).not.to.have.been.called;
     });
 
-    it('rejects malformed cdn-logs-report daily DB import date syntax', async () => {
+    it('rejects a malformed traffic day', async () => {
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution([
         'baseurl=https://example.com',
         `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
-        'mode=db',
         'date=2026/04/27',
       ], slackContext);
 
@@ -272,33 +287,60 @@ describe('BackfillLlmoCommand', () => {
       expect(sqsStub.sendMessage).not.to.have.been.called;
     });
 
-    it('requires mode=db for cdn-logs-report daily DB import date', async () => {
+    it('backfills a trailing window of days (oldest first)', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime());
+      dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution([
         'baseurl=https://example.com',
         `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
-        'date=2026-04-27',
+        'days=10',
+      ], slackContext);
+      clock.restore();
+
+      expect(slackContext.say.firstCall.args[0]).to.include('last 10 days');
+      expect(sqsStub.sendMessage.callCount).to.equal(10);
+      // yesterday = 2026-05-05; 10 days back → oldest traffic 2026-04-26 → reference 2026-04-27
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext).to.deep.equal({ date: '2026-04-27' });
+    });
+
+    it('rejects too many days', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'days=40',
       ], slackContext);
 
-      expect(slackContext.say.calledWith(
-        ':warning: For cdn-logs-report DB refreshes, use mode=db or mode=weekly-db with date=YYYY-MM-DD.',
-      )).to.be.true;
+      expect(slackContext.say.calledWith(`:warning: Max 31 days for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`)).to.be.true;
       expect(sqsStub.sendMessage).not.to.have.been.called;
     });
 
-    it('requires date when cdn-logs-report mode=db is used', async () => {
+    it('rejects non-positive days', async () => {
       const command = BackfillLlmoCommand(context);
 
       await command.handleExecution([
         'baseurl=https://example.com',
         `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
-        'mode=db',
+        'days=0',
       ], slackContext);
 
-      expect(slackContext.say.calledWith(
-        ':warning: mode=db requires date=YYYY-MM-DD for the traffic date.',
-      )).to.be.true;
+      expect(slackContext.say.calledWith(':warning: days must be a positive integer.')).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
+    it('rejects non-numeric days', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'days=abc',
+      ], slackContext);
+
+      expect(slackContext.say.calledWith(':warning: days must be a positive integer.')).to.be.true;
       expect(sqsStub.sendMessage).not.to.have.been.called;
     });
 
@@ -494,7 +536,7 @@ describe('BackfillLlmoCommand', () => {
       ], slackContext);
 
       expect(slackContext.say.calledWith(
-        ':warning: Unsupported mode. Use mode=db for daily DB imports or mode=weekly-db for weekly DB refresh.',
+        ':warning: Unsupported mode. Use mode=weekly-db for a weekly DB rollup refresh (daily DB import is the default — just pass weeks/days/date).',
       )).to.be.true;
       expect(sqsStub.sendMessage).not.to.have.been.called;
     });
@@ -541,7 +583,7 @@ describe('BackfillLlmoCommand', () => {
       ], slackContext);
 
       expect(slackContext.say.calledWith(
-        ':warning: Unsupported mode. Use mode=db for daily DB imports or mode=weekly-db for weekly DB refresh.',
+        ':warning: Unsupported mode. Use mode=weekly-db for a weekly DB rollup refresh (daily DB import is the default — just pass weeks/days/date).',
       )).to.be.true;
       expect(sqsStub.sendMessage).not.to.have.been.called;
     });
@@ -665,7 +707,7 @@ describe('BackfillLlmoCommand', () => {
 
       await command.handleExecution(['baseurl=https://example.com', `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`, 'weeks=5'], slackContext);
 
-      expect(slackContext.say.calledWith(`:warning: Max 4 weeks for ${AUDIT_TYPES.CDN_LOGS_REPORT}`)).to.be.true;
+      expect(slackContext.say.calledWith(`:warning: weeks must be between 0 and 4 for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`)).to.be.true;
     });
 
     it('rejects unsupported audit type', async () => {

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -344,6 +344,81 @@ describe('BackfillLlmoCommand', () => {
       expect(sqsStub.sendMessage).not.to.have.been.called;
     });
 
+    it('rejects days with trailing garbage (e.g. 7x)', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'days=7x',
+      ], slackContext);
+
+      expect(slackContext.say.calledWith(':warning: days must be a positive integer.')).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
+    it('rejects conflicting range selectors (days + weeks)', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'days=7',
+        'weeks=0',
+      ], slackContext);
+
+      expect(slackContext.say.calledWith(
+        ':warning: Specify only one of date=, days=, or weeks= (got: days, weeks).',
+      )).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
+    it('rejects conflicting range selectors (date + weeks)', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'date=2026-05-01',
+        'weeks=2',
+      ], slackContext);
+
+      expect(slackContext.say.calledWith(
+        ':warning: Specify only one of date=, days=, or weeks= (got: date, weeks).',
+      )).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
+    it('rejects non-numeric weeks instead of defaulting', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'weeks=foo',
+      ], slackContext);
+
+      expect(slackContext.say.calledWith(
+        `:warning: weeks must be an integer between 0 and 4 for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`,
+      )).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
+    it('rejects weeks with trailing garbage (e.g. 2x) instead of truncating', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'weeks=2x',
+      ], slackContext);
+
+      expect(slackContext.say.calledWith(
+        `:warning: weeks must be an integer between 0 and 4 for ${AUDIT_TYPES.CDN_LOGS_REPORT}.`,
+      )).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
     it('runs a cdn-logs-report weekly DB refresh through the weekly WRPC', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(siteStub);
       postgrestStub.rpc.resolves({

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -761,6 +761,21 @@ describe('BackfillLlmoCommand', () => {
       expect(sqsStub.sendMessage.callCount).to.equal(2);
     });
 
+    it('queues per-day cdn-logs-report imports for every site with baseurl=all', async () => {
+      const clock = sinon.useFakeTimers(new Date('2026-05-06T12:00:00Z').getTime()); // Wednesday
+      const site1 = { getId: () => 'site-1' };
+      const site2 = { getId: () => 'site-2' };
+      dataAccessStub.Site.all.resolves([site1, site2]);
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution(['baseurl=all', `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`, 'weeks=1'], slackContext);
+      clock.restore();
+
+      // 2 sites * 7 days (1 ISO week) = 14 messages; confirms sites.length * msgsPerSite.
+      expect(sqsStub.sendMessage.callCount).to.equal(14);
+      expect(slackContext.say.calledWith(':white_check_mark: Done! 14 messages queued.')).to.be.true;
+    });
+
     it('reports no sites enabled when baseurl=all and none enabled', async () => {
       dataAccessStub.Site.all.resolves([siteStub]);
       configStub.isHandlerEnabledForSite.returns(false);


### PR DESCRIPTION
## Summary

Simplifies the `cdn-logs-report` backfill to a single model — **a backfill is a set of traffic days**. The command enumerates the UTC days to backfill (oldest first) and queues one date-based daily-import message per day. The audit worker imports each day's agentic + referral traffic into PostgreSQL; the projector refreshes the daily serving table on every import and the weekly rollup when a week's closing Sunday lands.

## Commands (`audit=cdn-logs-report`)

| Arg | Backfills |
|-----|-----------|
| `weeks=N` | last N completed ISO weeks (default 2, max 4) |
| `weeks=0` | current week to date (Mon → yesterday) |
| `days=M` | last M days ending yesterday (max 31) |
| `date=YYYY-MM-DD` | a single traffic day |
| `mode=weekly-db date=YYYY-MM-DD` | force the weekly rollup refresh for that completed ISO week (`wrpc_refresh_agentic_traffic_weekly`) |

Days are queued oldest→newest, staggered 5s, as `{ auditContext: { date: trafficDay + 1 } }` (the worker exports the day before `date`). Each day import is idempotent and independently retryable.

## Removed / replaced

- The old `weekOffset` fan-out path (API emitted week-offset messages that the worker re-fanned into 7 daily messages) — the API now enumerates days directly.
- The `mode=db` daily flag (plain `date=` does it).

## Testing

`npm run lint` clean; backfill-llmo command tests passing; command-file coverage ~100% (gate 90%).

