### PR TITLE
docs(s2s): update restricted capability list to reflect executive-approval tier

### DIFF
--- a/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
+++ b/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
@@ -91,10 +91,13 @@ The S2S Admin and SpaceCat Security Team will review your JIRA request:
 
 - **Read capabilities** (`*:read`): Generally approved quickly
 - **Write capabilities** (`*:write`): Require business justification and scrutiny
-- **Restricted capabilities**: The following are typically denied:
-  - `fixEntity:write` - Never granted
+- **Restricted capabilities**: The following require executive approval:
+  - `fixEntity:write` - Rarely granted, requires executive approval
+  - `fixEntity:create` - Rarely granted, requires executive approval
   - `site:write` - Rarely granted, requires executive approval
+  - `site:create` - Rarely granted, requires executive approval
   - `organization:write` - Rarely granted, requires executive approval
+  - `configuration:write` - Rarely granted, requires executive approval
 
 The team will respond via JIRA with approval or request additional information.
 
@@ -650,12 +653,17 @@ the long-term fix is server-side cursor pagination (see
 | `organization:write` | Modify organizations | Update org settings (rarely granted) |
 | `opportunity:read` | Read opportunities | Access recommendations, issues |
 | `suggestion:read` | Read AI suggestions | Access AI-generated suggestions |
+| `configuration:read` | Read platform configuration | Access handlers, jobs, queue config |
+| `configuration:write` | Modify platform configuration | Update handlers, jobs, queues, audit types (rarely granted) |
 
-### Restricted Capabilities (Typically Denied)
+### Restricted Capabilities (Require Executive Approval)
 
-- `fixEntity:write` - Never granted, internal use only
+- `fixEntity:write` - Rarely granted, requires executive approval
+- `fixEntity:create` - Rarely granted, requires executive approval
 - `site:write` - Rarely granted, requires executive approval
+- `site:create` - Rarely granted, requires executive approval
 - `organization:write` - Rarely granted, requires executive approval
+- `configuration:write` - Rarely granted, requires executive approval
 
 ---
 

--- a/docs/s2s/S2S_ADMIN_GUIDE.md
+++ b/docs/s2s/S2S_ADMIN_GUIDE.md
@@ -26,7 +26,7 @@ As an S2S Admin, you are responsible for:
 2. **Access Management**: Reviewing and approving capability upgrade requests with security scrutiny
 3. **Security Enforcement**:
    - Scrutinizing write permission requests on all entities
-   - Denying restricted capabilities (e.g., `fixEntity:write`, `organization:write`, `site:write`)
+   - Scrutinizing restricted capabilities (e.g., `fixEntity:write`, `fixEntity:create`, `organization:write`, `site:write`, `site:create`, `configuration:write`) — all require executive approval
    - Ensuring least-privilege access principles
 4. **Lifecycle Management**: Suspending or revoking consumer access when necessary
 5. **Secret Rotation**: Coordinating secret rotation in response to security incidents or compromised credentials
@@ -161,10 +161,13 @@ When a consumer team requests capability changes:
    - Consider security implications
 
 2. **Check Restricted Capabilities**:
-   > 🚨 **CRITICAL**: The following capabilities are RESTRICTED and must be explicitly denied:
-   - `fixEntity:write` - Restricted capability for internal use only
+   > 🚨 **CRITICAL**: The following capabilities are RESTRICTED and require executive approval:
+   - `fixEntity:write` - Fix entity write access, rarely granted, requires executive approval
+   - `fixEntity:create` - Fix entity creation access, rarely granted, requires executive approval
    - `site:write` - Critical write access, rarely granted
+   - `site:create` - Admin-gated site creation, requires executive approval
    - `organization:write` - Critical write access, rarely granted
+   - `configuration:write` - Platform-wide configuration write access, requires executive approval
 
 3. **Validate Capability Format**: All capabilities must follow `entity:operation` format
    - Valid: `site:read`, `opportunity:write`
@@ -438,20 +441,25 @@ All capabilities must follow the format: `entity:operation`
 | `*:read` | Low | Generally safe, verify legitimate need |
 | `*:write` (general) | **High** | Requires strong business justification |
 | `*:delete` | **Critical** | Rarely granted, executive approval recommended |
-| `fixEntity:write` | **RESTRICTED** | Never grant under any circumstances |
+| `fixEntity:write` | **RESTRICTED** | Rarely granted; requires executive approval |
+| `fixEntity:create` | **RESTRICTED** | Rarely granted; requires executive approval |
 | `site:write` | **RESTRICTED** | Critical write access, rarely granted |
+| `site:create` | **RESTRICTED** | Admin-gated site creation; requires executive approval |
 | `organization:write` | **RESTRICTED** | Critical write access, rarely granted |
-| `site:create` | **RESTRICTED** | Admin-gated site creation for S2S consumers; explicit grant required |
+| `configuration:write` | **RESTRICTED** | Platform-wide config write access; requires executive approval |
 | `admin:*` | **INVALID** | Invalid capability |
 
 ### Restricted Capabilities
 
-The following capabilities are **RESTRICTED** and should **NEVER** be granted:
+The following capabilities are **RESTRICTED** and require **executive approval** before granting:
 
-1. **`fixEntity:write`**: Restricted capability for internal use only
-2. **`site:write`**: Critical write access to site configurations - rarely granted, requires executive approval
-3. **`organization:write`**: Critical write access to organization configurations - rarely granted, requires executive approval
-4. Wildcard capabilities (e.g., `*:*`, `*:write`)
+1. **`fixEntity:write`**: Fix entity write access - rarely granted, requires executive approval
+2. **`fixEntity:create`**: Fix entity creation access - rarely granted, requires executive approval
+3. **`site:write`**: Critical write access to site configurations - rarely granted, requires executive approval
+4. **`site:create`**: Admin-gated site creation - rarely granted, requires executive approval
+5. **`organization:write`**: Critical write access to organization configurations - rarely granted, requires executive approval
+6. **`configuration:write`**: Platform-wide configuration write access (handlers, jobs, queues, audit registration) - rarely granted, requires executive approval
+7. Wildcard capabilities (e.g., `*:*`, `*:write`)
 
 ### Review Questions for Write Permissions
 


### PR DESCRIPTION
## Summary

- Add `configuration:write`, `fixEntity:create`, and `site:create` to the restricted capabilities lists in both S2S guides (`S2S_ADMIN_GUIDE.md` and `CONSUMER_INTEGRATION_GUIDE.md`)
- Reclassify `fixEntity:write` and `fixEntity:create` from _internal-only / never granted_ to the **executive-approval** tier, consistent with `site:write`, `site:create`, `organization:write`, and `configuration:write`
- Update section headers and the Security Scrutiny Matrix to reflect that restricted capabilities require executive approval rather than being unconditionally denied

## Test plan

- [ ] Verify both markdown files render correctly
- [ ] Confirm all six restricted capabilities appear in the scrutiny matrix and restricted capabilities list

🤖 Generated with [Claude Code](https://claude.com/claude-code)