### PR TITLE
feat(prompts): persist intent on prompt upsert/update

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -6263,6 +6263,21 @@ V2Prompt:
       description: The source system or process that created the prompt
       example: "config"
       default: "config"
+    intent:
+      type: [string, 'null']
+      description: >-
+        Canonical search-intent bucket persisted for the prompt, or null when
+        unknown/unclassified. One of the canonical buckets (mirrors DRS prompt
+        generation).
+      enum:
+        - informational
+        - instructional
+        - comparative
+        - transactional
+        - planning
+        - delegation
+        - null
+      example: informational
     updatedAt:
       $ref: '#/DateTime'
     updatedBy:
@@ -6342,6 +6357,24 @@ V2PromptInput:
       type: string
       description: The source system or process that created the prompt
       default: "config"
+    intent:
+      type: string
+      description: >-
+        Optional search-intent bucket for the prompt. Normalized on write:
+        the value is lowercased, legacy labels are remapped
+        (`statistical`/`navigational` -> `informational`,
+        `commercial` -> `transactional`), and the result is validated against
+        the canonical buckets below. An absent, empty, or (post-remap) invalid
+        value is stored as null (NULL) — it is NOT coerced to a default
+        bucket. Canonical buckets mirror DRS prompt generation.
+      enum:
+        - informational
+        - instructional
+        - comparative
+        - transactional
+        - planning
+        - delegation
+      example: informational
 
 V2PromptBulkDeleteRequest:
   type: object

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -6361,19 +6361,16 @@ V2PromptInput:
       type: string
       description: >-
         Optional search-intent bucket for the prompt. Normalized on write:
-        the value is lowercased, legacy labels are remapped
+        the value is lowercased, legacy aliases are remapped
         (`statistical`/`navigational` -> `informational`,
         `commercial` -> `transactional`), and the result is validated against
-        the canonical buckets below. An absent, empty, or (post-remap) invalid
+        the canonical buckets. An absent, empty, or (post-remap) invalid
         value is stored as null (NULL) — it is NOT coerced to a default
-        bucket. Canonical buckets mirror DRS prompt generation.
-      enum:
-        - informational
-        - instructional
-        - comparative
-        - transactional
-        - planning
-        - delegation
+        bucket. Canonical buckets (mirror DRS prompt generation):
+        `informational`, `instructional`, `comparative`, `transactional`,
+        `planning`, `delegation`. No `enum` constraint is applied to the
+        input: legacy aliases (`statistical`, `navigational`, `commercial`)
+        are accepted and normalized on write.
       example: informational
 
 V2PromptBulkDeleteRequest:

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -15,6 +15,47 @@ import crypto from 'node:crypto';
 import { hasText, isValidUUID } from '@adobe/spacecat-shared-utils';
 
 /**
+ * The 6 canonical intent buckets persisted in `prompts.intent`. Mirrors the
+ * buckets DRS emits (see DRS `prompt_generation_agentic_traffic` generation
+ * prompts) and that the stats intent breakdown aggregates over.
+ */
+const INTENT_VALUES = ['informational', 'instructional', 'comparative', 'transactional', 'planning', 'delegation'];
+const CANONICAL_INTENTS = new Set(INTENT_VALUES);
+
+/**
+ * Legacy intent labels remapped onto the canonical buckets. Mirrors DRS
+ * `INTENT_REMAP` (src/providers/prompt_generation_agentic_traffic/utils/
+ * hard_validate.py) so values produced by older generations or external
+ * callers collapse onto the supported set instead of dropping to NULL.
+ */
+const INTENT_REMAP = {
+  statistical: 'informational',
+  navigational: 'informational',
+  commercial: 'transactional',
+};
+
+/**
+ * Normalizes a caller-supplied intent for persistence into `prompts.intent`.
+ *
+ * Lowercases the value, applies the legacy remap, then validates against the
+ * 6 canonical buckets. Absent, empty, or values that are still invalid after
+ * remapping yield `null` — gap-filling (e.g. LLM classification of
+ * human-added prompts) is handled elsewhere, so we never coerce to a default
+ * bucket here.
+ *
+ * @param {*} intent - Raw intent value from the request body
+ * @returns {string|null} Canonical lowercase intent, or null
+ */
+export function normalizeIntent(intent) {
+  if (!hasText(intent)) {
+    return null;
+  }
+  const lowered = intent.trim().toLowerCase();
+  const remapped = INTENT_REMAP[lowered] || lowered;
+  return CANONICAL_INTENTS.has(remapped) ? remapped : null;
+}
+
+/**
  * Resolves brandId (path param) to Postgres brands.id (uuid).
  * Tries: 1) valid uuid lookup, 2) case-insensitive name lookup.
  *
@@ -238,6 +279,7 @@ function mapRowToPrompt(row) {
     status: row.status || 'active',
     origin: row.origin || 'human',
     source: row.source || 'config',
+    intent: row.intent ?? null,
     createdAt: row.created_at,
     createdBy: row.created_by,
     updatedAt: row.updated_at,
@@ -335,6 +377,7 @@ export async function listPrompts({
     status,
     origin,
     source,
+    intent,
     category_id,
     topic_id,
     brand_id,
@@ -457,6 +500,7 @@ export async function getPromptById({
       status,
       origin,
       source,
+      intent,
       category_id,
       topic_id,
       brand_id,
@@ -574,6 +618,7 @@ export async function upsertPrompts({
       status: p.status || 'active',
       origin: p.origin || 'human',
       source: p.source || 'config',
+      intent: normalizeIntent(p.intent),
       updated_by: updatedBy,
     };
 
@@ -620,6 +665,7 @@ export async function upsertPrompts({
     status: r.status,
     origin: r.origin,
     source: r.source,
+    intent: r.intent,
     createdAt: r.created_at,
     createdBy: r.created_by,
     updatedBy: r.updated_by,
@@ -670,6 +716,9 @@ export async function updatePromptById({
   }
   if (updates.origin !== undefined) {
     patch.origin = updates.origin;
+  }
+  if (updates.intent !== undefined) {
+    patch.intent = normalizeIntent(updates.intent);
   }
   if (updates.categoryId !== undefined) {
     patch.category_id = hasText(updates.categoryId)
@@ -815,8 +864,6 @@ export async function checkPromptsExist({ brandUuid, prompts, postgrestClient })
 
   return data ?? [];
 }
-
-const INTENT_VALUES = ['informational', 'instructional', 'comparative', 'transactional', 'planning', 'delegation'];
 
 export async function getPromptStats({ organizationId, brandUuid, postgrestClient }) {
   if (!postgrestClient?.rpc) {

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -66,6 +66,11 @@ export function normalizeIntent(intent) {
  * migration, and bumping it pulls in unrelated migrations + a constraint that
  * rejects the IT seed brand. So the code self-defends: when `intent` is absent,
  * prompts are still written/read WITHOUT intent rather than 500-ing.
+ *
+ * TODO: remove this fallback (the WeakMap, `isMissingIntentColumnError`, and the
+ * try/detect/retry in withMissingIntentFallback) once the IT PostgREST image in
+ * `test/it/postgres/docker-compose.yml` is bumped to a mysticat-data-service
+ * version >= v5.27.0 that includes the `intent` column. Tracked in SITES-39521.
  */
 const intentColumnSupported = new WeakMap();
 
@@ -75,6 +80,13 @@ const intentColumnSupported = new WeakMap();
  * 'intent' column of 'prompts' in the schema cache") and the select error
  * (`42703`, "column prompts.intent does not exist").
  *
+ * Gated on the two specific error codes first, THEN on the column being
+ * `intent`. This deliberately avoids broad message matching: an error that
+ * merely mentions "intent" and "column" (e.g. a future check-constraint
+ * violation "column intent violates check constraint") must NOT be treated as
+ * a missing column, or the fallback would latch off and silently drop the
+ * intent the caller sent — the exact data-loss bug this code exists to fix.
+ *
  * @param {*} error - Error object from a PostgREST response (`{ message, details, hint, code }`)
  * @returns {boolean} true when the error is specifically about a missing `intent` column
  */
@@ -82,12 +94,45 @@ export function isMissingIntentColumnError(error) {
   if (!error) {
     return false;
   }
-  const haystack = [error.message, error.details, error.hint, error.code]
+  const code = String(error.code || '').toUpperCase();
+  if (code !== '42703' && code !== 'PGRST204') {
+    return false;
+  }
+  const haystack = [error.message, error.details, error.hint]
     .filter((v) => v != null)
     .join(' ')
     .toLowerCase();
-  return haystack.includes('intent')
-    && (haystack.includes('column') || haystack.includes('schema cache'));
+  return haystack.includes('intent');
+}
+
+/**
+ * Removes the `intent` key from a row/patch (used when the column is known-absent).
+ */
+function stripIntent(row) {
+  const { intent: _, ...rest } = row;
+  return rest;
+}
+
+/**
+ * Runs a PostgREST op that may reference `prompts.intent`, transparently degrading
+ * when the column is absent (see intentColumnSupported). `run(includeIntent)` builds
+ * AND executes the op with or without intent and resolves to a PostgREST result
+ * (`{ error, ... }`). On the first missing-`intent`-column error for a client it
+ * caches the fact and retries once without intent; subsequent calls skip intent up
+ * front. Centralizes the try/detect/cache/retry the read and write paths share.
+ *
+ * @param {object} postgrestClient - PostgREST client (WeakMap key)
+ * @param {(includeIntent: boolean) => Promise<object>} run - builds+executes the op
+ * @returns {Promise<object>} the PostgREST result
+ */
+async function withMissingIntentFallback(postgrestClient, run) {
+  const includeIntent = intentColumnSupported.get(postgrestClient) !== false;
+  const result = await run(includeIntent);
+  if (includeIntent && result?.error && isMissingIntentColumnError(result.error)) {
+    intentColumnSupported.set(postgrestClient, false);
+    return run(false);
+  }
+  return result;
 }
 
 /**
@@ -493,13 +538,7 @@ export async function listPrompts({
     return baseQuery.range(offset, offset + limitNum - 1);
   };
 
-  const tryIntent = intentColumnSupported.get(postgrestClient) !== false;
-  let { data: rows, error, count } = await run(tryIntent);
-
-  if (error && isMissingIntentColumnError(error)) {
-    intentColumnSupported.set(postgrestClient, false);
-    ({ data: rows, error, count } = await run(false));
-  }
+  const { data: rows, error, count } = await withMissingIntentFallback(postgrestClient, run);
 
   if (error) {
     throw new Error(`Failed to list prompts: ${error.message}`);
@@ -568,12 +607,7 @@ export async function getPromptById({
     .eq('prompt_id', promptId)
     .maybeSingle();
 
-  let { data, error } = await run(intentColumnSupported.get(postgrestClient) !== false);
-
-  if (error && isMissingIntentColumnError(error)) {
-    intentColumnSupported.set(postgrestClient, false);
-    ({ data, error } = await run(false));
-  }
+  const { data, error } = await withMissingIntentFallback(postgrestClient, run);
 
   if (error) {
     throw new Error(`Failed to get prompt: ${error.message}`);
@@ -698,25 +732,16 @@ export async function upsertPrompts({
   let updated = 0;
   const skipped = prompts.length - toInsert.length - toUpdate.length;
 
-  // Best-effort against environments where `prompts.intent` is absent (see
-  // intentColumnSupported): strip `intent` from rows known-unsupported up
-  // front, and on a missing-column error remember it and retry without intent.
-  const stripIntent = (row) => {
-    const { intent: _, ...rest } = row;
-    return rest;
-  };
-
+  // Best-effort against environments where `prompts.intent` is absent: the
+  // shared helper drops intent and retries when the column is missing.
   if (toInsert.length > 0) {
-    const knownUnsupported = intentColumnSupported.get(postgrestClient) === false;
-    const insertRows = knownUnsupported ? toInsert.map(stripIntent) : toInsert;
-    let { data: inserted, error } = await postgrestClient.from('prompts').insert(insertRows).select();
-    if (error && isMissingIntentColumnError(error)) {
-      intentColumnSupported.set(postgrestClient, false);
-      ({ data: inserted, error } = await postgrestClient
+    const { data: inserted, error } = await withMissingIntentFallback(
+      postgrestClient,
+      (includeIntent) => postgrestClient
         .from('prompts')
-        .insert(toInsert.map(stripIntent))
-        .select());
-    }
+        .insert(includeIntent ? toInsert : toInsert.map(stripIntent))
+        .select(),
+    );
     if (error) {
       throw new Error(`Failed to insert prompts: ${error.message}`);
     }
@@ -725,14 +750,14 @@ export async function upsertPrompts({
 
   for (const row of toUpdate) {
     const { id, ...patch } = row;
-    const knownUnsupported = intentColumnSupported.get(postgrestClient) === false;
-    // eslint-disable-next-line no-await-in-loop, max-len
-    let { error } = await postgrestClient.from('prompts').update(knownUnsupported ? stripIntent(patch) : patch).eq('id', id);
-    if (error && isMissingIntentColumnError(error)) {
-      intentColumnSupported.set(postgrestClient, false);
-      // eslint-disable-next-line no-await-in-loop, max-len
-      ({ error } = await postgrestClient.from('prompts').update(stripIntent(patch)).eq('id', id));
-    }
+    // eslint-disable-next-line no-await-in-loop
+    const { error } = await withMissingIntentFallback(
+      postgrestClient,
+      (includeIntent) => postgrestClient
+        .from('prompts')
+        .update(includeIntent ? patch : stripIntent(patch))
+        .eq('id', id),
+    );
     if (error) {
       throw new Error(`Failed to update prompt: ${error.message}`);
     }
@@ -798,10 +823,8 @@ export async function updatePromptById({
   if (updates.origin !== undefined) {
     patch.origin = updates.origin;
   }
-  // Only set patch.intent when the column is not known-unsupported for this
-  // client (see intentColumnSupported); a missing-column error below triggers
-  // a retry with intent dropped.
-  if (updates.intent !== undefined && intentColumnSupported.get(postgrestClient) !== false) {
+  if (updates.intent !== undefined) {
+    // The shared fallback strips intent when the column is known-absent.
     patch.intent = normalizeIntent(updates.intent);
   }
   if (updates.categoryId !== undefined) {
@@ -824,13 +847,10 @@ export async function updatePromptById({
     .select()
     .maybeSingle();
 
-  let { data, error } = await runUpdate(patch);
-
-  if (error && isMissingIntentColumnError(error)) {
-    intentColumnSupported.set(postgrestClient, false);
-    const { intent: _, ...patchWithoutIntent } = patch;
-    ({ data, error } = await runUpdate(patchWithoutIntent));
-  }
+  const { data, error } = await withMissingIntentFallback(
+    postgrestClient,
+    (includeIntent) => runUpdate(includeIntent ? patch : stripIntent(patch)),
+  );
 
   if (error) {
     throw new Error(`Failed to update prompt: ${error.message}`);

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -78,7 +78,7 @@ const intentColumnSupported = new WeakMap();
  * @param {*} error - Error object from a PostgREST response (`{ message, details, hint, code }`)
  * @returns {boolean} true when the error is specifically about a missing `intent` column
  */
-function isMissingIntentColumnError(error) {
+export function isMissingIntentColumnError(error) {
   if (!error) {
     return false;
   }

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -56,6 +56,41 @@ export function normalizeIntent(intent) {
 }
 
 /**
+ * Per-client cache of whether `prompts.intent` is selectable/writable. Keyed by
+ * the PostgREST client so unit tests (fresh mock clients) never bleed state and
+ * production detects once per client instance. Absent = unknown (try with
+ * intent); `false` = known-missing (skip intent up front).
+ *
+ * Why best-effort instead of bumping the IT image: the integration PostgREST
+ * image is pinned to a data-service version that predates the `intent`
+ * migration, and bumping it pulls in unrelated migrations + a constraint that
+ * rejects the IT seed brand. So the code self-defends: when `intent` is absent,
+ * prompts are still written/read WITHOUT intent rather than 500-ing.
+ */
+const intentColumnSupported = new WeakMap();
+
+/**
+ * Detects a PostgREST/Postgres error that indicates the `intent` column is
+ * absent. Covers the insert/upsert error (`PGRST204`, "Could not find the
+ * 'intent' column of 'prompts' in the schema cache") and the select error
+ * (`42703`, "column prompts.intent does not exist").
+ *
+ * @param {*} error - Error object from a PostgREST response (`{ message, details, hint, code }`)
+ * @returns {boolean} true when the error is specifically about a missing `intent` column
+ */
+function isMissingIntentColumnError(error) {
+  if (!error) {
+    return false;
+  }
+  const haystack = [error.message, error.details, error.hint, error.code]
+    .filter((v) => v != null)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes('intent')
+    && (haystack.includes('column') || haystack.includes('schema cache'));
+}
+
+/**
  * Resolves brandId (path param) to Postgres brands.id (uuid).
  * Tries: 1) valid uuid lookup, 2) case-insensitive name lookup.
  *
@@ -368,7 +403,18 @@ export async function listPrompts({
   const pageNum = Math.max(1, Number(page) || 1);
   const offset = (pageNum - 1) * limitNum;
 
-  const select = `
+  let categoryUuid = null;
+  let topicUuid = null;
+  if (hasText(categoryId) || hasText(topicId)) {
+    categoryUuid = hasText(categoryId)
+      ? await resolveCategoryUuid(organizationId, categoryId, postgrestClient)
+      : null;
+    topicUuid = hasText(topicId)
+      ? await resolveTopicUuid(organizationId, topicId, postgrestClient)
+      : null;
+  }
+
+  const buildSelect = (includeIntent) => `
     id,
     prompt_id,
     name,
@@ -376,8 +422,7 @@ export async function listPrompts({
     regions,
     status,
     origin,
-    source,
-    intent,
+    source,${includeIntent ? '\n    intent,' : ''}
     category_id,
     topic_id,
     brand_id,
@@ -390,66 +435,71 @@ export async function listPrompts({
     topics(id,topic_id,name)
   `;
 
-  let baseQuery = postgrestClient
-    .from('prompts')
-    .select(select, { count: 'exact' })
-    .eq('organization_id', organizationId);
+  // Best-effort against environments where `prompts.intent` is absent (see
+  // intentColumnSupported): try with intent, and on a missing-column error
+  // remember it for this client and re-run the select without intent.
+  const run = (includeIntent) => {
+    let baseQuery = postgrestClient
+      .from('prompts')
+      .select(buildSelect(includeIntent), { count: 'exact' })
+      .eq('organization_id', organizationId);
 
-  // Sorting
-  const sortCol = SORT_COLUMN_MAP[sort];
-  if (sortCol) {
-    const ascending = order === 'asc';
-    if (sortCol.includes('(')) {
-      const [foreignTable, col] = sortCol.replace(')', '').split('(');
-      baseQuery = baseQuery.order(col, { ascending, foreignTable });
+    // Sorting
+    const sortCol = SORT_COLUMN_MAP[sort];
+    if (sortCol) {
+      const ascending = order === 'asc';
+      if (sortCol.includes('(')) {
+        const [foreignTable, col] = sortCol.replace(')', '').split('(');
+        baseQuery = baseQuery.order(col, { ascending, foreignTable });
+      } else {
+        baseQuery = baseQuery.order(sortCol, { ascending });
+      }
+      baseQuery = baseQuery.order('id', { ascending: true });
     } else {
-      baseQuery = baseQuery.order(sortCol, { ascending });
+      baseQuery = baseQuery
+        .order('updated_at', { ascending: false })
+        .order('id', { ascending: true });
     }
-    baseQuery = baseQuery.order('id', { ascending: true });
-  } else {
-    baseQuery = baseQuery
-      .order('updated_at', { ascending: false })
-      .order('id', { ascending: true });
-  }
 
-  if (brandUuid) {
-    baseQuery = baseQuery.eq('brand_id', brandUuid);
-  }
-  if (hasText(status)) {
-    baseQuery = baseQuery.eq('status', status);
-  } else {
-    baseQuery = baseQuery.neq('status', 'deleted');
-  }
+    if (brandUuid) {
+      baseQuery = baseQuery.eq('brand_id', brandUuid);
+    }
+    if (hasText(status)) {
+      baseQuery = baseQuery.eq('status', status);
+    } else {
+      baseQuery = baseQuery.neq('status', 'deleted');
+    }
 
-  if (hasText(origin)) {
-    baseQuery = baseQuery.eq('origin', origin);
-  }
+    if (hasText(origin)) {
+      baseQuery = baseQuery.eq('origin', origin);
+    }
 
-  if (hasText(region)) {
-    baseQuery = baseQuery.contains('regions', [region]);
-  }
+    if (hasText(region)) {
+      baseQuery = baseQuery.contains('regions', [region]);
+    }
 
-  if (hasText(search)) {
-    const term = `%${search}%`;
-    baseQuery = baseQuery.or(`text.ilike.${term},name.ilike.${term}`);
-  }
+    if (hasText(search)) {
+      const term = `%${search}%`;
+      baseQuery = baseQuery.or(`text.ilike.${term},name.ilike.${term}`);
+    }
 
-  if (hasText(categoryId) || hasText(topicId)) {
-    const categoryUuid = hasText(categoryId)
-      ? await resolveCategoryUuid(organizationId, categoryId, postgrestClient)
-      : null;
-    const topicUuid = hasText(topicId)
-      ? await resolveTopicUuid(organizationId, topicId, postgrestClient)
-      : null;
     if (categoryUuid) {
       baseQuery = baseQuery.eq('category_id', categoryUuid);
     }
     if (topicUuid) {
       baseQuery = baseQuery.eq('topic_id', topicUuid);
     }
-  }
 
-  const { data: rows, error, count } = await baseQuery.range(offset, offset + limitNum - 1);
+    return baseQuery.range(offset, offset + limitNum - 1);
+  };
+
+  const tryIntent = intentColumnSupported.get(postgrestClient) !== false;
+  let { data: rows, error, count } = await run(tryIntent);
+
+  if (error && isMissingIntentColumnError(error)) {
+    intentColumnSupported.set(postgrestClient, false);
+    ({ data: rows, error, count } = await run(false));
+  }
 
   if (error) {
     throw new Error(`Failed to list prompts: ${error.message}`);
@@ -489,7 +539,9 @@ export async function getPromptById({
     return null;
   }
 
-  const { data, error } = await postgrestClient
+  // Best-effort against environments where `prompts.intent` is absent: try with
+  // intent, and on a missing-column error remember it and re-run without intent.
+  const run = (includeIntent) => postgrestClient
     .from('prompts')
     .select(`
       id,
@@ -499,8 +551,7 @@ export async function getPromptById({
       regions,
       status,
       origin,
-      source,
-      intent,
+      source,${includeIntent ? '\n      intent,' : ''}
       category_id,
       topic_id,
       brand_id,
@@ -516,6 +567,13 @@ export async function getPromptById({
     .eq('brand_id', brandUuid)
     .eq('prompt_id', promptId)
     .maybeSingle();
+
+  let { data, error } = await run(intentColumnSupported.get(postgrestClient) !== false);
+
+  if (error && isMissingIntentColumnError(error)) {
+    intentColumnSupported.set(postgrestClient, false);
+    ({ data, error } = await run(false));
+  }
 
   if (error) {
     throw new Error(`Failed to get prompt: ${error.message}`);
@@ -640,8 +698,25 @@ export async function upsertPrompts({
   let updated = 0;
   const skipped = prompts.length - toInsert.length - toUpdate.length;
 
+  // Best-effort against environments where `prompts.intent` is absent (see
+  // intentColumnSupported): strip `intent` from rows known-unsupported up
+  // front, and on a missing-column error remember it and retry without intent.
+  const stripIntent = (row) => {
+    const { intent: _, ...rest } = row;
+    return rest;
+  };
+
   if (toInsert.length > 0) {
-    const { data: inserted, error } = await postgrestClient.from('prompts').insert(toInsert).select();
+    const knownUnsupported = intentColumnSupported.get(postgrestClient) === false;
+    const insertRows = knownUnsupported ? toInsert.map(stripIntent) : toInsert;
+    let { data: inserted, error } = await postgrestClient.from('prompts').insert(insertRows).select();
+    if (error && isMissingIntentColumnError(error)) {
+      intentColumnSupported.set(postgrestClient, false);
+      ({ data: inserted, error } = await postgrestClient
+        .from('prompts')
+        .insert(toInsert.map(stripIntent))
+        .select());
+    }
     if (error) {
       throw new Error(`Failed to insert prompts: ${error.message}`);
     }
@@ -650,8 +725,14 @@ export async function upsertPrompts({
 
   for (const row of toUpdate) {
     const { id, ...patch } = row;
+    const knownUnsupported = intentColumnSupported.get(postgrestClient) === false;
     // eslint-disable-next-line no-await-in-loop, max-len
-    const { error } = await postgrestClient.from('prompts').update(patch).eq('id', id);
+    let { error } = await postgrestClient.from('prompts').update(knownUnsupported ? stripIntent(patch) : patch).eq('id', id);
+    if (error && isMissingIntentColumnError(error)) {
+      intentColumnSupported.set(postgrestClient, false);
+      // eslint-disable-next-line no-await-in-loop, max-len
+      ({ error } = await postgrestClient.from('prompts').update(stripIntent(patch)).eq('id', id));
+    }
     if (error) {
       throw new Error(`Failed to update prompt: ${error.message}`);
     }
@@ -717,7 +798,10 @@ export async function updatePromptById({
   if (updates.origin !== undefined) {
     patch.origin = updates.origin;
   }
-  if (updates.intent !== undefined) {
+  // Only set patch.intent when the column is not known-unsupported for this
+  // client (see intentColumnSupported); a missing-column error below triggers
+  // a retry with intent dropped.
+  if (updates.intent !== undefined && intentColumnSupported.get(postgrestClient) !== false) {
     patch.intent = normalizeIntent(updates.intent);
   }
   if (updates.categoryId !== undefined) {
@@ -731,14 +815,22 @@ export async function updatePromptById({
       : null;
   }
 
-  const { data, error } = await postgrestClient
+  const runUpdate = (p) => postgrestClient
     .from('prompts')
-    .update(patch)
+    .update(p)
     .eq('organization_id', organizationId)
     .eq('brand_id', brandUuid)
     .eq('prompt_id', promptId)
     .select()
     .maybeSingle();
+
+  let { data, error } = await runUpdate(patch);
+
+  if (error && isMissingIntentColumnError(error)) {
+    intentColumnSupported.set(postgrestClient, false);
+    const { intent: _, ...patchWithoutIntent } = patch;
+    ({ data, error } = await runUpdate(patchWithoutIntent));
+  }
 
   if (error) {
     throw new Error(`Failed to update prompt: ${error.message}`);

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -812,6 +812,43 @@ describe('Brands Controller', () => {
       expect(body).to.have.property('prompts');
     });
 
+    it('createPromptsByBrand persists normalized intent from the request body', async () => {
+      const thenable = (v) => ({ then: (resolve) => resolve(v), catch: () => thenable(v) });
+      const insertStub = sandbox.stub()
+        .returns({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) });
+      mockDataAccess.services.postgrestClient.from = sandbox.stub().callsFake((table) => {
+        if (table === 'prompts') {
+          return {
+            select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+            insert: insertStub,
+            update: () => ({ eq: () => thenable({ error: null }) }),
+          };
+        }
+        const chain = {
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          maybeSingle: sandbox.stub().resolves({ data: { id: BRAND_UUID }, error: null }),
+        };
+        if (table === 'llmo_customer_config') {
+          chain.maybeSingle = sandbox.stub()
+            .resolves({ data: { config: { customer: { brands: [] } } }, error: null });
+        }
+        return chain;
+      });
+
+      const response = await brandsController.createPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        // legacy 'commercial' -> 'transactional'; uppercase lowercased; bogus -> null
+        data: [{ prompt: 'P', regions: ['us'], intent: 'COMMERCIAL' }],
+        dataAccess: mockDataAccess,
+      });
+
+      expect(response.status).to.equal(201);
+      const inserted = insertStub.firstCall.args[0];
+      expect(inserted[0].intent).to.equal('transactional');
+    });
+
     it('createPromptsByBrand returns 400 when prompts not an array', async () => {
       const response = await brandsController.createPromptsByBrand({
         ...context,
@@ -889,6 +926,51 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(200);
       const body = await response.json();
       expect(body.id).to.equal(PROMPT_ID);
+    });
+
+    it('updatePromptByBrandAndId persists normalized intent from the request body', async () => {
+      const thenable = (v) => ({ then: (resolve) => resolve(v), catch: () => thenable(v) });
+      const updatedRow = {
+        prompt_id: PROMPT_ID,
+        name: 'Test',
+        text: 'Prompt text',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        intent: 'informational',
+        updated_at: '2026-01-01T00:00:00Z',
+        updated_by: 'system',
+        brands: { id: BRAND_UUID, name: 'Test Brand' },
+        categories: null,
+        topics: null,
+      };
+      const single = (data) => ({ maybeSingle: () => thenable({ data, error: null }) });
+      const updateStub = sandbox.stub().returns({
+        eq: () => ({ eq: () => ({ eq: () => ({ select: () => single(updatedRow) }) }) }),
+      });
+      mockDataAccess.services.postgrestClient.from = sandbox.stub().callsFake((table) => {
+        if (table === 'brands') {
+          return { select: () => ({ eq: () => ({ eq: () => single({ id: BRAND_UUID }) }) }) };
+        }
+        // prompts: update path + the getPromptById re-read
+        return {
+          update: updateStub,
+          select: () => ({ eq: () => ({ eq: () => ({ eq: () => single(updatedRow) }) }) }),
+        };
+      });
+
+      const response = await brandsController.updatePromptByBrandAndId({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID, promptId: PROMPT_ID },
+        // legacy 'statistical' -> 'informational'
+        data: { intent: 'Statistical' },
+        dataAccess: mockDataAccess,
+      });
+
+      expect(response.status).to.equal(200);
+      expect(updateStub.firstCall.args[0].intent).to.equal('informational');
+      const body = await response.json();
+      expect(body.intent).to.equal('informational');
     });
 
     it('updatePromptByBrandAndId uses empty object when data is undefined', async () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -2744,14 +2744,25 @@ describe('prompts-storage', () => {
         expect(isMissingIntentColumnError({ message: 'DB exploded' })).to.be.false;
       });
 
-      it('does not match an error that mentions intent but not column/schema cache', () => {
-        // Exercises the negative side of the `column || schema cache` branch:
-        // "intent" present, but neither qualifier — must NOT be swallowed.
+      it('does not match an intent-mentioning error without a missing-column code', () => {
+        // "intent" present but no 42703/PGRST204 code — must NOT be swallowed.
         expect(isMissingIntentColumnError({ message: 'invalid intent value supplied' })).to.be.false;
       });
 
-      it('does not match an error that mentions column but not intent', () => {
-        expect(isMissingIntentColumnError({ message: 'column foo does not exist' })).to.be.false;
+      it('does not match a missing-column code for a different column', () => {
+        // Correct code, but the column is not `intent` — must NOT latch the fallback.
+        expect(isMissingIntentColumnError({ code: '42703', message: 'column prompts.status does not exist' })).to.be.false;
+      });
+
+      it('does not match a check-constraint violation that mentions intent and column', () => {
+        // Regression (PR #2562 review): a future constraint error like
+        // "column intent violates check constraint" carries a non-missing-column
+        // code (e.g. 23514). Gating on the code prevents a false positive that
+        // would latch the fallback off and silently drop intent.
+        expect(isMissingIntentColumnError({
+          code: '23514',
+          message: 'new row violates check constraint; column intent ...',
+        })).to.be.false;
       });
     });
 

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -26,6 +26,7 @@ import {
   bulkDeletePrompts,
   checkPromptsExist,
   getPromptStats,
+  normalizeIntent,
 } from '../../src/support/prompts-storage.js';
 
 use(chaiAsPromised);
@@ -60,6 +61,41 @@ describe('prompts-storage', () => {
   }
 
   afterEach(() => sandbox.restore());
+
+  describe('normalizeIntent', () => {
+    it('returns null for absent, empty, or whitespace values', () => {
+      expect(normalizeIntent(undefined)).to.be.null;
+      expect(normalizeIntent(null)).to.be.null;
+      expect(normalizeIntent('')).to.be.null;
+      expect(normalizeIntent('   ')).to.be.null;
+    });
+
+    it('passes through canonical buckets unchanged', () => {
+      for (const v of [
+        'informational', 'instructional', 'comparative',
+        'transactional', 'planning', 'delegation',
+      ]) {
+        expect(normalizeIntent(v)).to.equal(v);
+      }
+    });
+
+    it('lowercases and trims uppercase/padded input', () => {
+      expect(normalizeIntent('INFORMATIONAL')).to.equal('informational');
+      expect(normalizeIntent('  Transactional  ')).to.equal('transactional');
+    });
+
+    it('remaps legacy labels onto canonical buckets', () => {
+      expect(normalizeIntent('statistical')).to.equal('informational');
+      expect(normalizeIntent('navigational')).to.equal('informational');
+      expect(normalizeIntent('commercial')).to.equal('transactional');
+      expect(normalizeIntent('COMMERCIAL')).to.equal('transactional');
+    });
+
+    it('returns null for values that are invalid after remap', () => {
+      expect(normalizeIntent('bogus')).to.be.null;
+      expect(normalizeIntent('navigation')).to.be.null;
+    });
+  });
 
   describe('resolveBrandUuid', () => {
     it('returns null when brandId is empty', async () => {
@@ -762,6 +798,55 @@ describe('prompts-storage', () => {
       expect(result.created).to.equal(1);
       expect(result.updated).to.equal(0);
       expect(result.prompts).to.have.lengthOf(1);
+    });
+
+    it('persists normalized intent on insert (lowercases, remaps; invalid -> null)', async () => {
+      const insertStub = sinon.stub().returns({
+        select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }),
+      });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({});
+        },
+      };
+      await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [
+          {
+            id: 'a', prompt: 'lower', regions: [], intent: 'informational',
+          },
+          {
+            id: 'b', prompt: 'upper', regions: [], intent: 'TRANSACTIONAL',
+          },
+          {
+            id: 'c', prompt: 'legacy', regions: [], intent: 'commercial',
+          },
+          {
+            id: 'd', prompt: 'invalid', regions: [], intent: 'bogus',
+          },
+          { id: 'e', prompt: 'absent', regions: [] },
+        ],
+        postgrestClient: client,
+      });
+      const inserted = insertStub.firstCall.args[0];
+      expect(inserted.map((r) => r.intent)).to.deep.equal([
+        'informational', 'transactional', 'transactional', null, null,
+      ]);
     });
 
     it('updates existing prompts by id', async () => {
@@ -1637,6 +1722,85 @@ describe('prompts-storage', () => {
           postgrestClient: client,
         }),
       ).to.be.rejectedWith('Failed to update prompt');
+    });
+
+    it('persists normalized intent on update (lowercases and remaps)', async () => {
+      const row = {
+        prompt_id: PROMPT_ID,
+        name: 'Test',
+        text: 'Text',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        intent: 'transactional',
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      const updateStub = sinon.stub().returns({
+        eq: () => ({
+          eq: () => ({
+            eq: () => ({
+              select: () => ({ maybeSingle: () => thenable({ data: row, error: null }) }),
+            }),
+          }),
+        }),
+      });
+      const client = {
+        from: () => ({
+          update: updateStub,
+          select: () => makeChain({ data: row, error: null }).select(),
+        }),
+      };
+      const result = await updatePromptById({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        promptId: PROMPT_ID,
+        updates: { intent: 'COMMERCIAL' },
+        postgrestClient: client,
+      });
+      expect(updateStub.firstCall.args[0].intent).to.equal('transactional');
+      expect(result.intent).to.equal('transactional');
+    });
+
+    it('sets intent to null on update when value is empty or invalid', async () => {
+      const row = {
+        prompt_id: PROMPT_ID,
+        name: 'Test',
+        text: 'Text',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        intent: null,
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      const updateStub = sinon.stub().returns({
+        eq: () => ({
+          eq: () => ({
+            eq: () => ({
+              select: () => ({ maybeSingle: () => thenable({ data: row, error: null }) }),
+            }),
+          }),
+        }),
+      });
+      const client = {
+        from: () => ({
+          update: updateStub,
+          select: () => makeChain({ data: row, error: null }).select(),
+        }),
+      };
+      const result = await updatePromptById({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        promptId: PROMPT_ID,
+        updates: { intent: 'bogus' },
+        postgrestClient: client,
+      });
+      expect(Object.prototype.hasOwnProperty.call(updateStub.firstCall.args[0], 'intent')).to.be.true;
+      expect(updateStub.firstCall.args[0].intent).to.be.null;
+      expect(result.intent).to.be.null;
     });
 
     it('sets categoryId and topicId to null when empty string', async () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -2406,4 +2406,265 @@ describe('prompts-storage', () => {
       expect(result.intents.informational).to.equal(410);
     });
   });
+
+  // Best-effort behavior against environments where `prompts.intent` is absent
+  // (the IT PostgREST image is pinned to a data-service version predating the
+  // intent migration). Writing/reading `intent` there 500s with a missing-
+  // column error; the storage layer detects this per-client (WeakMap) and
+  // retries without intent so prompts still persist/read.
+  describe('intent column best-effort fallback', () => {
+    const MISSING_INTENT_INSERT = {
+      code: 'PGRST204',
+      message: "Could not find the 'intent' column of 'prompts' in the schema cache",
+    };
+    const MISSING_INTENT_SELECT = {
+      code: '42703',
+      message: 'column prompts.intent does not exist',
+    };
+
+    it('upsertPrompts inserts without intent when the column is missing, then retries clean', async () => {
+      const insertStub = sinon.stub();
+      // First insert (with intent) -> missing-column error; retry -> success.
+      insertStub.onFirstCall().returns({
+        select: () => thenable({ data: null, error: MISSING_INTENT_INSERT }),
+      });
+      insertStub.onSecondCall().returns({
+        select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }),
+      });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{
+          id: 'a', prompt: 'hello', regions: [], intent: 'informational',
+        }],
+        postgrestClient: client,
+      });
+      expect(result.created).to.equal(1);
+      expect(insertStub.callCount).to.equal(2);
+      // First attempt carried intent; retry stripped it.
+      expect(insertStub.firstCall.args[0][0]).to.have.property('intent', 'informational');
+      expect(insertStub.secondCall.args[0][0]).to.not.have.property('intent');
+    });
+
+    it('upsertPrompts skips intent up front on a second call with the same client', async () => {
+      const insertStub = sinon.stub();
+      insertStub.onCall(0).returns({
+        select: () => thenable({ data: null, error: MISSING_INTENT_INSERT }),
+      });
+      insertStub.onCall(1).returns({
+        select: () => thenable({ data: [{ prompt_id: 'p1' }], error: null }),
+      });
+      insertStub.onCall(2).returns({
+        select: () => thenable({ data: [{ prompt_id: 'p2' }], error: null }),
+      });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const args = {
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        postgrestClient: client,
+      };
+      await upsertPrompts({ ...args, prompts: [{ id: 'p1', prompt: 'x', intent: 'planning' }] });
+      await upsertPrompts({ ...args, prompts: [{ id: 'p2', prompt: 'y', intent: 'planning' }] });
+      // 2 calls for the first upsert (error + retry), 1 for the second (no error).
+      expect(insertStub.callCount).to.equal(3);
+      expect(insertStub.getCall(2).args[0][0]).to.not.have.property('intent');
+    });
+
+    it('upsertPrompts updates without intent when the column is missing, then retries clean', async () => {
+      const existingData = {
+        data: [{
+          id: 'row-id', prompt_id: 'p1', text: 'old', regions: [], status: 'active',
+        }],
+        error: null,
+      };
+      const updateStub = sinon.stub();
+      updateStub.onFirstCall().returns({ eq: () => thenable({ error: MISSING_INTENT_INSERT }) });
+      updateStub.onSecondCall().returns({ eq: () => thenable({ error: null }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable(existingData),
+                    in: () => thenable(existingData),
+                  }),
+                }),
+              }),
+              insert: () => ({ select: () => thenable({ data: [], error: null }) }),
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{
+          id: 'p1', prompt: 'Updated', regions: [], intent: 'transactional',
+        }],
+        postgrestClient: client,
+      });
+      expect(result.updated).to.equal(1);
+      expect(updateStub.callCount).to.equal(2);
+      expect(updateStub.firstCall.args[0]).to.have.property('intent', 'transactional');
+      expect(updateStub.secondCall.args[0]).to.not.have.property('intent');
+    });
+
+    it('listPrompts retries the select without intent when the column is missing', async () => {
+      const row = {
+        prompt_id: PROMPT_ID,
+        text: 'Prompt',
+        regions: ['us'],
+        status: 'active',
+        origin: 'human',
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      let promptCall = 0;
+      const client = {
+        from: (table) => {
+          if (table === 'brands') {
+            return makeChain({ data: { id: BRAND_UUID }, error: null });
+          }
+          promptCall += 1;
+          // First select (with intent) errors; retry (without intent) succeeds.
+          return promptCall === 1
+            ? makeChain({ data: null, error: MISSING_INTENT_SELECT, count: null })
+            : makeChain({ data: [row], error: null, count: 1 });
+        },
+      };
+      const result = await listPrompts({
+        organizationId: ORG_ID,
+        brandId: BRAND_UUID,
+        postgrestClient: client,
+      });
+      expect(promptCall).to.equal(2);
+      expect(result.items).to.have.lengthOf(1);
+      expect(result.items[0].intent).to.be.null;
+    });
+
+    it('listPrompts skips intent up front on a second call with the same client', async () => {
+      const row = {
+        prompt_id: PROMPT_ID,
+        text: 'Prompt',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      let promptCall = 0;
+      const client = {
+        from: (table) => {
+          if (table === 'brands') {
+            return makeChain({ data: { id: BRAND_UUID }, error: null });
+          }
+          promptCall += 1;
+          return promptCall === 1
+            ? makeChain({ data: null, error: MISSING_INTENT_SELECT, count: null })
+            : makeChain({ data: [row], error: null, count: 1 });
+        },
+      };
+      const args = { organizationId: ORG_ID, brandId: BRAND_UUID, postgrestClient: client };
+      await listPrompts(args);
+      await listPrompts(args);
+      // Call 1: with-intent error, Call 2: retry, Call 3: second list goes
+      // straight to no-intent (no error) — 3 total, not 4.
+      expect(promptCall).to.equal(3);
+    });
+
+    it('getPromptById retries the select without intent when the column is missing', async () => {
+      const row = {
+        id: 'pk-uuid',
+        prompt_id: PROMPT_ID,
+        text: 'Prompt',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      let call = 0;
+      const client = {
+        from: () => {
+          call += 1;
+          return call === 1
+            ? makeChain({ data: null, error: MISSING_INTENT_SELECT })
+            : makeChain({ data: row, error: null });
+        },
+      };
+      const result = await getPromptById({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        promptId: PROMPT_ID,
+        postgrestClient: client,
+      });
+      expect(call).to.equal(2);
+      expect(result).to.not.be.null;
+      expect(result.intent).to.be.null;
+    });
+
+    it('still throws on a non-intent query error (no spurious retry)', async () => {
+      let call = 0;
+      const client = {
+        from: () => {
+          call += 1;
+          return makeChain({ data: null, error: { message: 'DB exploded' } });
+        },
+      };
+      await expect(
+        getPromptById({
+          organizationId: ORG_ID,
+          brandUuid: BRAND_UUID,
+          promptId: PROMPT_ID,
+          postgrestClient: client,
+        }),
+      ).to.be.rejectedWith('Failed to get prompt');
+      // No retry for a non-intent error.
+      expect(call).to.equal(1);
+    });
+  });
 });

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -27,6 +27,7 @@ import {
   checkPromptsExist,
   getPromptStats,
   normalizeIntent,
+  isMissingIntentColumnError,
 } from '../../src/support/prompts-storage.js';
 
 use(chaiAsPromised);
@@ -2550,6 +2551,61 @@ describe('prompts-storage', () => {
       expect(updateStub.secondCall.args[0]).to.not.have.property('intent');
     });
 
+    it('upsertPrompts update-loop strips intent up front on a second call with the same client', async () => {
+      const existingData = {
+        data: [{
+          id: 'row-id', prompt_id: 'p1', text: 'old', regions: [], status: 'active',
+        }],
+        error: null,
+      };
+      const updateStub = sinon.stub();
+      // Call 0: with-intent error, Call 1: retry success (marks unsupported),
+      // Call 2: second upsert's update goes straight to the stripped patch.
+      updateStub.onCall(0).returns({ eq: () => thenable({ error: MISSING_INTENT_INSERT }) });
+      updateStub.onCall(1).returns({ eq: () => thenable({ error: null }) });
+      updateStub.onCall(2).returns({ eq: () => thenable({ error: null }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable(existingData),
+                    in: () => thenable(existingData),
+                  }),
+                }),
+              }),
+              insert: () => ({ select: () => thenable({ data: [], error: null }) }),
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const args = {
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        postgrestClient: client,
+      };
+      await upsertPrompts({
+        ...args,
+        prompts: [{
+          id: 'p1', prompt: 'Updated', regions: [], intent: 'transactional',
+        }],
+      });
+      await upsertPrompts({
+        ...args,
+        prompts: [{
+          id: 'p1', prompt: 'Updated again', regions: [], intent: 'planning',
+        }],
+      });
+      // 2 update calls for the first upsert (error + retry), 1 for the second.
+      expect(updateStub.callCount).to.equal(3);
+      // Known-unsupported client: the second upsert's update patch carries no intent.
+      expect(updateStub.getCall(2).args[0]).to.not.have.property('intent');
+    });
+
     it('listPrompts retries the select without intent when the column is missing', async () => {
       const row = {
         prompt_id: PROMPT_ID,
@@ -2665,6 +2721,131 @@ describe('prompts-storage', () => {
       ).to.be.rejectedWith('Failed to get prompt');
       // No retry for a non-intent error.
       expect(call).to.equal(1);
+    });
+
+    describe('isMissingIntentColumnError', () => {
+      it('returns false for a null/undefined/falsy error', () => {
+        // Covers the defensive early-return guard; in production every call site
+        // is `error && isMissingIntentColumnError(error)`, so exercise it directly.
+        expect(isMissingIntentColumnError(null)).to.be.false;
+        expect(isMissingIntentColumnError(undefined)).to.be.false;
+        expect(isMissingIntentColumnError(0)).to.be.false;
+      });
+
+      it('matches the insert/upsert missing-column error (PGRST204, schema cache)', () => {
+        expect(isMissingIntentColumnError(MISSING_INTENT_INSERT)).to.be.true;
+      });
+
+      it('matches the select missing-column error (42703, column does not exist)', () => {
+        expect(isMissingIntentColumnError(MISSING_INTENT_SELECT)).to.be.true;
+      });
+
+      it('does not match a generic error mentioning neither intent nor column', () => {
+        expect(isMissingIntentColumnError({ message: 'DB exploded' })).to.be.false;
+      });
+
+      it('does not match an error that mentions intent but not column/schema cache', () => {
+        // Exercises the negative side of the `column || schema cache` branch:
+        // "intent" present, but neither qualifier — must NOT be swallowed.
+        expect(isMissingIntentColumnError({ message: 'invalid intent value supplied' })).to.be.false;
+      });
+
+      it('does not match an error that mentions column but not intent', () => {
+        expect(isMissingIntentColumnError({ message: 'column foo does not exist' })).to.be.false;
+      });
+    });
+
+    it('updatePromptById updates without intent when the column is missing, then retries clean', async () => {
+      const row = {
+        prompt_id: PROMPT_ID,
+        name: 'Test',
+        text: 'Updated',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      const updateStub = sinon.stub();
+      const updateChain = (result) => ({
+        eq: () => ({
+          eq: () => ({
+            eq: () => ({ select: () => ({ maybeSingle: () => thenable(result) }) }),
+          }),
+        }),
+      });
+      // First update (with intent) -> missing-column error; retry -> success.
+      updateStub.onFirstCall().returns(updateChain({ data: null, error: MISSING_INTENT_INSERT }));
+      updateStub.onSecondCall().returns(updateChain({ data: row, error: null }));
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return { update: updateStub, select: () => makeChain({ data: row, error: null }) };
+          }
+          return makeChain({ data: row, error: null });
+        },
+      };
+      const result = await updatePromptById({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        promptId: PROMPT_ID,
+        updates: { prompt: 'Updated', intent: 'transactional' },
+        postgrestClient: client,
+      });
+      expect(result).to.not.be.null;
+      expect(updateStub.callCount).to.equal(2);
+      // First attempt carried intent; retry stripped it.
+      expect(updateStub.firstCall.args[0]).to.have.property('intent', 'transactional');
+      expect(updateStub.secondCall.args[0]).to.not.have.property('intent');
+    });
+
+    it('updatePromptById skips intent up front on a second call with the same client', async () => {
+      const row = {
+        prompt_id: PROMPT_ID,
+        name: 'Test',
+        text: 'Updated',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      const updateStub = sinon.stub();
+      const updateChain = (result) => ({
+        eq: () => ({
+          eq: () => ({
+            eq: () => ({ select: () => ({ maybeSingle: () => thenable(result) }) }),
+          }),
+        }),
+      });
+      // Call 0: with-intent error, Call 1: retry success, Call 2: second update
+      // for the same client never carries intent (known-unsupported pre-strip).
+      updateStub.onCall(0).returns(updateChain({ data: null, error: MISSING_INTENT_INSERT }));
+      updateStub.onCall(1).returns(updateChain({ data: row, error: null }));
+      updateStub.onCall(2).returns(updateChain({ data: row, error: null }));
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return { update: updateStub, select: () => makeChain({ data: row, error: null }) };
+          }
+          return makeChain({ data: row, error: null });
+        },
+      };
+      const args = {
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        promptId: PROMPT_ID,
+        postgrestClient: client,
+      };
+      await updatePromptById({ ...args, updates: { prompt: 'a', intent: 'planning' } });
+      await updatePromptById({ ...args, updates: { prompt: 'b', intent: 'planning' } });
+      // 2 update calls for the first (error + retry), 1 for the second (no error).
+      expect(updateStub.callCount).to.equal(3);
+      // Known-unsupported client: intent never set on the patch up front, so the
+      // second update's patch carries no `intent` key.
+      expect(updateStub.getCall(2).args[0]).to.not.have.property('intent');
     });
   });
 });


### PR DESCRIPTION
## Problem

DRS already classifies a search-intent bucket for every prompt and forwards it to the API (`V2Prompt.intent` in `llmo-data-retrieval-service/.../spacecat_v2_prompts_sync.py`). The Postgres `prompts.intent` column exists (mysticat-data-service migration `20260601000000_prompts_branded_intent.sql`) and the live stats endpoint (`GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/stats`) aggregates over it.

But the API **dropped `intent` at ingestion**:
- `upsertPrompts()` in `src/support/prompts-storage.js` built the inserted row without `intent`.
- `updatePromptById()` did not handle `intent` in its update patch.
- The `V2PromptInput` OpenAPI schema had no `intent` property.

Result: every prompt landed with `intent = NULL`, so the stats intent breakdown was all zeros.

## Change

Persist the `intent` callers already send. **No LLM classification here** — classifying human-added prompts that arrive without an intent is a separate follow-up PR.

### Normalization (on write)
A small, unit-tested `normalizeIntent()` helper:
- lowercases + trims the value;
- applies the legacy remap mirroring DRS `INTENT_REMAP`: `statistical`/`navigational` -> `informational`, `commercial` -> `transactional`;
- validates against the 6 canonical buckets: `informational, instructional, comparative, transactional, planning, delegation`;
- if absent, empty, or invalid after remap -> stores `NULL`.

`NULL` (rather than coercing to `informational`) is deliberate: gap-filling is handled elsewhere, and silently defaulting would pollute the intent breakdown with prompts whose intent is genuinely unknown.

### Wiring
- Threads `intent` through the create path (`createPromptsByBrand`) and update path (`updatePromptByBrandAndId`) — the controllers already pass the full request body through, so the change lands in `upsertPrompts()` (insert row) and `updatePromptById()` (update patch).
- Surfaces `intent` on read: added to the `listPrompts`/`getPromptById` selects and `mapRowToPrompt`.
- Documents `intent` (allowed values + normalization rules) in the `V2PromptInput` and `V2Prompt` OpenAPI schemas.

## Tests
- `test/support/prompts-storage.test.js`: `normalizeIntent` unit tests (canonical passthrough, uppercase lowercased, legacy remap, absent/empty/invalid -> null); `upsertPrompts` captures normalized intent on the inserted row; `updatePromptById` captures normalized intent on the patch and null-on-invalid.
- `test/controllers/brands.test.js`: POST and PATCH carrying `intent` thread the normalized value down to the DB layer.

Commands run:
- `npx mocha test/support/prompts-storage.test.js test/controllers/brands.test.js` -> 370 passing.
- `npm test` -> 11249 passing, 1 failing (pre-existing, unrelated: `fixes.test.js` stubs a non-existent data-access method due to a stale local `@adobe/spacecat-shared-data-access`; fails identically on clean `origin/main`).
- `npm run docs:lint` -> valid (pre-existing warnings only).
- `npx eslint` on changed files -> clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update

### CI root cause (`ci/it-postgres`) — correcting the earlier note

The earlier claim that the *only* CI failure is the pre-existing, unrelated `fixes.test.js` was wrong. The `ci/it-postgres` job is genuinely red, and it is caused by this PR's `intent` work interacting with the integration environment:

- The integration PostgREST image is pinned to `mysticat-data-service:v5.13.0` (`test/it/postgres/docker-compose.yml`).
- `v5.13.0` **predates** the `prompts.intent` migration (`20260601000000_prompts_branded_intent.sql`, first released in data-service `v5.27.0`).
- So in that environment, writing/selecting `prompts.intent` makes PostgREST return 500 — insert: `PGRST204` "Could not find the 'intent' column of 'prompts' in the schema cache"; select: `42703` "column prompts.intent does not exist" — failing `test/it/shared/tests/categories-prompts.js`.

Bumping the pinned image is **not** viable: a newer image introduces a `chk_active_brand_has_site_id` constraint that rejects the IT seed brand and pulls in ~23 unrelated migrations.

### Best-effort missing-column fallback (`src/support/prompts-storage.js`)

The storage layer now self-defends so it works whether or not the `intent` column exists:

- A module-level `WeakMap` (`intentColumnSupported`), keyed by the PostgREST client, caches per-client support. Fresh clients (and unit-test mocks) start unknown; production detects once per client.
- `isMissingIntentColumnError(error)` recognizes the missing-`intent`-column case (lowercased `message`/`details`/`hint`/`code` contains `intent` and either `column` or `schema cache`), covering both the insert `PGRST204` and the select `42703`.
- The four touchpoints (`listPrompts`, `getPromptById`, `upsertPrompts` insert + update, `updatePromptById`) try **with** intent and, on a missing-column error, set the WeakMap to `false`, strip/omit `intent`, and retry that one operation. Once a client is known-unsupported, subsequent calls skip intent up front (no extra error/retry).
- **The happy path (column present) is byte-for-byte unchanged**: intent is still written/selected, no extra DB round-trips, no retry. All existing unit tests pass untouched.

Net effect: in the pinned-image IT environment, prompts are written/read **without** intent (201/200) instead of 500; in environments where the column exists, intent is persisted exactly as before.

### OpenAPI input-enum relaxation

`V2PromptInput.intent` previously pinned an `enum` of only the 6 canonical buckets, but the code accepts and normalizes legacy aliases (`statistical`/`navigational`/`commercial`). Removed the `enum` on the **input** schema (kept `type: string` + a description listing the canonical values and noting legacy aliases are accepted and normalized on write). The `V2Prompt` **output** schema is unchanged (still the canonical enum + nullable).

### Tests / gates (latest run)

- New `intent column best-effort fallback` suite in `test/support/prompts-storage.test.js`: missing-column error on insert -> retries and still inserts (without intent); update retries; `listPrompts`/`getPromptById` retry the select and succeed omitting intent; second call on the same client skips intent up front (WeakMap); a non-intent error still throws with no spurious retry.
- `npm test` -> 11256 passing, 1 failing — the single failure remains the pre-existing, unrelated `fixes.test.js` (stale local `@adobe/spacecat-shared-data-access` stub), identical on `origin/main`.
- `npm run docs:lint` -> valid (pre-existing warnings only). `npx eslint` on changed files -> clean.
- `it-postgres` cannot be run locally (no Docker/AWS); the fallback is validated by the pinned-image `ci/it-postgres` job plus the new unit tests.
