### PR TITLE
fix(plg): enroll config handlers in pre-onboarding fast path

### DIFF
--- a/src/controllers/plg/plg-onboarding/onboarding-flow.js
+++ b/src/controllers/plg/plg-onboarding/onboarding-flow.js
@@ -379,6 +379,7 @@ async function handlePreonboardedFastPath({
     const { entitlement } = await ensureAsoEntitlement(site, organization, context);
     await revokePreviousAsoEnrollmentsForOrg(site, organization, entitlement, context);
     await updateLaunchDarklyFlags(site, organization, context);
+    await enrollPlgConfigHandlers(site, context);
 
     const steps = { ...(onboarding.getSteps() || {}), entitlementCreated: true };
     if (needsOrgReassignment) {

--- a/src/controllers/plg/plg-onboarding/site-setup.js
+++ b/src/controllers/plg/plg-onboarding/site-setup.js
@@ -17,6 +17,7 @@ import { deriveProjectName } from '../../../support/utils.js';
 // continues even if the configuration table is briefly unwritable.
 export const PLG_CONFIG_HANDLERS = [
   'summit-plg',
+  'top-pages',
   'broken-backlinks',
   'broken-backlinks-auto-suggest',
   'broken-backlinks-auto-fix',
@@ -26,7 +27,6 @@ export const PLG_CONFIG_HANDLERS = [
   'cwv-auto-fix',
   'cwv-auto-suggest',
   'cwv',
-  'top-pages',
 ];
 
 export async function createOrFindProject(baseURL, organizationId, context) {

--- a/src/controllers/plg/plg-onboarding/site-setup.js
+++ b/src/controllers/plg/plg-onboarding/site-setup.js
@@ -17,6 +17,7 @@ import { deriveProjectName } from '../../../support/utils.js';
 // continues even if the configuration table is briefly unwritable.
 export const PLG_CONFIG_HANDLERS = [
   'summit-plg',
+  'broken-backlinks',
   'broken-backlinks-auto-suggest',
   'broken-backlinks-auto-fix',
   'alt-text-auto-fix',
@@ -25,6 +26,7 @@ export const PLG_CONFIG_HANDLERS = [
   'cwv-auto-fix',
   'cwv-auto-suggest',
   'cwv',
+  'top-pages',
 ];
 
 export async function createOrFindProject(baseURL, organizationId, context) {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -20,6 +20,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
 import { isSafeDomain } from '../../../src/controllers/plg/plg-onboarding.js';
+import { PLG_CONFIG_HANDLERS } from '../../../src/controllers/plg/plg-onboarding/site-setup.js';
 
 const PLG_MODEL_DOMAIN_HELPERS = {
   normalizeDomain: RealPlgOnboardingModel.normalizeDomain,
@@ -4865,14 +4866,16 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       controller = PlgOnboardingController({ log: mockLog });
     });
 
-    it('enrolls site in summit-plg config handler', async () => {
+    it('enrolls site in all PLG config handlers', async () => {
       const context = buildContext({ domain: TEST_DOMAIN });
 
       const res = await controller.onboard(context);
 
       expect(res.status).to.equal(200);
       const config = await mockDataAccess.Configuration.findLatest();
-      expect(config.enableHandlerForSite).to.have.been.calledWith('summit-plg', mockSite);
+      for (const handler of PLG_CONFIG_HANDLERS) {
+        expect(config.enableHandlerForSite).to.have.been.calledWith(handler, mockSite);
+      }
     });
 
     it('continues onboarding when summit-plg enrollment fails', async () => {

--- a/test/controllers/plg/plg-onboarding.test.js
+++ b/test/controllers/plg/plg-onboarding.test.js
@@ -4986,6 +4986,10 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(preonboardedOnboarding.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
       // Should NOT run other full onboarding steps
       expect(detectBotBlockerStub).to.not.have.been.called;
+      // Config handlers enrolled, no audit trigger
+      const config = await mockDataAccess.Configuration.findLatest();
+      expect(config.enableHandlerForSite).to.have.been.calledWith('summit-plg', mockSite);
+      expect(triggerAuditsStub).to.not.have.been.called;
     });
 
     it('fast-tracks preonboarded site with null steps', async () => {


### PR DESCRIPTION
## Summary
- `handlePreonboardedFastPath` was skipping `enrollPlgConfigHandlers`, so sites fast-tracked through `PRE_ONBOARDING` status never got `summit-plg`, auto-suggest, and auto-fix config handlers enabled
- Added `enrollPlgConfigHandlers` call after `updateLaunchDarklyFlags` in the fast path, without triggering audit runs
- Updated fast path test to assert `enableHandlerForSite` is called and `triggerAudits` is not

Jira: [SITES-46731](https://jira.corp.adobe.com/browse/SITES-46731)

## Test plan
- [ ] Fast path test passes: `npx mocha test/controllers/plg/plg-onboarding.test.js -g "preonboarding fast path"`
- [ ] Full test suite passes: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)