### PR TITLE
fix(brands): make baseSiteId immutable in upsertBrand (LLMO-5556)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1319,6 +1319,7 @@ function BrandsController(ctx, log, env) {
         brand: brandData,
         postgrestClient,
         updatedBy,
+        log,
       });
 
       return createResponse(created, 201);

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1381,14 +1381,21 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       // initial-brand write — the brand already exists so DRS sync still resolves
       // it; a human then decides whether the new site is a sub-brand or a URL.
       try {
-        const { data: existingBrand } = await postgrestClient
+        const { data: existingBrand, error: lookupError } = await postgrestClient
           .from('brands')
           .select('id, site_id')
           .eq('organization_id', organization.getId())
           .eq('name', brandName.trim())
           .maybeSingle();
 
-        if (existingBrand?.site_id && existingBrand.site_id !== site.getId()) {
+        if (lookupError) {
+          // Fail closed (LLMO-5556): PostgREST returns { data: null, error } on a
+          // query failure rather than throwing, so without this check a transient
+          // failure would fall through to upsertBrand and could re-point an
+          // existing brand's primary site. Skip the write as a precaution.
+          log.warn(`Skipping initial brand write: failed to look up existing brand "${brandName.trim()}" `
+            + `(org ${organization.getId()}): ${lookupError.message}`);
+        } else if (existingBrand?.site_id && existingBrand.site_id !== site.getId()) {
           log.warn(`Skipping initial brand write: brand "${brandName.trim()}" `
             + `(org ${organization.getId()}) already exists with a different primary site `
             + `(existing=${existingBrand.site_id}, onboarding=${site.getId()}). `

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1401,6 +1401,9 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
             + `(existing=${existingBrand.site_id}, onboarding=${site.getId()}). `
             + `Add ${baseURL} as a brand URL or onboard under a distinct brand name.`);
         } else {
+          // No collision: proceed with upsert (new brand, existing brand with a
+          // null primary site, or a re-onboard of the same site). upsertBrand's
+          // own guard keeps an already-set site_id immutable on the last case.
           await upsertBrand({
             organizationId: organization.getId(),
             brand: {

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1375,20 +1375,40 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       // Use baseURL (matches sites.base_url) so syncBrandSites can link the brand
       // to the site. overrideBaseURL may differ (e.g., www.blick.ch vs blick.ch)
       // and would fail the exact-match lookup against the sites table.
+      // LLMO-5556: a second site onboarded under an existing brand name must not
+      // re-point that brand's primary site, nor clobber its URLs/aliases via the
+      // full-replace syncs inside upsertBrand. Detect the collision and skip the
+      // initial-brand write — the brand already exists so DRS sync still resolves
+      // it; a human then decides whether the new site is a sub-brand or a URL.
       try {
-        await upsertBrand({
-          organizationId: organization.getId(),
-          brand: {
-            name: brandName.trim(),
-            status: 'active',
-            baseSiteId: site.getId(),
-            urls: [{ value: baseURL, type: 'base' }],
-            brandAliases: [{ name: brandName.trim(), regions: ['gl'] }],
-          },
-          postgrestClient,
-          updatedBy: 'llmo-onboarding',
-        });
-        log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
+        const { data: existingBrand } = await postgrestClient
+          .from('brands')
+          .select('id, site_id')
+          .eq('organization_id', organization.getId())
+          .eq('name', brandName.trim())
+          .maybeSingle();
+
+        if (existingBrand?.site_id && existingBrand.site_id !== site.getId()) {
+          log.warn(`Skipping initial brand write: brand "${brandName.trim()}" `
+            + `(org ${organization.getId()}) already exists with a different primary site `
+            + `(existing=${existingBrand.site_id}, onboarding=${site.getId()}). `
+            + `Add ${baseURL} as a brand URL or onboard under a distinct brand name.`);
+        } else {
+          await upsertBrand({
+            organizationId: organization.getId(),
+            brand: {
+              name: brandName.trim(),
+              status: 'active',
+              baseSiteId: site.getId(),
+              urls: [{ value: baseURL, type: 'base' }],
+              brandAliases: [{ name: brandName.trim(), regions: ['gl'] }],
+            },
+            postgrestClient,
+            updatedBy: 'llmo-onboarding',
+            log,
+          });
+          log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
+        }
       } catch (brandError) {
         log.warn(`Failed to create initial brand in normalized table: ${brandError.message}`);
       }

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -497,12 +497,21 @@ export async function upsertBrand({
   // Check if the brand already exists with a base site set.
   // This prevents silently downgrading an active brand to pending when a caller
   // re-upserts by name without passing baseSiteId.
-  const { data: existing } = await postgrestClient
+  const { data: existing, error: existingError } = await postgrestClient
     .from('brands')
     .select('site_id')
     .eq('organization_id', organizationId)
     .eq('name', brand.name)
     .maybeSingle();
+
+  // Fail closed (LLMO-5556): PostgREST returns { data: null, error } on a query
+  // failure instead of throwing. If we ignored the error, `existing` would be
+  // null and the immutability guard below would treat the brand as new — letting
+  // a transient failure overwrite an existing primary site. Surface the error
+  // instead so the caller (and SQS retry) handles it rather than guessing.
+  if (existingError) {
+    throw new Error(`Failed to look up existing brand "${brand.name}": ${existingError.message}`);
+  }
 
   // A brand cannot be active without a base site ID — but respect persisted state
   // on the update path (the DB row may already have site_id set).

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -482,6 +482,7 @@ export async function upsertBrand({
   brand,
   postgrestClient,
   updatedBy = 'system',
+  log = console,
 }) {
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
@@ -524,9 +525,20 @@ export async function upsertBrand({
     updated_by: updatedBy,
   };
 
-  // Set base site ID if provided.
-  if (hasText(brand.baseSiteId)) {
+  // baseSiteId is immutable once persisted (mirrors updateBrand). Only set it
+  // when the brand has no site_id yet — re-onboarding/re-upserting an existing
+  // brand by name must NOT re-point its primary site (LLMO-5556: this silently
+  // overwrote mongodb.com -> learn.mongodb.com and merck.com -> keytruda.com).
+  if (hasText(brand.baseSiteId) && !hasText(existing?.site_id)) {
     row.site_id = brand.baseSiteId;
+  } else if (
+    hasText(brand.baseSiteId)
+    && hasText(existing?.site_id)
+    && existing.site_id !== brand.baseSiteId
+  ) {
+    log.warn(`upsertBrand: ignoring baseSiteId change for brand "${brand.name}" `
+      + `(org ${organizationId}) — primary site is immutable `
+      + `(existing=${existing.site_id}, attempted=${brand.baseSiteId})`);
   }
 
   const { data: upserted, error } = await postgrestClient

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1814,6 +1814,217 @@ describe('LLMO Onboarding Functions', () => {
       );
     });
 
+    it('fails closed and skips the brand write when the existing-brand lookup errors (LLMO-5556)', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns({
+          updateLlmoBrand: sinon.stub(),
+          updateLlmoDataFolder: sinon.stub(),
+          getImports: sinon.stub().returns([]),
+          enableImport: sinon.stub(),
+          getFetchConfig: sinon.stub().returns({}),
+          updateFetchConfig: sinon.stub(),
+          getBrandProfile: sinon.stub().returns(null),
+        }),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        disableHandlerForSite: sinon.stub(),
+        isHandlerEnabledForSite: sinon.stub().returns(false),
+        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const selectRead = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select: selectRead,
+        upsert: upsertStub,
+      });
+
+      // Brand lookup returns a PostgREST error (does not throw).
+      const brandsMaybeSingle = sinon.stub().resolves({
+        data: null,
+        error: { message: 'connection reset' },
+      });
+      const brandsEq2 = sinon.stub().returns({ maybeSingle: brandsMaybeSingle });
+      const brandsEq1 = sinon.stub().returns({ eq: brandsEq2 });
+      const brandsSelect = sinon.stub().returns({ eq: brandsEq1 });
+      mockDataAccess.services.postgrestClient.from.withArgs('brands').returns({
+        select: brandsSelect,
+      });
+
+      const mockUpsertBrand = sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+
+      const { performLlmoOnboarding: onboardWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockUpsertBrand,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await onboardWithMocks(
+        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+        context,
+      );
+
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(mockUpsertBrand).to.not.have.been.called;
+      expect(mockLog.warn).to.have.been.calledWithMatch(
+        'failed to look up existing brand',
+      );
+    });
+
+    it('writes the initial brand when an existing same-name brand has no primary site yet', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns({
+          updateLlmoBrand: sinon.stub(),
+          updateLlmoDataFolder: sinon.stub(),
+          getImports: sinon.stub().returns([]),
+          enableImport: sinon.stub(),
+          getFetchConfig: sinon.stub().returns({}),
+          updateFetchConfig: sinon.stub(),
+          getBrandProfile: sinon.stub().returns(null),
+        }),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        disableHandlerForSite: sinon.stub(),
+        isHandlerEnabledForSite: sinon.stub().returns(false),
+        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const selectRead = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select: selectRead,
+        upsert: upsertStub,
+      });
+
+      // Existing brand exists by name but has no primary site (site_id null) —
+      // the write should proceed so the upsert sets it.
+      const brandsMaybeSingle = sinon.stub().resolves({
+        data: { id: 'existing-brand-1', site_id: null },
+        error: null,
+      });
+      const brandsEq2 = sinon.stub().returns({ maybeSingle: brandsMaybeSingle });
+      const brandsEq1 = sinon.stub().returns({ eq: brandsEq2 });
+      const brandsSelect = sinon.stub().returns({ eq: brandsEq1 });
+      mockDataAccess.services.postgrestClient.from.withArgs('brands').returns({
+        select: brandsSelect,
+      });
+
+      const mockUpsertBrand = sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+
+      const { performLlmoOnboarding: onboardWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockUpsertBrand,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await onboardWithMocks(
+        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+        context,
+      );
+
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(mockUpsertBrand).to.have.been.calledOnce;
+      expect(mockLog.info).to.have.been.calledWith('Created initial brand "Test Brand" in normalized table for site site123');
+    });
+
     it('should include detectedCdn in result when CDN is detected', async () => {
       const mockOrganization = {
         getId: sinon.stub().returns('org123'),

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -71,6 +71,17 @@ describe('LLMO Onboarding Functions', () => {
       upsert: defaultUpsert,
     });
 
+    // Default brands lookup (LLMO-5556 collision check) — no existing brand,
+    // so onboarding proceeds to write the initial brand. Tests can override
+    // .withArgs('brands') to simulate an existing same-name brand.
+    const brandsMaybeSingle = sinon.stub().resolves({ data: null, error: null });
+    const brandsEq2 = sinon.stub().returns({ maybeSingle: brandsMaybeSingle });
+    const brandsEq1 = sinon.stub().returns({ eq: brandsEq2 });
+    const brandsSelect = sinon.stub().returns({ eq: brandsEq1 });
+    mockDataAccess.services.postgrestClient.from.withArgs('brands').returns({
+      select: brandsSelect,
+    });
+
     // Create mock log
     mockLog = {
       info: sinon.stub(),
@@ -1692,6 +1703,115 @@ describe('LLMO Onboarding Functions', () => {
       // Brandalf job should still be submitted
       expect(mockDrsClient.createFrom().submitJob)
         .to.have.been.called;
+    });
+
+    it('skips the initial brand write when the brand name already exists on a different site (LLMO-5556)', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns({
+          updateLlmoBrand: sinon.stub(),
+          updateLlmoDataFolder: sinon.stub(),
+          getImports: sinon.stub().returns([]),
+          enableImport: sinon.stub(),
+          getFetchConfig: sinon.stub().returns({}),
+          updateFetchConfig: sinon.stub(),
+          getBrandProfile: sinon.stub().returns(null),
+        }),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        disableHandlerForSite: sinon.stub(),
+        isHandlerEnabledForSite: sinon.stub().returns(false),
+        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      // Feature flag postgrest mock
+      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const selectRead = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select: selectRead,
+        upsert: upsertStub,
+      });
+
+      // Existing brand with the same name already points at a DIFFERENT site.
+      const brandsMaybeSingle = sinon.stub().resolves({
+        data: { id: 'existing-brand-1', site_id: 'other-site-999' },
+        error: null,
+      });
+      const brandsEq2 = sinon.stub().returns({ maybeSingle: brandsMaybeSingle });
+      const brandsEq1 = sinon.stub().returns({ eq: brandsEq2 });
+      const brandsSelect = sinon.stub().returns({ eq: brandsEq1 });
+      mockDataAccess.services.postgrestClient.from.withArgs('brands').returns({
+        select: brandsSelect,
+      });
+
+      const mockUpsertBrand = sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+
+      const { performLlmoOnboarding: onboardWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockUpsertBrand,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await onboardWithMocks(
+        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+        context,
+      );
+
+      // Onboarding still completes
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      // The existing brand's primary site is NOT touched
+      expect(mockUpsertBrand).to.not.have.been.called;
+      expect(mockLog.warn).to.have.been.calledWithMatch(
+        'already exists with a different primary site',
+      );
     });
 
     it('should include detectedCdn in result when CDN is detected', async () => {

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -2025,6 +2025,111 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockLog.info).to.have.been.calledWith('Created initial brand "Test Brand" in normalized table for site site123');
     });
 
+    it('writes the initial brand on a same-site re-onboard (existing brand points at this site)', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns({
+          updateLlmoBrand: sinon.stub(),
+          updateLlmoDataFolder: sinon.stub(),
+          getImports: sinon.stub().returns([]),
+          enableImport: sinon.stub(),
+          getFetchConfig: sinon.stub().returns({}),
+          updateFetchConfig: sinon.stub(),
+          getBrandProfile: sinon.stub().returns(null),
+        }),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        disableHandlerForSite: sinon.stub(),
+        isHandlerEnabledForSite: sinon.stub().returns(false),
+        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
+      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const selectRead = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select: selectRead,
+        upsert: upsertStub,
+      });
+
+      // Existing brand already points at THIS site (same-site re-onboard) — no
+      // collision, so the write proceeds; upsertBrand's own guard keeps site_id.
+      const brandsMaybeSingle = sinon.stub().resolves({
+        data: { id: 'existing-brand-1', site_id: 'site123' },
+        error: null,
+      });
+      const brandsEq2 = sinon.stub().returns({ maybeSingle: brandsMaybeSingle });
+      const brandsEq1 = sinon.stub().returns({ eq: brandsEq2 });
+      const brandsSelect = sinon.stub().returns({ eq: brandsEq1 });
+      mockDataAccess.services.postgrestClient.from.withArgs('brands').returns({
+        select: brandsSelect,
+      });
+
+      const mockUpsertBrand = sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      originalSetTimeout = mockSetTimeoutImmediate();
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+
+      const { performLlmoOnboarding: onboardWithMocks } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockUpsertBrand,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        env: mockEnv,
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      const result = await onboardWithMocks(
+        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+        context,
+      );
+
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(mockUpsertBrand).to.have.been.calledOnce;
+      expect(mockLog.warn).to.not.have.been.calledWithMatch('already exists with a different primary site');
+    });
+
     it('should include detectedCdn in result when CDN is detected', async () => {
       const mockOrganization = {
         getId: sinon.stub().returns('org123'),

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -513,7 +513,10 @@ describe('brands-storage', () => {
 
     it('throws when brands upsert fails', async () => {
       const postgrestClient = createTableMockClient({
-        brands: { data: null, error: { message: 'upsert failed' } },
+        brands: [
+          { data: null, error: null }, // existing lookup OK (no brand)
+          { data: null, error: { message: 'upsert failed' } }, // upsert fails
+        ],
       });
 
       await expect(upsertBrand({
@@ -525,7 +528,10 @@ describe('brands-storage', () => {
 
     it('throws 409 when baseSiteId violates unique constraint on upsert', async () => {
       const postgrestClient = createTableMockClient({
-        brands: { data: null, error: { code: '23505', message: 'brands_base_site_unique' } },
+        brands: [
+          { data: null, error: null }, // existing lookup OK (no brand)
+          { data: null, error: { code: '23505', message: 'brands_base_site_unique' } }, // upsert 409
+        ],
       });
 
       const err = await upsertBrand({
@@ -639,6 +645,22 @@ describe('brands-storage', () => {
       });
 
       expect(log.warn).to.not.have.been.called;
+    });
+
+    it('fails closed by throwing when the existing-brand lookup errors (LLMO-5556)', async () => {
+      // PostgREST returns { data: null, error } instead of throwing — without the
+      // guard this would let a transient failure overwrite an existing site_id.
+      const postgrestClient = createTableMockClient({
+        brands: [
+          { data: null, error: { message: 'connection reset' } }, // existing lookup fails
+        ],
+      });
+
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'some-site' },
+        postgrestClient,
+      })).to.be.rejectedWith('Failed to look up existing brand "Test": connection reset');
     });
 
     it('successfully upserts a minimal brand with no aliases, competitors, or urls', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -466,6 +466,38 @@ describe('brands-storage', () => {
     return { from: sinon.stub().callsFake((table) => makeQuery(table)) };
   }
 
+  // Like createTableMockClient, but records the row passed to `.upsert(row, opts)`
+  // per table on `client.capturedCalls.upsert`, so tests can assert exactly what was
+  // written (e.g. that site_id was preserved rather than overwritten).
+  function createCapturingClient(tableMap) {
+    const calls = { upsert: [] };
+    const callCounts = {};
+    const makeQuery = (table) => {
+      const responses = tableMap[table] || [{ data: null, error: null }];
+      const arr = Array.isArray(responses) ? responses : [responses];
+      callCounts[table] = callCounts[table] || 0;
+      const idx = Math.min(callCounts[table], arr.length - 1);
+      callCounts[table] += 1;
+      const resolveWith = arr[idx];
+      const handler = {
+        get(target, prop) {
+          if (prop === 'then') {
+            return (resolve) => resolve(resolveWith);
+          }
+          if (prop === 'upsert') {
+            return (row, opts) => {
+              calls.upsert.push({ table, row, opts });
+              return new Proxy({}, handler);
+            };
+          }
+          return sinon.stub().returns(new Proxy({}, handler));
+        },
+      };
+      return new Proxy({}, handler);
+    };
+    return { from: sinon.stub().callsFake((t) => makeQuery(t)), capturedCalls: calls };
+  }
+
   describe('upsertBrand', () => {
     it('throws when postgrestClient is missing', async () => {
       await expect(upsertBrand({
@@ -546,6 +578,67 @@ describe('brands-storage', () => {
       });
 
       expect(result).to.include({ id: BRAND_ID, name: 'Test' });
+    });
+
+    it('writes site_id on the upsert row when the brand has no persisted site_id', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null }, // no existing brand
+          { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
+          { data: makeBrandRow({ name: 'Test', site_id: 'new-site' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'new-site' },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.site_id).to.equal('new-site');
+    });
+
+    it('does NOT overwrite an existing brand site_id and warns (LLMO-5556)', async () => {
+      const log = { warn: sinon.stub(), info: sinon.stub(), error: sinon.stub() };
+      const client = createCapturingClient({
+        brands: [
+          { data: { site_id: 'original-site' }, error: null }, // existing lookup
+          { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
+          { data: makeBrandRow({ name: 'Test', site_id: 'original-site' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'different-site' },
+        postgrestClient: client,
+        log,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row).to.not.have.property('site_id');
+      expect(log.warn).to.have.been.calledWithMatch('immutable');
+    });
+
+    it('does not warn when re-upserting with the same site_id', async () => {
+      const log = { warn: sinon.stub(), info: sinon.stub(), error: sinon.stub() };
+      const client = createCapturingClient({
+        brands: [
+          { data: { site_id: 'same-site' }, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test', site_id: 'same-site' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'same-site' },
+        postgrestClient: client,
+        log,
+      });
+
+      expect(log.warn).to.not.have.been.called;
     });
 
     it('successfully upserts a minimal brand with no aliases, competitors, or urls', async () => {


### PR DESCRIPTION
## Problem (LLMO-5556)

`upsertBrand` unconditionally wrote `site_id` from `baseSiteId` and upserted on `(organization_id, name)`. Re-onboarding a **second site under an existing brand name** resolved onto the existing row and **silently re-pointed the brand's primary site** — and, because `upsertBrand` calls the full-replace `syncBrandUrls`/`syncBrandSites`/alias syncs when those fields are passed, could also drop the brand's existing URLs/aliases.

Confirmed in production on two customers (both remediated manually):
- **MongoDB** — onboarding `learn.mongodb.com` overwrote primary `mongodb.com`.
- **Merck/MSD** — "Merck" brand primary became `keytruda.com` instead of `merck.com`.

`updateBrand` already had the immutability guard; `upsertBrand` did not.

## Fix

**Layer 1 — `src/support/brands-storage.js`:** guard `site_id` in `upsertBrand` — set it only when the brand has no persisted `site_id` (mirrors `updateBrand`); `log.warn` and ignore on an attempted change. Adds an optional `log` param, threaded from the controller.

**Layer 2 — `src/controllers/llmo/llmo-onboarding.js`:** before the initial-brand write, look up the existing brand by `(org, name)`; if it already points at a **different** site, skip the write and warn (surfacing the collision instead of overwriting / clobbering).

## Tests
- `test/support/brands-storage.test.js` — capturing-mock unit tests asserting the upsert payload **preserves** `site_id` on the update path, **sets** it on insert, **warns** on an attempted change, and does not warn for a same-site re-upsert.
- `test/controllers/llmo/llmo-onboarding.test.js` — onboarding collision test: existing brand on a different site ⇒ `upsertBrand` not called, warn logged, onboarding still completes.
- Full suite + 100% coverage gate pass; lint clean.

## Out of scope (follow-up)
Admin-gated "reassign primary site" path so genuine corrections don't require a direct DB write (the gap that blocked the original Support request). Tracked separately.