### PR TITLE
fix(SITES-46200): re-parent project in set imsorg, not just the site

### DIFF
--- a/src/support/slack/actions/set-ims-org-modal.js
+++ b/src/support/slack/actions/set-ims-org-modal.js
@@ -17,8 +17,71 @@ import {
   createEntitlementsForProducts,
   postEntitlementMessages,
 } from './entitlement-modal-utils.js';
+import { createProject } from '../../utils.js';
 
 const MODAL_CALLBACK_ID = 'set_ims_org_modal';
+
+/**
+ * Re-parents a site's project so it ends up in the target Spacecat org alongside
+ * the site. Re-parenting only `site.organizationId` (as this flow used to) leaves
+ * the associated project in the old org, so the site shows in
+ * `/organizations/{orgId}/sites` but disappears from the ASO site picker, which
+ * groups sites under `/organizations/{orgId}/projects` (SITES-46200).
+ *
+ * Mutates `site` in place (and may set its projectId); the caller is responsible
+ * for persisting the site via `site.save()`.
+ *
+ * - No project on the site: nothing to do.
+ * - Project already in the target org: nothing to do.
+ * - Site is the only member of its project: move the project to the target org
+ *   (the site keeps its projectId).
+ * - Other sites still share the project: split — move this site to a project in
+ *   the target org (find-or-create by name) so the siblings keep their project
+ *   in the source org.
+ *
+ * @param {object} params
+ * @param {object} params.site - The site being re-parented (already has its new orgId set).
+ * @param {string} params.targetOrgId - The Spacecat org id the site is moving to.
+ * @param {string} params.baseURL - The site's base URL (used to derive a project name).
+ * @param {object} params.lambdaContext - The Lambda context (provides dataAccess + log).
+ * @param {Function} params.say - Slack say function for operator feedback.
+ */
+export async function reparentSiteProject({
+  site, targetOrgId, baseURL, lambdaContext, say,
+}) {
+  const { dataAccess, log } = lambdaContext;
+  const { Project, Site } = dataAccess;
+
+  const projectId = site.getProjectId();
+  if (!projectId) {
+    return;
+  }
+
+  const project = await Project.findById(projectId);
+  if (!project) {
+    log.warn(`set imsorg: site ${site.getId()} references missing project ${projectId}; skipping project re-parent`);
+    return;
+  }
+
+  if (project.getOrganizationId() === targetOrgId) {
+    return;
+  }
+
+  const sitesOnProject = await Site.allByProjectId(projectId);
+  if (sitesOnProject.length <= 1) {
+    // Solo site on the project — move the whole project to the target org.
+    project.setOrganizationId(targetOrgId);
+    await project.save();
+    await say(
+      `:information_source: Moved project *${project.getProjectName()}* to the new org so the site stays visible in the site picker.`,
+    );
+  } else {
+    // Project is shared with sites that are staying behind — split it so the
+    // moved site gets a project in the target org and the siblings keep theirs.
+    const newProject = await createProject(lambdaContext, { say }, baseURL, targetOrgId, null);
+    site.setProjectId(newProject.getId());
+  }
+}
 
 /**
  * Opens the product selection modal for set-ims-org command.
@@ -114,6 +177,13 @@ export function setImsOrgModal(lambdaContext) {
         await spaceCatOrg.save();
 
         site.setOrganizationId(spaceCatOrg.getId());
+        await reparentSiteProject({
+          site,
+          targetOrgId: spaceCatOrg.getId(),
+          baseURL,
+          lambdaContext,
+          say,
+        });
         await site.save();
 
         // Remove the button by updating the message
@@ -136,6 +206,13 @@ export function setImsOrgModal(lambdaContext) {
       } else {
         // we already have a matching spacecat org
         site.setOrganizationId(spaceCatOrg.getId());
+        await reparentSiteProject({
+          site,
+          targetOrgId: spaceCatOrg.getId(),
+          baseURL,
+          lambdaContext,
+          say,
+        });
         await site.save();
 
         // Remove the button by updating the message

--- a/src/support/slack/actions/set-ims-org-modal.js
+++ b/src/support/slack/actions/set-ims-org-modal.js
@@ -72,9 +72,16 @@ export async function reparentSiteProject({
     // Solo site on the project — move the whole project to the target org.
     project.setOrganizationId(targetOrgId);
     await project.save();
-    await say(
-      `:information_source: Moved project *${project.getProjectName()}* to the new org so the site stays visible in the site picker.`,
-    );
+    // Slack feedback is best-effort: a posting failure here must not throw,
+    // otherwise the caller's site.save() would be skipped, leaving the project
+    // moved but the site's orgId change unpersisted.
+    try {
+      await say(
+        `:information_source: Moved project *${project.getProjectName()}* to the new org so the site stays visible in the site picker.`,
+      );
+    } catch (sayError) {
+      log.warn(`set imsorg: failed to post project move message: ${sayError.message}`);
+    }
   } else {
     // Project is shared with sites that are staying behind — split it so the
     // moved site gets a project in the target org and the siblings keep theirs.

--- a/test/support/slack/actions/set-ims-org-modal.test.js
+++ b/test/support/slack/actions/set-ims-org-modal.test.js
@@ -56,16 +56,23 @@ describe('SetImsOrgModal', () => {
   beforeEach(() => {
     mockLog = {
       info: sinon.stub(),
+      warn: sinon.stub(),
       error: sinon.stub(),
     };
 
     mockDataAccess = {
       Site: {
         findByBaseURL: sinon.stub(),
+        allByProjectId: sinon.stub().resolves([]),
       },
       Organization: {
         findByImsOrgId: sinon.stub(),
         create: sinon.stub(),
+      },
+      Project: {
+        findById: sinon.stub().resolves(null),
+        create: sinon.stub(),
+        allByOrganizationId: sinon.stub().resolves([]),
       },
     };
 
@@ -203,6 +210,7 @@ describe('SetImsOrgModal', () => {
       const ack = sinon.stub().resolves();
       const mockSite = {
         getId: () => 'site123',
+        getProjectId: () => null,
         setOrganizationId: sinon.stub(),
         save: sinon.stub().resolves(),
       };
@@ -257,6 +265,7 @@ describe('SetImsOrgModal', () => {
       const ack = sinon.stub().resolves();
       const mockSite = {
         getId: () => 'site123',
+        getProjectId: () => null,
         setOrganizationId: sinon.stub(),
         save: sinon.stub().resolves(),
       };
@@ -316,6 +325,7 @@ describe('SetImsOrgModal', () => {
       const ack = sinon.stub().resolves();
       const mockSite = {
         getId: () => 'site123',
+        getProjectId: () => null,
         setOrganizationId: sinon.stub(),
         save: sinon.stub().resolves(),
       };
@@ -397,6 +407,7 @@ describe('SetImsOrgModal', () => {
       const ack = sinon.stub().resolves();
       const mockSite = {
         getId: () => 'site456',
+        getProjectId: () => null,
         setOrganizationId: sinon.stub(),
         save: sinon.stub().resolves(),
       };
@@ -623,6 +634,173 @@ describe('SetImsOrgModal', () => {
       await handler({ ack, body, client });
 
       expect(mockLog.error.calledWith('Error handling modal submission:')).to.be.true;
+    });
+
+    describe('project re-parenting (SITES-46200)', () => {
+      const baseURL = 'https://example.com';
+
+      const makeBody = () => ({
+        view: {
+          private_metadata: JSON.stringify({
+            baseURL,
+            imsOrgId: 'ABC123@AdobeOrg',
+            channelId: 'C123',
+            threadTs: '1234567890.123456',
+            messageTs: '1234567890.123457',
+          }),
+          state: {
+            values: {
+              products_block: {
+                aso_checkbox: { selected_options: [] },
+                llmo_checkbox: { selected_options: [] },
+              },
+            },
+          },
+        },
+        user: { id: 'U123' },
+      });
+
+      const makeClient = () => ({
+        chat: {
+          postMessage: sinon.stub().resolves(),
+          update: sinon.stub().resolves(),
+        },
+      });
+
+      it('moves the project to the new org when the site is its only member', async () => {
+        const ack = sinon.stub().resolves();
+        const mockProject = {
+          getId: () => 'project123',
+          getProjectName: () => 'example.com',
+          getOrganizationId: () => 'oldOrg',
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        const mockSite = {
+          getId: () => 'site123',
+          getProjectId: () => 'project123',
+          setProjectId: sinon.stub(),
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        mockDataAccess.Site.findByBaseURL.resolves(mockSite);
+        mockDataAccess.Organization.findByImsOrgId.resolves({ getId: () => 'newOrg' });
+        mockDataAccess.Project.findById.resolves(mockProject);
+        mockDataAccess.Site.allByProjectId.resolves([mockSite]);
+
+        const client = makeClient();
+        await setImsOrgModal(lambdaContext)({ ack, body: makeBody(), client });
+
+        expect(mockDataAccess.Project.findById.calledWith('project123')).to.be.true;
+        expect(mockProject.setOrganizationId.calledWith('newOrg')).to.be.true;
+        expect(mockProject.save.calledOnce).to.be.true;
+        // The site keeps its projectId; only the project moved orgs.
+        expect(mockSite.setProjectId.called).to.be.false;
+        expect(mockSite.setOrganizationId.calledWith('newOrg')).to.be.true;
+        expect(mockSite.save.calledOnce).to.be.true;
+        expect(
+          client.chat.postMessage.getCalls().some((c) => c.args[0].text.includes('Moved project')),
+        ).to.be.true;
+      });
+
+      it('splits the project when other sites still share it', async () => {
+        const ack = sinon.stub().resolves();
+        const mockProject = {
+          getId: () => 'project123',
+          getProjectName: () => 'example.com',
+          getOrganizationId: () => 'oldOrg',
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        const newProject = {
+          getId: () => 'newProject456',
+          getProjectName: () => 'example.com',
+        };
+        const mockSite = {
+          getId: () => 'site123',
+          getProjectId: () => 'project123',
+          setProjectId: sinon.stub(),
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        const siblingSite = { getId: () => 'sibling999' };
+        mockDataAccess.Site.findByBaseURL.resolves(mockSite);
+        mockDataAccess.Organization.findByImsOrgId.resolves({ getId: () => 'newOrg' });
+        mockDataAccess.Project.findById.resolves(mockProject);
+        mockDataAccess.Site.allByProjectId.resolves([mockSite, siblingSite]);
+        mockDataAccess.Project.allByOrganizationId.resolves([]);
+        mockDataAccess.Project.create.resolves(newProject);
+
+        const client = makeClient();
+        await setImsOrgModal(lambdaContext)({ ack, body: makeBody(), client });
+
+        // The shared project must NOT be moved (would orphan the sibling)...
+        expect(mockProject.setOrganizationId.called).to.be.false;
+        expect(mockProject.save.called).to.be.false;
+        // ...instead a project is created in the target org and the site re-pointed.
+        expect(
+          mockDataAccess.Project.create.calledWith({
+            projectName: 'example.com',
+            organizationId: 'newOrg',
+          }),
+        ).to.be.true;
+        expect(mockSite.setProjectId.calledWith('newProject456')).to.be.true;
+        expect(mockSite.save.calledOnce).to.be.true;
+      });
+
+      it('does nothing to the project when it is already in the target org', async () => {
+        const ack = sinon.stub().resolves();
+        const mockProject = {
+          getId: () => 'project123',
+          getProjectName: () => 'example.com',
+          getOrganizationId: () => 'newOrg',
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        const mockSite = {
+          getId: () => 'site123',
+          getProjectId: () => 'project123',
+          setProjectId: sinon.stub(),
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        mockDataAccess.Site.findByBaseURL.resolves(mockSite);
+        mockDataAccess.Organization.findByImsOrgId.resolves({ getId: () => 'newOrg' });
+        mockDataAccess.Project.findById.resolves(mockProject);
+
+        const client = makeClient();
+        await setImsOrgModal(lambdaContext)({ ack, body: makeBody(), client });
+
+        expect(mockProject.setOrganizationId.called).to.be.false;
+        expect(mockProject.save.called).to.be.false;
+        expect(mockSite.setProjectId.called).to.be.false;
+        // No need to count siblings when the project is already aligned.
+        expect(mockDataAccess.Site.allByProjectId.called).to.be.false;
+        expect(mockSite.save.calledOnce).to.be.true;
+      });
+
+      it('skips project re-parenting and warns when the referenced project is missing', async () => {
+        const ack = sinon.stub().resolves();
+        const mockSite = {
+          getId: () => 'site123',
+          getProjectId: () => 'missingProject',
+          setProjectId: sinon.stub(),
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        mockDataAccess.Site.findByBaseURL.resolves(mockSite);
+        mockDataAccess.Organization.findByImsOrgId.resolves({ getId: () => 'newOrg' });
+        mockDataAccess.Project.findById.resolves(null);
+
+        const client = makeClient();
+        await setImsOrgModal(lambdaContext)({ ack, body: makeBody(), client });
+
+        expect(mockLog.warn.called).to.be.true;
+        expect(mockSite.setProjectId.called).to.be.false;
+        // Org update still persists even though the project could not be re-parented.
+        expect(mockSite.setOrganizationId.calledWith('newOrg')).to.be.true;
+        expect(mockSite.save.calledOnce).to.be.true;
+      });
     });
   });
 });

--- a/test/support/slack/actions/set-ims-org-modal.test.js
+++ b/test/support/slack/actions/set-ims-org-modal.test.js
@@ -639,7 +639,7 @@ describe('SetImsOrgModal', () => {
     describe('project re-parenting (SITES-46200)', () => {
       const baseURL = 'https://example.com';
 
-      const makeBody = () => ({
+      const makeBody = (selectedProducts = []) => ({
         view: {
           private_metadata: JSON.stringify({
             baseURL,
@@ -651,7 +651,9 @@ describe('SetImsOrgModal', () => {
           state: {
             values: {
               products_block: {
-                aso_checkbox: { selected_options: [] },
+                aso_checkbox: {
+                  selected_options: selectedProducts.map((value) => ({ value })),
+                },
                 llmo_checkbox: { selected_options: [] },
               },
             },
@@ -835,6 +837,43 @@ describe('SetImsOrgModal', () => {
         expect(mockProject.save.calledOnce).to.be.true;
         expect(mockSite.save.calledOnce).to.be.true;
         expect(mockLog.warn.called).to.be.true;
+      });
+
+      it('creates entitlements for the re-parented site when products are selected', async () => {
+        // Entitlements are org-scoped and resolved from the site at call time
+        // (TierClient.createForSite reads site.getOrganizationId()). They run
+        // after the project re-parent + site.save(), so they must operate on the
+        // re-parented site and land in the new org. This guards that ordering.
+        const ack = sinon.stub().resolves();
+        const mockProject = {
+          getId: () => 'project123',
+          getProjectName: () => 'example.com',
+          getOrganizationId: () => 'oldOrg',
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        const mockSite = {
+          getId: () => 'site123',
+          getProjectId: () => 'project123',
+          setProjectId: sinon.stub(),
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        mockDataAccess.Site.findByBaseURL.resolves(mockSite);
+        mockDataAccess.Organization.findByImsOrgId.resolves({ getId: () => 'newOrg' });
+        mockDataAccess.Project.findById.resolves(mockProject);
+        mockDataAccess.Site.allByProjectId.resolves([mockSite]);
+
+        const client = makeClient();
+        await setImsOrgModal(lambdaContext)({ ack, body: makeBody(['ASO']), client });
+
+        // Project moved to the new org, site persisted, THEN entitlements created
+        // against that same (now re-parented) site.
+        expect(mockProject.setOrganizationId.calledWith('newOrg')).to.be.true;
+        expect(mockSite.save.calledOnce).to.be.true;
+        expect(mockCreateEntitlementsForProducts.calledOnce).to.be.true;
+        expect(mockCreateEntitlementsForProducts.firstCall.args[1]).to.equal(mockSite);
+        expect(mockCreateEntitlementsForProducts.firstCall.args[2]).to.deep.equal(['ASO']);
       });
     });
   });

--- a/test/support/slack/actions/set-ims-org-modal.test.js
+++ b/test/support/slack/actions/set-ims-org-modal.test.js
@@ -874,6 +874,9 @@ describe('SetImsOrgModal', () => {
         expect(mockCreateEntitlementsForProducts.calledOnce).to.be.true;
         expect(mockCreateEntitlementsForProducts.firstCall.args[1]).to.equal(mockSite);
         expect(mockCreateEntitlementsForProducts.firstCall.args[2]).to.deep.equal(['ASO']);
+        // Mechanically enforce the ordering invariant: the re-parented site is
+        // persisted before entitlements are created against it.
+        sinon.assert.callOrder(mockSite.save, mockCreateEntitlementsForProducts);
       });
     });
   });

--- a/test/support/slack/actions/set-ims-org-modal.test.js
+++ b/test/support/slack/actions/set-ims-org-modal.test.js
@@ -801,6 +801,41 @@ describe('SetImsOrgModal', () => {
         expect(mockSite.setOrganizationId.calledWith('newOrg')).to.be.true;
         expect(mockSite.save.calledOnce).to.be.true;
       });
+
+      it('still saves the site when the project-move Slack message fails', async () => {
+        const ack = sinon.stub().resolves();
+        const mockProject = {
+          getId: () => 'project123',
+          getProjectName: () => 'example.com',
+          getOrganizationId: () => 'oldOrg',
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        const mockSite = {
+          getId: () => 'site123',
+          getProjectId: () => 'project123',
+          setProjectId: sinon.stub(),
+          setOrganizationId: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        mockDataAccess.Site.findByBaseURL.resolves(mockSite);
+        mockDataAccess.Organization.findByImsOrgId.resolves({ getId: () => 'newOrg' });
+        mockDataAccess.Project.findById.resolves(mockProject);
+        mockDataAccess.Site.allByProjectId.resolves([mockSite]);
+
+        // say() posts via client.chat.postMessage; make it fail so the
+        // best-effort guard is exercised.
+        const client = makeClient();
+        client.chat.postMessage.rejects(new Error('Slack down'));
+
+        await setImsOrgModal(lambdaContext)({ ack, body: makeBody(), client });
+
+        // The project move and the site save must both still happen — a Slack
+        // failure must not leave the project moved with the site unpersisted.
+        expect(mockProject.save.calledOnce).to.be.true;
+        expect(mockSite.save.calledOnce).to.be.true;
+        expect(mockLog.warn.called).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
## Problem

The Slack `set imsorg` flow re-parented a site to a new Spacecat org by updating **only** `site.organizationId`. The site's associated **project** stayed in the old org. Result: the site appears in `GET /organizations/{orgId}/sites` (enrollment-filtered) but vanishes from the ASO site picker, which groups sites under `GET /organizations/{orgId}/projects` — the `zepbound.lilly.com` symptom in SITES-46200.

## Change

Add `reparentSiteProject(...)`, invoked in **both** branches (org-found and org-created) right after `site.setOrganizationId(...)` and before `site.save()`, following the decision guide in the ticket:

| Situation | Action |
|---|---|
| Site has no project / project already in target org | no-op |
| Site is the **only** member of its project (Case A/C) | move the project to the target org (`project.setOrganizationId` + `save`); site keeps its `projectId` |
| Project is **shared** with sites staying behind (Case B) | split — find-or-create a project in the target org for the moved site and re-point it (`site.setProjectId`); siblings keep their project in the source org |
| Referenced project is missing | `log.warn` and skip (org update still persists) |

Reuses the existing `createProject()` find-or-create helper and `deriveProjectName()` from `support/utils.js`, so project-name derivation and the operator Slack feedback stay consistent with the onboarding flow.

This pairs with the sibling PR that blocks `projectId` changes on `PATCH /sites/:siteId`, closing the two write paths that could diverge `site.organizationId` from `project.organizationId`. (Bulk audit/remediation of already-mismatched rows and the ASO picker "unassigned" hardening are separate follow-ups.)

### Tests
`test/support/slack/actions/set-ims-org-modal.test.js` — added the solo-move, shared-split, already-aligned, and missing-project cases; updated the existing success-path mocks (added `getProjectId`, a `Project` DAO stub, `Site.allByProjectId`, and `log.warn`). Full suite green (**15 passing**).

## Related Issues
- SITES-46200

🤖 Generated with [Claude Code](https://claude.com/claude-code)