### PR TITLE
fix: paginate topic-research prompts via single ALL-engine call | LLMO-5671

### DIFF
--- a/src/support/ai-visibility/handlers/topics.js
+++ b/src/support/ai-visibility/handlers/topics.js
@@ -648,40 +648,37 @@ function mergeMultiLlmPromptRows(listResults, totalsResults, sort, mapRow, limit
 
 /**
  * Fetches one page of prompts for the given topic ids via `promptsByTopicIDs`
- * (+ `promptsByTopicIDsTotal`). When an `engine`/`llm` is given, a single LLM is
- * queried; otherwise results are fanned across FTS_LLMS and merged like the FTS path.
+ * (+ `promptsByTopicIDsTotal`) in a SINGLE call. For the all-engines view this uses
+ * `LLM_ENUM.ALL` so the backend aggregates and paginates server-side. A per-LLM fan-out
+ * + client merge cannot paginate correctly here: each LLM receives the same `offset`, and
+ * the summed total over-counts the merged set, so page 2+ comes back empty. Pass a specific
+ * `llm` to scope to a single engine.
  * @returns {Promise<{ data: object[], total: number }>}
  */
 async function promptsByTopicIdsPage({
-  clients, topicIds, country, llm, order, sort, limit, offset,
+  clients, topicIds, country, llm, order, limit, offset,
 }) {
-  if (llm) {
-    const engineSlug = llmToEngine(llm);
-    const pr = await Promise.allSettled([
-      clients.promptClient.promptsByTopicIDsTotal({ country, llm, topicIds }),
-      clients.promptClient.promptsByTopicIDs({
-        country, llm, topicIds, order, range: { limit, offset },
-      }),
-    ]);
-    if (pr[1].status !== 'fulfilled') {
-      throw pr[1].reason;
-    }
-    const raw = pr[1].value;
-    const totalsRaw = settledValueOrElse(pr[0], { total: 0 });
-    const data = (raw.prompts || []).map((p) => {
-      const row = mapTopicIdsPromptRow(p);
-      row.engine = engineSlug || row.engine;
-      return row;
-    });
-    return { data, total: num(totalsRaw.total) };
-  }
-  const prPair = await Promise.all([
-    Promise.all(FTS_LLMS.map((l) => clients.promptClient.promptsByTopicIDsTotal({ country, llm: l, topicIds }).catch(() => ({ total: 0 })))),
-    Promise.all(FTS_LLMS.map((l) => clients.promptClient.promptsByTopicIDs({
-      country, llm: l, topicIds, order, range: { limit, offset },
-    }).catch(() => ({ prompts: [] })))),
+  const llmEnum = llm ?? LLM_ENUM.ALL;
+  // For a single-engine request, force the requested engine on every row; for ALL, each row
+  // carries its own engine (mapped from `p.llm` in mapTopicIdsPromptRow).
+  const singleEngineSlug = llm ? llmToEngine(llm) : '';
+  const pr = await Promise.allSettled([
+    clients.promptClient.promptsByTopicIDsTotal({ country, llm: llmEnum, topicIds }),
+    clients.promptClient.promptsByTopicIDs({
+      country, llm: llmEnum, topicIds, order, range: { limit, offset },
+    }),
   ]);
-  return mergeMultiLlmPromptRows(prPair[1], prPair[0], sort, mapTopicIdsPromptRow, limit);
+  if (pr[1].status !== 'fulfilled') {
+    throw pr[1].reason;
+  }
+  const raw = pr[1].value;
+  const totalsRaw = settledValueOrElse(pr[0], { total: 0 });
+  const data = (raw.prompts || []).map((p) => {
+    const row = mapTopicIdsPromptRow(p);
+    if (singleEngineSlug) { row.engine = singleEngineSlug; }
+    return row;
+  });
+  return { data, total: num(totalsRaw.total) };
 }
 
 export async function handleTopicsResearchPrompts(sp, clients) {
@@ -704,7 +701,7 @@ export async function handleTopicsResearchPrompts(sp, clients) {
     if (sort.error) { return sort.error; }
     const order = { by: sort.by, direction: sort.direction };
     const { data, total } = await promptsByTopicIdsPage({
-      clients, topicIds: topicFilter.topicIds, country, llm, order, sort, limit, offset,
+      clients, topicIds: topicFilter.topicIds, country, llm, order, limit, offset,
     });
     return {
       status: 200,

--- a/test/support/ai-visibility/handlers/topics.test.js
+++ b/test/support/ai-visibility/handlers/topics.test.js
@@ -918,6 +918,20 @@ describe('AI Visibility – topics handlers', () => {
         expect(clients.promptClient.promptsByTopicIDs.firstCall.args[0].topicIds).to.deep.equal([1n, 2n]);
       });
 
+      it('forwards a non-zero offset to the single backend call (page-2 pagination)', async () => {
+        // Regression guard for the bug this fix targets: page 2 must reach the backend with the
+        // requested offset on a single aggregated call (not a per-engine fan-out that empties it).
+        clients.promptClient.promptsByTopicIDsTotal.resolves({ total: 18 });
+        clients.promptClient.promptsByTopicIDs.resolves({ prompts: [] });
+        const sp = new URLSearchParams('topicId=1&limit=10&offset=10');
+        const res = await handleTopicsResearchPrompts(sp, clients);
+        expect(res.status).to.equal(200);
+        expect(clients.promptClient.promptsByTopicIDs.callCount).to.equal(1);
+        expect(clients.promptClient.promptsByTopicIDs.firstCall.args[0].range).to.deep.equal({ limit: 10, offset: 10 });
+        expect(res.body.offset).to.equal(10);
+        expect(res.body.total).to.equal(18);
+      });
+
       it('returns 400 for a non-numeric topicId', async () => {
         const sp = new URLSearchParams('topicId=abc');
         const res = await handleTopicsResearchPrompts(sp, clients);

--- a/test/support/ai-visibility/handlers/topics.test.js
+++ b/test/support/ai-visibility/handlers/topics.test.js
@@ -885,23 +885,28 @@ describe('AI Visibility – topics handlers', () => {
         expect(res.body.data[0].responseExcerpt).to.equal('hi');
       });
 
-      it('all LLMs: fans out across engines and sums per-LLM totals', async () => {
-        for (const llm of FTS_LLMS) {
-          clients.promptClient.promptsByTopicIDsTotal.withArgs(sinon.match({ llm })).resolves({ total: 1 });
-          clients.promptClient.promptsByTopicIDs.withArgs(sinon.match({ llm })).resolves({
-            prompts: [{
-              prompt: 'Same prompt', promptHash: 'h1', serpId: 's1', topicId: '1', llm, mentionedBrandsCount: 2, sourcesCount: 1,
-            }],
-          });
-        }
+      it('all engines: one LLM_ENUM.ALL call, server-side total (no per-engine fan-out)', async () => {
+        clients.promptClient.promptsByTopicIDsTotal.resolves({ total: 12 });
+        clients.promptClient.promptsByTopicIDs.resolves({
+          prompts: [
+            {
+              prompt: 'P', promptHash: 'h1', serpId: 's1', topicId: '1', llm: FTS_LLMS[0], mentionedBrandsCount: 2, sourcesCount: 1,
+            },
+            {
+              prompt: 'P', promptHash: 'h1', serpId: 's2', topicId: '1', llm: FTS_LLMS[1], mentionedBrandsCount: 3, sourcesCount: 0,
+            },
+          ],
+        });
         const sp = new URLSearchParams('topicId=1');
         const res = await handleTopicsResearchPrompts(sp, clients);
         expect(res.status).to.equal(200);
-        expect(res.body.total).to.equal(FTS_LLMS.length);
-        res.body.data.forEach((d) => {
-          expect(d).to.not.have.property('mentionSortKey');
-          expect(d).to.not.have.property('promptNormKey');
-        });
+        // A single aggregated call — not one per engine (which would break offset pagination).
+        expect(clients.promptClient.promptsByTopicIDs.callCount).to.equal(1);
+        expect(clients.promptClient.promptsByTopicIDs.firstCall.args[0].llm).to.equal(LLM_ENUM.ALL);
+        expect(clients.promptClient.promptsByTopicIDsTotal.firstCall.args[0].llm).to.equal(LLM_ENUM.ALL);
+        // Server-side total is passed through verbatim (not summed across per-LLM calls).
+        expect(res.body.total).to.equal(12);
+        expect(res.body.data).to.have.length(2);
       });
 
       it('accepts repeated topicIds and forwards all ids', async () => {


### PR DESCRIPTION
## Summary
Follow-up to #2629 (LLMO-5671). The topic-scoped prompts path (`GET /llmo/ai-visibility/topics/research/prompts?topicId=…`) couldn't paginate: it fanned out one `promptsByTopicIDs` call per engine with the same `offset` and summed the per-engine totals. So page 2 sent `offset=10` to every engine — each of which had fewer rows — returning empty, and the summed `total` over-counted the merged set. It now makes a single `promptsByTopicIDs` call with `LLM_ENUM.ALL` (or the specific engine when filtered), letting the backend aggregate and paginate server-side with a correct total — matching how prompts/metrics are fetched elsewhere.

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-5671

## Changes
- `handleTopicsResearchPrompts` topicId path: replace per-engine fan-out + client-side merge with a single `promptsByTopicIDs`/`promptsByTopicIDsTotal` call using `LLM_ENUM.ALL` (engine slug forced per row only when a specific engine is requested).
- Update the topicId unit tests to assert the single `ALL` call + server-side total passthrough (no per-engine fan-out).

## Test plan
- [x] `npx mocha test/support/ai-visibility/handlers/topics.test.js` — 114 passing (updated all-engines case asserts one `LLM_ENUM.ALL` call, `llm` forwarded to both list + totals, server-side total passed through).
- [x] `npm run lint` clean on changed files.
- [x] Verified live (Chrome DevTools, prompt-research dashboard): expanding a topic → page 1 shows 10 rows, **page 2 shows the remaining rows** ("11-18 of 18"); previously page 2 was empty.

---
Checklist:
- [x] Related issue linked above.
- [x] API behavior change (pagination/total of an existing endpoint) → no spec shape change; response contract `{ data, total, offset, limit }` unchanged.