### PR TITLE
feat: add v2 brand claims guidance fields

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -6721,6 +6721,20 @@ CustomerConfigBrand:
       type: string
       description: Detailed description of the brand
       example: "Adobe's flagship image editing software"
+    brandContext:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional claims extraction context for this brand. Blank values clear the stored value.
+      example: "Adobe Photoshop is Adobe's image editing product for creative professionals."
+    mentionSentimentGuidance:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional guidance for classifying brand mention sentiment. Blank values clear the stored value.
+      example: "Treat comparisons about subscription cost as neutral unless the answer explicitly recommends against the brand."
     updatedAt:
       $ref: '#/DateTime'
       description: When the brand was last updated
@@ -7367,6 +7381,18 @@ V2Brand:
         - string
         - 'null'
       description: Brand description
+    brandContext:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional claims extraction context for this brand. Blank values clear the stored value.
+    mentionSentimentGuidance:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional guidance for classifying brand mention sentiment. Blank values clear the stored value.
     vertical:
       type:
         - string
@@ -7430,6 +7456,8 @@ V2Brand:
     status: 'active'
     origin: 'human'
     description: 'An example brand'
+    brandContext: "Example Brand is a B2B analytics platform."
+    mentionSentimentGuidance: "Treat factual pricing mentions as neutral unless the response recommends against the brand."
     vertical: 'technology'
     region: ['US', 'DE']
     urls:
@@ -7472,6 +7500,18 @@ V2BrandInput:
       default: human
     description:
       type: string
+    brandContext:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional claims extraction context for this brand. Omit to preserve, blank or null to clear.
+    mentionSentimentGuidance:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional guidance for classifying brand mention sentiment. Omit to preserve, blank or null to clear.
     vertical:
       type: string
     region:
@@ -7513,6 +7553,18 @@ V2BrandUpdateInput:
       enum: [human, ai]
     description:
       type: string
+    brandContext:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional claims extraction context for this brand. Omit to preserve, blank or null to clear.
+    mentionSentimentGuidance:
+      type:
+        - string
+        - 'null'
+      maxLength: 4000
+      description: Optional guidance for classifying brand mention sentiment. Omit to preserve, blank or null to clear.
     vertical:
       type: string
     region:

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -171,7 +171,9 @@ function BrandsController(ctx, log, env) {
         if (typeof value !== 'string') {
           return badRequest(`${field} must be a string or null`);
         }
-        if (value.length > BRAND_GUIDANCE_MAX_LENGTH) {
+        // Validate the trimmed length: storage trims before persisting, so this
+        // mirrors what is actually stored (and the schema's maxLength).
+        if (value.trim().length > BRAND_GUIDANCE_MAX_LENGTH) {
           return badRequest(`${field} must be at most ${BRAND_GUIDANCE_MAX_LENGTH} characters`);
         }
       }

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -68,6 +68,8 @@ import {
 } from '../support/topics-storage.js';
 
 const HEADER_ERROR = 'x-error';
+const BRAND_GUIDANCE_MAX_LENGTH = 4000;
+const BRAND_GUIDANCE_FIELDS = ['brandContext', 'mentionSentimentGuidance'];
 
 /**
  * BrandsController. Provides methods to read brands and brand guidelines.
@@ -160,6 +162,21 @@ function BrandsController(ctx, log, env) {
       });
     }
     return internalServerError(error.message);
+  }
+
+  function validateBrandGuidanceFields(brandData = {}) {
+    for (const field of BRAND_GUIDANCE_FIELDS) {
+      const value = brandData[field];
+      if (value !== undefined && value !== null) {
+        if (typeof value !== 'string') {
+          return badRequest(`${field} must be a string or null`);
+        }
+        if (value.length > BRAND_GUIDANCE_MAX_LENGTH) {
+          return badRequest(`${field} must be at most ${BRAND_GUIDANCE_MAX_LENGTH} characters`);
+        }
+      }
+    }
+    return null;
   }
 
   /**
@@ -1298,6 +1315,10 @@ function BrandsController(ctx, log, env) {
       if (!hasText(brandData.name)) {
         return badRequest('Brand name is required');
       }
+      const invalidGuidance = validateBrandGuidanceFields(brandData);
+      if (invalidGuidance) {
+        return invalidGuidance;
+      }
 
       const organization = await getOrganizationOrNotFound(spaceCatId);
       if (organization.status) {
@@ -1343,6 +1364,10 @@ function BrandsController(ctx, log, env) {
       }
       if (!hasText(brandId)) {
         return badRequest('Brand ID required');
+      }
+      const invalidGuidance = validateBrandGuidanceFields(updates);
+      if (invalidGuidance) {
+        return invalidGuidance;
       }
 
       const organization = await getOrganizationOrNotFound(spaceCatId);

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -34,7 +34,11 @@ function normalizeNullableText(value, fieldName) {
     return null;
   }
   if (typeof value !== 'string') {
-    throw new Error(`${fieldName} must be a string or null`);
+    // Tag with a 400 status so callers that reach storage without going through
+    // the controller's validation surface a client error rather than a 500.
+    const error = new Error(`${fieldName} must be a string or null`);
+    error.status = 400;
+    throw error;
   }
   const trimmed = value.trim();
   return hasText(trimmed) ? trimmed : null;
@@ -134,8 +138,8 @@ function mapDbBrandToV2(row) {
     status: row.status || 'active',
     origin: row.origin || 'human',
     description: row.description || null,
-    brandContext: row.brand_context || null,
-    mentionSentimentGuidance: row.mention_sentiment_guidance || null,
+    brandContext: row.brand_context ?? null,
+    mentionSentimentGuidance: row.mention_sentiment_guidance ?? null,
     vertical: row.vertical || null,
     region: row.regions || [],
     urls,

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -26,6 +26,20 @@ const BRAND_SELECT = [
   'brand_urls(url)',
 ].join(', ');
 
+function normalizeNullableText(value, fieldName) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string or null`);
+  }
+  const trimmed = value.trim();
+  return hasText(trimmed) ? trimmed : null;
+}
+
 /**
  * Splits a full URL string into its base URL and path.
  * e.g. "https://example.com/products" -> { base: "https://example.com", path: "/products" }
@@ -120,6 +134,8 @@ function mapDbBrandToV2(row) {
     status: row.status || 'active',
     origin: row.origin || 'human',
     description: row.description || null,
+    brandContext: row.brand_context || null,
+    mentionSentimentGuidance: row.mention_sentiment_guidance || null,
     vertical: row.vertical || null,
     region: row.regions || [],
     urls,
@@ -534,6 +550,19 @@ export async function upsertBrand({
     updated_by: updatedBy,
   };
 
+  const brandContext = normalizeNullableText(brand.brandContext, 'brandContext');
+  if (brandContext !== undefined) {
+    row.brand_context = brandContext;
+  }
+
+  const mentionSentimentGuidance = normalizeNullableText(
+    brand.mentionSentimentGuidance,
+    'mentionSentimentGuidance',
+  );
+  if (mentionSentimentGuidance !== undefined) {
+    row.mention_sentiment_guidance = mentionSentimentGuidance;
+  }
+
   // baseSiteId is immutable once persisted (mirrors updateBrand). Only set it
   // when the brand has no site_id yet — re-onboarding/re-upserting an existing
   // brand by name must NOT re-point its primary site (LLMO-5556: this silently
@@ -619,6 +648,15 @@ export async function updateBrand({
   }
   if (updates.description !== undefined) {
     patch.description = updates.description;
+  }
+  if (updates.brandContext !== undefined) {
+    patch.brand_context = normalizeNullableText(updates.brandContext, 'brandContext');
+  }
+  if (updates.mentionSentimentGuidance !== undefined) {
+    patch.mention_sentiment_guidance = normalizeNullableText(
+      updates.mentionSentimentGuidance,
+      'mentionSentimentGuidance',
+    );
   }
   if (updates.vertical !== undefined) {
     patch.vertical = updates.vertical;

--- a/src/support/customer-config-mapper.js
+++ b/src/support/customer-config-mapper.js
@@ -42,6 +42,27 @@ const DEFAULT_VERTICALS = [
   'Government & Public Services',
 ];
 
+const BRAND_GUIDANCE_MAX_LENGTH = 4000;
+
+function normalizeBrandGuidance(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!hasText(trimmed)) {
+    return null;
+  }
+  return trimmed.length > BRAND_GUIDANCE_MAX_LENGTH
+    ? trimmed.slice(0, BRAND_GUIDANCE_MAX_LENGTH)
+    : trimmed;
+}
+
 /**
  * Generates a deterministic hash from a string.
  * @param {string} input - Input string to hash
@@ -166,8 +187,8 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
     origin: 'system',
     region: brandRegions,
     description: '',
-    brandContext: llmoConfig.claims?.brandContext,
-    mentionSentimentGuidance: llmoConfig.claims?.sentimentGuidance,
+    brandContext: normalizeBrandGuidance(llmoConfig.claims?.brandContext),
+    mentionSentimentGuidance: normalizeBrandGuidance(llmoConfig.claims?.sentimentGuidance),
     updatedAt: primaryAlias.updatedAt || new Date().toISOString(),
     updatedBy: 'system',
     vertical: '',

--- a/src/support/customer-config-mapper.js
+++ b/src/support/customer-config-mapper.js
@@ -166,6 +166,8 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
     origin: 'system',
     region: brandRegions,
     description: '',
+    brandContext: llmoConfig.claims?.brandContext,
+    mentionSentimentGuidance: llmoConfig.claims?.sentimentGuidance,
     updatedAt: primaryAlias.updatedAt || new Date().toISOString(),
     updatedBy: 'system',
     vertical: '',

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -4364,6 +4364,26 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('returns 400 when brand guidance fields have the wrong type', async () => {
+      const response = await brandsController.createBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'New Brand', brandContext: { text: 'wrong' } },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when brand guidance fields are longer than 4000 characters', async () => {
+      const response = await brandsController.createBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'New Brand', mentionSentimentGuidance: 'x'.repeat(4001) },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
     it('returns 400 when params is undefined', async () => {
       const response = await brandsController.createBrandForOrg({
         ...context,
@@ -4522,6 +4542,26 @@ describe('Brands Controller', () => {
         ...context,
         params: { spaceCatId: 'not-a-uuid', brandId: BRAND_UUID },
         data: { name: 'Updated Brand' },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when brand guidance update fields have the wrong type', async () => {
+      const response = await brandsController.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { mentionSentimentGuidance: ['wrong'] },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when brand guidance update fields are longer than 4000 characters', async () => {
+      const response = await brandsController.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { brandContext: 'x'.repeat(4001) },
         dataAccess: mockDataAccess,
       });
       expect(response.status).to.equal(400);

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -4384,6 +4384,20 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(400);
     });
 
+    it('accepts brand guidance that trims to within the limit despite surrounding whitespace', async () => {
+      // 4004 raw characters, but 4000 after trim — storage trims before persisting,
+      // so the controller validates the trimmed length and must not reject this.
+      const padded = `  ${'x'.repeat(4000)}  `;
+      const response = await brandsController.createBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'New Brand', brandContext: padded },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+      });
+      expect(response.status).to.equal(201);
+    });
+
     it('returns 400 when params is undefined', async () => {
       const response = await brandsController.createBrandForOrg({
         ...context,

--- a/test/it/postgres/brands.test.js
+++ b/test/it/postgres/brands.test.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ctx } from './harness.js';
+import { resetPostgres } from './seed.js';
+import brandsTests from '../shared/tests/brands.js';
+
+brandsTests(() => ctx.httpClient, resetPostgres);

--- a/test/it/postgres/docker-compose.yml
+++ b/test/it/postgres/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   data-service:
-    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.38.0
+    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.41.0
     container_name: spacecat-it-data-service
     depends_on:
       db:

--- a/test/it/shared/tests/brands.js
+++ b/test/it/shared/tests/brands.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ORG_1_ID } from '../seed-ids.js';
+
+export default function brandsTests(getHttpClient, resetData) {
+  describe('Brands v2 claims guidance', () => {
+    before(() => resetData());
+
+    it('creates, returns, preserves, and clears brand guidance fields', async () => {
+      const http = getHttpClient();
+
+      const createRes = await http.admin.post(
+        `/v2/orgs/${ORG_1_ID}/brands`,
+        {
+          name: 'Claims Guidance Brand',
+          brandContext: '  Context for claims extraction  ',
+          mentionSentimentGuidance: '  Sentiment guidance text  ',
+          region: ['US'],
+        },
+      );
+      expect(createRes.status).to.equal(201);
+      expect(createRes.body.brandContext).to.equal('Context for claims extraction');
+      expect(createRes.body.mentionSentimentGuidance).to.equal('Sentiment guidance text');
+      const { id: brandId } = createRes.body;
+
+      const getRes = await http.admin.get(`/v2/orgs/${ORG_1_ID}/brands/${brandId}`);
+      expect(getRes.status).to.equal(200);
+      expect(getRes.body.brandContext).to.equal('Context for claims extraction');
+      expect(getRes.body.mentionSentimentGuidance).to.equal('Sentiment guidance text');
+
+      const listRes = await http.admin.get(`/v2/orgs/${ORG_1_ID}/brands`);
+      expect(listRes.status).to.equal(200);
+      const listed = listRes.body.brands.find((brand) => brand.id === brandId);
+      expect(listed.brandContext).to.equal('Context for claims extraction');
+      expect(listed.mentionSentimentGuidance).to.equal('Sentiment guidance text');
+
+      const preserveRes = await http.admin.patch(
+        `/v2/orgs/${ORG_1_ID}/brands/${brandId}`,
+        { description: 'Updated without guidance fields' },
+      );
+      expect(preserveRes.status).to.equal(200);
+      expect(preserveRes.body.brandContext).to.equal('Context for claims extraction');
+      expect(preserveRes.body.mentionSentimentGuidance).to.equal('Sentiment guidance text');
+
+      const clearRes = await http.admin.patch(
+        `/v2/orgs/${ORG_1_ID}/brands/${brandId}`,
+        {
+          brandContext: null,
+          mentionSentimentGuidance: '   ',
+        },
+      );
+      expect(clearRes.status).to.equal(200);
+      expect(clearRes.body.brandContext).to.equal(null);
+      expect(clearRes.body.mentionSentimentGuidance).to.equal(null);
+    });
+
+    it('rejects invalid brand guidance payloads', async () => {
+      const http = getHttpClient();
+
+      const wrongType = await http.admin.post(
+        `/v2/orgs/${ORG_1_ID}/brands`,
+        { name: 'Bad Claims Guidance Brand', brandContext: { value: 'wrong' } },
+      );
+      expect(wrongType.status).to.equal(400);
+
+      const tooLong = await http.admin.post(
+        `/v2/orgs/${ORG_1_ID}/brands`,
+        {
+          name: 'Long Claims Guidance Brand',
+          mentionSentimentGuidance: 'x'.repeat(4001),
+        },
+      );
+      expect(tooLong.status).to.equal(400);
+    });
+  });
+}

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -56,6 +56,8 @@ describe('brands-storage', () => {
       status: 'active',
       origin: 'human',
       description: null,
+      brand_context: null,
+      mention_sentiment_guidance: null,
       vertical: null,
       regions: [],
       brand_aliases: [],
@@ -100,6 +102,8 @@ describe('brands-storage', () => {
 
       expect(result).to.have.length(1);
       expect(result[0]).to.include({ name: 'TestBrand', status: 'active' });
+      expect(result[0].brandContext).to.equal(null);
+      expect(result[0].mentionSentimentGuidance).to.equal(null);
       expect(result[0].region).to.deep.equal(['US']);
       expect(result[0].brandAliases).to.deep.equal([{ name: 'TB', regions: ['US'] }]);
       expect(result[0].socialAccounts).to.deep.equal([{ url: 'https://twitter.com/test', regions: ['US'] }]);
@@ -210,6 +214,20 @@ describe('brands-storage', () => {
       const postgrestClient = { from: sinon.stub().returns(query) };
 
       await expect(listBrands(ORG_ID, postgrestClient)).to.be.rejectedWith('Failed to list brands');
+    });
+
+    it('maps brand guidance columns to flat V2 fields', async () => {
+      const dbRow = makeBrandRow({
+        brand_context: 'Context for this brand',
+        mention_sentiment_guidance: 'Sentiment guidance',
+      });
+
+      const query = createChainableQuery({ data: [dbRow], error: null });
+      const postgrestClient = { from: sinon.stub().returns(query) };
+
+      const result = await listBrands(ORG_ID, postgrestClient);
+      expect(result[0].brandContext).to.equal('Context for this brand');
+      expect(result[0].mentionSentimentGuidance).to.equal('Sentiment guidance');
     });
   });
 
@@ -466,11 +484,10 @@ describe('brands-storage', () => {
     return { from: sinon.stub().callsFake((table) => makeQuery(table)) };
   }
 
-  // Like createTableMockClient, but records the row passed to `.upsert(row, opts)`
-  // per table on `client.capturedCalls.upsert`, so tests can assert exactly what was
-  // written (e.g. that site_id was preserved rather than overwritten).
+  // Like createTableMockClient, but records rows passed to write methods so
+  // tests can assert exactly what was written.
   function createCapturingClient(tableMap) {
-    const calls = { upsert: [] };
+    const calls = { upsert: [], update: [] };
     const callCounts = {};
     const makeQuery = (table) => {
       const responses = tableMap[table] || [{ data: null, error: null }];
@@ -487,6 +504,12 @@ describe('brands-storage', () => {
           if (prop === 'upsert') {
             return (row, opts) => {
               calls.upsert.push({ table, row, opts });
+              return new Proxy({}, handler);
+            };
+          }
+          if (prop === 'update') {
+            return (row) => {
+              calls.update.push({ table, row });
               return new Proxy({}, handler);
             };
           }
@@ -603,6 +626,59 @@ describe('brands-storage', () => {
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
       expect(brandsUpsert.row.site_id).to.equal('new-site');
+    });
+
+    it('normalizes brand guidance fields in upsert row', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          {
+            data: makeBrandRow({
+              name: 'Test',
+              brand_context: 'Context text',
+              mention_sentiment_guidance: null,
+            }),
+            error: null,
+          },
+        ],
+      });
+
+      const result = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          brandContext: '  Context text  ',
+          mentionSentimentGuidance: '   ',
+        },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.brand_context).to.equal('Context text');
+      expect(brandsUpsert.row.mention_sentiment_guidance).to.equal(null);
+      expect(result.brandContext).to.equal('Context text');
+      expect(result.mentionSentimentGuidance).to.equal(null);
+    });
+
+    it('omits brand guidance columns in upsert row when fields are omitted', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { site_id: 'existing-site' }, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test' },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row).to.not.have.property('brand_context');
+      expect(brandsUpsert.row).to.not.have.property('mention_sentiment_guidance');
     });
 
     it('does NOT overwrite an existing brand site_id and warns (LLMO-5556)', async () => {
@@ -1570,6 +1646,64 @@ describe('brands-storage', () => {
       });
 
       expect(result).to.include({ name: 'NewName', status: 'pending' });
+    });
+
+    it('normalizes brand guidance fields in update patch', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { id: BRAND_ID }, error: null },
+          {
+            data: makeBrandRow({
+              brand_context: null,
+              mention_sentiment_guidance: 'Keep this guidance',
+            }),
+            error: null,
+          },
+        ],
+      });
+
+      const result = await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: {
+          brandContext: null,
+          mentionSentimentGuidance: '  Keep this guidance  ',
+        },
+        postgrestClient: client,
+      });
+
+      const brandsUpdate = client.capturedCalls.update.find((c) => c.table === 'brands');
+      expect(brandsUpdate.row.brand_context).to.equal(null);
+      expect(brandsUpdate.row.mention_sentiment_guidance).to.equal('Keep this guidance');
+      expect(result.brandContext).to.equal(null);
+      expect(result.mentionSentimentGuidance).to.equal('Keep this guidance');
+    });
+
+    it('omits brand guidance columns in update patch when fields are omitted', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { id: BRAND_ID }, error: null },
+          {
+            data: makeBrandRow({
+              description: 'new desc',
+              brand_context: 'Existing context',
+              mention_sentiment_guidance: 'Existing guidance',
+            }),
+            error: null,
+          },
+        ],
+      });
+
+      await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { description: 'new desc' },
+        postgrestClient: client,
+      });
+
+      const brandsUpdate = client.capturedCalls.update.find((c) => c.table === 'brands');
+      expect(brandsUpdate.row).to.not.have.property('brand_context');
+      expect(brandsUpdate.row).to.not.have.property('mention_sentiment_guidance');
     });
 
     it('successfully updates region and urls', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -229,6 +229,20 @@ describe('brands-storage', () => {
       expect(result[0].brandContext).to.equal('Context for this brand');
       expect(result[0].mentionSentimentGuidance).to.equal('Sentiment guidance');
     });
+
+    it('preserves empty string guidance values from the database', async () => {
+      const dbRow = makeBrandRow({
+        brand_context: '',
+        mention_sentiment_guidance: '',
+      });
+
+      const query = createChainableQuery({ data: [dbRow], error: null });
+      const postgrestClient = { from: sinon.stub().returns(query) };
+
+      const result = await listBrands(ORG_ID, postgrestClient);
+      expect(result[0].brandContext).to.equal('');
+      expect(result[0].mentionSentimentGuidance).to.equal('');
+    });
   });
 
   describe('getBrandById', () => {
@@ -534,6 +548,16 @@ describe('brands-storage', () => {
       })).to.be.rejectedWith('Brand name is required');
     });
 
+    it('throws when brand guidance input has the wrong type', async () => {
+      await expect(upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', brandContext: ['wrong'] },
+        postgrestClient: createTableMockClient({
+          brands: { data: null, error: null },
+        }),
+      })).to.be.rejectedWith('brandContext must be a string or null');
+    });
+
     it('throws when brands upsert fails', async () => {
       const postgrestClient = createTableMockClient({
         brands: [
@@ -679,6 +703,27 @@ describe('brands-storage', () => {
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
       expect(brandsUpsert.row).to.not.have.property('brand_context');
       expect(brandsUpsert.row).to.not.have.property('mention_sentiment_guidance');
+    });
+
+    it('rejects non-string brand guidance with a 400-tagged error', async () => {
+      const client = createCapturingClient({
+        brands: [{ data: null, error: null }],
+      });
+
+      let caught;
+      try {
+        await upsertBrand({
+          organizationId: ORG_ID,
+          brand: { name: 'Test', brandContext: { wrong: true } },
+          postgrestClient: client,
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).to.be.an('error');
+      expect(caught.message).to.equal('brandContext must be a string or null');
+      expect(caught.status).to.equal(400);
     });
 
     it('does NOT overwrite an existing brand site_id and warns (LLMO-5556)', async () => {
@@ -1532,6 +1577,15 @@ describe('brands-storage', () => {
       });
 
       expect(result).to.be.null;
+    });
+
+    it('throws when brand guidance update input has the wrong type', async () => {
+      await expect(updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { mentionSentimentGuidance: ['wrong'] },
+        postgrestClient: { from: () => {} },
+      })).to.be.rejectedWith('mentionSentimentGuidance must be a string or null');
     });
 
     it('throws when update query fails', async () => {

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -156,6 +156,26 @@ describe('Customer Config Mapper', () => {
       expect(result.customer.brands[0].mentionSentimentGuidance).to.equal(null);
     });
 
+    it('handles null and non-string legacy claims guidance values', () => {
+      const llmoConfig = {
+        brands: {
+          aliases: [
+            { name: 'Test Brand', regions: ['US'] },
+          ],
+        },
+        claims: {
+          brandContext: null,
+          sentimentGuidance: { text: 'ignore me' },
+        },
+        categories: {},
+        topics: {},
+      };
+
+      const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
+      expect(result.customer.brands[0].brandContext).to.equal(null);
+      expect(result.customer.brands[0].mentionSentimentGuidance).to.equal(undefined);
+    });
+
     it('handles brand alias with regions property (array)', () => {
       const llmoConfig = {
         brands: {

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -135,6 +135,27 @@ describe('Customer Config Mapper', () => {
       expect(result.customer.brands[0].region).to.include('us');
     });
 
+    it('normalizes legacy claims guidance for the v2 brand shape', () => {
+      const llmoConfig = {
+        brands: {
+          aliases: [
+            { name: 'Test Brand', regions: ['US'] },
+          ],
+        },
+        claims: {
+          brandContext: `  ${'a'.repeat(4001)}  `,
+          sentimentGuidance: '   ',
+        },
+        categories: {},
+        topics: {},
+      };
+
+      const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
+      expect(result.customer.brands[0].brandContext).to.have.lengthOf(4000);
+      expect(result.customer.brands[0].brandContext).to.equal('a'.repeat(4000));
+      expect(result.customer.brands[0].mentionSentimentGuidance).to.equal(null);
+    });
+
     it('handles brand alias with regions property (array)', () => {
       const llmoConfig = {
         brands: {

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -50,6 +50,10 @@ describe('Customer Config Mapper', () => {
             ],
           },
         },
+        claims: {
+          brandContext: 'Photoshop is Adobe creative software.',
+          sentimentGuidance: 'Treat factual price mentions as neutral.',
+        },
       };
 
       const result = convertV1ToV2(llmoConfig, 'Adobe', '1234@AdobeOrg');
@@ -65,6 +69,8 @@ describe('Customer Config Mapper', () => {
       expect(brand.brandAliases).to.have.lengthOf(2);
       expect(brand.competitors).to.have.lengthOf(1);
       expect(brand.prompts).to.have.lengthOf(1);
+      expect(brand.brandContext).to.equal('Photoshop is Adobe creative software.');
+      expect(brand.mentionSentimentGuidance).to.equal('Treat factual price mentions as neutral.');
 
       const prompt = brand.prompts[0];
       expect(prompt.prompt).to.equal('What is the best photo editing software?');


### PR DESCRIPTION
## Summary
- expose flat v2 brand guidance fields brandContext and mentionSentimentGuidance on existing brand APIs
- validate wrong types and over-4000-character guidance with 400 responses
- normalize persistence so omitted fields preserve, blank/null clears, and non-empty strings are trimmed
- map legacy v1 claims guidance into the v2 brand shape and document fields in OpenAPI
- add unit and Postgres integration coverage for create/get/list/update/clear behavior

## Testing
- npm test -- --spec=test/support/brands-storage.test.js --spec=test/controllers/brands.test.js --spec=test/support/customer-config-mapper.test.js
- npx mocha --timeout 10000 test/support/brands-storage.test.js test/controllers/brands.test.js test/support/customer-config-mapper.test.js
- IT_SERVER_PORT=3005 npx mocha --require test/it/postgres/harness.js --timeout 30000 test/it/postgres/brands.test.js
- IT_SERVER_PORT=3005 npx mocha --require test/it/postgres/harness.js --timeout 30000 test/it/postgres/**/*.test.js using local mysticat-data-service checkout image/migrations
- npm run docs:lint
- npm run lint