### PR TITLE
feat(s2s): single-site identity endpoint to bootstrap customer-scoped tokens (GET /sites/:siteId/identity)

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -232,6 +232,8 @@ paths:
     $ref: './site-metrics-api.yaml#/site-metrics-latest'
   /sites/{siteId}:
     $ref: './site-api.yaml#/site'
+  /sites/{siteId}/identity:
+    $ref: './site-api.yaml#/site-identity'
   /sites/{siteId}/audits:
     $ref: './audits-api.yaml#/audits-for-site'
   /sites/{siteId}/audits/{auditType}:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -704,6 +704,38 @@ Site:
         outputLocation: 'test-output-location'
     createdAt: '2023-12-15T09:30:00Z'
     updatedAt: '2024-01-19T11:20:00Z'
+SiteIdentity:
+  type: object
+  description: |
+    The minimal routing identity for a single site, returned by
+    `GET /sites/{siteId}/identity`. Exposes only what a platform `site:readAll` consumer
+    needs to resolve a site's owning organization and mint a customer-scoped token.
+  properties:
+    siteId:
+      description: The site ID in uuid format
+      $ref: '#/Id'
+    organizationId:
+      description: The ID of the organization this site belongs to, or null if unresolved
+      oneOf:
+        - $ref: '#/Id'
+        - type: 'null'
+    imsOrgId:
+      description: The Adobe IMS organization ID of the owning organization, or null if unresolved
+      oneOf:
+        - $ref: '#/ImsOrganizationId'
+        - type: 'null'
+    baseURL:
+      description: The base URL of the site
+      $ref: '#/URL'
+    deliveryType:
+      description: The type of the delivery this site is using
+      $ref: '#/DeliveryType'
+  example:
+    siteId: '7511d4b9-1234-4abc-8def-0123456789ab'
+    organizationId: '160da889-5678-4cde-9f01-23456789abcd'
+    imsOrgId: '8C6043F15F43B6390A49401A@AdobeOrg'
+    baseURL: 'https://example.com'
+    deliveryType: 'aem_edge'
 SiteWithLatestAudit:
   allOf:
     - $ref: '#/Site'

--- a/docs/openapi/site-api.yaml
+++ b/docs/openapi/site-api.yaml
@@ -1193,3 +1193,44 @@ site-graph:
     security:
       - ims_key: [ ]
       - scoped_api_key: [ ]
+site-identity:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - site
+    summary: Retrieve the minimal routing identity for a single site
+    description: |
+      Returns only the routing identity for a site - its id, owning organization ids
+      (internal `organizationId` and Adobe `imsOrgId`), `baseURL`, and `deliveryType`.
+      No site config, LLMO data, or audits.
+
+      This is a readAll-class route gated on the `site:readAll` capability (the same as
+      the bulk `GET /sites`), not `site:read`. It lets a platform S2S consumer that holds
+      only a site UUID resolve the site's `imsOrgId` and mint a customer-scoped token -
+      the `site -> organization` join it cannot perform without already being scoped.
+
+      `imsOrgId` (and `organizationId`) may be `null` when the site has no resolvable
+      owning organization; the response is still `200`.
+
+      Required capabilities: admin access (legacy admin path) or S2S `site:readAll`.
+    operationId: getSiteIdentity
+    responses:
+      '200':
+        description: Successful operation with the site identity returned
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/SiteIdentity'
+      '400':
+        $ref: './responses.yaml#/400-no-site-id'
+      '401':
+        $ref: './responses.yaml#/401'
+      '403':
+        $ref: './responses.yaml#/403'
+      '404':
+        $ref: './responses.yaml#/404-site-not-found-with-id'
+      '500':
+        $ref: './responses.yaml#/500'
+    security:
+      - api_key: [ ]

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -692,6 +692,9 @@ function SitesController(ctx, log, env) {
 
     if (s2sResult.allowed) {
       log.info(`[s2s-readall] GET /sites/:siteId/identity granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_SITE_READ_ALL} siteId=${siteId} requestId=${requestId}`);
+    } else if (isAdmin) {
+      // This is a cross-tenant readAll-class route; log admin access for auditability too.
+      log.info(`[acl] GET /sites/:siteId/identity granted via admin bypass siteId=${siteId} requestId=${requestId}`);
     }
 
     return ok(SiteIdentityDto.toJSON(site, imsOrgId));

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -38,6 +38,7 @@ import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/confi
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import TierClient from '@adobe/spacecat-shared-tier-client';
 import { SiteDto } from '../dto/site.js';
+import { SiteIdentityDto } from '../dto/site-identity.js';
 import { OrganizationDto } from '../dto/organization.js';
 import { AuditDto } from '../dto/audit.js';
 import { validateRepoUrl } from '../utils/validations.js';
@@ -643,6 +644,57 @@ function SitesController(ctx, log, env) {
     }
 
     return ok(SiteDto.toJSON(site));
+  };
+
+  /**
+   * Gets the minimal routing identity for a single site: its id, owning org ids
+   * (internal `organizationId` + `imsOrgId`), baseURL, and deliveryType.
+   *
+   * This is a readAll-class route, not a tenant-scoped one. It exists so a platform
+   * S2S consumer that only holds a site UUID can resolve the site's `imsOrgId` and mint
+   * a customer-scoped token - the `site -> organization` join it cannot perform without
+   * already being scoped. Access mirrors `GET /sites` (admin bypass + `site:readAll`),
+   * NOT `hasAccess(site)`. It exposes strictly less than the bulk `GET /sites` a
+   * `site:readAll` holder can already enumerate. See `docs/s2s/READALL_CAPABILITY_DESIGN.md`.
+   * @param {object} context - Context of the request.
+   * @returns {Promise<Response>} Site identity response.
+   */
+  const getIdentity = async (context) => {
+    const requestId = context?.invocation?.id || 'unknown';
+    // Read-only admin and full admin both bypass the S2S capability check;
+    // S2S consumers must hold site:readAll. See READALL_CAPABILITY_DESIGN.md.
+    const isAdmin = accessControlUtil.hasAdminReadAccess();
+    const s2sResult = isAdmin
+      ? { allowed: false, reason: 'admin-bypass' }
+      : await accessControlUtil.hasS2SCapability(CAP_SITE_READ_ALL);
+    if (!isAdmin && !s2sResult.allowed) {
+      log.info(`[acl] Denied GET /sites/:siteId/identity - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} requestId=${requestId}`);
+      return forbidden('Forbidden: admin access or site:readAll capability required');
+    }
+
+    const siteId = context.params?.siteId;
+    if (!isValidUUID(siteId)) {
+      return badRequest('Site ID required');
+    }
+
+    const site = await Site.findById(siteId);
+    if (!site) {
+      return notFound('Site not found');
+    }
+
+    // Resolve imsOrgId via the site -> organization join (the entire value-add of this
+    // route). A site without an organization, an orphaned organizationId, or an org
+    // without an imsOrgId all yield imsOrgId: null with a 200 - the site identity still
+    // exists; it is up to the consumer to treat null as "cannot scope".
+    const organizationId = site.getOrganizationId();
+    const organization = organizationId ? await Organization.findById(organizationId) : null;
+    const imsOrgId = organization ? organization.getImsOrgId() : null;
+
+    if (s2sResult.allowed) {
+      log.info(`[s2s-readall] GET /sites/:siteId/identity granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_SITE_READ_ALL} siteId=${siteId} requestId=${requestId}`);
+    }
+
+    return ok(SiteIdentityDto.toJSON(site, imsOrgId));
   };
 
   const getBrandProfile = async (context) => {
@@ -1725,6 +1777,7 @@ function SitesController(ctx, log, env) {
     getByBaseURL,
     getAllByDeliveryType,
     getByID,
+    getIdentity,
     removeSite,
     updateSite,
     updateCdnLogsConfig,

--- a/src/dto/site-identity.js
+++ b/src/dto/site-identity.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Data transfer object for a site's minimal routing identity.
+ *
+ * Deliberately narrow: it exposes only the fields a platform (`site:readAll`) consumer
+ * needs to bootstrap a customer-scoped token for a site it knows by UUID - the
+ * `siteId -> imsOrgId` join it cannot perform without already being scoped. Keeping the
+ * surface frozen prevents it from accreting tenant config, LLMO data, or audits over time.
+ *
+ * See `docs/s2s/READALL_CAPABILITY_DESIGN.md` and GET /sites/:siteId/identity.
+ */
+export const SiteIdentityDto = {
+  /**
+   * Converts a Site (plus its server-resolved imsOrgId) into the identity JSON object.
+   * @param {Readonly<Site>} site - Site object.
+   * @param {string|null} imsOrgId - The IMS org id of the site's owning organization,
+   *   or null when the site has no organization or the organization has no imsOrgId.
+   * @returns {{
+   *   siteId: string,
+   *   organizationId: string|null,
+   *   imsOrgId: string|null,
+   *   baseURL: string,
+   *   deliveryType: string
+   * }}
+   */
+  toJSON: (site, imsOrgId) => ({
+    siteId: site.getId(),
+    organizationId: site.getOrganizationId() ?? null,
+    imsOrgId: imsOrgId ?? null,
+    baseURL: site.getBaseURL(),
+    deliveryType: site.getDeliveryType(),
+  }),
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -252,6 +252,7 @@ export default function getRouteHandlers(
     'GET /sites.csv': sitesController.getAllAsCsv,
     'GET /sites.xlsx': sitesController.getAllAsExcel,
     'GET /sites/:siteId': sitesController.getByID,
+    'GET /sites/:siteId/identity': sitesController.getIdentity,
     'PATCH /sites/:siteId': sitesController.updateSite,
     'PATCH /sites/:siteId/config/cdn-logs': sitesController.updateCdnLogsConfig,
     'GET /sites/:siteId/config/scraper': sitesController.getScraperConfig,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -340,6 +340,10 @@ const routeRequiredCapabilities = {
   // GET /sites is the cross-tenant list endpoint - guarded by site:readAll, not site:read.
   // Tenant-scoped /sites/:siteId stays on site:read. See READALL_CAPABILITY_DESIGN.md.
   'GET /sites': CAP_SITE_READ_ALL,
+  // GET /sites/:siteId/identity is a readAll-class single-site route: it returns only the
+  // routing identity (org ids, baseURL, deliveryType) a site:readAll holder can already
+  // derive from the bulk list + org join, so it is gated on site:readAll, not site:read.
+  'GET /sites/:siteId/identity': CAP_SITE_READ_ALL,
   'POST /sites': CAP_SITE_CREATE,
   'POST /sites/detect/jobs': 'site:write',
   'GET /sites/detect/jobs/:jobId': 'site:read',

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -130,6 +130,7 @@ describe('Sites Controller', () => {
     'getAuditForSite',
     'getByBaseURL',
     'getByID',
+    'getIdentity',
     'getBrandProfile',
     'removeSite',
     'updateSite',
@@ -1349,6 +1350,132 @@ describe('Sites Controller', () => {
     expect(mockDataAccess.Site.findById).to.have.been.calledOnce;
     expect(result.status).to.equal(403);
     expect(error).to.have.property('message', 'Only users belonging to the organization can view its sites');
+  });
+
+  describe('getIdentity (GET /sites/:siteId/identity)', () => {
+    const ORG_ID = '11111111-1111-4111-b111-111111111111';
+
+    function makeS2SConsumer({ clientId = 'svc-1', imsOrgId = 'AAA111111111111111111111@AdobeOrg' } = {}) {
+      return { getClientId: () => clientId, getImsOrgId: () => imsOrgId };
+    }
+
+    function makeFreshConsumer({
+      id = 'consumer-id-1',
+      capabilities = ['site:readAll'],
+      status = 'ACTIVE',
+      revoked = false,
+    } = {}) {
+      return {
+        getId: () => id,
+        getCapabilities: () => capabilities,
+        getStatus: () => status,
+        isRevoked: () => revoked,
+      };
+    }
+
+    it('admin: returns the site identity and resolves imsOrgId via the org join', async () => {
+      sites[0].getOrganizationId = () => ORG_ID;
+      mockDataAccess.Organization.findById.resolves({ getImsOrgId: () => 'ABC123DEF456@AdobeOrg' });
+
+      const result = await sitesController.getIdentity({ params: { siteId: SITE_IDS[0] } });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Site.findById).to.have.been.calledOnceWith(SITE_IDS[0]);
+      expect(mockDataAccess.Organization.findById).to.have.been.calledOnceWith(ORG_ID);
+      expect(body).to.deep.equal({
+        siteId: SITE_IDS[0],
+        organizationId: ORG_ID,
+        imsOrgId: 'ABC123DEF456@AdobeOrg',
+        baseURL: 'https://site1.com',
+        deliveryType: 'aem_edge',
+      });
+    });
+
+    it('returns 404 for an unknown site without touching the org lookup', async () => {
+      mockDataAccess.Site.findById.resolves(null);
+
+      const result = await sitesController.getIdentity({ params: { siteId: SITE_IDS[0] } });
+      const error = await result.json();
+
+      expect(result.status).to.equal(404);
+      expect(error).to.have.property('message', 'Site not found');
+      expect(mockDataAccess.Organization.findById).to.not.have.been.called;
+    });
+
+    it('returns 400 for an invalid site id', async () => {
+      const result = await sitesController.getIdentity({ params: { siteId: 'not-a-uuid' } });
+
+      expect(result.status).to.equal(400);
+      expect(mockDataAccess.Site.findById).to.not.have.been.called;
+    });
+
+    it('returns 200 with imsOrgId null when the owning org has no imsOrgId', async () => {
+      sites[0].getOrganizationId = () => ORG_ID;
+      mockDataAccess.Organization.findById.resolves({ getImsOrgId: () => null });
+
+      const result = await sitesController.getIdentity({ params: { siteId: SITE_IDS[0] } });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.organizationId).to.equal(ORG_ID);
+      expect(body.imsOrgId).to.equal(null);
+    });
+
+    it('returns 200 with null ids when the site has no organization', async () => {
+      sites[0].getOrganizationId = () => undefined;
+
+      const result = await sitesController.getIdentity({ params: { siteId: SITE_IDS[0] } });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.organizationId).to.equal(null);
+      expect(body.imsOrgId).to.equal(null);
+      expect(mockDataAccess.Organization.findById).to.not.have.been.called;
+    });
+
+    it('grants access to an S2S consumer holding site:readAll', async () => {
+      context.attributes.authInfo.withProfile({ is_admin: false });
+      context.s2sConsumer = makeS2SConsumer();
+      context.invocation = { id: 'req-identity-1' };
+      mockDataAccess.Consumer = {
+        findByClientIdAndImsOrgId: sandbox.stub().resolves(makeFreshConsumer()),
+      };
+      sites[0].getOrganizationId = () => ORG_ID;
+      mockDataAccess.Organization.findById.resolves({ getImsOrgId: () => 'ABC123DEF456@AdobeOrg' });
+
+      const result = await sitesController.getIdentity({
+        ...context, params: { siteId: SITE_IDS[0] },
+      });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.imsOrgId).to.equal('ABC123DEF456@AdobeOrg');
+      expect(mockDataAccess.Consumer.findByClientIdAndImsOrgId).to.have.been.calledOnce;
+      expect(loggerStub.info).to.have.been.calledWithMatch(
+        /\[s2s-readall\] GET \/sites\/:siteId\/identity granted clientId=svc-1 consumerId=consumer-id-1 capability=site:readAll siteId=.* requestId=req-identity-1/,
+      );
+    });
+
+    it('denies an S2S consumer that only holds site:read', async () => {
+      context.attributes.authInfo.withProfile({ is_admin: false });
+      context.s2sConsumer = makeS2SConsumer();
+      mockDataAccess.Consumer = {
+        findByClientIdAndImsOrgId: sandbox.stub().resolves(makeFreshConsumer({ capabilities: ['site:read'] })),
+      };
+
+      const result = await sitesController.getIdentity({
+        ...context, params: { siteId: SITE_IDS[0] },
+      });
+      const error = await result.json();
+
+      expect(result.status).to.equal(403);
+      expect(error).to.have.property('message', 'Forbidden: admin access or site:readAll capability required');
+      expect(mockDataAccess.Site.findById).to.not.have.been.called;
+      expect(loggerStub.info).to.have.been.calledWithMatch(
+        /\[acl\] Denied GET \/sites\/:siteId\/identity - reason=missing-capability clientId=svc-1 consumerId=consumer-id-1/,
+      );
+    });
   });
 
   it('gets a site by base URL', async () => {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1450,6 +1450,18 @@ describe('Sites Controller', () => {
       expect(mockDataAccess.Organization.findById).to.not.have.been.called;
     });
 
+    it('propagates a data-access failure to the error wrapper (no silent swallow)', async () => {
+      // Documents the contract: like getByID, getIdentity does not try/catch the data
+      // layer - a thrown Organization.findById propagates and is mapped to a 500 by the
+      // middleware error wrapper rather than being swallowed into a misleading 200.
+      sites[0].getOrganizationId = () => ORG_ID;
+      mockDataAccess.Organization.findById.rejects(new Error('boom'));
+
+      await expect(
+        sitesController.getIdentity({ params: { siteId: SITE_IDS[0] } }),
+      ).to.be.rejectedWith('boom');
+    });
+
     it('grants access to an S2S consumer holding site:readAll', async () => {
       context.attributes.authInfo.withProfile({ is_admin: false });
       context.s2sConsumer = makeS2SConsumer();

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1390,6 +1390,9 @@ describe('Sites Controller', () => {
         baseURL: 'https://site1.com',
         deliveryType: 'aem_edge',
       });
+      expect(loggerStub.info).to.have.been.calledWithMatch(
+        /\[acl\] GET \/sites\/:siteId\/identity granted via admin bypass siteId=.* requestId=unknown/,
+      );
     });
 
     it('returns 404 for an unknown site without touching the org lookup', async () => {
@@ -1418,6 +1421,19 @@ describe('Sites Controller', () => {
       const body = await result.json();
 
       expect(result.status).to.equal(200);
+      expect(body.organizationId).to.equal(ORG_ID);
+      expect(body.imsOrgId).to.equal(null);
+    });
+
+    it('returns 200 with imsOrgId null when the organizationId is orphaned (org not found)', async () => {
+      sites[0].getOrganizationId = () => ORG_ID;
+      mockDataAccess.Organization.findById.resolves(null);
+
+      const result = await sitesController.getIdentity({ params: { siteId: SITE_IDS[0] } });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Organization.findById).to.have.been.calledOnceWith(ORG_ID);
       expect(body.organizationId).to.equal(ORG_ID);
       expect(body.imsOrgId).to.equal(null);
     });

--- a/test/dto/site-identity.test.js
+++ b/test/dto/site-identity.test.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { SiteIdentityDto } from '../../src/dto/site-identity.js';
+
+describe('SiteIdentityDto', () => {
+  const buildSite = ({
+    id = '7511d4b9-1234-4abc-8def-0123456789ab',
+    organizationId = '160da889-5678-4cde-9f01-23456789abcd',
+    baseURL = 'https://example.com',
+    deliveryType = 'aem_edge',
+  } = {}) => ({
+    getId: () => id,
+    getOrganizationId: () => organizationId,
+    getBaseURL: () => baseURL,
+    getDeliveryType: () => deliveryType,
+  });
+
+  describe('toJSON', () => {
+    it('exposes exactly the minimal routing identity surface', () => {
+      const result = SiteIdentityDto.toJSON(buildSite(), '8C6043F15F43B6390A49401A@AdobeOrg');
+
+      expect(result).to.deep.equal({
+        siteId: '7511d4b9-1234-4abc-8def-0123456789ab',
+        organizationId: '160da889-5678-4cde-9f01-23456789abcd',
+        imsOrgId: '8C6043F15F43B6390A49401A@AdobeOrg',
+        baseURL: 'https://example.com',
+        deliveryType: 'aem_edge',
+      });
+    });
+
+    it('does not leak any tenant fields beyond the frozen surface', () => {
+      const result = SiteIdentityDto.toJSON(buildSite(), '8C6043F15F43B6390A49401A@AdobeOrg');
+
+      expect(Object.keys(result)).to.have.members([
+        'siteId', 'organizationId', 'imsOrgId', 'baseURL', 'deliveryType',
+      ]);
+    });
+
+    it('normalizes a missing imsOrgId to null', () => {
+      expect(SiteIdentityDto.toJSON(buildSite(), null).imsOrgId).to.equal(null);
+      expect(SiteIdentityDto.toJSON(buildSite(), undefined).imsOrgId).to.equal(null);
+    });
+
+    it('normalizes a missing organizationId to null', () => {
+      const orglessSite = {
+        getId: () => '7511d4b9-1234-4abc-8def-0123456789ab',
+        getOrganizationId: () => undefined,
+        getBaseURL: () => 'https://example.com',
+        getDeliveryType: () => 'aem_edge',
+      };
+      const result = SiteIdentityDto.toJSON(orglessSite, null);
+
+      expect(result.organizationId).to.equal(null);
+      expect(result.imsOrgId).to.equal(null);
+    });
+  });
+});

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -292,8 +292,15 @@ export default function siteTests(getHttpClient, resetData) {
         const http = getHttpClient();
         const res = await http.s2sConsumerReadAll.get(`/sites/${SITE_1_ID}/identity`);
         expect(res.status).to.equal(200);
-        expect(res.body.siteId).to.equal(SITE_1_ID);
-        expect(res.body.imsOrgId).to.equal(ORG_1_IMS_ORG_ID);
+        // Full-shape assertion (like the admin case) so an accidental extra field
+        // leaking through the readAll path is caught, not just siteId/imsOrgId.
+        expect(res.body).to.deep.equal({
+          siteId: SITE_1_ID,
+          organizationId: ORG_1_ID,
+          imsOrgId: ORG_1_IMS_ORG_ID,
+          baseURL: SITE_1_BASE_URL,
+          deliveryType: 'aem_edge',
+        });
       });
 
       it('s2sConsumerReadOnly: returns 403 (only has site:read, no site:readAll)', async () => {

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import { expectISOTimestamp } from '../helpers/assertions.js';
 import {
   ORG_1_ID,
+  ORG_1_IMS_ORG_ID,
   ORG_2_ID,
   SITE_1_ID,
   SITE_1_BASE_URL,
@@ -265,6 +266,60 @@ export default function siteTests(getHttpClient, resetData) {
         const http = getHttpClient();
         const res = await http.readOnlyAdmin.post('/sites', { baseURL: 'https://ro-admin-test.example.com' });
         expect(res.status).to.equal(403);
+      });
+    });
+
+    describe('GET /sites/:siteId/identity', () => {
+      // readAll-class single-site route: returns only the routing identity and resolves
+      // imsOrgId via the site->organization join. Gated on site:readAll, NOT site:read,
+      // so it is cross-tenant and there is no hasAccess(site) per-entity check.
+      // See docs/s2s/READALL_CAPABILITY_DESIGN.md.
+
+      it('admin: returns the routing identity with the resolved imsOrgId', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get(`/sites/${SITE_1_ID}/identity`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.deep.equal({
+          siteId: SITE_1_ID,
+          organizationId: ORG_1_ID,
+          imsOrgId: ORG_1_IMS_ORG_ID,
+          baseURL: SITE_1_BASE_URL,
+          deliveryType: 'aem_edge',
+        });
+      });
+
+      it('s2sConsumerReadAll: returns the identity for any site (site:readAll, cross-tenant)', async () => {
+        const http = getHttpClient();
+        const res = await http.s2sConsumerReadAll.get(`/sites/${SITE_1_ID}/identity`);
+        expect(res.status).to.equal(200);
+        expect(res.body.siteId).to.equal(SITE_1_ID);
+        expect(res.body.imsOrgId).to.equal(ORG_1_IMS_ORG_ID);
+      });
+
+      it('s2sConsumerReadOnly: returns 403 (only has site:read, no site:readAll)', async () => {
+        // Layer 1 (s2sAuthWrapper) denies — the route maps to site:readAll which
+        // CONSUMER_1 does NOT hold.
+        const http = getHttpClient();
+        const res = await http.s2sConsumerReadOnly.get(`/sites/${SITE_1_ID}/identity`);
+        expect(res.status).to.equal(403);
+      });
+
+      it('s2sConsumerUnknown: returns 403 (no Consumer row for the (clientId, imsOrgId) pair)', async () => {
+        const http = getHttpClient();
+        const res = await http.s2sConsumerUnknown.get(`/sites/${SITE_1_ID}/identity`);
+        expect(res.status).to.equal(403);
+      });
+
+      it('admin: returns 404 for a non-existent site', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get(`/sites/${NON_EXISTENT_SITE_ID}/identity`);
+        expect(res.status).to.equal(404);
+      });
+
+      it('returns 400 for an invalid UUID', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites/not-a-uuid/identity');
+        expect(res.status).to.equal(400);
       });
     });
 

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -46,6 +46,7 @@ describe('getRouteHandlers', () => {
     getAllAsExcel: sinon.stub(),
     getAllWithLatestAudit: sinon.stub(),
     getByID: sinon.stub(),
+    getIdentity: sinon.stub(),
     getByBaseURL: sinon.stub(),
     getPageCitabilityCounts: sinon.stub(),
   };
@@ -858,6 +859,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/preflights/:preflightId',
       'GET /sites/detect/jobs/:jobId',
       'GET /sites/:siteId',
+      'GET /sites/:siteId/identity',
       'PATCH /sites/:siteId',
       'PATCH /sites/:siteId/config/cdn-logs',
       'GET /sites/:siteId/config/scraper',
@@ -1173,6 +1175,8 @@ describe('getRouteHandlers', () => {
     expect(dynamicRoutes['DELETE /organizations/:organizationId/feature-flags/:product/:flagName'].paramNames).to.deep.equal(['organizationId', 'product', 'flagName']);
     expect(dynamicRoutes['GET /sites/:siteId'].handler).to.equal(mockSitesController.getByID);
     expect(dynamicRoutes['GET /sites/:siteId'].paramNames).to.deep.equal(['siteId']);
+    expect(dynamicRoutes['GET /sites/:siteId/identity'].handler).to.equal(mockSitesController.getIdentity);
+    expect(dynamicRoutes['GET /sites/:siteId/identity'].paramNames).to.deep.equal(['siteId']);
     expect(dynamicRoutes['GET /sites/by-delivery-type/:deliveryType'].handler).to.equal(mockSitesController.getAllByDeliveryType);
     expect(dynamicRoutes['GET /sites/by-delivery-type/:deliveryType'].paramNames).to.deep.equal(['deliveryType']);
     expect(dynamicRoutes['GET /sites/by-base-url/:baseURL'].handler).to.equal(mockSitesController.getByBaseURL);


### PR DESCRIPTION
## Problem

Platform S2S consumers (notably DRS / llmo-data-retrieval-service) hold a SpaceCat **site UUID** and need to read tenant-scoped routes such as `GET /sites/{siteId}` (`site:read`). Under the S2S model those require a **customer-scoped** token minted for the site's owning IMS org — but the only authoritative source of that `imsOrgId` is `GET /sites/{id}`, the very call the consumer cannot make yet. This bootstrap circularity forced DRS to enumerate the entire estate (`GET /sites` + `GET /organizations`) and cache a `siteId -> {imsOrgId, baseURL}` index in memory. On a cold Lambda container that index isn't built, resolution fails, the platform token falls back onto the tenant route, and SpaceCat correctly returns **403** — the recurring cold-start 403 class (Jira LLMO-5147, LLMO-5512).

## Change

Adds a single-site **identity** endpoint that returns the minimal routing identity for one site, gated on the **existing `site:readAll` capability** platform consumers already hold:

```
GET /sites/{siteId}/identity        capability: site:readAll (CAP_SITE_READ_ALL)
```

```json
{
  "siteId": "7511d4b9-...",
  "organizationId": "160da889-...",
  "imsOrgId": "8C6043F15F43B6390A49401A@AdobeOrg",
  "baseURL": "https://example.com",
  "deliveryType": "aem_edge"
}
```

The consumer then bootstraps deterministically — `GET /sites/{id}/identity` (platform token, always callable) -> `imsOrgId` -> mint customer-scoped token -> `GET /sites/{id}`. No index, no S3 snapshot, no warm-up race, no cold-start 403.

### Design notes

- The `Site -> Organization` join (`imsOrgId`) is the entire value-add — exactly the field a consumer cannot obtain without already being scoped, and no existing route performs it behind a readAll gate.
- Access mirrors the `GET /sites` readAll list handler (admin bypass + `hasS2SCapability(CAP_SITE_READ_ALL)`), **not** `hasAccess(site)`. This is intentionally a readAll-class route: it exposes strictly **less** than the bulk `GET /sites` a `site:readAll` holder can already enumerate, so it leaks no field bulk readAll doesn't already return, and it does not weaken tenant isolation for any other route.
- A dedicated, minimal `SiteIdentityDto` keeps the surface frozen so it cannot accrete tenant config / LLMO data / audits over time.
- An unresolvable owning org (no `organizationId`, orphaned org, or org without an `imsOrgId`) yields `imsOrgId: null` with a **200** — the site identity still exists; the consumer treats `null` as "cannot scope". The contract defines only `200` (site found) and `404` (no site).
- **No auth-service change and no new capability grant** — the DRS platform consumer already holds `site:readAll`. Consistent with `docs/s2s/READALL_CAPABILITY_DESIGN.md`.

## What's included

- Route wired in `src/routes/index.js`; capability mapped to `CAP_SITE_READ_ALL` in `src/routes/required-capabilities.js` (readAll group).
- `getIdentity` controller method in `src/controllers/sites.js` and new `src/dto/site-identity.js`.
- OpenAPI: `GET /sites/{siteId}/identity` path + `SiteIdentity` schema; `npm run docs:lint` valid, `docs:build` regenerated.
- Unit tests — controller (200 happy path, 404 unknown site, 400 invalid id, null-imsOrg and org-less edge cases, S2S readAll grant + S2S read-only 403), DTO (frozen surface + null normalization), route map + capability-drift coverage. `npm run lint` and the affected unit suites are green.
- Integration tests in `test/it/shared/tests/sites.js` — admin 200 (asserts resolved `imsOrgId`), `s2sConsumerReadAll` 200 (cross-tenant), `s2sConsumerReadOnly`/`s2sConsumerUnknown` 403, 404 unknown, 400 invalid UUID.

> Note: the IT suite (`test/it/postgres`) was not executed locally — it pulls `mysticat-data-service` from dev ECR and the local AWS session is expired (needs interactive `klam login`). The IT block mirrors the existing, passing `GET /sites` readAll tests exactly; CI has ECR access and will run it.

## Consumer-side follow-up (separate, in DRS)

DRS repoints its cold-miss scope resolution to this endpoint and retires (or downgrades to best-effort) the in-memory site index — eliminating the cold-start 403 class structurally. Tracked under Jira LLMO-5512.

## Related Issues

Closes adobe/spacecat-api-service#2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)