### PR TITLE
feat: enable money-pages audit in paid onboarding profile

### DIFF
--- a/static/onboard/profiles.json
+++ b/static/onboard/profiles.json
@@ -133,7 +133,8 @@
 			"structured-data": {},
 			"sitemap": {},
 			"toc": {},
-			"wikipedia-analysis": {}
+			"wikipedia-analysis": {},
+			"money-pages": {}
 		},
 		"imports": {
 			"organic-traffic" : {},


### PR DESCRIPTION
## What
Add `money-pages` to the **`paid`** profile in `static/onboard/profiles.json`.

```diff
 			"toc": {},
-			"wikipedia-analysis": {}
+			"wikipedia-analysis": {},
+			"money-pages": {}
```

## Why
Goal: make `money-pages` a first-class audit for **paid** customers, the way `broken-internal-links` already is. Investigation of how `broken-internal-links` is wired showed:

| Mechanism | broken-internal-links | money-pages (before) |
|---|---|---|
| Slack `run audit` (`ALL_AUDITS`) | ✅ | ✅ already present |
| Onboarding profiles (`profiles.json`) | ✅ plg/demo/paid → enabled on ~146 sites | ❌ **none** → had to be enabled manually per-site |
| Scheduled job / reports / `GET /trigger` | n/a here | out of scope |

The missing onboarding-profile membership is why money-pages had to be enabled by hand on individual sites. Adding it to the `paid` profile means paid onboarding now both **enables** it (`enableHandlerForSite`) and **triggers** it (`triggerAuditForSite`) automatically — see `src/controllers/plg/plg-onboarding/onboarding-flow.js` (steps 8 & 11). `money-pages` is already a registered handler (`productCodes: ["ASO"]`) and paid onboarding grants the ASO entitlement + enrollment, so all downstream gates pass.

## Scope
- **`paid` profile only** — `plg` and `demo` intentionally left unchanged.
- No `-auto-suggest`/`-auto-fix` variants added (none exist for money-pages; only the base handler).

## Testing
- `jq` validates JSON; `money-pages` present in `paid` only.
- `npx mocha test/utils/slack/base.test.js` (the only test touching `profiles.json`, via mocked fs) — 34 passing.
- No source lines added, so coverage is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)