### PR TITLE
feat(s2s): allow S2S consumers with configuration:write to toggle site audits

### DIFF
--- a/src/controllers/sites-audits-toggle.js
+++ b/src/controllers/sites-audits-toggle.js
@@ -39,7 +39,7 @@ export default (ctx) => {
   const { Configuration, Site, Organization } = dataAccess;
   const accessControlUtil = AccessControlUtil.fromContext(ctx);
 
-  const authorizeConfigWrite = async (context, route) => {
+  const authorizeConfigWrite = async (context, route, message) => {
     const requestId = context?.invocation?.id || 'unknown';
     const isAdmin = accessControlUtil.hasAdminAccess();
     const s2sResult = isAdmin
@@ -47,7 +47,7 @@ export default (ctx) => {
       : await accessControlUtil.hasS2SCapability(CAP_CONFIGURATION_WRITE);
     if (!isAdmin && !s2sResult.allowed) {
       log.info(`[acl] Denied ${route} - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} requestId=${requestId}`);
-      return forbidden('Only admins can change configuration settings.');
+      return forbidden(message);
     }
     if (s2sResult.allowed) {
       log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} capability=${CAP_CONFIGURATION_WRITE} requestId=${requestId}`);
@@ -89,7 +89,7 @@ export default (ctx) => {
    * @returns {Promise<Response|*>}
    */
   const execute = async (context) => {
-    const denied = await authorizeConfigWrite(context, 'PATCH /configurations/sites/audits');
+    const denied = await authorizeConfigWrite(context, 'PATCH /configurations/sites/audits', 'Only admins can change configuration settings.');
     if (denied) {
       return denied;
     }
@@ -183,7 +183,7 @@ export default (ctx) => {
 
       if (hasUpdates === true) {
         const { authInfo: { profile } } = context.attributes;
-        const s2sClientId = ctx.s2sConsumer?.getClientId?.();
+        const s2sClientId = context.s2sConsumer?.getClientId?.();
         configuration.setUpdatedBy(
           profile.email || (s2sClientId ? `s2s:${s2sClientId}` : 'system'),
         );
@@ -192,7 +192,7 @@ export default (ctx) => {
 
       return createResponse(responses, 207);
     } catch (error) {
-      context.log.error(error.message);
+      log.error(error.message);
       return internalServerError('An error occurred while trying to enable or disable audits.');
     }
   };

--- a/src/controllers/sites-audits-toggle.js
+++ b/src/controllers/sites-audits-toggle.js
@@ -20,6 +20,7 @@ import {
   hasText, isValidUrl, isNonEmptyObject,
 } from '@adobe/spacecat-shared-utils';
 import AccessControlUtil from '../support/access-control-util.js';
+import { CAP_CONFIGURATION_WRITE } from '../routes/capability-constants.js';
 
 /**
  * @param {object} ctx - Context of the request.
@@ -30,13 +31,29 @@ export default (ctx) => {
   if (!isNonEmptyObject(ctx)) {
     throw new Error('Context required');
   }
-  const { dataAccess } = ctx;
+  const { dataAccess, log } = ctx;
   if (!isNonEmptyObject(dataAccess)) {
     throw new Error('Data access required');
   }
 
   const { Configuration, Site, Organization } = dataAccess;
   const accessControlUtil = AccessControlUtil.fromContext(ctx);
+
+  const authorizeConfigWrite = async (context, route) => {
+    const requestId = context?.invocation?.id || 'unknown';
+    const isAdmin = accessControlUtil.hasAdminAccess();
+    const s2sResult = isAdmin
+      ? { allowed: false, reason: 'admin-bypass' }
+      : await accessControlUtil.hasS2SCapability(CAP_CONFIGURATION_WRITE);
+    if (!isAdmin && !s2sResult.allowed) {
+      log.info(`[acl] Denied ${route} - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} requestId=${requestId}`);
+      return forbidden('Only admins can change configuration settings.');
+    }
+    if (s2sResult.allowed) {
+      log.info(`[s2s] ${route} granted clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} capability=${CAP_CONFIGURATION_WRITE} requestId=${requestId}`);
+    }
+    return null;
+  };
 
   const validateInput = ({
     baseURL, organizationId, auditType, enable,
@@ -72,14 +89,15 @@ export default (ctx) => {
    * @returns {Promise<Response|*>}
    */
   const execute = async (context) => {
-    if (!accessControlUtil.hasAdminAccess()) {
-      return forbidden('Only admins can change configuration settings.');
+    const denied = await authorizeConfigWrite(context, 'PATCH /configurations/sites/audits');
+    if (denied) {
+      return denied;
     }
     if (!isNonEmptyObject(context)) {
       return internalServerError('An error occurred while trying to enable or disable audits.');
     }
 
-    const { data: requestBody, log } = context;
+    const { data: requestBody } = context;
 
     if (!requestBody || requestBody.length === 0) {
       return badRequest('Request body is required.');
@@ -165,13 +183,16 @@ export default (ctx) => {
 
       if (hasUpdates === true) {
         const { authInfo: { profile } } = context.attributes;
-        configuration.setUpdatedBy(profile.email || 'system');
+        const s2sClientId = ctx.s2sConsumer?.getClientId?.();
+        configuration.setUpdatedBy(
+          profile.email || (s2sClientId ? `s2s:${s2sClientId}` : 'system'),
+        );
         await configuration.save();
       }
 
       return createResponse(responses, 207);
     } catch (error) {
-      log.error(error.message);
+      context.log.error(error.message);
       return internalServerError('An error occurred while trying to enable or disable audits.');
     }
   };

--- a/test/controllers/sites-audits-toggle.test.js
+++ b/test/controllers/sites-audits-toggle.test.js
@@ -240,7 +240,7 @@ describe('Sites Audits Controller', () => {
       const error = await response.json();
 
       expect(
-        logMock.error.calledWith(privateInternalServerError),
+        contextMock.log.error.calledWith(privateInternalServerError),
         'Expected log.error to be called with the privateInternalServerError message',
       ).to.be.true;
 
@@ -934,6 +934,7 @@ describe('Sites Audits Controller', () => {
         data: requestData,
         log: logMock,
         invocation: { id: 'req-toggle-1' },
+        s2sConsumer: contextMock.s2sConsumer,
         attributes: contextMock.attributes,
       });
 
@@ -955,6 +956,7 @@ describe('Sites Audits Controller', () => {
         data: requestData,
         log: logMock,
         invocation: { id: 'req-toggle-1' },
+        s2sConsumer: contextMock.s2sConsumer,
         attributes: contextMock.attributes,
       });
 

--- a/test/controllers/sites-audits-toggle.test.js
+++ b/test/controllers/sites-audits-toggle.test.js
@@ -12,6 +12,7 @@
 
 import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 
 import AuthInfo from '@adobe/spacecat-shared-http-utils/src/auth/auth-info.js';
@@ -19,6 +20,7 @@ import AuthInfo from '@adobe/spacecat-shared-http-utils/src/auth/auth-info.js';
 import SitesAuditsToggleController from '../../src/controllers/sites-audits-toggle.js';
 
 use(chaiAsPromised);
+use(sinonChai);
 
 describe('Sites Audits Controller', () => {
   const sandbox = sinon.createSandbox();
@@ -81,6 +83,11 @@ describe('Sites Audits Controller', () => {
 
     contextMock = {
       dataAccess: dataAccessMock,
+      log: {
+        info: sandbox.stub(),
+        warn: sandbox.stub(),
+        error: sandbox.stub(),
+      },
       pathInfo: {
         headers: { 'x-product': 'abcd' },
       },
@@ -595,6 +602,11 @@ describe('Sites Audits Controller', () => {
       // Create a new non-admin context
       const nonAdminContext = {
         dataAccess: dataAccessMock,
+        log: {
+          info: sandbox.stub(),
+          warn: sandbox.stub(),
+          error: sandbox.stub(),
+        },
         env: {},
         pathInfo: {
           headers: { 'x-product': 'abcd' },
@@ -882,6 +894,130 @@ describe('Sites Audits Controller', () => {
       });
       expect(configurationMock.setUpdatedBy).to.have.been.calledOnceWith('system');
       expect(configurationMock.save.called).to.be.true;
+    });
+  });
+
+  describe('S2S configuration:write capability', () => {
+    const makeS2SConsumer = ({
+      clientId = 'svc-toggle-write', imsOrgId = 'CCC333333333333333333333@AdobeOrg',
+    } = {}) => ({ getClientId: () => clientId, getImsOrgId: () => imsOrgId });
+
+    const makeFreshConsumer = ({
+      id = 'consumer-toggle-write-1',
+      capabilities = ['configuration:write'],
+      status = 'ACTIVE',
+      revoked = false,
+    } = {}) => ({
+      getId: () => id,
+      getCapabilities: () => capabilities,
+      getStatus: () => status,
+      isRevoked: () => revoked,
+    });
+
+    beforeEach(() => {
+      contextMock.attributes.authInfo.withProfile({ is_admin: false });
+      contextMock.s2sConsumer = makeS2SConsumer();
+      contextMock.invocation = { id: 'req-toggle-1' };
+      dataAccessMock.Consumer = { findByClientIdAndImsOrgId: sandbox.stub() };
+      sitesAuditsToggleController = SitesAuditsToggleController(contextMock);
+    });
+
+    it('grants execute to an S2S consumer holding configuration:write', async () => {
+      dataAccessMock.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:write'] }));
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(sites[0]);
+
+      const requestData = [
+        { baseURL: 'https://site0.com', auditType: 'cwv', enable: true },
+      ];
+      const response = await sitesAuditsToggleController.execute({
+        data: requestData,
+        log: logMock,
+        invocation: { id: 'req-toggle-1' },
+        attributes: contextMock.attributes,
+      });
+
+      expect(response.status).to.equal(207);
+      expect(contextMock.log.info).to.have.been.calledWithMatch(
+        /\[s2s\] PATCH \/configurations\/sites\/audits granted clientId=svc-toggle-write consumerId=consumer-toggle-write-1 capability=configuration:write requestId=req-toggle-1/,
+      );
+    });
+
+    it('sets updatedBy to s2s:<clientId> for S2S write callers', async () => {
+      dataAccessMock.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:write'] }));
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(sites[0]);
+
+      const requestData = [
+        { baseURL: 'https://site0.com', auditType: 'cwv', enable: true },
+      ];
+      await sitesAuditsToggleController.execute({
+        data: requestData,
+        log: logMock,
+        invocation: { id: 'req-toggle-1' },
+        attributes: contextMock.attributes,
+      });
+
+      expect(configurationMock.setUpdatedBy).to.have.been.calledWith('s2s:svc-toggle-write');
+    });
+
+    it('denies an S2S consumer lacking configuration:write', async () => {
+      dataAccessMock.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:read'] }));
+
+      const requestData = [
+        { baseURL: 'https://site0.com', auditType: 'cwv', enable: true },
+      ];
+      const response = await sitesAuditsToggleController.execute({
+        data: requestData,
+        log: logMock,
+        invocation: { id: 'req-toggle-1' },
+        attributes: contextMock.attributes,
+      });
+      const error = await response.json();
+
+      expect(response.status).to.equal(403);
+      expect(error).to.have.property('message', 'Only admins can change configuration settings.');
+      expect(dataAccessMock.Configuration.findLatest).to.not.have.been.called;
+      expect(contextMock.log.info).to.have.been.calledWithMatch(
+        /\[acl\] Denied PATCH \/configurations\/sites\/audits - reason=missing-capability clientId=svc-toggle-write consumerId=consumer-toggle-write-1/,
+      );
+    });
+
+    it('denies a revoked S2S consumer', async () => {
+      dataAccessMock.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ revoked: true }));
+
+      const requestData = [
+        { baseURL: 'https://site0.com', auditType: 'cwv', enable: true },
+      ];
+      const response = await sitesAuditsToggleController.execute({
+        data: requestData,
+        log: logMock,
+        invocation: { id: 'req-toggle-1' },
+        attributes: contextMock.attributes,
+      });
+
+      expect(response.status).to.equal(403);
+      expect(dataAccessMock.Configuration.findLatest).to.not.have.been.called;
+      expect(contextMock.log.info).to.have.been.calledWithMatch(/reason=revoked/);
+    });
+
+    it('logs requestId=unknown when invocation id is missing', async () => {
+      dataAccessMock.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:read'] }));
+
+      const requestData = [
+        { baseURL: 'https://site0.com', auditType: 'cwv', enable: true },
+      ];
+      const response = await sitesAuditsToggleController.execute({
+        data: requestData,
+        log: logMock,
+        attributes: contextMock.attributes,
+      });
+
+      expect(response.status).to.equal(403);
+      expect(contextMock.log.info).to.have.been.calledWithMatch(/requestId=unknown/);
     });
   });
 

--- a/test/controllers/sites-audits-toggle.test.js
+++ b/test/controllers/sites-audits-toggle.test.js
@@ -974,6 +974,7 @@ describe('Sites Audits Controller', () => {
         data: requestData,
         log: logMock,
         invocation: { id: 'req-toggle-1' },
+        s2sConsumer: contextMock.s2sConsumer,
         attributes: contextMock.attributes,
       });
       const error = await response.json();
@@ -997,12 +998,35 @@ describe('Sites Audits Controller', () => {
         data: requestData,
         log: logMock,
         invocation: { id: 'req-toggle-1' },
+        s2sConsumer: contextMock.s2sConsumer,
         attributes: contextMock.attributes,
       });
 
       expect(response.status).to.equal(403);
       expect(dataAccessMock.Configuration.findLatest).to.not.have.been.called;
       expect(contextMock.log.info).to.have.been.calledWithMatch(/reason=revoked/);
+    });
+
+    it('prefers profile.email over s2s:<clientId> when both are present', async () => {
+      dataAccessMock.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['configuration:write'] }));
+      dataAccessMock.Site.findByBaseURL.withArgs('https://site0.com').resolves(sites[0]);
+      // Override profile to include an email even though s2sConsumer is set
+      contextMock.attributes.authInfo.withProfile({ is_admin: false, email: 'svc@example.com' });
+      sitesAuditsToggleController = SitesAuditsToggleController(contextMock);
+
+      const requestData = [
+        { baseURL: 'https://site0.com', auditType: 'cwv', enable: true },
+      ];
+      await sitesAuditsToggleController.execute({
+        data: requestData,
+        log: logMock,
+        invocation: { id: 'req-toggle-1' },
+        s2sConsumer: contextMock.s2sConsumer,
+        attributes: contextMock.attributes,
+      });
+
+      expect(configurationMock.setUpdatedBy).to.have.been.calledWith('svc@example.com');
     });
 
     it('logs requestId=unknown when invocation id is missing', async () => {
@@ -1015,6 +1039,7 @@ describe('Sites Audits Controller', () => {
       const response = await sitesAuditsToggleController.execute({
         data: requestData,
         log: logMock,
+        s2sConsumer: contextMock.s2sConsumer,
         attributes: contextMock.attributes,
       });
 


### PR DESCRIPTION
## Summary

- `PATCH /configurations/sites/audits` was already gated by `CAP_CONFIGURATION_WRITE` at Layer 1 (`s2sAuthWrapper`) but `sites-audits-toggle.js` used a bare `hasAdminAccess()` check that blocked all S2S callers regardless of their capabilities
- Add `authorizeConfigWrite` helper (same dual-layer pattern as `configuration.js`): admin bypass first, then fresh DB fetch via `hasS2SCapability(CAP_CONFIGURATION_WRITE)` with structured `[acl]`/`[s2s]` log lines
- Update `setUpdatedBy` to emit `s2s:<clientId>` instead of the opaque `system` string for S2S callers, giving a traceable audit trail for mutations

## Test plan

- [ ] 5 new unit tests: grant, `updatedBy` audit trail, missing-capability denial, revoked consumer denial, `requestId=unknown` fallback
- [ ] All 31 tests in `sites-audits-toggle.test.js` pass (`npm test`)
- [ ] Capability-constants drift test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)