### PR TITLE
docs(fanout-report): use placeholder bucket/region in S3 redirect example

### DIFF
--- a/docs/openapi/fanout-report-api.yaml
+++ b/docs/openapi/fanout-report-api.yaml
@@ -59,7 +59,7 @@ fanout-report:
             schema:
               type: string
               format: uri
-              example: 'https://spacecat-prod.s3.amazonaws.com/fanout/llmo/<spaceCatId>/<brandId>/data.json.gz?X-Amz-Algorithm=...'
+              example: 'https://<BUCKET>.s3.<REGION>.amazonaws.com/fanout/llmo/<spaceCatId>/<brandId>/data.json.gz?X-Amz-Algorithm=...'
       '400':
         $ref: './responses.yaml#/400'
       '401':


### PR DESCRIPTION
## Summary
- The `302` `Location` example in `docs/openapi/fanout-report-api.yaml` used a concrete bucket name (`spacecat-prod`) that doesn't match runtime behaviour and reads as a real Adobe asset.
- Swapped it for explicit `<BUCKET>` / `<REGION>` placeholders, matching the angle-bracket convention already used for `<spaceCatId>` / `<brandId>` on the same line. S3 bucket names can't contain `<>` or uppercase, so the placeholder is unambiguous and can never resolve.
- Regenerated `docs/index.html` via `npm run docs:build`.

## Test plan
- [x] `npm run docs:lint` — passes (`Your API description is valid 🎉`; 196 pre-existing warnings unrelated)
- [x] `npm run docs:build` — bundles successfully
- [x] `grep "spacecat-prod\.s3" docs/index.html` — 0 matches after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)