### PR TITLE
fix(prerender): ai-only-missing mode should include FIXED suggestions

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -108,7 +108,7 @@ function RunAuditCommand(context) {
   const baseCommand = BaseCommand({
     id: 'run-audit',
     name: 'Run Audit',
-    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed); `mode:ai-only-missing` runs AI-only for current-tab suggestions missing an AI summary. CSV uploads are batched at 320 URLs.',
+    description: 'Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed); `mode:ai-only-missing` runs AI-only for NEW/FIXED suggestions missing an AI summary. CSV uploads are batched at 320 URLs.',
     phrases: PHRASES,
     usageText: `${PHRASES[0]} {site} [auditType] [auditData] OR {site} audit:{auditType} [mode:all|ai-only|ai-only-current|ai-only-missing] [key:value ...]`,
   });
@@ -230,7 +230,7 @@ function RunAuditCommand(context) {
   };
 
   /**
-   * Fetches unique URLs from current-tab prerender suggestions that are also
+   * Fetches unique URLs from NEW or FIXED prerender suggestions that are
    * missing an AI summary (aiSummary is absent or empty).
    * @param {string} siteId - The site ID.
    * @returns {Promise<string[]>} Deduplicated URLs.
@@ -246,9 +246,12 @@ function RunAuditCommand(context) {
       // eslint-disable-next-line no-await-in-loop
       const suggestions = await opp.getSuggestions();
       suggestions
-        .filter((s) => isCurrentTabSuggestion(s) && !s.getData().aiSummary)
+        .filter((s) => PRERENDER_SUGGESTION_STATUSES.includes(s.getStatus()))
         .forEach((s) => {
-          urls.add(s.getData().url);
+          const url = s.getData()?.url;
+          if (url && isValidUrl(url) && !url.includes('*') && !s.getData().aiSummary) {
+            urls.add(url);
+          }
         });
     }
 
@@ -507,7 +510,7 @@ function RunAuditCommand(context) {
           [PRERENDER_MODES.ALL]: 'with status NEW or FIXED',
           [PRERENDER_MODES.AI_ONLY]: 'with status NEW or FIXED',
           [PRERENDER_MODES.AI_ONLY_CURRENT]: 'matching current-tab filters',
-          [PRERENDER_MODES.AI_ONLY_MISSING]: 'matching current-tab filters with missing AI summary',
+          [PRERENDER_MODES.AI_ONLY_MISSING]: 'with status NEW or FIXED and missing AI summary',
         };
         const modeLabel = MODE_LABELS[prerenderMode];
         await say(`:hourglass_flowing_sand: Fetching ${modeLabel}`

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -87,7 +87,7 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       expect(command.id).to.equal('run-audit');
       expect(command.name).to.equal('Run Audit');
-      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed); `mode:ai-only-missing` runs AI-only for current-tab suggestions missing an AI summary. CSV uploads are batched at 320 URLs.');
+      expect(command.description).to.equal('Run audit for a previously added site. Supports both positional and keyword arguments. Runs lhs-mobile by default if no audit type is specified. Use `audit:all` to run all audits. For prerender: `mode:all` runs full audit for NEW/FIXED suggestions; `mode:ai-only` runs AI-only for NEW/FIXED; `mode:ai-only-current` runs AI-only for current-tab suggestions only (NEW, not covered/deployed); `mode:ai-only-missing` runs AI-only for NEW/FIXED suggestions missing an AI summary. CSV uploads are batched at 320 URLs.');
     });
   });
 
@@ -993,7 +993,7 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say).to.have.been.calledWithMatch(/nothing to audit/);
     });
 
-    it('mode:ai-only-missing fetches current-tab suggestions missing an aiSummary', async () => {
+    it('mode:ai-only-missing fetches NEW and FIXED suggestions missing an aiSummary', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/no-summary', 'NEW'),
@@ -1002,6 +1002,7 @@ describe('RunAuditCommand', () => {
           makeSuggestion('https://site.com/deployed', 'NEW', { edgeDeployed: true }),
           makeSuggestion('https://site.com/pattern', 'NEW', { coveredByPattern: true }),
           makeSuggestion('https://site.com/fixed', 'FIXED'),
+          makeSuggestion('https://site.com/fixed-with-summary', 'FIXED', { aiSummary: 'done' }),
         ]),
       ]);
 
@@ -1010,7 +1011,13 @@ describe('RunAuditCommand', () => {
 
       expect(sqsStub.sendMessage).to.have.been.calledOnce;
       const { urls } = sqsStub.sendMessage.firstCall.args[1].auditContext;
-      expect(urls).to.deep.equal(['https://site.com/no-summary']);
+      expect(urls).to.have.members([
+        'https://site.com/no-summary',
+        'https://site.com/covered',
+        'https://site.com/deployed',
+        'https://site.com/pattern',
+        'https://site.com/fixed',
+      ]);
       const msgData = JSON.parse(sqsStub.sendMessage.firstCall.args[1].data);
       expect(msgData.mode).to.equal('ai-only');
     });
@@ -1048,7 +1055,7 @@ describe('RunAuditCommand', () => {
       expect(urls).to.deep.equal(['https://site.com/empty-summary']);
     });
 
-    it('mode:ai-only-missing reports nothing when all current-tab suggestions already have an aiSummary', async () => {
+    it('mode:ai-only-missing reports nothing when all NEW/FIXED suggestions already have an aiSummary', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
           makeSuggestion('https://site.com/page-1', 'NEW', { aiSummary: 'summary for page 1' }),
@@ -1064,11 +1071,12 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say).to.have.been.calledWithMatch(/missing AI summary/);
     });
 
-    it('mode:ai-only-missing reports nothing when all suggestions are covered or filtered', async () => {
+    it('mode:ai-only-missing reports nothing when all suggestions have aiSummary or wrong status', async () => {
       dataAccessStub.Opportunity.allBySiteId.resolves([
         makeOpportunity('prerender', [
-          makeSuggestion('https://site.com/covered', 'NEW', { coveredByDomainWide: true }),
-          makeSuggestion('https://site.com/deployed', 'NEW', { edgeDeployed: true }),
+          makeSuggestion('https://site.com/has-summary', 'NEW', { aiSummary: 'done' }),
+          makeSuggestion('https://site.com/outdated', 'OUTDATED'),
+          makeSuggestion('https://site.com/skipped', 'SKIPPED'),
         ]),
       ]);
 


### PR DESCRIPTION
## Summary

- `fetchMissingAiPrerenderSuggestionUrls` now uses `PRERENDER_SUGGESTION_STATUSES` (NEW + FIXED) instead of `isCurrentTabSuggestion` (NEW only)
- Aligns `ai-only-missing` mode with the same base status filter as `ai-only` and `mode:all`

## Problem

`mode:ai-only-missing` used `isCurrentTabSuggestion` which only accepted status=NEW and additionally excluded suggestions with `coveredByDomainWide`, `edgeDeployed`, or `coveredByPattern`. This meant:

- FIXED suggestions missing AI summaries were silently skipped
- The URL count reported to Slack (e.g. 297) was lower than the actual eligible pool (e.g. 488)
- The audit-worker then ignored the undersized scope due to a URL normalization mismatch (fixed in adobe/spacecat-audit-worker#2703) and processed a different count

## Fix

Replace `isCurrentTabSuggestion(s) && !s.getData().aiSummary` with `PRERENDER_SUGGESTION_STATUSES.includes(s.getStatus())` plus valid URL + missing aiSummary checks — matching the same base filter used by `fetchPrerenderSuggestionUrls` (ai-only mode).

## Test plan

- [x] Updated test: FIXED suggestions without aiSummary are now included
- [x] Updated test: suggestions with coveredByDomainWide/edgeDeployed/coveredByPattern are no longer excluded
- [x] Updated test: "reports nothing" now tests OUTDATED/SKIPPED status + existing aiSummary
- [x] All 74 tests pass