### PR TITLE
feat(slack): add mode:ai-only-missing for prerender suggestions without AI summary

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -110,7 +110,7 @@ function RunAuditCommand(context) {
     name: 'Run Audit',
     description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed); `mode:ai-only-missing` runs AI-only for current-tab suggestions missing an AI summary. CSV uploads are batched at 320 URLs.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:all|ai-only|ai-only-current] [key:value ...]`,
+    usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:all|ai-only|ai-only-current|ai-only-missing] [key:value ...]`,
   });
 
   const { dataAccess, log } = context;
@@ -183,6 +183,27 @@ function RunAuditCommand(context) {
   };
 
   /**
+   * Returns true when a suggestion belongs to the "current" tab:
+   * status NEW, valid non-wildcard URL, not coveredByDomainWide,
+   * not edgeDeployed, not coveredByPattern.
+   * @param {object} s - A suggestion object.
+   * @returns {boolean}
+   */
+  const isCurrentTabSuggestion = (s) => {
+    if (s.getStatus() !== 'NEW') {
+      return false;
+    }
+    const d = s.getData();
+    if (!d?.url || d.url.includes('*')) {
+      return false;
+    }
+    if (d.coveredByDomainWide || d.edgeDeployed || d.coveredByPattern) {
+      return false;
+    }
+    return isValidUrl(d.url);
+  };
+
+  /**
    * Fetches unique URLs from prerender suggestions matching the "current" tab:
    * status NEW, not coveredByDomainWide, not edgeDeployed, not coveredByPattern.
    * @param {string} siteId - The site ID.
@@ -199,19 +220,7 @@ function RunAuditCommand(context) {
       // eslint-disable-next-line no-await-in-loop
       const suggestions = await opp.getSuggestions();
       suggestions
-        .filter((s) => {
-          if (s.getStatus() !== 'NEW') {
-            return false;
-          }
-          const d = s.getData();
-          if (!d?.url || d.url.includes('*')) {
-            return false;
-          }
-          if (d.coveredByDomainWide || d.edgeDeployed || d.coveredByPattern) {
-            return false;
-          }
-          return isValidUrl(d.url);
-        })
+        .filter(isCurrentTabSuggestion)
         .forEach((s) => {
           urls.add(s.getData().url);
         });
@@ -221,10 +230,8 @@ function RunAuditCommand(context) {
   };
 
   /**
-   * Fetches unique URLs from prerender suggestions matching the "current" tab
-   * that are also missing an AI summary.
-   * Filters: status NEW, not coveredByDomainWide, not edgeDeployed, not
-   * coveredByPattern, and aiSummary is absent or empty.
+   * Fetches unique URLs from current-tab prerender suggestions that are also
+   * missing an AI summary (aiSummary is absent or empty).
    * @param {string} siteId - The site ID.
    * @returns {Promise<string[]>} Deduplicated URLs.
    */
@@ -239,22 +246,7 @@ function RunAuditCommand(context) {
       // eslint-disable-next-line no-await-in-loop
       const suggestions = await opp.getSuggestions();
       suggestions
-        .filter((s) => {
-          if (s.getStatus() !== 'NEW') {
-            return false;
-          }
-          const d = s.getData();
-          if (!d?.url || d.url.includes('*')) {
-            return false;
-          }
-          if (d.coveredByDomainWide || d.edgeDeployed || d.coveredByPattern) {
-            return false;
-          }
-          if (d.aiSummary) {
-            return false;
-          }
-          return isValidUrl(d.url);
-        })
+        .filter((s) => isCurrentTabSuggestion(s) && !s.getData().aiSummary)
         .forEach((s) => {
           urls.add(s.getData().url);
         });

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -222,9 +222,9 @@ function RunAuditCommand(context) {
 
   /**
    * Fetches unique URLs from prerender suggestions matching the "current" tab
-   * that are also missing an AI-generated prerendered HTML summary.
+   * that are also missing an AI summary.
    * Filters: status NEW, not coveredByDomainWide, not edgeDeployed, not
-   * coveredByPattern, and prerenderedHtmlKey is absent.
+   * coveredByPattern, and aiSummary is absent or empty.
    * @param {string} siteId - The site ID.
    * @returns {Promise<string[]>} Deduplicated URLs.
    */
@@ -250,7 +250,7 @@ function RunAuditCommand(context) {
           if (d.coveredByDomainWide || d.edgeDeployed || d.coveredByPattern) {
             return false;
           }
-          if (d.prerenderedHtmlKey) {
+          if (d.aiSummary) {
             return false;
           }
           return isValidUrl(d.url);

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -36,6 +36,7 @@ const PRERENDER_MODES = {
   ALL: 'all',
   AI_ONLY: 'ai-only',
   AI_ONLY_CURRENT: 'ai-only-current',
+  AI_ONLY_MISSING: 'ai-only-missing',
 };
 const PRERENDER_SUGGESTION_STATUSES = ['NEW', 'FIXED'];
 const ALL_AUDITS = [
@@ -107,7 +108,7 @@ function RunAuditCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-audit',
     name: 'Run Audit',
-    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed). CSV uploads are batched at 320 URLs.',
+    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed); `mode:ai-only-missing` runs AI-only for current-tab suggestions missing an AI summary. CSV uploads are batched at 320 URLs.',
     phrases: PHRASES,
     usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:all|ai-only|ai-only-current] [key:value ...]`,
   });
@@ -117,7 +118,8 @@ function RunAuditCommand(context) {
 
   const buildEffectiveData = (baseData, mode) => {
     if (mode !== PRERENDER_MODES.AI_ONLY
-      && mode !== PRERENDER_MODES.AI_ONLY_CURRENT) {
+      && mode !== PRERENDER_MODES.AI_ONLY_CURRENT
+      && mode !== PRERENDER_MODES.AI_ONLY_MISSING) {
       return baseData;
     }
     return JSON.stringify({
@@ -206,6 +208,49 @@ function RunAuditCommand(context) {
             return false;
           }
           if (d.coveredByDomainWide || d.edgeDeployed || d.coveredByPattern) {
+            return false;
+          }
+          return isValidUrl(d.url);
+        })
+        .forEach((s) => {
+          urls.add(s.getData().url);
+        });
+    }
+
+    return [...urls];
+  };
+
+  /**
+   * Fetches unique URLs from prerender suggestions matching the "current" tab
+   * that are also missing an AI-generated prerendered HTML summary.
+   * Filters: status NEW, not coveredByDomainWide, not edgeDeployed, not
+   * coveredByPattern, and prerenderedHtmlKey is absent.
+   * @param {string} siteId - The site ID.
+   * @returns {Promise<string[]>} Deduplicated URLs.
+   */
+  const fetchMissingAiPrerenderSuggestionUrls = async (siteId) => {
+    const opportunities = await Opportunity.allBySiteId(siteId);
+    const prerenderOpps = opportunities.filter(
+      (opp) => opp.getType() === PRERENDER,
+    );
+
+    const urls = new Set();
+    for (const opp of prerenderOpps) {
+      // eslint-disable-next-line no-await-in-loop
+      const suggestions = await opp.getSuggestions();
+      suggestions
+        .filter((s) => {
+          if (s.getStatus() !== 'NEW') {
+            return false;
+          }
+          const d = s.getData();
+          if (!d?.url || d.url.includes('*')) {
+            return false;
+          }
+          if (d.coveredByDomainWide || d.edgeDeployed || d.coveredByPattern) {
+            return false;
+          }
+          if (d.prerenderedHtmlKey) {
             return false;
           }
           return isValidUrl(d.url);
@@ -416,7 +461,8 @@ function RunAuditCommand(context) {
       const hasPrerenderMode = auditType === PRERENDER
         && (prerenderMode === PRERENDER_MODES.ALL
           || prerenderMode === PRERENDER_MODES.AI_ONLY
-          || prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT);
+          || prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT
+          || prerenderMode === PRERENDER_MODES.AI_ONLY_MISSING);
       const isPrerenderCsvRun = hasValidBaseURL
         && hasFiles && auditType === PRERENDER;
 
@@ -434,6 +480,13 @@ function RunAuditCommand(context) {
           [PRERENDER_MODES.ALL]: 'all',
           [PRERENDER_MODES.AI_ONLY]: 'AI-only',
           [PRERENDER_MODES.AI_ONLY_CURRENT]: 'AI-only-current',
+          [PRERENDER_MODES.AI_ONLY_MISSING]: 'AI-only-missing',
+        };
+        const MODE_HINTS = {
+          [PRERENDER_MODES.ALL]: 'with status NEW or FIXED',
+          [PRERENDER_MODES.AI_ONLY]: 'with status NEW or FIXED',
+          [PRERENDER_MODES.AI_ONLY_CURRENT]: 'matching current-tab filters',
+          [PRERENDER_MODES.AI_ONLY_MISSING]: 'matching current-tab filters with missing AI summary',
         };
         const modeLabel = MODE_LABELS[prerenderMode];
         await say(`:hourglass_flowing_sand: Fetching ${modeLabel}`
@@ -445,15 +498,17 @@ function RunAuditCommand(context) {
           return;
         }
 
-        const isCurrentMode = prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT;
-        const urls = isCurrentMode
-          ? await fetchCurrentPrerenderSuggestionUrls(site.getId())
-          : await fetchPrerenderSuggestionUrls(site.getId());
+        let urls;
+        if (prerenderMode === PRERENDER_MODES.AI_ONLY_CURRENT) {
+          urls = await fetchCurrentPrerenderSuggestionUrls(site.getId());
+        } else if (prerenderMode === PRERENDER_MODES.AI_ONLY_MISSING) {
+          urls = await fetchMissingAiPrerenderSuggestionUrls(site.getId());
+        } else {
+          urls = await fetchPrerenderSuggestionUrls(site.getId());
+        }
 
         if (urls.length === 0) {
-          const hint = isCurrentMode
-            ? 'matching current-tab filters'
-            : 'with status NEW or FIXED';
+          const hint = MODE_HINTS[prerenderMode];
           await say(':white_check_mark: No active suggestions'
             + ` ${hint} for *${baseURL}*`
             + ' — nothing to audit.');

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -84,7 +84,7 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       expect(command.id).to.equal('run-audit');
       expect(command.name).to.equal('Run Audit');
-      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed). CSV uploads are batched at 320 URLs.');
+      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed); `mode:ai-only-missing` runs AI-only for current-tab suggestions missing an AI summary. CSV uploads are batched at 320 URLs.');
     });
   });
 
@@ -987,6 +987,130 @@ describe('RunAuditCommand', () => {
 
       expect(sqsStub.sendMessage).to.not.have.been.called;
       expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
+    });
+
+    it('mode:ai-only-missing fetches current-tab suggestions missing a prerenderedHtmlKey', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/no-summary', 'NEW'),
+          makeSuggestion('https://site.com/has-summary', 'NEW', { prerenderedHtmlKey: 's3://bucket/key' }),
+          makeSuggestion('https://site.com/covered', 'NEW', { coveredByDomainWide: true }),
+          makeSuggestion('https://site.com/deployed', 'NEW', { edgeDeployed: true }),
+          makeSuggestion('https://site.com/pattern', 'NEW', { coveredByPattern: true }),
+          makeSuggestion('https://site.com/fixed', 'FIXED'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.deep.equal(['https://site.com/no-summary']);
+      const msgData = JSON.parse(sqsStub.sendMessage.firstCall.args[1].data);
+      expect(msgData.mode).to.equal('ai-only');
+    });
+
+    it('mode:ai-only-missing filters out wildcard and null URLs', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/valid', 'NEW'),
+          makeSuggestion('https://site.com/wildcard/*', 'NEW'),
+          makeSuggestion(null, 'NEW'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.deep.equal(['https://site.com/valid']);
+    });
+
+    it('mode:ai-only-missing reports nothing when all current-tab suggestions already have a summary', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW', { prerenderedHtmlKey: 's3://bucket/key-1' }),
+          makeSuggestion('https://site.com/page-2', 'NEW', { prerenderedHtmlKey: 's3://bucket/key-2' }),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing'], slackContext);
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+      expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
+      expect(slackContext.say).to.have.been.calledWithMatch(/missing AI summary/);
+    });
+
+    it('mode:ai-only-missing reports nothing when all suggestions are covered or filtered', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/covered', 'NEW', { coveredByDomainWide: true }),
+          makeSuggestion('https://site.com/deployed', 'NEW', { edgeDeployed: true }),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing'], slackContext);
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+      expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
+    });
+
+    it('mode:ai-only-missing deduplicates URLs across multiple opportunities', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+        ]),
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+          makeSuggestion('https://site.com/page-2', 'NEW'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing'], slackContext);
+
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.have.length(2);
+      expect(urls).to.include('https://site.com/page-1');
+      expect(urls).to.include('https://site.com/page-2');
+    });
+
+    it('mode:ai-only-missing sends batch-wise Slack messages for large result sets', async () => {
+      const suggestions = Array.from(
+        { length: 500 },
+        (_, i) => makeSuggestion(`https://site.com/page-${i + 1}`, 'NEW'),
+      );
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', suggestions),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledTwice;
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext.urls).to.have.length(320);
+      expect(sqsStub.sendMessage.secondCall.args[1].auditContext.urls).to.have.length(180);
+      expect(slackContext.say).to.have.been.calledWithMatch(/320 URLs \(batch 1\/2\)/);
+      expect(slackContext.say).to.have.been.calledWithMatch(/180 URLs \(batch 2\/2\)/);
+    });
+
+    it('mode:ai-only-missing merges mode into data field alongside other keyword args', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/page-1', 'NEW'),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing', 'source:test'], slackContext);
+
+      const msgData = JSON.parse(sqsStub.sendMessage.firstCall.args[1].data);
+      expect(msgData.mode).to.equal('ai-only');
+      expect(msgData.source).to.equal('test');
     });
   });
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -1028,6 +1028,22 @@ describe('RunAuditCommand', () => {
       expect(urls).to.deep.equal(['https://site.com/valid']);
     });
 
+    it('mode:ai-only-missing treats empty-string aiSummary as missing', async () => {
+      dataAccessStub.Opportunity.allBySiteId.resolves([
+        makeOpportunity('prerender', [
+          makeSuggestion('https://site.com/empty-summary', 'NEW', { aiSummary: '' }),
+          makeSuggestion('https://site.com/has-summary', 'NEW', { aiSummary: 'some AI text' }),
+        ]),
+      ]);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'audit:prerender', 'mode:ai-only-missing'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
+      expect(urls).to.deep.equal(['https://site.com/empty-summary']);
+    });
+
     it('mode:ai-only-missing reports nothing when all current-tab suggestions already have an aiSummary', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -989,11 +989,11 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
     });
 
-    it('mode:ai-only-missing fetches current-tab suggestions missing a prerenderedHtmlKey', async () => {
+    it('mode:ai-only-missing fetches current-tab suggestions missing an aiSummary', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/no-summary', 'NEW'),
-          makeSuggestion('https://site.com/has-summary', 'NEW', { prerenderedHtmlKey: 's3://bucket/key' }),
+          makeSuggestion('https://site.com/has-summary', 'NEW', { aiSummary: 'some AI text' }),
           makeSuggestion('https://site.com/covered', 'NEW', { coveredByDomainWide: true }),
           makeSuggestion('https://site.com/deployed', 'NEW', { edgeDeployed: true }),
           makeSuggestion('https://site.com/pattern', 'NEW', { coveredByPattern: true }),
@@ -1028,11 +1028,11 @@ describe('RunAuditCommand', () => {
       expect(urls).to.deep.equal(['https://site.com/valid']);
     });
 
-    it('mode:ai-only-missing reports nothing when all current-tab suggestions already have a summary', async () => {
+    it('mode:ai-only-missing reports nothing when all current-tab suggestions already have an aiSummary', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
-          makeSuggestion('https://site.com/page-1', 'NEW', { prerenderedHtmlKey: 's3://bucket/key-1' }),
-          makeSuggestion('https://site.com/page-2', 'NEW', { prerenderedHtmlKey: 's3://bucket/key-2' }),
+          makeSuggestion('https://site.com/page-1', 'NEW', { aiSummary: 'summary for page 1' }),
+          makeSuggestion('https://site.com/page-2', 'NEW', { aiSummary: 'summary for page 2' }),
         ]),
       ]);
 


### PR DESCRIPTION
## Summary

- Adds `mode:ai-only-missing` to the `run-audit` Slack command for the `prerender` audit type
- Filters the same current-tab suggestions as `ai-only-current` (status NEW, not `coveredByDomainWide`, not `edgeDeployed`, not `coveredByPattern`) but additionally excludes suggestions that already have an `aiSummary` — i.e. only queues URLs where the AI summary is absent
- Sends the audit with `mode: ai-only` in the data payload, identical to `ai-only-current`
- Batch size and entitlement checks are unchanged (320 URLs per batch)

## Test plan

- [x] 7 new unit tests covering: basic filtering, wildcard/null URL exclusion, no-results messaging, deduplication across opportunities, batching, and keyword merging
- [x] All 68 tests in `run-audit.test.js` pass
- [x] ESLint clean on changed files