### PR TITLE
feat(serenity): defer Semrush provisioning for pending (draft) brands

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -3823,6 +3823,29 @@ Brand:
         scope per-brand Semrush views to the sub-workspace.
       type: [string, 'null']
       readOnly: true
+    pendingProvisioning:
+      description: >-
+        Read-only. Deferred Semrush provisioning data for a pending (draft)
+        brand: the primary URL + initial market chosen at "Save as pending"
+        before the brand's sub-workspace + project exist. Fed into activation;
+        each market that provisions is removed and the field is nulled once none
+        remain (failed markets stay for retry). Null for a non-pending brand (or
+        a draft with no provisioning data yet). primaryUrl may be null (saved as
+        pending before a URL was entered).
+      type: [object, 'null']
+      readOnly: true
+      properties:
+        primaryUrl:
+          type: [string, 'null']
+        markets:
+          type: array
+          items:
+            type: object
+            properties:
+              market:
+                type: string
+              languageCode:
+                type: string
     imsOrgId:
       description: The IMS Organization ID of the brand
       $ref: '#/ImsOrganizationId'

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -3841,6 +3841,9 @@ Brand:
           type: array
           items:
             type: object
+            required:
+              - market
+              - languageCode
             properties:
               market:
                 type: string

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -3823,7 +3823,7 @@ Brand:
         scope per-brand Semrush views to the sub-workspace.
       type: [string, 'null']
       readOnly: true
-    pendingProvisioning:
+    pendingSemrushProvisioning:
       description: >-
         Read-only. Deferred Semrush provisioning data for a pending (draft)
         brand: the primary URL + initial market chosen at "Save as pending"

--- a/docs/serenity.md
+++ b/docs/serenity.md
@@ -152,7 +152,9 @@ A brand runs in one of two modes, decided entirely by `brands.semrush_workspace_
 3. set brands.status = 'active' once >= 1 market is live
 ```
 
-- Body: `{ brandDomain, brandNames, brandDisplayName?, markets: [{ market, languageCode, name? }] }`. `markets` is **capped at 50** (400 above that) — each market is a sequential upstream create+publish.
+- Body: `{ brandDomain?, brandNames, brandDisplayName?, markets?: [{ market, languageCode, name? }] }`. `markets` is **capped at 50** (400 above that) — each market is a sequential upstream create+publish.
+- **Deferred-provisioning fallback (pending/draft brands).** `markets` and `brandDomain` are optional in the body: a brand saved via the wizard's "Save as pending" path carries its intended market(s) and primary URL in `brands.pending_semrush_provisioning`. When the body omits them, activate falls back to the stash — `markets` come from `pendingSemrushProvisioning.markets`, and `brandDomain` is derived from `pendingSemrushProvisioning.primaryUrl` (hostname only, via the shared `hostnameFromUrlString`). The body always wins when both are present. After resolution `markets` must be non-empty (else 400) and `brandDomain` must resolve (else 400) — a draft saved without a primary URL must supply `brandDomain` in the body.
+- **Stash lifecycle.** Each market that provisions (201, or 409 `sliceExists`) is removed from the stash; the column is set back to `null` once none remain. Markets that fail stay in the stash (with the primaryUrl) for a later retry, and the brand still flips to `active` if at least one market went live. The stash trim is saved atomically with the status flip.
 - Response: 200 when every market is live; **207 Multi-Status** when at least one market failed (per-market outcomes in `markets[]`); status `active`/`pending`.
 - Idempotent: a market already live upstream returns 409 `sliceExists` and still counts as live, so a full re-activate of an already-live brand is a 200.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@adobe/spacecat-shared-athena-client": "1.9.12",
         "@adobe/spacecat-shared-brand-client": "1.1.42",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "3.78.0",
+        "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.29.1",
@@ -3295,9 +3295,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.78.0.tgz",
-      "integrity": "sha512-zg1HumFjMlFrIZmYaoMjDsjRoHeFQbiwVcD3rMzQqllZsA20RE2XiW0lADtEYZemEr+9f6K+obuvFWpZvVtGgw==",
+      "version": "3.79.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.79.0.tgz",
+      "integrity": "sha512-T/wYoqQfQ/pQC+JXiUGdM/LRcBZVS6bZUmE1OpBJymqdmfYxvN5eF3Dl8PPRdHVI1s5xlwENq5ff9aXKf1Gxpg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@adobe/spacecat-shared-athena-client": "1.9.12",
     "@adobe/spacecat-shared-brand-client": "1.1.42",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "3.78.0",
+    "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.29.1",

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -27,6 +27,7 @@ import {
 } from '@adobe/spacecat-shared-utils';
 
 import { ErrorWithStatusCode, getImsUserToken, getImsUserTokenStrict } from '../support/utils.js';
+import { hostnameFromUrlString } from '../support/url-utils.js';
 import {
   STATUS_BAD_REQUEST,
 } from '../utils/constants.js';
@@ -92,15 +93,7 @@ function brandDomainFromPayload(brandData) {
   const first = urls
     .map((u) => (typeof u === 'string' ? u : u?.value))
     .find(hasText);
-  if (!hasText(first)) {
-    return null;
-  }
-  try {
-    const url = new URL(first.includes('://') ? first : `https://${first}`);
-    return url.hostname || null;
-  } catch {
-    return null;
-  }
+  return hostnameFromUrlString(first);
 }
 
 /**
@@ -1413,6 +1406,10 @@ function BrandsController(ctx, log, env) {
           const primaryUrl = (Array.isArray(brandData.urls) ? brandData.urls : [])
             .map((u) => (typeof u === 'string' ? u : u?.value))
             .find(hasText) || null;
+          // TODO: the wizard creates a draft with a single market today, so we
+          // stash exactly one (market, languageCode). The activate flow already
+          // handles N stashed markets — if multi-market draft creation is ever
+          // added, build this `markets` array from all selected markets here.
           brandData.pendingSemrushProvisioning = {
             primaryUrl,
             markets: [{ market, languageCode }],
@@ -1534,6 +1531,14 @@ function BrandsController(ctx, log, env) {
 
       // baseUrl is read-only (resolved from baseSiteId) — strip from updates.
       delete updates.baseUrl;
+
+      // pendingSemrushProvisioning is system-controlled: written only when a
+      // brand is saved as 'pending' (createBrandForOrg) and consumed/cleared by
+      // the activate flow. It is marked readOnly in the OpenAPI schema, but that
+      // is a doc hint with no runtime teeth — strip it here so a PATCH caller
+      // cannot inject a primaryUrl/markets that activation would later trust for
+      // Semrush provisioning.
+      delete updates.pendingSemrushProvisioning;
 
       // Capture the competitor list BEFORE the update so the Semrush re-sync can
       // compute which competitors were removed (old − new) — the only ones it

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1405,7 +1405,7 @@ function BrandsController(ctx, log, env) {
           // Defer provisioning: persist the chosen (market, languageCode) AND
           // the primary URL (if the user entered one before saving as pending)
           // on the brand, so activation can provision the real sub-workspace +
-          // project later (stored in brands.pending_provisioning). The primary
+          // project later (stored in brands.pending_semrush_provisioning). The primary
           // URL otherwise lives only on the Semrush side, so a site-less draft
           // would have nowhere to keep it. The row lands as 'pending' because it
           // has no anchor (no site_id, no semrush_workspace_id) — see
@@ -1413,7 +1413,7 @@ function BrandsController(ctx, log, env) {
           const primaryUrl = (Array.isArray(brandData.urls) ? brandData.urls : [])
             .map((u) => (typeof u === 'string' ? u : u?.value))
             .find(hasText) || null;
-          brandData.pendingProvisioning = {
+          brandData.pendingSemrushProvisioning = {
             primaryUrl,
             markets: [{ market, languageCode }],
           };

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1390,56 +1390,79 @@ function BrandsController(ctx, log, env) {
       // brand never exists without a valid Semrush side. The pre-generated id is
       // the sub-workspace title key and is forced onto the row.
       let provisionedBrandId = null;
+      // A pending (draft) brand defers ALL Semrush provisioning: no
+      // sub-workspace, no project, and crucially no primary URL required. The
+      // wizard's "Save as pending" path lands here so a user can stash a brand
+      // before picking its primary URL.
+      const isPendingBrand = brandData.status === 'pending';
       const { semrushMarket } = brandData;
       if (isNonEmptyObject(semrushMarket)) {
         const { market, languageCode } = semrushMarket;
         if (!hasText(market) || !hasText(languageCode)) {
           return badRequest('semrushMarket requires market and languageCode');
         }
-        const brandDomain = brandDomainFromPayload(brandData);
-        if (!hasText(brandDomain)) {
-          return badRequest('A primary URL is required to provision a Semrush brand');
+        if (isPendingBrand) {
+          // Defer provisioning: persist the chosen (market, languageCode) AND
+          // the primary URL (if the user entered one before saving as pending)
+          // on the brand, so activation can provision the real sub-workspace +
+          // project later (stored in brands.pending_provisioning). The primary
+          // URL otherwise lives only on the Semrush side, so a site-less draft
+          // would have nowhere to keep it. The row lands as 'pending' because it
+          // has no anchor (no site_id, no semrush_workspace_id) — see
+          // upsertBrand's anchor check. Models are collected at activation.
+          const primaryUrl = (Array.isArray(brandData.urls) ? brandData.urls : [])
+            .map((u) => (typeof u === 'string' ? u : u?.value))
+            .find(hasText) || null;
+          brandData.pendingProvisioning = {
+            primaryUrl,
+            markets: [{ market, languageCode }],
+          };
+        } else {
+          const brandDomain = brandDomainFromPayload(brandData);
+          if (!hasText(brandDomain)) {
+            return badRequest('A primary URL is required to provision a Semrush brand');
+          }
+          // The project needs at least one AI model (LLM) to track. The wizard
+          // collects them; reject a Semrush create that omits them.
+          const modelIds = Array.isArray(brandData.semrushModelIds)
+            ? brandData.semrushModelIds.filter(hasText)
+            : [];
+          if (modelIds.length === 0) {
+            return badRequest('semrushModelIds must list at least one AI model to track');
+          }
+          // Brand aliases drive branded/non-branded prompt classification. Accept
+          // both shapes the create payload may carry: plain strings or {name}.
+          const brandAliases = Array.isArray(brandData.brandAliases)
+            ? brandData.brandAliases
+              .map((a) => (typeof a === 'string' ? a : a?.name))
+              .filter(hasText)
+            : [];
+          // Brand URLs (own sites + social + earned) are pushed onto the initial
+          // market's project benchmark. The row isn't written yet, so they come
+          // straight from the create payload (same V2 shape upsertBrand persists).
+          const brandUrlSources = {
+            urls: brandData.urls,
+            socialAccounts: brandData.socialAccounts,
+            earnedContent: brandData.earnedContent,
+          };
+          provisionedBrandId = randomUUID();
+          const provisioned = await provisionBrandSubworkspace(context, {
+            spaceCatId,
+            brandId: provisionedBrandId,
+            brandName: brandData.name,
+            market,
+            languageCode,
+            brandDomain,
+            modelIds,
+            brandAliases,
+            brandUrlSources,
+            // Competitors ("other brands to track") are merged into the initial
+            // market's CI competitor list. Like URLs, they come from the create
+            // payload (the brand row isn't written yet).
+            competitors: brandData.competitors,
+          }, log);
+          provisionedWorkspaceId = provisioned.semrushWorkspaceId;
         }
-        // The project needs at least one AI model (LLM) to track. The wizard
-        // collects them; reject a Semrush create that omits them.
-        const modelIds = Array.isArray(brandData.semrushModelIds)
-          ? brandData.semrushModelIds.filter(hasText)
-          : [];
-        if (modelIds.length === 0) {
-          return badRequest('semrushModelIds must list at least one AI model to track');
-        }
-        // Brand aliases drive branded/non-branded prompt classification. Accept
-        // both shapes the create payload may carry: plain strings or {name}.
-        const brandAliases = Array.isArray(brandData.brandAliases)
-          ? brandData.brandAliases
-            .map((a) => (typeof a === 'string' ? a : a?.name))
-            .filter(hasText)
-          : [];
-        // Brand URLs (own sites + social + earned) are pushed onto the initial
-        // market's project benchmark. The row isn't written yet, so they come
-        // straight from the create payload (same V2 shape upsertBrand persists).
-        const brandUrlSources = {
-          urls: brandData.urls,
-          socialAccounts: brandData.socialAccounts,
-          earnedContent: brandData.earnedContent,
-        };
-        provisionedBrandId = randomUUID();
-        const provisioned = await provisionBrandSubworkspace(context, {
-          spaceCatId,
-          brandId: provisionedBrandId,
-          brandName: brandData.name,
-          market,
-          languageCode,
-          brandDomain,
-          modelIds,
-          brandAliases,
-          brandUrlSources,
-          // Competitors ("other brands to track") are merged into the initial
-          // market's CI competitor list. Like URLs, they come from the create
-          // payload (the brand row isn't written yet).
-          competitors: brandData.competitors,
-        }, log);
-        provisionedWorkspaceId = provisioned.semrushWorkspaceId;
       }
 
       const created = await upsertBrand({

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -60,6 +60,7 @@ import {
   getBrandAliasNames, getBrandUrlSources, getBrandCompetitors,
 } from '../support/brands-storage.js';
 import { ErrorWithStatusCode } from '../support/utils.js';
+import { hostnameFromUrlString } from '../support/url-utils.js';
 
 const MAX_ERR_MSG_LEN = 500;
 const BEARER_PREFIX = 'Bearer ';
@@ -74,24 +75,6 @@ const MAX_MARKETS = 50;
  */
 function safeError(msg) {
   return cleanupHeaderValue(String(msg || '')).slice(0, MAX_ERR_MSG_LEN);
-}
-
-/**
- * Derives the bare hostname (Semrush project domain) from a URL or host string.
- * Mirrors brandDomainFromPayload in the brands controller so a draft's stashed
- * primary URL resolves to the same domain at activation as it would at create.
- * Returns null for empty/unparseable input.
- */
-function domainFromUrl(value) {
-  if (!hasText(value)) {
-    return null;
-  }
-  try {
-    const u = new URL(value.includes('://') ? value : `https://${value}`);
-    return u.hostname || null;
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -799,7 +782,16 @@ function SerenityController(context, log, env) {
       // the stashed draft primary URL (the wizard's "Save as pending" URL).
       const brandDomain = hasText(body.brandDomain)
         ? body.brandDomain
-        : domainFromUrl(pendingSemrushProvisioning?.primaryUrl);
+        : hostnameFromUrlString(pendingSemrushProvisioning?.primaryUrl);
+      // Fail fast with the same discipline as the direct create path
+      // (brands.js guards `if (!hasText(brandDomain)) return badRequest(...)`).
+      // A draft saved without a primary URL, activated without a body
+      // brandDomain, has no domain to provision against — a null would
+      // propagate into handleCreateMarketSubworkspace and surface as an opaque
+      // upstream error or an orphaned sub-workspace rather than a clear 400.
+      if (!hasText(brandDomain)) {
+        throw new ErrorWithStatusCode('brandDomain is required to provision a Semrush market', 400);
+      }
       // Brand aliases are brand-level: read once and apply to every market's
       // project (Semrush brand_names) in this batch.
       const brandAliases = await getBrandAliasNames(
@@ -907,6 +899,13 @@ function SerenityController(context, log, env) {
 
       if (anyLive && typeof brand.setStatus === 'function') {
         brand.setStatus('active');
+        // Stash cleanup is intentionally coupled to this anyLive + setStatus
+        // guard so the flip-to-active and the stash trim happen in one
+        // brand.save() (atomic). If NOTHING went live (anyLive false) we skip
+        // both: the brand stays 'pending' with its stash intact, and a retry
+        // re-provisions — Semrush create is idempotent (a re-provisioned market
+        // returns 409, treated as success), so the coupling cannot strand a
+        // market or lose the stash.
         // Update the stash to just the not-yet-provisioned markets (or null when
         // all are done). Saved atomically with the status flip below.
         const canSetStash = hadPendingSemrushProvisioning

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -776,15 +776,15 @@ function SerenityController(context, log, env) {
       const brand = await loadBrand(ctx, auth.brandUuid);
       // Markets + primary URL come from the request body, but a pending (draft)
       // brand activated from the wizard supplies none: fall back to what the
-      // wizard stashed at "Save as pending" (brands.pending_provisioning =
+      // wizard stashed at "Save as pending" (brands.pending_semrush_provisioning =
       // { primaryUrl, markets }). A reactivation of an already-live brand
       // re-supplies them in the body, so the body wins when present.
-      const pendingProvisioning = isNonEmptyObject(brand.getPendingProvisioning?.())
-        ? brand.getPendingProvisioning()
+      const pendingSemrushProvisioning = isNonEmptyObject(brand.getPendingSemrushProvisioning?.())
+        ? brand.getPendingSemrushProvisioning()
         : null;
-      const hadPendingProvisioning = pendingProvisioning != null;
-      const storedMarkets = Array.isArray(pendingProvisioning?.markets)
-        ? pendingProvisioning.markets
+      const hadPendingSemrushProvisioning = pendingSemrushProvisioning != null;
+      const storedMarkets = Array.isArray(pendingSemrushProvisioning?.markets)
+        ? pendingSemrushProvisioning.markets
         : [];
       const markets = Array.isArray(body.markets) && body.markets.length > 0
         ? body.markets
@@ -799,7 +799,7 @@ function SerenityController(context, log, env) {
       // the stashed draft primary URL (the wizard's "Save as pending" URL).
       const brandDomain = hasText(body.brandDomain)
         ? body.brandDomain
-        : domainFromUrl(pendingProvisioning?.primaryUrl);
+        : domainFromUrl(pendingSemrushProvisioning?.primaryUrl);
       // Brand aliases are brand-level: read once and apply to every market's
       // project (Semrush brand_names) in this batch.
       const brandAliases = await getBrandAliasNames(
@@ -909,12 +909,14 @@ function SerenityController(context, log, env) {
         brand.setStatus('active');
         // Update the stash to just the not-yet-provisioned markets (or null when
         // all are done). Saved atomically with the status flip below.
-        if (hadPendingProvisioning && typeof brand.setPendingProvisioning === 'function') {
-          brand.setPendingProvisioning(
-            remainingMarkets.length > 0
-              ? { primaryUrl: pendingProvisioning.primaryUrl ?? null, markets: remainingMarkets }
-              : null,
-          );
+        const canSetStash = hadPendingSemrushProvisioning
+          && typeof brand.setPendingSemrushProvisioning === 'function';
+        if (canSetStash) {
+          const stashPrimaryUrl = pendingSemrushProvisioning.primaryUrl ?? null;
+          const remainingStash = remainingMarkets.length > 0
+            ? { primaryUrl: stashPrimaryUrl, markets: remainingMarkets }
+            : null;
+          brand.setPendingSemrushProvisioning(remainingStash);
         }
         try {
           await brand.save();

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -77,6 +77,33 @@ function safeError(msg) {
 }
 
 /**
+ * Derives the bare hostname (Semrush project domain) from a URL or host string.
+ * Mirrors brandDomainFromPayload in the brands controller so a draft's stashed
+ * primary URL resolves to the same domain at activation as it would at create.
+ * Returns null for empty/unparseable input.
+ */
+function domainFromUrl(value) {
+  if (!hasText(value)) {
+    return null;
+  }
+  try {
+    const u = new URL(value.includes('://') ? value : `https://${value}`);
+    return u.hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stable identity for a market (market + languageCode), used to match a
+ * provisioned market against the deferred-provisioning stash. Case/space
+ * insensitive so 'US'/'us' and ' en'/'en' compare equal.
+ */
+function marketKey(market, languageCode) {
+  return `${String(market ?? '').trim().toLowerCase()}|${String(languageCode ?? '').trim().toLowerCase()}`;
+}
+
+/**
  * Extracts query params from the request URL. Does NOT fall back to
  * `context.data` (the request body) — body keys must never become query keys
  * on a GET (silent attribute-confusion vector).
@@ -745,15 +772,34 @@ function SerenityController(context, log, env) {
         return auth.error;
       }
       const body = ctx.data || {};
-      const markets = Array.isArray(body.markets) ? body.markets : [];
+      const transport = buildTransport(ctx, imsToken);
+      const brand = await loadBrand(ctx, auth.brandUuid);
+      // Markets + primary URL come from the request body, but a pending (draft)
+      // brand activated from the wizard supplies none: fall back to what the
+      // wizard stashed at "Save as pending" (brands.pending_provisioning =
+      // { primaryUrl, markets }). A reactivation of an already-live brand
+      // re-supplies them in the body, so the body wins when present.
+      const pendingProvisioning = isNonEmptyObject(brand.getPendingProvisioning?.())
+        ? brand.getPendingProvisioning()
+        : null;
+      const hadPendingProvisioning = pendingProvisioning != null;
+      const storedMarkets = Array.isArray(pendingProvisioning?.markets)
+        ? pendingProvisioning.markets
+        : [];
+      const markets = Array.isArray(body.markets) && body.markets.length > 0
+        ? body.markets
+        : storedMarkets;
       if (markets.length === 0) {
         throw new ErrorWithStatusCode('markets must be a non-empty array', 400);
       }
       if (markets.length > MAX_MARKETS) {
         throw new ErrorWithStatusCode(`markets must not exceed ${MAX_MARKETS} entries`, 400);
       }
-      const transport = buildTransport(ctx, imsToken);
-      const brand = await loadBrand(ctx, auth.brandUuid);
+      // The Semrush project domain: the request's brandDomain, else derived from
+      // the stashed draft primary URL (the wizard's "Save as pending" URL).
+      const brandDomain = hasText(body.brandDomain)
+        ? body.brandDomain
+        : domainFromUrl(pendingProvisioning?.primaryUrl);
       // Brand aliases are brand-level: read once and apply to every market's
       // project (Semrush brand_names) in this batch.
       const brandAliases = await getBrandAliasNames(
@@ -792,7 +838,7 @@ function SerenityController(context, log, env) {
         const createBody = {
           market: m.market,
           languageCode: m.languageCode,
-          brandDomain: body.brandDomain,
+          brandDomain,
           brandNames: body.brandNames,
           brandDisplayName: body.brandDisplayName,
           name: m.name,
@@ -845,8 +891,31 @@ function SerenityController(context, log, env) {
         });
       }
 
+      // Per-market cleanup of the deferred-provisioning stash: drop every market
+      // that was just provisioned (201 = created now, 409 = already live), so a
+      // retry re-provisions ONLY the markets that still failed. When nothing
+      // remains, clear the whole blob (the draft is fully provisioned). Markets
+      // that failed this round stay stashed (with the primary URL) for retry.
+      const provisionedKeys = new Set(
+        results
+          .filter((r) => r.status === 201 || r.status === 409)
+          .map((r) => marketKey(r.market, r.languageCode)),
+      );
+      const remainingMarkets = storedMarkets.filter(
+        (m) => !provisionedKeys.has(marketKey(m.market, m.languageCode)),
+      );
+
       if (anyLive && typeof brand.setStatus === 'function') {
         brand.setStatus('active');
+        // Update the stash to just the not-yet-provisioned markets (or null when
+        // all are done). Saved atomically with the status flip below.
+        if (hadPendingProvisioning && typeof brand.setPendingProvisioning === 'function') {
+          brand.setPendingProvisioning(
+            remainingMarkets.length > 0
+              ? { primaryUrl: pendingProvisioning.primaryUrl ?? null, markets: remainingMarkets }
+              : null,
+          );
+        }
         try {
           await brand.save();
         } catch (saveError) {

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -46,7 +46,7 @@ function normalizeNullableText(value, fieldName) {
 
 /**
  * Normalizes the deferred Semrush provisioning data of a pending (draft) brand
- * into the shape persisted in `brands.pending_provisioning` (a JSONB object
+ * into the shape persisted in `brands.pending_semrush_provisioning` (a JSONB object
  * `{ primaryUrl?, markets: [{ market, languageCode }] }`). These are the primary
  * URL + initial market the add-brand wizard collected before a
  * sub-workspace/project exist; activation reads them back to provision the real
@@ -60,7 +60,7 @@ function normalizeNullableText(value, fieldName) {
  * @returns {{primaryUrl: (string|null), markets: Array<{market: string,
  *   languageCode: string}>}|null|undefined}
  */
-function normalizePendingProvisioning(value) {
+function normalizePendingSemrushProvisioning(value) {
   if (value === undefined) {
     return undefined;
   }
@@ -68,7 +68,7 @@ function normalizePendingProvisioning(value) {
     return null;
   }
   if (typeof value !== 'object' || Array.isArray(value)) {
-    const error = new Error('pendingProvisioning must be an object or null');
+    const error = new Error('pendingSemrushProvisioning must be an object or null');
     error.status = 400;
     throw error;
   }
@@ -188,7 +188,7 @@ function mapDbBrandToV2(row) {
     // languageCode }] } the wizard collected before provisioning; null once
     // activation has provisioned it (or for a non-pending brand). Lets the UI
     // re-hydrate the draft's primary URL + market on the activation form.
-    pendingProvisioning: row.pending_provisioning || null,
+    pendingSemrushProvisioning: row.pending_semrush_provisioning || null,
     status: row.status || 'active',
     origin: row.origin || 'human',
     description: row.description || null,
@@ -740,9 +740,11 @@ export async function upsertBrand({
   // URL + desired (market, languageCode) the wizard collected before a
   // sub-workspace / project exist. Persisted as JSONB so activation can
   // provision it later, then cleared. Undefined leaves the column untouched.
-  const pendingProvisioning = normalizePendingProvisioning(brand.pendingProvisioning);
-  if (pendingProvisioning !== undefined) {
-    row.pending_provisioning = pendingProvisioning;
+  const pendingSemrushProvisioning = normalizePendingSemrushProvisioning(
+    brand.pendingSemrushProvisioning,
+  );
+  if (pendingSemrushProvisioning !== undefined) {
+    row.pending_semrush_provisioning = pendingSemrushProvisioning;
   }
 
   // A Semrush-anchored create (serenity-first, semrushWorkspaceId set) is NEVER
@@ -873,10 +875,12 @@ export async function updateBrand({
   }
 
   // Deferred Semrush provisioning data (pending/draft brands). Activation passes
-  // `pendingProvisioning: null` to clear it once the real projects are
+  // `pendingSemrushProvisioning: null` to clear it once the real projects are
   // provisioned.
-  if (updates.pendingProvisioning !== undefined) {
-    patch.pending_provisioning = normalizePendingProvisioning(updates.pendingProvisioning);
+  if (updates.pendingSemrushProvisioning !== undefined) {
+    patch.pending_semrush_provisioning = normalizePendingSemrushProvisioning(
+      updates.pendingSemrushProvisioning,
+    );
   }
 
   // Clear legacy columns on any brand update so old data doesn't linger.

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -45,6 +45,50 @@ function normalizeNullableText(value, fieldName) {
 }
 
 /**
+ * Normalizes the deferred Semrush provisioning data of a pending (draft) brand
+ * into the shape persisted in `brands.pending_provisioning` (a JSONB object
+ * `{ primaryUrl?, markets: [{ market, languageCode }] }`). These are the primary
+ * URL + initial market the add-brand wizard collected before a
+ * sub-workspace/project exist; activation reads them back to provision the real
+ * Semrush projects, then clears the column.
+ *
+ * Returns `undefined` when the caller did not supply the field (leave the column
+ * untouched), `null` when explicitly cleared or nothing useful remains, or the
+ * cleaned object otherwise.
+ *
+ * @param {unknown} value - `{ primaryUrl?, markets }`, null, or undefined.
+ * @returns {{primaryUrl: (string|null), markets: Array<{market: string,
+ *   languageCode: string}>}|null|undefined}
+ */
+function normalizePendingProvisioning(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    const error = new Error('pendingProvisioning must be an object or null');
+    error.status = 400;
+    throw error;
+  }
+  const markets = (Array.isArray(value.markets) ? value.markets : [])
+    .map((m) => ({
+      market: typeof m?.market === 'string' ? m.market.trim() : '',
+      languageCode: typeof m?.languageCode === 'string' ? m.languageCode.trim() : '',
+    }))
+    .filter((m) => hasText(m.market) && hasText(m.languageCode));
+  const primaryUrl = typeof value.primaryUrl === 'string' && hasText(value.primaryUrl)
+    ? value.primaryUrl.trim()
+    : null;
+  // Nothing worth persisting → treat as cleared.
+  if (markets.length === 0 && !hasText(primaryUrl)) {
+    return null;
+  }
+  return { primaryUrl, markets };
+}
+
+/**
  * Splits a full URL string into its base URL and path.
  * e.g. "https://example.com/products" -> { base: "https://example.com", path: "/products" }
  * A root path "/" is treated as no path (empty string).
@@ -139,6 +183,12 @@ function mapDbBrandToV2(row) {
     // brands still in flat mode (no sub-workspace minted yet). Consumers use it
     // to scope per-brand Semrush views to the sub-workspace.
     semrushWorkspaceId: row.semrush_workspace_id || null,
+    // Read-only: deferred Semrush provisioning data for a pending (draft) brand
+    // (serenity dual-mode). Object { primaryUrl, markets: [{ market,
+    // languageCode }] } the wizard collected before provisioning; null once
+    // activation has provisioned it (or for a non-pending brand). Lets the UI
+    // re-hydrate the draft's primary URL + market on the activation form.
+    pendingProvisioning: row.pending_provisioning || null,
     status: row.status || 'active',
     origin: row.origin || 'human',
     description: row.description || null,
@@ -686,6 +736,15 @@ export async function upsertBrand({
     row.mention_sentiment_guidance = mentionSentimentGuidance;
   }
 
+  // Deferred Semrush provisioning data for a pending (draft) brand: the primary
+  // URL + desired (market, languageCode) the wizard collected before a
+  // sub-workspace / project exist. Persisted as JSONB so activation can
+  // provision it later, then cleared. Undefined leaves the column untouched.
+  const pendingProvisioning = normalizePendingProvisioning(brand.pendingProvisioning);
+  if (pendingProvisioning !== undefined) {
+    row.pending_provisioning = pendingProvisioning;
+  }
+
   // A Semrush-anchored create (serenity-first, semrushWorkspaceId set) is NEVER
   // anchored by a SpaceCat site: its primary URL is the Semrush project domain,
   // which may coincidentally match an onboarded site. Setting site_id from that
@@ -811,6 +870,13 @@ export async function updateBrand({
   if (updates.region !== undefined) {
     patch.regions = (updates.region || [])
       .map((r) => (typeof r === 'string' ? r : String(r))).filter(hasText);
+  }
+
+  // Deferred Semrush provisioning data (pending/draft brands). Activation passes
+  // `pendingProvisioning: null` to clear it once the real projects are
+  // provisioned.
+  if (updates.pendingProvisioning !== undefined) {
+    patch.pending_provisioning = normalizePendingProvisioning(updates.pendingProvisioning);
   }
 
   // Clear legacy columns on any brand update so old data doesn't linger.

--- a/src/support/url-utils.js
+++ b/src/support/url-utils.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasText } from '@adobe/spacecat-shared-utils';
+
+/**
+ * Derives the bare hostname from a URL or host string, tolerating a missing
+ * scheme (bare hostnames). Returns null for empty/unparseable input.
+ *
+ * Single source of truth for brand → Semrush project domain derivation. Both
+ * the direct brand-create path (`brandDomainFromPayload` in the brands
+ * controller) and the deferred-activation path (the serenity activate flow)
+ * call it, so a draft brand resolves to the same domain at activation as it
+ * would at create — keeping the two paths from diverging (e.g. one gaining
+ * `www.` stripping or punycode normalization without the other).
+ *
+ * @param {string} value - a URL or bare hostname
+ * @returns {string|null} the hostname, or null when absent/unparseable
+ */
+export function hostnameFromUrlString(value) {
+  if (!hasText(value)) {
+    return null;
+  }
+  try {
+    const url = new URL(value.includes('://') ? value : `https://${value}`);
+    return url.hostname || null;
+  } catch {
+    return null;
+  }
+}

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -4563,6 +4563,86 @@ describe('Brands Controller', () => {
         expect(response.status).to.equal(201);
         expect(provisionStub.called).to.equal(false);
       });
+
+      it('saves a pending draft WITHOUT a primary URL: no provisioning, market stashed (201)', async () => {
+        const provisionStub = sinon.stub().resolves({ semrushWorkspaceId: 'ws-1' });
+        const upsertStub = sinon.stub().resolves({ id: 'draft-id', name: 'New Brand', status: 'pending' });
+        const controller = await buildController({
+          provisionBrandSubworkspace: provisionStub, upsertBrand: upsertStub,
+        });
+
+        const response = await controller.createBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID },
+          // status pending, market chosen, but NO urls — the wizard's "Save as
+          // pending" from the Primary URL step.
+          data: {
+            name: 'New Brand',
+            status: 'pending',
+            urls: [],
+            semrushMarket: { market: 'us', languageCode: 'en' },
+          },
+          dataAccess: mockDataAccess,
+          attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+        });
+
+        expect(response.status).to.equal(201);
+        // Provisioning is deferred for a draft.
+        expect(provisionStub.called).to.equal(false);
+        // The market is stashed for activation; no primary URL yet.
+        const upsertArgs = upsertStub.firstCall.args[0];
+        expect(upsertArgs.brand.pendingProvisioning).to.deep.equal({
+          primaryUrl: null,
+          markets: [{ market: 'us', languageCode: 'en' }],
+        });
+        // A draft is never bound to a workspace at create time.
+        expect(upsertArgs.semrushWorkspaceId).to.equal(null);
+        expect(upsertArgs.forceBrandId).to.equal(null);
+      });
+
+      it('stashes the primary URL on a pending draft when one was entered (still no provisioning)', async () => {
+        const provisionStub = sinon.stub().resolves({ semrushWorkspaceId: 'ws-1' });
+        const upsertStub = sinon.stub().resolves({ id: 'draft-id', name: 'New Brand', status: 'pending' });
+        const controller = await buildController({
+          provisionBrandSubworkspace: provisionStub, upsertBrand: upsertStub,
+        });
+
+        const response = await controller.createBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID },
+          data: {
+            name: 'New Brand',
+            status: 'pending',
+            urls: [{ value: 'https://acme.com/path' }],
+            semrushMarket: { market: 'us', languageCode: 'en' },
+          },
+          dataAccess: mockDataAccess,
+          attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+        });
+
+        expect(response.status).to.equal(201);
+        expect(provisionStub.called).to.equal(false);
+        expect(upsertStub.firstCall.args[0].brand.pendingProvisioning).to.deep.equal({
+          primaryUrl: 'https://acme.com/path',
+          markets: [{ market: 'us', languageCode: 'en' }],
+        });
+      });
+
+      it('still requires market and languageCode even for a pending draft', async () => {
+        const provisionStub = sinon.stub().resolves({ semrushWorkspaceId: 'ws-1' });
+        const controller = await buildController({ provisionBrandSubworkspace: provisionStub });
+
+        const response = await controller.createBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID },
+          data: { name: 'New Brand', status: 'pending', semrushMarket: { market: 'us' } },
+          dataAccess: mockDataAccess,
+          attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+        });
+
+        expect(response.status).to.equal(400);
+        expect(provisionStub.called).to.equal(false);
+      });
     });
 
     it('returns 400 when brand name is missing', async () => {

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -4591,7 +4591,7 @@ describe('Brands Controller', () => {
         expect(provisionStub.called).to.equal(false);
         // The market is stashed for activation; no primary URL yet.
         const upsertArgs = upsertStub.firstCall.args[0];
-        expect(upsertArgs.brand.pendingProvisioning).to.deep.equal({
+        expect(upsertArgs.brand.pendingSemrushProvisioning).to.deep.equal({
           primaryUrl: null,
           markets: [{ market: 'us', languageCode: 'en' }],
         });
@@ -4622,7 +4622,7 @@ describe('Brands Controller', () => {
 
         expect(response.status).to.equal(201);
         expect(provisionStub.called).to.equal(false);
-        expect(upsertStub.firstCall.args[0].brand.pendingProvisioning).to.deep.equal({
+        expect(upsertStub.firstCall.args[0].brand.pendingSemrushProvisioning).to.deep.equal({
           primaryUrl: 'https://acme.com/path',
           markets: [{ market: 'us', languageCode: 'en' }],
         });

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -4899,6 +4899,36 @@ describe('Brands Controller', () => {
       expect(syncStub).to.not.have.been.called;
     });
 
+    it('strips system-controlled pendingSemrushProvisioning from a PATCH (no runtime injection)', async () => {
+      const updateBrandStub = sinon.stub().resolves({ id: BRAND_UUID, semrushWorkspaceId: null });
+      const controller = await buildUpdateController({
+        updateBrand: updateBrandStub,
+        syncBrandUrlsAcrossMarkets: sinon.stub().resolves({}),
+        createSerenityTransport: sinon.stub(),
+      });
+
+      const response = await controller.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: {
+          description: 'legit edit',
+          // An attacker-supplied stash that activation would otherwise trust.
+          pendingSemrushProvisioning: {
+            primaryUrl: 'https://evil.example',
+            markets: [{ market: 'us', languageCode: 'en' }],
+          },
+        },
+        dataAccess: mockDataAccess,
+        pathInfo: { headers: { authorization: 'Bearer tok' } },
+        attributes: { authInfo: { profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(200);
+      expect(updateBrandStub).to.have.been.calledOnce;
+      const { updates } = updateBrandStub.firstCall.args[0];
+      expect(updates).to.not.have.property('pendingSemrushProvisioning');
+    });
+
     it('does NOT re-sync a flat-mode brand (no sub-workspace) even when URLs change', async () => {
       const updateBrandStub = sinon.stub().resolves({
         id: BRAND_UUID, semrushWorkspaceId: null, urls: [], socialAccounts: [], earnedContent: [],

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1063,6 +1063,104 @@ describe('SerenityController', () => {
       expect(brand.save).to.have.been.called;
     });
 
+    it('activate falls back to the stashed pending_provisioning when the body omits markets + brandDomain', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      const setPendingProvisioning = sinon.stub();
+      const brand = makeBrandModel({
+        getPendingProvisioning: () => ({
+          primaryUrl: 'https://acme.com/path',
+          markets: [{ market: 'us', languageCode: 'en' }],
+        }),
+        setPendingProvisioning,
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      // A pending (draft) brand activated from the wizard: body carries no
+      // markets and no brandDomain — both come from the stash.
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandNames: ['X'] },
+      }));
+      expect(response.status).to.equal(200);
+      expect(handlers.handleCreateMarketSubworkspace).to.have.been.calledOnce;
+      const createBody = handlers.handleCreateMarketSubworkspace.firstCall.args[3];
+      expect(createBody.market).to.equal('us');
+      expect(createBody.languageCode).to.equal('en');
+      // brandDomain derived from the stashed primary URL (hostname only).
+      expect(createBody.brandDomain).to.equal('acme.com');
+      // The draft staging data is cleared on success, atomically with the flip.
+      expect(setPendingProvisioning).to.have.been.calledWith(null);
+      expect(brand.setStatus).to.have.been.calledWith('active');
+      expect(brand.save).to.have.been.called;
+    });
+
+    it('activate prefers body markets + brandDomain over the stash, and clears the stash when its market is provisioned', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      const setPendingProvisioning = sinon.stub();
+      const brand = makeBrandModel({
+        getPendingProvisioning: () => ({
+          primaryUrl: 'https://stash.com',
+          markets: [{ market: 'us', languageCode: 'en' }],
+        }),
+        setPendingProvisioning,
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandDomain: 'body.com', brandNames: ['X'], markets: [{ market: 'us', languageCode: 'en' }] },
+      }));
+      expect(response.status).to.equal(200);
+      expect(handlers.handleCreateMarketSubworkspace).to.have.been.calledOnce;
+      const createBody = handlers.handleCreateMarketSubworkspace.firstCall.args[3];
+      expect(createBody.market).to.equal('us');
+      expect(createBody.brandDomain).to.equal('body.com');
+      // The stash market (us/en) was provisioned → nothing remains → cleared.
+      expect(setPendingProvisioning).to.have.been.calledWith(null);
+    });
+
+    it('activate removes ONLY the provisioned markets from the stash, keeping failed ones for retry', async () => {
+      // Stash has two draft markets; the first provisions (201), the second
+      // throws. The provisioned market is dropped; the failed one stays stashed
+      // (with the primary URL) so a retry re-provisions just that one.
+      handlers.handleCreateMarketSubworkspace
+        .onFirstCall().resolves({ status: 201, body: {} })
+        .onSecondCall().rejects(new ErrorWithStatusCode('upstream boom', 502));
+      const setPendingProvisioning = sinon.stub();
+      const brand = makeBrandModel({
+        getPendingProvisioning: () => ({
+          primaryUrl: 'https://acme.com',
+          markets: [{ market: 'us', languageCode: 'en' }, { market: 'de', languageCode: 'de' }],
+        }),
+        setPendingProvisioning,
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      // Body omits markets → both come from the stash.
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandNames: ['X'] },
+      }));
+      // One live, one failed → 207.
+      expect(response.status).to.equal(207);
+      expect(setPendingProvisioning).to.have.been.calledOnceWith({
+        primaryUrl: 'https://acme.com',
+        markets: [{ market: 'de', languageCode: 'de' }],
+      });
+      // Brand still flips active (≥1 market live) even with markets remaining.
+      expect(brand.setStatus).to.have.been.calledWith('active');
+    });
+
+    it('activate does NOT clear a stash on a brand that has none (no setPendingProvisioning call)', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      const setPendingProvisioning = sinon.stub();
+      const brand = makeBrandModel({ setPendingProvisioning });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandDomain: 'x.com', brandNames: ['X'], markets: [{ market: 'us', languageCode: 'en' }] },
+      }));
+      expect(response.status).to.equal(200);
+      expect(setPendingProvisioning).to.not.have.been.called;
+    });
+
     it('activate reads the brand aliases once and applies them to every market', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
       getBrandAliasNamesStub.resolves(['Acme Inc']);

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1093,11 +1093,12 @@ describe('SerenityController', () => {
       expect(brand.save).to.have.been.called;
     });
 
-    it('activate derives a null brandDomain when the stash has markets but no primary URL (saved as pending before a URL was entered)', async () => {
+    it('activate 400s when the stash has markets but no primary URL and the body omits brandDomain (no domain to provision)', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
       const brand = makeBrandModel({
         // A draft saved before a primary URL was entered: markets present, no
-        // primaryUrl. domainFromUrl(undefined) → null, so brandDomain is null.
+        // primaryUrl. hostnameFromUrlString(undefined) → null, so there is no
+        // domain to provision against → fail fast (mirrors the create path).
         getPendingSemrushProvisioning: () => ({
           markets: [{ market: 'us', languageCode: 'en' }],
         }),
@@ -1108,17 +1109,15 @@ describe('SerenityController', () => {
         brand,
         data: { brandNames: ['X'] },
       }));
-      expect(response.status).to.equal(200);
-      const createBody = handlers.handleCreateMarketSubworkspace.firstCall.args[3];
-      expect(createBody.market).to.equal('us');
-      expect(createBody.brandDomain).to.equal(null);
+      expect(response.status).to.equal(400);
+      expect(handlers.handleCreateMarketSubworkspace).to.not.have.been.called;
     });
 
-    it('activate derives a null brandDomain when the stashed primary URL is unparseable', async () => {
+    it('activate 400s when the stashed primary URL is unparseable and the body omits brandDomain', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
       const brand = makeBrandModel({
-        // An unparseable primaryUrl makes new URL() throw → domainFromUrl
-        // returns null rather than propagating; activation still proceeds.
+        // An unparseable primaryUrl makes new URL() throw → hostnameFromUrlString
+        // returns null → no domain → 400 rather than a null propagating upstream.
         getPendingSemrushProvisioning: () => ({
           primaryUrl: 'https://[',
           markets: [{ market: 'us', languageCode: 'en' }],
@@ -1130,10 +1129,8 @@ describe('SerenityController', () => {
         brand,
         data: { brandNames: ['X'] },
       }));
-      expect(response.status).to.equal(200);
-      const createBody = handlers.handleCreateMarketSubworkspace.firstCall.args[3];
-      expect(createBody.market).to.equal('us');
-      expect(createBody.brandDomain).to.equal(null);
+      expect(response.status).to.equal(400);
+      expect(handlers.handleCreateMarketSubworkspace).to.not.have.been.called;
     });
 
     it('activate prefers body markets + brandDomain over the stash, and clears the stash when its market is provisioned', async () => {

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1093,6 +1093,49 @@ describe('SerenityController', () => {
       expect(brand.save).to.have.been.called;
     });
 
+    it('activate derives a null brandDomain when the stash has markets but no primary URL (saved as pending before a URL was entered)', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      const brand = makeBrandModel({
+        // A draft saved before a primary URL was entered: markets present, no
+        // primaryUrl. domainFromUrl(undefined) → null, so brandDomain is null.
+        getPendingSemrushProvisioning: () => ({
+          markets: [{ market: 'us', languageCode: 'en' }],
+        }),
+        setPendingSemrushProvisioning: sinon.stub(),
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandNames: ['X'] },
+      }));
+      expect(response.status).to.equal(200);
+      const createBody = handlers.handleCreateMarketSubworkspace.firstCall.args[3];
+      expect(createBody.market).to.equal('us');
+      expect(createBody.brandDomain).to.equal(null);
+    });
+
+    it('activate derives a null brandDomain when the stashed primary URL is unparseable', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      const brand = makeBrandModel({
+        // An unparseable primaryUrl makes new URL() throw → domainFromUrl
+        // returns null rather than propagating; activation still proceeds.
+        getPendingSemrushProvisioning: () => ({
+          primaryUrl: 'https://[',
+          markets: [{ market: 'us', languageCode: 'en' }],
+        }),
+        setPendingSemrushProvisioning: sinon.stub(),
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandNames: ['X'] },
+      }));
+      expect(response.status).to.equal(200);
+      const createBody = handlers.handleCreateMarketSubworkspace.firstCall.args[3];
+      expect(createBody.market).to.equal('us');
+      expect(createBody.brandDomain).to.equal(null);
+    });
+
     it('activate prefers body markets + brandDomain over the stash, and clears the stash when its market is provisioned', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
       const setPendingSemrushProvisioning = sinon.stub();

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1063,15 +1063,15 @@ describe('SerenityController', () => {
       expect(brand.save).to.have.been.called;
     });
 
-    it('activate falls back to the stashed pending_provisioning when the body omits markets + brandDomain', async () => {
+    it('activate falls back to the stashed pending_semrush_provisioning when the body omits markets + brandDomain', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
-      const setPendingProvisioning = sinon.stub();
+      const setPendingSemrushProvisioning = sinon.stub();
       const brand = makeBrandModel({
-        getPendingProvisioning: () => ({
+        getPendingSemrushProvisioning: () => ({
           primaryUrl: 'https://acme.com/path',
           markets: [{ market: 'us', languageCode: 'en' }],
         }),
-        setPendingProvisioning,
+        setPendingSemrushProvisioning,
       });
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       // A pending (draft) brand activated from the wizard: body carries no
@@ -1088,20 +1088,20 @@ describe('SerenityController', () => {
       // brandDomain derived from the stashed primary URL (hostname only).
       expect(createBody.brandDomain).to.equal('acme.com');
       // The draft staging data is cleared on success, atomically with the flip.
-      expect(setPendingProvisioning).to.have.been.calledWith(null);
+      expect(setPendingSemrushProvisioning).to.have.been.calledWith(null);
       expect(brand.setStatus).to.have.been.calledWith('active');
       expect(brand.save).to.have.been.called;
     });
 
     it('activate prefers body markets + brandDomain over the stash, and clears the stash when its market is provisioned', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
-      const setPendingProvisioning = sinon.stub();
+      const setPendingSemrushProvisioning = sinon.stub();
       const brand = makeBrandModel({
-        getPendingProvisioning: () => ({
+        getPendingSemrushProvisioning: () => ({
           primaryUrl: 'https://stash.com',
           markets: [{ market: 'us', languageCode: 'en' }],
         }),
-        setPendingProvisioning,
+        setPendingSemrushProvisioning,
       });
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const response = await controller.activate(fakeContext({
@@ -1114,7 +1114,7 @@ describe('SerenityController', () => {
       expect(createBody.market).to.equal('us');
       expect(createBody.brandDomain).to.equal('body.com');
       // The stash market (us/en) was provisioned → nothing remains → cleared.
-      expect(setPendingProvisioning).to.have.been.calledWith(null);
+      expect(setPendingSemrushProvisioning).to.have.been.calledWith(null);
     });
 
     it('activate removes ONLY the provisioned markets from the stash, keeping failed ones for retry', async () => {
@@ -1124,13 +1124,13 @@ describe('SerenityController', () => {
       handlers.handleCreateMarketSubworkspace
         .onFirstCall().resolves({ status: 201, body: {} })
         .onSecondCall().rejects(new ErrorWithStatusCode('upstream boom', 502));
-      const setPendingProvisioning = sinon.stub();
+      const setPendingSemrushProvisioning = sinon.stub();
       const brand = makeBrandModel({
-        getPendingProvisioning: () => ({
+        getPendingSemrushProvisioning: () => ({
           primaryUrl: 'https://acme.com',
           markets: [{ market: 'us', languageCode: 'en' }, { market: 'de', languageCode: 'de' }],
         }),
-        setPendingProvisioning,
+        setPendingSemrushProvisioning,
       });
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       // Body omits markets → both come from the stash.
@@ -1140,7 +1140,7 @@ describe('SerenityController', () => {
       }));
       // One live, one failed → 207.
       expect(response.status).to.equal(207);
-      expect(setPendingProvisioning).to.have.been.calledOnceWith({
+      expect(setPendingSemrushProvisioning).to.have.been.calledOnceWith({
         primaryUrl: 'https://acme.com',
         markets: [{ market: 'de', languageCode: 'de' }],
       });
@@ -1148,17 +1148,17 @@ describe('SerenityController', () => {
       expect(brand.setStatus).to.have.been.calledWith('active');
     });
 
-    it('activate does NOT clear a stash on a brand that has none (no setPendingProvisioning call)', async () => {
+    it('activate does NOT clear a stash on a brand that has none (no setPendingSemrushProvisioning call)', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
-      const setPendingProvisioning = sinon.stub();
-      const brand = makeBrandModel({ setPendingProvisioning });
+      const setPendingSemrushProvisioning = sinon.stub();
+      const brand = makeBrandModel({ setPendingSemrushProvisioning });
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const response = await controller.activate(fakeContext({
         brand,
         data: { brandDomain: 'x.com', brandNames: ['X'], markets: [{ market: 'us', languageCode: 'en' }] },
       }));
       expect(response.status).to.equal(200);
-      expect(setPendingProvisioning).to.not.have.been.called;
+      expect(setPendingSemrushProvisioning).to.not.have.been.called;
     });
 
     it('activate reads the brand aliases once and applies them to every market', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -304,6 +304,27 @@ describe('brands-storage', () => {
       expect(flatResult.semrushWorkspaceId).to.equal(null);
     });
 
+    it('maps pending_provisioning to pendingProvisioning (draft), null when absent', async () => {
+      const draft = { primaryUrl: 'https://acme.com', markets: [{ market: 'US', languageCode: 'en' }] };
+      const draftRow = makeBrandRow({ status: 'pending', pending_provisioning: draft });
+      const draftQuery = createChainableQuery({ data: draftRow, error: null });
+      const draftResult = await getBrandById(
+        ORG_ID,
+        BRAND_ID,
+        { from: sinon.stub().returns(draftQuery) },
+      );
+      expect(draftResult.pendingProvisioning).to.deep.equal(draft);
+
+      // Non-draft brand: no pending_provisioning column → null.
+      const flatQuery = createChainableQuery({ data: makeBrandRow(), error: null });
+      const flatResult = await getBrandById(
+        ORG_ID,
+        BRAND_ID,
+        { from: sinon.stub().returns(flatQuery) },
+      );
+      expect(flatResult.pendingProvisioning).to.equal(null);
+    });
+
     it('defaults to empty regions when competitor regions is missing', async () => {
       const dbRow = makeBrandRow({
         competitors: [{ name: 'Rival', url: null }], // no regions key — triggers || []
@@ -912,6 +933,96 @@ describe('brands-storage', () => {
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
       expect(brandsUpsert.row.status).to.equal('pending');
+    });
+
+    it('persists pending_provisioning (primaryUrl + markets) for a pending draft', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          status: 'pending',
+          pendingProvisioning: {
+            primaryUrl: 'https://acme.com',
+            markets: [{ market: 'US', languageCode: 'en' }],
+          },
+        },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.status).to.equal('pending');
+      expect(brandsUpsert.row.pending_provisioning).to.deep.equal({
+        primaryUrl: 'https://acme.com',
+        markets: [{ market: 'US', languageCode: 'en' }],
+      });
+    });
+
+    it('drops invalid markets and a blank primaryUrl from pending_provisioning, nulling it when empty', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          status: 'pending',
+          pendingProvisioning: {
+            primaryUrl: '   ',
+            markets: [{ market: '', languageCode: 'en' }, { market: 'US' }],
+          },
+        },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.pending_provisioning).to.equal(null);
+    });
+
+    it('omits pending_provisioning from the row when not supplied', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'site-1' },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row).to.not.have.property('pending_provisioning');
+    });
+
+    it('throws 400 when pendingProvisioning is not an object', async () => {
+      const client = createCapturingClient({
+        brands: [{ data: null, error: null }],
+      });
+
+      const err = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', pendingProvisioning: ['not', 'an', 'object'] },
+        postgrestClient: client,
+      }).catch((e) => e);
+
+      expect(err).to.be.an('error');
+      expect(err.status).to.equal(400);
     });
 
     it('normalizes brand guidance fields in upsert row', async () => {
@@ -1962,6 +2073,25 @@ describe('brands-storage', () => {
       });
 
       expect(result).to.include({ name: 'NewName', status: 'pending' });
+    });
+
+    it('clears pending_provisioning when updates pass pendingProvisioning: null', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { id: BRAND_ID }, error: null },
+          { data: makeBrandRow({ status: 'active' }), error: null },
+        ],
+      });
+
+      await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { pendingProvisioning: null },
+        postgrestClient: client,
+      });
+
+      const brandsUpdate = client.capturedCalls.update.find((c) => c.table === 'brands');
+      expect(brandsUpdate.row.pending_provisioning).to.equal(null);
     });
 
     it('normalizes brand guidance fields in update patch', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -304,25 +304,25 @@ describe('brands-storage', () => {
       expect(flatResult.semrushWorkspaceId).to.equal(null);
     });
 
-    it('maps pending_provisioning to pendingProvisioning (draft), null when absent', async () => {
+    it('maps pending_semrush_provisioning to pendingSemrushProvisioning (draft), null when absent', async () => {
       const draft = { primaryUrl: 'https://acme.com', markets: [{ market: 'US', languageCode: 'en' }] };
-      const draftRow = makeBrandRow({ status: 'pending', pending_provisioning: draft });
+      const draftRow = makeBrandRow({ status: 'pending', pending_semrush_provisioning: draft });
       const draftQuery = createChainableQuery({ data: draftRow, error: null });
       const draftResult = await getBrandById(
         ORG_ID,
         BRAND_ID,
         { from: sinon.stub().returns(draftQuery) },
       );
-      expect(draftResult.pendingProvisioning).to.deep.equal(draft);
+      expect(draftResult.pendingSemrushProvisioning).to.deep.equal(draft);
 
-      // Non-draft brand: no pending_provisioning column → null.
+      // Non-draft brand: no pending_semrush_provisioning column → null.
       const flatQuery = createChainableQuery({ data: makeBrandRow(), error: null });
       const flatResult = await getBrandById(
         ORG_ID,
         BRAND_ID,
         { from: sinon.stub().returns(flatQuery) },
       );
-      expect(flatResult.pendingProvisioning).to.equal(null);
+      expect(flatResult.pendingSemrushProvisioning).to.equal(null);
     });
 
     it('defaults to empty regions when competitor regions is missing', async () => {
@@ -935,7 +935,7 @@ describe('brands-storage', () => {
       expect(brandsUpsert.row.status).to.equal('pending');
     });
 
-    it('persists pending_provisioning (primaryUrl + markets) for a pending draft', async () => {
+    it('persists pending_semrush_provisioning (primaryUrl + markets) for a pending draft', async () => {
       const client = createCapturingClient({
         brands: [
           { data: null, error: null },
@@ -949,7 +949,7 @@ describe('brands-storage', () => {
         brand: {
           name: 'Test',
           status: 'pending',
-          pendingProvisioning: {
+          pendingSemrushProvisioning: {
             primaryUrl: 'https://acme.com',
             markets: [{ market: 'US', languageCode: 'en' }],
           },
@@ -959,13 +959,13 @@ describe('brands-storage', () => {
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
       expect(brandsUpsert.row.status).to.equal('pending');
-      expect(brandsUpsert.row.pending_provisioning).to.deep.equal({
+      expect(brandsUpsert.row.pending_semrush_provisioning).to.deep.equal({
         primaryUrl: 'https://acme.com',
         markets: [{ market: 'US', languageCode: 'en' }],
       });
     });
 
-    it('drops invalid markets and a blank primaryUrl from pending_provisioning, nulling it when empty', async () => {
+    it('drops invalid markets and a blank primaryUrl from pending_semrush_provisioning, nulling it when empty', async () => {
       const client = createCapturingClient({
         brands: [
           { data: null, error: null },
@@ -979,7 +979,7 @@ describe('brands-storage', () => {
         brand: {
           name: 'Test',
           status: 'pending',
-          pendingProvisioning: {
+          pendingSemrushProvisioning: {
             primaryUrl: '   ',
             markets: [{ market: '', languageCode: 'en' }, { market: 'US' }],
           },
@@ -988,10 +988,10 @@ describe('brands-storage', () => {
       });
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
-      expect(brandsUpsert.row.pending_provisioning).to.equal(null);
+      expect(brandsUpsert.row.pending_semrush_provisioning).to.equal(null);
     });
 
-    it('omits pending_provisioning from the row when not supplied', async () => {
+    it('omits pending_semrush_provisioning from the row when not supplied', async () => {
       const client = createCapturingClient({
         brands: [
           { data: null, error: null },
@@ -1007,17 +1007,17 @@ describe('brands-storage', () => {
       });
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
-      expect(brandsUpsert.row).to.not.have.property('pending_provisioning');
+      expect(brandsUpsert.row).to.not.have.property('pending_semrush_provisioning');
     });
 
-    it('throws 400 when pendingProvisioning is not an object', async () => {
+    it('throws 400 when pendingSemrushProvisioning is not an object', async () => {
       const client = createCapturingClient({
         brands: [{ data: null, error: null }],
       });
 
       const err = await upsertBrand({
         organizationId: ORG_ID,
-        brand: { name: 'Test', pendingProvisioning: ['not', 'an', 'object'] },
+        brand: { name: 'Test', pendingSemrushProvisioning: ['not', 'an', 'object'] },
         postgrestClient: client,
       }).catch((e) => e);
 
@@ -2075,7 +2075,7 @@ describe('brands-storage', () => {
       expect(result).to.include({ name: 'NewName', status: 'pending' });
     });
 
-    it('clears pending_provisioning when updates pass pendingProvisioning: null', async () => {
+    it('clears pending_semrush_provisioning when updates pass pendingSemrushProvisioning: null', async () => {
       const client = createCapturingClient({
         brands: [
           { data: { id: BRAND_ID }, error: null },
@@ -2086,12 +2086,12 @@ describe('brands-storage', () => {
       await updateBrand({
         organizationId: ORG_ID,
         brandId: BRAND_ID,
-        updates: { pendingProvisioning: null },
+        updates: { pendingSemrushProvisioning: null },
         postgrestClient: client,
       });
 
       const brandsUpdate = client.capturedCalls.update.find((c) => c.table === 'brands');
-      expect(brandsUpdate.row.pending_provisioning).to.equal(null);
+      expect(brandsUpdate.row.pending_semrush_provisioning).to.equal(null);
     });
 
     it('normalizes brand guidance fields in update patch', async () => {

--- a/test/support/url-utils.test.js
+++ b/test/support/url-utils.test.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { hostnameFromUrlString } from '../../src/support/url-utils.js';
+
+describe('url-utils: hostnameFromUrlString', () => {
+  it('extracts the hostname from a full URL', () => {
+    expect(hostnameFromUrlString('https://acme.com/path?q=1')).to.equal('acme.com');
+  });
+
+  it('tolerates a bare hostname (no scheme)', () => {
+    expect(hostnameFromUrlString('acme.com')).to.equal('acme.com');
+  });
+
+  it('returns null for empty/whitespace/non-string input', () => {
+    expect(hostnameFromUrlString('')).to.equal(null);
+    expect(hostnameFromUrlString('   ')).to.equal(null);
+    expect(hostnameFromUrlString(undefined)).to.equal(null);
+    expect(hostnameFromUrlString(null)).to.equal(null);
+  });
+
+  it('returns null for an unparseable URL (new URL throws)', () => {
+    expect(hostnameFromUrlString('https://[')).to.equal(null);
+  });
+});


### PR DESCRIPTION
## What

Lets the add-brand wizard's "Save as pending" store a Semrush brand with **no sub-workspace, no project, and no primary URL** — deferring all Semrush provisioning to activation.

Previously a pending save still 400'd with `A primary URL is required to provision a Semrush brand`, because `createBrandForOrg` branched only on whether `semrushMarket` was present, never on status. The elmo client already sent `{ status: 'pending', semrushMarket }` correctly — the fix is server-side.

## Changes

- **createBrandForOrg**: when status is `pending`, skip provisioning entirely and stash `{ primaryUrl: first url || null, markets:[{market,languageCode}] }` on the brand instead of requiring a primary URL + AI models. The row lands as `pending` (no anchor — no site_id, no semrush_workspace_id). The active path is unchanged (still provisions).
- **brands-storage**: persist / clear / surface `pending_semrush_provisioning` (`upsertBrand`, `updateBrand`, `mapDbBrandToV2`).
- **activate**: fall back to the stash when the request omits `markets` / `brandDomain`, then remove each market that provisions (status 201 or 409) from the stash — nulling the column once none remain, keeping failed markets (with the primary URL) for retry. The brand still flips active on any live market.
- OpenAPI `Brand` schema documents the read-only `pendingSemrushProvisioning` field.

## Storage shape

One JSONB column `brands.pending_semrush_provisioning = { primaryUrl?, markets:[{market, languageCode}] }`. It folds both the deferred market and the primary URL (which otherwise lives only on the Semrush side) into a single draft-only staging area.

## Out of scope

AI models for a pending brand are not stored, and `activate` does not attach models (pre-existing — models go via `PUT /serenity/models`). Models chosen during a pending save are dropped.

## Tests

581 passing in the touched suites (+12 new: pending create paths, storage persist/clear, activate fallback + per-market removal). Lint, OpenAPI validation, and elmo tsc/build all clean.

## Dependency ordering

Requires both to ship first:

- mysticat-data-service migration for `brands.pending_semrush_provisioning`: https://github.com/adobe/mysticat-data-service/pull/710
- spacecat-shared brand `pendingSemrushProvisioning` attribute: https://github.com/adobe/spacecat-shared/pull/1692 (bump the dependency once published)

Reads are forward-safe before then (base collection selects `*`; `save()` only patches dirty attributes), but the pending-**create** write needs the column to exist.

UI companion (already updated): https://github.com/adobe/project-elmo-ui/pull/2078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
