### PR TITLE
feat(s2s): allow S2S consumers with configuration:write to modify configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,38 @@ const hasAccess = await accessControlUtil.hasAccess(
 );
 ```
 
+**S2S consumer capability pattern** — use this instead of a bare `hasAdminAccess()` when a route is already mapped in `required-capabilities.js` and should be reachable by S2S consumers:
+
+```javascript
+import { CAP_CONFIGURATION_WRITE } from '../routes/capability-constants.js';
+
+// Dual-layer check: admin bypass first, then fresh DB fetch for S2S consumers.
+// Returns a forbidden Response when denied, null when access is granted.
+const authorizeWrite = async (context, route) => {
+  const requestId = context?.invocation?.id || 'unknown';
+  const isAdmin = accessControlUtil.hasAdminAccess();
+  const s2sResult = isAdmin
+    ? { allowed: false, reason: 'admin-bypass' }
+    : await accessControlUtil.hasS2SCapability(CAP_CONFIGURATION_WRITE);
+  if (!isAdmin && !s2sResult.allowed) {
+    log.info(`[acl] Denied ${route} - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} requestId=${requestId}`);
+    return forbidden('Forbidden');
+  }
+  if (s2sResult.allowed) {
+    log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} capability=${CAP_CONFIGURATION_WRITE} requestId=${requestId}`);
+  }
+  return null;
+};
+
+// In the handler:
+const denied = await authorizeWrite(context, 'PATCH /configurations/latest');
+if (denied) {
+  return denied;
+}
+```
+
+Capability constants live in `src/routes/capability-constants.js`. Both the route map (`required-capabilities.js`) and the controller must reference the **same constant** — the `capability-constants drift coverage` test enforces this. See `docs/s2s/READALL_CAPABILITY_DESIGN.md` for the full two-layer design.
+
 **Authentication precedence** (checked in order):
 1. JWT with scopes
 2. Adobe IMS

--- a/src/controllers/configuration.js
+++ b/src/controllers/configuration.js
@@ -104,7 +104,7 @@ function ConfigurationController(ctx) {
       return forbidden(message);
     }
     if (s2sResult.allowed) {
-      log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_CONFIGURATION_WRITE} requestId=${requestId}`);
+      log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} capability=${CAP_CONFIGURATION_WRITE} requestId=${requestId}`);
     }
     return null;
   };

--- a/src/controllers/configuration.js
+++ b/src/controllers/configuration.js
@@ -27,7 +27,7 @@ import { checkConfiguration } from '@adobe/spacecat-shared-data-access';
 
 import { ConfigurationDto } from '../dto/configuration.js';
 import AccessControlUtil from '../support/access-control-util.js';
-import { CAP_CONFIGURATION_READ } from '../routes/capability-constants.js';
+import { CAP_CONFIGURATION_READ, CAP_CONFIGURATION_WRITE } from '../routes/capability-constants.js';
 
 function ConfigurationController(ctx) {
   if (!isNonEmptyObject(ctx)) {
@@ -44,12 +44,17 @@ function ConfigurationController(ctx) {
 
   /**
    * Helper function to set updatedBy field from the authenticated user's profile.
+   * For S2S consumers the caller is identified as `s2s:<clientId>` when profile.email
+   * is absent, giving a traceable audit trail without exposing a human email.
    * @param {object} configuration - The configuration entity to update.
    * @param {object} context - The request context containing authInfo.
    */
   const setUpdatedBy = (configuration, context) => {
     const { authInfo: { profile } } = context.attributes;
-    configuration.setUpdatedBy(profile.email || 'system');
+    const s2sClientId = context.s2sConsumer?.getClientId?.();
+    configuration.setUpdatedBy(
+      profile.email || (s2sClientId ? `s2s:${s2sClientId}` : 'system'),
+    );
   };
 
   /**
@@ -74,6 +79,32 @@ function ConfigurationController(ctx) {
     }
     if (s2sResult.allowed) {
       log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_CONFIGURATION_READ} requestId=${requestId}`);
+    }
+    return null;
+  };
+
+  /**
+   * Authorizes a configuration write. Full admins pass as before.
+   * Additionally, an S2S consumer holding `configuration:write` is allowed —
+   * the capability is enforced at Layer 1 by `s2sAuthWrapper` and re-checked
+   * here at Layer 2 via a fresh DB fetch (same dual-layer pattern as read).
+   * @param {UniversalContext} context - Request context.
+   * @param {string} route - Route label used in structured logs.
+   * @param {string} message - Forbidden message returned to the caller.
+   * @returns {Promise<Response|null>} A `forbidden` response when denied, else null.
+   */
+  const authorizeConfigWrite = async (context, route, message) => {
+    const requestId = context?.invocation?.id || 'unknown';
+    const isAdmin = accessControlUtil.hasAdminAccess();
+    const s2sResult = isAdmin
+      ? { allowed: false, reason: 'admin-bypass' }
+      : await accessControlUtil.hasS2SCapability(CAP_CONFIGURATION_WRITE);
+    if (!isAdmin && !s2sResult.allowed) {
+      log.info(`[acl] Denied ${route} - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} requestId=${requestId}`);
+      return forbidden(message);
+    }
+    if (s2sResult.allowed) {
+      log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_CONFIGURATION_WRITE} requestId=${requestId}`);
     }
     return null;
   };
@@ -129,8 +160,9 @@ function ConfigurationController(ctx) {
   };
 
   const registerAudit = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can register audits');
+    const denied = await authorizeConfigWrite(context, 'POST /configurations/audits', 'Only admins can register audits');
+    if (denied) {
+      return denied;
     }
 
     const {
@@ -155,8 +187,9 @@ function ConfigurationController(ctx) {
   };
 
   const unregisterAudit = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can unregister audits');
+    const denied = await authorizeConfigWrite(context, 'DELETE /configurations/audits/:auditType', 'Only admins can unregister audits');
+    if (denied) {
+      return denied;
     }
 
     const auditType = context.params?.auditType;
@@ -181,8 +214,9 @@ function ConfigurationController(ctx) {
    * @return {Promise<Response>} Updated configuration response.
    */
   const updateQueues = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can update queue configuration');
+    const denied = await authorizeConfigWrite(context, 'PUT /configurations/latest/queues', 'Only admins can update queue configuration');
+    if (denied) {
+      return denied;
     }
 
     const queues = context.data;
@@ -213,8 +247,9 @@ function ConfigurationController(ctx) {
    * @return {Promise<Response>} Updated configuration response.
    */
   const updateJob = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can update job configuration');
+    const denied = await authorizeConfigWrite(context, 'PATCH /configurations/latest/jobs/:jobType', 'Only admins can update job configuration');
+    if (denied) {
+      return denied;
     }
 
     const { jobType } = context.params;
@@ -250,8 +285,9 @@ function ConfigurationController(ctx) {
    * @return {Promise<Response>} Updated configuration response.
    */
   const updateHandler = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can update handler configuration');
+    const denied = await authorizeConfigWrite(context, 'PATCH /configurations/latest/handlers/:handlerType', 'Only admins can update handler configuration');
+    if (denied) {
+      return denied;
     }
 
     const { handlerType } = context.params;
@@ -288,8 +324,9 @@ function ConfigurationController(ctx) {
    * @return {Promise<Response>} Updated configuration response.
    */
   const updateConfiguration = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can update configuration');
+    const denied = await authorizeConfigWrite(context, 'PATCH /configurations/latest', 'Only admins can update configuration');
+    if (denied) {
+      return denied;
     }
 
     const configData = context.data;
@@ -330,8 +367,9 @@ function ConfigurationController(ctx) {
    * @return {Promise<Response>} Configuration response.
    */
   const restoreVersion = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can restore configurations');
+    const denied = await authorizeConfigWrite(context, 'POST /configurations/:version/restore', 'Only admins can restore configurations');
+    if (denied) {
+      return denied;
     }
 
     const versionToRestore = context.params?.version;

--- a/src/routes/capability-constants.js
+++ b/src/routes/capability-constants.js
@@ -23,6 +23,7 @@ export const CAP_SITE_READ_ALL = 'site:readAll';
 export const CAP_ORG_READ_ALL = 'organization:readAll';
 
 export const CAP_CONFIGURATION_READ = 'configuration:read';
+export const CAP_CONFIGURATION_WRITE = 'configuration:write';
 
 export const CAP_SITE_CREATE = 'site:create';
 

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -12,6 +12,7 @@
 
 import {
   CAP_CONFIGURATION_READ,
+  CAP_CONFIGURATION_WRITE,
   CAP_FIX_ENTITY_CREATE,
   CAP_ORG_READ_ALL,
   CAP_SITE_CREATE,
@@ -227,15 +228,15 @@ const routeRequiredCapabilities = {
 
   // Configuration
   'GET /configurations/latest': CAP_CONFIGURATION_READ,
-  'PATCH /configurations/latest': 'configuration:write',
-  'POST /configurations/:version/restore': 'configuration:write',
+  'PATCH /configurations/latest': CAP_CONFIGURATION_WRITE,
+  'POST /configurations/:version/restore': CAP_CONFIGURATION_WRITE,
   'GET /configurations/:version': CAP_CONFIGURATION_READ,
-  'POST /configurations/audits': 'configuration:write',
-  'DELETE /configurations/audits/:auditType': 'configuration:write',
-  'PUT /configurations/latest/queues': 'configuration:write',
-  'PATCH /configurations/latest/jobs/:jobType': 'configuration:write',
-  'PATCH /configurations/latest/handlers/:handlerType': 'configuration:write',
-  'PATCH /configurations/sites/audits': 'configuration:write',
+  'POST /configurations/audits': CAP_CONFIGURATION_WRITE,
+  'DELETE /configurations/audits/:auditType': CAP_CONFIGURATION_WRITE,
+  'PUT /configurations/latest/queues': CAP_CONFIGURATION_WRITE,
+  'PATCH /configurations/latest/jobs/:jobType': CAP_CONFIGURATION_WRITE,
+  'PATCH /configurations/latest/handlers/:handlerType': CAP_CONFIGURATION_WRITE,
+  'PATCH /configurations/sites/audits': CAP_CONFIGURATION_WRITE,
 
   // Organizations
   'GET /organizations': CAP_ORG_READ_ALL,

--- a/test/controllers/configurations.test.js
+++ b/test/controllers/configurations.test.js
@@ -408,6 +408,138 @@ describe('Configurations Controller', () => {
     });
   });
 
+  describe('configuration write - S2S configuration:write capability', () => {
+    const makeS2SConsumer = ({
+      clientId = 'svc-cfg-write', imsOrgId = 'BBB222222222222222222222@AdobeOrg',
+    } = {}) => ({ getClientId: () => clientId, getImsOrgId: () => imsOrgId });
+
+    const makeFreshConsumer = ({
+      id = 'consumer-cfg-write-1',
+      capabilities = ['configuration:write'],
+      status = 'ACTIVE',
+      revoked = false,
+    } = {}) => ({
+      getId: () => id,
+      getCapabilities: () => capabilities,
+      getStatus: () => status,
+      isRevoked: () => revoked,
+    });
+
+    beforeEach(() => {
+      context.attributes.authInfo.withProfile({ is_admin: false });
+      context.s2sConsumer = makeS2SConsumer();
+      context.invocation = { id: 'req-cfg-write-1' };
+      mockDataAccess.Consumer = { findByClientIdAndImsOrgId: sandbox.stub() };
+    });
+
+    it('grants registerAudit to an S2S consumer holding configuration:write', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:write'] }));
+      context.data = {
+        auditType: 'lcp',
+        enabledByDefault: true,
+        interval: 'daily',
+        productCodes: ['ASO'],
+      };
+
+      const result = await configurationsController.registerAudit(context);
+
+      expect(result.status).to.equal(201);
+      expect(mockDataAccess.Consumer.findByClientIdAndImsOrgId).to.have.been.calledOnce;
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /\[s2s\] POST \/configurations\/audits granted clientId=svc-cfg-write consumerId=consumer-cfg-write-1 capability=configuration:write requestId=req-cfg-write-1/,
+      );
+    });
+
+    it('sets updatedBy to s2s:<clientId> for S2S write callers', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:write'] }));
+      context.data = {
+        auditType: 'lcp',
+        enabledByDefault: true,
+        interval: 'daily',
+        productCodes: ['ASO'],
+      };
+
+      await configurationsController.registerAudit(context);
+
+      expect(configurations[1].setUpdatedBy).to.have.been.calledWith('s2s:svc-cfg-write');
+    });
+
+    it('denies an S2S consumer lacking configuration:write', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:read'] }));
+      context.data = {
+        auditType: 'lcp',
+        enabledByDefault: true,
+        interval: 'daily',
+        productCodes: ['ASO'],
+      };
+
+      const result = await configurationsController.registerAudit(context);
+      const error = await result.json();
+
+      expect(result.status).to.equal(403);
+      expect(error).to.have.property('message', 'Only admins can register audits');
+      expect(mockDataAccess.Configuration.findLatest).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /\[acl\] Denied POST \/configurations\/audits - reason=missing-capability clientId=svc-cfg-write consumerId=consumer-cfg-write-1/,
+      );
+    });
+
+    it('denies a revoked S2S consumer on write', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ revoked: true }));
+      context.data = {
+        auditType: 'lcp',
+        enabledByDefault: true,
+        interval: 'daily',
+        productCodes: ['ASO'],
+      };
+
+      const result = await configurationsController.registerAudit(context);
+
+      expect(result.status).to.equal(403);
+      expect(mockDataAccess.Configuration.findLatest).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWithMatch(/reason=revoked/);
+    });
+
+    it('logs requestId=unknown when invocation id is missing on write', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:read'] }));
+      delete context.invocation;
+      context.data = {
+        auditType: 'lcp',
+        enabledByDefault: true,
+        interval: 'daily',
+        productCodes: ['ASO'],
+      };
+
+      const result = await configurationsController.registerAudit(context);
+
+      expect(result.status).to.equal(403);
+      expect(context.log.info).to.have.been.calledWithMatch(/requestId=unknown/);
+    });
+
+    it('grants updateConfiguration to an S2S consumer holding configuration:write', async () => {
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:write'] }));
+      const updateConfiguration = sandbox.stub();
+      mockDataAccess.Configuration.findLatest.resolves({
+        ...configurations[1],
+        updateConfiguration,
+      });
+      context.data = { handlers: { cwv: { enabledByDefault: true, productCodes: ['ASO'] } } };
+
+      const result = await configurationsController.updateConfiguration(context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /\[s2s\] PATCH \/configurations\/latest granted clientId=svc-cfg-write consumerId=consumer-cfg-write-1 capability=configuration:write requestId=req-cfg-write-1/,
+      );
+    });
+  });
+
   it('returns not found when a configuration is not found by version', async () => {
     mockDataAccess.Configuration.findByVersion.resolves(null);
 


### PR DESCRIPTION

Add dual-layer S2S capability check for all 7 configuration write operations (registerAudit, unregisterAudit, updateQueues, updateJob, updateHandler, updateConfiguration, restoreVersion) so S2S consumers holding the configuration:write capability are no longer blocked by the bare hasAdminAccess() guard.

- Add CAP_CONFIGURATION_WRITE constant and use it in required-capabilities.js (replacing 8 literal strings) to close the read/write constant gap
- Add authorizeConfigWrite mirroring the existing authorizeConfigRead pattern: admin check first, then fresh DB fetch via hasS2SCapability(CAP_CONFIGURATION_WRITE); structured [acl]/[s2s] log lines with clientId, consumerId, capability, requestId
- Update setUpdatedBy to emit s2s:<clientId> instead of the opaque system when profile.email is absent, giving a traceable audit trail for S2S mutations
- Add 6 unit tests covering grant, updatedBy trail, missing-capability denial, revoked consumer denial, requestId=unknown fallback, and a second write op
