### PR TITLE
fix(consent-banner): gate POST /consent-banner on scrapeJob:write

### DIFF
--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -222,8 +222,10 @@ const routeRequiredCapabilities = {
   // Audits
   'GET /audits/latest/:auditType': 'audit:read',
 
-  // Consent Banner
-  'POST /consent-banner': 'organization:write',
+  // Consent Banner — POST is a screenshot *scrape* trigger, so it's gated like
+  // the sibling `/tools/scrape/jobs` POST (scrapeJob:write) rather than
+  // organization:write, letting S2S scrape consumers (e.g. Mystique) trigger it.
+  'POST /consent-banner': 'scrapeJob:write',
   'GET /consent-banner/:jobId': 'organization:read',
 
   // Configuration


### PR DESCRIPTION
## Summary

`POST /consent-banner` triggers a screenshot **scrape**, but it was gated on `organization:write` — an org-admin capability rarely granted to S2S consumers. As a result, S2S scrape consumers (e.g. Mystique's cookie-consent crew) hit **403 Forbidden** when triggering it, even though they hold `scrapeJob:write`.

This aligns the route with the sibling scrape route `POST /tools/scrape/jobs`, which is gated on `scrapeJob:write`.

## Change

`src/routes/required-capabilities.js`:
- `POST /consent-banner`: `organization:write` → **`scrapeJob:write`**
- `GET /consent-banner/:jobId`: unchanged (`organization:read`)

## Rationale

- `POST /consent-banner` is a scrape trigger — `scrapeJob:write` matches its semantics and the established `/tools/scrape/jobs` convention (`src/routes/required-capabilities.js` already gates `POST /tools/scrape/jobs` on `scrapeJob:write`).
- `organization:write` is an org-admin write capability that a screenshot-scrape consumer shouldn't need to hold.

## Scope / safety

- Pure route→capability value change. `consentBanner.js` does no explicit `hasS2SCapability(...)` check, so no controller change is required.
- `required-capabilities.test.js` is structural (validates `entity:action` form, `write` is allowed) and the `capability-constants` drift test governs only `CAP_`/`readAll` **constants** — `scrapeJob:write` is an inline value (as the scrape-jobs routes already use), so neither is affected.

## Testing

- `eslint` clean on the changed file
- `test/routes/required-capabilities.test.js` + `test/routes/capability-constants.test.js` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
