### PR TITLE
feat: expose GET /organizations/:organizationId/trial-users to S2S consumers via trialUser:read capability

### DIFF
--- a/src/controllers/trial-users.js
+++ b/src/controllers/trial-users.js
@@ -31,6 +31,7 @@ import { TrialUser as TrialUserModel } from '@adobe/spacecat-shared-data-access'
 import { ImsClient } from '@adobe/spacecat-shared-ims-client';
 import { TrialUserDto } from '../dto/trial-user.js';
 import AccessControlUtil from '../support/access-control-util.js';
+import { CAP_TRIAL_USER_READ } from '../routes/capability-constants.js';
 
 /**
  * Builds the email payload XML for trial user invitation.
@@ -81,7 +82,16 @@ function TrialUsersController(ctx) {
         return notFound('Organization not found');
       }
 
-      if (!await accessControlUtil.hasAccess(organization)) {
+      // Dual-layer access check: admin bypass → S2S capability → org membership
+      const isAdmin = accessControlUtil.hasAdminAccess();
+      const s2sResult = isAdmin
+        ? { allowed: false, reason: 'admin-bypass' }
+        : await accessControlUtil.hasS2SCapability(CAP_TRIAL_USER_READ);
+
+      if (s2sResult.allowed) {
+        const requestId = context?.invocation?.id || 'unknown';
+        context.log.info(`[s2s] GET /organizations/:organizationId/trial-users granted clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} capability=${CAP_TRIAL_USER_READ} requestId=${requestId}`);
+      } else if (!isAdmin && !await accessControlUtil.hasAccess(organization)) {
         return forbidden('Access denied to this organization');
       }
 

--- a/src/controllers/trial-users.js
+++ b/src/controllers/trial-users.js
@@ -83,15 +83,16 @@ function TrialUsersController(ctx) {
       }
 
       // Dual-layer access check: admin bypass → S2S capability → org membership
+      const requestId = context?.invocation?.id || 'unknown';
       const isAdmin = accessControlUtil.hasAdminAccess();
       const s2sResult = isAdmin
         ? { allowed: false, reason: 'admin-bypass' }
         : await accessControlUtil.hasS2SCapability(CAP_TRIAL_USER_READ);
 
       if (s2sResult.allowed) {
-        const requestId = context?.invocation?.id || 'unknown';
         context.log.info(`[s2s] GET /organizations/:organizationId/trial-users granted clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} capability=${CAP_TRIAL_USER_READ} requestId=${requestId}`);
       } else if (!isAdmin && !await accessControlUtil.hasAccess(organization)) {
+        context.log.info(`[acl] Denied GET /organizations/:organizationId/trial-users - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'} requestId=${requestId}`);
         return forbidden('Access denied to this organization');
       }
 

--- a/src/routes/capability-constants.js
+++ b/src/routes/capability-constants.js
@@ -30,3 +30,5 @@ export const CAP_SITE_CREATE = 'site:create';
 export const CAP_FIX_ENTITY_CREATE = 'fixEntity:create';
 
 export const CAP_SUGGESTION_WRITE = 'suggestion:write';
+
+export const CAP_TRIAL_USER_READ = 'trialUser:read';

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -18,6 +18,7 @@ import {
   CAP_SITE_CREATE,
   CAP_SITE_READ_ALL,
   CAP_SUGGESTION_WRITE,
+  CAP_TRIAL_USER_READ,
 } from './capability-constants.js';
 
 /**
@@ -138,9 +139,8 @@ export const INTERNAL_ROUTES = [
   'PATCH /plg/records/:plgOnboardingId',
   'DELETE /plg/records/:plgOnboardingId',
 
-  // Tier-specific - user activities (POST only), trial users, user details: end-user/admin flows
+  // Tier-specific - user activities (POST only), user details: end-user/admin flows
   'POST /sites/:siteId/user-activities',
-  'GET /organizations/:organizationId/trial-users',
   'GET /admin/users/:userId',
   'GET /organizations/:organizationId/userDetails/:externalUserId',
   'POST /organizations/:organizationId/userDetails',
@@ -619,6 +619,9 @@ const routeRequiredCapabilities = {
 
   // Site Enrollments
   'GET /sites/:siteId/site-enrollments': 'siteEnrollment:read',
+
+  // Trial Users
+  'GET /organizations/:organizationId/trial-users': CAP_TRIAL_USER_READ,
 
   // Entitlements
   'GET /organizations/:organizationId/entitlements': 'entitlement:read',

--- a/test/controllers/trial-users.test.js
+++ b/test/controllers/trial-users.test.js
@@ -102,6 +102,8 @@ describe('Trial User Controller', () => {
 
   const mockAccessControlUtil = {
     hasAccess: sandbox.stub().resolves(true),
+    hasAdminAccess: sandbox.stub().returns(false),
+    hasS2SCapability: sandbox.stub().resolves({ allowed: false, reason: 'no-capability' }),
   };
 
   const mockLogger = {
@@ -119,6 +121,8 @@ describe('Trial User Controller', () => {
     // Create a mock AccessControlUtil instance that will be used by the controller
     const mockAccessControlUtilInstance = {
       hasAccess: sandbox.stub().resolves(true),
+      hasAdminAccess: sandbox.stub().returns(false),
+      hasS2SCapability: sandbox.stub().resolves({ allowed: false, reason: 'no-capability' }),
     };
 
     // Stub AccessControlUtil.fromContext to return our mock instance
@@ -168,8 +172,10 @@ describe('Trial User Controller', () => {
     mockDataAccess.TrialUser.allByEmailId = sandbox.stub().resolves([]);
     mockDataAccess.Organization.findById = sandbox.stub().resolves(mockOrganization);
 
-    // Store reference to the mock instance for test manipulation
+    // Store references to the mock instance for test manipulation
     mockAccessControlUtil.hasAccess = mockAccessControlUtilInstance.hasAccess;
+    mockAccessControlUtil.hasAdminAccess = mockAccessControlUtilInstance.hasAdminAccess;
+    mockAccessControlUtil.hasS2SCapability = mockAccessControlUtilInstance.hasS2SCapability;
   });
 
   afterEach(() => {
@@ -362,6 +368,59 @@ describe('Trial User Controller', () => {
       const body = await result.json();
       expect(body.message).to.equal('Organization lookup failed');
       expect(mockLogger.error).to.have.been.calledWith(`Error getting trial users for organization ${organizationId}: ${orgError.message}`);
+    });
+
+    it('should allow S2S consumer with trialUser:read capability', async () => {
+      mockAccessControlUtil.hasAdminAccess.returns(false);
+      mockAccessControlUtil.hasS2SCapability.resolves({
+        allowed: true,
+        clientId: 's2s-client-id',
+        consumerId: 's2s-consumer-id',
+      });
+
+      const context = {
+        params: { organizationId },
+        dataAccess: mockDataAccess,
+        log: mockLogger,
+        invocation: { id: 'req-123' },
+        attributes: {
+          authInfo: new AuthInfo()
+            .withType('jwt')
+            .withProfile({})
+            .withAuthenticated(true),
+        },
+      };
+
+      const result = await trialUserController.getByOrganizationID(context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.be.an('array');
+      expect(mockLogger.info).to.have.been.calledWithMatch(/\[s2s\] GET \/organizations\/:organizationId\/trial-users granted/);
+    });
+
+    it('should deny S2S consumer without trialUser:read capability and no org access', async () => {
+      mockAccessControlUtil.hasAdminAccess.returns(false);
+      mockAccessControlUtil.hasS2SCapability.resolves({ allowed: false, reason: 'missing-capability' });
+      mockAccessControlUtil.hasAccess.resolves(false);
+
+      const context = {
+        params: { organizationId },
+        dataAccess: mockDataAccess,
+        log: mockLogger,
+        attributes: {
+          authInfo: new AuthInfo()
+            .withType('jwt')
+            .withProfile({})
+            .withAuthenticated(true),
+        },
+      };
+
+      const result = await trialUserController.getByOrganizationID(context);
+
+      expect(result.status).to.equal(403);
+      const body = await result.json();
+      expect(body.message).to.equal('Access denied to this organization');
     });
   });
 

--- a/test/controllers/trial-users.test.js
+++ b/test/controllers/trial-users.test.js
@@ -370,6 +370,29 @@ describe('Trial User Controller', () => {
       expect(mockLogger.error).to.have.been.calledWith(`Error getting trial users for organization ${organizationId}: ${orgError.message}`);
     });
 
+    it('should allow admin without calling hasS2SCapability or hasAccess', async () => {
+      mockAccessControlUtil.hasAdminAccess.returns(true);
+
+      const context = {
+        params: { organizationId },
+        dataAccess: mockDataAccess,
+        log: mockLogger,
+        invocation: { id: 'req-admin' },
+        attributes: {
+          authInfo: new AuthInfo()
+            .withType('jwt')
+            .withProfile({ is_admin: true })
+            .withAuthenticated(true),
+        },
+      };
+
+      const result = await trialUserController.getByOrganizationID(context);
+
+      expect(result.status).to.equal(200);
+      expect(mockAccessControlUtil.hasS2SCapability).to.not.have.been.called;
+      expect(mockAccessControlUtil.hasAccess).to.not.have.been.called;
+    });
+
     it('should allow S2S consumer with trialUser:read capability', async () => {
       mockAccessControlUtil.hasAdminAccess.returns(false);
       mockAccessControlUtil.hasS2SCapability.resolves({

--- a/test/it/postgres/seed-data/consumers.js
+++ b/test/it/postgres/seed-data/consumers.js
@@ -24,8 +24,8 @@ import {
 /**
  * Immutable baseline consumers for IT tests.
  * Consumer 1 — ACTIVE with site:read + site:write (no readAll).
- * Consumer 2 — ACTIVE with site:readAll + organization:readAll. Used to exercise
- *   the readAll capability path through GET /sites and GET /organizations.
+ * Consumer 2 — ACTIVE with site:readAll + organization:readAll + trialUser:read. Used to
+ *   exercise readAll and trialUser:read capability paths.
  *
  * Format: snake_case (v3 / PostgreSQL / PostgREST)
  */
@@ -50,7 +50,7 @@ export const consumers = [
     ims_org_id: CONSUMER_2_IMS_ORG_ID,
     consumer_name: 'IT Test Consumer (readAll)',
     status: 'ACTIVE',
-    capabilities: ['site:readAll', 'organization:readAll'],
+    capabilities: ['site:readAll', 'organization:readAll', 'trialUser:read'],
     revoked_at: null,
     created_at: '2026-01-15T10:00:00.000Z',
     updated_at: '2026-01-15T10:00:00.000Z',

--- a/test/it/postgres/trial-users.test.js
+++ b/test/it/postgres/trial-users.test.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ctx } from './harness.js';
+import { resetPostgres } from './seed.js';
+import trialUsersTests from '../shared/tests/trial-users.js';
+
+trialUsersTests(() => ctx.httpClient, resetPostgres);

--- a/test/it/shared/tests/trial-users.js
+++ b/test/it/shared/tests/trial-users.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  ORG_1_ID,
+  ORG_2_ID,
+  NON_EXISTENT_ORG_ID,
+  TRIAL_USER_1_ID,
+} from '../seed-ids.js';
+
+/**
+ * Shared trial-users endpoint tests.
+ * Exercises GET /organizations/:organizationId/trial-users across auth personas,
+ * including the S2S capability grant/denial paths introduced in this PR.
+ *
+ * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
+ * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
+ */
+export default function trialUsersTests(getHttpClient, resetData) {
+  describe('Trial Users', () => {
+    describe('GET /organizations/:organizationId/trial-users', () => {
+      before(() => resetData());
+
+      // ── Admin path ──
+
+      it('admin: returns trial users for accessible org', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get(`/organizations/${ORG_1_ID}/trial-users`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf.at.least(1);
+        const ids = res.body.map((u) => u.id);
+        expect(ids).to.include(TRIAL_USER_1_ID);
+      });
+
+      // ── Regular user paths ──
+
+      it('user: returns trial users for accessible org', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`/organizations/${ORG_1_ID}/trial-users`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf.at.least(1);
+      });
+
+      it('user: returns 403 for org without access', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`/organizations/${ORG_2_ID}/trial-users`);
+        expect(res.status).to.equal(403);
+      });
+
+      it('user: returns 404 for non-existent org', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get(`/organizations/${NON_EXISTENT_ORG_ID}/trial-users`);
+        expect(res.status).to.equal(404);
+      });
+
+      // ── S2S capability paths ──
+
+      it('s2sConsumerReadAll: returns trial users (has trialUser:read)', async () => {
+        const http = getHttpClient();
+        const res = await http.s2sConsumerReadAll.get(`/organizations/${ORG_1_ID}/trial-users`);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf.at.least(1);
+        const ids = res.body.map((u) => u.id);
+        expect(ids).to.include(TRIAL_USER_1_ID);
+      });
+
+      it('s2sConsumerReadOnly: returns 403 (missing trialUser:read)', async () => {
+        // CONSUMER_1 has only site:read + site:write — Layer 1 denies at the
+        // capability check before the controller is even reached.
+        const http = getHttpClient();
+        const res = await http.s2sConsumerReadOnly.get(`/organizations/${ORG_1_ID}/trial-users`);
+        expect(res.status).to.equal(403);
+      });
+
+      it('s2sConsumerUnknown: returns 403 (no Consumer row)', async () => {
+        const http = getHttpClient();
+        const res = await http.s2sConsumerUnknown.get(`/organizations/${ORG_1_ID}/trial-users`);
+        expect(res.status).to.equal(403);
+      });
+    });
+  });
+}

--- a/test/routes/capability-constants.test.js
+++ b/test/routes/capability-constants.test.js
@@ -88,6 +88,7 @@ describe('capability-constants drift coverage', () => {
       join(projectRoot, 'src/controllers/organizations.js'),
       join(projectRoot, 'src/controllers/suggestions.js'),
       join(projectRoot, 'src/controllers/configuration.js'),
+      join(projectRoot, 'src/controllers/trial-users.js'),
     ];
     const controllerSource = controllerFiles
       .map((file) => readFileSync(file, 'utf8'))


### PR DESCRIPTION
## Summary

- Adds `CAP_TRIAL_USER_READ = 'trialUser:read'` constant to `capability-constants.js`
- Moves `GET /organizations/:organizationId/trial-users` from `INTERNAL_ROUTES` to `routeRequiredCapabilities` mapped to `CAP_TRIAL_USER_READ`
- Adds dual-layer access check in `TrialUsersController.getByOrganizationID`: admin bypass → S2S capability check → org membership fallback
- Adds `trial-users.js` to the capability drift coverage test scanner

## Motivation

SITES-46077 — DXM Insights dashboard (LLMO Activation & Usage Dashboard) needs to read trial users per org via S2S credentials after an auth method change broke their data refresh.

## Test plan

- [ ] `npm test` passes (all tests green)
- [ ] Existing forbidden/not-found/error paths unaffected
- [ ] New S2S tests: consumer with `trialUser:read` gets 200; consumer without capability and no org access gets 403
- [ ] Capability drift test passes with `trial-users.js` added to scanner

🤖 Generated with [Claude Code](https://claude.com/claude-code)