### PR TITLE
fix(llmo): retire categories.category_id business key; resolve prompt category filter by UUID (LLMO-5515)

### DIFF
--- a/docs/openapi/categories-v2-api.yaml
+++ b/docs/openapi/categories-v2-api.yaml
@@ -67,7 +67,7 @@ v2-categories-for-org:
         downgraded from `human` to `ai`), returns `200 OK` with the
         updated row.
       - **Soft-deleted row matched** — resurrected: status flipped to
-        `active`, stable `id` (slug) preserved, returns `201 Created`.
+        `active`, stable `id` (UUID) preserved, returns `201 Created`.
 
       Clients discriminating creation from idempotent update should inspect
       the HTTP status, not the response body (identical in both cases).
@@ -88,10 +88,9 @@ v2-categories-for-org:
     responses:
       '200':
         description: |
-          Existing category returned (idempotent update or no-op).
-          The `id` (slug) of the returned row is authoritative — it may
-          differ from a client-supplied `id` if the stored row was created
-          with a different slug.
+          Existing category returned (idempotent update or no-op). The `id`
+          (UUID) of the returned row is the server-assigned primary key and
+          is authoritative.
         content:
           application/json:
             schema:
@@ -118,9 +117,7 @@ v2-categories-for-org:
              deleted) between our lookup and our update — message
              `Category was concurrently modified; please retry`.
           2. A unique-constraint other than `uq_category_name_per_org` was
-             tripped on insert (e.g. `uq_category_id_per_org` when the
-             client-supplied slug collides with an unrelated existing
-             row). Message echoes the actual constraint name.
+             tripped on insert. Message echoes the actual constraint name.
           Treated as an idempotent retry signal by DRS-class clients;
           logged at WARN (not ERROR) server-side.
       '500':
@@ -141,10 +138,11 @@ v2-category-for-org:
     - name: categoryId
       in: path
       required: true
-      description: Category business key (category_id slug)
+      description: Category UUID (categories.id)
       schema:
         type: string
-        example: 'baseurl-discovery-research'
+        format: uuid
+        example: 'a1b2c3d4-5678-90ab-cdef-1234567890ab'
   patch:
     tags:
       - customer-config

--- a/docs/openapi/prompts-v2-api.yaml
+++ b/docs/openapi/prompts-v2-api.yaml
@@ -37,7 +37,11 @@ v2-prompts-by-brand:
       required: false
       schema:
         type: string
-      description: Filter by category business key
+        format: uuid
+      description: |
+        Filter by category UUID (categories.id). A categoryId that does not
+        resolve to a category in this organization returns an empty page
+        (the filter fails closed; it is never silently dropped).
     - name: topicId
       in: query
       required: false

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -6246,7 +6246,8 @@ V2Prompt:
       description: Regions where this prompt is applicable
     categoryId:
       type: string
-      description: Category business key
+      format: uuid
+      description: Category UUID (categories.id)
     topicId:
       type: string
       description: Topic business key
@@ -6293,14 +6294,17 @@ V2Prompt:
       properties:
         id:
           type: string
+          format: uuid
           description: |
-            Currently the UUID PK (categories.id) for backward compat —
-            aligning this to the category_id business key is a deferred
-            breaking change. Use `uuid` for FK linkage today.
+            UUID primary key (categories.id). The sole category identifier
+            (the legacy category_id business key was retired — LLMO-5515).
+            `id` and `uuid` carry the same value; either works for FK linkage.
         uuid:
           type: string
           format: uuid
-          description: UUID primary key (categories.id)
+          description: |
+            UUID primary key (categories.id). Alias of `id`, kept for
+            backward compatibility.
         name:
           type: string
         origin:
@@ -7493,12 +7497,16 @@ V2Category:
   properties:
     id:
       type: string
-      description: Category business key (category_id slug). Stable once assigned.
-      example: 'baseurl-discovery-research'
+      format: uuid
+      description: |
+        UUID primary key (categories.id) — the sole category identifier.
+        Use this value on the CRUD path params and the `?categoryId=` prompt
+        filter. The legacy category_id business key was retired (LLMO-5515).
+      example: 'a1b2c3d4-5678-90ab-cdef-1234567890ab'
     uuid:
       type: string
       format: uuid
-      description: UUID primary key (categories.id)
+      description: UUID primary key (categories.id). Alias of `id`.
     name:
       type: string
       description: |
@@ -7541,12 +7549,6 @@ V2CategoryInput:
   required:
     - name
   properties:
-    id:
-      type: string
-      description: |
-        Client-supplied slug. Used only when inserting a brand-new row; for
-        existing rows the stored `id` is preserved (FK stability).
-      example: 'discovery-research'
     name:
       type: string
       description: Human-readable category name. Canonicalized on write.

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -943,7 +943,7 @@ function BrandsController(ctx, log, env) {
       // without grepping messages. LLMO-4370 #15.
       log.info(`Category POST resolved for organization ${spaceCatId}`, {
         organization_id: spaceCatId,
-        category_id: category.id,
+        category_uuid: category.id,
         outcome,
       });
 
@@ -978,6 +978,9 @@ function BrandsController(ctx, log, env) {
       }
       if (!hasText(categoryId)) {
         return badRequest('Category ID required');
+      }
+      if (!isValidUUID(categoryId)) {
+        return badRequest('Category ID must be a valid UUID');
       }
 
       const organization = await getOrganizationOrNotFound(spaceCatId);
@@ -1033,6 +1036,9 @@ function BrandsController(ctx, log, env) {
       }
       if (!hasText(categoryId)) {
         return badRequest('Category ID required');
+      }
+      if (!isValidUUID(categoryId)) {
+        return badRequest('Category ID must be a valid UUID');
       }
 
       const organization = await getOrganizationOrNotFound(spaceCatId);

--- a/src/support/categories-storage.js
+++ b/src/support/categories-storage.js
@@ -45,8 +45,16 @@ function conflictError(message, cause) {
 }
 
 function mapDbCategoryToV2(row) {
+  // `id` is the UUID primary key (`categories.id`). It is the sole public
+  // identifier the v2 API exposes and the value clients send back on the
+  // CRUD path params and the `?categoryId=` prompt filter. The legacy TEXT
+  // business key (`categories.category_id`) is being retired (LLMO-5515): it
+  // could hold a UUID-shaped slug for multibyte names, which the prompt-filter
+  // resolver misread as a real UUID and silently dropped the filter, returning
+  // every prompt for the brand. `uuid` is kept as an alias of `id` for any
+  // consumer still reading it; both now carry the same UUID.
   return {
-    id: row.category_id,
+    id: row.id,
     uuid: row.id,
     name: row.name,
     status: row.status || 'active',
@@ -193,7 +201,7 @@ async function resolveExistingCategory(
     // reading individual rows. LLMO-4370 #13.
     log?.warn?.('Blocked origin downgrade human->ai on category', {
       organization_id: organizationId,
-      category_id: existing.category_id,
+      category_uuid: existing.id,
       attempted_origin: category.origin,
       current_origin: existing.origin,
     });
@@ -223,18 +231,17 @@ async function resolveExistingCategory(
  *
  * If a non-deleted category with the same name already exists for the
  * organization, its non-key fields are refreshed (origin/status/updated_by)
- * and the existing row is returned — the stable `category_id` slug is
- * preserved so foreign-key references remain valid.
+ * and the existing row is returned — its UUID primary key (`categories.id`)
+ * is stable so foreign-key references remain valid.
  *
  * Rationale: clients (notably DRS) re-post the same canonical categories
- * on every sync run with a potentially drifted slug. Without name-level
- * idempotency, every such re-post trips `uq_category_name_per_org` and
- * surfaces as a 409 — thousands per day of false-positive ERROR logs.
- * See LLMO-4370.
+ * on every sync run. Without name-level idempotency, every such re-post
+ * trips `uq_category_name_per_org` and surfaces as a 409 — thousands per day
+ * of false-positive ERROR logs. See LLMO-4370.
  *
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat organization UUID
- * @param {object} params.category - Category data { name, id?, origin?, status? }
+ * @param {object} params.category - Category data { name, origin?, status? }
  * @param {object} params.postgrestClient - PostgREST client
  * @param {string} [params.updatedBy] - User performing the operation
  * @param {object} [params.log] - Logger for operator signals (downgrade blocks)
@@ -271,28 +278,13 @@ export async function createCategory({
     );
   }
 
-  // Derive a slug from the canonical name when none supplied, trimming
-  // leading/trailing dashes so "   !!  " and Unicode-only names don't
-  // produce a degenerate bare '-'. The client-supplied slug is trusted
-  // verbatim (FK-stability).
-  let derivedSlug;
-  if (category.id) {
-    derivedSlug = category.id;
-  } else {
-    derivedSlug = canonicalName
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-    if (!derivedSlug) {
-      throw new Error(
-        'Category name produces an empty slug after normalization; supply an explicit `id`',
-      );
-    }
-  }
-
+  // The UUID primary key (`categories.id`) is the only identifier we manage.
+  // We no longer derive or persist the legacy `category_id` slug (LLMO-5515):
+  // the column defaults to `gen_random_uuid()::text` in the DB and is unused
+  // by the application layer. A slug derived from a multibyte name could be
+  // empty or UUID-shaped — the latter is exactly what broke the prompt filter.
   const row = {
     organization_id: organizationId,
-    category_id: derivedSlug,
     name: canonicalName,
     origin: category.origin || 'human',
     status: category.status || 'active',
@@ -330,11 +322,11 @@ export async function createCategory({
           );
         }
       } else {
-        // Any other unique-constraint violation (e.g. slug collision via
-        // uq_category_id_per_org when the client ships a drifted `id` that
-        // maps to a different name already occupying that slug) surfaces as
-        // a typed 409 echoing the actual constraint — mirrors the topics
-        // pattern so callers don't have to mine 500 bodies. LLMO-4370 #5/#6.
+        // Any other unique-constraint violation surfaces as a typed 409
+        // echoing the actual constraint — mirrors the topics pattern so
+        // callers don't have to mine 500 bodies. LLMO-4370 #5/#6. (The legacy
+        // `uq_category_per_org` slug constraint is no longer reachable from
+        // here now that `category_id` is left to its random DB default.)
         throw conflictError(
           `Category conflicts with ${constraint} for this organization`,
           error,
@@ -347,11 +339,11 @@ export async function createCategory({
 }
 
 /**
- * Updates a category by its business key (category_id).
+ * Updates a category by its UUID primary key (categories.id).
  *
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat organization UUID
- * @param {string} params.categoryId - category_id business key
+ * @param {string} params.categoryId - categories.id UUID
  * @param {object} params.updates - Partial category data
  * @param {object} params.postgrestClient - PostgREST client
  * @param {string} [params.updatedBy] - User performing the operation
@@ -379,7 +371,7 @@ export async function updateCategory({
     .from('categories')
     .update(patch)
     .eq('organization_id', organizationId)
-    .eq('category_id', categoryId)
+    .eq('id', categoryId)
     .select()
     .maybeSingle();
 
@@ -407,7 +399,7 @@ export async function updateCategory({
  *
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat organization UUID
- * @param {string} params.categoryId - category_id business key
+ * @param {string} params.categoryId - categories.id UUID
  * @param {object} params.postgrestClient - PostgREST client
  * @param {string} [params.updatedBy] - User performing the operation
  * @returns {Promise<boolean>} True if deleted, false if not found
@@ -423,7 +415,7 @@ export async function deleteCategory({
     .from('categories')
     .update({ status: 'deleted', updated_by: updatedBy })
     .eq('organization_id', organizationId)
-    .eq('category_id', categoryId)
+    .eq('id', categoryId)
     .select('id')
     .maybeSingle();
 

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -176,26 +176,32 @@ export async function resolveBrandUuid(organizationId, brandId, postgrestClient)
 }
 
 /**
- * Resolves category business key or UUID to categories.id (uuid).
- * When categoryId is a UUID it is looked up by primary key scoped to the
- * organization (consistent with resolveBrandUuid) — this validates org
- * ownership rather than blindly trusting the caller-supplied UUID.
- * When categoryId is a business key it is looked up by category_id as before.
+ * Resolves a category UUID to categories.id (uuid), validating that the row
+ * belongs to the organization. The v2 API exposes only the UUID primary key
+ * (`categories.id`) as the category identifier, so the input must be a UUID.
+ *
+ * Returns null for anything that is not a valid UUID or does not resolve to a
+ * row in the org. Callers that filter by category MUST treat null as "no
+ * match" (return empty), never as "no filter" — the legacy dual-path
+ * (UUID-or-business-key) silently dropped the filter when a UUID-shaped
+ * business key failed to resolve, returning every prompt for the brand
+ * (LLMO-5515).
  *
  * @param {string} organizationId - SpaceCat organization UUID
- * @param {string} categoryId - Business key or UUID
+ * @param {string} categoryId - categories.id UUID
  * @param {object} postgrestClient - PostgREST client
  * @returns {Promise<string|null>} categories.id (uuid) or null
  */
 export async function resolveCategoryUuid(organizationId, categoryId, postgrestClient) {
-  if (!hasText(categoryId) || !postgrestClient?.from) {
+  if (!hasText(categoryId) || !isValidUUID(categoryId) || !postgrestClient?.from) {
     return null;
   }
-  const query = postgrestClient.from('categories').select('id').eq('organization_id', organizationId);
-  const { data, error } = await (isValidUUID(categoryId)
-    ? query.eq('id', categoryId)
-    : query.eq('category_id', categoryId)
-  ).maybeSingle();
+  const { data, error } = await postgrestClient
+    .from('categories')
+    .select('id')
+    .eq('organization_id', organizationId)
+    .eq('id', categoryId)
+    .maybeSingle();
   return !error && data?.id ? data.id : null;
 }
 
@@ -256,7 +262,9 @@ async function buildLookupMaps(organizationId, postgrestClient) {
  * Ensures that all referenced categories and topics exist in their respective
  * tables. Creates any missing ones (by name) and updates the lookup maps in place.
  * Map keys are normalized (lowercase + trim) for case-insensitive matching.
- * The name is also used as the business key (category_id / topic_id) for new entries.
+ * New categories dedup on (organization_id, name) — the legacy `category_id`
+ * business key is no longer set and falls to its random DB default (LLMO-5515).
+ * New topics still set the `topic_id` business key from the name.
  */
 // eslint-disable-next-line max-len
 async function ensureLookupEntries(organizationId, prompts, categoryMap, topicMap, postgrestClient, updatedBy) {
@@ -281,13 +289,12 @@ async function ensureLookupEntries(organizationId, prompts, categoryMap, topicMa
         .upsert(
           missingCatNames.map((name) => ({
             organization_id: organizationId,
-            category_id: name,
             name,
             origin: 'human',
             status: 'active',
             updated_by: updatedBy,
           })),
-          { onConflict: 'organization_id,category_id' },
+          { onConflict: 'organization_id,name' },
         )
         .select('id,name')
         .then(({ data, error }) => {
@@ -398,8 +405,8 @@ function mapRowToPrompt(row) {
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat organization UUID
  * @param {string} [params.brandId] - Filter by brand (uuid or config id)
- * @param {string} [params.categoryId] - Filter by category business key
- * @param {string} [params.topicId] - Filter by topic business key
+ * @param {string} [params.categoryId] - Filter by category UUID (categories.id)
+ * @param {string} [params.topicId] - Filter by topic business key or UUID
  * @param {string} [params.status] - Filter by status (active, pending, deleted)
  * @param {string} [params.search] - Free-text search across prompt text, name,
  * topic name, category name
@@ -448,15 +455,29 @@ export async function listPrompts({
   const pageNum = Math.max(1, Number(page) || 1);
   const offset = (pageNum - 1) * limitNum;
 
+  // Resolve category/topic filters up front and FAIL CLOSED: when a filter is
+  // requested but does not resolve to a row in this org, return an empty page
+  // rather than dropping the filter and returning every prompt for the brand.
+  // Mirrors the brandUuid guard above. The unfiltered-leak this prevents was
+  // LLMO-5515 (a UUID-shaped category business key that resolved to no row).
+  const emptyPage = {
+    items: [], total: 0, limit: limitNum, page: pageNum,
+  };
+
   let categoryUuid = null;
+  if (hasText(categoryId)) {
+    categoryUuid = await resolveCategoryUuid(organizationId, categoryId, postgrestClient);
+    if (!categoryUuid) {
+      return emptyPage;
+    }
+  }
+
   let topicUuid = null;
-  if (hasText(categoryId) || hasText(topicId)) {
-    categoryUuid = hasText(categoryId)
-      ? await resolveCategoryUuid(organizationId, categoryId, postgrestClient)
-      : null;
-    topicUuid = hasText(topicId)
-      ? await resolveTopicUuid(organizationId, topicId, postgrestClient)
-      : null;
+  if (hasText(topicId)) {
+    topicUuid = await resolveTopicUuid(organizationId, topicId, postgrestClient);
+    if (!topicUuid) {
+      return emptyPage;
+    }
   }
 
   const buildSelect = (includeIntent) => `
@@ -476,7 +497,7 @@ export async function listPrompts({
     updated_at,
     updated_by,
     brands(id,name),
-    categories(id,category_id,name,origin),
+    categories(id,name,origin),
     topics(id,topic_id,name)
   `;
 
@@ -599,7 +620,7 @@ export async function getPromptById({
       updated_at,
       updated_by,
       brands(id,name),
-      categories(id,category_id,name,origin),
+      categories(id,name,origin),
       topics(id,topic_id,name)
     `)
     .eq('organization_id', organizationId)

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -38,6 +38,9 @@ describe('Brands Controller', () => {
   };
 
   const ORGANIZATION_ID = '9033554c-de8a-44ac-a356-09b51af8cc28';
+  // Category CRUD now addresses rows by the categories.id UUID, not the
+  // retired category_id business key (LLMO-5515).
+  const CATEGORY_UUID = 'c1111111-1111-4111-b111-111111111111';
   const SITE_ID = '0b4dcf79-fe5f-410b-b11f-641f0bf56da3';
   const IMS_ORG_ID = '1234567890ABCDEF12345678@AdobeOrg';
   const BRAND_ID = 'brand123';
@@ -3126,7 +3129,8 @@ describe('Brands Controller', () => {
       const response = await brandsController.createCategoryForOrg({
         ...context,
         params: { spaceCatId: ORGANIZATION_ID },
-        // Client posts a drifted slug; the stable `category_id` must be preserved.
+        // Client posts a stray `id`; it is ignored. The stable UUID PK is
+        // authoritative and is what `id` reflects (LLMO-5515).
         data: { id: 'discovery-research', name: 'Discovery & Research' },
         dataAccess: mockDataAccess,
         attributes: { authInfo: { profile: { email: 'tester@adobe.com' } } },
@@ -3134,7 +3138,9 @@ describe('Brands Controller', () => {
 
       expect(response.status).to.equal(200);
       const body = await response.json();
-      expect(body.id).to.equal('baseurl-discovery-research');
+      // `id` is now the UUID primary key (== `uuid`), not the retired
+      // category_id business key.
+      expect(body.id).to.equal('uuid-existing');
       expect(body.uuid).to.equal('uuid-existing');
     });
 
@@ -3274,7 +3280,7 @@ describe('Brands Controller', () => {
     it('returns 200 when category is updated', async () => {
       const response = await brandsController.updateCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         data: { name: 'Updated Category' },
         dataAccess: mockDataAccess,
         attributes: { authInfo: { profile: { email: 'user@test.com' } } },
@@ -3297,7 +3303,7 @@ describe('Brands Controller', () => {
     it('returns 400 when spaceCatId is not a valid UUID', async () => {
       const response = await brandsController.updateCategoryForOrg({
         ...context,
-        params: { spaceCatId: 'not-a-uuid', categoryId: 'my-category' },
+        params: { spaceCatId: 'not-a-uuid', categoryId: CATEGORY_UUID },
         data: { name: 'Updated' },
         dataAccess: mockDataAccess,
       });
@@ -3314,13 +3320,23 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('returns 400 when categoryId is not a valid UUID (business keys retired, LLMO-5515)', async () => {
+      const response = await brandsController.updateCategoryForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        data: { name: 'Updated' },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
     it('returns 404 when organization is not found', async () => {
       mockDataAccess.Organization.findById.resolves(null);
       brandsController = BrandsController(context, loggerStub, mockEnv);
 
       const response = await brandsController.updateCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         data: { name: 'Updated' },
         dataAccess: mockDataAccess,
       });
@@ -3333,7 +3349,7 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.updateCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         data: { name: 'Updated' },
         dataAccess: mockDataAccess,
       });
@@ -3355,7 +3371,7 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.updateCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'nonexistent' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         data: { name: 'Updated' },
         dataAccess: mockDataAccess,
       });
@@ -3379,7 +3395,7 @@ describe('Brands Controller', () => {
       }, loggerStub, mockEnv);
 
       const response = await unauthorizedController.updateCategoryForOrg({
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         data: { name: 'Updated' },
         dataAccess: mockDataAccess,
       });
@@ -3394,7 +3410,7 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.updateCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         data: { name: 'Updated' },
         dataAccess: mockDataAccess,
       });
@@ -3427,7 +3443,7 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.updateCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         data: { name: 'Collides With Sibling' },
         dataAccess: mockDataAccess,
         attributes: { authInfo: { profile: { email: 'tester@adobe.com' } } },
@@ -3457,7 +3473,7 @@ describe('Brands Controller', () => {
     it('returns 204 when category is deleted', async () => {
       const response = await brandsController.deleteCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         dataAccess: mockDataAccess,
         attributes: { authInfo: { profile: { email: 'user@test.com' } } },
       });
@@ -3476,7 +3492,7 @@ describe('Brands Controller', () => {
     it('returns 400 when spaceCatId is not a valid UUID', async () => {
       const response = await brandsController.deleteCategoryForOrg({
         ...context,
-        params: { spaceCatId: 'not-a-uuid', categoryId: 'my-category' },
+        params: { spaceCatId: 'not-a-uuid', categoryId: CATEGORY_UUID },
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(400);
@@ -3491,13 +3507,22 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('returns 400 when categoryId is not a valid UUID (business keys retired, LLMO-5515)', async () => {
+      const response = await brandsController.deleteCategoryForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
     it('returns 404 when organization is not found', async () => {
       mockDataAccess.Organization.findById.resolves(null);
       brandsController = BrandsController(context, loggerStub, mockEnv);
 
       const response = await brandsController.deleteCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(404);
@@ -3509,7 +3534,7 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.deleteCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(503);
@@ -3530,7 +3555,7 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.deleteCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'nonexistent' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(404);
@@ -3553,7 +3578,7 @@ describe('Brands Controller', () => {
       }, loggerStub, mockEnv);
 
       const response = await unauthorizedController.deleteCategoryForOrg({
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(403);
@@ -3567,7 +3592,7 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.deleteCategoryForOrg({
         ...context,
-        params: { spaceCatId: ORGANIZATION_ID, categoryId: 'my-category' },
+        params: { spaceCatId: ORGANIZATION_ID, categoryId: CATEGORY_UUID },
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(500);

--- a/test/it/shared/tests/categories-prompts.js
+++ b/test/it/shared/tests/categories-prompts.js
@@ -13,138 +13,173 @@
 import { expect } from 'chai';
 import { ORG_1_ID, BRAND_1_ID } from '../seed-ids.js';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
- * Integration tests for the category slug-as-name bug (LLMO-4060).
+ * Integration tests for category identity and the category prompt-count filter.
+ *
+ * The legacy `categories.category_id` TEXT business key has been retired
+ * (LLMO-5515). Categories are now addressed exclusively by their `categories.id`
+ * UUID primary key, and the prompt-list `categoryId` filter resolves against
+ * that UUID and FAILS CLOSED — a categoryId that does not resolve returns an
+ * empty page rather than the brand's full prompt set. The original bug: a
+ * UUID-shaped business key resolved to no row, the filter was silently dropped,
+ * and a brand-new (e.g. Japanese-named) category showed a phantom prompt count
+ * equal to every prompt for the brand.
  *
  * Validates:
- * 1. Fallback path: category exists with unprefixed slug, prompt references prefixed slug
- *    — the fallback strips the DRS prefix and resolves to the existing category
- * 2. Fix verification: POST categories with explicit id preserves name, no duplicates
- * 3. Idempotency: duplicate category creation returns 200 (idempotent update),
- *    not 201 (insert). See LLMO-4370 — the status-code contract flipped from
- *    `201|409` (old upsert) to `200|201` (idempotent-by-name), so callers can
- *    discriminate a fresh row from a re-post without parsing the body.
+ * 1. Category create returns a UUID `id` (== `uuid`), idempotent by name.
+ * 2. A non-ASCII (multibyte) category name is stored and listed without error.
+ * 3. The prompt-list `categoryId` filter resolves by UUID and fails closed for
+ *    unknown UUIDs and for non-UUID values (no phantom counts).
  *
  * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
  * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
  */
 export default function categoriesPromptsTests(getHttpClient, resetData) {
-  describe('Categories & Prompts (LLMO-4060)', () => {
-    // ── Fallback path (slugToName defense-in-depth) ──
+  describe('Categories & Prompts (UUID identity, LLMO-5515)', () => {
+    // ── Category identity is a UUID, idempotent by name ──
 
-    describe('Fallback: category exists with unprefixed slug, prompt references prefixed slug', () => {
+    describe('Category create returns a UUID id and is idempotent by name', () => {
       before(() => resetData());
 
-      it('resolves to the existing category via unprefixed slug lookup', async () => {
+      it('returns a UUID id on create and the same id on idempotent re-post', async () => {
         const http = getHttpClient();
 
-        // 1. Create a category WITHOUT an explicit id — API auto-derives slug from name
-        //    Stored category_id = "comparison-decision" (no prefix)
-        const catRes = await http.admin.post(
-          `/v2/orgs/${ORG_1_ID}/categories`,
-          { name: 'Comparison & Decision', origin: 'ai' },
-        );
-        expect(catRes.status).to.equal(201);
-        expect(catRes.body.id).to.equal('comparison-decision');
+        const payload = { name: 'Comparison & Decision', origin: 'ai' };
 
-        // 2. Post prompts referencing "baseurl-comparison-decision" (prefixed slug).
-        //    Upsert fails (name collision), fallback strips prefix and finds
-        //    the existing "comparison-decision" category.
-        const promptRes = await http.admin.post(
-          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
-          [
-            {
-              prompt: 'What is the best tool for comparison?',
-              regions: ['us'],
-              categoryId: 'baseurl-comparison-decision',
-            },
-          ],
-        );
-        expect(promptRes.status).to.equal(201);
-        expect(promptRes.body.created).to.equal(1);
+        // First POST — inserts a new row, server assigns the UUID primary key.
+        const res1 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/categories`, payload);
+        expect(res1.status).to.equal(201);
+        expect(res1.body.id).to.match(UUID_RE);
+        expect(res1.body.uuid).to.equal(res1.body.id);
+        expect(res1.body.name).to.equal('Comparison & Decision');
+        const { id: categoryUuid } = res1.body;
 
-        // 3. Only ONE category should exist — no duplicate created
+        // Second POST with the same name — idempotent by name, returns 200 and
+        // the SAME stable UUID. No client-supplied identifier is honored.
+        const res2 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/categories`, payload);
+        expect(res2.status).to.equal(200);
+        expect(res2.body.id).to.equal(categoryUuid);
+
+        // Only ONE category exists — no duplicate.
         const listRes = await http.admin.get(`/v2/orgs/${ORG_1_ID}/categories`);
         expect(listRes.status).to.equal(200);
-
-        const cats = listRes.body.categories;
-        const matches = cats.filter((c) => c.name === 'Comparison & Decision');
+        const matches = listRes.body.categories.filter((c) => c.name === 'Comparison & Decision');
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].id).to.equal('comparison-decision');
+        expect(matches[0].id).to.equal(categoryUuid);
         expect(matches[0].origin).to.equal('ai');
       });
-    });
 
-    // ── Fix verification ──
-
-    describe('Fix: POST categories with explicit id', () => {
-      before(() => resetData());
-
-      it('stores category with the provided id and preserves the readable name', async () => {
+      it('ignores a client-supplied id — the UUID primary key is authoritative', async () => {
         const http = getHttpClient();
 
-        // 1. Create category WITH explicit id (the DRS fix)
-        const catRes = await http.admin.post(
+        const res = await http.admin.post(
           `/v2/orgs/${ORG_1_ID}/categories`,
           { id: 'baseurl-discovery-research', name: 'Discovery & Research', origin: 'ai' },
         );
-        expect(catRes.status).to.equal(201);
-        expect(catRes.body.id).to.equal('baseurl-discovery-research');
-        expect(catRes.body.name).to.equal('Discovery & Research');
-
-        // 2. Post prompts referencing the same prefixed categoryId
-        const promptRes = await http.admin.post(
-          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
-          [
-            {
-              prompt: 'How do users discover products?',
-              regions: ['us'],
-              categoryId: 'baseurl-discovery-research',
-            },
-          ],
-        );
-        expect(promptRes.status).to.equal(201);
-        expect(promptRes.body.created).to.equal(1);
-
-        // 3. Verify: only ONE category with that id, name is the readable one
-        const listRes = await http.admin.get(`/v2/orgs/${ORG_1_ID}/categories`);
-        expect(listRes.status).to.equal(200);
-
-        const cats = listRes.body.categories;
-        const matches = cats.filter((c) => c.id === 'baseurl-discovery-research');
-        expect(matches).to.have.lengthOf(1);
-        expect(matches[0].name).to.equal('Discovery & Research');
-        expect(matches[0].origin).to.equal('ai');
+        expect(res.status).to.equal(201);
+        // The stray slug-shaped id is NOT used; the returned id is a UUID.
+        expect(res.body.id).to.match(UUID_RE);
+        expect(res.body.id).to.not.equal('baseurl-discovery-research');
+        expect(res.body.name).to.equal('Discovery & Research');
       });
     });
 
-    // ── Idempotency ──
+    // ── Multibyte names (the cohort that surfaced the bug) ──
 
-    describe('Category creation is idempotent by name (200 on re-post)', () => {
+    describe('Multibyte category names are stored and listed without error', () => {
       before(() => resetData());
 
-      it('second POST with the same name returns 200 (idempotent update)', async () => {
+      it('creates a Japanese-named category with a UUID id', async () => {
         const http = getHttpClient();
 
-        const payload = { id: 'baseurl-test', name: 'Test', origin: 'ai' };
+        const res = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/categories`,
+          { name: '日本語カテゴリ', origin: 'human' },
+        );
+        expect(res.status).to.equal(201);
+        expect(res.body.id).to.match(UUID_RE);
+        expect(res.body.name).to.equal('日本語カテゴリ');
 
-        const res1 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/categories`, payload);
-        expect(res1.status).to.equal(201);
-
-        // Second call — idempotent by name: the existing row is matched,
-        // no-op short-circuits (identical fields), response is 200. This
-        // lets DRS-class clients discriminate "created new" from "ensured
-        // existing" without parsing the body. LLMO-4370.
-        const res2 = await http.admin.post(`/v2/orgs/${ORG_1_ID}/categories`, payload);
-        expect(res2.status).to.equal(200);
-
-        // Only one category exists — no duplicate.
         const listRes = await http.admin.get(`/v2/orgs/${ORG_1_ID}/categories`);
         expect(listRes.status).to.equal(200);
-
-        const matches = listRes.body.categories.filter((c) => c.id === 'baseurl-test');
+        const matches = listRes.body.categories.filter((c) => c.name === '日本語カテゴリ');
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].name).to.equal('Test');
+        expect(matches[0].id).to.equal(res.body.id);
+      });
+    });
+
+    // ── The category prompt-count filter (the LLMO-5515 regression guard) ──
+
+    describe('Prompt-list categoryId filter resolves by UUID and fails closed', () => {
+      before(() => resetData());
+
+      it('returns only the prompts linked to the category, and an empty page for unresolved filters', async () => {
+        const http = getHttpClient();
+
+        // 1. Create a category; capture its UUID.
+        const catRes = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/categories`,
+          { name: 'Editing', origin: 'human' },
+        );
+        expect(catRes.status).to.equal(201);
+        const categoryUuid = catRes.body.id;
+        expect(categoryUuid).to.match(UUID_RE);
+
+        // 2. Post two prompts under that category (linked by category name) and
+        //    one prompt with NO category.
+        const promptRes = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
+          [
+            { prompt: 'How do I crop an image?', regions: ['us'], category: 'Editing' },
+            { prompt: 'How do I remove a background?', regions: ['us'], category: 'Editing' },
+            { prompt: 'Unrelated prompt with no category', regions: ['us'] },
+          ],
+        );
+        expect(promptRes.status).to.equal(201);
+        expect(promptRes.body.created).to.equal(3);
+
+        // 3. Filtering by the real category UUID returns exactly the two linked
+        //    prompts — and their embedded category.id / .uuid is that UUID.
+        const filtered = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts?categoryId=${categoryUuid}`,
+        );
+        expect(filtered.status).to.equal(200);
+        expect(filtered.body.total).to.equal(2);
+        expect(filtered.body.items).to.have.lengthOf(2);
+        filtered.body.items.forEach((p) => {
+          expect(p.category.id).to.equal(categoryUuid);
+          expect(p.category.uuid).to.equal(categoryUuid);
+        });
+
+        // 4. No filter returns all three prompts — proving the filter above
+        //    actually narrowed the set rather than the brand being empty.
+        const unfiltered = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
+        );
+        expect(unfiltered.status).to.equal(200);
+        expect(unfiltered.body.total).to.equal(3);
+
+        // 5. FAIL CLOSED: a valid-but-unknown category UUID returns an EMPTY
+        //    page — never the brand's full prompt set (the LLMO-5515 phantom
+        //    count). This is the core regression guard.
+        const unknownUuid = 'f0000000-0000-4000-b000-000000000000';
+        const unknown = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts?categoryId=${unknownUuid}`,
+        );
+        expect(unknown.status).to.equal(200);
+        expect(unknown.body.total).to.equal(0);
+        expect(unknown.body.items).to.have.lengthOf(0);
+
+        // 6. FAIL CLOSED: a non-UUID categoryId (e.g. a legacy business key)
+        //    also returns an empty page — business keys are retired.
+        const legacyKey = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts?categoryId=baseurl-editing`,
+        );
+        expect(legacyKey.status).to.equal(200);
+        expect(legacyKey.body.total).to.equal(0);
+        expect(legacyKey.body.items).to.have.lengthOf(0);
       });
     });
   });

--- a/test/it/shared/tests/topics.js
+++ b/test/it/shared/tests/topics.js
@@ -142,19 +142,21 @@ export default function topicTests(getHttpClient, resetData) {
       it('drops soft-deleted categories from categoryUuids', async () => {
         const http = getHttpClient();
 
-        // Create two categories and link both to one topic
+        // Create two categories and link both to one topic. Categories are
+        // addressed exclusively by their UUID `id` (LLMO-5515) — the server
+        // assigns it; no client-supplied business key is honored.
         const catARes = await http.admin.post(
           `/v2/orgs/${ORG_1_ID}/categories`,
-          { id: 'soft-del-cat-a', name: 'CatA', origin: 'human' },
+          { name: 'CatA', origin: 'human' },
         );
         const catBRes = await http.admin.post(
           `/v2/orgs/${ORG_1_ID}/categories`,
-          { id: 'soft-del-cat-b', name: 'CatB', origin: 'human' },
+          { name: 'CatB', origin: 'human' },
         );
         expect(catARes.status).to.equal(201);
         expect(catBRes.status).to.equal(201);
-        const catA = catARes.body.uuid;
-        const catB = catBRes.body.uuid;
+        const catA = catARes.body.id;
+        const catB = catBRes.body.id;
 
         // Create topic linked to catA, then patch a second link to catB via
         // re-POST (upsert keeps both junction rows).
@@ -167,9 +169,9 @@ export default function topicTests(getHttpClient, resetData) {
           { id: 'multi-cat-topic', name: 'Multi Cat Topic', categoryId: catB },
         );
 
-        // Soft-delete catB
+        // Soft-delete catB by its UUID
         const delRes = await http.admin.delete(
-          `/v2/orgs/${ORG_1_ID}/categories/soft-del-cat-b`,
+          `/v2/orgs/${ORG_1_ID}/categories/${catB}`,
         );
         expect(delRes.status).to.be.oneOf([200, 204]);
 

--- a/test/support/categories-storage.test.js
+++ b/test/support/categories-storage.test.js
@@ -74,7 +74,9 @@ describe('categories-storage', () => {
 
       const result = await listCategories({ organizationId: ORG_ID, postgrestClient });
       expect(result).to.have.length(1);
-      expect(result[0].id).to.equal('brand-awareness');
+      // `id` is now the UUID primary key (categories.id), not the legacy
+      // category_id business key. `uuid` is an alias carrying the same value.
+      expect(result[0].id).to.equal('uuid-1');
       expect(result[0].uuid).to.equal('uuid-1');
       expect(result[0].name).to.equal('Brand Awareness');
       expect(result[0].createdAt).to.equal('2026-01-01T00:00:00Z');
@@ -192,25 +194,15 @@ describe('categories-storage', () => {
       })).to.be.rejectedWith('Category name is required');
     });
 
-    it('rejects names that canonicalize to a degenerate slug when no id is supplied', async () => {
-      // Non-ASCII-only names collapse to a bare "-" via the slug derivation
-      // `replace(/[^a-z0-9]+/g, '-')`. Rejecting at the API boundary keeps
-      // such rows from landing with meaningless FKs. Caller can opt out
-      // by supplying an explicit `id`.
-      const postgrestClient = createSequentialClient([
-        { data: null, error: null },
-      ]);
-      await expect(createCategory({
-        organizationId: ORG_ID,
-        category: { name: '日本語' },
-        postgrestClient,
-      })).to.be.rejectedWith(/empty slug/);
-    });
-
-    it('accepts non-ASCII names when the client supplies an explicit slug', async () => {
+    it('inserts non-ASCII (e.g. multibyte) names without deriving a slug', async () => {
+      // Regression guard for LLMO-5515: a multibyte name like "日本語" used
+      // to collapse to a degenerate slug and either throw or fall back to a
+      // random UUID-shaped category_id. We no longer derive a slug at all —
+      // the UUID primary key is the only identifier, so the insert just
+      // succeeds and the returned `id` is the server-assigned UUID.
       const insertedRow = {
         id: 'uuid-jp',
-        category_id: 'japanese-cat',
+        category_id: 'gen-random-default-ignored',
         name: '日本語',
         status: 'active',
         origin: 'human',
@@ -226,14 +218,44 @@ describe('categories-storage', () => {
 
       const result = await createCategory({
         organizationId: ORG_ID,
-        category: { id: 'japanese-cat', name: '日本語' },
+        category: { name: '日本語' },
         postgrestClient,
         updatedBy: 'user@test.com',
       });
 
       expect(result.created).to.be.true;
       expect(result.outcome).to.equal('insert');
-      expect(result.category.id).to.equal('japanese-cat');
+      expect(result.category.id).to.equal('uuid-jp');
+    });
+
+    it('ignores a client-supplied id on insert — the UUID primary key is authoritative', async () => {
+      // The v2 API no longer accepts a client-supplied slug. Even if a legacy
+      // caller sends `id`, it is dropped: the returned `id` is the DB UUID PK.
+      const insertedRow = {
+        id: 'uuid-server-assigned',
+        category_id: 'ignored',
+        name: 'New Category',
+        status: 'active',
+        origin: 'human',
+        created_at: '2026-04-20',
+        created_by: 'user@test.com',
+        updated_at: '2026-04-20',
+        updated_by: 'user@test.com',
+      };
+      const postgrestClient = createSequentialClient([
+        { data: null, error: null },
+        { data: insertedRow, error: null },
+      ]);
+
+      const result = await createCategory({
+        organizationId: ORG_ID,
+        category: { id: 'client-slug', name: 'New Category' },
+        postgrestClient,
+        updatedBy: 'user@test.com',
+      });
+
+      expect(result.created).to.be.true;
+      expect(result.category.id).to.equal('uuid-server-assigned');
     });
 
     it('canonicalizes the stored name (trim, whitespace-collapse, NFC) and finds case-variants as existing', async () => {
@@ -308,8 +330,9 @@ describe('categories-storage', () => {
       });
 
       expect(capturedInsert.row.name).to.equal('Edge Case');
-      // Slug is derived from the canonical name too.
-      expect(capturedInsert.row.category_id).to.equal('edge-case');
+      // No slug/business key is derived anymore — the DB default fills
+      // category_id (a deprecated column) and the UUID PK is authoritative.
+      expect(capturedInsert.row).to.not.have.property('category_id');
     });
 
     it('inserts a new category when no row matches by name', async () => {
@@ -341,7 +364,7 @@ describe('categories-storage', () => {
 
       expect(result.created).to.be.true;
       expect(result.outcome).to.equal('insert');
-      expect(result.category.id).to.equal('my-new-category');
+      expect(result.category.id).to.equal('uuid-new');
       expect(result.category.name).to.equal('My New Category');
       expect(result.category.createdAt).to.equal('2026-03-01T00:00:00Z');
     });
@@ -378,7 +401,7 @@ describe('categories-storage', () => {
       expect(result.created).to.be.false;
       expect(result.outcome).to.equal('noop');
       expect(result.category.uuid).to.equal('uuid-existing');
-      expect(result.category.id).to.equal('baseurl-discovery-research');
+      expect(result.category.id).to.equal('uuid-existing');
       // Audit fields preserved — no UPDATE fired.
       expect(result.category.updatedBy).to.equal('first@test.com');
       expect(postgrestClient.from).to.have.been.calledOnce;
@@ -558,7 +581,7 @@ describe('categories-storage', () => {
       expect(result.created).to.be.false;
       expect(result.outcome).to.equal('race_retry_noop');
       expect(result.category.uuid).to.equal('uuid-raced');
-      expect(result.category.id).to.equal('concurrent');
+      expect(result.category.id).to.equal('uuid-raced');
     });
 
     it('marks the race-recovery path outcome as race_retry when a patch actually applies', async () => {
@@ -603,13 +626,13 @@ describe('categories-storage', () => {
       expect(result.category.status).to.equal('active');
     });
 
-    it('surfaces a typed 409 when a 23505 fires against a non-name constraint (slug collision)', async () => {
-      // Scenario: client POSTs {id: 'foo', name: 'NewName'}. Lookup by
-      // 'NewName' finds nothing. INSERT trips `uq_category_id_per_org`
-      // because slug `foo` is already occupied by a different row with a
-      // different name. Mirror the topics pattern — surface as a typed
-      // 409 with constraint echo so callers don't see a generic 500 on
-      // what is really a constraint conflict. LLMO-4370 #5/#6.
+    it('surfaces a typed 409 when a 23505 fires against a non-name constraint', async () => {
+      // Defensive path: any 23505 whose constraint is NOT
+      // `uq_category_name_per_org` is surfaced as a typed 409 with the
+      // constraint echoed, rather than a generic 500. The legacy
+      // `uq_category_id_per_org` constraint still exists on the deprecated
+      // category_id column (DB drop deferred — LLMO-5515); a DB-default
+      // UUID collision there would land here. Mirror the topics pattern.
       const insertError = {
         code: '23505',
         message: 'duplicate key value violates unique constraint "uq_category_id_per_org"',
@@ -621,7 +644,7 @@ describe('categories-storage', () => {
 
       const err = await createCategory({
         organizationId: ORG_ID,
-        category: { id: 'foo', name: 'NewName' },
+        category: { name: 'NewName' },
         postgrestClient,
       }).catch((e) => e);
 
@@ -791,7 +814,7 @@ describe('categories-storage', () => {
       expect(result.outcome).to.equal('resurrect');
       expect(result.category.uuid).to.equal('uuid-deleted');
       expect(result.category.status).to.equal('active');
-      expect(result.category.id).to.equal('legacy-slug');
+      expect(result.category.id).to.equal('uuid-deleted');
     });
 
     // Resurrection × provenance matrix — LLMO-4370 #10.
@@ -962,11 +985,13 @@ describe('categories-storage', () => {
 
       expect(log.warn).to.have.been.calledOnce;
       // Structured fields are passed as a second arg so operators can
-      // filter by organization_id / category_id in Coralogix.
+      // filter by organization_id / category_uuid in Coralogix. We log the
+      // stable UUID (categories.id), not the retired category_id business
+      // key (LLMO-5515).
       const [, fields] = log.warn.firstCall.args;
       expect(fields).to.include({
         organization_id: ORG_ID,
-        category_id: 'curated-warn',
+        category_uuid: 'uuid-warn',
         attempted_origin: 'ai',
         current_origin: 'human',
       });
@@ -1041,7 +1066,9 @@ describe('categories-storage', () => {
       });
 
       expect(result).to.not.be.null;
-      expect(result.id).to.equal('test');
+      // `id` is the UUID primary key (categories.id), not the retired
+      // category_id business key (LLMO-5515).
+      expect(result.id).to.equal('uuid-1');
       expect(result.origin).to.equal('ai');
       expect(result.status).to.equal('pending');
     });

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -574,6 +574,47 @@ describe('prompts-storage', () => {
       expect(result.total).to.equal(0);
     });
 
+    it('fails closed (empty page) when a topicId filter does not resolve', async () => {
+      // Regression guard for LLMO-5515: symmetric with the categoryId guard
+      // above. A topicId that does not resolve to a topic in this org must
+      // return an EMPTY page, never the full unfiltered set. We use a
+      // valid-but-unknown UUID so the topics lookup actually fires and
+      // returns no row.
+      const unknownUuid = 'd4444444-4444-4444-b444-444444444444';
+      const row = {
+        prompt_id: PROMPT_ID,
+        name: 'Test',
+        text: 'Prompt',
+        regions: [],
+        status: 'active',
+        origin: 'human',
+        updated_at: '2026-01-01T00:00:00Z',
+        updated_by: 'system',
+        brands: { id: BRAND_UUID, name: 'Brand' },
+        categories: null,
+        topics: null,
+      };
+      const client = {
+        from: (table) => {
+          if (table === 'brands') {
+            return makeChain({ data: { id: BRAND_UUID }, error: null });
+          }
+          if (table === 'topics') {
+            return makeChain({ data: null, error: null });
+          }
+          return makeChain({ data: [row], error: null, count: 1 });
+        },
+      };
+      const result = await listPrompts({
+        organizationId: ORG_ID,
+        brandId: BRAND_UUID,
+        topicId: unknownUuid,
+        postgrestClient: client,
+      });
+      expect(result.items).to.have.lengthOf(0);
+      expect(result.total).to.equal(0);
+    });
+
     it('applies categoryId and topicId filters when provided', async () => {
       const categoryUuid = 'a1111111-1111-4111-b111-111111111111';
       const row = {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -153,10 +153,13 @@ describe('prompts-storage', () => {
       expect(result).to.be.null;
     });
 
-    it('returns category id when found by business key', async () => {
+    it('returns null when categoryId is not a valid UUID (business-key lookup retired, LLMO-5515)', async () => {
+      // Pre-LLMO-5515 this resolved a TEXT business key to its UUID. The
+      // category_id business key is gone — the only accepted identifier is
+      // the categories.id UUID. A non-UUID never hits the DB and fails closed.
       const client = { from: () => makeChain({ data: { id: 'cat-uuid' }, error: null }) };
       const result = await resolveCategoryUuid(ORG_ID, 'cat-1', client);
-      expect(result).to.equal('cat-uuid');
+      expect(result).to.be.null;
     });
 
     it('resolves by primary key scoped to org when categoryId is a valid UUID', async () => {
@@ -508,7 +511,14 @@ describe('prompts-storage', () => {
       expect(result.items[0].status).to.equal('pending');
     });
 
-    it('skips category filter when categoryId not found', async () => {
+    it('fails closed (empty page) when a categoryId filter does not resolve', async () => {
+      // Regression guard for LLMO-5515: a categoryId that does not resolve to
+      // a category in this org must return an EMPTY page, never the full
+      // unfiltered set. The old behavior silently dropped the filter (fail
+      // open), surfacing every prompt for the brand as a phantom count. We
+      // use a valid-but-unknown UUID so the DB lookup actually fires and
+      // returns no row.
+      const unknownUuid = 'c3333333-3333-4333-b333-333333333333';
       const row = {
         prompt_id: PROMPT_ID,
         name: 'Test',
@@ -536,13 +546,36 @@ describe('prompts-storage', () => {
       const result = await listPrompts({
         organizationId: ORG_ID,
         brandId: BRAND_UUID,
+        categoryId: unknownUuid,
+        postgrestClient: client,
+      });
+      expect(result.items).to.have.lengthOf(0);
+      expect(result.total).to.equal(0);
+    });
+
+    it('fails closed (empty page) when a categoryId is not a valid UUID', async () => {
+      // A non-UUID categoryId can never match (business keys are retired,
+      // LLMO-5515). It must fail closed without even hitting the DB.
+      const client = {
+        from: (table) => {
+          if (table === 'brands') {
+            return makeChain({ data: { id: BRAND_UUID }, error: null });
+          }
+          return makeChain({ data: null, error: null });
+        },
+      };
+      const result = await listPrompts({
+        organizationId: ORG_ID,
+        brandId: BRAND_UUID,
         categoryId: 'nonexistent-category',
         postgrestClient: client,
       });
-      expect(result.items).to.have.lengthOf(1);
+      expect(result.items).to.have.lengthOf(0);
+      expect(result.total).to.equal(0);
     });
 
     it('applies categoryId and topicId filters when provided', async () => {
+      const categoryUuid = 'a1111111-1111-4111-b111-111111111111';
       const row = {
         id: 'prompt-pk-uuid-2',
         prompt_id: PROMPT_ID,
@@ -555,10 +588,10 @@ describe('prompts-storage', () => {
         updated_by: 'system',
         brands: { id: BRAND_UUID, name: 'Brand' },
         categories: {
-          id: 'cat-uuid', category_id: 'photoshop', name: 'Photoshop', origin: 'human',
+          id: categoryUuid, name: 'Photoshop', origin: 'human',
         },
         topics: {
-          id: 'topic-uuid', topic_id: 'editing', name: 'Editing', category_id: 'photoshop',
+          id: 'topic-uuid', topic_id: 'editing', name: 'Editing', category_id: categoryUuid,
         },
       };
       const client = {
@@ -567,7 +600,7 @@ describe('prompts-storage', () => {
             return makeChain({ data: { id: BRAND_UUID }, error: null });
           }
           if (table === 'categories') {
-            return makeChain({ data: { id: 'cat-uuid' }, error: null });
+            return makeChain({ data: { id: categoryUuid }, error: null });
           }
           if (table === 'topics') {
             return makeChain({ data: { id: 'topic-uuid' }, error: null });
@@ -578,7 +611,7 @@ describe('prompts-storage', () => {
       const result = await listPrompts({
         organizationId: ORG_ID,
         brandId: BRAND_UUID,
-        categoryId: 'photoshop',
+        categoryId: categoryUuid,
         topicId: 'editing',
         postgrestClient: client,
       });
@@ -589,7 +622,7 @@ describe('prompts-storage', () => {
       // topic.uuid to populate brand_presence_executions.category_id /
       // .topic_id FKs.
       expect(result.items[0].category).to.deep.equal({
-        id: 'cat-uuid', uuid: 'cat-uuid', name: 'Photoshop', origin: 'human',
+        id: categoryUuid, uuid: categoryUuid, name: 'Photoshop', origin: 'human',
       });
       expect(result.items[0].topic).to.deep.equal({
         id: 'topic-uuid', uuid: 'topic-uuid', name: 'Editing',
@@ -1108,7 +1141,10 @@ describe('prompts-storage', () => {
               }),
             }),
             upsert: (rows) => {
-              if (rows[0]?.category_id !== undefined) {
+              // Categories dedup on (organization_id, name) and carry an
+              // `origin` field; topics still carry the `topic_id` business
+              // key (out of scope for LLMO-5515).
+              if (rows[0]?.origin !== undefined) {
                 upsertedRows.categories = rows;
               }
               if (rows[0]?.topic_id !== undefined) {
@@ -1137,9 +1173,11 @@ describe('prompts-storage', () => {
         postgrestClient: client,
       });
       expect(result.created).to.equal(1);
-      // Verify the upserted rows use the name as both category_id/topic_id and name
+      // Categories dedup on name only — no category_id business key is set
+      // anymore (LLMO-5515); the DB default fills the deprecated column.
       expect(upsertedRows.categories[0].name).to.equal('New Cat');
-      expect(upsertedRows.categories[0].category_id).to.equal('New Cat');
+      expect(upsertedRows.categories[0]).to.not.have.property('category_id');
+      // Topics still set the topic_id business key from the name.
       expect(upsertedRows.topics[0].name).to.equal('New Topic');
       expect(upsertedRows.topics[0].topic_id).to.equal('New Topic');
     });


### PR DESCRIPTION
## Problem

A brand-new category (e.g. a Japanese-named one) showed a **phantom "Prompts" count** equal to *every* prompt for the brand.

Root cause: the legacy `categories.category_id` TEXT business key (DB default `gen_random_uuid()::text`) was exposed as the category `id`. The prompt-list `categoryId` filter resolved that value against `categories.id` (the real UUIDv7 PK), found **no row**, and `listPrompts` then **silently dropped the filter (fail-open)** — returning the brand's entire prompt set.

`categories.category_id` was always redundant: `name` is already unique per org (`uq_category_name_per_org`) and `id` is the UUIDv7 PK. The duplicate business key was pure surface area for bugs.

## Change (app layer now, DB column drop deferred)

- **`mapDbCategoryToV2`** returns `id = uuid = categories.id` (the UUID PK). No more business key.
- **`createCategory`** no longer sets `category_id` (the DB default fills it); no slug derivation.
- **`resolveCategoryUuid`** is **UUID-only** — non-UUID input resolves to `null`.
- **`listPrompts`** **fails closed**: when a `categoryId`/`topicId` filter is requested but doesn't resolve, it returns an **empty page** instead of the full set.
- **Category CRUD** (`update`/`delete`) addresses rows by UUID `id`; controllers validate the path param is a UUID (`400` otherwise).
- OpenAPI specs (`categoryId` → `format: uuid`, fail-closed note, `V2Category.id` → uuid, removed client-supplied id), unit tests, and the PostgreSQL IT factory updated.

The physical column drop (`categories.category_id`, `uq_category_per_org`, `idx_categories_category_id`) is filed as a **follow-up** (screen for non-spacecat consumers first).

## Testing

- `npm run lint` ✓ · `npm test` (436 in touched suites, full build job green) ✓ · `npm run docs:lint` / `docs:build` ✓
- `it-postgres` ✓ (after fixing one pre-existing IT that soft-deleted a category by its legacy slug instead of UUID)

## Paired change

Requires the matching UI change in **project-elmo-ui** (consumes `categories.id` as the single identifier).

Relates to LLMO-5476 · Fixes LLMO-5515

🤖 Generated with [Claude Code](https://claude.com/claude-code)