### PR TITLE
feat(onboarding): add structured-data, sitemap, toc audits to paid profile

### DIFF
--- a/static/onboard/profiles.json
+++ b/static/onboard/profiles.json
@@ -130,6 +130,9 @@
 			"hreflang": {},
 			"security-vulnerabilities": {},
 			"security-vulnerabilities-auto-suggest": {},
+			"structured-data": {},
+			"sitemap": {},
+			"toc": {},
 			"wikipedia-analysis": {}
 		},
 		"imports": {


### PR DESCRIPTION
## What

Adds three audits to the `paid` onboarding profile in `static/onboard/profiles.json`:

- `structured-data`
- `sitemap`
- `toc`

## Why

These audits should run for paid-profile sites during onboarding.

## Validation

Audit names verified against the `spacecat-audit-worker` `HANDLERS` registry (`src/index.js`):

| Audit | Registered key | Line |
|-------|----------------|------|
| `structured-data` | `'structured-data'` | 155 |
| `sitemap` | `sitemap` | 138 |
| `toc` | `toc` | 202 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)