### PR TITLE
feat(llmo): auto-create missing value columns on sheet-row patch

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -617,8 +617,10 @@ llmo-data-row-with-datasource:
       each other.
 
       Within each entry, the `match` object must uniquely identify exactly one row
-      (no match → 404, multiple matches → 409). Column names in `match` and `values`
-      must exist in the worksheet header row.
+      (no match → 404, multiple matches → 409). `match` column names must exist in the
+      worksheet header row (unknown → 400). `values` column names that do not exist yet
+      are created on the fly (appended after the last header column), so the first write
+      of e.g. a `status` column the generator never emitted succeeds rather than 400ing.
     operationId: patchLlmoDataRow
     requestBody:
       required: true
@@ -679,7 +681,9 @@ llmo-data-row-with-type:
 
       Used by the elmo UI to mark prompt(s) in the Strategic Recommendations
       workbook as deleted by writing `"deleted": "true"` on the matching row(s) of
-      the `Semrush`, `Synthetic Personas`, or `Citation Attempt` worksheet.
+      the `Semrush`, `Synthetic Personas`, or `Citation Attempt` worksheet, and to
+      dismiss GSC prompts by writing `"status": "dismissed"` on the matching row of
+      the GSC workbook — the `status` column is created automatically on first write.
     operationId: patchLlmoDataRowWithType
     requestBody:
       required: true

--- a/src/controllers/llmo/llmo-sheet-write.js
+++ b/src/controllers/llmo/llmo-sheet-write.js
@@ -220,13 +220,33 @@ export const validateSheetRowPatch = (data) => {
 // identical to the pre-batch contract.
 const updateWorksheet = (worksheet, entryRef, headerMap, match, values) => {
   const prefix = entryRef ? `${entryRef}: ` : '';
+
+  // `match` columns must already exist — you cannot identify a row by a column the
+  // worksheet doesn't have, so an unknown match column is a caller error (400).
   const unknownMatchCols = Object.keys(match).filter((c) => !headerMap.has(c));
-  const unknownValueCols = Object.keys(values).filter((c) => !headerMap.has(c));
-  if (unknownMatchCols.length > 0 || unknownValueCols.length > 0) {
+  if (unknownMatchCols.length > 0) {
     const headers = [...headerMap.keys()].join(', ');
-    const err = new Error(`${prefix}Unknown column(s) ${[...unknownMatchCols, ...unknownValueCols].join(', ')}. Available: ${headers}`);
+    const err = new Error(`${prefix}Unknown match column(s) ${unknownMatchCols.join(', ')}. Available: ${headers}`);
     err.statusCode = 400;
     throw err;
+  }
+
+  // `values` columns are created on demand: a value column that isn't in the header
+  // row yet is appended after the last existing column, so e.g. the first-ever GSC
+  // prompt dismissal can introduce a `status` column the generator never emitted.
+  // `headerMap` is mutated in place so subsequent entries in the same batch (which
+  // share the cached map) see the new column. Existing data rows leave the new cell
+  // empty — only the matched row below gets a value.
+  const missingValueCols = Object.keys(values).filter((c) => !headerMap.has(c));
+  if (missingValueCols.length > 0) {
+    const headerRow = worksheet.getRow(1);
+    let nextCol = headerMap.size > 0 ? Math.max(...headerMap.values()) : 0;
+    missingValueCols.forEach((column) => {
+      nextCol += 1;
+      headerRow.getCell(nextCol).value = column;
+      headerMap.set(column, nextCol);
+    });
+    headerRow.commit();
   }
 
   const matchedRows = findRowMatching(worksheet, headerMap, match);
@@ -259,6 +279,8 @@ const updateWorksheet = (worksheet, entryRef, headerMap, match, values) => {
  *  - All-or-nothing. Every entry must validate AND match exactly one row in its
  *    target worksheet before any writes happen. The first failing entry throws
  *    with `.statusCode` (400/404/409) and the workbook is not uploaded.
+ *  - `values` columns missing from the header row are created on the fly (appended
+ *    after the last column); `match` columns must already exist (unknown → 400).
  *  - Worksheet header maps are cached per-sheet across entries so a 100-update
  *    batch against the same sheet still scans the header row once.
  *

--- a/src/controllers/llmo/llmo-sheet-write.js
+++ b/src/controllers/llmo/llmo-sheet-write.js
@@ -33,6 +33,18 @@ const SAFE_PATH_SEGMENT_RE = /^[A-Za-z0-9_-]+$/;
 export const isSafePathSegment = (value) => typeof value === 'string'
   && value.length > 0 && SAFE_PATH_SEGMENT_RE.test(value);
 
+// A `values` write may create a header column that doesn't exist yet (see
+// updateWorksheet). Existing columns are never re-validated, but a *new* column
+// name is gated so an authenticated caller can't pollute the worksheet header with
+// arbitrary or oversized keys. The set is deliberately wider than isSafePathSegment
+// (sheet headers legitimately contain spaces and '+', e.g. "Source GSC+Keywords")
+// but still excludes control characters and caps length.
+export const MAX_NEW_COLUMN_NAME_LENGTH = 100;
+const NEW_COLUMN_NAME_RE = /^[\w .+-]+$/;
+export const isCreatableColumnName = (value) => typeof value === 'string'
+  && value.length > 0 && value.length <= MAX_NEW_COLUMN_NAME_LENGTH
+  && NEW_COLUMN_NAME_RE.test(value);
+
 const buildSharePointPath = (dataFolder, sheetType, dataSource) => {
   const segments = [SHAREPOINT_FILE_PREFIX, dataFolder];
   if (sheetType) {
@@ -239,6 +251,12 @@ const updateWorksheet = (worksheet, entryRef, headerMap, match, values) => {
   // empty — only the matched row below gets a value.
   const missingValueCols = Object.keys(values).filter((c) => !headerMap.has(c));
   if (missingValueCols.length > 0) {
+    const invalidNewCols = missingValueCols.filter((c) => !isCreatableColumnName(c));
+    if (invalidNewCols.length > 0) {
+      const err = new Error(`${prefix}Cannot create column(s) ${invalidNewCols.join(', ')}: new column names must be 1-${MAX_NEW_COLUMN_NAME_LENGTH} characters of letters, digits, spaces, and . _ + - only`);
+      err.statusCode = 400;
+      throw err;
+    }
     const headerRow = worksheet.getRow(1);
     let nextCol = headerMap.size > 0 ? Math.max(...headerMap.values()) : 0;
     missingValueCols.forEach((column) => {

--- a/test/controllers/llmo/llmo-sheet-write.test.js
+++ b/test/controllers/llmo/llmo-sheet-write.test.js
@@ -406,7 +406,7 @@ describe('llmo-sheet-write', () => {
       }
     });
 
-    it('returns 400 when match/values reference unknown columns', async () => {
+    it('returns 400 when match references an unknown column', async () => {
       const initialBuffer = await buildWorkbookBuffer(sheets());
       const { sharepointClient } = buildStubClient({ initialBuffer });
       try {
@@ -414,8 +414,8 @@ describe('llmo-sheet-write', () => {
           {
             ...baseArgs,
             sheet: 'Semrush',
-            match: { topic_id: '111' },
-            values: { nonexistent_column: 'true' },
+            match: { nonexistent_column: '111' },
+            values: { deleted: 'true' },
           },
           baseEnv,
           { sharepointClient, fetch: sinon.stub() },
@@ -423,8 +423,37 @@ describe('llmo-sheet-write', () => {
         expect.fail('Expected throw');
       } catch (e) {
         expect(e.statusCode).to.equal(400);
-        expect(e.message).to.match(/Unknown column/);
+        expect(e.message).to.match(/Unknown match column/);
       }
+    });
+
+    it('creates a value column that does not exist yet, then writes it', async () => {
+      const initialBuffer = await buildWorkbookBuffer(sheets());
+      const { sharepointClient, document, uploaded } = buildStubClient({ initialBuffer });
+
+      const result = await patchSheetRow(
+        {
+          ...baseArgs,
+          sheet: 'Semrush',
+          match: { topic_id: '111', prompt: 'first prompt' },
+          values: { status: 'dismissed' },
+        },
+        baseEnv,
+        { sharepointClient, fetch: sinon.stub().resolves({ ok: true, status: 200 }), adminKey: 'k' },
+      );
+
+      expect(result).to.deep.include({ rowNumber: 2, updated: { status: 'dismissed' } });
+      expect(document.uploadRawDocument).to.have.been.calledOnce;
+
+      const verifyWorkbook = new ExcelJS.Workbook();
+      await verifyWorkbook.xlsx.load(uploaded.buffer);
+      const semrush = verifyWorkbook.getWorksheet('Semrush');
+      // The new column is appended after the 3 existing headers (topic_id, prompt, deleted).
+      expect(semrush.getRow(1).getCell(4).value).to.equal('status');
+      // The matched row gets the value...
+      expect(semrush.getRow(2).getCell(4).value).to.equal('dismissed');
+      // ...and non-matched rows leave the new cell empty.
+      expect(semrush.getRow(3).getCell(4).value).to.satisfy((v) => v === null || v === '' || v === undefined);
     });
 
     it('returns 404 when no row matches', async () => {
@@ -606,7 +635,7 @@ describe('llmo-sheet-write', () => {
       expect(document.uploadRawDocument).to.not.have.been.called;
     });
 
-    it('surfaces the offending index for unknown columns and ambiguous matches', async () => {
+    it('surfaces the offending index for unknown match columns', async () => {
       const initialBuffer = await buildWorkbookBuffer(sheets());
       const { sharepointClient } = buildStubClient({ initialBuffer });
 
@@ -615,7 +644,7 @@ describe('llmo-sheet-write', () => {
           {
             ...baseArgs,
             updates: [
-              { sheet: 'Semrush', match: { topic_id: '111' }, values: { unknown: 'col' } },
+              { sheet: 'Semrush', match: { unknown: 'col' }, values: { deleted: 'true' } },
             ],
           },
           baseEnv,
@@ -625,9 +654,37 @@ describe('llmo-sheet-write', () => {
       } catch (e) {
         // Single-update batches drop the prefix for back-compat with the original wording.
         expect(e.statusCode).to.equal(400);
-        expect(e.message).to.match(/Unknown column/);
+        expect(e.message).to.match(/Unknown match column/);
         expect(e.message).to.not.match(/updates\[0\]/);
       }
+    });
+
+    it('creates a missing value column once and reuses it across batch entries', async () => {
+      const initialBuffer = await buildWorkbookBuffer(sheets());
+      const { sharepointClient, uploaded } = buildStubClient({ initialBuffer });
+
+      const { results } = await patchSheetRows(
+        {
+          ...baseArgs,
+          updates: [
+            { sheet: 'Semrush', match: { topic_id: '111' }, values: { status: 'dismissed' } },
+            { sheet: 'Semrush', match: { topic_id: '333' }, values: { status: 'dismissed' } },
+          ],
+        },
+        baseEnv,
+        { sharepointClient, fetch: sinon.stub().resolves({ ok: true, status: 200 }), adminKey: 'k' },
+      );
+
+      expect(results).to.have.lengthOf(2);
+
+      const verifyWorkbook = new ExcelJS.Workbook();
+      await verifyWorkbook.xlsx.load(uploaded.buffer);
+      const semrush = verifyWorkbook.getWorksheet('Semrush');
+      // Column created exactly once at index 4 (after topic_id, prompt, deleted) — not duplicated.
+      expect(semrush.getRow(1).getCell(4).value).to.equal('status');
+      expect(semrush.getRow(1).getCell(5).value).to.satisfy((v) => v === null || v === '' || v === undefined);
+      expect(semrush.getRow(2).getCell(4).value).to.equal('dismissed'); // topic_id 111
+      expect(semrush.getRow(4).getCell(4).value).to.equal('dismissed'); // topic_id 333
     });
 
     it('worksheet-not-found reports the entry index', async () => {

--- a/test/controllers/llmo/llmo-sheet-write.test.js
+++ b/test/controllers/llmo/llmo-sheet-write.test.js
@@ -25,8 +25,10 @@ import {
   sharepointPathFor,
   publishPathFor,
   isSafePathSegment,
+  isCreatableColumnName,
   cellValueAsString,
   MAX_UPDATES_PER_REQUEST,
+  MAX_NEW_COLUMN_NAME_LENGTH,
 } from '../../../src/controllers/llmo/llmo-sheet-write.js';
 
 use(sinonChai);
@@ -237,6 +239,25 @@ describe('llmo-sheet-write', () => {
       expect(isSafePathSegment(null)).to.equal(false);
       expect(isSafePathSegment(undefined)).to.equal(false);
       expect(isSafePathSegment(123)).to.equal(false);
+    });
+  });
+
+  describe('isCreatableColumnName', () => {
+    it('accepts real-world header names including spaces and +', () => {
+      expect(isCreatableColumnName('status')).to.equal(true);
+      expect(isCreatableColumnName('prompt_en')).to.equal(true);
+      expect(isCreatableColumnName('Source GSC+Keywords')).to.equal(true);
+      expect(isCreatableColumnName('Reasoning')).to.equal(true);
+    });
+
+    it('rejects empty, over-long, control-char, and non-string names', () => {
+      expect(isCreatableColumnName('')).to.equal(false);
+      expect(isCreatableColumnName('a'.repeat(MAX_NEW_COLUMN_NAME_LENGTH + 1))).to.equal(false);
+      expect(isCreatableColumnName('bad\nname')).to.equal(false);
+      expect(isCreatableColumnName('with/slash')).to.equal(false);
+      expect(isCreatableColumnName('tab\tname')).to.equal(false);
+      expect(isCreatableColumnName(null)).to.equal(false);
+      expect(isCreatableColumnName(123)).to.equal(false);
     });
   });
 
@@ -454,6 +475,54 @@ describe('llmo-sheet-write', () => {
       expect(semrush.getRow(2).getCell(4).value).to.equal('dismissed');
       // ...and non-matched rows leave the new cell empty.
       expect(semrush.getRow(3).getCell(4).value).to.satisfy((v) => v === null || v === '' || v === undefined);
+    });
+
+    it('creates multiple new value columns in one update, in input order', async () => {
+      const initialBuffer = await buildWorkbookBuffer(sheets());
+      const { sharepointClient, uploaded } = buildStubClient({ initialBuffer });
+
+      await patchSheetRow(
+        {
+          ...baseArgs,
+          sheet: 'Semrush',
+          match: { topic_id: '111' },
+          values: { status: 'dismissed', priority: 'low' },
+        },
+        baseEnv,
+        { sharepointClient, fetch: sinon.stub().resolves({ ok: true, status: 200 }), adminKey: 'k' },
+      );
+
+      const verifyWorkbook = new ExcelJS.Workbook();
+      await verifyWorkbook.xlsx.load(uploaded.buffer);
+      const semrush = verifyWorkbook.getWorksheet('Semrush');
+      // Existing headers occupy cols 1-3; the two new columns are appended at 4 and 5.
+      expect(semrush.getRow(1).getCell(4).value).to.equal('status');
+      expect(semrush.getRow(1).getCell(5).value).to.equal('priority');
+      expect(semrush.getRow(2).getCell(4).value).to.equal('dismissed');
+      expect(semrush.getRow(2).getCell(5).value).to.equal('low');
+    });
+
+    it('returns 400 when a new value column name is invalid', async () => {
+      const initialBuffer = await buildWorkbookBuffer(sheets());
+      const { sharepointClient, document } = buildStubClient({ initialBuffer });
+      try {
+        await patchSheetRow(
+          {
+            ...baseArgs,
+            sheet: 'Semrush',
+            match: { topic_id: '111' },
+            values: { 'bad/col': 'x' },
+          },
+          baseEnv,
+          { sharepointClient, fetch: sinon.stub() },
+        );
+        expect.fail('Expected throw');
+      } catch (e) {
+        expect(e.statusCode).to.equal(400);
+        expect(e.message).to.match(/Cannot create column/);
+      }
+      // No write happens when column creation is rejected.
+      expect(document.uploadRawDocument).to.not.have.been.called;
     });
 
     it('returns 404 when no row matches', async () => {
@@ -685,6 +754,35 @@ describe('llmo-sheet-write', () => {
       expect(semrush.getRow(1).getCell(5).value).to.satisfy((v) => v === null || v === '' || v === undefined);
       expect(semrush.getRow(2).getCell(4).value).to.equal('dismissed'); // topic_id 111
       expect(semrush.getRow(4).getCell(4).value).to.equal('dismissed'); // topic_id 333
+    });
+
+    it('discards an earlier entry\'s new column when a later entry fails (all-or-nothing)', async () => {
+      const initialBuffer = await buildWorkbookBuffer(sheets());
+      const { sharepointClient, document } = buildStubClient({ initialBuffer });
+
+      try {
+        await patchSheetRows(
+          {
+            ...baseArgs,
+            updates: [
+              // First entry creates the `status` column in the in-memory workbook...
+              { sheet: 'Semrush', match: { topic_id: '111' }, values: { status: 'dismissed' } },
+              // ...then a later entry fails to match, aborting before any upload.
+              { sheet: 'Semrush', match: { topic_id: 'does-not-exist' }, values: { status: 'dismissed' } },
+            ],
+          },
+          baseEnv,
+          { sharepointClient, fetch: sinon.stub(), adminKey: 'k' },
+        );
+        expect.fail('Expected throw');
+      } catch (e) {
+        expect(e.statusCode).to.equal(404);
+        expect(e.message).to.match(/updates\[1\]/);
+      }
+      // The workbook was downloaded and mutated in memory, but never uploaded —
+      // so the newly created `status` column is discarded with the rest of the batch.
+      expect(document.getDocumentContent).to.have.been.calledOnce;
+      expect(document.uploadRawDocument).to.not.have.been.called;
     });
 
     it('worksheet-not-found reports the entry index', async () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -4012,16 +4012,16 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(500);
     });
 
-    it('maps a 400 from sheet-write (unknown column) to 400 response', async () => {
+    it('maps a 400 from sheet-write (unknown match column) to 400 response', async () => {
       const { subjectController } = await buildControllerWithSheetWriteStub(async () => {
-        const err = new Error('Unknown column(s) foo. Available: topic_id, prompt, deleted');
+        const err = new Error('Unknown match column(s) foo. Available: topic_id, prompt, deleted');
         err.statusCode = 400;
         throw err;
       });
       const result = await subjectController.patchLlmoDataRow({
         ...mockContext,
         params: baseParams,
-        data: { sheet: 'Semrush', match: { topic_id: 'x' }, values: { foo: 'bar' } },
+        data: { sheet: 'Semrush', match: { foo: 'x' }, values: { deleted: 'true' } },
       });
       expect(result.status).to.equal(400);
     });


### PR DESCRIPTION
## What

Makes the LLMO sheet-write endpoint (`PATCH /sites/:siteId/llmo/data/.../row`) create a `values` column on the fly when it isn't already in the worksheet header, instead of rejecting the write with a 400.

## Why

GSC prompt dismissal needs to set a `status` column on the GSC workbook (`ai-prompts-gsc.xlsx`). The GSC generator in data-retrieval-service does not emit a `status` column, so the first dismissal had no column to write into and `patchSheetRows` returned `400 Unknown column`. Rather than pre-emitting the column from the generator, the dismiss-write path now lazily creates it — matching the request *"when a prompt is dismissed from GSC, the sheet should be updated; if the column does not exist yet, add it."*

This was discussed in the GSC prompt-dismissal thread: SharePoint stays the source of truth (no DB table), consistent with how Strategic Recommendations soft-delete already uses this same generic endpoint.

## Behavior

- **`values` columns** missing from the header row are appended after the last existing column and written. The cached header map is mutated in place so a batch creates the column **once** and reuses it across entries.
- **`match` columns** must still exist — an unknown match column returns `400`, since you can't identify a row by a column the sheet doesn't have.
- Existing data rows leave the new cell empty; only the matched row gets a value.
- Universal: applies to all callers of the endpoint (strategic-recommendations, brand-presence, GSC), not gated behind a flag.

## ⚠️ Known limitation (intentional, out of scope)

This is the **dismiss-write path only**. GSC regeneration overwrites `ai-prompts-gsc.xlsx` with a freshly built workbook that has no `status` column, so dismissals reset on the next GSC run. Making dismissals durable across regen requires a preserve-on-regen merge step in `data-retrieval-service` (the `mergeSemrushRows` equivalent), tracked separately. Accepted as ephemeral for now.

## Tests

- New unit tests: auto-create a value column (single + batch reuse), unknown *match* column still 400s.
- Updated the controller error-mapping test wording to match.
- `npx mocha test/controllers/llmo/llmo-sheet-write.test.js` → 44 passing
- `npx mocha test/controllers/llmo/llmo.test.js test/routes/index.test.js` → 401 passing
- `npm run docs:lint` → API description valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)