### PR TITLE
feat: adding new `ensure preflight` slack command

### DIFF
--- a/src/support/slack/actions/open-preflight-config.js
+++ b/src/support/slack/actions/open-preflight-config.js
@@ -167,6 +167,28 @@ export default function openPreflightConfig(lambdaContext) {
               text: 'Document Authoring: main--site--owner.aem.live. CS/CS-Crosswalk: AEM CS URL (author-p12345-e67890.adobeaemcloud.com). AMS URL (https://author.adobecqms.net).',
             },
           },
+          {
+            type: 'input',
+            block_id: 'content_source_path_input',
+            optional: true,
+            element: {
+              type: 'plain_text_input',
+              action_id: 'content_source_path',
+              placeholder: {
+                type: 'plain_text',
+                text: '/content/mysite',
+              },
+              initial_value: currentDeliveryConfig.contentSourcePath || '',
+            },
+            label: {
+              type: 'plain_text',
+              text: 'Content Source Path',
+            },
+            hint: {
+              type: 'plain_text',
+              text: 'Required for Cloud Service when multiple sites in this organization share the same program and environment ID. Optional otherwise.',
+            },
+          },
         ],
       };
 

--- a/src/support/slack/actions/preflight-config-modal.js
+++ b/src/support/slack/actions/preflight-config-modal.js
@@ -133,7 +133,6 @@ export function preflightConfigModal(lambdaContext) {
           deliveryConfigFromPreview.programId,
           deliveryConfigFromPreview.environmentId,
           authoringType,
-          log,
         );
 
         if (contentSourcePathRequired && !hasText(contentSourcePath)) {

--- a/src/support/slack/actions/preflight-config-modal.js
+++ b/src/support/slack/actions/preflight-config-modal.js
@@ -133,6 +133,7 @@ export function preflightConfigModal(lambdaContext) {
           deliveryConfigFromPreview.programId,
           deliveryConfigFromPreview.environmentId,
           authoringType,
+          log,
         );
 
         if (contentSourcePathRequired && !hasText(contentSourcePath)) {

--- a/src/support/slack/actions/preflight-config-modal.js
+++ b/src/support/slack/actions/preflight-config-modal.js
@@ -10,43 +10,21 @@
  * governing permissions and limitations under the License.
  */
 
-import { isValidUrl } from '@adobe/spacecat-shared-utils';
+import { hasText, isValidUrl } from '@adobe/spacecat-shared-utils';
 import { extractDeliveryConfigFromPreviewUrl } from './onboard-modal.js';
-
-/**
- * Extracts helix configuration from a helix preview URL
- * @param {string} previewUrl - The helix preview URL (e.g., main--site--owner.hlx.live)
- * @returns {Object|null} - The helix config object or null if invalid
- */
-function extractHelixConfigFromPreviewUrl(previewUrl) {
-  const url = new URL(previewUrl);
-  const domain = url.hostname;
-
-  // Parse helix RSO from domain using the same regex as hooks.js
-  const regex = /^([\w-]+)--([\w-]+)--([\w-]+)\.(hlx\.live|aem\.live)$/;
-  const match = domain.match(regex);
-
-  if (!match) {
-    return null;
-  }
-
-  return {
-    hlxVersion: 5,
-    rso: {
-      ref: match[1],
-      site: match[2],
-      owner: match[3],
-      tld: match[4],
-    },
-  };
-}
+import {
+  enablePreflightAuditForSite,
+  extractHelixConfigFromPreviewUrl,
+  isContentSourcePathRequired,
+  isCSAuthoringType,
+} from '../preflight/preflight-config.js';
 
 /**
  * Handles preflight configuration modal submission
  */
 export function preflightConfigModal(lambdaContext) {
   const { dataAccess, log } = lambdaContext;
-  const { Site, Configuration } = dataAccess;
+  const { Site } = dataAccess;
 
   return async ({ ack, body, client }) => {
     try {
@@ -65,6 +43,8 @@ export function preflightConfigModal(lambdaContext) {
 
       const authoringType = values.authoring_type_input?.authoring_type?.selected_option?.value;
       const previewUrl = values.preview_url_input?.preview_url?.value?.trim();
+      const contentSourcePath = values.content_source_path_input?.content_source_path?.value
+        ?.trim();
 
       if (!authoringType) {
         await ack({
@@ -86,13 +66,11 @@ export function preflightConfigModal(lambdaContext) {
         return;
       }
 
-      // Determine URL type based on authoring type and validate accordingly
       let deliveryConfigFromPreview = null;
       let helixConfigFromPreview = null;
       let amsAuthorUrl;
 
-      if (authoringType === 'cs' || authoringType === 'cs/crosswalk') {
-        // For AEM CS authoring types, expect AEM CS preview URL
+      if (isCSAuthoringType(authoringType)) {
         deliveryConfigFromPreview = extractDeliveryConfigFromPreviewUrl(previewUrl, null);
         if (!deliveryConfigFromPreview) {
           await ack({
@@ -137,10 +115,9 @@ export function preflightConfigModal(lambdaContext) {
         return;
       }
 
-      await ack();
-
       const site = await Site.findById(siteId);
       if (!site) {
+        await ack();
         await client.chat.postMessage({
           channel: channelId,
           text: ':x: Error: Site not found. Please try again.',
@@ -149,13 +126,44 @@ export function preflightConfigModal(lambdaContext) {
         return;
       }
 
+      if (deliveryConfigFromPreview) {
+        const contentSourcePathRequired = await isContentSourcePathRequired(
+          dataAccess,
+          site,
+          deliveryConfigFromPreview.programId,
+          deliveryConfigFromPreview.environmentId,
+          authoringType,
+        );
+
+        if (contentSourcePathRequired && !hasText(contentSourcePath)) {
+          await ack({
+            response_action: 'errors',
+            errors: {
+              content_source_path_input: 'Content source path is required when multiple sites in this organization share the same AEM CS program and environment.',
+            },
+          });
+          return;
+        }
+      }
+
+      await ack();
+
       site.setAuthoringType(authoringType);
 
       let configDetails = '';
       if (deliveryConfigFromPreview) {
-        site.setDeliveryConfig(deliveryConfigFromPreview);
+        const deliveryConfig = {
+          ...deliveryConfigFromPreview,
+        };
+        if (hasText(contentSourcePath)) {
+          deliveryConfig.contentSourcePath = contentSourcePath;
+        }
+        site.setDeliveryConfig(deliveryConfig);
         configDetails = `:gear: *Delivery Config:* Program ${deliveryConfigFromPreview.programId}, Environment ${deliveryConfigFromPreview.environmentId}\n`
                        + `:link: *Preview URL:* ${previewUrl}`;
+        if (hasText(contentSourcePath)) {
+          configDetails += `\n:file_folder: *Content Source Path:* ${contentSourcePath}`;
+        }
       } else if (helixConfigFromPreview) {
         site.setHlxConfig(helixConfigFromPreview);
         configDetails = `:gear: *Helix Config:* ${helixConfigFromPreview.rso.ref}--${helixConfigFromPreview.rso.site}--${helixConfigFromPreview.rso.owner}.${helixConfigFromPreview.rso.tld}\n`
@@ -168,10 +176,7 @@ export function preflightConfigModal(lambdaContext) {
       }
 
       await site.save();
-
-      const configuration = await Configuration.findLatest();
-      configuration.enableHandlerForSite(auditType, site);
-      await configuration.save();
+      await enablePreflightAuditForSite(site, dataAccess);
 
       await client.chat.postMessage({
         channel: channelId,

--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -40,6 +40,7 @@ import getLlmoConfigSummary from './commands/get-llmo-config-summary.js';
 import getLlmoOpportunityUsage from './commands/get-llmo-opportunity-usage.js';
 import runBrandProfile from './commands/run-brand-profile.js';
 import ensureEntitlementSite from './commands/ensure-entitlement-site.js';
+import ensurePreflight from './commands/ensure-preflight.js';
 import ensureEntitlementImsOrg from './commands/ensure-entitlement-imsorg.js';
 import getEntitlementSite from './commands/get-entitlement-site.js';
 import getEntitlementImsOrg from './commands/get-entitlement-imsorg.js';
@@ -96,6 +97,7 @@ export default (context) => [
   getLlmoOpportunityUsage(context),
   runBrandProfile(context),
   ensureEntitlementSite(context),
+  ensurePreflight(context),
   ensureEntitlementImsOrg(context),
   getEntitlementSite(context),
   getEntitlementImsOrg(context),

--- a/src/support/slack/commands/ensure-preflight.js
+++ b/src/support/slack/commands/ensure-preflight.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { isValidUrl } from '@adobe/spacecat-shared-utils';
+import BaseCommand from './base.js';
+import { extractURLFromSlackInput, postErrorMessage } from '../../../utils/slack/base.js';
+import {
+  enablePreflightAuditForSite,
+  ERROR_MESSAGE_PREFIX,
+  isPreflightSiteConfigReady,
+  PREFLIGHT_AUDIT_TYPE,
+  promptPreflightConfig,
+  SUCCESS_MESSAGE_PREFIX,
+} from '../preflight/preflight-config.js';
+
+const PHRASES = ['ensure preflight'];
+
+export default (context) => {
+  const baseCommand = BaseCommand({
+    id: 'ensure-preflight',
+    name: 'Ensure Preflight for Site',
+    description: 'Validates site preflight configuration and enables the preflight audit for a site.',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {site}`,
+  });
+
+  const { log, dataAccess } = context;
+  const { Configuration, Site } = dataAccess;
+
+  /**
+   * Executes the command to ensure preflight configuration for a site.
+   *
+   * @param {Array<string>} args - The arguments provided to the command.
+   * @param {Object} slackContext - The Slack context object.
+   * @param {Function} slackContext.say - The Slack say function.
+   * @returns {Promise} A promise that resolves when the operation is complete.
+   */
+  const handleExecution = async (args, slackContext) => {
+    const { say } = slackContext;
+    let baseURL;
+
+    try {
+      const [baseURLInput] = args;
+      baseURL = extractURLFromSlackInput(baseURLInput);
+
+      if (!isValidUrl(baseURL)) {
+        await say(`${ERROR_MESSAGE_PREFIX}Please provide a valid site baseURL.`);
+        return;
+      }
+
+      const site = await Site.findByBaseURL(baseURL);
+      if (!site) {
+        await say(`${ERROR_MESSAGE_PREFIX}Cannot update site with baseURL: "${baseURL}", site not found.`);
+        return;
+      }
+
+      const configuration = await Configuration.findLatest();
+      const registeredAudits = configuration.getHandlers();
+      if (!registeredAudits[PREFLIGHT_AUDIT_TYPE]) {
+        await say(`${ERROR_MESSAGE_PREFIX}The "${PREFLIGHT_AUDIT_TYPE}" audit is not present in the configuration.`);
+        return;
+      }
+
+      const { ready, missingLabels } = await isPreflightSiteConfigReady(site, context);
+      if (!ready) {
+        if (missingLabels.length === 1 && missingLabels[0] === 'Content Source Path') {
+          await say({
+            text: `:warning: Preflight audit requires additional configuration for \`${site.getBaseURL()}\``,
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: `:warning: *Preflight audit requires additional configuration for:*\n\`${site.getBaseURL()}\`\n\n*Missing:*\n• Content Source Path\n\nMultiple sites in this organization share the same AEM CS program and environment. Please provide a content source path to distinguish this site.`,
+                },
+              },
+              {
+                type: 'actions',
+                elements: [
+                  {
+                    type: 'button',
+                    text: {
+                      type: 'plain_text',
+                      text: 'Configure & Enable',
+                    },
+                    style: 'primary',
+                    action_id: 'open_preflight_config',
+                    value: JSON.stringify({
+                      siteId: site.getId(),
+                      auditType: PREFLIGHT_AUDIT_TYPE,
+                    }),
+                  },
+                ],
+              },
+            ],
+          });
+          return;
+        }
+
+        await promptPreflightConfig(slackContext, site, PREFLIGHT_AUDIT_TYPE);
+        return;
+      }
+
+      await enablePreflightAuditForSite(site, dataAccess);
+      await say(`${SUCCESS_MESSAGE_PREFIX}Preflight audit has been enabled for "${site.getBaseURL()}".`);
+    } catch (error) {
+      log.error(error);
+      await say(
+        `${ERROR_MESSAGE_PREFIX}An error occurred while trying to ensure preflight for site "${baseURL}": ${error.message}`,
+      );
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+};

--- a/src/support/slack/commands/ensure-preflight.js
+++ b/src/support/slack/commands/ensure-preflight.js
@@ -12,7 +12,7 @@
 
 import { isValidUrl } from '@adobe/spacecat-shared-utils';
 import BaseCommand from './base.js';
-import { extractURLFromSlackInput, postErrorMessage } from '../../../utils/slack/base.js';
+import { extractURLFromSlackInput } from '../../../utils/slack/base.js';
 import {
   enablePreflightAuditForSite,
   ERROR_MESSAGE_PREFIX,
@@ -47,9 +47,9 @@ export default (context) => {
   const handleExecution = async (args, slackContext) => {
     const { say } = slackContext;
     let baseURL;
+    const [baseURLInput] = args;
 
     try {
-      const [baseURLInput] = args;
       baseURL = extractURLFromSlackInput(baseURLInput);
 
       if (!isValidUrl(baseURL)) {
@@ -115,9 +115,8 @@ export default (context) => {
     } catch (error) {
       log.error(error);
       await say(
-        `${ERROR_MESSAGE_PREFIX}An error occurred while trying to ensure preflight for site "${baseURL}": ${error.message}`,
+        `${ERROR_MESSAGE_PREFIX}An error occurred while trying to ensure preflight for site "${baseURL ?? baseURLInput ?? 'unknown'}": ${error.message}`,
       );
-      await postErrorMessage(say, error);
     }
   };
 

--- a/src/support/slack/commands/ensure-preflight.js
+++ b/src/support/slack/commands/ensure-preflight.js
@@ -70,9 +70,9 @@ export default (context) => {
         return;
       }
 
-      const { ready, missingLabels } = await isPreflightSiteConfigReady(site, context);
+      const { ready, needsContentSourcePath } = await isPreflightSiteConfigReady(site, context);
       if (!ready) {
-        if (missingLabels.length === 1 && missingLabels[0] === 'Content Source Path') {
+        if (needsContentSourcePath) {
           await say({
             text: `:warning: Preflight audit requires additional configuration for \`${site.getBaseURL()}\``,
             blocks: [

--- a/src/support/slack/commands/toggle-site-audit.js
+++ b/src/support/slack/commands/toggle-site-audit.js
@@ -124,7 +124,7 @@ export default (context) => {
         ? auditTypeOrProfileInput.toLowerCase() : null;
 
       if (isEnableAudit) {
-        await say(`${ERROR_MESSAGE_PREFIX}The \`audit enable\` command is deprecated. Use one-off \`run audit\` from Slack without enabling the site. To disable audits, use \`audit disable\`.`);
+        await say(`${ERROR_MESSAGE_PREFIX}The \`audit enable\` command is deprecated. Use one-off \`run audit\` from Slack without enabling the site. To enable Preflight, use \`ensure preflight <site>\`. To disable audits, use \`audit disable\`.`);
         return;
       }
 

--- a/src/support/slack/preflight/preflight-config.js
+++ b/src/support/slack/preflight/preflight-config.js
@@ -98,6 +98,23 @@ export function getPreflightMissingConfigLabels(site) {
 }
 
 /**
+ * @param {Object} site
+ * @returns {Object}
+ */
+function toSiblingSiteLogEntry(site) {
+  const deliveryConfig = site.getDeliveryConfig?.() || {};
+  return {
+    siteId: site.getId?.(),
+    baseURL: site.getBaseURL?.(),
+    organizationId: site.getOrganizationId?.(),
+    authoringType: site.getAuthoringType?.(),
+    programId: deliveryConfig.programId,
+    environmentId: deliveryConfig.environmentId,
+    contentSourcePath: deliveryConfig.contentSourcePath,
+  };
+}
+
+/**
  * Determines whether contentSourcePath is required for a CS or CS/Crosswalk site when
  * multiple sites in the same organization share the same program, environment, and
  * authoring type.
@@ -106,6 +123,7 @@ export function getPreflightMissingConfigLabels(site) {
  * @param {string} programId
  * @param {string} environmentId
  * @param {string} authoringType
+ * @param {Object} [log] - Optional logger for sibling resolution diagnostics
  * @returns {Promise<boolean>}
  */
 export async function isContentSourcePathRequired(
@@ -114,6 +132,7 @@ export async function isContentSourcePathRequired(
   programId,
   environmentId,
   authoringType,
+  log,
 ) {
   if (!hasText(programId) || !hasText(environmentId) || !isCSAuthoringType(authoringType)) {
     return false;
@@ -133,6 +152,27 @@ export async function isContentSourcePathRequired(
       && candidate.getOrganizationId() === organizationId
       && candidate.getAuthoringType() === authoringType,
   );
+
+  if (log?.info) {
+    const siblingsInOrg = siblings.filter(
+      (candidate) => candidate.getOrganizationId() === organizationId,
+    );
+    log.info('preflight.contentSourcePath.siblingCheck', {
+      siteId: site.getId(),
+      baseURL: site.getBaseURL(),
+      organizationId,
+      authoringType,
+      programId,
+      environmentId,
+      externalOwnerId,
+      externalSiteId,
+      siblingsByExternalIds: siblings.map(toSiblingSiteLogEntry),
+      siblingsInOrg: siblingsInOrg.map(toSiblingSiteLogEntry),
+      siblingsInOrgWithSameAuthoringType: othersInOrgWithSameAuthoringType
+        .map(toSiblingSiteLogEntry),
+      contentSourcePathRequired: othersInOrgWithSameAuthoringType.length >= 1,
+    });
+  }
 
   return othersInOrgWithSameAuthoringType.length >= 1;
 }
@@ -162,6 +202,7 @@ export async function isPreflightSiteConfigReady(site, context) {
       programId,
       environmentId,
       authoringType,
+      context.log,
     );
 
     if (contentSourcePathRequired && !hasText(contentSourcePath)) {

--- a/src/support/slack/preflight/preflight-config.js
+++ b/src/support/slack/preflight/preflight-config.js
@@ -98,23 +98,6 @@ export function getPreflightMissingConfigLabels(site) {
 }
 
 /**
- * @param {Object} site
- * @returns {Object}
- */
-function toSiblingSiteLogEntry(site) {
-  const deliveryConfig = site.getDeliveryConfig?.() || {};
-  return {
-    siteId: site.getId?.(),
-    baseURL: site.getBaseURL?.(),
-    organizationId: site.getOrganizationId?.(),
-    authoringType: site.getAuthoringType?.(),
-    programId: deliveryConfig.programId,
-    environmentId: deliveryConfig.environmentId,
-    contentSourcePath: deliveryConfig.contentSourcePath,
-  };
-}
-
-/**
  * Determines whether contentSourcePath is required for a CS or CS/Crosswalk site when
  * multiple sites in the same organization share the same program, environment, and
  * authoring type.
@@ -123,7 +106,6 @@ function toSiblingSiteLogEntry(site) {
  * @param {string} programId
  * @param {string} environmentId
  * @param {string} authoringType
- * @param {Object} [log] - Optional logger for sibling resolution diagnostics
  * @returns {Promise<boolean>}
  */
 export async function isContentSourcePathRequired(
@@ -132,7 +114,6 @@ export async function isContentSourcePathRequired(
   programId,
   environmentId,
   authoringType,
-  log,
 ) {
   if (!hasText(programId) || !hasText(environmentId) || !isCSAuthoringType(authoringType)) {
     return false;
@@ -152,27 +133,6 @@ export async function isContentSourcePathRequired(
       && candidate.getOrganizationId() === organizationId
       && candidate.getAuthoringType() === authoringType,
   );
-
-  if (log?.info) {
-    const siblingsInOrg = siblings.filter(
-      (candidate) => candidate.getOrganizationId() === organizationId,
-    );
-    log.info('preflight.contentSourcePath.siblingCheck', {
-      siteId: site.getId(),
-      baseURL: site.getBaseURL(),
-      organizationId,
-      authoringType,
-      programId,
-      environmentId,
-      externalOwnerId,
-      externalSiteId,
-      siblingsByExternalIds: siblings.map(toSiblingSiteLogEntry),
-      siblingsInOrg: siblingsInOrg.map(toSiblingSiteLogEntry),
-      siblingsInOrgWithSameAuthoringType: othersInOrgWithSameAuthoringType
-        .map(toSiblingSiteLogEntry),
-      contentSourcePathRequired: othersInOrgWithSameAuthoringType.length >= 1,
-    });
-  }
 
   return othersInOrgWithSameAuthoringType.length >= 1;
 }
@@ -202,7 +162,6 @@ export async function isPreflightSiteConfigReady(site, context) {
       programId,
       environmentId,
       authoringType,
-      context.log,
     );
 
     if (contentSourcePathRequired && !hasText(contentSourcePath)) {

--- a/src/support/slack/preflight/preflight-config.js
+++ b/src/support/slack/preflight/preflight-config.js
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { AUTHORING_TYPES, hasText } from '@adobe/spacecat-shared-utils';
+
+const ERROR_MESSAGE_PREFIX = ':x: ';
+const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
+const PREFLIGHT_AUDIT_TYPE = 'preflight';
+
+export const CS_AUTHORING_TYPES = [AUTHORING_TYPES.CS, AUTHORING_TYPES.CS_CW];
+
+/**
+ * @param {string} authoringType
+ * @returns {boolean}
+ */
+export const isCSAuthoringType = (authoringType) => CS_AUTHORING_TYPES.includes(authoringType);
+
+/**
+ * @param {string} programId
+ * @param {string} environmentId
+ * @returns {{ externalOwnerId: string, externalSiteId: string }}
+ */
+export const toExternalDeliveryIds = (programId, environmentId) => ({
+  externalOwnerId: `p${programId}`,
+  externalSiteId: `e${environmentId}`,
+});
+
+/**
+ * Extracts helix configuration from a helix preview URL
+ * @param {string} previewUrl - The helix preview URL (e.g., main--site--owner.hlx.live)
+ * @returns {Object|null} - The helix config object or null if invalid
+ */
+export function extractHelixConfigFromPreviewUrl(previewUrl) {
+  const url = new URL(previewUrl);
+  const domain = url.hostname;
+
+  const regex = /^([\w-]+)--([\w-]+)--([\w-]+)\.(hlx\.live|aem\.live)$/;
+  const match = domain.match(regex);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    hlxVersion: 5,
+    rso: {
+      ref: match[1],
+      site: match[2],
+      owner: match[3],
+      tld: match[4],
+    },
+  };
+}
+
+/**
+ * Returns human-readable labels for missing preflight site configuration.
+ * @param {Object} site - The site object
+ * @returns {string[]}
+ */
+export function getPreflightMissingConfigLabels(site) {
+  const currentAuthoringType = site.getAuthoringType();
+  const currentDeliveryConfig = site.getDeliveryConfig() || {};
+  const currentHelixConfig = site.getHlxConfig() || {};
+
+  const missingItems = [];
+  if (!currentAuthoringType) {
+    missingItems.push('Authoring Type');
+    missingItems.push('Preview URL');
+  } else if (currentAuthoringType === AUTHORING_TYPES.DA) {
+    // Document authoring require helix config
+    const hasHelixConfig = currentHelixConfig?.rso
+      && Object.keys(currentHelixConfig.rso).length > 0;
+    if (!hasHelixConfig) {
+      missingItems.push('Helix Preview URL');
+    }
+  } else if (isCSAuthoringType(currentAuthoringType)) {
+    // CS authoring types require program and environment IDs
+    const hasDeliveryConfig = currentDeliveryConfig.programId
+      && currentDeliveryConfig.environmentId;
+    if (!hasDeliveryConfig) {
+      missingItems.push('AEM CS Preview URL');
+    }
+  } else if (currentAuthoringType === AUTHORING_TYPES.AMS && !currentDeliveryConfig.authorURL) {
+    // AMS authoring type requires an author URL
+    missingItems.push('AMS URL');
+  }
+
+  return missingItems;
+}
+
+/**
+ * Determines whether contentSourcePath is required for a CS or CS/Crosswalk site when
+ * multiple sites in the same organization share the same program, environment, and
+ * authoring type.
+ * @param {Object} dataAccess
+ * @param {Object} site
+ * @param {string} programId
+ * @param {string} environmentId
+ * @param {string} authoringType
+ * @returns {Promise<boolean>}
+ */
+export async function isContentSourcePathRequired(
+  dataAccess,
+  site,
+  programId,
+  environmentId,
+  authoringType,
+) {
+  if (!hasText(programId) || !hasText(environmentId) || !isCSAuthoringType(authoringType)) {
+    return false;
+  }
+
+  const { Site } = dataAccess;
+  const { externalOwnerId, externalSiteId } = toExternalDeliveryIds(programId, environmentId);
+  const siblings = await Site.allByExternalOwnerIdAndExternalSiteId(
+    externalOwnerId,
+    externalSiteId,
+  );
+  const organizationId = site.getOrganizationId();
+
+  // Filter sites to only include ones with the same authoring type and organization ID
+  const othersInOrgWithSameAuthoringType = siblings.filter(
+    (candidate) => candidate.getId() !== site.getId()
+      && candidate.getOrganizationId() === organizationId
+      && candidate.getAuthoringType() === authoringType,
+  );
+
+  return othersInOrgWithSameAuthoringType.length >= 1;
+}
+
+/**
+ * Checks whether a site has the configuration required to enable preflight.
+ * @param {Object} site - The site object
+ * @param {Object} context
+ * @returns {Promise<{ ready: boolean, missingLabels: string[], needsContentSourcePath: boolean }>}
+ */
+export async function isPreflightSiteConfigReady(site, context) {
+  // Check if the site has any missing configuration
+  const missingLabels = getPreflightMissingConfigLabels(site);
+
+  if (missingLabels.length > 0) {
+    return { ready: false, missingLabels, needsContentSourcePath: false };
+  }
+
+  // Check if the site has contentSourcePath required for a CS or CS/Crosswalk site
+  const authoringType = site.getAuthoringType();
+  if (isCSAuthoringType(authoringType)) {
+    const deliveryConfig = site.getDeliveryConfig() || {};
+    const { programId, environmentId, contentSourcePath } = deliveryConfig;
+    const contentSourcePathRequired = await isContentSourcePathRequired(
+      context.dataAccess,
+      site,
+      programId,
+      environmentId,
+      authoringType,
+    );
+
+    if (contentSourcePathRequired && !hasText(contentSourcePath)) {
+      return {
+        ready: false,
+        missingLabels: ['Content Source Path'],
+        needsContentSourcePath: true,
+      };
+    }
+  }
+
+  return { ready: true, missingLabels: [], needsContentSourcePath: false };
+}
+
+/**
+ * Posts a message with a button to configure preflight audit requirements
+ * @param {Object} slackContext - The Slack context object
+ * @param {Object} site - The site object
+ * @param {string} auditType - The audit type (should be 'preflight')
+ */
+export async function promptPreflightConfig(slackContext, site, auditType) {
+  const { say } = slackContext;
+  const missingItems = getPreflightMissingConfigLabels(site);
+
+  return say({
+    text: `:warning: Preflight audit requires additional configuration for \`${site.getBaseURL()}\``,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `:warning: *Preflight audit requires additional configuration for:*\n\`${site.getBaseURL()}\`\n\n*Missing:*\n${missingItems.map((item) => `• ${item}`)
+            .join('\n')}`,
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: {
+              type: 'plain_text',
+              text: 'Configure & Enable',
+            },
+            style: 'primary',
+            action_id: 'open_preflight_config',
+            value: JSON.stringify({
+              siteId: site.getId(),
+              auditType,
+            }),
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/**
+ * Enables the preflight audit handler for a site in configuration.
+ * @param {Object} site
+ * @param {Object} dataAccess
+ * @returns {Promise<void>}
+ */
+export async function enablePreflightAuditForSite(site, dataAccess) {
+  const { Configuration } = dataAccess;
+  const configuration = await Configuration.findLatest();
+  configuration.enableHandlerForSite(PREFLIGHT_AUDIT_TYPE, site);
+  await configuration.save();
+}
+
+export {
+  ERROR_MESSAGE_PREFIX,
+  SUCCESS_MESSAGE_PREFIX,
+  PREFLIGHT_AUDIT_TYPE,
+};

--- a/src/support/slack/preflight/preflight-config.js
+++ b/src/support/slack/preflight/preflight-config.js
@@ -12,9 +12,9 @@
 
 import { AUTHORING_TYPES, hasText } from '@adobe/spacecat-shared-utils';
 
-const ERROR_MESSAGE_PREFIX = ':x: ';
-const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
-const PREFLIGHT_AUDIT_TYPE = 'preflight';
+export const ERROR_MESSAGE_PREFIX = ':x: ';
+export const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
+export const PREFLIGHT_AUDIT_TYPE = 'preflight';
 
 export const CS_AUTHORING_TYPES = [AUTHORING_TYPES.CS, AUTHORING_TYPES.CS_CW];
 
@@ -272,9 +272,3 @@ export async function enablePreflightAuditForSite(site, dataAccess) {
   configuration.enableHandlerForSite(PREFLIGHT_AUDIT_TYPE, site);
   await configuration.save();
 }
-
-export {
-  ERROR_MESSAGE_PREFIX,
-  SUCCESS_MESSAGE_PREFIX,
-  PREFLIGHT_AUDIT_TYPE,
-};

--- a/test/support/slack/actions/preflight-config-modal.test.js
+++ b/test/support/slack/actions/preflight-config-modal.test.js
@@ -35,6 +35,9 @@ describe('preflight-config-modal', () => {
 
     siteMock = {
       findById: sandbox.stub(),
+      allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([]),
+      getId: sandbox.stub().returns('site123'),
+      getOrganizationId: sandbox.stub().returns('org1'),
       getBaseURL: sandbox.stub().returns('https://example.com'),
       setAuthoringType: sandbox.stub(),
       setDeliveryConfig: sandbox.stub(),
@@ -100,6 +103,79 @@ describe('preflight-config-modal', () => {
   });
 
   describe('preflightConfigModal', () => {
+    it('should require content source path when multiple sites share program and environment', async () => {
+      siteMock.allByExternalOwnerIdAndExternalSiteId.resolves([
+        siteMock,
+        {
+          getId: () => 'site456',
+          getOrganizationId: () => 'org1',
+          getAuthoringType: () => 'cs',
+        },
+      ]);
+      siteMock.findById.resolves(siteMock);
+
+      const mockedModule = await esmock('../../../../src/support/slack/actions/preflight-config-modal.js', {
+        '../../../../src/support/slack/actions/onboard-modal.js': {
+          extractDeliveryConfigFromPreviewUrl: sinon.stub().returns({
+            programId: '12345',
+            environmentId: '67890',
+            authorURL: 'https://author-p12345-e67890.adobeaemcloud.com',
+          }),
+        },
+      });
+
+      const modalAction = mockedModule.preflightConfigModal(context);
+      await modalAction({
+        ack: ackMock,
+        body,
+        client: clientMock,
+      });
+
+      expect(ackMock).to.have.been.calledWith({
+        response_action: 'errors',
+        errors: {
+          content_source_path_input: 'Content source path is required when multiple sites in this organization share the same AEM CS program and environment.',
+        },
+      });
+    });
+
+    it('should persist optional content source path for unique program and environment', async () => {
+      body.view.state.values.content_source_path_input = {
+        content_source_path: {
+          value: '/content/mysite',
+        },
+      };
+
+      const mockedModule = await esmock('../../../../src/support/slack/actions/preflight-config-modal.js', {
+        '../../../../src/support/slack/actions/onboard-modal.js': {
+          extractDeliveryConfigFromPreviewUrl: sinon.stub().returns({
+            programId: '12345',
+            environmentId: '67890',
+            authorURL: 'https://author-p12345-e67890.adobeaemcloud.com',
+          }),
+        },
+      });
+
+      siteMock.findById.resolves(siteMock);
+
+      const modalAction = mockedModule.preflightConfigModal(context);
+      await modalAction({
+        ack: ackMock,
+        body,
+        client: clientMock,
+      });
+
+      expect(siteMock.setDeliveryConfig).to.have.been.calledWith({
+        programId: '12345',
+        environmentId: '67890',
+        authorURL: 'https://author-p12345-e67890.adobeaemcloud.com',
+        contentSourcePath: '/content/mysite',
+      });
+      expect(clientMock.chat.postMessage).to.have.been.calledWithMatch({
+        text: sinon.match(/Content Source Path:\* \/content\/mysite/),
+      });
+    });
+
     it('should handle AEM CS preview URL for cs authoring type', async () => {
       const mockedModule = await esmock('../../../../src/support/slack/actions/preflight-config-modal.js', {
         '../../../../src/support/slack/actions/onboard-modal.js': {

--- a/test/support/slack/commands/ensure-preflight.test.js
+++ b/test/support/slack/commands/ensure-preflight.test.js
@@ -28,6 +28,7 @@ describe('EnsurePreflightCommand', () => {
   let isPreflightSiteConfigReadyStub;
   let promptPreflightConfigStub;
   let enablePreflightAuditForSiteStub;
+  let postErrorMessageStub;
 
   const site = {
     getId: () => 'site1',
@@ -39,6 +40,7 @@ describe('EnsurePreflightCommand', () => {
     isPreflightSiteConfigReadyStub = sandbox.stub();
     promptPreflightConfigStub = sandbox.stub().resolves();
     enablePreflightAuditForSiteStub = sandbox.stub().resolves();
+    postErrorMessageStub = sandbox.stub().resolves();
 
     configurationMock = {
       enableHandlerForSite: sandbox.stub(),
@@ -73,6 +75,10 @@ describe('EnsurePreflightCommand', () => {
         PREFLIGHT_AUDIT_TYPE: 'preflight',
         ERROR_MESSAGE_PREFIX,
         SUCCESS_MESSAGE_PREFIX,
+      },
+      '../../../../src/utils/slack/base.js': {
+        extractURLFromSlackInput: (value) => value,
+        postErrorMessage: postErrorMessageStub,
       },
     });
   });
@@ -147,5 +153,24 @@ describe('EnsurePreflightCommand', () => {
 
     expect(enablePreflightAuditForSiteStub).to.have.been.calledWith(site, dataAccessMock);
     expect(slackContextMock.say).to.have.been.calledWith(`${SUCCESS_MESSAGE_PREFIX}Preflight audit has been enabled for "https://example.com".`);
+  });
+
+  it('handles unexpected errors and reports them to Slack', async () => {
+    const error = new Error('enable failed');
+    isPreflightSiteConfigReadyStub.resolves({
+      ready: true,
+      missingLabels: [],
+      needsContentSourcePath: false,
+    });
+    enablePreflightAuditForSiteStub.rejects(error);
+
+    const command = EnsurePreflightCommand(contextMock);
+    await command.handleExecution(['https://example.com'], slackContextMock);
+
+    expect(contextMock.log.error).to.have.been.calledWith(error);
+    expect(slackContextMock.say).to.have.been.calledWith(
+      `${ERROR_MESSAGE_PREFIX}An error occurred while trying to ensure preflight for site "https://example.com": enable failed`,
+    );
+    expect(postErrorMessageStub).to.have.been.calledWith(slackContextMock.say, error);
   });
 });

--- a/test/support/slack/commands/ensure-preflight.test.js
+++ b/test/support/slack/commands/ensure-preflight.test.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import sinon from 'sinon';
+import { expect } from 'chai';
+import esmock from 'esmock';
+
+const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
+const ERROR_MESSAGE_PREFIX = ':x: ';
+
+describe('EnsurePreflightCommand', () => {
+  const sandbox = sinon.createSandbox();
+
+  let configurationMock;
+  let dataAccessMock;
+  let contextMock;
+  let slackContextMock;
+  let EnsurePreflightCommand;
+  let isPreflightSiteConfigReadyStub;
+  let promptPreflightConfigStub;
+  let enablePreflightAuditForSiteStub;
+
+  const site = {
+    getId: () => 'site1',
+    getBaseURL: () => 'https://example.com',
+    getOrganizationId: () => 'org1',
+  };
+
+  beforeEach(async () => {
+    isPreflightSiteConfigReadyStub = sandbox.stub();
+    promptPreflightConfigStub = sandbox.stub().resolves();
+    enablePreflightAuditForSiteStub = sandbox.stub().resolves();
+
+    configurationMock = {
+      enableHandlerForSite: sandbox.stub(),
+      getHandlers: sandbox.stub().returns({ preflight: { type: 'preflight' } }),
+      save: sandbox.stub().resolves(),
+    };
+
+    dataAccessMock = {
+      Configuration: {
+        findLatest: sandbox.stub().resolves(configurationMock),
+      },
+      Site: {
+        findByBaseURL: sandbox.stub().resolves(site),
+        allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([]),
+      },
+    };
+
+    contextMock = {
+      log: { error: sandbox.stub() },
+      dataAccess: dataAccessMock,
+    };
+
+    slackContextMock = {
+      say: sandbox.stub().resolves(),
+    };
+
+    EnsurePreflightCommand = await esmock('../../../../src/support/slack/commands/ensure-preflight.js', {
+      '../../../../src/support/slack/preflight/preflight-config.js': {
+        isPreflightSiteConfigReady: isPreflightSiteConfigReadyStub,
+        promptPreflightConfig: promptPreflightConfigStub,
+        enablePreflightAuditForSite: enablePreflightAuditForSiteStub,
+        PREFLIGHT_AUDIT_TYPE: 'preflight',
+        ERROR_MESSAGE_PREFIX,
+        SUCCESS_MESSAGE_PREFIX,
+      },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('shows usage when base URL is invalid', async () => {
+    const command = EnsurePreflightCommand(contextMock);
+    await command.handleExecution(['not-a-url'], slackContextMock);
+
+    expect(slackContextMock.say).to.have.been.calledWith(`${ERROR_MESSAGE_PREFIX}Please provide a valid site baseURL.`);
+  });
+
+  it('shows error when site is not found', async () => {
+    dataAccessMock.Site.findByBaseURL.resolves(null);
+    const command = EnsurePreflightCommand(contextMock);
+    await command.handleExecution(['https://missing.example.com'], slackContextMock);
+
+    expect(slackContextMock.say).to.have.been.calledWith(`${ERROR_MESSAGE_PREFIX}Cannot update site with baseURL: "https://missing.example.com", site not found.`);
+  });
+
+  it('shows error when preflight audit is not registered', async () => {
+    configurationMock.getHandlers.returns({});
+    const command = EnsurePreflightCommand(contextMock);
+    await command.handleExecution(['https://example.com'], slackContextMock);
+
+    expect(slackContextMock.say).to.have.been.calledWith(`${ERROR_MESSAGE_PREFIX}The "preflight" audit is not present in the configuration.`);
+  });
+
+  it('prompts for configuration when site config is not ready', async () => {
+    isPreflightSiteConfigReadyStub.resolves({
+      ready: false,
+      missingLabels: ['Authoring Type', 'Preview URL'],
+      needsContentSourcePath: false,
+    });
+
+    const command = EnsurePreflightCommand(contextMock);
+    await command.handleExecution(['https://example.com'], slackContextMock);
+
+    expect(promptPreflightConfigStub).to.have.been.calledWith(slackContextMock, site, 'preflight');
+    expect(enablePreflightAuditForSiteStub.called).to.be.false;
+  });
+
+  it('prompts with content source path guidance when only content source path is missing', async () => {
+    isPreflightSiteConfigReadyStub.resolves({
+      ready: false,
+      missingLabels: ['Content Source Path'],
+      needsContentSourcePath: true,
+    });
+
+    const command = EnsurePreflightCommand(contextMock);
+    await command.handleExecution(['https://example.com'], slackContextMock);
+
+    expect(promptPreflightConfigStub.called).to.be.false;
+    expect(slackContextMock.say).to.have.been.calledOnce;
+    const message = slackContextMock.say.firstCall.args[0];
+    expect(message.blocks[0].text.text).to.include('Content Source Path');
+    expect(message.blocks[1].elements[0].action_id).to.equal('open_preflight_config');
+  });
+
+  it('enables preflight when site config is ready', async () => {
+    isPreflightSiteConfigReadyStub.resolves({
+      ready: true,
+      missingLabels: [],
+      needsContentSourcePath: false,
+    });
+
+    const command = EnsurePreflightCommand(contextMock);
+    await command.handleExecution(['https://example.com'], slackContextMock);
+
+    expect(enablePreflightAuditForSiteStub).to.have.been.calledWith(site, dataAccessMock);
+    expect(slackContextMock.say).to.have.been.calledWith(`${SUCCESS_MESSAGE_PREFIX}Preflight audit has been enabled for "https://example.com".`);
+  });
+});

--- a/test/support/slack/commands/ensure-preflight.test.js
+++ b/test/support/slack/commands/ensure-preflight.test.js
@@ -28,7 +28,6 @@ describe('EnsurePreflightCommand', () => {
   let isPreflightSiteConfigReadyStub;
   let promptPreflightConfigStub;
   let enablePreflightAuditForSiteStub;
-  let postErrorMessageStub;
 
   const site = {
     getId: () => 'site1',
@@ -40,7 +39,6 @@ describe('EnsurePreflightCommand', () => {
     isPreflightSiteConfigReadyStub = sandbox.stub();
     promptPreflightConfigStub = sandbox.stub().resolves();
     enablePreflightAuditForSiteStub = sandbox.stub().resolves();
-    postErrorMessageStub = sandbox.stub().resolves();
 
     configurationMock = {
       enableHandlerForSite: sandbox.stub(),
@@ -78,7 +76,6 @@ describe('EnsurePreflightCommand', () => {
       },
       '../../../../src/utils/slack/base.js': {
         extractURLFromSlackInput: (value) => value,
-        postErrorMessage: postErrorMessageStub,
       },
     });
   });
@@ -171,6 +168,5 @@ describe('EnsurePreflightCommand', () => {
     expect(slackContextMock.say).to.have.been.calledWith(
       `${ERROR_MESSAGE_PREFIX}An error occurred while trying to ensure preflight for site "https://example.com": enable failed`,
     );
-    expect(postErrorMessageStub).to.have.been.calledWith(slackContextMock.say, error);
   });
 });

--- a/test/support/slack/commands/toggle-site-audit.test.js
+++ b/test/support/slack/commands/toggle-site-audit.test.js
@@ -107,7 +107,7 @@ describe('UpdateSitesAuditsCommand', () => {
     await command.handleExecution(args, slackContextMock);
 
     expect(
-      slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}The \`audit enable\` command is deprecated. Use one-off \`run audit\` from Slack without enabling the site. To disable audits, use \`audit disable\`.`),
+      slackContextMock.say.calledWith(`${ERROR_MESSAGE_PREFIX}The \`audit enable\` command is deprecated. Use one-off \`run audit\` from Slack without enabling the site. To enable Preflight, use \`ensure preflight <site>\`. To disable audits, use \`audit disable\`.`),
       'Expected deprecation message for audit enable',
     ).to.be.true;
     expect(configurationMock.enableHandlerForSite.called).to.be.false;

--- a/test/support/slack/preflight/preflight-config.test.js
+++ b/test/support/slack/preflight/preflight-config.test.js
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  extractHelixConfigFromPreviewUrl,
+  getPreflightMissingConfigLabels,
+  isContentSourcePathRequired,
+  isCSAuthoringType,
+  isPreflightSiteConfigReady,
+  toExternalDeliveryIds,
+} from '../../../../src/support/slack/preflight/preflight-config.js';
+
+describe('preflight-config helpers', () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('toExternalDeliveryIds', () => {
+    it('maps program and environment IDs to external IDs', () => {
+      expect(toExternalDeliveryIds('12345', '67890')).to.deep.equal({
+        externalOwnerId: 'p12345',
+        externalSiteId: 'e67890',
+      });
+    });
+  });
+
+  describe('isCSAuthoringType', () => {
+    it('returns true for cs and cs/crosswalk', () => {
+      expect(isCSAuthoringType('cs')).to.be.true;
+      expect(isCSAuthoringType('cs/crosswalk')).to.be.true;
+      expect(isCSAuthoringType('ams')).to.be.false;
+    });
+  });
+
+  describe('extractHelixConfigFromPreviewUrl', () => {
+    it('parses a valid helix preview URL', () => {
+      expect(extractHelixConfigFromPreviewUrl('https://main--site--owner.hlx.live')).to.deep.equal({
+        hlxVersion: 5,
+        rso: {
+          ref: 'main',
+          site: 'site',
+          owner: 'owner',
+          tld: 'hlx.live',
+        },
+      });
+    });
+
+    it('returns null for invalid helix preview URL', () => {
+      expect(extractHelixConfigFromPreviewUrl('https://invalid.example.com')).to.be.null;
+    });
+  });
+
+  describe('getPreflightMissingConfigLabels', () => {
+    it('flags missing authoring type and preview URL', () => {
+      const site = {
+        getAuthoringType: () => null,
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
+      };
+
+      expect(getPreflightMissingConfigLabels(site)).to.deep.equal([
+        'Authoring Type',
+        'Preview URL',
+      ]);
+    });
+
+    it('flags missing AEM CS preview URL for cs authoring type', () => {
+      const site = {
+        getAuthoringType: () => 'cs',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
+      };
+
+      expect(getPreflightMissingConfigLabels(site)).to.deep.equal(['AEM CS Preview URL']);
+    });
+  });
+
+  describe('isContentSourcePathRequired', () => {
+    it('returns false when program or environment ID is missing', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+      };
+      const dataAccess = { Site: { allByExternalOwnerIdAndExternalSiteId: sandbox.stub() } };
+
+      expect(await isContentSourcePathRequired(dataAccess, site, '', '67890', 'cs')).to.be.false;
+      expect(dataAccess.Site.allByExternalOwnerIdAndExternalSiteId.called).to.be.false;
+    });
+
+    it('returns false for non-CS authoring types', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+      };
+      const dataAccess = { Site: { allByExternalOwnerIdAndExternalSiteId: sandbox.stub() } };
+
+      expect(await isContentSourcePathRequired(dataAccess, site, '12345', '67890', 'ams')).to.be.false;
+      expect(dataAccess.Site.allByExternalOwnerIdAndExternalSiteId.called).to.be.false;
+    });
+
+    it('returns true when another cs site in the same org shares program and environment', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+        getAuthoringType: () => 'cs',
+      };
+      const dataAccess = {
+        Site: {
+          allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([
+            site,
+            {
+              getId: () => 'site2',
+              getOrganizationId: () => 'org1',
+              getAuthoringType: () => 'cs',
+            },
+            {
+              getId: () => 'site3',
+              getOrganizationId: () => 'org2',
+              getAuthoringType: () => 'cs',
+            },
+          ]),
+        },
+      };
+
+      expect(await isContentSourcePathRequired(dataAccess, site, '12345', '67890', 'cs')).to.be.true;
+      expect(dataAccess.Site.allByExternalOwnerIdAndExternalSiteId).to.have.been.calledWith('p12345', 'e67890');
+    });
+
+    it('returns true when another cs/crosswalk site shares program and environment', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+        getAuthoringType: () => 'cs/crosswalk',
+      };
+      const dataAccess = {
+        Site: {
+          allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([
+            site,
+            {
+              getId: () => 'site2',
+              getOrganizationId: () => 'org1',
+              getAuthoringType: () => 'cs/crosswalk',
+            },
+          ]),
+        },
+      };
+
+      expect(await isContentSourcePathRequired(dataAccess, site, '12345', '67890', 'cs/crosswalk')).to.be.true;
+    });
+
+    it('returns false when only a different authoring type shares program and environment', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+        getAuthoringType: () => 'cs',
+      };
+      const dataAccess = {
+        Site: {
+          allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([
+            site,
+            {
+              getId: () => 'site2',
+              getOrganizationId: () => 'org1',
+              getAuthoringType: () => 'cs/crosswalk',
+            },
+          ]),
+        },
+      };
+
+      expect(await isContentSourcePathRequired(dataAccess, site, '12345', '67890', 'cs')).to.be.false;
+    });
+
+    it('returns false when only the current site shares program and environment in the org', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+        getAuthoringType: () => 'cs',
+      };
+      const dataAccess = {
+        Site: {
+          allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([site]),
+        },
+      };
+
+      expect(await isContentSourcePathRequired(dataAccess, site, '12345', '67890', 'cs')).to.be.false;
+    });
+  });
+
+  describe('isPreflightSiteConfigReady', () => {
+    it('returns not ready when CS site is missing content source path and siblings exist', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+        getAuthoringType: () => 'cs',
+        getDeliveryConfig: () => ({
+          programId: '12345',
+          environmentId: '67890',
+        }),
+        getHlxConfig: () => ({}),
+      };
+      const context = {
+        dataAccess: {
+          Site: {
+            allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([
+              site,
+              {
+                getId: () => 'site2',
+                getOrganizationId: () => 'org1',
+                getAuthoringType: () => 'cs',
+              },
+            ]),
+          },
+        },
+      };
+
+      const result = await isPreflightSiteConfigReady(site, context);
+      expect(result.ready).to.be.false;
+      expect(result.needsContentSourcePath).to.be.true;
+      expect(result.missingLabels).to.deep.equal(['Content Source Path']);
+    });
+
+    it('returns not ready when CS/Crosswalk site is missing content source path and siblings exist', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+        getAuthoringType: () => 'cs/crosswalk',
+        getDeliveryConfig: () => ({
+          programId: '12345',
+          environmentId: '67890',
+        }),
+        getHlxConfig: () => ({}),
+      };
+      const context = {
+        dataAccess: {
+          Site: {
+            allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([
+              site,
+              {
+                getId: () => 'site2',
+                getOrganizationId: () => 'org1',
+                getAuthoringType: () => 'cs/crosswalk',
+              },
+            ]),
+          },
+        },
+      };
+
+      const result = await isPreflightSiteConfigReady(site, context);
+      expect(result.ready).to.be.false;
+      expect(result.needsContentSourcePath).to.be.true;
+    });
+
+    it('returns ready when CS site has all required config including content source path', async () => {
+      const site = {
+        getId: () => 'site1',
+        getOrganizationId: () => 'org1',
+        getAuthoringType: () => 'cs',
+        getDeliveryConfig: () => ({
+          programId: '12345',
+          environmentId: '67890',
+          contentSourcePath: '/content/mysite',
+        }),
+        getHlxConfig: () => ({}),
+      };
+      const context = {
+        dataAccess: {
+          Site: {
+            allByExternalOwnerIdAndExternalSiteId: sandbox.stub().resolves([
+              site,
+              {
+                getId: () => 'site2',
+                getOrganizationId: () => 'org1',
+                getAuthoringType: () => 'cs',
+              },
+            ]),
+          },
+        },
+      };
+
+      const result = await isPreflightSiteConfigReady(site, context);
+      expect(result.ready).to.be.true;
+    });
+  });
+});

--- a/test/support/slack/preflight/preflight-config.test.js
+++ b/test/support/slack/preflight/preflight-config.test.js
@@ -18,6 +18,7 @@ import {
   isContentSourcePathRequired,
   isCSAuthoringType,
   isPreflightSiteConfigReady,
+  promptPreflightConfig,
   toExternalDeliveryIds,
 } from '../../../../src/support/slack/preflight/preflight-config.js';
 
@@ -85,6 +86,70 @@ describe('preflight-config helpers', () => {
       };
 
       expect(getPreflightMissingConfigLabels(site)).to.deep.equal(['AEM CS Preview URL']);
+    });
+
+    it('flags missing helix preview URL for document authoring type', () => {
+      const site = {
+        getAuthoringType: () => 'documentauthoring',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
+      };
+
+      expect(getPreflightMissingConfigLabels(site)).to.deep.equal(['Helix Preview URL']);
+    });
+
+    it('returns no missing labels when document authoring has helix config', () => {
+      const site = {
+        getAuthoringType: () => 'documentauthoring',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({
+          rso: {
+            ref: 'main',
+            site: 'site',
+            owner: 'owner',
+            tld: 'hlx.live',
+          },
+        }),
+      };
+
+      expect(getPreflightMissingConfigLabels(site)).to.deep.equal([]);
+    });
+
+    it('flags missing AMS URL for ams authoring type', () => {
+      const site = {
+        getAuthoringType: () => 'ams',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
+      };
+
+      expect(getPreflightMissingConfigLabels(site)).to.deep.equal(['AMS URL']);
+    });
+  });
+
+  describe('promptPreflightConfig', () => {
+    it('posts a configuration prompt with missing items and open modal button', async () => {
+      const site = {
+        getId: () => 'site1',
+        getBaseURL: () => 'https://example.com',
+        getAuthoringType: () => 'ams',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
+      };
+      const say = sandbox.stub().resolves();
+      const slackContext = { say };
+
+      await promptPreflightConfig(slackContext, site, 'preflight');
+
+      expect(say).to.have.been.calledOnce;
+      const message = say.firstCall.args[0];
+      expect(message.text).to.include('https://example.com');
+      expect(message.blocks[0].text.text).to.include('*Missing:*');
+      expect(message.blocks[0].text.text).to.include('AMS URL');
+      expect(message.blocks[1].elements[0].action_id).to.equal('open_preflight_config');
+      expect(JSON.parse(message.blocks[1].elements[0].value)).to.deep.equal({
+        siteId: 'site1',
+        auditType: 'preflight',
+      });
     });
   });
 
@@ -200,6 +265,26 @@ describe('preflight-config helpers', () => {
   });
 
   describe('isPreflightSiteConfigReady', () => {
+    it('returns not ready with needsContentSourcePath false when base config is missing', async () => {
+      const site = {
+        getAuthoringType: () => 'documentauthoring',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
+      };
+      const context = {
+        dataAccess: {
+          Site: { allByExternalOwnerIdAndExternalSiteId: sandbox.stub() },
+        },
+      };
+
+      const result = await isPreflightSiteConfigReady(site, context);
+
+      expect(result.ready).to.be.false;
+      expect(result.needsContentSourcePath).to.be.false;
+      expect(result.missingLabels).to.deep.equal(['Helix Preview URL']);
+      expect(context.dataAccess.Site.allByExternalOwnerIdAndExternalSiteId.called).to.be.false;
+    });
+
     it('returns not ready when CS site is missing content source path and siblings exist', async () => {
       const site = {
         getId: () => 'site1',


### PR DESCRIPTION
Related Issue: https://jira.corp.adobe.com/browse/SITES-45215

## Summary

Adds a new Slack command `@spacecat ensure preflight <baseURL>` that validates site preflight configuration and enables the preflight audit. This ports the preflight enablement logic removed from `audit enable` in #1674 into a dedicated command, without reintroducing bulk enable.

## What changed

### New command: `ensure preflight`
- Validates the site exists and that `preflight` is registered in configuration
- Checks site readiness (authoring type, preview URL / delivery config, etc.)
- If config is missing → posts a Slack message with **Configure & Enable** button
- If only `contentSourcePath` is missing (CS sibling disambiguation case) → posts a tailored message explaining shared program/environment
- If ready → enables preflight immediately via `Configuration.enableHandlerForSite`

### Shared preflight helpers (`src/support/slack/preflight/preflight-config.js`)
- `getPreflightMissingConfigLabels()` — DA / CS / CS-Crosswalk / AMS missing config detection
- `isContentSourcePathRequired()` — requires path when another site in the **same org** shares the same program, environment, and **authoring type** (`cs` vs `cs/crosswalk` are separate pools; aligned with preflight MFE `findMatchingSite`)
- `isPreflightSiteConfigReady()`, `promptPreflightConfig()`, `enablePreflightAuditForSite()`

### Modal updates (reused existing handlers)
- `open-preflight-config.js` — added **Content Source Path** field
- `preflight-config-modal.js` — validates and persists `deliveryConfig.contentSourcePath`; refactored to use shared helpers

### Deprecation message
- `toggle-site-audit.js` — `audit enable` deprecation text now points to `ensure preflight <site>`

## Out of scope (follow-ups)
- Audit-worker `isAuditDisabledForSite` change (deferred)
- UE as a separate authoring type in the modal (MFE maps UE → `cs/crosswalk`)
- Uniqueness validation of `contentSourcePath` across siblings
- Onboarding wiki update (`audit enable … preflight` → `ensure preflight <site>`)

## Test plan

- [x] Unit tests: `ensure-preflight.test.js`, `preflight-config.test.js`, updated modal/toggle tests
- [x] Manual dev Slack validation:
  - [ ] Invalid URL / site not found errors
  - [ ] Ready CS site → immediate enable
  - [ ] Missing base config → generic prompt → modal → enable
  - [ ] CS sibling (same authoring type) → custom content-source-path message → path required in modal
  - [ ] Cross-type sibling (`cs` + `cs/crosswalk`) → path **not** required
  - [ ] `get site-audits` shows `preflight` enabled after success
  - [ ] `audit enable … preflight` shows deprecation message


Thanks for contributing!
