### PR TITLE
feat(preflight): mint IMS token via dedicated client (SITES-46699)

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -483,7 +483,7 @@ function PreflightController(ctx, log, env) {
       }
     }
 
-    // Mint a spacecat-api-service IMS v3 service token for the Mystique CGW
+    // Mint a spacecat-api-service IMS service token for the Mystique CGW
     // edge gate (SITES-43236 / SITES-46699 / mystique-deploy PR #463). Sent
     // on the dedicated x-ims-authorization header — separate from
     // `Authorization` above, which carries the customer site's page-auth
@@ -491,22 +491,19 @@ function PreflightController(ctx, log, env) {
     //
     // Constructs a custom-env ImsClient with the dedicated PREFLIGHT_IMS_*
     // credentials provisioned in Vault for this S2S use case (SITES-46699).
-    // The default IMS client wired into `context.imsClient` by
-    // `imsClientWrapper` is not registered for the `client_credentials`
-    // grant type, so v3 service-token minting cannot succeed against it.
-    // ASO team manages a dedicated client for this purpose, following the
-    // established spacecat one-IMS-client-per-purpose convention (see
-    // `email-service.js` / `trial-users.js` / cloud-manager-client /
-    // brand-client — each swaps IMS env at construction for their own
-    // dedicated identity).
+    // ASO team manages a dedicated IMS client (`aem_site_optimizer_preflight`)
+    // for this purpose, following the established spacecat
+    // one-IMS-client-per-purpose convention (see `email-service.js` /
+    // `trial-users.js` / cloud-manager-client / brand-client — each swaps
+    // IMS env at construction for their own dedicated identity).
     //
-    // Uses getServicePrincipalAccessToken(imsOrgId) rather than
-    // getServiceAccessTokenV3() because the PREFLIGHT IMS client is
-    // ownerless — it has no default org bound at registration, so per the
-    // IMS Client Credentials wiki (wiki x/Olwxn) every v3 mint must
-    // explicitly carry org_id. The required Service Principal Binding
-    // between the client and PREFLIGHT_IMS_ORG_ID is provisioned out-of-band
-    // (SITES-46699 acceptance criterion).
+    // Uses getServiceAccessToken (v2 authorization_code) against the
+    // IMSS-provisioned permanent authorization code (Service Token row on
+    // the client) — the synthetic service-account identity is encoded in
+    // the code itself, so no org_id is needed at mint time and no Service
+    // Principal Binding is required. The CGW-Flex edge gate validates the
+    // `client_id` claim, which is identical across v2 and v3 tokens for
+    // this client, so v2 satisfies the gate.
     //
     // Mint before the AsyncJob / Preflight DB writes so a transient IMS
     // failure doesn't leave orphaned IN_PROGRESS records to clean up.
@@ -523,21 +520,17 @@ function PreflightController(ctx, log, env) {
         ...env,
         IMS_CLIENT_ID: env.PREFLIGHT_IMS_CLIENT_ID,
         IMS_CLIENT_SECRET: env.PREFLIGHT_IMS_CLIENT_SECRET,
-        // IMS_CLIENT_CODE is required by ImsClient.createFrom's constructor
-        // validation even though v3 `client_credentials` doesn't send it to
-        // IMS — bind to our own PREFLIGHT_IMS_CLIENT_CODE so the dedicated
-        // client is fully self-contained rather than inheriting the default
-        // client's CLIENT_CODE via the env spread above.
         IMS_CLIENT_CODE: env.PREFLIGHT_IMS_CLIENT_CODE,
+        // IMS_SCOPE is unused by v2 getServiceAccessToken (scope is bound
+        // to the permanent code at IMSS registration time), but kept here
+        // for forward-compat if/when this client moves to v3.
         IMS_SCOPE: env.PREFLIGHT_IMS_SCOPE,
       };
       const preflightImsClient = ImsClient.createFrom({
         ...context,
         env: preflightImsEnv,
       });
-      const tokenPayload = await preflightImsClient.getServicePrincipalAccessToken(
-        env.PREFLIGHT_IMS_ORG_ID,
-      );
+      const tokenPayload = await preflightImsClient.getServiceAccessToken();
       imsServiceToken = tokenPayload?.access_token;
       // Post-condition: a successful mint must yield a non-empty access_token.
       // Guards against an SDK shape change (e.g. `{ accessToken }` or `{}`)

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -484,34 +484,21 @@ function PreflightController(ctx, log, env) {
     }
 
     // Mint a spacecat-api-service IMS v3 service token for the Mystique CGW
-    // edge gate (SITES-43236 / mystique-deploy PR #463). Sent on the dedicated
-    // x-ims-authorization header — separate from `Authorization` above, which
-    // carries the customer site's page-auth token for DRS upstream.
+    // edge gate (SITES-43236 / SITES-46699 / mystique-deploy PR #463). Sent
+    // on the dedicated x-ims-authorization header — separate from
+    // `Authorization` above, which carries the customer site's page-auth
+    // token for DRS upstream.
     //
-    // Constructs a custom-env ImsClient with IMS_SCOPE='system' hardcoded
-    // because the default spacecat IMS client (`aem-project-collab-service`
-    // per Vault `dx_mysticat`) has no `IMS_SCOPE` provisioned for the v3
-    // client_credentials grant — empirically confirmed in dev where the
-    // wrapper-wired `context.imsClient` produced an IMS 400 (invalid_scope).
-    // 'system' is the Adobe IMS mandated scope for v3 service-client tokens
-    // (per ASO team Slack thread, 2026-06-17). This mirrors the existing
-    // pattern in `email-service.js` and `trial-users.js` of overriding IMS
-    // env at construction, but differs in intent: those callers have their
-    // own dedicated IMS clients (LLMO email, etc.) and MUST swap credentials
-    // entirely; we keep the default client and only override scope. That
-    // makes this hardcode a transitional bypass for missing Vault config,
-    // NOT the desired permanent shape.
-    //
-    // Reversibility: if `IMS_SCOPE=system` is provisioned in Vault for
-    // `aem-project-collab-service`, this hardcode can be reverted to the
-    // wrapper-wired `await context.imsClient.getServiceAccessTokenV3()` and
-    // the `imsClient` destructure + `isNonEmptyObject(imsClient)` constructor
-    // guard on `PreflightController` restored alongside (both removed in the
-    // same PR as this hardcode — see git history under `SITES-43236`). The
-    // revert also restores singleton token caching across warm-Lambda
-    // invocations, which this construction loses — accepted cost during the
-    // transition, since per-invocation mint sidesteps the not-expiry-aware
-    // cache concern from the prior review thread on PR #2611.
+    // Constructs a custom-env ImsClient with the dedicated PREFLIGHT_IMS_*
+    // credentials provisioned in Vault for this S2S use case (SITES-46699).
+    // The default IMS client wired into `context.imsClient` by
+    // `imsClientWrapper` is not registered for the `client_credentials`
+    // grant type, so v3 service-token minting cannot succeed against it.
+    // ASO team manages a dedicated client for this purpose, following the
+    // established spacecat one-IMS-client-per-purpose convention (see
+    // `email-service.js` / `trial-users.js` / cloud-manager-client /
+    // brand-client — each swaps IMS env at construction for their own
+    // dedicated identity).
     //
     // Mint before the AsyncJob / Preflight DB writes so a transient IMS
     // failure doesn't leave orphaned IN_PROGRESS records to clean up.
@@ -524,11 +511,17 @@ function PreflightController(ctx, log, env) {
     // this a narrow availability cost in practice.
     let imsServiceToken;
     try {
-      const scopedImsClient = ImsClient.createFrom({
+      const preflightImsEnv = {
+        ...env,
+        IMS_CLIENT_ID: env.PREFLIGHT_IMS_CLIENT_ID,
+        IMS_CLIENT_SECRET: env.PREFLIGHT_IMS_CLIENT_SECRET,
+        IMS_SCOPE: env.PREFLIGHT_IMS_SCOPE,
+      };
+      const preflightImsClient = ImsClient.createFrom({
         ...context,
-        env: { ...context.env, IMS_SCOPE: 'system' },
+        env: preflightImsEnv,
       });
-      const tokenPayload = await scopedImsClient.getServiceAccessTokenV3();
+      const tokenPayload = await preflightImsClient.getServiceAccessTokenV3();
       imsServiceToken = tokenPayload?.access_token;
       // Post-condition: a successful mint must yield a non-empty access_token.
       // Guards against an SDK shape change (e.g. `{ accessToken }` or `{}`)

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -515,6 +515,12 @@ function PreflightController(ctx, log, env) {
         ...env,
         IMS_CLIENT_ID: env.PREFLIGHT_IMS_CLIENT_ID,
         IMS_CLIENT_SECRET: env.PREFLIGHT_IMS_CLIENT_SECRET,
+        // IMS_CLIENT_CODE is required by ImsClient.createFrom's constructor
+        // validation even though v3 `client_credentials` doesn't send it to
+        // IMS — bind to our own PREFLIGHT_IMS_CLIENT_CODE so the dedicated
+        // client is fully self-contained rather than inheriting the default
+        // client's CLIENT_CODE via the env spread above.
+        IMS_CLIENT_CODE: env.PREFLIGHT_IMS_CLIENT_CODE,
         IMS_SCOPE: env.PREFLIGHT_IMS_SCOPE,
       };
       const preflightImsClient = ImsClient.createFrom({

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -500,6 +500,14 @@ function PreflightController(ctx, log, env) {
     // brand-client — each swaps IMS env at construction for their own
     // dedicated identity).
     //
+    // Uses getServicePrincipalAccessToken(imsOrgId) rather than
+    // getServiceAccessTokenV3() because the PREFLIGHT IMS client is
+    // ownerless — it has no default org bound at registration, so per the
+    // IMS Client Credentials wiki (wiki x/Olwxn) every v3 mint must
+    // explicitly carry org_id. The required Service Principal Binding
+    // between the client and PREFLIGHT_IMS_ORG_ID is provisioned out-of-band
+    // (SITES-46699 acceptance criterion).
+    //
     // Mint before the AsyncJob / Preflight DB writes so a transient IMS
     // failure doesn't leave orphaned IN_PROGRESS records to clean up.
     //
@@ -527,7 +535,9 @@ function PreflightController(ctx, log, env) {
         ...context,
         env: preflightImsEnv,
       });
-      const tokenPayload = await preflightImsClient.getServiceAccessTokenV3();
+      const tokenPayload = await preflightImsClient.getServicePrincipalAccessToken(
+        env.PREFLIGHT_IMS_ORG_ID,
+      );
       imsServiceToken = tokenPayload?.access_token;
       // Post-condition: a successful mint must yield a non-empty access_token.
       // Guards against an SDK shape change (e.g. `{ accessToken }` or `{}`)

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1137,10 +1137,10 @@ describe('Preflight Controller', () => {
       // ImsClient with the dedicated PREFLIGHT_IMS_* credentials at the mint
       // call site (see preflight.js for rationale). Tests esmock
       // `ImsClient.createFrom` to return the shared mockImsClient stub; tests
-      // control mint behavior by overriding getServiceAccessTokenV3 on that
-      // stub per case.
+      // control mint behavior by overriding getServicePrincipalAccessToken
+      // on that stub per case (ownerless client → mint passes org_id).
       mockImsClient = {
-        getServiceAccessTokenV3: sandbox.stub().resolves({
+        getServicePrincipalAccessToken: sandbox.stub().resolves({
           access_token: 'test-ims-service-token',
           token_type: 'bearer',
           expires_in: 3600,
@@ -1183,6 +1183,9 @@ describe('Preflight Controller', () => {
           PREFLIGHT_IMS_CLIENT_SECRET: 'test-preflight-client-secret',
           PREFLIGHT_IMS_CLIENT_CODE: 'test-preflight-client-code',
           PREFLIGHT_IMS_SCOPE: 'test-preflight-scope',
+          // Ownerless IMS client → v3 mint requires explicit org_id (Service
+          // Principal Binding provisioned out-of-band, see SITES-46699).
+          PREFLIGHT_IMS_ORG_ID: 'test-preflight-org@AdobeOrg',
         },
       );
     });
@@ -1607,13 +1610,14 @@ describe('Preflight Controller', () => {
         attributes: { authInfo: mockAuthInfo },
       });
       expect(response.status).to.equal(202);
-      expect(mockImsClient.getServiceAccessTokenV3).to.have.been.calledOnce;
-      // Load-bearing contract (SITES-46699): the custom-env ImsClient
-      // construction MUST pass the dedicated PREFLIGHT_IMS_* credentials
-      // through to ImsClient.createFrom — that's the whole point of the
-      // dedicated-client approach. If a future refactor accidentally swaps
-      // the wrong env keys (or reverts to the wrapper-wired default client),
-      // this assertion fails.
+      // Load-bearing contracts (SITES-46699):
+      //   1. Custom-env ImsClient construction passes the dedicated
+      //      PREFLIGHT_IMS_* credentials through to ImsClient.createFrom.
+      //   2. Mint uses getServicePrincipalAccessToken (not v3-without-org)
+      //      and threads PREFLIGHT_IMS_ORG_ID — the client is ownerless,
+      //      so per-request org_id is required.
+      // If a future refactor reverts to v3-without-org or swaps the wrong
+      // env keys, one of these assertions fails.
       expect(createFromStub).to.have.been.calledWith(
         sinon.match({
           env: sinon.match({
@@ -1623,6 +1627,9 @@ describe('Preflight Controller', () => {
             IMS_SCOPE: 'test-preflight-scope',
           }),
         }),
+      );
+      expect(mockImsClient.getServicePrincipalAccessToken).to.have.been.calledOnceWith(
+        'test-preflight-org@AdobeOrg',
       );
       const [, calledOptions] = fetchStub.secondCall.args;
       // Bearer prefix mirrors the v3-token convention; verified against the
@@ -1687,7 +1694,7 @@ describe('Preflight Controller', () => {
     });
 
     it('returns 500 PREFLIGHT_INTERNAL_ERROR when IMS service-token mint fails', async () => {
-      mockImsClient.getServiceAccessTokenV3.rejects(new Error('IMS down'));
+      mockImsClient.getServicePrincipalAccessToken.rejects(new Error('IMS down'));
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
@@ -1702,7 +1709,7 @@ describe('Preflight Controller', () => {
     it('does not create AsyncJob or Preflight records when IMS mint fails', async () => {
       // Mint happens before DB writes — a transient IMS failure must not
       // leave orphaned IN_PROGRESS records that the caller can't reconcile.
-      mockImsClient.getServiceAccessTokenV3.rejects(new Error('IMS down'));
+      mockImsClient.getServicePrincipalAccessToken.rejects(new Error('IMS down'));
       await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
@@ -1713,7 +1720,7 @@ describe('Preflight Controller', () => {
     });
 
     it('does not call Mysticat when IMS mint fails', async () => {
-      mockImsClient.getServiceAccessTokenV3.rejects(new Error('IMS down'));
+      mockImsClient.getServicePrincipalAccessToken.rejects(new Error('IMS down'));
       await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
@@ -1732,7 +1739,7 @@ describe('Preflight Controller', () => {
       // SDK shape drift guard (e.g. `{ accessToken: ... }` after a version bump
       // or `{}` on partial responses) — must surface as an explicit 500, not
       // silently drop the header.
-      mockImsClient.getServiceAccessTokenV3.resolves({});
+      mockImsClient.getServicePrincipalAccessToken.resolves({});
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1137,10 +1137,10 @@ describe('Preflight Controller', () => {
       // ImsClient with the dedicated PREFLIGHT_IMS_* credentials at the mint
       // call site (see preflight.js for rationale). Tests esmock
       // `ImsClient.createFrom` to return the shared mockImsClient stub; tests
-      // control mint behavior by overriding getServicePrincipalAccessToken
-      // on that stub per case (ownerless client → mint passes org_id).
+      // control mint behavior by overriding getServiceAccessToken on that
+      // stub per case (v2 authorization_code service-token mint).
       mockImsClient = {
-        getServicePrincipalAccessToken: sandbox.stub().resolves({
+        getServiceAccessToken: sandbox.stub().resolves({
           access_token: 'test-ims-service-token',
           token_type: 'bearer',
           expires_in: 3600,
@@ -1183,9 +1183,6 @@ describe('Preflight Controller', () => {
           PREFLIGHT_IMS_CLIENT_SECRET: 'test-preflight-client-secret',
           PREFLIGHT_IMS_CLIENT_CODE: 'test-preflight-client-code',
           PREFLIGHT_IMS_SCOPE: 'test-preflight-scope',
-          // Ownerless IMS client → v3 mint requires explicit org_id (Service
-          // Principal Binding provisioned out-of-band, see SITES-46699).
-          PREFLIGHT_IMS_ORG_ID: 'test-preflight-org@AdobeOrg',
         },
       );
     });
@@ -1613,11 +1610,10 @@ describe('Preflight Controller', () => {
       // Load-bearing contracts (SITES-46699):
       //   1. Custom-env ImsClient construction passes the dedicated
       //      PREFLIGHT_IMS_* credentials through to ImsClient.createFrom.
-      //   2. Mint uses getServicePrincipalAccessToken (not v3-without-org)
-      //      and threads PREFLIGHT_IMS_ORG_ID — the client is ownerless,
-      //      so per-request org_id is required.
-      // If a future refactor reverts to v3-without-org or swaps the wrong
-      // env keys, one of these assertions fails.
+      //   2. Mint uses getServiceAccessToken (v2 authorization_code against
+      //      the IMSS-provisioned permanent code — no org_id, no SP binding).
+      // If a future refactor swaps to v3 client_credentials or wires the
+      // wrong env keys, one of these assertions fails.
       expect(createFromStub).to.have.been.calledWith(
         sinon.match({
           env: sinon.match({
@@ -1628,9 +1624,7 @@ describe('Preflight Controller', () => {
           }),
         }),
       );
-      expect(mockImsClient.getServicePrincipalAccessToken).to.have.been.calledOnceWith(
-        'test-preflight-org@AdobeOrg',
-      );
+      expect(mockImsClient.getServiceAccessToken).to.have.been.calledOnce;
       const [, calledOptions] = fetchStub.secondCall.args;
       // Bearer prefix mirrors the v3-token convention; verified against the
       // mystique-deploy CGW-Flex validator (Authorization on /v1/apply uses
@@ -1694,7 +1688,7 @@ describe('Preflight Controller', () => {
     });
 
     it('returns 500 PREFLIGHT_INTERNAL_ERROR when IMS service-token mint fails', async () => {
-      mockImsClient.getServicePrincipalAccessToken.rejects(new Error('IMS down'));
+      mockImsClient.getServiceAccessToken.rejects(new Error('IMS down'));
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
@@ -1709,7 +1703,7 @@ describe('Preflight Controller', () => {
     it('does not create AsyncJob or Preflight records when IMS mint fails', async () => {
       // Mint happens before DB writes — a transient IMS failure must not
       // leave orphaned IN_PROGRESS records that the caller can't reconcile.
-      mockImsClient.getServicePrincipalAccessToken.rejects(new Error('IMS down'));
+      mockImsClient.getServiceAccessToken.rejects(new Error('IMS down'));
       await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
@@ -1720,7 +1714,7 @@ describe('Preflight Controller', () => {
     });
 
     it('does not call Mysticat when IMS mint fails', async () => {
-      mockImsClient.getServicePrincipalAccessToken.rejects(new Error('IMS down'));
+      mockImsClient.getServiceAccessToken.rejects(new Error('IMS down'));
       await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
@@ -1739,7 +1733,7 @@ describe('Preflight Controller', () => {
       // SDK shape drift guard (e.g. `{ accessToken: ... }` after a version bump
       // or `{}` on partial responses) — must surface as an explicit 500, not
       // silently drop the header.
-      mockImsClient.getServicePrincipalAccessToken.resolves({});
+      mockImsClient.getServiceAccessToken.resolves({});
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1181,6 +1181,7 @@ describe('Preflight Controller', () => {
           // SITES-46699: dedicated IMS client credentials used by callMysticatAnalyze.
           PREFLIGHT_IMS_CLIENT_ID: 'test-preflight-client-id',
           PREFLIGHT_IMS_CLIENT_SECRET: 'test-preflight-client-secret',
+          PREFLIGHT_IMS_CLIENT_CODE: 'test-preflight-client-code',
           PREFLIGHT_IMS_SCOPE: 'test-preflight-scope',
         },
       );
@@ -1618,6 +1619,7 @@ describe('Preflight Controller', () => {
           env: sinon.match({
             IMS_CLIENT_ID: 'test-preflight-client-id',
             IMS_CLIENT_SECRET: 'test-preflight-client-secret',
+            IMS_CLIENT_CODE: 'test-preflight-client-code',
             IMS_SCOPE: 'test-preflight-scope',
           }),
         }),

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1133,11 +1133,12 @@ describe('Preflight Controller', () => {
       mockDataAccess.Preflight.create = sandbox.stub().resolves(mockPreflight);
       hasAccessStub = sandbox.stub().resolves(true);
 
-      // SITES-43236: createPreflight constructs a custom-env ImsClient with
-      // IMS_SCOPE='system' hardcoded at the mint call site (see preflight.js
-      // for rationale). Tests esmock `ImsClient.createFrom` to return the
-      // shared mockImsClient stub; tests control mint behavior by overriding
-      // getServiceAccessTokenV3 on that stub per case.
+      // SITES-43236 / SITES-46699: createPreflight constructs a custom-env
+      // ImsClient with the dedicated PREFLIGHT_IMS_* credentials at the mint
+      // call site (see preflight.js for rationale). Tests esmock
+      // `ImsClient.createFrom` to return the shared mockImsClient stub; tests
+      // control mint behavior by overriding getServiceAccessTokenV3 on that
+      // stub per case.
       mockImsClient = {
         getServiceAccessTokenV3: sandbox.stub().resolves({
           access_token: 'test-ims-service-token',
@@ -1146,9 +1147,10 @@ describe('Preflight Controller', () => {
         }),
       };
       // Stub-ify ImsClient.createFrom so tests can assert that the source
-      // passes IMS_SCOPE='system' through to the factory (the load-bearing
-      // contract of the hardcode; if a future refactor accidentally drops
-      // the override, this stub's call args won't match and assertions fail).
+      // passes the dedicated PREFLIGHT_IMS_* credentials through to the
+      // factory (the load-bearing contract of SITES-46699; if a future
+      // refactor accidentally swaps the wrong env keys, this stub's call
+      // args won't match and assertions fail).
       createFromStub = sandbox.stub().returns(mockImsClient);
 
       // SITES-46202: createPreflight no longer consults Configuration / TierClient
@@ -1176,6 +1178,10 @@ describe('Preflight Controller', () => {
           AUDIT_JOBS_QUEUE_URL: 'https://sqs.test.amazonaws.com/audit-queue',
           MYSTIQUE_API_BASE_URL: 'https://mysticat.example.com',
           AWS_ENV: 'prod',
+          // SITES-46699: dedicated IMS client credentials used by callMysticatAnalyze.
+          PREFLIGHT_IMS_CLIENT_ID: 'test-preflight-client-id',
+          PREFLIGHT_IMS_CLIENT_SECRET: 'test-preflight-client-secret',
+          PREFLIGHT_IMS_SCOPE: 'test-preflight-scope',
         },
       );
     });
@@ -1601,13 +1607,20 @@ describe('Preflight Controller', () => {
       });
       expect(response.status).to.equal(202);
       expect(mockImsClient.getServiceAccessTokenV3).to.have.been.calledOnce;
-      // Load-bearing contract of this PR: the custom-env ImsClient construction
-      // MUST pass IMS_SCOPE='system' through to ImsClient.createFrom — that's
-      // the hardcoded scope value that lets the v3 client_credentials grant
-      // succeed against `aem-project-collab-service` (per SITES-43236). If a
-      // future refactor accidentally drops the override, this assertion fails.
+      // Load-bearing contract (SITES-46699): the custom-env ImsClient
+      // construction MUST pass the dedicated PREFLIGHT_IMS_* credentials
+      // through to ImsClient.createFrom — that's the whole point of the
+      // dedicated-client approach. If a future refactor accidentally swaps
+      // the wrong env keys (or reverts to the wrapper-wired default client),
+      // this assertion fails.
       expect(createFromStub).to.have.been.calledWith(
-        sinon.match({ env: sinon.match({ IMS_SCOPE: 'system' }) }),
+        sinon.match({
+          env: sinon.match({
+            IMS_CLIENT_ID: 'test-preflight-client-id',
+            IMS_CLIENT_SECRET: 'test-preflight-client-secret',
+            IMS_SCOPE: 'test-preflight-scope',
+          }),
+        }),
       );
       const [, calledOptions] = fetchStub.secondCall.args;
       // Bearer prefix mirrors the v3-token convention; verified against the


### PR DESCRIPTION
## What & why

[SITES-46699](https://jira.corp.adobe.com/browse/SITES-46699) - `callMysticatAnalyze` now mints its IMS service token via a dedicated `aem_sites_optimizer_preflight_service` IMS client (ASO-team-managed), following the established spacecat one-IMS-client-per-purpose convention (email-service, trial-users, cloud-manager-client, brand-client all swap IMS env at construction for their own identity).

The previous attempt ([#2611](https://github.com/adobe/spacecat-api-service/pull/2611) + scope-hardcode [#2627](https://github.com/adobe/spacecat-api-service/pull/2627)) tried to reuse the borrowed `aem-project-collab-service` IMS client via `getServiceAccessTokenV3()` (v3 client_credentials). Ravi confirmed via Slack that client isn't registered for `client_credentials` grant at all - the IMS 400 we were chasing was `unauthorized_client`, which the new IMS-body-in-error-message diagnostic ([SITES-46698](https://jira.corp.adobe.com/browse/SITES-46698), [adobe/spacecat-shared#1689](https://github.com/adobe/spacecat-shared/pull/1689), published as `@adobe/spacecat-shared-ims-client@1.14.0`) now surfaces directly.

### Hindsight

In retrospect, `aem-project-collab-service` does have an `authorization_code` grant + IMSS-provisioned Service Token - so a **v2** `getServiceAccessToken()` against it would have worked from day one. We never tried it because PR #2611 set v3 as the path and we accepted that constraint, then chased scope/grant issues inside the v3 box without seeing IMS's `unauthorized_client` response. SITES-46698 closes that diagnostic loop.

A dedicated client is still the right architecture, not a consolation prize: independent rotation + scope + CGW allowlisting, cleaner Splunk/IMS audit-trail attribution, and `allowedClientIDs` is more meaningful per-consumer than one bucket of shared traffic.

## v2, not v3

Mint uses `getServiceAccessToken()` (v2 `authorization_code`) against the IMSS-provisioned permanent authorization code on the client's Service Token. v2 needs **no org_id** and **no Service Principal Binding** - the synthetic service-account identity (`aem_sites_optimizer_preflight_service@AdobeService`) is encoded in the permanent code at IMSS registration time.

We initially refactored to v3 `getServicePrincipalAccessToken(orgId)` (the path for ownerless clients), then pivoted to v2 when the IMSS console surfaced an auto-provisioned Service Token on the client. The CGW-Flex edge gate keys on the `client_id` claim, which is identical across v2 and v3 tokens for this client, so v2 satisfies the gate. `IMS_SCOPE` mapping is retained in the env spread (unused by v2, but forward-compat if/when this client moves to v3).

## Files

- `src/controllers/preflight.js` - custom-env `ImsClient` wrapper in `callMysticatAnalyze`; swap to v2 mint
- `test/controllers/preflight.test.js` - factory env carries 4 `PREFLIGHT_IMS_*` test values; load-bearing assertions pin both the credential threading through `ImsClient.createFrom` and the v2 method on the stub

## Vault state (dev only)

`PREFLIGHT_IMS_CLIENT_ID` / `PREFLIGHT_IMS_CLIENT_SECRET` / `PREFLIGHT_IMS_CLIENT_CODE` / `PREFLIGHT_IMS_SCOPE` provisioned in `dx_mysticat/dev/api-service`. **Production rollout is tracked separately under [SITES-46770](https://jira.corp.adobe.com/browse/SITES-46770)** - explicitly blocked on this ticket landing + dev empirical verification so we don't burn the prod IMS-client + Vault provisioning effort until the v2 flow is proven on dev.

## Sequencing

This PR doesn't unblock end-to-end on its own. The companion change on the deploy side is [mystique-deploy #470](https://git.corp.adobe.com/experience-platform/mystique-deploy/pull/470), which adds `aem_sites_optimizer_preflight_service` to `m-dev.adobe.io`'s `allowedClientIDs` for `/v1/preflight/analyze`. (Supersedes closed-unmerged [mystique-deploy #466](https://git.corp.adobe.com/experience-platform/mystique-deploy/pull/466) which targeted the old borrowed client.) Edge gate remains `optional: true` in Phase 1 - once both PRs land and dev redeploys, empirical verification can flip Phase 2's `optional: false`.

## Test plan

- [x] `npx mocha test/controllers/preflight.test.js` - 90/90 pass
- [x] Coverage maintained
- [ ] Once merged + dev redeployed: trigger a preflight on a dev site, watch CloudWatch for the IMS mint + CGW-Flex edge handshake (mystique-dev pod receives the request with `x-ims-authorization` bearing a valid `aem_sites_optimizer_preflight_service`-issued v2 token)
- [ ] When the mystique-deploy companion PR lands and the edge gate flips to `optional: false` + `tokenType: service`, this becomes load-bearing

## Related

- [SITES-43236](https://jira.corp.adobe.com/browse/SITES-43236) - motivating ticket (resolved on the strength of #2611 + #2627; the actual unblock work moved here under SITES-46699)
- [SITES-46698](https://jira.corp.adobe.com/browse/SITES-46698) - diagnostic that exposed the root cause; resolved
- [SITES-46770](https://jira.corp.adobe.com/browse/SITES-46770) - production sibling, blocked on this ticket
- [mystique-deploy #470](https://git.corp.adobe.com/experience-platform/mystique-deploy/pull/470) - deploy-side companion (this PR's pair)
- closed-unmerged [mystique-deploy #466](https://git.corp.adobe.com/experience-platform/mystique-deploy/pull/466) - superseded
- [mystique-deploy #463](https://git.corp.adobe.com/experience-platform/mystique-deploy/pull/463) - Phase 1 CGW-Flex preflight endpoint setup