### PR TITLE
feat: add CJA referral traffic source and document referral-traffic API

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -534,6 +534,31 @@ paths:
     $ref: './llmo-api.yaml#/llmo-agentic-traffic-weeks'
   /sites/{siteId}/agentic-traffic/movers:
     $ref: './llmo-api.yaml#/llmo-agentic-traffic-movers'
+  # Referral Traffic PG
+  /sites/{siteId}/referral-traffic/has-data:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-has-data'
+  /sites/{siteId}/referral-traffic/filter-dimensions:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-filter-dimensions'
+  /sites/{siteId}/referral-traffic/kpis:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-kpis'
+  /sites/{siteId}/referral-traffic/trend:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-trend'
+  /sites/{siteId}/referral-traffic/by-platform:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-by-platform'
+  /sites/{siteId}/referral-traffic/by-region:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-by-region'
+  /sites/{siteId}/referral-traffic/by-page-intent:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-by-page-intent'
+  /sites/{siteId}/referral-traffic/by-url:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-by-url'
+  /sites/{siteId}/referral-traffic/by-url-trend:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-by-url-trend'
+  /sites/{siteId}/referral-traffic/by-device:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-by-device'
+  /sites/{siteId}/referral-traffic/business-impact:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-business-impact'
+  /sites/{siteId}/referral-traffic/weeks:
+    $ref: './llmo-api.yaml#/llmo-referral-traffic-weeks'
   /org/{spaceCatId}/brands/{brandId}/fanout-report:
     $ref: './fanout-report-api.yaml#/fanout-report'
   /org/{spaceCatId}/brands/{brandId}/brand-presence/filter-dimensions:

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -3682,3 +3682,513 @@ brand-presence-prompt-execution-status:
       - api_key: []
       - ims_key: []
       - scoped_api_key: []
+
+# ============ Referral Traffic PG (mysticat PostgREST) ============
+# Site-scoped referral traffic read endpoints backed by the mysticat PostgREST
+# data service. siteId path param is declared at path level via
+# parameters.yaml#/siteId. When the PostgREST / Postgres data service is absent
+# these endpoints return 400 (not 503). Supported `source` values: optel, cdn,
+# adobe_analytics, ga4, cja (Customer Journey Analytics).
+#
+# Date range guardrail (shared with agentic traffic): on by-url, by-url-trend
+# and business-impact, `startDate` and `endDate` must be supplied together —
+# providing only one returns 400. The requested span may not exceed 62 days; a
+# wider span returns 400. Omitting both applies the default 28-day window.
+
+llmo-referral-traffic-has-data:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Whether the site has referral traffic data
+    description: |
+      Returns whether the site has any referral traffic data and which sources
+      are available. Uses a direct table existence check (no RPC). Ignores the
+      `source` query param. Response is cacheable. `availableSources` items are
+      `optel` or `cdn` only, in priority order (optel first).
+    operationId: getReferralTrafficHasData
+    responses:
+      '200':
+        description: Referral traffic availability
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficHasData'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-filter-dimensions:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Distinct referral traffic filter values
+    description: |
+      Returns the distinct filter values (platforms, regions, devices, page
+      intents) and available sources for the selected site and date range.
+      Queries `rpc_referral_traffic_filter_dimensions`.
+    operationId: getReferralTrafficFilterDimensions
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+    responses:
+      '200':
+        description: Referral traffic filter dimensions
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficFilterDimensions'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-kpis:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Aggregated referral traffic KPIs for a site
+    description: |
+      Returns a single row of aggregated referral traffic KPI metrics for the
+      site over the requested date range. Queries `rpc_referral_traffic_kpis`.
+      `bounceRate` and `consentRate` are null for `cdn` / `adobe_analytics`
+      sources; meaningful for `optel` / `ga4`.
+    operationId: getReferralTrafficKpis
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+    responses:
+      '200':
+        description: Aggregated KPI metrics
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficKpis'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-trend:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Referral traffic KPI time series for a site
+    description: |
+      Returns referral traffic metrics per day over the requested date range.
+      Queries `rpc_referral_traffic_trend`. Business metrics (revenue, orders,
+      conversionRate, etc.) are non-null only for `adobe_analytics` / `ga4` /
+      `cja` sources; null for `optel` / `cdn`.
+    operationId: getReferralTrafficTrend
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+    responses:
+      '200':
+        description: Referral traffic KPI time series
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficTrend'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-by-platform:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Referral traffic grouped by platform
+    description: |
+      Queries `rpc_referral_traffic_by_platform`. Returns rows ordered by
+      pageviews descending. `visits`, `avgTimeOnSite`, `revenue`, `visitors`
+      and `orders` are null for `optel` / `cdn` sources.
+    operationId: getReferralTrafficByPlatform
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by platform
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficByPlatform'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-by-region:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Referral traffic grouped by region
+    description: Queries `rpc_referral_traffic_by_region`. Returns rows ordered by pageviews descending.
+    operationId: getReferralTrafficByRegion
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by region
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficByRegion'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-by-page-intent:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Referral traffic grouped by page intent
+    description: Queries `rpc_referral_traffic_by_page_intent`. Returns rows ordered by pageviews descending.
+    operationId: getReferralTrafficByPageIntent
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by page intent
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficByPageIntent'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-by-url:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Per-URL referral traffic performance analysis (paginated)
+    description: |
+      Queries `rpc_referral_traffic_by_url`. Returns a page of `pageSize` rows
+      (default 50, max 500) plus `totalCount` for pagination context. Supports
+      server-side substring search via `urlPathSearch`.
+
+      Date range guardrail: `startDate` and `endDate` must be supplied together —
+      providing only one returns `400`. The requested span may not exceed
+      62 days; a wider span returns `400`. Omitting both applies the default
+      28-day window.
+    operationId: getReferralTrafficByUrl
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - name: startDate
+        in: query
+        description: Range start (`YYYY-MM-DD`). Required if `endDate` is set; span with `endDate` must be <= 62 days.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        description: Range end (`YYYY-MM-DD`). Required if `startDate` is set; span with `startDate` must be <= 62 days.
+        schema: { type: string, format: date }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - name: pageSize
+        in: query
+        description: 'Number of rows per page (default 50, max 500). Aliases: page_size, limit'
+        schema: { type: integer, minimum: 1, maximum: 500, default: 50 }
+      - name: pageOffset
+        in: query
+        description: 'Zero-based row offset for pagination. Alias: page_offset'
+        schema: { type: integer, minimum: 0, default: 0 }
+      - name: urlPathSearch
+        in: query
+        description: 'Substring search applied to url_path server-side. Alias: url_path_search'
+        schema: { type: string }
+      - name: sortBy
+        in: query
+        description: 'Aliases: sort_by'
+        schema:
+          type: string
+          enum: [total_pageviews, url_path, bounce_rate, consent_rate, page_intent, entries, exits, avg_time_on_site, revenue]
+          default: total_pageviews
+      - name: sortOrder
+        in: query
+        description: 'Alias: sort_order'
+        schema:
+          type: string
+          enum: [asc, desc]
+          default: desc
+    responses:
+      '200':
+        description: Paginated per-URL performance analysis
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficByUrl'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-by-url-trend:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Weekly pageview trend for a single URL
+    description: |
+      Queries `rpc_referral_traffic_by_url_trend`. Returns a weekly pageview
+      time series for the exact `urlPath` (e.g. `/blog/my-post`). `urlPath` is
+      required — omitting it returns `400`.
+
+      Date range guardrail: `startDate` and `endDate` must be supplied together —
+      providing only one returns `400`. The requested span may not exceed
+      62 days; a wider span returns `400`. Omitting both applies the default
+      28-day window.
+    operationId: getReferralTrafficByUrlTrend
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - name: startDate
+        in: query
+        description: Range start (`YYYY-MM-DD`). Required if `endDate` is set; span with `endDate` must be <= 62 days.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        description: Range end (`YYYY-MM-DD`). Required if `startDate` is set; span with `startDate` must be <= 62 days.
+        schema: { type: string, format: date }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - name: urlPath
+        in: query
+        required: true
+        description: Exact URL path to trend (e.g. `/blog/my-post`). Required.
+        schema: { type: string }
+    responses:
+      '200':
+        description: Weekly pageview trend for the URL
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficUrlTrend'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-by-device:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Referral traffic grouped by device
+    description: |
+      Queries `rpc_referral_traffic_by_device`. Returns rows ordered by
+      pageviews descending. `bounceRate` is null for `cdn` / `adobe_analytics`
+      sources.
+    operationId: getReferralTrafficByDevice
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+      - { name: startDate, in: query, schema: { type: string, format: date } }
+      - { name: endDate, in: query, schema: { type: string, format: date } }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+    responses:
+      '200':
+        description: Traffic by device
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficByDevice'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-business-impact:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Referral traffic business impact metrics
+    description: |
+      Queries `rpc_referral_traffic_business_impact`. Returns aggregated business
+      impact metrics (visits, revenue, orders, conversion rate, etc.). Only
+      available for `adobe_analytics`, `ga4` and `cja` sources — supplying
+      `optel` or `cdn` returns `400` ("Business impact is only available for
+      adobe_analytics, ga4 and cja sources").
+
+      Date range guardrail: `startDate` and `endDate` must be supplied together —
+      providing only one returns `400`. The requested span may not exceed
+      62 days; a wider span returns `400`. Omitting both applies the default
+      28-day window.
+    operationId: getReferralTrafficBusinessImpact
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficBusinessImpactSource' }
+      - name: startDate
+        in: query
+        description: Range start (`YYYY-MM-DD`). Required if `endDate` is set; span with `endDate` must be <= 62 days.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        description: Range end (`YYYY-MM-DD`). Required if `startDate` is set; span with `startDate` must be <= 62 days.
+        schema: { type: string, format: date }
+      - { name: platform, in: query, schema: { type: string } }
+      - { name: region, in: query, schema: { type: string } }
+      - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
+      - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+    responses:
+      '200':
+        description: Business impact metrics
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficBusinessImpact'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []
+
+llmo-referral-traffic-weeks:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+  get:
+    tags:
+      - llmo
+    summary: Available ISO weeks for the site's referral traffic data
+    description: |
+      Returns the ISO weeks for which the site has referral traffic data,
+      derived from a min/max `traffic_date` scan (no RPC).
+    operationId: getReferralTrafficWeeks
+    parameters:
+      - name: source
+        in: query
+        schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
+    responses:
+      '200':
+        description: Available ISO weeks
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/ReferralTrafficWeeks'
+      '400': { $ref: './responses.yaml#/400' }
+      '401': { $ref: './responses.yaml#/401' }
+      '403': { $ref: './responses.yaml#/403' }
+      '500': { $ref: './responses.yaml#/500' }
+    security:
+      - api_key: []
+      - ims_key: []
+      - scoped_api_key: []

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -10466,3 +10466,492 @@ SerenityErrorResponse:
   properties:
     error: { type: string }
     message: { type: string }
+
+# ── Referral Traffic PG schemas ───────────────────────────────────────────────
+
+ReferralTrafficSource:
+  type: string
+  enum: [optel, cdn, adobe_analytics, ga4, cja]
+  default: optel
+  description: "Referral traffic data source. Unrecognised values are silently coerced to `optel` (the default) — the server does not reject out-of-enum values."
+
+ReferralTrafficBusinessImpactSource:
+  type: string
+  enum: [adobe_analytics, ga4, cja]
+  default: adobe_analytics
+  description: "Business-impact data source. Unlike the generic referral-traffic endpoints, an unrecognised or non-business-impact source (optel/cdn) returns HTTP 400."
+
+ReferralTrafficHasData:
+  type: object
+  description: Whether the site has referral traffic data and which sources are available
+  properties:
+    hasData:
+      type: boolean
+      example: true
+    availableSources:
+      type: array
+      description: Available sources in priority order; items are `optel` or `cdn` only (optel first)
+      items:
+        type: string
+        enum: [optel, cdn]
+      example: ['optel', 'cdn']
+  required:
+    - hasData
+    - availableSources
+
+ReferralTrafficFilterDimensions:
+  type: object
+  description: Distinct referral traffic filter values for the selected site and date range
+  properties:
+    platforms:
+      type: array
+      items:
+        type: string
+      example: ['ChatGPT', 'Perplexity']
+    regions:
+      type: array
+      items:
+        type: string
+      example: ['US', 'DE']
+    devices:
+      type: array
+      items:
+        type: string
+      example: ['desktop', 'mobile']
+    pageIntents:
+      type: array
+      items:
+        type: string
+      example: ['informational', 'transactional']
+    availableSources:
+      type: array
+      items:
+        type: string
+      example: ['optel', 'cdn']
+  required:
+    - platforms
+    - regions
+    - devices
+    - pageIntents
+    - availableSources
+
+ReferralTrafficKpis:
+  type: object
+  description: Aggregated KPI metrics for a site's referral traffic
+  properties:
+    totalPageviews:
+      type: number
+      example: 12450
+    bounceRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for cdn / adobe_analytics / cja; meaningful for optel / ga4
+      example: 42.1
+    consentRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for cdn / adobe_analytics / cja; meaningful for optel / ga4
+      example: 88.0
+  required:
+    - totalPageviews
+    - bounceRate
+    - consentRate
+
+ReferralTrafficTrendRow:
+  type: object
+  description: Referral traffic metrics for a single day
+  properties:
+    date:
+      type: string
+      format: date
+      example: '2026-03-02'
+    pageviews:
+      type: number
+      example: 600
+    entries:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 540
+    revenue:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Non-null only for adobe_analytics / ga4 / cja sources
+      example: 1250.5
+    bounceRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 41.0
+    consentRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 87.0
+    avgSessionDuration:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 132.4
+    pagesPerVisit:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 2.3
+    orders:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Non-null only for adobe_analytics / ga4 / cja sources
+      example: 18
+    conversionRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Non-null only for adobe_analytics / ga4 / cja sources
+      example: 3.1
+  required:
+    - date
+    - pageviews
+
+ReferralTrafficTrend:
+  type: object
+  description: Referral traffic KPI time series ordered by date ascending
+  properties:
+    trend:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficTrendRow'
+  required:
+    - trend
+
+ReferralTrafficByPlatformRow:
+  type: object
+  properties:
+    platform:
+      type: string
+      example: 'ChatGPT'
+    pageviews:
+      type: number
+      example: 4200
+    bounceRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 39.5
+    channels:
+      type: array
+      items:
+        type: string
+      example: ['referral', 'organic']
+    visits:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for optel / cdn sources
+      example: 3800
+    avgTimeOnSite:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for optel / cdn sources
+      example: 142.0
+    revenue:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for optel / cdn sources
+      example: 980.0
+    visitors:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for optel / cdn sources
+      example: 3100
+    orders:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for optel / cdn sources
+      example: 12
+  required:
+    - platform
+    - pageviews
+    - channels
+
+ReferralTrafficByPlatform:
+  type: object
+  description: Referral traffic grouped by platform, ordered by pageviews descending
+  properties:
+    rows:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficByPlatformRow'
+  required:
+    - rows
+
+ReferralTrafficByRegionRow:
+  type: object
+  properties:
+    region:
+      type: string
+      example: 'US'
+    pageviews:
+      type: number
+      example: 3200
+  required:
+    - region
+    - pageviews
+
+ReferralTrafficByRegion:
+  type: object
+  description: Referral traffic grouped by region, ordered by pageviews descending
+  properties:
+    rows:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficByRegionRow'
+  required:
+    - rows
+
+ReferralTrafficByPageIntentRow:
+  type: object
+  properties:
+    pageIntent:
+      type: string
+      example: 'informational'
+    pageviews:
+      type: number
+      example: 2100
+  required:
+    - pageIntent
+    - pageviews
+
+ReferralTrafficByPageIntent:
+  type: object
+  description: Referral traffic grouped by page intent, ordered by pageviews descending
+  properties:
+    rows:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficByPageIntentRow'
+  required:
+    - rows
+
+ReferralTrafficByUrlRow:
+  type: object
+  properties:
+    urlPath:
+      type: string
+      example: '/blog/my-post'
+    host:
+      type: string
+      example: 'www.adobe.com'
+    pageviews:
+      type: number
+      example: 1500
+    bounceRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 38.0
+    consentRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 86.0
+    pageIntent:
+      oneOf:
+        - type: string
+        - type: 'null'
+      example: 'informational'
+    entries:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 1320
+    exits:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 980
+    avgTimeOnSite:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 128.5
+    revenue:
+      oneOf:
+        - type: number
+        - type: 'null'
+      example: 540.0
+  required:
+    - urlPath
+    - host
+    - pageviews
+
+ReferralTrafficByUrl:
+  type: object
+  description: Paginated per-URL referral traffic performance analysis
+  properties:
+    totalCount:
+      type: number
+      description: Total number of URLs matching the filters (across all pages)
+      example: 1240
+    rows:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficByUrlRow'
+      description: URLs for the requested page
+  required:
+    - totalCount
+    - rows
+
+ReferralTrafficUrlTrendRow:
+  type: object
+  properties:
+    weekStart:
+      type: string
+      format: date
+      example: '2026-03-02'
+    pageviews:
+      type: number
+      example: 320
+  required:
+    - weekStart
+    - pageviews
+
+ReferralTrafficUrlTrend:
+  type: object
+  description: Weekly pageview trend for a single URL
+  properties:
+    trend:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficUrlTrendRow'
+  required:
+    - trend
+
+ReferralTrafficByDeviceRow:
+  type: object
+  properties:
+    device:
+      type: string
+      example: 'desktop'
+    pageviews:
+      type: number
+      example: 5400
+    bounceRate:
+      oneOf:
+        - type: number
+        - type: 'null'
+      description: Null for cdn / adobe_analytics / cja sources
+      example: 40.0
+  required:
+    - device
+    - pageviews
+
+ReferralTrafficByDevice:
+  type: object
+  description: Referral traffic grouped by device, ordered by pageviews descending
+  properties:
+    rows:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficByDeviceRow'
+  required:
+    - rows
+
+ReferralTrafficBusinessImpact:
+  type: object
+  description: Aggregated business impact metrics; only available for adobe_analytics / ga4 / cja sources
+  properties:
+    source:
+      type: string
+      enum: [adobe_analytics, ga4, cja]
+      example: 'adobe_analytics'
+    totalPageviews:
+      type: number
+      example: 12450
+    metrics:
+      type: object
+      properties:
+        visits:
+          type: number
+          example: 9800
+        bounceRate:
+          oneOf:
+            - type: number
+            - type: 'null'
+          example: 41.0
+        entries:
+          oneOf:
+            - type: number
+            - type: 'null'
+          example: 8900
+        avgSessionDuration:
+          oneOf:
+            - type: number
+            - type: 'null'
+          example: 135.0
+        pagesPerVisit:
+          oneOf:
+            - type: number
+            - type: 'null'
+          example: 2.4
+        conversionRate:
+          oneOf:
+            - type: number
+            - type: 'null'
+          example: 3.0
+        orders:
+          type: number
+          example: 120
+        revenue:
+          type: number
+          example: 15400.0
+      required:
+        - visits
+        - orders
+        - revenue
+  required:
+    - source
+    - totalPageviews
+    - metrics
+
+ReferralTrafficWeekEntry:
+  type: object
+  description: An ISO week for which the site has referral traffic data
+  properties:
+    week:
+      type: string
+      description: ISO week label (YYYY-WNN)
+      example: '2026-W10'
+    startDate:
+      oneOf:
+        - type: string
+          format: date
+        - type: 'null'
+      example: '2026-03-02'
+    endDate:
+      oneOf:
+        - type: string
+          format: date
+        - type: 'null'
+      example: '2026-03-08'
+  required:
+    - week
+
+ReferralTrafficWeeks:
+  type: object
+  description: Available ISO weeks for the site's referral traffic data
+  properties:
+    weeks:
+      type: array
+      items:
+        $ref: '#/ReferralTrafficWeekEntry'
+  required:
+    - weeks

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -30,7 +30,7 @@ import { checkDateRange } from './traffic-date-range.js';
 const ERR_SITE_ACCESS = 'belonging to the organization';
 const ERR_NOT_FOUND = 'not found';
 
-const VALID_SOURCES = new Set(['optel', 'cdn', 'adobe_analytics', 'ga4']);
+const VALID_SOURCES = new Set(['optel', 'cdn', 'adobe_analytics', 'ga4', 'cja']);
 const DEFAULT_SOURCE = 'optel';
 
 const SOURCE_TO_TABLE = {
@@ -38,6 +38,7 @@ const SOURCE_TO_TABLE = {
   cdn: 'referral_traffic_cdn',
   adobe_analytics: 'referral_traffic_adobe_analytics',
   ga4: 'referral_traffic_ga4',
+  cja: 'referral_traffic_cja',
 };
 
 const DEFAULT_BY_URL_PAGE_SIZE = 50;
@@ -557,7 +558,7 @@ export function createReferralTrafficByUrlHandler(getSiteAndValidateAccess) {
  * GET /sites/:siteId/referral-traffic/weeks
  *
  * Returns the ISO weeks for which the site has referral traffic data for the
- * requested source. Accepts ?source (optel|cdn|adobe_analytics|ga4, default optel).
+ * requested source. Accepts ?source (optel|cdn|adobe_analytics|ga4|cja, default optel).
  * Powers the ContinuousWeekPicker (custom-weeks time range option) — each source
  * tab passes its own source so the picker shows only weeks where that source has data.
  *
@@ -631,16 +632,18 @@ export function createReferralTrafficWeeksHandler(getSiteAndValidateAccess) {
 /**
  * GET /sites/:siteId/referral-traffic/business-impact
  *
- * Aggregates business metrics from adobe_analytics or ga4 sources. Returns a
+ * Aggregates business metrics from adobe_analytics, ga4 or cja sources. Returns a
  * normalized shape so the UI can render the same metric cards regardless of
- * provider. Defaults to source=adobe_analytics; caller passes ?source=ga4 for GA4.
+ * provider. Defaults to source=adobe_analytics; caller passes ?source=ga4 or
+ * ?source=cja for the other providers. CJA mirrors adobe_analytics one-for-one.
  * Passing any other source (optel, cdn) returns a 400 — those sources do not
  * carry the business metric columns required by this endpoint.
  *
  * bounce_rate is computed server-side as SUM(bounces) / SUM(visits); null when
  * visits = 0.
  */
-const VALID_BUSINESS_IMPACT_SOURCES = new Set(['ga4', 'adobe_analytics']);
+const VALID_BUSINESS_IMPACT_SOURCES = new Set(['ga4', 'adobe_analytics', 'cja']);
+const DEFAULT_BUSINESS_IMPACT_SOURCE = 'adobe_analytics';
 
 // ============================================================================
 // /by-url-trend
@@ -705,9 +708,9 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
         const q = ctx.data || {};
         const rawSource = q.source;
         if (rawSource != null && !VALID_BUSINESS_IMPACT_SOURCES.has(rawSource)) {
-          return badRequest('Business impact is only available for adobe_analytics and ga4 sources');
+          return badRequest('Business impact is only available for adobe_analytics, ga4 and cja sources');
         }
-        const source = rawSource === 'ga4' ? 'ga4' : 'adobe_analytics';
+        const source = rawSource != null ? rawSource : DEFAULT_BUSINESS_IMPACT_SOURCE;
         const parsed = { ...parseParams(ctx), source };
 
         const { data, error } = await client.rpc(

--- a/src/controllers/llmo/llmo-url-inspector.js
+++ b/src/controllers/llmo/llmo-url-inspector.js
@@ -59,7 +59,7 @@ import { cachedOk } from '../../support/cached-response.js';
 // unknown 10th positional parameter), and PostgREST then applies the
 // function's own `DEFAULT 'optel'` on the new build. Mirrors the same
 // "omit when absent" pattern used for `p_agent_types` (LLMO-4526).
-const VALID_REFERRAL_SOURCES = new Set(['optel', 'cdn', 'adobe_analytics', 'ga4']);
+const VALID_REFERRAL_SOURCES = new Set(['optel', 'cdn', 'adobe_analytics', 'ga4', 'cja']);
 const DEFAULT_REFERRAL_SOURCE = 'optel';
 
 function parseReferralSource(q) {

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -861,6 +861,9 @@ describe('llmo-referral-traffic', () => {
       expect(body.metrics.bounceRate).to.be.closeTo(0.2, 1e-6);
       expect(body.metrics.orders).to.equal(3);
       expect(body.metrics.revenue).to.equal(300);
+      // pins the reworked source resolve (controller :713): the validated
+      // source must be forwarded verbatim to the RPC, not collapsed.
+      expect(client.rpc.getCall(0).args[1].p_source).to.equal('adobe_analytics');
     });
 
     it('maps RPC row to source+metrics for ga4', async () => {
@@ -871,9 +874,27 @@ describe('llmo-referral-traffic', () => {
       });
       const handler = createReferralTrafficBusinessImpactHandler(stubbedValidateAccess);
       const res = await handler(makeContext({ client, data: { source: 'ga4' } }));
+      expect(res.status).to.equal(200);
       const body = await res.json();
       expect(body.source).to.equal('ga4');
       expect(body.metrics.visits).to.equal(7);
+      expect(client.rpc.getCall(0).args[1].p_source).to.equal('ga4');
+    });
+
+    it('maps RPC row to source+metrics for cja and forwards p_source=cja', async () => {
+      const client = makeRpcClient({
+        data: [{
+          total_pageviews: 25, visits: 11, bounce_rate: 0.3, orders: 4, revenue: 250,
+        }],
+      });
+      const handler = createReferralTrafficBusinessImpactHandler(stubbedValidateAccess);
+      const res = await handler(makeContext({ client, data: { source: 'cja' } }));
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.source).to.equal('cja');
+      expect(body.metrics.visits).to.equal(11);
+      expect(body.metrics.revenue).to.equal(250);
+      expect(client.rpc.getCall(0).args[1].p_source).to.equal('cja');
     });
 
     it('uses {} when context.data is null — defaults source to adobe_analytics (line 553)', async () => {
@@ -1010,6 +1031,16 @@ describe('llmo-referral-traffic', () => {
       const handler = createReferralTrafficWeeksHandler(stubbedValidateAccess);
       await handler(makeContext({ client, data: { source: 'cdn' } }));
       expect(client.from.calledWith('referral_traffic_cdn')).to.be.true;
+    });
+
+    it('queries referral_traffic_cja when ?source=cja', async () => {
+      const client = makeWeeksChainClient(
+        { data: [{ traffic_date: '2026-01-05' }], error: null },
+        { data: [{ traffic_date: '2026-01-12' }], error: null },
+      );
+      const handler = createReferralTrafficWeeksHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { source: 'cja' } }));
+      expect(client.from.calledWith('referral_traffic_cja')).to.be.true;
     });
 
     it('defaults to referral_traffic_optel when source is omitted', async () => {
@@ -1207,6 +1238,16 @@ describe('llmo-referral-traffic', () => {
       const handler = createReferralTrafficKpisHandler(stubbedValidateAccess);
       await handler(makeContext({ client, data: { source: 'cdn' } }));
       expect(client.rpc.getCall(0).args[1].p_source).to.equal('cdn');
+    });
+
+    it('forwards cja source through parseParams (proves VALID_SOURCES gained cja)', async () => {
+      // Guards the controller:33 one-char diff: if cja were dropped from
+      // VALID_SOURCES it would silently fall back to optel here, and every
+      // Traffic-Insights handler (kpis/trend/by-*) shares this validation path.
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficKpisHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { source: 'cja' } }));
+      expect(client.rpc.getCall(0).args[1].p_source).to.equal('cja');
     });
 
     it('falls back to optel when source is invalid', async () => {

--- a/test/controllers/llmo/llmo-url-inspector.test.js
+++ b/test/controllers/llmo/llmo-url-inspector.test.js
@@ -838,10 +838,10 @@ describe('URL Inspector Handlers', () => {
     });
 
     it('forwards every whitelisted referralSource verbatim', async () => {
-      // Pin the four known sources so a future contributor adding (or
+      // Pin the known sources so a future contributor adding (or
       // removing) one in the whitelist must update this assertion in lock-
       // step with the controller + the underlying RPC's CASE branches.
-      for (const source of ['optel', 'cdn', 'adobe_analytics', 'ga4']) {
+      for (const source of ['optel', 'cdn', 'adobe_analytics', 'ga4', 'cja']) {
         // eslint-disable-next-line no-await-in-loop
         const { context, rpcStub } = createContext(
           {},


### PR DESCRIPTION
## What

Adds **Customer Journey Analytics (CJA)** as a new referral-traffic data `source`, alongside `optel`, `cdn`, `adobe_analytics`, and `ga4`. CJA mirrors the `adobe_analytics` schema one-for-one.

Also **documents the 12 previously-undocumented referral-traffic REST endpoints** in OpenAPI (they existed in code + routes but had zero spec coverage).

## Changes

**Source code**
- `src/controllers/llmo/llmo-referral-traffic.js` — thread `'cja'` through `VALID_SOURCES`, `SOURCE_TO_TABLE` (`referral_traffic_cja`), and `VALID_BUSINESS_IMPACT_SOURCES`. Rework the business-impact source resolve to forward any validated source verbatim — the old `rawSource === 'ga4' ? 'ga4' : 'adobe_analytics'` ternary would have silently mislabeled `cja` as `adobe_analytics`.
- `src/controllers/llmo/llmo-url-inspector.js` — add `'cja'` to `VALID_REFERRAL_SOURCES`.

**OpenAPI**
- Document all 12 `/sites/{siteId}/referral-traffic/*` endpoints: path blocks (`llmo-api.yaml`), response schemas (`schemas.yaml`), registrations (`api.yaml`).
- Extract reusable `ReferralTrafficSource` / `ReferralTrafficBusinessImpactSource` enum components; document the source-coercion contract (generic endpoints silently coerce unknown → `optel`; business-impact returns `400`).

**Tests**
- Assert `p_source` forwarding for all business-impact sources (`adobe_analytics`/`ga4`/`cja`) — pins the reworked resolve.
- Assert `cja` survives `VALID_SOURCES` validation and queries `referral_traffic_cja`.

## Upstream dependency (already shipped)

Backing `referral_traffic_cja` table + `cja` branches in `rpc_referral_traffic_*` / `rpc_url_inspector_owned_urls` ship in **mysticat-data-service v5.34.2 (prod)**. This PR is inert without it; it is live.

## Review

Passed a local multi-persona review loop (staff/distinguished/conventions/qa/security), 2 iterations → 0 Critical / 0 Important.

**Deferred (tracked, not in this PR):**
- Integration tests in `test/it/` for the `cja` source — endpoints pre-existed (only the source enum widened, fully unit-covered); IT needs upstream `referral_traffic_cja` seed data. Worth a dedicated PR covering the whole referral/agentic-traffic surface, which currently lacks IT coverage.
- Code-side single-source-of-truth for sources (derive `VALID_SOURCES` from `Object.keys(SOURCE_TO_TABLE)`) — directional refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)