### PR TITLE
docs: update S2S consumer guide example to a non-paginated endpoint | SITES-41367

### DIFF
--- a/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
+++ b/docs/s2s/CONSUMER_INTEGRATION_GUIDE.md
@@ -230,10 +230,10 @@ async function getSpaceCatSessionToken(imsAccessToken, imsOrgId) {
 Use the session token for subsequent SpaceCat API calls:
 
 ```javascript
-// Example: Get all sites
-async function getSites(sessionToken) {
+// Example: Get a specific site by ID
+async function getSite(sessionToken, siteId) {
   const response = await axios.get(
-    'https://spacecat.experiencecloud.live/api/ci/sites',
+    `https://spacecat.experiencecloud.live/api/ci/sites/${siteId}`,
     {
       headers: {
         'Authorization': `Bearer ${sessionToken}`,


### PR DESCRIPTION
## What
Step 3 of the S2S Consumer Integration Guide showed a `getSites` example that fetched all sites in one call. `GET /sites` is now cursor-paginated, so that example no longer matches the real response shape and is hitting the legacy.

## Change
Swapped it for a single-site fetch (`GET /sites/{siteId}`) - a clean tenant-scoped read that pairs naturally with the opportunities example below it.

Docs-only change

## Issues
SITES-41367