### PR TITLE
fix(it): bump pinned data-service image to v5.38.0

### DIFF
--- a/test/it/postgres/docker-compose.yml
+++ b/test/it/postgres/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   data-service:
-    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.37.0
+    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.38.0
     container_name: spacecat-it-data-service
     depends_on:
       db:


### PR DESCRIPTION
## What

Bumps the `mysticat-data-service` ECR image pinned in the IT PostgreSQL suite from `v5.37.0` to `v5.38.0` (latest release).

## Why

The `test/it/postgres/docker-compose.yml` `data-service` container pins a specific ECR image tag. The ECR lifecycle policy prunes older image tags, so a previously-pinned tag periodically disappears and the `it-postgres` CI job fails with:

```
Error response from daemon: manifest for 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:vX.Y.Z not found: manifest unknown: Requested image not found
```

This is the same lifecycle-pruning failure mode that has hit before (e.g. the recently-pruned `v5.13.0`). Pinning the newest released tag (`v5.38.0`) keeps the suite on an image that lifecycle will not prune for the longest.

## Verification

- `v5.38.0` is the current latest release of `adobe/mysticat-data-service` (2026-06-16) — as the newest tag it is guaranteed present in ECR.
- Single-line change to the pinned image tag; no functional code change. CI `it-postgres` will exercise the pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)