### PR TITLE
feat: expose GET /sites/:siteId/agentic-traffic/has-data to S2S consumers

### DIFF
--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -100,7 +100,6 @@ export const INTERNAL_ROUTES = [
   'GET /sites/:siteId/agentic-traffic/filter-dimensions',
   'GET /sites/:siteId/agentic-traffic/weeks',
   'GET /sites/:siteId/agentic-traffic/movers',
-  'GET /sites/:siteId/agentic-traffic/has-data',
   'POST /sites/:siteId/agentic-traffic/urls/export',
   'GET /sites/:siteId/agentic-traffic/urls/export/:exportId',
 
@@ -368,6 +367,9 @@ const routeRequiredCapabilities = {
   'POST /sites/:siteId/url-store': 'site:write',
   'PATCH /sites/:siteId/url-store': 'site:write',
   'POST /sites/:siteId/url-store/delete': 'site:write',
+
+  // Agentic traffic
+  'GET /sites/:siteId/agentic-traffic/has-data': 'site:read',
 
   // Agentic URL classification rules
   'GET /sites/:siteId/agentic-categories': 'site:read',


### PR DESCRIPTION
## Summary

- Moves `GET /sites/:siteId/agentic-traffic/has-data` from `INTERNAL_ROUTES` to `routeRequiredCapabilities` with the `site:read` capability
- S2S consumers granted `site:read` can now call this endpoint to check whether agentic traffic data exists for a site, without requiring admin access
- No test changes needed — the existing disjoint/coverage tests in `test/routes/required-capabilities.test.js` enforce correctness automatically (all 2562 tests pass)

## Test plan

- [x] `npx mocha test/routes/required-capabilities.test.js` — all tests pass, including the disjoint and route-coverage invariant checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)