### PR TITLE
fix: honor date filter on gap-topics endpoints | LLMO-5625

### DIFF
--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics-export.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics-export.js
@@ -49,7 +49,15 @@ export async function handleGapTopicsExport(sp, clients) {
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const sortBy = sp.get('sortBy') || TOPICS_REQUEST_ORDER_BY_ENUM.TOTAL_COMPETITOR_MENTIONS;
   const sortDirection = sp.get('sortDirection') || ORDER_DIRECTION_ENUM.DESC;
-  const date = sp.get('date');
+  // `GapTopicsRequest.date` is a `common.v1.Date` message, not the string
+  // `target_date`. Parse an exact `YYYY-MM-DD` snapshot day so the export honors
+  // the date filter like the list/totals handlers; omit otherwise for latest. See
+  // gap-topics.js.
+  const dateRaw = sp.get('date')?.trim();
+  const dm = dateRaw && /^(\d{4})-(\d{2})-(\d{1,2})$/.exec(dateRaw);
+  const snapshotDate = dm
+    ? { year: Number(dm[1]), month: Number(dm[2]), day: Number(dm[3]) }
+    : undefined;
   const { limit, offset } = parseLimitOffset(sp);
 
   const gapKindsRaw = sp.get('gapKinds');
@@ -78,7 +86,7 @@ export async function handleGapTopicsExport(sp, clients) {
         range: { limit, offset },
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterResult.metricFilterQl,
-        target_date: date,
+        ...(snapshotDate ? { date: snapshotDate } : {}),
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics-totals.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics-totals.js
@@ -39,7 +39,14 @@ export async function handleGapTopicsTotals(sp, clients) {
   const competitorDomains = parseCompetitorDomainsList(sp);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
-  const date = sp.get('date');
+  // `GapTopicsTotalsRequest.date` is a `common.v1.Date` message — parse an exact
+  // `YYYY-MM-DD` snapshot day so the count matches the date-filtered list; omit
+  // otherwise so the upstream uses the latest snapshot. See gap-topics.js.
+  const dateRaw = sp.get('date')?.trim();
+  const dm = dateRaw && /^(\d{4})-(\d{2})-(\d{1,2})$/.exec(dateRaw);
+  const snapshotDate = dm
+    ? { year: Number(dm[1]), month: Number(dm[2]), day: Number(dm[3]) }
+    : undefined;
 
   const dimensionFilterQl = buildGapTopicsDimensionFilterQl(sp);
   const metricFilterResult = buildGapTopicsMetricFilterQl(sp);
@@ -58,7 +65,7 @@ export async function handleGapTopicsTotals(sp, clients) {
         competitors: competitorDomains.map(brandTarget),
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterResult.metricFilterQl,
-        target_date: date,
+        ...(snapshotDate ? { date: snapshotDate } : {}),
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
@@ -73,7 +73,15 @@ export async function handleGapTopics(sp, clients) {
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const sortBy = sp.get('sortBy') || TOPICS_REQUEST_ORDER_BY_ENUM.TOTAL_COMPETITOR_MENTIONS;
   const sortDirection = sp.get('sortDirection') || ORDER_DIRECTION_ENUM.DESC;
-  const date = sp.get('date');
+  // `GapTopicsRequest.date` is a `common.v1.Date` message — not the string
+  // `target_date` used by brand-topics. Parse an exact `YYYY-MM-DD` snapshot day
+  // (same shape as source-opportunities' `gapSnapshotDate`); omit otherwise so the
+  // upstream uses the latest snapshot rather than failing on a day-less date.
+  const dateRaw = sp.get('date')?.trim();
+  const dm = dateRaw && /^(\d{4})-(\d{2})-(\d{1,2})$/.exec(dateRaw);
+  const snapshotDate = dm
+    ? { year: Number(dm[1]), month: Number(dm[2]), day: Number(dm[3]) }
+    : undefined;
   const { limit, offset } = parseLimitOffset(sp);
 
   const gapKindsRaw = sp.get('gapKinds');
@@ -102,7 +110,7 @@ export async function handleGapTopics(sp, clients) {
         range: { limit, offset },
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterResult.metricFilterQl,
-        target_date: date,
+        ...(snapshotDate ? { date: snapshotDate } : {}),
       },
       PROTO_FROM_JSON,
     );


### PR DESCRIPTION
## Summary
The Topic Opportunities table (and its CSV export) on the Visibility Overview dashboard ignored the date-range filter. The gap-topics handlers set `target_date` (a string) on `GapTopicsRequest` / `GapTopicsTotalsRequest`, but those protos have no `target_date` field — only `date` (a `common.v1.Date` message). With `ignoreUnknownFields`, the value was silently dropped and never reached the upstream gRPC. This fixes the list, totals, and export handlers to send the proto `date` message instead.

## Changes
- `gap-topics.js`, `gap-topics-totals.js`, `gap-topics-export.js`: parse the incoming `date` query param (`YYYY-MM-DD`) into a `{year, month, day}` `date` message and drop the silently-dropped `target_date` string — mirroring the working `source-opportunities` handler.
- The `date` is omitted when absent/invalid, so the upstream falls back to the latest snapshot rather than failing on a day-less date.
- `brand-topics` is intentionally untouched: its proto has a real `target_date` string field, so it was already correct.

## Test plan
- [x] Verified live (local stack): `gap-topics-totals` ALL count now varies by snapshot day — 1,013,763 (`2026-06-06`) and 1,006,366 (`2026-06-10`) vs the previously-constant 1,000,437.
- [x] `eslint` passes on all three handlers.
- [ ] Confirm Topic Opportunities table + CSV export reflect the selected date on stage (export not yet live-verified).

## Notes
No unit tests added — these handlers are excluded from coverage (`/* c8 ignore */`) per the existing convention; behavior verified manually against the live stack.

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-5625

---
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- API specification is unchanged (the `date` query param was already accepted; this only fixes how it maps to the proto), so the API-spec checklist items below are N/A.