### PR TITLE
test: reduce llmo controller test bloat

### DIFF
--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -717,6 +717,22 @@ describe('LlmoController', () => {
     sinon.restore();
   });
 
+  // getSiteAndValidateLlmo is a shared guard used by every handler below.
+  // Test each exit path once here rather than copying it into every handler block.
+  describe('getSiteAndValidateLlmo shared guards', () => {
+    it('returns 404 when site is not found', async () => {
+      mockDataAccess.Site.findById.resolves(null);
+      const result = await controller.getLlmoSheetData(mockContext);
+      expect(result.status).to.equal(404);
+    });
+
+    it('returns 403 when user does not have access', async () => {
+      const deniedController = controllerWithAccessDenied(mockContext);
+      const result = await deniedController.getLlmoCustomerIntent(mockContext);
+      expect(result.status).to.equal(403);
+    });
+  });
+
   describe('getLlmoSheetData', () => {
     const testUrl = `${EXTERNAL_API_BASE_URL}/${TEST_FOLDER}/test-data.json`;
 
@@ -1029,12 +1045,6 @@ describe('LlmoController', () => {
         expect(tracingFetchStub).to.not.have.been.called;
       });
     });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.getLlmoSheetData(mockContext);
-      expect(result.status).to.equal(404);
-    });
   });
 
   describe('getLlmoGlobalSheetData', () => {
@@ -1125,12 +1135,6 @@ describe('LlmoController', () => {
 
       expect(result.status).to.equal(200);
       expect(await result.json()).to.deep.equal({ data: 'test-data' });
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.getLlmoGlobalSheetData(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -1654,12 +1658,6 @@ describe('LlmoController', () => {
         sinon.match.object,
       );
     });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.queryLlmoSheetData(mockContext);
-      expect(result.status).to.equal(404);
-    });
   });
 
   describe('getLlmoConfig', () => {
@@ -1766,12 +1764,6 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody.version).to.be.null;
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.getLlmoConfig(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -2252,12 +2244,6 @@ describe('LlmoController', () => {
       const responseBody = await result.json();
       expect(responseBody.message).to.equal('Only LLMO administrators can update the LLMO config');
     });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.updateLlmoConfig(mockContext);
-      expect(result.status).to.equal(404);
-    });
   });
 
   describe('getLlmoQuestions', () => {
@@ -2277,12 +2263,6 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(200);
       const responseBody = await result.json();
       expect(responseBody).to.deep.equal({});
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.getLlmoQuestions(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -2344,12 +2324,6 @@ describe('LlmoController', () => {
       const responseBody = await result.json();
       expect(responseBody.message).to.equal('Only LLMO administrators can add questions');
     });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.addLlmoQuestion(mockContext);
-      expect(result.status).to.equal(404);
-    });
   });
 
   describe('removeLlmoQuestion', () => {
@@ -2399,12 +2373,6 @@ describe('LlmoController', () => {
       const responseBody = await result.json();
       expect(responseBody.message).to.equal('Only LLMO administrators can remove questions');
     });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.removeLlmoQuestion(mockContext);
-      expect(result.status).to.equal(404);
-    });
   });
 
   describe('patchLlmoQuestion', () => {
@@ -2433,12 +2401,6 @@ describe('LlmoController', () => {
       const responseBody = await result.json();
       expect(responseBody.message).to.equal('Only LLMO administrators can update questions');
     });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.patchLlmoQuestion(mockContext);
-      expect(result.status).to.equal(404);
-    });
   });
 
   describe('getLlmoCustomerIntent', () => {
@@ -2460,14 +2422,6 @@ describe('LlmoController', () => {
       expect(responseBody).to.deep.equal([]);
     });
 
-    it('should return 403 when user does not have access', async () => {
-      const deniedController = controllerWithAccessDenied(mockContext);
-
-      const result = await deniedController.getLlmoCustomerIntent(mockContext);
-
-      expect(result.status).to.equal(403);
-    });
-
     it('should return 400 for database errors', async () => {
       mockDataAccess.Site.findById.rejects(new Error('Database error'));
 
@@ -2476,12 +2430,6 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(400);
       const responseBody = await result.json();
       expect(responseBody.message).to.equal('Database error');
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.getLlmoCustomerIntent(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -2564,15 +2512,6 @@ describe('LlmoController', () => {
       },
     );
 
-    it('should return 403 when user does not have access', async () => {
-      const deniedController = controllerWithAccessDenied(mockContext);
-      mockContext.data = [{ key: 'new_target', value: 'enterprise customers' }];
-
-      const result = await deniedController.addLlmoCustomerIntent(mockContext);
-
-      expect(result.status).to.equal(403);
-    });
-
     it('should return 400 for database errors', async () => {
       mockDataAccess.Site.findById.rejects(new Error('Database connection failed'));
       mockContext.data = [{ key: 'new_target', value: 'enterprise customers' }];
@@ -2597,12 +2536,6 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(403);
       const responseBody = await result.json();
       expect(responseBody.message).to.equal('Only LLMO administrators can add customer intent');
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.addLlmoCustomerIntent(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -2653,26 +2586,12 @@ describe('LlmoController', () => {
       },
     );
 
-    it('should return 403 when user does not have access', async () => {
-      const deniedController = controllerWithAccessDenied(mockContext);
-
-      const result = await deniedController.removeLlmoCustomerIntent(mockContext);
-
-      expect(result.status).to.equal(403);
-    });
-
     it('should return 400 for database errors', async () => {
       mockDataAccess.Site.findById.rejects(new Error('Database error'));
 
       const result = await controller.removeLlmoCustomerIntent(mockContext);
 
       expect(result.status).to.equal(400);
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.removeLlmoCustomerIntent(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -2721,14 +2640,6 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(400);
     });
 
-    it('should return 403 when user does not have access', async () => {
-      const deniedController = controllerWithAccessDenied(mockContext);
-
-      const result = await deniedController.patchLlmoCustomerIntent(mockContext);
-
-      expect(result.status).to.equal(403);
-    });
-
     it('should return 400 for database errors', async () => {
       mockDataAccess.Site.findById.rejects(new Error('Database error'));
 
@@ -2753,12 +2664,6 @@ describe('LlmoController', () => {
         expect(body).to.be.an('array');
       },
     );
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.patchLlmoCustomerIntent(mockContext);
-      expect(result.status).to.equal(404);
-    });
   });
 
   describe('patchLlmoCdnLogsFilter', () => {
@@ -2898,18 +2803,6 @@ describe('LlmoController', () => {
         const responseBody = await result.json();
         expect(responseBody.message).to.equal('Only LLMO administrators can update the CDN bucket config');
       });
-
-      it('should return 404 when site is not found', async () => {
-        mockDataAccess.Site.findById.resolves(null);
-        const result = await controller.patchLlmoCdnBucketConfig(mockContext);
-        expect(result.status).to.equal(404);
-      });
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.patchLlmoCdnLogsFilter(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -3699,12 +3592,6 @@ describe('LlmoController', () => {
       expect(mockLog.error).to.have.been.calledWith(
         'Error during LLMO offboarding for site site123: Offboarding failed',
       );
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.offboardCustomer(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 
@@ -8217,12 +8104,6 @@ describe('LlmoController', () => {
       expect(result.status).to.equal(400);
       const responseBody = await result.json();
       expect(responseBody.message).to.equal('Database connection failed');
-    });
-
-    it('should return 404 when site is not found', async () => {
-      mockDataAccess.Site.findById.resolves(null);
-      const result = await controller.markOpportunitiesReviewed(mockContext);
-      expect(result.status).to.equal(404);
     });
   });
 


### PR DESCRIPTION
## Summary

- Consolidates 21 copy-pasted guard tests in `test/controllers/llmo/llmo.test.js` into 2 canonical `describe` blocks
- **17 identical 404 tests** (each a simple `Site.findById → null` check routed through the shared `getSiteAndValidateLlmo` function) → 1 canonical test
- **4 identical no-access 403 tests** (all routed through the same `getSiteAndValidateLlmo → hasAccess` check) → 1 canonical test
- All per-handler `isLLMOAdministrator()` 403 tests are **preserved** — they verify independent code paths in each handler
- Net: **400 → 381 tests** (−19 tests, no coverage lost)

## Test plan

- [x] `npx mocha test/controllers/llmo/llmo.test.js --timeout 30000` → 381 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)