### PR TITLE
docs: add money-pages to OpenAPI AuditType enum and audit examples

### DIFF
--- a/docs/openapi/audit-api.yaml
+++ b/docs/openapi/audit-api.yaml
@@ -38,6 +38,8 @@ audit-for-site:
                 $ref: './examples.yaml#/related-urls-audit'
               broken-internal-links-audit:
                 $ref: './examples.yaml#/broken-internal-links-audit'
+              money-pages-audit:
+                $ref: './examples.yaml#/money-pages-audit'
       '400':
         $ref: './responses.yaml#/400-audit-for-site'
       '401':
@@ -87,6 +89,8 @@ latest-audit-for-site:
                 $ref: './examples.yaml#/related-urls-audit'
               broken-internal-links-audit:
                 $ref: './examples.yaml#/broken-internal-links-audit'
+              money-pages-audit:
+                $ref: './examples.yaml#/money-pages-audit'
       '400':
         $ref: './responses.yaml#/400-latest-audit-for-site'
       '401':

--- a/docs/openapi/examples.yaml
+++ b/docs/openapi/examples.yaml
@@ -218,6 +218,17 @@ broken-internal-links-audit:
         priority: 'high'
         trafficDomain: 65272
       finalUrl: "www.example.com/uk/"
+money-pages-audit:
+  summary: Example for a money-pages audit
+  value:
+    id: '123e4567-e89b-12d3-a456-426614174000'
+    siteId: 'a1b2c3d4-e5f6-7g8h-9i0j-k11l12m13n14'
+    auditedAt: '2024-01-20T12:00:00Z'
+    expiresAt: '2024-07-20T12:00:00Z'
+    deliveryType: 'aem_edge'
+    fullAuditRef: 'https://www.example.com'
+    auditResult:
+      siteUrl: 'https://www.example.com'
 costs-audit:
   summary: Example for a costs audit
   value:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -159,6 +159,7 @@ AuditType:
     - 'related-urls'
     - 'summarization'
     - 'faqs'
+    - 'money-pages'
   example: 'cwv'
 URL:
   type: string
@@ -1110,6 +1111,17 @@ AuditResult:
           type: string
         finalUrl:
           description: The final URL for the audited page.
+          type: string
+    - type: object
+      description: |
+        The result of money-pages audit.
+      properties:
+        siteUrl:
+          description: The resolved site URL the money-pages audit was run against.
+          type: string
+        fullAuditRef:
+          description: |
+            A reference by which the full external result of an audit can be accessed, which is dependent on the audit type.
           type: string
     - type: array
       description: Information about the provided URLs in the Google index.


### PR DESCRIPTION
## What
Document `money-pages` as a valid audit type in the OpenAPI spec.

- **`schemas.yaml`** — add `money-pages` to the `AuditType` enum, and a money-pages variant to the `AuditResult` `oneOf` (`{ siteUrl, fullAuditRef }`, matching the audit-worker handler output).
- **`examples.yaml`** — add a `money-pages-audit` example (mirrors `broken-internal-links-audit`).
- **`audit-api.yaml`** — reference the new example in both audit response blocks (`audit-for-site`, `latest-audit-for-site`).
- **`docs/index.html`** — regenerated via `npm run docs:build` (repo convention for spec changes).

## Why
`money-pages` is a real, queryable audit type (e.g. `GET /sites/{siteId}/audits/money-pages`) but was missing from the `AuditType` enum. That enum is `$ref`'d by the `:auditType` path/query parameters (`parameters.yaml`), so the documented contract omitted a valid type. Pure doc/contract-accuracy fix — no runtime behavior change.

## Scope notes
- **Not** added to the `OpportunityType` enum — money-pages produces no opportunities (the audit only emits an SQS message to Mystique); listing it there would document a type that never exists.
- The vendored OpenAPI snapshot in `llmo-data-retrieval-service` is intentionally untouched (reference-only; nothing consumes/enforces it).

## Testing
- `npm run docs:lint` → exits 0 (`API description is valid 🎉`). The one `no-invalid-media-type-examples` warning on the new example is structural to `AuditResult`'s `oneOf` (its first variant is `additionalProperties: true`, so every per-type example matches 2 variants) — this same warning already occurs 46× for the existing examples (broken-backlinks, costs, meta-tags, …), so the addition is consistent.
- `npm run docs:build` → bundles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)