### PR TITLE
fix(SITES-46200): reject projectId updates on PATCH /sites/:siteId

### DIFF
--- a/docs/openapi/site-api.yaml
+++ b/docs/openapi/site-api.yaml
@@ -61,6 +61,12 @@ site:
       This endpoint is useful for updating a site.
       Only the fields as per the request body schema will be updated.
       At least one field to update must be provided in the request body.
+
+      Re-parenting a site is not allowed through this endpoint: changing
+      `organizationId` or `projectId` returns 403. Both reference org-scoped
+      records, so re-parenting must go through controlled flows (e.g.
+      `PATCH /projects/{projectId}`) to keep a site and its project in the same
+      organization.
     operationId: patchSite
     security:
       - admin_key: [ ]
@@ -77,6 +83,18 @@ site:
           application/json:
             schema:
               $ref: './schemas.yaml#/Site'
+      '403':
+        description: >-
+          Attempted to change a field that is not allowed via this endpoint
+          (organizationId or projectId).
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: "Updating project ID is not allowed"
       '400':
         $ref: './responses.yaml#/400-no-site-id-request-body-no-updates'
       '401':

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -786,6 +786,16 @@ function SitesController(ctx, log, env) {
       return forbidden('Updating organization ID is not allowed');
     }
 
+    // A projectId references a project record that is itself scoped to an
+    // organizationId. Allowing ad-hoc projectId patches here lets a site point
+    // at a project in a different org, which hides the site from the org's site
+    // picker (SITES-46200). Re-parenting must go through controlled flows
+    // (e.g. PATCH /projects/:projectId), so reject it here like organizationId.
+    if (hasText(requestBody.projectId)
+      && requestBody.projectId !== site.getProjectId()) {
+      return forbidden('Updating project ID is not allowed');
+    }
+
     if (requestBody.name !== site.getName()) {
       site.setName(requestBody.name);
       updates = true;
@@ -886,11 +896,6 @@ function SitesController(ctx, log, env) {
     }
 
     // Handle localization fields
-    if (requestBody.projectId !== site.getProjectId() && isValidUUID(requestBody.projectId)) {
-      site.setProjectId(requestBody.projectId);
-      updates = true;
-    }
-
     if (isBoolean(requestBody.isPrimaryLocale)
         && requestBody.isPrimaryLocale !== site.getIsPrimaryLocale()) {
       site.setIsPrimaryLocale(requestBody.isPrimaryLocale);

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -4467,21 +4467,43 @@ describe('Sites Controller', () => {
   });
 
   describe('isPrimaryLocale, language, and region updates', () => {
-    it('updates site with projectId', async () => {
+    it('returns forbidden when trying to update projectId', async () => {
       const site = sites[0];
       const currentProjectId = '550e8400-e29b-41d4-a716-446655440000';
       const newProjectId = '650e8400-e29b-41d4-a716-446655440000';
       site.getProjectId = sandbox.stub().returns(currentProjectId);
       site.setProjectId = sandbox.stub();
-      site.save = sandbox.stub().resolves(site);
+      site.save = sandbox.spy(site.save);
 
       const response = await sitesController.updateSite({
         params: { siteId: SITE_IDS[0] },
         data: { projectId: newProjectId },
         ...defaultAuthAttributes,
       });
+      const error = await response.json();
 
-      expect(site.setProjectId).to.have.been.calledWith(newProjectId);
+      expect(site.setProjectId).to.have.not.been.called;
+      expect(site.save).to.have.not.been.called;
+      expect(response.status).to.equal(403);
+      expect(error).to.have.property('message', 'Updating project ID is not allowed');
+    });
+
+    it('ignores projectId when it matches the current projectId', async () => {
+      const site = sites[0];
+      const currentProjectId = '550e8400-e29b-41d4-a716-446655440000';
+      site.getProjectId = sandbox.stub().returns(currentProjectId);
+      site.setProjectId = sandbox.stub();
+      site.getIsPrimaryLocale = sandbox.stub().returns(false);
+      site.setIsPrimaryLocale = sandbox.stub();
+      site.save = sandbox.stub().resolves(site);
+
+      const response = await sitesController.updateSite({
+        params: { siteId: SITE_IDS[0] },
+        data: { projectId: currentProjectId, isPrimaryLocale: true },
+        ...defaultAuthAttributes,
+      });
+
+      expect(site.setProjectId).to.have.not.been.called;
       expect(site.save).to.have.been.calledOnce;
       expect(response.status).to.equal(200);
     });

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -4466,7 +4466,7 @@ describe('Sites Controller', () => {
     });
   });
 
-  describe('isPrimaryLocale, language, and region updates', () => {
+  describe('projectId, isPrimaryLocale, language, and region updates', () => {
     it('returns forbidden when trying to update projectId', async () => {
       const site = sites[0];
       const currentProjectId = '550e8400-e29b-41d4-a716-446655440000';
@@ -4503,6 +4503,27 @@ describe('Sites Controller', () => {
         ...defaultAuthAttributes,
       });
 
+      expect(site.setProjectId).to.have.not.been.called;
+      expect(site.save).to.have.been.calledOnce;
+      expect(response.status).to.equal(200);
+    });
+
+    it('ignores an empty-string projectId (guarded by hasText)', async () => {
+      const site = sites[0];
+      site.getProjectId = sandbox.stub().returns('550e8400-e29b-41d4-a716-446655440000');
+      site.setProjectId = sandbox.stub();
+      site.getIsPrimaryLocale = sandbox.stub().returns(false);
+      site.setIsPrimaryLocale = sandbox.stub();
+      site.save = sandbox.stub().resolves(site);
+
+      const response = await sitesController.updateSite({
+        params: { siteId: SITE_IDS[0] },
+        data: { projectId: '', isPrimaryLocale: true },
+        ...defaultAuthAttributes,
+      });
+
+      // Empty string is not "text", so the guard is skipped — no 403 — and the
+      // other field still saves.
       expect(site.setProjectId).to.have.not.been.called;
       expect(site.save).to.have.been.calledOnce;
       expect(response.status).to.equal(200);

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -25,6 +25,7 @@ import {
   SITE_NEW_LLMO_ID,
   NON_EXISTENT_SITE_ID,
   PROJECT_1_ID,
+  PROJECT_2_ID,
 } from '../seed-ids.js';
 
 // LLMO-4176 mode-resolution test sites are seeded with intentionally
@@ -497,6 +498,17 @@ export default function siteTests(getHttpClient, resetData) {
         const http = getHttpClient();
         const res = await http.user.patch(`/sites/${SITE_1_ID}`, {
           organizationId: ORG_2_ID,
+        });
+        expect(res.status).to.equal(403);
+      });
+
+      it('user: returns 403 when trying to change projectId', async () => {
+        // Re-parenting a site to a project in another org via this endpoint is
+        // disallowed (projects are org-scoped) — SITES-46200. SITE_1 belongs to
+        // PROJECT_1_ID, so patching it to PROJECT_2_ID must be rejected.
+        const http = getHttpClient();
+        const res = await http.user.patch(`/sites/${SITE_1_ID}`, {
+          projectId: PROJECT_2_ID,
         });
         expect(res.status).to.equal(403);
       });


### PR DESCRIPTION
## Problem

When a site is re-parented to a different Spacecat organization, its `projectId` can keep pointing at a project record that still lives in the **old** org. The site then shows up in `GET /organizations/{orgId}/sites` (enrollment-filtered) but is **missing from the ASO site picker**, which groups sites under projects from `GET /organizations/{orgId}/projects`. This is the `zepbound.lilly.com` symptom in SITES-46200.

`PATCH /sites/:siteId` currently *allows* `projectId` changes. Because a `projectId` references a project that is itself scoped to an `organizationId`, an ad-hoc `projectId` patch can point a site at a project in a different org and recreate exactly this mismatch.

## Change

Reject `projectId` changes on `PATCH /sites/:siteId` the same way `organizationId` changes are already rejected:

```js
if (hasText(requestBody.projectId)
  && requestBody.projectId !== site.getProjectId()) {
  return forbidden('Updating project ID is not allowed');
}
```

A matching/absent `projectId` is a no-op (does not error, does not trigger a save), mirroring the `organizationId` guard. Re-parenting must go through controlled flows (e.g. `PATCH /projects/:projectId`), not free-form site `projectId` updates.

This is one of several SITES-46200 follow-ups; the `set imsorg` project move/split and the ASO picker "unassigned" hardening are separate PRs.

### Tests
- Inverted the former `updates site with projectId` test -> now asserts **403** + no `setProjectId`/`save`.
- Added a test that a `projectId` equal to the current value is ignored (no error, save still proceeds for other fields).
- Full `test/controllers/sites.test.js` suite green (336 passing).

### Note on the API spec
The `SiteUpdate` schema lists `projectId` exactly as it lists `organizationId`. `organizationId` has had this same 403 behavior for a while with **no** schema note, so to keep the schema internally consistent I did **not** add a note for only `projectId`. Happy to document both in a follow-up if reviewers prefer.

## Related Issues
- SITES-46200

🤖 Generated with [Claude Code](https://claude.com/claude-code)