### PR TITLE
feat(preflight): restore mystiqueUrl dev override on site-scoped endpoint (SITES-46216)

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -365,7 +365,35 @@ function PreflightController(ctx, log, env) {
       return preflightError('PREFLIGHT_INVALID_REQUEST', 'url is missing or not a valid URI', 400);
     }
 
-    if (!hasText(env.MYSTIQUE_API_BASE_URL)) {
+    // mystiqueUrl override (SITES-46216): in non-prod, allow the caller to
+    // point this request at a specific Mysticat host instead of the
+    // env-configured one. Same shape as the legacy /preflight/beta/jobs
+    // override (PR #2140, hardened in 746138e4), restored here after the
+    // SITES-44686 redesign dropped it. Guards:
+    //   1. AWS_ENV !== 'prod' — dead code in prod regardless of body content
+    //   2. Valid URL parse
+    //   3. Hostname suffix-match against *.adobe.io — broader than the
+    //      original *.stage.cloud.adobe.io because corp-only Ethos hosts
+    //      proved unreachable from public Lambda networking, and m-dev.adobe.io
+    //      is the current publicly-reachable canonical dev host
+    //   4. Tenancy boundary unchanged — caller must still pass hasAccess(site)
+    const isDevForOverride = env.AWS_ENV !== 'prod';
+    const useMystiqueUrlOverride = isDevForOverride && hasText(data.mystiqueUrl);
+    if (useMystiqueUrlOverride) {
+      if (!isValidUrl(data.mystiqueUrl)) {
+        return preflightError('PREFLIGHT_INVALID_REQUEST', 'mystiqueUrl must be a valid URL', 400);
+      }
+      const overrideHost = new URL(data.mystiqueUrl).hostname;
+      if (!/\.adobe\.io$/.test(overrideHost)) {
+        return preflightError('PREFLIGHT_INVALID_REQUEST', 'mystiqueUrl must point at an *.adobe.io host', 400);
+      }
+    }
+
+    const mysticatBaseUrl = useMystiqueUrlOverride
+      ? data.mystiqueUrl
+      : env.MYSTIQUE_API_BASE_URL;
+
+    if (!hasText(mysticatBaseUrl)) {
       return preflightError('PREFLIGHT_INTERNAL_ERROR', 'Analyze service not configured', 500);
     }
 
@@ -481,7 +509,7 @@ function PreflightController(ctx, log, env) {
 
     try {
       await callMysticatAnalyze(
-        env.MYSTIQUE_API_BASE_URL,
+        mysticatBaseUrl,
         asyncJob.getId(),
         siteId,
         url,

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -383,10 +383,14 @@ function PreflightController(ctx, log, env) {
       if (!isValidUrl(data.mystiqueUrl)) {
         return preflightError('PREFLIGHT_INVALID_REQUEST', 'mystiqueUrl must be a valid URL', 400);
       }
-      const overrideHost = new URL(data.mystiqueUrl).hostname;
-      if (!/\.adobe\.io$/.test(overrideHost)) {
+      const parsedOverride = new URL(data.mystiqueUrl);
+      if (parsedOverride.protocol !== 'https:') {
+        return preflightError('PREFLIGHT_INVALID_REQUEST', 'mystiqueUrl must use https://', 400);
+      }
+      if (!/\.adobe\.io$/.test(parsedOverride.hostname)) {
         return preflightError('PREFLIGHT_INVALID_REQUEST', 'mystiqueUrl must point at an *.adobe.io host', 400);
       }
+      log.info(`Using caller-supplied mystiqueUrl override: ${data.mystiqueUrl}`);
     }
 
     const mysticatBaseUrl = useMystiqueUrlOverride

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1203,6 +1203,140 @@ describe('Preflight Controller', () => {
       expect(result.errorCode).to.equal('PREFLIGHT_INTERNAL_ERROR');
     });
 
+    // -- mystiqueUrl dev override (SITES-46216) --
+
+    // The default preflightController in this describe block is built with
+    // AWS_ENV='prod'. Override tests need a separate dev-mode controller.
+    const buildDevController = () => CreatePreflightController(
+      {
+        dataAccess: mockDataAccess,
+        sqs: mockSqs,
+        attributes: { authInfo: mockAuthInfo },
+        pathInfo: { headers: {} },
+      },
+      loggerStub,
+      {
+        AUDIT_JOBS_QUEUE_URL: 'https://sqs.test.amazonaws.com/audit-queue',
+        MYSTIQUE_API_BASE_URL: 'https://mysticat.example.com',
+        AWS_ENV: 'dev',
+      },
+    );
+
+    it('honors mystiqueUrl override on non-prod when host is *.adobe.io', async () => {
+      const devController = buildDevController();
+      const response = await devController.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: {
+          url: 'https://main--example-site.aem.page/test.html',
+          mystiqueUrl: 'https://m-dev.adobe.io',
+        },
+        attributes: { authInfo: mockAuthInfo },
+      });
+      expect(response.status).to.equal(202);
+      const [calledUrl] = fetchStub.secondCall.args;
+      expect(calledUrl).to.equal('https://m-dev.adobe.io/v1/preflight/analyze');
+    });
+
+    it('falls back to env.MYSTIQUE_API_BASE_URL when mystiqueUrl is absent on non-prod', async () => {
+      const devController = buildDevController();
+      const response = await devController.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: { url: 'https://main--example-site.aem.page/test.html' },
+        attributes: { authInfo: mockAuthInfo },
+      });
+      expect(response.status).to.equal(202);
+      const [calledUrl] = fetchStub.secondCall.args;
+      expect(calledUrl).to.equal('https://mysticat.example.com/v1/preflight/analyze');
+    });
+
+    it('returns 400 PREFLIGHT_INVALID_REQUEST when mystiqueUrl is not a valid URL', async () => {
+      const devController = buildDevController();
+      const response = await devController.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: {
+          url: 'https://main--example-site.aem.page/test.html',
+          mystiqueUrl: 'not-a-url',
+        },
+      });
+      expect(response.status).to.equal(400);
+      const result = await response.json();
+      expect(result.errorCode).to.equal('PREFLIGHT_INVALID_REQUEST');
+      expect(result.message).to.include('mystiqueUrl');
+    });
+
+    it('returns 400 PREFLIGHT_INVALID_REQUEST when mystiqueUrl host is not *.adobe.io', async () => {
+      const devController = buildDevController();
+      const response = await devController.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: {
+          url: 'https://main--example-site.aem.page/test.html',
+          mystiqueUrl: 'https://evil.example.com',
+        },
+      });
+      expect(response.status).to.equal(400);
+      const result = await response.json();
+      expect(result.errorCode).to.equal('PREFLIGHT_INVALID_REQUEST');
+      expect(result.message).to.include('*.adobe.io');
+    });
+
+    it('ignores mystiqueUrl in prod (override is dead code there)', async () => {
+      const controller = CreatePreflightController(
+        {
+          dataAccess: mockDataAccess,
+          sqs: mockSqs,
+          attributes: { authInfo: mockAuthInfo },
+          pathInfo: { headers: {} },
+        },
+        loggerStub,
+        {
+          AUDIT_JOBS_QUEUE_URL: 'https://sqs.test.amazonaws.com/audit-queue',
+          MYSTIQUE_API_BASE_URL: 'https://mysticat.example.com',
+          AWS_ENV: 'prod',
+        },
+      );
+      const response = await controller.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: {
+          url: 'https://main--example-site.aem.page/test.html',
+          mystiqueUrl: 'https://m-dev.adobe.io', // would be allowed in dev, ignored in prod
+        },
+        attributes: { authInfo: mockAuthInfo },
+      });
+      expect(response.status).to.equal(202);
+      const [calledUrl] = fetchStub.secondCall.args;
+      // Hit the env-configured URL, NOT the body-supplied override
+      expect(calledUrl).to.equal('https://mysticat.example.com/v1/preflight/analyze');
+    });
+
+    it('allows mystiqueUrl override even when MYSTIQUE_API_BASE_URL env is empty (non-prod)', async () => {
+      // Sanity check that an operator can use the override to test even if
+      // the env var hasn't been configured yet — the override path should
+      // sidestep the "Analyze service not configured" 500.
+      const controller = CreatePreflightController(
+        {
+          dataAccess: mockDataAccess,
+          sqs: mockSqs,
+          attributes: { authInfo: mockAuthInfo },
+          pathInfo: { headers: {} },
+        },
+        loggerStub,
+        {
+          AUDIT_JOBS_QUEUE_URL: 'https://sqs.test.amazonaws.com/audit-queue',
+          AWS_ENV: 'dev',
+          // MYSTIQUE_API_BASE_URL: deliberately unset
+        },
+      );
+      const response = await controller.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: {
+          url: 'https://main--example-site.aem.page/test.html',
+          mystiqueUrl: 'https://m-dev.adobe.io',
+        },
+        attributes: { authInfo: mockAuthInfo },
+      });
+      expect(response.status).to.equal(202);
+    });
+
     it('returns 404 when site is not found', async () => {
       mockDataAccess.Site.findById.resolves(null);
       const response = await preflightController.createPreflight({

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1279,6 +1279,21 @@ describe('Preflight Controller', () => {
       expect(result.message).to.include('*.adobe.io');
     });
 
+    it('returns 400 PREFLIGHT_INVALID_REQUEST when mystiqueUrl scheme is not https', async () => {
+      const devController = buildDevController();
+      const response = await devController.createPreflight({
+        params: { siteId: 'test-site-123' },
+        data: {
+          url: 'https://main--example-site.aem.page/test.html',
+          mystiqueUrl: 'http://m-dev.adobe.io', // http, not https
+        },
+      });
+      expect(response.status).to.equal(400);
+      const result = await response.json();
+      expect(result.errorCode).to.equal('PREFLIGHT_INVALID_REQUEST');
+      expect(result.message).to.include('https');
+    });
+
     it('ignores mystiqueUrl in prod (override is dead code there)', async () => {
       const controller = CreatePreflightController(
         {
@@ -1335,6 +1350,9 @@ describe('Preflight Controller', () => {
         attributes: { authInfo: mockAuthInfo },
       });
       expect(response.status).to.equal(202);
+      // Confirm the override was actually used — not just that the request
+      // avoided the "Analyze service not configured" 500.
+      expect(fetchStub.secondCall.args[0]).to.equal('https://m-dev.adobe.io/v1/preflight/analyze');
     });
 
     it('returns 404 when site is not found', async () => {


### PR DESCRIPTION
## Summary

Restores the `mystiqueUrl` body parameter override on `POST /sites/:siteId/preflights`. The override existed on the legacy `/preflight/beta/jobs` endpoint (PR #2140, hardened in 746138e4) but wasn't carried forward when SITES-44686 (PR #2478) replaced beta/jobs with the site-scoped endpoint. SITES-46216 puts it back.

## Why

The current dev env has `MYSTIQUE_API_BASE_URL` configured to an Ethos provisioner URL (`*.stage.cloud.adobe.io`) whose CNAME chain passes through `*.corp.ethos.adobe.net` — **not resolvable from public AWS Lambda DNS**. Result: every call to the new endpoint surfaces as `502 PREFLIGHT_UPSTREAM_ERROR` with `fetch failed`. Diagnosis trail in the SITES-46216 ticket.

The dev override is a parallel mechanism that lets per-request callers point at a reachable Mysticat host (e.g. `https://m-dev.adobe.io`) without waiting on a deploy-cycle secret update. Same approach the team had on the legacy endpoint; just porting it.

## Guards

Mirroring the original implementation with one allowlist widening:

1. **Environment gate** — only honored when `env.AWS_ENV !== 'prod'`. Dead code in production regardless of body content.
2. **Valid URL parse**.
3. **Hostname allowlist: `*.adobe.io`**. Broader than the original `*.stage.cloud.adobe.io` because corp-only Ethos hosts proved unreachable from public Lambda networking, and `m-dev.adobe.io` (the publicly-reachable canonical dev host) doesn't match the old pattern. `*.adobe.io` stays scoped to Adobe-owned hosts.
4. **Tenancy boundary unchanged** — caller must still pass `accessControlUtil.hasAccess(site)`.

When the override is present and valid, `callMysticatAnalyze` receives the override URL instead of `env.MYSTIQUE_API_BASE_URL`. The override also sidesteps the "Analyze service not configured" 500 — useful when the secret hasn't been wired yet for a new env.

## What changed

**`src/controllers/preflight.js`** — added override-validation block at the start of `createPreflight` (after URL/data validation, before the env-var check). Computed `mysticatBaseUrl` is threaded through to `callMysticatAnalyze`.

**`test/controllers/preflight.test.js`** — 6 new tests under the `createPreflight` describe block:
- honors override on non-prod with `*.adobe.io` host (202 + correct fetch target)
- falls back to env var when override absent on non-prod
- rejects invalid URL with 400 PREFLIGHT_INVALID_REQUEST
- rejects non-`*.adobe.io` host with 400 PREFLIGHT_INVALID_REQUEST
- ignores override in prod (dead code path)
- allows override even when MYSTIQUE_API_BASE_URL env is empty (non-prod)

## Test plan

- [x] `npx mocha test/controllers/preflight.test.js --grep createPreflight` → 60 passing (was 54, +6 for the new override paths)
- [x] No OpenAPI changes (the override stays undocumented per the fd027b5a precedent for the legacy endpoint)
- [ ] Reviewer: confirm the security guard set is sufficient (env-gate + valid-URL + hostname allowlist + access check)
- [ ] After merge: I'll update `docs/isolated-dev-environment.md` in `aem-sites-optimizer-preflight` to reflect the new endpoint shape

## Security review notes

Threat model:
- Override path is gated on **non-prod** + **org-membership** + **`*.adobe.io` hostname allowlist** — all three guards must clear.
- SSRF risk scoped to Adobe-owned hosts; even within `*.adobe.io`, no credentials are forwarded by the controller (the `Authorization` header is the page-auth bearer from `retrievePageAuthentication`, only set when `checkEnableAuthentication` returns true, and is only relevant to the customer URL — not to the Mysticat host).
- Same threat shape the team already approved on the legacy `/preflight/beta/jobs` endpoint (PR #2140, 746138e4). Just porting forward; not introducing a new pattern.

If anyone wants stricter guards (signed override, audit-log on use, separate scope check) — happy to add. The historical precedent felt sufficient here for the same risk level.

## Notes

- This PR is purely additive for non-prod. Prod behavior is unchanged.
- The proper long-term fix is still to update the dev-env secret to point at a publicly-reachable Mysticat host. That's a parallel ops task; this PR just removes the dev-blocking gap in the meantime.
- Doc update for `aem-sites-optimizer-preflight` will follow as a separate PR.

Related: [SITES-44686](https://jira.corp.adobe.com/browse/SITES-44686) (parent — the redesign that dropped the override), [SITES-46202](https://jira.corp.adobe.com/browse/SITES-46202) (the most-recent preflight controller change just landed in PR #2572).

🤖 Generated with [Claude Code](https://claude.com/claude-code)