### PR TITLE
fix(topics): guard topic_categories link against non-UUID categoryId and log SQLSTATE

### DIFF
--- a/src/support/topics-storage.js
+++ b/src/support/topics-storage.js
@@ -145,7 +145,9 @@ export async function createTopic({
       // A non-UUID categoryId (e.g. a category slug / business-key) can never
       // satisfy the uuid FK to categories.id and would only produce a
       // guaranteed PostgREST 400. Skip the doomed write rather than emit it.
-      log?.warn(`Skipping topic_categories link for topic ${data.id}: categoryId "${categoryId}" is not a valid UUID`);
+      // The value is caller-controlled and unbounded — truncate it so a
+      // malformed payload cannot produce multi-KB log lines.
+      log?.warn(`Skipping topic_categories link for topic ${data.id}: categoryId "${String(categoryId).slice(0, 64)}" is not a valid UUID`);
     } else {
       const { error: junctionError } = await postgrestClient
         .from('topic_categories')

--- a/src/support/topics-storage.js
+++ b/src/support/topics-storage.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { hasText } from '@adobe/spacecat-shared-utils';
+import { hasText, isValidUUID } from '@adobe/spacecat-shared-utils';
 
 import { throwOnPgConstraintViolation } from './errors.js';
 
@@ -141,17 +141,28 @@ export async function createTopic({
   // categoryId is a UUID FK to categories.id — resolve it from the payload.
   const categoryId = topic.categoryId || null;
   if (categoryId && data?.id) {
-    const { error: junctionError } = await postgrestClient
-      .from('topic_categories')
-      .upsert(
-        { topic_id: data.id, category_id: categoryId },
-        { onConflict: 'topic_id,category_id' },
-      );
-    // Upsert errors are intentionally not thrown — the topic was already
-    // created successfully.  A missing or invalid categoryId should not
-    // fail the entire operation.
-    if (junctionError) {
-      log?.warn(`Failed to link topic ${data.id} to category ${categoryId}: ${junctionError.message}`);
+    if (!isValidUUID(categoryId)) {
+      // A non-UUID categoryId (e.g. a category slug / business-key) can never
+      // satisfy the uuid FK to categories.id and would only produce a
+      // guaranteed PostgREST 400. Skip the doomed write rather than emit it.
+      log?.warn(`Skipping topic_categories link for topic ${data.id}: categoryId "${categoryId}" is not a valid UUID`);
+    } else {
+      const { error: junctionError } = await postgrestClient
+        .from('topic_categories')
+        .upsert(
+          { topic_id: data.id, category_id: categoryId },
+          { onConflict: 'topic_id,category_id' },
+        );
+      // Upsert errors are intentionally not thrown — the topic was already
+      // created successfully. A missing or invalid categoryId should not fail
+      // the entire operation. The SQLSTATE + details are logged (not just the
+      // message) so a recurring failure — e.g. 23503 when the category row is
+      // not committed yet or belongs to another org — is diagnosable.
+      if (junctionError) {
+        const code = junctionError.code ?? 'n/a';
+        const details = junctionError.details ? `, details=${junctionError.details}` : '';
+        log?.warn(`Failed to link topic ${data.id} to category ${categoryId}: ${junctionError.message} (code=${code}${details})`);
+      }
     }
   }
 

--- a/test/support/topics-storage.test.js
+++ b/test/support/topics-storage.test.js
@@ -371,6 +371,43 @@ describe('topics-storage', () => {
       expect(log.warn.firstCall.args[0]).to.match(/not a valid UUID/i);
     });
 
+    it('truncates an over-long non-UUID categoryId in the skip warning', async () => {
+      // A caller-controlled categoryId can be arbitrarily long (a URL or
+      // base64 blob); bound it so a malformed value cannot produce multi-KB
+      // log lines.
+      const dbRow = {
+        id: 'uuid-long-cat',
+        topic_id: 'long-cat-topic',
+        name: 'Long Cat',
+        description: null,
+        status: 'active',
+        brand_id: null,
+        created_at: '2026-04-01T00:00:00Z',
+        created_by: 'system',
+        updated_at: '2026-04-01',
+        updated_by: 'system',
+      };
+      const query = createChainableQuery({ data: dbRow, error: null });
+      const fromStub = sinon.stub().returns(query);
+      const postgrestClient = { from: fromStub };
+      const log = { warn: sinon.stub() };
+      const longCategoryId = 'x'.repeat(500);
+
+      await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'Long Cat', categoryId: longCategoryId },
+        postgrestClient,
+        log,
+      });
+
+      expect(fromStub).to.not.have.been.calledWith('topic_categories');
+      expect(log.warn).to.have.been.calledOnce;
+      const msg = log.warn.firstCall.args[0];
+      // The full 500-char value must not land in the log line.
+      expect(msg).to.not.include(longCategoryId);
+      expect(msg.length).to.be.lessThan(200);
+    });
+
     it('includes the PostgREST error code and details in the warn when the junction upsert fails', async () => {
       // When a well-formed category UUID still fails the junction upsert
       // (e.g. 23503 — the category row is not committed yet, or belongs to a

--- a/test/support/topics-storage.test.js
+++ b/test/support/topics-storage.test.js
@@ -242,7 +242,7 @@ describe('topics-storage', () => {
         status: 'active',
         brand_id: null,
         topic_categories: [
-          { category_id: 'cat-uuid-123', categories: { status: 'active' } },
+          { category_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', categories: { status: 'active' } },
         ],
         created_at: '2026-04-01T00:00:00Z',
         created_by: 'system',
@@ -259,14 +259,14 @@ describe('topics-storage', () => {
 
       const result = await createTopic({
         organizationId: ORG_ID,
-        topic: { name: 'Category Linked', categoryId: 'cat-uuid-123' },
+        topic: { name: 'Category Linked', categoryId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
         postgrestClient,
       });
 
       expect(fromStub).to.have.been.calledWith('topic_categories');
       // Response is symmetric with GET /topics — POST callers see the
       // category they just linked.
-      expect(result.categoryUuids).to.deep.equal(['cat-uuid-123']);
+      expect(result.categoryUuids).to.deep.equal(['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa']);
     });
 
     it('warns via log when topic_categories upsert fails', async () => {
@@ -293,7 +293,7 @@ describe('topics-storage', () => {
 
       const result = await createTopic({
         organizationId: ORG_ID,
-        topic: { name: 'Warn Topic', categoryId: 'bad-category-uuid' },
+        topic: { name: 'Warn Topic', categoryId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb' },
         postgrestClient,
         log,
       });
@@ -303,6 +303,8 @@ describe('topics-storage', () => {
       // Warning was emitted
       expect(log.warn).to.have.been.calledOnce;
       expect(log.warn.firstCall.args[0]).to.include('FK violation');
+      // An error without a SQLSTATE still logs cleanly via the code=n/a fallback.
+      expect(log.warn.firstCall.args[0]).to.include('code=n/a');
     });
 
     it('skips topic_categories when categoryId is not provided', async () => {
@@ -330,6 +332,91 @@ describe('topics-storage', () => {
       });
 
       expect(fromStub).to.not.have.been.calledWith('topic_categories');
+    });
+
+    it('skips the topic_categories upsert when categoryId is not a valid UUID', async () => {
+      // A non-UUID categoryId (e.g. a category slug / business-key a caller
+      // sent by mistake) can never satisfy the uuid FK to categories.id and
+      // would produce a guaranteed PostgREST 400. Skip the doomed write and
+      // warn instead. Regression guard for the onboarding-burst 400s on
+      // POST /topic_categories.
+      const dbRow = {
+        id: 'uuid-bad-cat',
+        topic_id: 'bad-cat-topic',
+        name: 'Bad Cat',
+        description: null,
+        status: 'active',
+        brand_id: null,
+        created_at: '2026-04-01T00:00:00Z',
+        created_by: 'system',
+        updated_at: '2026-04-01',
+        updated_by: 'system',
+      };
+      const query = createChainableQuery({ data: dbRow, error: null });
+      const fromStub = sinon.stub().returns(query);
+      const postgrestClient = { from: fromStub };
+      const log = { warn: sinon.stub() };
+
+      const result = await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'Bad Cat', categoryId: 'marketing-tips' },
+        postgrestClient,
+        log,
+      });
+
+      // Topic creation still succeeds; the junction write is never attempted.
+      expect(result.id).to.equal('bad-cat-topic');
+      expect(fromStub).to.not.have.been.calledWith('topic_categories');
+      expect(log.warn).to.have.been.calledOnce;
+      expect(log.warn.firstCall.args[0]).to.match(/not a valid UUID/i);
+    });
+
+    it('includes the PostgREST error code and details in the warn when the junction upsert fails', async () => {
+      // When a well-formed category UUID still fails the junction upsert
+      // (e.g. 23503 — the category row is not committed yet, or belongs to a
+      // different org) the warn must carry the SQLSTATE + details so the
+      // failure is diagnosable from logs. The onboarding burst of 400s was
+      // invisible precisely because only `.message` was logged.
+      const dbRow = {
+        id: 'uuid-code',
+        topic_id: 'code-topic',
+        name: 'Code Topic',
+        description: null,
+        status: 'active',
+        brand_id: null,
+        created_at: '2026-04-01T00:00:00Z',
+        created_by: 'system',
+        updated_at: '2026-04-01',
+        updated_by: 'system',
+      };
+      const topicsQuery = createChainableQuery({ data: dbRow, error: null });
+      const tcQuery = createChainableQuery({
+        data: null,
+        error: {
+          message: 'insert or update on table "topic_categories" violates foreign key constraint',
+          code: '23503',
+          details: 'Key (category_id)=(99999999-9999-4999-8999-999999999999) is not present in table "categories".',
+        },
+      });
+      const fromStub = sinon.stub();
+      fromStub.withArgs('topics').returns(topicsQuery);
+      fromStub.withArgs('topic_categories').returns(tcQuery);
+      const postgrestClient = { from: fromStub };
+      const log = { warn: sinon.stub() };
+
+      const result = await createTopic({
+        organizationId: ORG_ID,
+        topic: { name: 'Code Topic', categoryId: '99999999-9999-4999-8999-999999999999' },
+        postgrestClient,
+        log,
+      });
+
+      expect(result.id).to.equal('code-topic');
+      expect(fromStub).to.have.been.calledWith('topic_categories');
+      expect(log.warn).to.have.been.calledOnce;
+      const msg = log.warn.firstCall.args[0];
+      expect(msg).to.include('code=23503');
+      expect(msg).to.include('not present in table');
     });
 
     it('falls back to upsert payload (categoryUuids:[]) and warns when refetch errors', async () => {
@@ -372,7 +459,7 @@ describe('topics-storage', () => {
 
       const result = await createTopic({
         organizationId: ORG_ID,
-        topic: { name: 'Refetch Err', categoryId: 'cat-id' },
+        topic: { name: 'Refetch Err', categoryId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd' },
         postgrestClient,
         log,
       });


### PR DESCRIPTION
## What

`createTopic` (`src/support/topics-storage.js`) upserts a `topic_categories` junction row from the request payload's `categoryId`, which is a `uuid` FK to `categories.id`. Two problems:

1. A non-UUID `categoryId` (a category slug / business-key sent by mistake) can never satisfy the FK and produced a **guaranteed PostgREST 400** — observed in prod as a burst of ~41 identical `POST /topic_categories ... 400` lines during a single org onboarding flow.
2. The junction error was swallowed with only `.message` logged, so the failures were **invisible** in `spacecat-api-service` (the topic create still returns 201). They only surfaced now that data-service ships its PostgREST access log to Splunk.

## Changes

- **Skip the junction upsert when `categoryId` is not a valid UUID** — warn instead of firing a doomed write. Uses `isValidUUID` from `@adobe/spacecat-shared-utils` (version-agnostic regex, so v7 category IDs validate correctly).
- **On a real junction failure, log the SQLSTATE (`.code`) and `.details`** so a recurring cause is diagnosable from logs — e.g. `23503` when the category row is not committed yet or belongs to another org (the onboarding race that's the most likely driver of the observed burst).

Topic creation remains **non-fatal** on junction errors (unchanged behavior).

## Not in scope

This does not change the onboarding flow that creates categories + topics in the same ~0.5s burst (the suspected race). The richer logging is deliberately the enabling step: it lets us confirm `23503` (race) vs `22P02` (slug) on the next occurrence before touching that flow.

## Testing

TDD. Two new failing tests written first (skip-on-invalid-UUID; SQLSTATE+details in the warn), then implementation. Existing tests that used non-UUID category fixtures (`'cat-uuid-123'`, `'bad-category-uuid'`, `'cat-id'`) were corrected to real UUIDs — production category IDs are always UUIDs.

- `test/support/topics-storage.test.js`: 32 passing (incl. `code=n/a` fallback when an error carries no SQLSTATE).
- `test/controllers/brands.test.js`: 274 passing (caller unaffected).
- `npx eslint` clean.

## Context

Surfaced by the data-service → Splunk (ECS FireLens) cutover analysis (SITES-46451 / SITES-45430). The `topic_categories` 400 flood was the only error-level access log in the new stream.