### PR TITLE
feat(preflight): defer eligibility to Mysticat on site-scoped endpoints (SITES-46202)

### DIFF
--- a/docs/decisions/002-preflight-api-rest-redesign.md
+++ b/docs/decisions/002-preflight-api-rest-redesign.md
@@ -101,7 +101,6 @@ Body:
 |--------|-------------|-----------|
 | `400 Bad Request` | `PREFLIGHT_INVALID_REQUEST` | `url` is missing, not a valid URI, or does not belong to the site identified by `:siteId` |
 | `403 Forbidden` | `PREFLIGHT_ACCESS_DENIED` | Caller does not have access to the site |
-| `403 Forbidden` | `PREFLIGHT_NOT_ENABLED` | Preflight is not enabled for the site |
 | `404 Not Found` | `PREFLIGHT_SITE_NOT_FOUND` | `siteId` does not exist |
 | `502 Bad Gateway` | `PREFLIGHT_UPSTREAM_ERROR` | Mysticat returned a 5xx response |
 | `500 Internal Server Error` | `PREFLIGHT_INTERNAL_ERROR` | Unexpected error within this service |
@@ -109,16 +108,16 @@ Body:
 Error response body:
 ```json
 {
-  "errorCode": "PREFLIGHT_NOT_ENABLED",
-  "message": "Preflight is not enabled for this site"
+  "errorCode": "PREFLIGHT_ACCESS_DENIED",
+  "message": "Access denied"
 }
 ```
 
 `errorCode` gives consumers a stable machine-readable contract; `message` is a human-readable hint and should not be parsed by clients.
 
-No job record is created for `400`, `403`, or `404` responses. The current `/preflight/beta/jobs`
-behavior of creating a job and immediately setting it to `CANCELLED` when preflight is disabled
-is not carried forward — a `403` is returned immediately, keeping the job store clean.
+**Eligibility is Mysticat's decision, not SpaceCat's.** This endpoint does not consult `Configuration.handlers.preflight`, `Entitlement`, `SiteEnrollment`, or any product-code gating to decide whether the call should proceed. The only gate SpaceCat enforces is the tenancy boundary (`accessControlUtil.hasAccess(site)` — IMS org membership) plus the basic URL-belongs-to-site sanity check. Past those, the request proceeds to Mysticat unconditionally, and Mysticat's three-gate model (Gate 0 tier features, Gate 1 `enabled_opportunity_types`, Gates 2/3 per-fact + per-site overrides) is the sole source of truth for what runs. A site whose tier disables preflight will return `200` with `audits: []` — not a `403` from SpaceCat. See SITES-46202.
+
+No job record is created for `400`, `403`, or `404` responses **emitted by SpaceCat's own checks** (access, URL validation). Once those pass, the `AsyncJob` + `Preflight` rows are created unconditionally before dispatching to Mysticat; any subsequent Mysticat-side `5xx` flips the rows to `FAILED` with a `502 PREFLIGHT_UPSTREAM_ERROR` response.
 
 ---
 
@@ -230,10 +229,11 @@ Key changes:
   always a human-readable address for technical accounts). `displayName` is composed from
   `profile.first_name + ' ' + profile.last_name` (falling back to `profile.name`). No
   additional IMS lookup required — both fields are on the authenticated profile.
-- **No phantom jobs for rejected requests.** If the site is not found, the caller lacks access,
-  or preflight is not enabled for the site, the endpoint returns an error immediately without
-  creating a job record. The previous behavior of creating a `CANCELLED` job in these cases
-  is removed.
+- **No phantom jobs for SpaceCat-side rejections.** If the site is not found or the caller lacks
+  access, the endpoint returns an error immediately without creating a job record. The previous
+  behavior of creating a `CANCELLED` job in these cases is removed. Note that preflight-eligibility
+  is **not** a SpaceCat-side concern (see Eligibility below) — sites whose tier disables preflight
+  pass through to Mysticat and receive a `200` with `audits: []`, not a SpaceCat `403`.
 - **No `organizationId` in the path.** `siteId` is a globally unique UUID, consistent with
   all other site-scoped resources in this service.
 
@@ -264,5 +264,8 @@ That decision was aligned with @ekdogan (SITES-44675) before implementation bega
 - Existing consumers of `/preflight/jobs` are unaffected for now; migration timeline to be
   coordinated separately.
 - Job records are only created for requests that pass validation and access checks, keeping the
-  job store clean. Callers that previously relied on polling a `CANCELLED` job to detect a
-  disabled-preflight condition must handle `403` instead.
+  job store clean. Eligibility (which audits run, whether the tier enables preflight at all) is
+  delegated to Mysticat — see [SITES-46202](https://jira.corp.adobe.com/browse/SITES-46202). Callers
+  that previously relied on polling a `CANCELLED` job to detect a disabled-preflight condition
+  must now poll `Preflight.status` and inspect `result.audits` (an empty list signals the tier
+  has nothing eligible to run for this site).

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -401,13 +401,7 @@ function PreflightController(ctx, log, env) {
       return preflightError('PREFLIGHT_INVALID_REQUEST', 'URL does not belong to this site', 400);
     }
 
-    // Eligibility (which audits run, whether the site's tier even enables
-    // preflight) is owned by Mysticat — see SITES-46202. SpaceCat's only gate
-    // is the tenancy boundary above (org-membership via hasAccess). A request
-    // that survives access + URL validation proceeds to Mysticat unconditionally;
-    // Mysticat's three-gate model (Gate 0 tier features + Gate 1
-    // enabled_opportunity_types + Gate 2 run_in_preflight + Gate 3 per-site
-    // goal_overrides) is the single source of truth.
+    // Eligibility is Mysticat's decision — see SITES-46202 + ADR-002.
 
     // Resolve page authentication if required.
     // checkEnableAuthentication does a bare HEAD fetch against the customer

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -18,7 +18,6 @@ import {
 } from '@adobe/spacecat-shared-http-utils';
 import { AsyncJob } from '@adobe/spacecat-shared-data-access';
 import { retrievePageAuthentication } from '@adobe/spacecat-shared-ims-client';
-import { TierClient } from '@adobe/spacecat-shared-tier-client';
 import AccessControlUtil from '../support/access-control-util.js';
 import { PreflightDto } from '../dto/preflight.js';
 import { ErrorWithStatusCode } from '../support/utils.js';
@@ -97,41 +96,6 @@ function PreflightController(ctx, log, env) {
         `Invalid request: step must be either ${AUDIT_STEP_IDENTIFY} or ${AUDIT_STEP_SUGGEST}`,
       );
     }
-  }
-
-  /**
-   * Checks if a handler type is enabled for a site, including product code
-   * entitlement verification. Mirrors the audit worker's isAuditEnabledForSite.
-   */
-  async function isAuditEnabledForSite(type, site, configuration) {
-    const handler = configuration.getHandlers()?.[type];
-    if (!handler) {
-      log.info(`Handler ${type} not found in Configuration`);
-      return false;
-    }
-    if (isNonEmptyArray(handler.productCodes)) {
-      const tierContext = { dataAccess, log };
-      const enrollmentChecks = await Promise.all(
-        handler.productCodes.map(async (productCode) => {
-          try {
-            const tierClient = await TierClient.createForSite(tierContext, site, productCode);
-            const tierResult = await tierClient.checkValidEntitlement();
-            return tierResult.siteEnrollment || false;
-          } catch (e) {
-            log.error(`Failed to check entitlement for ${productCode}: ${e.message}`);
-            return false;
-          }
-        }),
-      );
-      if (!enrollmentChecks.some((has) => has)) {
-        log.info(`No valid site enrollment for handler ${type} with product codes ${handler.productCodes} for site ${site.getId()}`);
-        return false;
-      }
-    } else {
-      log.info(`Handler ${type} has no product codes`);
-      return false;
-    }
-    return configuration.isHandlerEnabledForSite(type, site);
   }
 
   /**
@@ -437,21 +401,13 @@ function PreflightController(ctx, log, env) {
       return preflightError('PREFLIGHT_INVALID_REQUEST', 'URL does not belong to this site', 400);
     }
 
-    let configuration;
-    try {
-      configuration = await dataAccess.Configuration.findLatest();
-      if (!configuration) {
-        return preflightError('PREFLIGHT_INTERNAL_ERROR', 'Configuration not available', 500);
-      }
-    } catch (e) {
-      log.error(`Failed to load Configuration: ${e.message}`);
-      return preflightError('PREFLIGHT_INTERNAL_ERROR', 'Failed to load configuration', 500);
-    }
-
-    const preflightEnabled = await isAuditEnabledForSite('preflight', site, configuration);
-    if (!preflightEnabled) {
-      return preflightError('PREFLIGHT_NOT_ENABLED', 'Preflight is not enabled for this site', 403);
-    }
+    // Eligibility (which audits run, whether the site's tier even enables
+    // preflight) is owned by Mysticat — see SITES-46202. SpaceCat's only gate
+    // is the tenancy boundary above (org-membership via hasAccess). A request
+    // that survives access + URL validation proceeds to Mysticat unconditionally;
+    // Mysticat's three-gate model (Gate 0 tier features + Gate 1
+    // enabled_opportunity_types + Gate 2 run_in_preflight + Gate 3 per-site
+    // goal_overrides) is the single source of truth.
 
     // Resolve page authentication if required.
     // checkEnableAuthentication does a bare HEAD fetch against the customer

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1114,9 +1114,6 @@ describe('Preflight Controller', () => {
   describe('createPreflight', () => {
     let fetchStub;
     let CreatePreflightController;
-    const mockTierClient = {
-      checkValidEntitlement: sandbox.stub().resolves({ siteEnrollment: true }),
-    };
     let hasAccessStub;
 
     beforeEach(async () => {
@@ -1132,26 +1129,13 @@ describe('Preflight Controller', () => {
       mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
       mockDataAccess.Site.findByPreviewURL = sandbox.stub().resolves(mockSite);
       mockDataAccess.Preflight.create = sandbox.stub().resolves(mockPreflight);
-      mockDataAccess.Configuration.findLatest = sandbox.stub().resolves(mockConfiguration);
-      mockConfiguration.isHandlerEnabledForSite.returns(true);
-      mockConfiguration.getHandlers.returns({
-        preflight: {
-          productCodes: ['ASO'],
-          enabledByDefault: false,
-          enabled: { sites: ['test-site-123'], orgs: [] },
-          disabled: { sites: [], orgs: [] },
-        },
-      });
-      mockConfiguration.getEnabledAuditsForSite.returns([
-        'alt-text-preflight', 'headings-preflight', 'links-preflight',
-      ]);
-      mockTierClient.checkValidEntitlement.resolves({ siteEnrollment: true });
       hasAccessStub = sandbox.stub().resolves(true);
 
+      // SITES-46202: createPreflight no longer consults Configuration / TierClient
+      // for eligibility — Mysticat owns that decision. The controller is mocked
+      // here only against AccessControlUtil (tenancy boundary) and the standard
+      // dataAccess stubs.
       CreatePreflightController = await esmock('../../src/controllers/preflight.js', {
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().resolves(mockTierClient) },
-        },
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
         },
@@ -1286,50 +1270,27 @@ describe('Preflight Controller', () => {
       expect(result.errorCode).to.equal('PREFLIGHT_INTERNAL_ERROR');
     });
 
-    it('returns 500 when Configuration.findLatest throws', async () => {
-      mockDataAccess.Configuration.findLatest = sandbox.stub().rejects(new Error('DB error'));
-      const response = await preflightController.createPreflight({
-        params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
-      });
-      expect(response.status).to.equal(500);
-      const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_INTERNAL_ERROR');
-      expect(result.message).to.equal('Failed to load configuration');
-    });
+    it('does not consult Configuration / TierClient (eligibility deferred to Mysticat per SITES-46202)', async () => {
+      // Stub Configuration / TierClient to throw if anyone calls them. After
+      // SITES-46202, createPreflight must not touch either — eligibility is
+      // Mysticat's decision (Gate 0 tier features + Gates 1/2/3). This test
+      // guards against a future regression that re-introduces SpaceCat-side
+      // entitlement checks on the new endpoints.
+      mockDataAccess.Configuration.findLatest = sandbox.stub().rejects(
+        new Error('Configuration.findLatest must NOT be called by createPreflight'),
+      );
 
-    it('returns 500 when Configuration.findLatest returns null', async () => {
-      mockDataAccess.Configuration.findLatest = sandbox.stub().resolves(null);
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
+        attributes: { authInfo: mockAuthInfo },
       });
-      expect(response.status).to.equal(500);
-      const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_INTERNAL_ERROR');
-      expect(result.message).to.equal('Configuration not available');
-    });
 
-    it('returns 403 when preflight is not enabled for site', async () => {
-      mockConfiguration.isHandlerEnabledForSite.returns(false);
-      const response = await preflightController.createPreflight({
-        params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
-      });
-      expect(response.status).to.equal(403);
-      const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_NOT_ENABLED');
-    });
-
-    it('returns 403 when site has no valid entitlement', async () => {
-      mockTierClient.checkValidEntitlement.resolves({ siteEnrollment: false });
-      const response = await preflightController.createPreflight({
-        params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
-      });
-      expect(response.status).to.equal(403);
-      const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_NOT_ENABLED');
+      expect(response.status).to.equal(202);
+      expect(mockDataAccess.Configuration.findLatest).to.not.have.been.called;
+      // Mysticat WAS called (it owns the decision now).
+      const mysticatCall = fetchStub.secondCall;
+      expect(mysticatCall.args[0]).to.equal('https://mysticat.example.com/v1/preflight/analyze');
     });
 
     it('returns 502 when Mysticat analyze returns non-ok status', async () => {
@@ -1463,70 +1424,6 @@ describe('Preflight Controller', () => {
       });
     });
 
-    // -- isAuditEnabledForSite error / not-found paths --
-
-    it('returns 403 PREFLIGHT_NOT_ENABLED when the preflight handler is not in Configuration', async () => {
-      mockConfiguration.getHandlers.returns({}); // no `preflight` handler
-      const response = await preflightController.createPreflight({
-        params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
-      });
-      expect(response.status).to.equal(403);
-      const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_NOT_ENABLED');
-    });
-
-    it('returns 403 PREFLIGHT_NOT_ENABLED when the preflight handler has no productCodes', async () => {
-      mockConfiguration.getHandlers.returns({
-        preflight: {
-          // no productCodes
-          enabledByDefault: false,
-          enabled: { sites: ['test-site-123'], orgs: [] },
-          disabled: { sites: [], orgs: [] },
-        },
-      });
-      const response = await preflightController.createPreflight({
-        params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
-      });
-      expect(response.status).to.equal(403);
-      const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_NOT_ENABLED');
-    });
-
-    it('returns 403 PREFLIGHT_NOT_ENABLED when TierClient.createForSite throws (caught, returns false)', async () => {
-      // Rebuild the controller so the TierClient esmock rejects this run.
-      const ControllerWithFailingTier = await esmock('../../src/controllers/preflight.js', {
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().rejects(new Error('tier-client-down')) },
-        },
-        '../../src/support/access-control-util.js': {
-          default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
-        },
-      });
-      const controller = ControllerWithFailingTier(
-        {
-          dataAccess: mockDataAccess,
-          sqs: mockSqs,
-          attributes: { authInfo: mockAuthInfo },
-          pathInfo: { headers: {} },
-        },
-        loggerStub,
-        {
-          AUDIT_JOBS_QUEUE_URL: 'https://sqs.test.amazonaws.com/audit-queue',
-          MYSTIQUE_API_BASE_URL: 'https://mysticat.example.com',
-          AWS_ENV: 'prod',
-        },
-      );
-      const response = await controller.createPreflight({
-        params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
-      });
-      expect(response.status).to.equal(403);
-      const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_NOT_ENABLED');
-    });
-
     // -- enableAuthentication=true path (HEAD returns 401) --
 
     it('forwards Authorization header to Mysticat for auth-required URL with x-promise-token header', async () => {
@@ -1549,9 +1446,6 @@ describe('Preflight Controller', () => {
       const ControllerWithIms = await esmock('../../src/controllers/preflight.js', {
         '@adobe/spacecat-shared-ims-client': {
           retrievePageAuthentication: mockRetrievePageAuth,
-        },
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().resolves(mockTierClient) },
         },
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
@@ -1597,9 +1491,6 @@ describe('Preflight Controller', () => {
       mockDataAccess.Site.findById.resolves(csSite);
       mockDataAccess.Site.findByPreviewURL.resolves(csSite);
       const ControllerWithStubbed = await esmock('../../src/controllers/preflight.js', {
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().resolves(mockTierClient) },
-        },
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
         },
@@ -1643,9 +1534,6 @@ describe('Preflight Controller', () => {
       mockDataAccess.Site.findById.resolves(brokenSite);
       mockDataAccess.Site.findByPreviewURL.resolves(brokenSite);
       const ControllerWithStubbed = await esmock('../../src/controllers/preflight.js', {
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().resolves(mockTierClient) },
-        },
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
         },
@@ -1690,9 +1578,6 @@ describe('Preflight Controller', () => {
       const ControllerWithIms = await esmock('../../src/controllers/preflight.js', {
         '@adobe/spacecat-shared-ims-client': {
           retrievePageAuthentication: mockRetrievePageAuth,
-        },
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().resolves(mockTierClient) },
         },
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
@@ -1759,9 +1644,6 @@ describe('Preflight Controller', () => {
         '@adobe/spacecat-shared-ims-client': {
           retrievePageAuthentication: mockRetrievePageAuth,
         },
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().resolves(mockTierClient) },
-        },
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
         },
@@ -1807,9 +1689,6 @@ describe('Preflight Controller', () => {
       const ControllerWithIms = await esmock('../../src/controllers/preflight.js', {
         '@adobe/spacecat-shared-ims-client': {
           retrievePageAuthentication: mockRetrievePageAuth,
-        },
-        '@adobe/spacecat-shared-tier-client': {
-          TierClient: { createForSite: sandbox.stub().resolves(mockTierClient) },
         },
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1293,6 +1293,36 @@ describe('Preflight Controller', () => {
       expect(mysticatCall.args[0]).to.equal('https://mysticat.example.com/v1/preflight/analyze');
     });
 
+    it('returns 202 and does NOT roll back rows when Mysticat returns 200 with empty audits (tier-ineligible site)', async () => {
+      // Post-SITES-46202 contract: a site whose Mysticat tier disables preflight
+      // (Gate 0 features.preflight=false, or all goals opted out via Gate 3) gets
+      // a 200 with `audits: []` from Mysticat — NOT a 4xx. SpaceCat must treat
+      // this as a successful dispatch: the Preflight + AsyncJob rows remain in
+      // IN_PROGRESS, no FAILED rollback, no error response. The projector
+      // eventually flips the rows to COMPLETED with empty result.
+      fetchStub.onSecondCall().resolves({
+        ok: true,
+        status: 200,
+        json: async () => ({ pageUrl: 'https://main--example-site.aem.page/test.html', audits: [], profiling: {} }),
+      });
+
+      const response = await preflightController.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: { url: 'https://main--example-site.aem.page/test.html' },
+        attributes: { authInfo: mockAuthInfo },
+      });
+
+      // 202 with the Preflight payload — same as any other successful dispatch.
+      expect(response.status).to.equal(202);
+      const body = await response.json();
+      expect(body.preflightId).to.equal(preflightId);
+
+      // No FAILED rollback path was taken.
+      expect(mockPreflight.setStatus).to.not.have.been.calledWith('FAILED');
+      expect(mockJob.setStatus).to.not.have.been.calledWith('FAILED');
+      expect(mockPreflight.setError).to.not.have.been.called;
+    });
+
     it('returns 502 when Mysticat analyze returns non-ok status', async () => {
       fetchStub.onSecondCall().resolves({ ok: false, status: 503, text: async () => 'Service Unavailable' });
       const response = await preflightController.createPreflight({


### PR DESCRIPTION
## Summary

- Removes SpaceCat-side preflight eligibility check (`isAuditEnabledForSite` + `Configuration.handlers.preflight` + `TierClient.checkValidEntitlement`) from the new `POST /sites/:siteId/preflights` endpoint. Eligibility now lives **only** in Mysticat, which already owns the three-gate model (Gate 0 `tier.features.preflight`, Gate 1 `enabled_opportunity_types`, Gates 2/3 per-fact + per-site overrides) — see SITES-44736.
- Closes the source-of-truth drift that let a PLG Free site pass SpaceCat (`SiteEnrollment` exists for the productCode) but fail Mysticat's stricter Gate 0 silently as a `200` with `audits: []`.
- The legacy `/preflight/jobs` endpoints are unchanged — explicit out-of-scope per the [SITES-46202](https://jira.corp.adobe.com/browse/SITES-46202) brief.
- Aligns ADR-002 (response-codes table, "no phantom jobs" prose, consequences passage). ADR-003 verified — no eligibility prose, no change needed.

## What changed

**`src/controllers/preflight.js`** — removed:
- `isAuditEnabledForSite` function
- `Configuration.findLatest()` lookup that fed it
- `PREFLIGHT_NOT_ENABLED` error code path on the new endpoint
- `TierClient` import (no longer used)

**Kept unchanged**: `accessControlUtil.hasAccess(site)` tenancy boundary, URL hostname validation, page-auth resolution (`resolvePromiseToken` / `checkEnableAuthentication` / `retrievePageAuthentication`), `AsyncJob` + `Preflight` entity creation, **all** legacy `/preflight/jobs` endpoints.

**`test/controllers/preflight.test.js`** — removed 5 dead tests, added one positive test (`does not consult Configuration / TierClient (eligibility deferred to Mysticat per SITES-46202)`) that pins the new contract by stubbing `Configuration.findLatest` to throw — guards against a future regression.

**`docs/decisions/002-preflight-api-rest-redesign.md`** — error-codes table, error-body example, no-phantom-jobs section, and consequences passage updated. New paragraph explicitly documents "Eligibility is Mysticat's decision, not SpaceCat's."

## Test plan

- [x] `npx mocha test/controllers/preflight.test.js` → 76 passing
- [x] `npm run docs:lint` → clean (warnings unrelated to this PR)
- [x] Full suite: ~11,562 passing; small number of pre-existing flaky hook-timeouts in unrelated files (`ephemeral-run`, `Bot Blocker`, `Sites Controller` brand-profile, `approveSiteCandidate`, `edge-routing-auth`) — none touch preflight code
- [ ] Reviewer: please verify the ADR-002 prose changes read clearly to a fresh-eyes reader
- [ ] Reviewer: confirm no other consumer of `PREFLIGHT_NOT_ENABLED` (MFE, downstream tooling) needs updating in lockstep

## Notes

- The new `/sites/:siteId/preflights` endpoints aren't documented in OpenAPI yet (a separate gap from PR #2478 that didn't get backfilled). No OpenAPI changes needed here as a result; that's worth its own follow-up.
- An empty `audits: []` response from Mysticat is now the contract for "tier disables preflight" / "all opted out" — callers that polled a `CANCELLED` job for disabled-preflight detection must poll `Preflight.status` and inspect `result.audits` instead.

Related: [SITES-44686](https://jira.corp.adobe.com/browse/SITES-44686) (parent — REST redesign), [SITES-44736](https://jira.corp.adobe.com/browse/SITES-44736) (Mysticat-side gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)