### PR TITLE
feat(slack): add prerender modes (full/ai-only) and CSV batching to run-audit command

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -115,6 +115,17 @@ function RunAuditCommand(context) {
   const { dataAccess, log } = context;
   const { Configuration, Site, Opportunity } = dataAccess;
 
+  const buildEffectiveData = (baseData, mode) => {
+    if (mode !== PRERENDER_MODES.AI_ONLY
+      && mode !== PRERENDER_MODES.AI_ONLY_CURRENT) {
+      return baseData;
+    }
+    return JSON.stringify({
+      ...(baseData ? JSON.parse(baseData) : {}),
+      mode: PRERENDER_MODES.AI_ONLY,
+    });
+  };
+
   const parsePrerenderUrlsFromCsv = async (files, botToken, say) => {
     if (files.length > 1) {
       await say(':warning: Please provide only one CSV file.');
@@ -449,15 +460,7 @@ function RunAuditCommand(context) {
           return;
         }
 
-        // ai-only and ai-only-current both send mode:ai-only to the worker
-        const isAiOnly = prerenderMode === PRERENDER_MODES.AI_ONLY
-          || isCurrentMode;
-        const effectiveData = isAiOnly
-          ? JSON.stringify({
-            ...(auditDataInputArg ? JSON.parse(auditDataInputArg) : {}),
-            mode: PRERENDER_MODES.AI_ONLY,
-          })
-          : auditDataInputArg;
+        const effectiveData = buildEffectiveData(auditDataInputArg, prerenderMode);
         await say(`:adobe-run: Triggering ${PRERENDER} audit`
           + ` for ${baseURL} with ${urls.length} URLs`
           + ` (${modeLabel} mode).`);
@@ -468,14 +471,7 @@ function RunAuditCommand(context) {
           return;
         }
 
-        const csvIsAiOnly = prerenderMode === PRERENDER_MODES.AI_ONLY
-          || prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT;
-        const effectiveData = csvIsAiOnly
-          ? JSON.stringify({
-            ...(auditDataInputArg ? JSON.parse(auditDataInputArg) : {}),
-            mode: PRERENDER_MODES.AI_ONLY,
-          })
-          : auditDataInputArg;
+        const effectiveData = buildEffectiveData(auditDataInputArg, prerenderMode);
         await say(`:adobe-run: Triggering ${PRERENDER} audit`
           + ` for site ${baseURL} with ${urls.length} URLs.`);
         await runPrerenderAuditForUrls(baseURL, PRERENDER, effectiveData, urls, slackContext);

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -31,9 +31,8 @@ import { triggerAuditForSite } from '../../utils.js';
 const PHRASES = ['run audit'];
 const LHS_MOBILE = 'lhs-mobile';
 const PRERENDER = 'prerender';
-const PRERENDER_AI = 'prerender-ai';
 const PRERENDER_BATCH_SIZE = 320;
-const PRERENDER_MODES = { FULL: 'full', AI_ONLY: 'ai-only' };
+const PRERENDER_MODES = { ALL: 'all', AI_ONLY: 'ai-only' };
 const PRERENDER_SUGGESTION_STATUSES = ['NEW', 'FIXED'];
 const ALL_AUDITS = [
   'apex',
@@ -104,9 +103,9 @@ function RunAuditCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-audit',
     name: 'Run Audit',
-    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender audits: `mode:full` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but triggers AI-only content generation. CSV uploads are batched at 320 URLs.',
+    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but passes ai-only to the worker. CSV uploads are batched at 320 URLs.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:full|ai-only] [key:value ...]`,
+    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:all|ai-only] [key:value ...]`,
   });
 
   const { dataAccess, log } = context;
@@ -235,7 +234,7 @@ function RunAuditCommand(context) {
     }
   };
 
-  const runPrerenderAuditForUrls = async (baseURL, auditType, auditData, urls, slackContext) => {
+  const runPrerenderAuditForUrls = async (baseURL, auditData, urls, slackContext, mode) => {
     const { say } = slackContext;
 
     try {
@@ -247,14 +246,14 @@ function RunAuditCommand(context) {
         return;
       }
 
-      if (!configuration.isHandlerEnabledForSite(auditType, site)) {
-        await say(`:x: Will not audit site '${baseURL}' because audits of type '${auditType}' are disabled for this site.`);
+      if (!configuration.isHandlerEnabledForSite(PRERENDER, site)) {
+        await say(`:x: Will not audit site '${baseURL}' because audits of type '${PRERENDER}' are disabled for this site.`);
         return;
       }
 
-      const handler = configuration.getHandlers()?.[auditType];
+      const handler = configuration.getHandlers()?.[PRERENDER];
       if (!isNonEmptyArray(handler?.productCodes)) {
-        await say(`:x: Will not audit site '${baseURL}' because no product codes are configured for audit type '${auditType}'.`);
+        await say(`:x: Will not audit site '${baseURL}' because no product codes are configured for audit type '${PRERENDER}'.`);
         return;
       }
 
@@ -279,6 +278,7 @@ function RunAuditCommand(context) {
       const batchCount = Math.ceil(
         urls.length / PRERENDER_BATCH_SIZE,
       );
+      const auditContext = { ...(mode ? { mode } : {}) };
 
       for (let i = 0; i < batchCount; i += 1) {
         const start = i * PRERENDER_BATCH_SIZE;
@@ -286,22 +286,23 @@ function RunAuditCommand(context) {
         // eslint-disable-next-line no-await-in-loop
         await triggerAuditForSite(
           site,
-          auditType,
+          PRERENDER,
           auditData,
           slackContext,
           context,
-          { urls: batch },
+          { ...auditContext, urls: batch },
         );
 
         const batchLabel = batchCount > 1
           ? ` (batch ${i + 1}/${batchCount})`
           : '';
+        const modeLabel = mode ? ` [${mode}]` : '';
         // eslint-disable-next-line no-await-in-loop
-        await say(`:white_check_mark: ${auditType} audit queued`
-          + ` for ${batch.length} URLs${batchLabel}.`);
+        await say(`:white_check_mark: ${PRERENDER} audit queued`
+          + ` for ${batch.length} URLs${batchLabel}${modeLabel}.`);
       }
     } catch (error) {
-      log.error(`Error running audit ${auditType} for site ${baseURL}`, error);
+      log.error(`Error running ${PRERENDER} audit for site ${baseURL}`, error);
       await postErrorMessage(say, error);
     }
   };
@@ -358,25 +359,18 @@ function RunAuditCommand(context) {
         return;
       }
 
-      let auditType = auditTypeInputArg || LHS_MOBILE;
+      const auditType = auditTypeInputArg || LHS_MOBILE;
       const prerenderMode = keywords.mode;
 
-      // Resolve prerender mode
-      if (auditType === PRERENDER && prerenderMode === PRERENDER_MODES.AI_ONLY) {
-        auditType = PRERENDER_AI;
-      }
-
-      const isPrerenderMode = auditType === PRERENDER
-        && prerenderMode === PRERENDER_MODES.FULL;
-      const isPrerenderAiMode = auditType === PRERENDER_AI;
+      const hasPrerenderMode = auditType === PRERENDER
+        && (prerenderMode === PRERENDER_MODES.ALL
+          || prerenderMode === PRERENDER_MODES.AI_ONLY);
       const isPrerenderCsvRun = hasValidBaseURL
-        && hasFiles
-        && (auditType === PRERENDER || isPrerenderAiMode);
+        && hasFiles && auditType === PRERENDER;
 
-      // mode:full or mode:ai-only without CSV → fetch URLs from suggestions
+      // mode:all or mode:ai-only without CSV → fetch URLs from suggestions
       const isSuggestionRun = hasValidBaseURL
-        && !hasFiles
-        && (isPrerenderMode || isPrerenderAiMode);
+        && !hasFiles && hasPrerenderMode;
 
       if (hasValidBaseURL && hasFiles && !isPrerenderCsvRun) {
         await say(':warning: Please provide either a baseURL or a CSV file with a list of site URLs.');
@@ -385,7 +379,7 @@ function RunAuditCommand(context) {
 
       if (isSuggestionRun) {
         const modeLabel = prerenderMode === PRERENDER_MODES.AI_ONLY
-          ? 'AI-only' : 'full';
+          ? 'AI-only' : 'all';
         await say(`:hourglass_flowing_sand: Fetching ${modeLabel}`
           + ` prerender suggestions for ${baseURL}…`);
 
@@ -406,24 +400,23 @@ function RunAuditCommand(context) {
           return;
         }
 
-        await say(`:adobe-run: Triggering ${auditType} audit`
+        const mode = prerenderMode === PRERENDER_MODES.AI_ONLY
+          ? PRERENDER_MODES.AI_ONLY : undefined;
+        await say(`:adobe-run: Triggering ${PRERENDER} audit`
           + ` for ${baseURL} with ${urls.length} URLs`
           + ` (${modeLabel} mode).`);
-        await runPrerenderAuditForUrls(
-          baseURL,
-          auditType,
-          auditDataInputArg,
-          urls,
-          slackContext,
-        );
+        await runPrerenderAuditForUrls(baseURL, auditDataInputArg, urls, slackContext, mode);
       } else if (isPrerenderCsvRun) {
         const urls = await parsePrerenderUrlsFromCsv(files, botToken, say);
         if (!urls) {
           return;
         }
 
-        await say(`:adobe-run: Triggering ${auditType} audit for site ${baseURL} with ${urls.length} URLs.`);
-        await runPrerenderAuditForUrls(baseURL, auditType, auditDataInputArg, urls, slackContext);
+        const mode = prerenderMode === PRERENDER_MODES.AI_ONLY
+          ? PRERENDER_MODES.AI_ONLY : undefined;
+        await say(`:adobe-run: Triggering ${PRERENDER} audit`
+          + ` for site ${baseURL} with ${urls.length} URLs.`);
+        await runPrerenderAuditForUrls(baseURL, auditDataInputArg, urls, slackContext, mode);
       } else if (hasFiles) {
         const [, auditTypeInput, auditData] = ['', baseURLInputArg, auditTypeInputArg];
         const csvAuditType = auditTypeInput || LHS_MOBILE;

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -27,6 +27,7 @@ import { triggerAuditForSite } from '../../utils.js';
 const PHRASES = ['run audit'];
 const LHS_MOBILE = 'lhs-mobile';
 const PRERENDER = 'prerender';
+const PRERENDER_AI = 'prerender-ai';
 const ALL_AUDITS = [
   'apex',
   'cwv',
@@ -96,9 +97,9 @@ function RunAuditCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-audit',
     name: 'Run Audit',
-    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. Use `product-metatags` for Product Detail Page (PDP) analysis of commerce sites.',
+    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. Use `product-metatags` for Product Detail Page (PDP) analysis of commerce sites. For prerender audits, use `mode:ai-only` to run AI-only content generation without a full scrape.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [key:value ...]`,
+    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:ai-only] [key:value ...]`,
   });
 
   const { dataAccess, log } = context;
@@ -275,9 +276,10 @@ function RunAuditCommand(context) {
         [baseURLInputArg] = positionalArgs;
         auditTypeInputArg = keywords.audit;
 
-        // Build audit data from remaining keywords (excluding 'audit')
+        // Build audit data from remaining keywords (excluding 'audit' and 'mode')
         const auditDataKeywords = { ...keywords };
         delete auditDataKeywords.audit;
+        delete auditDataKeywords.mode;
 
         auditDataInputArg = Object.keys(auditDataKeywords).length > 0
           ? JSON.stringify(auditDataKeywords)
@@ -298,8 +300,16 @@ function RunAuditCommand(context) {
         return;
       }
 
-      const auditType = auditTypeInputArg || LHS_MOBILE;
-      const isPrerenderCsvRun = hasValidBaseURL && hasFiles && auditType === PRERENDER;
+      let auditType = auditTypeInputArg || LHS_MOBILE;
+
+      // Resolve prerender mode: mode:ai-only switches audit type to prerender-ai
+      if (auditType === PRERENDER && keywords.mode === 'ai-only') {
+        auditType = PRERENDER_AI;
+      }
+
+      const isPrerenderCsvRun = hasValidBaseURL
+        && hasFiles
+        && (auditType === PRERENDER || auditType === PRERENDER_AI);
 
       if (hasValidBaseURL && hasFiles && !isPrerenderCsvRun) {
         await say(':warning: Please provide either a baseURL or a CSV file with a list of site URLs.');

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -278,7 +278,11 @@ function RunAuditCommand(context) {
       const batchCount = Math.ceil(
         urls.length / PRERENDER_BATCH_SIZE,
       );
-      const auditContext = { ...(mode ? { mode } : {}) };
+      // Pass mode in the data field (SQS message.data) so the worker
+      // can read it via getModeFromData(data). URLs go in auditContext.
+      const effectiveData = mode
+        ? JSON.stringify({ ...(auditData ? JSON.parse(auditData) : {}), mode })
+        : auditData;
 
       for (let i = 0; i < batchCount; i += 1) {
         const start = i * PRERENDER_BATCH_SIZE;
@@ -287,10 +291,10 @@ function RunAuditCommand(context) {
         await triggerAuditForSite(
           site,
           PRERENDER,
-          auditData,
+          effectiveData,
           slackContext,
           context,
-          { ...auditContext, urls: batch },
+          { urls: batch },
         );
 
         const batchLabel = batchCount > 1

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -234,7 +234,7 @@ function RunAuditCommand(context) {
     }
   };
 
-  const runPrerenderAuditForUrls = async (baseURL, auditData, urls, slackContext, mode) => {
+  const runPrerenderAuditForUrls = async (baseURL, auditType, auditData, urls, slackContext) => {
     const { say } = slackContext;
 
     try {
@@ -246,14 +246,14 @@ function RunAuditCommand(context) {
         return;
       }
 
-      if (!configuration.isHandlerEnabledForSite(PRERENDER, site)) {
-        await say(`:x: Will not audit site '${baseURL}' because audits of type '${PRERENDER}' are disabled for this site.`);
+      if (!configuration.isHandlerEnabledForSite(auditType, site)) {
+        await say(`:x: Will not audit site '${baseURL}' because audits of type '${auditType}' are disabled for this site.`);
         return;
       }
 
-      const handler = configuration.getHandlers()?.[PRERENDER];
+      const handler = configuration.getHandlers()?.[auditType];
       if (!isNonEmptyArray(handler?.productCodes)) {
-        await say(`:x: Will not audit site '${baseURL}' because no product codes are configured for audit type '${PRERENDER}'.`);
+        await say(`:x: Will not audit site '${baseURL}' because no product codes are configured for audit type '${auditType}'.`);
         return;
       }
 
@@ -278,11 +278,6 @@ function RunAuditCommand(context) {
       const batchCount = Math.ceil(
         urls.length / PRERENDER_BATCH_SIZE,
       );
-      // Pass mode in the data field (SQS message.data) so the worker
-      // can read it via getModeFromData(data). URLs go in auditContext.
-      const effectiveData = mode
-        ? JSON.stringify({ ...(auditData ? JSON.parse(auditData) : {}), mode })
-        : auditData;
 
       for (let i = 0; i < batchCount; i += 1) {
         const start = i * PRERENDER_BATCH_SIZE;
@@ -290,8 +285,8 @@ function RunAuditCommand(context) {
         // eslint-disable-next-line no-await-in-loop
         await triggerAuditForSite(
           site,
-          PRERENDER,
-          effectiveData,
+          auditType,
+          auditData,
           slackContext,
           context,
           { urls: batch },
@@ -300,13 +295,12 @@ function RunAuditCommand(context) {
         const batchLabel = batchCount > 1
           ? ` (batch ${i + 1}/${batchCount})`
           : '';
-        const modeLabel = mode ? ` [${mode}]` : '';
         // eslint-disable-next-line no-await-in-loop
-        await say(`:white_check_mark: ${PRERENDER} audit queued`
-          + ` for ${batch.length} URLs${batchLabel}${modeLabel}.`);
+        await say(`:white_check_mark: ${auditType} audit queued`
+          + ` for ${batch.length} URLs${batchLabel}.`);
       }
     } catch (error) {
-      log.error(`Error running ${PRERENDER} audit for site ${baseURL}`, error);
+      log.error(`Error running audit ${auditType} for site ${baseURL}`, error);
       await postErrorMessage(say, error);
     }
   };
@@ -404,23 +398,33 @@ function RunAuditCommand(context) {
           return;
         }
 
-        const mode = prerenderMode === PRERENDER_MODES.AI_ONLY
-          ? PRERENDER_MODES.AI_ONLY : undefined;
+        // Merge mode into the data field so the worker reads it
+        // via getModeFromData(data).
+        const effectiveData = prerenderMode === PRERENDER_MODES.AI_ONLY
+          ? JSON.stringify({
+            ...(auditDataInputArg ? JSON.parse(auditDataInputArg) : {}),
+            mode: PRERENDER_MODES.AI_ONLY,
+          })
+          : auditDataInputArg;
         await say(`:adobe-run: Triggering ${PRERENDER} audit`
           + ` for ${baseURL} with ${urls.length} URLs`
           + ` (${modeLabel} mode).`);
-        await runPrerenderAuditForUrls(baseURL, auditDataInputArg, urls, slackContext, mode);
+        await runPrerenderAuditForUrls(baseURL, PRERENDER, effectiveData, urls, slackContext);
       } else if (isPrerenderCsvRun) {
         const urls = await parsePrerenderUrlsFromCsv(files, botToken, say);
         if (!urls) {
           return;
         }
 
-        const mode = prerenderMode === PRERENDER_MODES.AI_ONLY
-          ? PRERENDER_MODES.AI_ONLY : undefined;
+        const effectiveData = prerenderMode === PRERENDER_MODES.AI_ONLY
+          ? JSON.stringify({
+            ...(auditDataInputArg ? JSON.parse(auditDataInputArg) : {}),
+            mode: PRERENDER_MODES.AI_ONLY,
+          })
+          : auditDataInputArg;
         await say(`:adobe-run: Triggering ${PRERENDER} audit`
           + ` for site ${baseURL} with ${urls.length} URLs.`);
-        await runPrerenderAuditForUrls(baseURL, auditDataInputArg, urls, slackContext, mode);
+        await runPrerenderAuditForUrls(baseURL, PRERENDER, effectiveData, urls, slackContext);
       } else if (hasFiles) {
         const [, auditTypeInput, auditData] = ['', baseURLInputArg, auditTypeInputArg];
         const csvAuditType = auditTypeInput || LHS_MOBILE;

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -28,6 +28,7 @@ const PHRASES = ['run audit'];
 const LHS_MOBILE = 'lhs-mobile';
 const PRERENDER = 'prerender';
 const PRERENDER_AI = 'prerender-ai';
+const PRERENDER_BATCH_SIZE = 320;
 const ALL_AUDITS = [
   'apex',
   'cwv',
@@ -240,8 +241,26 @@ function RunAuditCommand(context) {
         return;
       }
 
-      await triggerAuditForSite(site, auditType, auditData, slackContext, context, { urls });
-      await say(`:white_check_mark: ${auditType} audit queued for ${urls.length} URLs.`);
+      const batchCount = Math.ceil(urls.length / PRERENDER_BATCH_SIZE);
+
+      for (let i = 0; i < batchCount; i += 1) {
+        const start = i * PRERENDER_BATCH_SIZE;
+        const batchUrls = urls.slice(start, start + PRERENDER_BATCH_SIZE);
+        // eslint-disable-next-line no-await-in-loop
+        await triggerAuditForSite(
+          site,
+          auditType,
+          auditData,
+          slackContext,
+          context,
+          { urls: batchUrls },
+        );
+        log.info(`[run-audit] ${baseURL}: queued batch ${i + 1}/${batchCount}`
+          + ` (${batchUrls.length} URLs, ${auditType})`);
+      }
+
+      const batchMsg = batchCount > 1 ? ` in ${batchCount} batches` : '';
+      await say(`:white_check_mark: ${auditType} audit queued for ${urls.length} URLs${batchMsg}.`);
     } catch (error) {
       log.error(`Error running audit ${auditType} for site ${baseURL}`, error);
       await postErrorMessage(say, error);

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { isNonEmptyArray, isNonEmptyObject, isValidUrl } from '@adobe/spacecat-shared-utils';
+import {
+  isNonEmptyArray,
+  isNonEmptyObject,
+  isValidUrl,
+} from '@adobe/spacecat-shared-utils';
 import TierClient from '@adobe/spacecat-shared-tier-client';
 
 import BaseCommand from './base.js';
@@ -29,6 +33,8 @@ const LHS_MOBILE = 'lhs-mobile';
 const PRERENDER = 'prerender';
 const PRERENDER_AI = 'prerender-ai';
 const PRERENDER_BATCH_SIZE = 320;
+const PRERENDER_MODES = { FULL: 'full', AI_ONLY: 'ai-only' };
+const PRERENDER_SUGGESTION_STATUSES = ['NEW', 'FIXED'];
 const ALL_AUDITS = [
   'apex',
   'cwv',
@@ -98,13 +104,13 @@ function RunAuditCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-audit',
     name: 'Run Audit',
-    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. Use `product-metatags` for Product Detail Page (PDP) analysis of commerce sites. For prerender audits, use `mode:ai-only` to run AI-only content generation without a full scrape.',
+    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender audits: `mode:full` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but triggers AI-only content generation. CSV uploads are batched at 320 URLs.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:ai-only] [key:value ...]`,
+    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:full|ai-only] [key:value ...]`,
   });
 
   const { dataAccess, log } = context;
-  const { Configuration, Site } = dataAccess;
+  const { Configuration, Site, Opportunity } = dataAccess;
 
   const parsePrerenderUrlsFromCsv = async (files, botToken, say) => {
     if (files.length > 1) {
@@ -129,6 +135,35 @@ function RunAuditCommand(context) {
     }
 
     return urls;
+  };
+
+  /**
+   * Fetches unique URLs from prerender suggestions with NEW or FIXED status.
+   * @param {string} siteId - The site ID.
+   * @returns {Promise<string[]>} Deduplicated URLs.
+   */
+  const fetchPrerenderSuggestionUrls = async (siteId) => {
+    const opportunities = await Opportunity.allBySiteId(siteId);
+    const prerenderOpps = opportunities.filter(
+      (opp) => opp.getType() === PRERENDER,
+    );
+
+    const urls = new Set();
+    for (const opp of prerenderOpps) {
+      // eslint-disable-next-line no-await-in-loop
+      const suggestions = await opp.getSuggestions();
+      suggestions
+        .filter((s) => PRERENDER_SUGGESTION_STATUSES
+          .includes(s.getStatus()))
+        .forEach((s) => {
+          const url = s.getData()?.url;
+          if (url && isValidUrl(url) && !url.includes('*')) {
+            urls.add(url);
+          }
+        });
+    }
+
+    return [...urls];
   };
 
   /**
@@ -241,11 +276,13 @@ function RunAuditCommand(context) {
         return;
       }
 
-      const batchCount = Math.ceil(urls.length / PRERENDER_BATCH_SIZE);
+      const batchCount = Math.ceil(
+        urls.length / PRERENDER_BATCH_SIZE,
+      );
 
       for (let i = 0; i < batchCount; i += 1) {
         const start = i * PRERENDER_BATCH_SIZE;
-        const batchUrls = urls.slice(start, start + PRERENDER_BATCH_SIZE);
+        const batch = urls.slice(start, start + PRERENDER_BATCH_SIZE);
         // eslint-disable-next-line no-await-in-loop
         await triggerAuditForSite(
           site,
@@ -253,14 +290,16 @@ function RunAuditCommand(context) {
           auditData,
           slackContext,
           context,
-          { urls: batchUrls },
+          { urls: batch },
         );
-        log.info(`[run-audit] ${baseURL}: queued batch ${i + 1}/${batchCount}`
-          + ` (${batchUrls.length} URLs, ${auditType})`);
-      }
 
-      const batchMsg = batchCount > 1 ? ` in ${batchCount} batches` : '';
-      await say(`:white_check_mark: ${auditType} audit queued for ${urls.length} URLs${batchMsg}.`);
+        const batchLabel = batchCount > 1
+          ? ` (batch ${i + 1}/${batchCount})`
+          : '';
+        // eslint-disable-next-line no-await-in-loop
+        await say(`:white_check_mark: ${auditType} audit queued`
+          + ` for ${batch.length} URLs${batchLabel}.`);
+      }
     } catch (error) {
       log.error(`Error running audit ${auditType} for site ${baseURL}`, error);
       await postErrorMessage(say, error);
@@ -320,22 +359,64 @@ function RunAuditCommand(context) {
       }
 
       let auditType = auditTypeInputArg || LHS_MOBILE;
+      const prerenderMode = keywords.mode;
 
-      // Resolve prerender mode: mode:ai-only switches audit type to prerender-ai
-      if (auditType === PRERENDER && keywords.mode === 'ai-only') {
+      // Resolve prerender mode
+      if (auditType === PRERENDER && prerenderMode === PRERENDER_MODES.AI_ONLY) {
         auditType = PRERENDER_AI;
       }
 
+      const isPrerenderMode = auditType === PRERENDER
+        && prerenderMode === PRERENDER_MODES.FULL;
+      const isPrerenderAiMode = auditType === PRERENDER_AI;
       const isPrerenderCsvRun = hasValidBaseURL
         && hasFiles
-        && (auditType === PRERENDER || auditType === PRERENDER_AI);
+        && (auditType === PRERENDER || isPrerenderAiMode);
+
+      // mode:full or mode:ai-only without CSV → fetch URLs from suggestions
+      const isSuggestionRun = hasValidBaseURL
+        && !hasFiles
+        && (isPrerenderMode || isPrerenderAiMode);
 
       if (hasValidBaseURL && hasFiles && !isPrerenderCsvRun) {
         await say(':warning: Please provide either a baseURL or a CSV file with a list of site URLs.');
         return;
       }
 
-      if (isPrerenderCsvRun) {
+      if (isSuggestionRun) {
+        const modeLabel = prerenderMode === PRERENDER_MODES.AI_ONLY
+          ? 'AI-only' : 'full';
+        await say(`:hourglass_flowing_sand: Fetching ${modeLabel}`
+          + ` prerender suggestions for ${baseURL}…`);
+
+        const site = await Site.findByBaseURL(baseURL);
+        if (!isNonEmptyObject(site)) {
+          await postSiteNotFoundMessage(say, baseURL);
+          return;
+        }
+
+        const urls = await fetchPrerenderSuggestionUrls(
+          site.getId(),
+        );
+
+        if (urls.length === 0) {
+          await say(':white_check_mark: No active suggestions'
+            + ` with status NEW or FIXED for *${baseURL}*`
+            + ' — nothing to audit.');
+          return;
+        }
+
+        await say(`:adobe-run: Triggering ${auditType} audit`
+          + ` for ${baseURL} with ${urls.length} URLs`
+          + ` (${modeLabel} mode).`);
+        await runPrerenderAuditForUrls(
+          baseURL,
+          auditType,
+          auditDataInputArg,
+          urls,
+          slackContext,
+        );
+      } else if (isPrerenderCsvRun) {
         const urls = await parsePrerenderUrlsFromCsv(files, botToken, say);
         if (!urls) {
           return;

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -32,7 +32,11 @@ const PHRASES = ['run audit'];
 const LHS_MOBILE = 'lhs-mobile';
 const PRERENDER = 'prerender';
 const PRERENDER_BATCH_SIZE = 320;
-const PRERENDER_MODES = { ALL: 'all', AI_ONLY: 'ai-only' };
+const PRERENDER_MODES = {
+  ALL: 'all',
+  AI_ONLY: 'ai-only',
+  AI_ONLY_CURRENT: 'ai-only-current',
+};
 const PRERENDER_SUGGESTION_STATUSES = ['NEW', 'FIXED'];
 const ALL_AUDITS = [
   'apex',
@@ -103,9 +107,9 @@ function RunAuditCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-audit',
     name: 'Run Audit',
-    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but passes ai-only to the worker. CSV uploads are batched at 320 URLs.',
+    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed). CSV uploads are batched at 320 URLs.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:all|ai-only] [key:value ...]`,
+    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:all|ai-only|ai-only-current] [key:value ...]`,
   });
 
   const { dataAccess, log } = context;
@@ -159,6 +163,44 @@ function RunAuditCommand(context) {
           if (url && isValidUrl(url) && !url.includes('*')) {
             urls.add(url);
           }
+        });
+    }
+
+    return [...urls];
+  };
+
+  /**
+   * Fetches unique URLs from prerender suggestions matching the "current" tab:
+   * status NEW, not coveredByDomainWide, not edgeDeployed, not coveredByPattern.
+   * @param {string} siteId - The site ID.
+   * @returns {Promise<string[]>} Deduplicated URLs.
+   */
+  const fetchCurrentPrerenderSuggestionUrls = async (siteId) => {
+    const opportunities = await Opportunity.allBySiteId(siteId);
+    const prerenderOpps = opportunities.filter(
+      (opp) => opp.getType() === PRERENDER,
+    );
+
+    const urls = new Set();
+    for (const opp of prerenderOpps) {
+      // eslint-disable-next-line no-await-in-loop
+      const suggestions = await opp.getSuggestions();
+      suggestions
+        .filter((s) => {
+          if (s.getStatus() !== 'NEW') {
+            return false;
+          }
+          const d = s.getData();
+          if (!d?.url || d.url.includes('*')) {
+            return false;
+          }
+          if (d.coveredByDomainWide || d.edgeDeployed || d.coveredByPattern) {
+            return false;
+          }
+          return isValidUrl(d.url);
+        })
+        .forEach((s) => {
+          urls.add(s.getData().url);
         });
     }
 
@@ -362,7 +404,8 @@ function RunAuditCommand(context) {
 
       const hasPrerenderMode = auditType === PRERENDER
         && (prerenderMode === PRERENDER_MODES.ALL
-          || prerenderMode === PRERENDER_MODES.AI_ONLY);
+          || prerenderMode === PRERENDER_MODES.AI_ONLY
+          || prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT);
       const isPrerenderCsvRun = hasValidBaseURL
         && hasFiles && auditType === PRERENDER;
 
@@ -376,8 +419,12 @@ function RunAuditCommand(context) {
       }
 
       if (isSuggestionRun) {
-        const modeLabel = prerenderMode === PRERENDER_MODES.AI_ONLY
-          ? 'AI-only' : 'all';
+        const MODE_LABELS = {
+          [PRERENDER_MODES.ALL]: 'all',
+          [PRERENDER_MODES.AI_ONLY]: 'AI-only',
+          [PRERENDER_MODES.AI_ONLY_CURRENT]: 'AI-only-current',
+        };
+        const modeLabel = MODE_LABELS[prerenderMode];
         await say(`:hourglass_flowing_sand: Fetching ${modeLabel}`
           + ` prerender suggestions for ${baseURL}…`);
 
@@ -387,20 +434,25 @@ function RunAuditCommand(context) {
           return;
         }
 
-        const urls = await fetchPrerenderSuggestionUrls(
-          site.getId(),
-        );
+        const isCurrentMode = prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT;
+        const urls = isCurrentMode
+          ? await fetchCurrentPrerenderSuggestionUrls(site.getId())
+          : await fetchPrerenderSuggestionUrls(site.getId());
 
         if (urls.length === 0) {
+          const hint = isCurrentMode
+            ? 'matching current-tab filters'
+            : 'with status NEW or FIXED';
           await say(':white_check_mark: No active suggestions'
-            + ` with status NEW or FIXED for *${baseURL}*`
+            + ` ${hint} for *${baseURL}*`
             + ' — nothing to audit.');
           return;
         }
 
-        // Merge mode into the data field so the worker reads it
-        // via getModeFromData(data).
-        const effectiveData = prerenderMode === PRERENDER_MODES.AI_ONLY
+        // ai-only and ai-only-current both send mode:ai-only to the worker
+        const isAiOnly = prerenderMode === PRERENDER_MODES.AI_ONLY
+          || isCurrentMode;
+        const effectiveData = isAiOnly
           ? JSON.stringify({
             ...(auditDataInputArg ? JSON.parse(auditDataInputArg) : {}),
             mode: PRERENDER_MODES.AI_ONLY,
@@ -416,7 +468,9 @@ function RunAuditCommand(context) {
           return;
         }
 
-        const effectiveData = prerenderMode === PRERENDER_MODES.AI_ONLY
+        const csvIsAiOnly = prerenderMode === PRERENDER_MODES.AI_ONLY
+          || prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT;
+        const effectiveData = csvIsAiOnly
           ? JSON.stringify({
             ...(auditDataInputArg ? JSON.parse(auditDataInputArg) : {}),
             mode: PRERENDER_MODES.AI_ONLY,

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -83,7 +83,7 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       expect(command.id).to.equal('run-audit');
       expect(command.name).to.equal('Run Audit');
-      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. Use `product-metatags` for Product Detail Page (PDP) analysis of commerce sites.');
+      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. Use `product-metatags` for Product Detail Page (PDP) analysis of commerce sites. For prerender audits, use `mode:ai-only` to run AI-only content generation without a full scrape.');
     });
   });
 
@@ -694,6 +694,63 @@ describe('RunAuditCommand', () => {
         'date-start': '2025-09-07',
         source: 'test-source',
       });
+    });
+  });
+
+  describe('Prerender AI-Only Mode', () => {
+    beforeEach(() => {
+      dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'siteId' });
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock(['prerender', 'prerender-ai'], ['LLMO']));
+    });
+
+    it('switches audit type to prerender-ai when mode:ai-only is provided', async () => {
+      const command = RunAuditCommand(context);
+
+      await command.handleExecution(['validsite.com', 'audit:prerender', 'mode:ai-only'], slackContext);
+
+      expect(slackContext.say.firstCall.args[0]).to.include(':adobe-run: Triggering prerender-ai audit for https://validsite.com');
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender-ai' });
+    });
+
+    it('does not include mode in audit data when mode:ai-only is consumed', async () => {
+      const command = RunAuditCommand(context);
+
+      await command.handleExecution(['validsite.com', 'audit:prerender', 'mode:ai-only', 'source:test'], slackContext);
+
+      expect(slackContext.say.firstCall.args[0]).to.include(':adobe-run: Triggering prerender-ai audit for https://validsite.com');
+      const auditData = sqsStub.sendMessage.firstCall.args[1].data;
+      const parsedData = JSON.parse(auditData);
+      expect(parsedData).to.deep.equal({ source: 'test' });
+      expect(parsedData).to.not.have.property('mode');
+    });
+
+    it('keeps audit type as prerender when no mode is provided', async () => {
+      const command = RunAuditCommand(context);
+
+      await command.handleExecution(['validsite.com', 'audit:prerender'], slackContext);
+
+      expect(slackContext.say.firstCall.args[0]).to.include(':adobe-run: Triggering prerender audit for https://validsite.com');
+      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
+    });
+
+    it('allows prerender-ai CSV run with mode:ai-only and attached file', async () => {
+      slackContext.files = [
+        {
+          name: 'urls.csv',
+          url_private: 'https://example.com/urls.csv',
+        },
+      ];
+      nock('https://example.com')
+        .get('/urls.csv')
+        .reply(200, 'https://valid.site/page-1\nhttps://valid.site/page-2');
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only'], slackContext);
+
+      expect(slackContext.say.firstCall.args[0]).to.equal(':adobe-run: Triggering prerender-ai audit for site https://site.com with 2 URLs.');
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender-ai' });
     });
   });
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -935,20 +935,6 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say).to.have.been.calledWithMatch(/320 URLs \(batch 1\/2\)/);
       expect(slackContext.say).to.have.been.calledWithMatch(/180 URLs \(batch 2\/2\)/);
     });
-
-    it('sends batch-wise Slack messages with mode label for ai-only', async () => {
-      const suggestions = Array.from({ length: 500 }, (_, i) => makeSuggestion(`https://site.com/page-${i + 1}`, i % 2 === 0 ? 'NEW' : 'FIXED'));
-      dataAccessStub.Opportunity.allBySiteId.resolves([
-        makeOpportunity('prerender', suggestions),
-      ]);
-
-      const command = RunAuditCommand(context);
-      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only'], slackContext);
-
-      expect(sqsStub.sendMessage).to.have.been.calledTwice;
-      expect(slackContext.say).to.have.been.calledWithMatch(/320 URLs \(batch 1\/2\) \[ai-only\]/);
-      expect(slackContext.say).to.have.been.calledWithMatch(/180 URLs \(batch 2\/2\) \[ai-only\]/);
-    });
   });
 
   describe('Entitlement Checks', () => {

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -84,7 +84,7 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       expect(command.id).to.equal('run-audit');
       expect(command.name).to.equal('Run Audit');
-      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender audits: `mode:full` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but triggers AI-only content generation. CSV uploads are batched at 320 URLs.');
+      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but passes ai-only to the worker. CSV uploads are batched at 320 URLs.');
     });
   });
 
@@ -741,11 +741,11 @@ describe('RunAuditCommand', () => {
     beforeEach(() => {
       dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'siteId' });
       dataAccessStub.Configuration.findLatest.resolves(
-        createDefaultConfigurationMock(['prerender', 'prerender-ai'], ['LLMO']),
+        createDefaultConfigurationMock('prerender', ['LLMO']),
       );
     });
 
-    it('mode:full fetches NEW/FIXED suggestions and triggers prerender audit', async () => {
+    it('mode:all fetches NEW/FIXED suggestions and triggers prerender audit', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/page-1', 'NEW'),
@@ -755,15 +755,16 @@ describe('RunAuditCommand', () => {
       ]);
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:all'], slackContext);
 
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
       expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
-      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      const { urls, mode } = sqsStub.sendMessage.firstCall.args[1].auditContext;
       expect(urls).to.deep.equal(['https://site.com/page-1', 'https://site.com/page-2']);
+      expect(mode).to.be.undefined;
     });
 
-    it('mode:ai-only fetches NEW/FIXED suggestions and triggers prerender-ai audit', async () => {
+    it('mode:ai-only fetches suggestions and passes mode in auditContext', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/page-1', 'NEW'),
@@ -775,7 +776,8 @@ describe('RunAuditCommand', () => {
       await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only'], slackContext);
 
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
-      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender-ai' });
+      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.equal('ai-only');
     });
 
     it('deduplicates URLs across multiple prerender opportunities', async () => {
@@ -790,7 +792,7 @@ describe('RunAuditCommand', () => {
       ]);
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:all'], slackContext);
 
       const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
       expect(urls).to.have.length(2);
@@ -809,7 +811,7 @@ describe('RunAuditCommand', () => {
       ]);
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:all'], slackContext);
 
       const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
       expect(urls).to.deep.equal(['https://site.com/page-1']);
@@ -823,7 +825,7 @@ describe('RunAuditCommand', () => {
       ]);
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:all'], slackContext);
 
       expect(sqsStub.sendMessage).to.not.have.been.called;
       expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
@@ -837,7 +839,7 @@ describe('RunAuditCommand', () => {
       ]);
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:all'], slackContext);
 
       expect(sqsStub.sendMessage).to.not.have.been.called;
       expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
@@ -847,13 +849,13 @@ describe('RunAuditCommand', () => {
       dataAccessStub.Site.findByBaseURL.resolves(null);
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['unknownsite.com', 'audit:prerender', 'mode:full'], slackContext);
+      await command.handleExecution(['unknownsite.com', 'audit:prerender', 'mode:all'], slackContext);
 
       expect(sqsStub.sendMessage).to.not.have.been.called;
       expect(slackContext.say).to.have.been.calledWith(':x: No site found with base URL \'https://unknownsite.com\'.');
     });
 
-    it('does not include mode in audit data', async () => {
+    it('does not include mode in audit data payload', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/page-1', 'NEW'),
@@ -869,7 +871,7 @@ describe('RunAuditCommand', () => {
       expect(parsedData).to.not.have.property('mode');
     });
 
-    it('keeps audit type as prerender when no mode is provided', async () => {
+    it('runs normal prerender when no mode is provided', async () => {
       const command = RunAuditCommand(context);
 
       await command.handleExecution(['validsite.com', 'audit:prerender'], slackContext);
@@ -878,7 +880,7 @@ describe('RunAuditCommand', () => {
       expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
     });
 
-    it('allows prerender-ai CSV run with mode:ai-only and attached file', async () => {
+    it('CSV with mode:ai-only passes mode in auditContext', async () => {
       slackContext.files = [
         {
           name: 'urls.csv',
@@ -892,27 +894,57 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only'], slackContext);
 
-      expect(slackContext.say).to.have.been.calledWithMatch(/Triggering prerender-ai audit for site/);
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
-      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender-ai' });
+      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.equal('ai-only');
+    });
+
+    it('CSV without mode does not include mode in auditContext', async () => {
+      slackContext.files = [
+        {
+          name: 'urls.csv',
+          url_private: 'https://example.com/urls.csv',
+        },
+      ];
+      nock('https://example.com')
+        .get('/urls.csv')
+        .reply(200, 'https://valid.site/page-1');
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.be.undefined;
     });
 
     it('sends batch-wise Slack messages for suggestion-based mode', async () => {
-      // Generate 500 suggestions → 2 batches (320 + 180)
       const suggestions = Array.from({ length: 500 }, (_, i) => makeSuggestion(`https://site.com/page-${i + 1}`, i % 2 === 0 ? 'NEW' : 'FIXED'));
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', suggestions),
       ]);
 
       const command = RunAuditCommand(context);
-      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:all'], slackContext);
 
       expect(sqsStub.sendMessage).to.have.been.calledTwice;
       expect(sqsStub.sendMessage.firstCall.args[1].auditContext.urls).to.have.length(320);
       expect(sqsStub.sendMessage.secondCall.args[1].auditContext.urls).to.have.length(180);
-      // Batch-wise Slack messages (after the initial triggering + fetching messages)
       expect(slackContext.say).to.have.been.calledWithMatch(/320 URLs \(batch 1\/2\)/);
       expect(slackContext.say).to.have.been.calledWithMatch(/180 URLs \(batch 2\/2\)/);
+    });
+
+    it('sends batch-wise Slack messages with mode label for ai-only', async () => {
+      const suggestions = Array.from({ length: 500 }, (_, i) => makeSuggestion(`https://site.com/page-${i + 1}`, i % 2 === 0 ? 'NEW' : 'FIXED'));
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', suggestions),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledTwice;
+      expect(slackContext.say).to.have.been.calledWithMatch(/320 URLs \(batch 1\/2\) \[ai-only\]/);
+      expect(slackContext.say).to.have.been.calledWithMatch(/180 URLs \(batch 2\/2\) \[ai-only\]/);
     });
   });
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -84,7 +84,7 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       expect(command.id).to.equal('run-audit');
       expect(command.name).to.equal('Run Audit');
-      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but passes ai-only to the worker. CSV uploads are batched at 320 URLs.');
+      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed). CSV uploads are batched at 320 URLs.');
     });
   });
 
@@ -728,9 +728,9 @@ describe('RunAuditCommand', () => {
   });
 
   describe('Prerender Modes', () => {
-    const makeSuggestion = (url, status) => ({
+    const makeSuggestion = (url, status, extraData = {}) => ({
       getStatus: () => status,
-      getData: () => ({ url }),
+      getData: () => ({ url, ...extraData }),
     });
 
     const makeOpportunity = (type, suggestions) => ({
@@ -934,6 +934,42 @@ describe('RunAuditCommand', () => {
       expect(sqsStub.sendMessage.secondCall.args[1].auditContext.urls).to.have.length(180);
       expect(slackContext.say).to.have.been.calledWithMatch(/320 URLs \(batch 1\/2\)/);
       expect(slackContext.say).to.have.been.calledWithMatch(/180 URLs \(batch 2\/2\)/);
+    });
+
+    it('mode:ai-only-current fetches only current-tab suggestions', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/current', 'NEW'),
+          makeSuggestion('https://site.com/covered', 'NEW', { coveredByDomainWide: true }),
+          makeSuggestion('https://site.com/deployed', 'NEW', { edgeDeployed: true }),
+          makeSuggestion('https://site.com/pattern', 'NEW', { coveredByPattern: true }),
+          makeSuggestion('https://site.com/fixed', 'FIXED'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-current'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.deep.equal(['https://site.com/current']);
+      const msgData = JSON.parse(sqsStub.sendMessage.firstCall.args[1].data);
+      expect(msgData.mode).to.equal('ai-only');
+    });
+
+    it('mode:ai-only-current reports nothing when all suggestions are filtered out', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/covered', 'NEW', { coveredByDomainWide: true }),
+          makeSuggestion('https://site.com/deployed', 'NEW', { edgeDeployed: true }),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-current'], slackContext);
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+      expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
     });
   });
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -843,6 +843,16 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
     });
 
+    it('shows site-not-found for suggestion-based mode when site does not exist', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(null);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['unknownsite.com', 'audit:prerender', 'mode:full'], slackContext);
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+      expect(slackContext.say).to.have.been.calledWith(':x: No site found with base URL \'https://unknownsite.com\'.');
+    });
+
     it('does not include mode in audit data', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -230,6 +230,33 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say.secondCall.args[0]).to.equal(':white_check_mark: prerender audit queued for 2 URLs.');
     });
 
+    it('splits large prerender CSV into batches of 320', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('prerender', ['LLMO']));
+      slackContext.files = [
+        {
+          name: 'urls.csv',
+          url_private: 'https://example.com/urls.csv',
+        },
+      ];
+      // Generate 500 valid URLs → should produce 2 batches (320 + 180)
+      const urls = Array.from({ length: 500 }, (_, i) => `https://valid.site/page-${i + 1}`);
+      nock('https://example.com')
+        .get('/urls.csv')
+        .reply(200, urls.join('\n'));
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'prerender'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledTwice;
+      // First batch: 320 URLs
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.urls).to.have.length(320);
+      // Second batch: 180 URLs
+      expect(sqsStub.sendMessage.secondCall.args[1].auditContext.urls).to.have.length(180);
+      expect(slackContext.say.secondCall.args[0]).to.equal(':white_check_mark: prerender audit queued for 500 URLs in 2 batches.');
+    });
+
     it('warns when a prerender CSV has no valid URLs', async () => {
       slackContext.files = [
         {

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -55,6 +55,7 @@ describe('RunAuditCommand', () => {
     dataAccessStub = {
       Configuration: { findLatest: sinon.stub() },
       Site: { findByBaseURL: sinon.stub() },
+      Opportunity: { allBySiteId: sinon.stub().resolves([]) },
     };
     sqsStub = {
       sendMessage: sinon.stub().resolves(),
@@ -83,7 +84,7 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       expect(command.id).to.equal('run-audit');
       expect(command.name).to.equal('Run Audit');
-      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. Use `product-metatags` for Product Detail Page (PDP) analysis of commerce sites. For prerender audits, use `mode:ai-only` to run AI-only content generation without a full scrape.');
+      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender audits: `mode:full` fetches NEW/FIXED suggestions and runs a full prerender audit; `mode:ai-only` does the same but triggers AI-only content generation. CSV uploads are batched at 320 URLs.');
     });
   });
 
@@ -230,7 +231,7 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say.secondCall.args[0]).to.equal(':white_check_mark: prerender audit queued for 2 URLs.');
     });
 
-    it('splits large prerender CSV into batches of 320', async () => {
+    it('sends batch-wise Slack messages for large prerender CSV', async () => {
       const site = { getId: () => '123' };
       dataAccessStub.Site.findByBaseURL.resolves(site);
       dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('prerender', ['LLMO']));
@@ -254,7 +255,9 @@ describe('RunAuditCommand', () => {
       expect(sqsStub.sendMessage.firstCall.args[1].auditContext.urls).to.have.length(320);
       // Second batch: 180 URLs
       expect(sqsStub.sendMessage.secondCall.args[1].auditContext.urls).to.have.length(180);
-      expect(slackContext.say.secondCall.args[0]).to.equal(':white_check_mark: prerender audit queued for 500 URLs in 2 batches.');
+      // Batch-wise Slack messages
+      expect(slackContext.say.secondCall.args[0]).to.equal(':white_check_mark: prerender audit queued for 320 URLs (batch 1/2).');
+      expect(slackContext.say.thirdCall.args[0]).to.equal(':white_check_mark: prerender audit queued for 180 URLs (batch 2/2).');
     });
 
     it('warns when a prerender CSV has no valid URLs', async () => {
@@ -724,28 +727,132 @@ describe('RunAuditCommand', () => {
     });
   });
 
-  describe('Prerender AI-Only Mode', () => {
-    beforeEach(() => {
-      dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'siteId' });
-      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock(['prerender', 'prerender-ai'], ['LLMO']));
+  describe('Prerender Modes', () => {
+    const makeSuggestion = (url, status) => ({
+      getStatus: () => status,
+      getData: () => ({ url }),
     });
 
-    it('switches audit type to prerender-ai when mode:ai-only is provided', async () => {
+    const makeOpportunity = (type, suggestions) => ({
+      getType: () => type,
+      getSuggestions: sinon.stub().resolves(suggestions),
+    });
+
+    beforeEach(() => {
+      dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'siteId' });
+      dataAccessStub.Configuration.findLatest.resolves(
+        createDefaultConfigurationMock(['prerender', 'prerender-ai'], ['LLMO']),
+      );
+    });
+
+    it('mode:full fetches NEW/FIXED suggestions and triggers prerender audit', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+          makeSuggestion('https://site.com/page-2', 'FIXED'),
+          makeSuggestion('https://site.com/page-3', 'OUTDATED'),
+        ]),
+      ]);
+
       const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
 
-      await command.handleExecution(['validsite.com', 'audit:prerender', 'mode:ai-only'], slackContext);
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.deep.equal(['https://site.com/page-1', 'https://site.com/page-2']);
+    });
 
-      expect(slackContext.say.firstCall.args[0]).to.include(':adobe-run: Triggering prerender-ai audit for https://validsite.com');
+    it('mode:ai-only fetches NEW/FIXED suggestions and triggers prerender-ai audit', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+          makeSuggestion('https://site.com/page-2', 'FIXED'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only'], slackContext);
+
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
       expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender-ai' });
     });
 
-    it('does not include mode in audit data when mode:ai-only is consumed', async () => {
+    it('deduplicates URLs across multiple prerender opportunities', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+        ]),
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'FIXED'),
+          makeSuggestion('https://site.com/page-2', 'NEW'),
+        ]),
+      ]);
+
       const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
 
-      await command.handleExecution(['validsite.com', 'audit:prerender', 'mode:ai-only', 'source:test'], slackContext);
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.have.length(2);
+      expect(urls).to.include('https://site.com/page-1');
+      expect(urls).to.include('https://site.com/page-2');
+    });
 
-      expect(slackContext.say.firstCall.args[0]).to.include(':adobe-run: Triggering prerender-ai audit for https://validsite.com');
+    it('filters out wildcard and invalid URLs from suggestions', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+          makeSuggestion('https://site.com/wildcard/*', 'NEW'),
+          makeSuggestion('invalid-url', 'NEW'),
+          makeSuggestion(null, 'NEW'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.deep.equal(['https://site.com/page-1']);
+    });
+
+    it('reports nothing to audit when no NEW/FIXED suggestions exist', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'OUTDATED'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+      expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
+    });
+
+    it('reports nothing to audit when no prerender opportunities exist', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('broken-backlinks', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+      expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
+    });
+
+    it('does not include mode in audit data', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only', 'source:test'], slackContext);
+
       const auditData = sqsStub.sendMessage.firstCall.args[1].data;
       const parsedData = JSON.parse(auditData);
       expect(parsedData).to.deep.equal({ source: 'test' });
@@ -775,9 +882,27 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only'], slackContext);
 
-      expect(slackContext.say.firstCall.args[0]).to.equal(':adobe-run: Triggering prerender-ai audit for site https://site.com with 2 URLs.');
+      expect(slackContext.say).to.have.been.calledWithMatch(/Triggering prerender-ai audit for site/);
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
       expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender-ai' });
+    });
+
+    it('sends batch-wise Slack messages for suggestion-based mode', async () => {
+      // Generate 500 suggestions → 2 batches (320 + 180)
+      const suggestions = Array.from({ length: 500 }, (_, i) => makeSuggestion(`https://site.com/page-${i + 1}`, i % 2 === 0 ? 'NEW' : 'FIXED'));
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', suggestions),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:full'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledTwice;
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.urls).to.have.length(320);
+      expect(sqsStub.sendMessage.secondCall.args[1].auditContext.urls).to.have.length(180);
+      // Batch-wise Slack messages (after the initial triggering + fetching messages)
+      expect(slackContext.say).to.have.been.calledWithMatch(/320 URLs \(batch 1\/2\)/);
+      expect(slackContext.say).to.have.been.calledWithMatch(/180 URLs \(batch 2\/2\)/);
     });
   });
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -957,6 +957,23 @@ describe('RunAuditCommand', () => {
       expect(msgData.mode).to.equal('ai-only');
     });
 
+    it('mode:ai-only-current filters out wildcard and null URLs', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/valid', 'NEW'),
+          makeSuggestion('https://site.com/wildcard/*', 'NEW'),
+          makeSuggestion(null, 'NEW'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-current'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.deep.equal(['https://site.com/valid']);
+    });
+
     it('mode:ai-only-current reports nothing when all suggestions are filtered out', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -764,7 +764,7 @@ describe('RunAuditCommand', () => {
       expect(mode).to.be.undefined;
     });
 
-    it('mode:ai-only fetches suggestions and passes mode in auditContext', async () => {
+    it('mode:ai-only fetches suggestions and passes mode in data field', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/page-1', 'NEW'),
@@ -777,7 +777,9 @@ describe('RunAuditCommand', () => {
 
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
       expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
-      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.equal('ai-only');
+      const msgData = JSON.parse(sqsStub.sendMessage.firstCall.args[1].data);
+      expect(msgData.mode).to.equal('ai-only');
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.be.undefined;
     });
 
     it('deduplicates URLs across multiple prerender opportunities', async () => {
@@ -855,7 +857,7 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say).to.have.been.calledWith(':x: No site found with base URL \'https://unknownsite.com\'.');
     });
 
-    it('does not include mode in audit data payload', async () => {
+    it('merges mode into data field alongside other keyword args', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/page-1', 'NEW'),
@@ -865,10 +867,9 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only', 'source:test'], slackContext);
 
-      const auditData = sqsStub.sendMessage.firstCall.args[1].data;
-      const parsedData = JSON.parse(auditData);
-      expect(parsedData).to.deep.equal({ source: 'test' });
-      expect(parsedData).to.not.have.property('mode');
+      const msgData = JSON.parse(sqsStub.sendMessage.firstCall.args[1].data);
+      expect(msgData.mode).to.equal('ai-only');
+      expect(msgData.source).to.equal('test');
     });
 
     it('runs normal prerender when no mode is provided', async () => {
@@ -880,7 +881,7 @@ describe('RunAuditCommand', () => {
       expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
     });
 
-    it('CSV with mode:ai-only passes mode in auditContext', async () => {
+    it('CSV with mode:ai-only passes mode in data field', async () => {
       slackContext.files = [
         {
           name: 'urls.csv',
@@ -896,10 +897,12 @@ describe('RunAuditCommand', () => {
 
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
       expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.include({ type: 'prerender' });
-      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.equal('ai-only');
+      const msgData = JSON.parse(sqsStub.sendMessage.firstCall.args[1].data);
+      expect(msgData.mode).to.equal('ai-only');
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.be.undefined;
     });
 
-    it('CSV without mode does not include mode in auditContext', async () => {
+    it('CSV without mode does not include mode in data', async () => {
       slackContext.files = [
         {
           name: 'urls.csv',
@@ -914,7 +917,7 @@ describe('RunAuditCommand', () => {
       await command.handleExecution(['site.com', 'audit:prerender'], slackContext);
 
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
-      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.mode).to.be.undefined;
+      expect(sqsStub.sendMessage.firstCall.args[1].data).to.be.undefined;
     });
 
     it('sends batch-wise Slack messages for suggestion-based mode', async () => {


### PR DESCRIPTION
## Summary

Adds three prerender modes and CSV batching to the `run audit` command.

1. **`mode:all`** — Fetches all prerender suggestions with status `NEW` or `FIXED`, triggers `prerender` audit in batches of 320 URLs
2. **`mode:ai-only`** — Same as above but merges `mode: 'ai-only'` into the SQS `data` field for the audit worker
3. **`mode:ai-only-current`** — Fetches only "current tab" suggestions (status `NEW`, not `coveredByDomainWide`, not `edgeDeployed`, not `coveredByPattern`), sends `mode: 'ai-only'` to the worker
4. **CSV batching** — When a CSV file is uploaded with >320 URLs, automatically splits into batches of 320. Supports optional `mode:ai-only` with CSV too.

All modes send batch-wise Slack messages per batch.

## Usage

```
# Full prerender audit from NEW/FIXED suggestions
run audit site.com audit:prerender mode:all

# AI-only from NEW/FIXED suggestions
run audit site.com audit:prerender mode:ai-only

# AI-only for current-tab suggestions only
run audit site.com audit:prerender mode:ai-only-current

# CSV with mode:ai-only
run audit site.com audit:prerender mode:ai-only [attach CSV]

# CSV without mode (existing behavior, now with batching)
run audit site.com prerender [attach CSV]
```

## Current-tab filter (`ai-only-current`)

Only includes suggestions matching all of:
- Status = `NEW`
- `coveredByDomainWide` is falsy
- `edgeDeployed` is falsy
- `coveredByPattern` is falsy
- Valid URL, no wildcards

Both `ai-only` and `ai-only-current` send `mode: 'ai-only'` to the worker — the difference is which suggestions are selected on the API side.

## Test plan (60 tests, 100% statement coverage)

- [x] `mode:all` fetches NEW/FIXED suggestions
- [x] `mode:ai-only` fetches NEW/FIXED suggestions, merges mode into data
- [x] `mode:ai-only-current` fetches only current-tab suggestions
- [x] `ai-only-current` excludes coveredByDomainWide, edgeDeployed, coveredByPattern
- [x] `ai-only-current` reports nothing when all filtered out
- [x] Mode merged alongside other keyword args
- [x] Deduplicates URLs, filters wildcards
- [x] Site-not-found handling
- [x] CSV + mode:ai-only passes mode in data
- [x] CSV without mode unchanged
- [x] Batch-wise Slack messages
- [x] All existing tests pass