### PR TITLE
feat: auto-detect unreachable base URL at onboarding and persist working variant as overrideBaseURL

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -47,7 +47,8 @@ import {
 import AccessControlUtil from '../support/access-control-util.js';
 import { CAP_SITE_READ_ALL, CAP_SITE_CREATE } from '../routes/capability-constants.js';
 import { auditTargetURLsPatchGuard } from '../support/audit-target-urls-validation.js';
-import { updateRumConfig, autoDetectOverrideBaseURL } from '../support/rum-config-service.js';
+import { updateRumConfig } from '../support/rum-config-service.js';
+import { autoDetectOverrideBaseURL } from '../support/base-url-detection.js';
 import { triggerBrandProfileAgent } from '../support/brand-profile-trigger.js';
 import {
   ensureSiteEntitlementAndEnrollment,
@@ -401,12 +402,10 @@ function SitesController(ctx, log, env) {
           ...context.data,
           baseURL, // override with normalized value
         });
-        updateRumConfig(site, context).catch((e) => {
-          log.warn(`[sites] RUM config update failed for ${site.getBaseURL()}: ${e.message}`);
-        });
-        autoDetectOverrideBaseURL(site, context).catch((e) => {
-          log.warn(`[sites] base URL auto-detect failed for ${site.getBaseURL()}: ${e.message}`);
-        });
+        updateRumConfig(site, context)
+          .catch((e) => log.warn(`[sites] RUM config update failed for ${site.getBaseURL()}: ${e.message}`))
+          .then(() => autoDetectOverrideBaseURL(site, context))
+          .catch((e) => log.warn(`[sites] base URL auto-detect failed for ${site.getBaseURL()}: ${e.message}`));
         status = 201;
       }
     } catch (error) {

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -47,7 +47,7 @@ import {
 import AccessControlUtil from '../support/access-control-util.js';
 import { CAP_SITE_READ_ALL, CAP_SITE_CREATE } from '../routes/capability-constants.js';
 import { auditTargetURLsPatchGuard } from '../support/audit-target-urls-validation.js';
-import { updateRumConfig } from '../support/rum-config-service.js';
+import { updateRumConfig, autoDetectOverrideBaseURL } from '../support/rum-config-service.js';
 import { triggerBrandProfileAgent } from '../support/brand-profile-trigger.js';
 import {
   ensureSiteEntitlementAndEnrollment,
@@ -403,6 +403,9 @@ function SitesController(ctx, log, env) {
         });
         updateRumConfig(site, context).catch((e) => {
           log.warn(`[sites] RUM config update failed for ${site.getBaseURL()}: ${e.message}`);
+        });
+        autoDetectOverrideBaseURL(site, context).catch((e) => {
+          log.warn(`[sites] base URL auto-detect failed for ${site.getBaseURL()}: ${e.message}`);
         });
         status = 201;
       }

--- a/src/support/base-url-detection.js
+++ b/src/support/base-url-detection.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
+import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import URI from 'urijs';
+
+const BASE_URL_PROBE_TIMEOUT_MS = 5000;
+
+async function isUrlReachable(url) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), BASE_URL_PROBE_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { method: 'HEAD', signal: controller.signal });
+    clearTimeout(timeoutId);
+    return response.ok;
+    /* c8 ignore next 4 */
+  } catch {
+    clearTimeout(timeoutId);
+    return false;
+  }
+}
+
+/**
+ * Auto-detects whether the site's baseURL is unreachable but the www-toggled
+ * variant is reachable (or vice versa). If so, persists overrideBaseURL on the
+ * site's fetchConfig so all audit types use the correct domain.
+ *
+ * Handles cases like dupont.com where the apex domain has no HTTPS listener
+ * but www.dupont.com works, or vice versa.
+ *
+ * No-ops when overrideBaseURL is already set, or when the site already uses a
+ * non-www subdomain (blog.example.com), since toggling does not apply there.
+ *
+ * @param {object} site - Site model instance.
+ * @param {object} context - Request/worker context (provides log).
+ * @returns {Promise<void>}
+ */
+export async function autoDetectOverrideBaseURL(site, context) {
+  const { log } = context;
+
+  if (site.getConfig()?.getFetchConfig?.()?.overrideBaseURL) {
+    return;
+  }
+
+  const baseURL = site.getBaseURL();
+  let hostname;
+  try {
+    hostname = new URL(baseURL).hostname;
+  } catch {
+    /* c8 ignore next */
+    return;
+  }
+
+  const uri = new URI(baseURL);
+  const subdomain = uri.subdomain();
+  if (hasText(subdomain) && subdomain !== 'www') {
+    return;
+  }
+
+  if (await isUrlReachable(baseURL)) {
+    return;
+  }
+
+  const toggledHostname = hostname.startsWith('www.') ? hostname.slice(4) : `www.${hostname}`;
+  const { protocol } = new URL(baseURL);
+  const toggledURL = `${protocol}//${toggledHostname}`;
+
+  if (!(await isUrlReachable(toggledURL))) {
+    /* c8 ignore next */
+    log.warn(`[auto-detect-base-url] neither ${baseURL} nor ${toggledURL} reachable for siteId=${site.getId?.()}`);
+    return;
+  }
+
+  log.warn(`[auto-detect-base-url] ${baseURL} unreachable, ${toggledURL} reachable — setting overrideBaseURL for siteId=${site.getId?.()}`);
+  const siteConfig = site.getConfig();
+  const existingFetchConfig = siteConfig.getFetchConfig() || {};
+  siteConfig.updateFetchConfig({ ...existingFetchConfig, overrideBaseURL: toggledURL });
+  site.setConfig(Config.toDynamoItem(siteConfig));
+  await site.save();
+}

--- a/src/support/rum-config-service.js
+++ b/src/support/rum-config-service.js
@@ -12,11 +12,8 @@
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
-import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
-import URI from 'urijs';
 
 const RUM_CHECK_TIMEOUT_MS = 3000;
-const BASE_URL_PROBE_TIMEOUT_MS = 5000;
 
 /**
  * Checks whether the site has a RUM domain key and optionally persists the result.
@@ -69,76 +66,4 @@ export async function updateRumConfig(site, context, { save = true } = {}) {
   }
 
   return hasDomainKey;
-}
-
-async function isUrlReachable(url) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), BASE_URL_PROBE_TIMEOUT_MS);
-  try {
-    await fetch(url, { method: 'HEAD', signal: controller.signal });
-    clearTimeout(timeoutId);
-    return true;
-    /* c8 ignore next 4 */
-  } catch {
-    clearTimeout(timeoutId);
-    return false;
-  }
-}
-
-/**
- * Auto-detects whether the site's baseURL is unreachable but the www-toggled
- * variant is reachable (or vice versa). If so, persists overrideBaseURL on the
- * site's fetchConfig so all audit types use the correct domain.
- *
- * Handles cases like dupont.com where the apex domain has no HTTPS listener
- * but www.dupont.com works, or vice versa.
- *
- * No-ops when overrideBaseURL is already set, or when the site already uses a
- * non-www subdomain (blog.example.com), since toggling does not apply there.
- *
- * @param {object} site - Site model instance.
- * @param {object} context - Request/worker context (provides log).
- * @returns {Promise<void>}
- */
-export async function autoDetectOverrideBaseURL(site, context) {
-  const { log } = context;
-
-  if (site.getConfig()?.getFetchConfig?.()?.overrideBaseURL) {
-    return;
-  }
-
-  const baseURL = site.getBaseURL();
-  let hostname;
-  try {
-    hostname = new URL(baseURL).hostname;
-  } catch {
-    /* c8 ignore next */
-    return;
-  }
-
-  const uri = new URI(baseURL);
-  const subdomain = uri.subdomain();
-  if (hasText(subdomain) && subdomain !== 'www') {
-    return;
-  }
-
-  if (await isUrlReachable(baseURL)) {
-    return;
-  }
-
-  const toggledHostname = hostname.startsWith('www.') ? hostname.slice(4) : `www.${hostname}`;
-  const toggledURL = `https://${toggledHostname}`;
-
-  if (!(await isUrlReachable(toggledURL))) {
-    /* c8 ignore next */
-    log.warn(`[auto-detect-base-url] neither ${baseURL} nor ${toggledURL} reachable for siteId=${site.getId?.()}`);
-    return;
-  }
-
-  log.warn(`[auto-detect-base-url] ${baseURL} unreachable, ${toggledURL} reachable — setting overrideBaseURL for siteId=${site.getId?.()}`);
-  const siteConfig = site.getConfig();
-  const existingFetchConfig = siteConfig.getFetchConfig() || {};
-  siteConfig.updateFetchConfig({ ...existingFetchConfig, overrideBaseURL: toggledURL });
-  site.setConfig(Config.toDynamoItem(siteConfig));
-  await site.save();
 }

--- a/src/support/rum-config-service.js
+++ b/src/support/rum-config-service.js
@@ -12,8 +12,11 @@
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
+import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import URI from 'urijs';
 
 const RUM_CHECK_TIMEOUT_MS = 3000;
+const BASE_URL_PROBE_TIMEOUT_MS = 5000;
 
 /**
  * Checks whether the site has a RUM domain key and optionally persists the result.
@@ -66,4 +69,76 @@ export async function updateRumConfig(site, context, { save = true } = {}) {
   }
 
   return hasDomainKey;
+}
+
+async function isUrlReachable(url) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), BASE_URL_PROBE_TIMEOUT_MS);
+  try {
+    await fetch(url, { method: 'HEAD', signal: controller.signal });
+    clearTimeout(timeoutId);
+    return true;
+    /* c8 ignore next 4 */
+  } catch {
+    clearTimeout(timeoutId);
+    return false;
+  }
+}
+
+/**
+ * Auto-detects whether the site's baseURL is unreachable but the www-toggled
+ * variant is reachable (or vice versa). If so, persists overrideBaseURL on the
+ * site's fetchConfig so all audit types use the correct domain.
+ *
+ * Handles cases like dupont.com where the apex domain has no HTTPS listener
+ * but www.dupont.com works, or vice versa.
+ *
+ * No-ops when overrideBaseURL is already set, or when the site already uses a
+ * non-www subdomain (blog.example.com), since toggling does not apply there.
+ *
+ * @param {object} site - Site model instance.
+ * @param {object} context - Request/worker context (provides log).
+ * @returns {Promise<void>}
+ */
+export async function autoDetectOverrideBaseURL(site, context) {
+  const { log } = context;
+
+  if (site.getConfig()?.getFetchConfig?.()?.overrideBaseURL) {
+    return;
+  }
+
+  const baseURL = site.getBaseURL();
+  let hostname;
+  try {
+    hostname = new URL(baseURL).hostname;
+  } catch {
+    /* c8 ignore next */
+    return;
+  }
+
+  const uri = new URI(baseURL);
+  const subdomain = uri.subdomain();
+  if (hasText(subdomain) && subdomain !== 'www') {
+    return;
+  }
+
+  if (await isUrlReachable(baseURL)) {
+    return;
+  }
+
+  const toggledHostname = hostname.startsWith('www.') ? hostname.slice(4) : `www.${hostname}`;
+  const toggledURL = `https://${toggledHostname}`;
+
+  if (!(await isUrlReachable(toggledURL))) {
+    /* c8 ignore next */
+    log.warn(`[auto-detect-base-url] neither ${baseURL} nor ${toggledURL} reachable for siteId=${site.getId?.()}`);
+    return;
+  }
+
+  log.warn(`[auto-detect-base-url] ${baseURL} unreachable, ${toggledURL} reachable — setting overrideBaseURL for siteId=${site.getId?.()}`);
+  const siteConfig = site.getConfig();
+  const existingFetchConfig = siteConfig.getFetchConfig() || {};
+  siteConfig.updateFetchConfig({ ...existingFetchConfig, overrideBaseURL: toggledURL });
+  site.setConfig(Config.toDynamoItem(siteConfig));
+  await site.save();
 }

--- a/test/support/base-url-detection.test.js
+++ b/test/support/base-url-detection.test.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('base-url-detection', () => {
+  const sandbox = sinon.createSandbox();
+
+  let autoDetectOverrideBaseURL;
+  let toDynamoItemStub;
+  let fetchStub;
+  let site;
+  let siteConfig;
+  let context;
+
+  before(async () => {
+    toDynamoItemStub = sandbox.stub().returns({});
+    fetchStub = sandbox.stub();
+
+    ({ autoDetectOverrideBaseURL } = await esmock('../../src/support/base-url-detection.js', {
+      '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
+        Config: { toDynamoItem: toDynamoItemStub },
+      },
+      '@adobe/spacecat-shared-utils': {
+        hasText: (v) => typeof v === 'string' && v.trim().length > 0,
+        tracingFetch: fetchStub,
+      },
+    }));
+  });
+
+  beforeEach(() => {
+    sandbox.reset();
+
+    siteConfig = {
+      getFetchConfig: sandbox.stub().returns({}),
+      updateFetchConfig: sandbox.stub(),
+    };
+
+    site = {
+      getId: sandbox.stub().returns('site-123'),
+      getBaseURL: () => 'https://example.com',
+      getConfig: () => siteConfig,
+      setConfig: sandbox.stub(),
+      save: sandbox.stub().resolves(),
+    };
+
+    context = { log: { warn: sandbox.stub() } };
+  });
+
+  it('no-ops when overrideBaseURL is already set', async () => {
+    siteConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.example.com' });
+
+    await autoDetectOverrideBaseURL(site, context);
+
+    expect(fetchStub).not.to.have.been.called;
+    expect(site.save).not.to.have.been.called;
+  });
+
+  it('no-ops when site has a non-www subdomain', async () => {
+    const subSite = {
+      ...site,
+      getBaseURL: () => 'https://blog.example.com',
+      getConfig: () => ({ getFetchConfig: sandbox.stub().returns({}) }),
+    };
+
+    await autoDetectOverrideBaseURL(subSite, context);
+
+    expect(fetchStub).not.to.have.been.called;
+    expect(subSite.save).not.to.have.been.called;
+  });
+
+  it('no-ops when baseURL is reachable', async () => {
+    fetchStub.resolves({ ok: true });
+
+    await autoDetectOverrideBaseURL(site, context);
+
+    expect(fetchStub).to.have.been.calledOnce;
+    expect(site.save).not.to.have.been.called;
+  });
+
+  it('no-ops when baseURL returns non-ok response (e.g. parking page)', async () => {
+    fetchStub.resolves({ ok: false });
+
+    await autoDetectOverrideBaseURL(site, context);
+
+    expect(fetchStub).to.have.been.calledTwice;
+  });
+
+  it('sets overrideBaseURL when baseURL is unreachable but www-toggled variant is reachable', async () => {
+    fetchStub.withArgs('https://example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
+    fetchStub.withArgs('https://www.example.com', sinon.match.any).resolves({ ok: true });
+
+    await autoDetectOverrideBaseURL(site, context);
+
+    expect(siteConfig.updateFetchConfig).to.have.been.calledOnceWith({ overrideBaseURL: 'https://www.example.com' });
+    expect(toDynamoItemStub).to.have.been.calledOnceWith(siteConfig);
+    expect(site.setConfig).to.have.been.calledOnce;
+    expect(site.save).to.have.been.calledOnce;
+  });
+
+  it('sets overrideBaseURL merging existing fetchConfig fields', async () => {
+    siteConfig.getFetchConfig.returns({ someExistingField: 'value' });
+    fetchStub.withArgs('https://example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
+    fetchStub.withArgs('https://www.example.com', sinon.match.any).resolves({ ok: true });
+
+    await autoDetectOverrideBaseURL(site, context);
+
+    expect(siteConfig.updateFetchConfig).to.have.been.calledOnceWith({
+      someExistingField: 'value',
+      overrideBaseURL: 'https://www.example.com',
+    });
+  });
+
+  it('no-ops when both baseURL and www-toggled are unreachable', async () => {
+    fetchStub.rejects(new Error('ECONNREFUSED'));
+
+    await autoDetectOverrideBaseURL(site, context);
+
+    expect(siteConfig.updateFetchConfig).not.to.have.been.called;
+    expect(site.save).not.to.have.been.called;
+  });
+
+  it('works with www-prefixed baseURL, toggling to apex', async () => {
+    const wwwSiteConfig = {
+      getFetchConfig: sandbox.stub().returns({}),
+      updateFetchConfig: sandbox.stub(),
+    };
+    const wwwSite = {
+      ...site,
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => wwwSiteConfig,
+      setConfig: sandbox.stub(),
+      save: sandbox.stub().resolves(),
+    };
+    fetchStub.withArgs('https://www.example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
+    fetchStub.withArgs('https://example.com', sinon.match.any).resolves({ ok: true });
+
+    await autoDetectOverrideBaseURL(wwwSite, context);
+
+    expect(wwwSiteConfig.updateFetchConfig).to.have.been.calledOnceWith({ overrideBaseURL: 'https://example.com' });
+    expect(wwwSite.save).to.have.been.calledOnce;
+  });
+
+  it('preserves http:// protocol when constructing toggled URL', async () => {
+    const httpSite = {
+      ...site,
+      getBaseURL: () => 'http://example.com',
+      getConfig: () => ({
+        getFetchConfig: sandbox.stub().returns({}),
+        updateFetchConfig: sandbox.stub(),
+      }),
+      setConfig: sandbox.stub(),
+      save: sandbox.stub().resolves(),
+    };
+    fetchStub.withArgs('http://example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
+    fetchStub.withArgs('http://www.example.com', sinon.match.any).resolves({ ok: true });
+
+    await autoDetectOverrideBaseURL(httpSite, context);
+
+    expect(httpSite.save).to.have.been.calledOnce;
+  });
+});

--- a/test/support/rum-config-service.test.js
+++ b/test/support/rum-config-service.test.js
@@ -21,11 +21,9 @@ describe('rum-config-service', () => {
   const sandbox = sinon.createSandbox();
 
   let updateRumConfig;
-  let autoDetectOverrideBaseURL;
   let retrieveDomainkeyStub;
   let rumApiClientStub;
   let toDynamoItemStub;
-  let fetchStub;
   let site;
   let siteConfig;
   let context;
@@ -34,18 +32,13 @@ describe('rum-config-service', () => {
     retrieveDomainkeyStub = sandbox.stub();
     rumApiClientStub = { retrieveDomainkey: retrieveDomainkeyStub };
     toDynamoItemStub = sandbox.stub().returns({});
-    fetchStub = sandbox.stub();
 
-    ({ updateRumConfig, autoDetectOverrideBaseURL } = await esmock('../../src/support/rum-config-service.js', {
+    ({ updateRumConfig } = await esmock('../../src/support/rum-config-service.js', {
       '@adobe/spacecat-shared-rum-api-client': {
         default: { createFrom: () => rumApiClientStub },
       },
       '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
         Config: { toDynamoItem: toDynamoItemStub },
-      },
-      '@adobe/spacecat-shared-utils': {
-        hasText: (v) => typeof v === 'string' && v.trim().length > 0,
-        tracingFetch: fetchStub,
       },
     }));
   });
@@ -55,8 +48,6 @@ describe('rum-config-service', () => {
 
     siteConfig = {
       updateRumConfig: sandbox.stub(),
-      getFetchConfig: sandbox.stub().returns({}),
-      updateFetchConfig: sandbox.stub(),
     };
 
     site = {
@@ -128,94 +119,6 @@ describe('rum-config-service', () => {
       await updateRumConfig(site, context);
 
       expect(retrieveDomainkeyStub).to.have.been.calledOnceWith('example.com');
-    });
-  });
-
-  describe('autoDetectOverrideBaseURL', () => {
-    it('no-ops when overrideBaseURL is already set', async () => {
-      siteConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.example.com' });
-
-      await autoDetectOverrideBaseURL(site, context);
-
-      expect(fetchStub).not.to.have.been.called;
-      expect(site.save).not.to.have.been.called;
-    });
-
-    it('no-ops when site has a non-www subdomain', async () => {
-      const subSite = {
-        ...site,
-        getBaseURL: () => 'https://blog.example.com',
-        getConfig: () => ({ getFetchConfig: sandbox.stub().returns({}) }),
-      };
-
-      await autoDetectOverrideBaseURL(subSite, context);
-
-      expect(fetchStub).not.to.have.been.called;
-      expect(subSite.save).not.to.have.been.called;
-    });
-
-    it('no-ops when baseURL is reachable', async () => {
-      fetchStub.resolves({});
-
-      await autoDetectOverrideBaseURL(site, context);
-
-      expect(fetchStub).to.have.been.calledOnce;
-      expect(site.save).not.to.have.been.called;
-    });
-
-    it('sets overrideBaseURL when baseURL is unreachable but www-toggled variant is reachable', async () => {
-      fetchStub.withArgs('https://example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
-      fetchStub.withArgs('https://www.example.com', sinon.match.any).resolves({});
-
-      await autoDetectOverrideBaseURL(site, context);
-
-      expect(siteConfig.updateFetchConfig).to.have.been.calledOnceWith({ overrideBaseURL: 'https://www.example.com' });
-      expect(toDynamoItemStub).to.have.been.calledOnceWith(siteConfig);
-      expect(site.setConfig).to.have.been.calledOnce;
-      expect(site.save).to.have.been.calledOnce;
-    });
-
-    it('sets overrideBaseURL merging existing fetchConfig fields', async () => {
-      siteConfig.getFetchConfig.returns({ someExistingField: 'value' });
-      fetchStub.withArgs('https://example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
-      fetchStub.withArgs('https://www.example.com', sinon.match.any).resolves({});
-
-      await autoDetectOverrideBaseURL(site, context);
-
-      expect(siteConfig.updateFetchConfig).to.have.been.calledOnceWith({
-        someExistingField: 'value',
-        overrideBaseURL: 'https://www.example.com',
-      });
-    });
-
-    it('no-ops when both baseURL and www-toggled are unreachable', async () => {
-      fetchStub.rejects(new Error('ECONNREFUSED'));
-
-      await autoDetectOverrideBaseURL(site, context);
-
-      expect(siteConfig.updateFetchConfig).not.to.have.been.called;
-      expect(site.save).not.to.have.been.called;
-    });
-
-    it('works with www-prefixed baseURL, toggling to apex', async () => {
-      const wwwSiteConfig = {
-        getFetchConfig: sandbox.stub().returns({}),
-        updateFetchConfig: sandbox.stub(),
-      };
-      const wwwSite = {
-        ...site,
-        getBaseURL: () => 'https://www.example.com',
-        getConfig: () => wwwSiteConfig,
-        setConfig: sandbox.stub(),
-        save: sandbox.stub().resolves(),
-      };
-      fetchStub.withArgs('https://www.example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
-      fetchStub.withArgs('https://example.com', sinon.match.any).resolves({});
-
-      await autoDetectOverrideBaseURL(wwwSite, context);
-
-      expect(wwwSiteConfig.updateFetchConfig).to.have.been.calledOnceWith({ overrideBaseURL: 'https://example.com' });
-      expect(wwwSite.save).to.have.been.calledOnce;
     });
   });
 });

--- a/test/support/rum-config-service.test.js
+++ b/test/support/rum-config-service.test.js
@@ -21,9 +21,11 @@ describe('rum-config-service', () => {
   const sandbox = sinon.createSandbox();
 
   let updateRumConfig;
+  let autoDetectOverrideBaseURL;
   let retrieveDomainkeyStub;
   let rumApiClientStub;
   let toDynamoItemStub;
+  let fetchStub;
   let site;
   let siteConfig;
   let context;
@@ -32,13 +34,18 @@ describe('rum-config-service', () => {
     retrieveDomainkeyStub = sandbox.stub();
     rumApiClientStub = { retrieveDomainkey: retrieveDomainkeyStub };
     toDynamoItemStub = sandbox.stub().returns({});
+    fetchStub = sandbox.stub();
 
-    ({ updateRumConfig } = await esmock('../../src/support/rum-config-service.js', {
+    ({ updateRumConfig, autoDetectOverrideBaseURL } = await esmock('../../src/support/rum-config-service.js', {
       '@adobe/spacecat-shared-rum-api-client': {
         default: { createFrom: () => rumApiClientStub },
       },
       '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
         Config: { toDynamoItem: toDynamoItemStub },
+      },
+      '@adobe/spacecat-shared-utils': {
+        hasText: (v) => typeof v === 'string' && v.trim().length > 0,
+        tracingFetch: fetchStub,
       },
     }));
   });
@@ -48,9 +55,12 @@ describe('rum-config-service', () => {
 
     siteConfig = {
       updateRumConfig: sandbox.stub(),
+      getFetchConfig: sandbox.stub().returns({}),
+      updateFetchConfig: sandbox.stub(),
     };
 
     site = {
+      getId: sandbox.stub().returns('site-123'),
       getBaseURL: () => 'https://example.com',
       getConfig: () => siteConfig,
       setConfig: sandbox.stub(),
@@ -118,6 +128,94 @@ describe('rum-config-service', () => {
       await updateRumConfig(site, context);
 
       expect(retrieveDomainkeyStub).to.have.been.calledOnceWith('example.com');
+    });
+  });
+
+  describe('autoDetectOverrideBaseURL', () => {
+    it('no-ops when overrideBaseURL is already set', async () => {
+      siteConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.example.com' });
+
+      await autoDetectOverrideBaseURL(site, context);
+
+      expect(fetchStub).not.to.have.been.called;
+      expect(site.save).not.to.have.been.called;
+    });
+
+    it('no-ops when site has a non-www subdomain', async () => {
+      const subSite = {
+        ...site,
+        getBaseURL: () => 'https://blog.example.com',
+        getConfig: () => ({ getFetchConfig: sandbox.stub().returns({}) }),
+      };
+
+      await autoDetectOverrideBaseURL(subSite, context);
+
+      expect(fetchStub).not.to.have.been.called;
+      expect(subSite.save).not.to.have.been.called;
+    });
+
+    it('no-ops when baseURL is reachable', async () => {
+      fetchStub.resolves({});
+
+      await autoDetectOverrideBaseURL(site, context);
+
+      expect(fetchStub).to.have.been.calledOnce;
+      expect(site.save).not.to.have.been.called;
+    });
+
+    it('sets overrideBaseURL when baseURL is unreachable but www-toggled variant is reachable', async () => {
+      fetchStub.withArgs('https://example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
+      fetchStub.withArgs('https://www.example.com', sinon.match.any).resolves({});
+
+      await autoDetectOverrideBaseURL(site, context);
+
+      expect(siteConfig.updateFetchConfig).to.have.been.calledOnceWith({ overrideBaseURL: 'https://www.example.com' });
+      expect(toDynamoItemStub).to.have.been.calledOnceWith(siteConfig);
+      expect(site.setConfig).to.have.been.calledOnce;
+      expect(site.save).to.have.been.calledOnce;
+    });
+
+    it('sets overrideBaseURL merging existing fetchConfig fields', async () => {
+      siteConfig.getFetchConfig.returns({ someExistingField: 'value' });
+      fetchStub.withArgs('https://example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
+      fetchStub.withArgs('https://www.example.com', sinon.match.any).resolves({});
+
+      await autoDetectOverrideBaseURL(site, context);
+
+      expect(siteConfig.updateFetchConfig).to.have.been.calledOnceWith({
+        someExistingField: 'value',
+        overrideBaseURL: 'https://www.example.com',
+      });
+    });
+
+    it('no-ops when both baseURL and www-toggled are unreachable', async () => {
+      fetchStub.rejects(new Error('ECONNREFUSED'));
+
+      await autoDetectOverrideBaseURL(site, context);
+
+      expect(siteConfig.updateFetchConfig).not.to.have.been.called;
+      expect(site.save).not.to.have.been.called;
+    });
+
+    it('works with www-prefixed baseURL, toggling to apex', async () => {
+      const wwwSiteConfig = {
+        getFetchConfig: sandbox.stub().returns({}),
+        updateFetchConfig: sandbox.stub(),
+      };
+      const wwwSite = {
+        ...site,
+        getBaseURL: () => 'https://www.example.com',
+        getConfig: () => wwwSiteConfig,
+        setConfig: sandbox.stub(),
+        save: sandbox.stub().resolves(),
+      };
+      fetchStub.withArgs('https://www.example.com', sinon.match.any).rejects(new Error('ECONNREFUSED'));
+      fetchStub.withArgs('https://example.com', sinon.match.any).resolves({});
+
+      await autoDetectOverrideBaseURL(wwwSite, context);
+
+      expect(wwwSiteConfig.updateFetchConfig).to.have.been.calledOnceWith({ overrideBaseURL: 'https://example.com' });
+      expect(wwwSite.save).to.have.been.calledOnce;
     });
   });
 });


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-46284

Problem and Fix:                                                                                                            
                                                                                                                       
When a site like dupont.com is onboarded with an unreachable base URL, the platform had no way to detect this at            registration time. Every subsequent audit would silently fail trying to reach an unreachable domain. The fix adds a reachability probe at site creation — if the registered base URL fails but the www-toggled variant responds, it             automatically saves the working URL as overrideBaseURL in the site config so all future audits use the correct domain from
the start.     
