### PR TITLE
fix(prompts): deterministic 500 on POST /prompts — dedup + error classification + collation fix

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -492,7 +492,7 @@ function BrandsController(ctx, log, env) {
       return createResponse({ created, updated, prompts: outPrompts }, 201);
     } catch (error) {
       if (error?.status === 409) {
-        log.warn(`Prompt unique-constraint conflict for brand ${brandId}: ${error.message}`);
+        log.warn(`Prompt unique-constraint conflict for brand ${brandId} (org ${spaceCatId}): ${error.message}`);
         return createErrorResponse(error);
       }
       log.error(`Error creating prompts for brand ${brandId}:`, error);

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -491,6 +491,10 @@ function BrandsController(ctx, log, env) {
 
       return createResponse({ created, updated, prompts: outPrompts }, 201);
     } catch (error) {
+      if (error?.status === 409) {
+        log.warn(`Prompt unique-constraint conflict for brand ${brandId}: ${error.message}`);
+        return createErrorResponse(error);
+      }
       log.error(`Error creating prompts for brand ${brandId}:`, error);
       return createErrorResponse(error);
     }

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -15,6 +15,7 @@ import crypto from 'node:crypto';
 import { hasText, isValidUUID } from '@adobe/spacecat-shared-utils';
 
 import { classifyIntents } from './intent-classifier.js';
+import { throwOnPgConstraintViolation } from './errors.js';
 import { INTENT_VALUES, normalizeIntent } from './intent.js';
 
 // Re-exported for backward compatibility — `normalizeIntent`/`INTENT_VALUES` now
@@ -762,6 +763,9 @@ export async function upsertPrompts({
         .select(),
     );
     if (error) {
+      throwOnPgConstraintViolation(error, {
+        23505: { status: 409, message: 'A prompt with the same text and region already exists for this brand.' },
+      });
       throw new Error(`Failed to insert prompts: ${error.message}`);
     }
     created = inserted?.length ?? toInsert.length;

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -719,6 +719,45 @@ export async function upsertPrompts({
     }
   }
 
+  // Guard against uq_prompt_text_region_per_brand: deduplicate toInsert by
+  // (lower(text), sorted_regions) before the bulk INSERT. For a new brand
+  // existingByKey is empty, so cross-topic text collisions all land here.
+  // Deterministic tie-break: sort by (topic_id, prompt_id) asc, keep first.
+  // Each drop is logged (warn) with a text hash — auditable without echoing
+  // customer data. Dropped entries are removed from processed so counts stay
+  // honest.
+  if (toInsert.length > 1) {
+    const dedupKey = (row) => `${String(row.text || '').toLowerCase()}:${[...(row.regions || [])].sort().join(',')}`;
+    const sortedForDedup = [...toInsert].sort((a, b) => {
+      const tCmp = String(a.topic_id ?? '').localeCompare(String(b.topic_id ?? ''));
+      return tCmp !== 0 ? tCmp : String(a.prompt_id).localeCompare(String(b.prompt_id));
+    });
+    const winnerByKey = new Map();
+    const droppedIds = new Set();
+    for (const row of sortedForDedup) {
+      const key = dedupKey(row);
+      if (winnerByKey.has(key)) {
+        droppedIds.add(row.prompt_id);
+        // eslint-disable-next-line no-console
+        console.warn('[upsertPrompts] dedup-drop', {
+          brand_id: row.brand_id,
+          text_hash: crypto.createHash('sha256').update(row.text || '').digest('hex').slice(0, 12),
+          dropped_prompt_id: row.prompt_id,
+          dropped_topic_id: row.topic_id ?? null,
+          winning_prompt_id: winnerByKey.get(key).prompt_id,
+          winning_topic_id: winnerByKey.get(key).topic_id ?? null,
+        });
+      } else {
+        winnerByKey.set(key, row);
+      }
+    }
+    if (droppedIds.size > 0) {
+      const keep = (r) => !droppedIds.has(r.prompt_id);
+      toInsert.splice(0, toInsert.length, ...toInsert.filter(keep));
+      processed.splice(0, processed.length, ...processed.filter(keep));
+    }
+  }
+
   // Best-effort intent classification for prompts that arrived WITHOUT an
   // intent (typically human-added). Pipeline prompts already carry a
   // normalized intent and are skipped. Failures leave intent null; they MUST

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -660,7 +660,7 @@ export async function upsertPrompts({
 
   const getKey = (p) => {
     const norm = (p.regions || []).map((r) => String(r).toLowerCase()).sort();
-    return `${String(p.prompt || p.text || '').trim()}:${norm.join(',')}`;
+    return `${String(p.prompt || p.text || '').trim().toLowerCase()}:${norm.join(',')}`;
   };
 
   const existingById = new Map((existing || []).map((p) => [p.prompt_id, p]));

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -725,9 +725,13 @@ export async function upsertPrompts({
   // Deterministic tie-break: sort by (topic_id, prompt_id) asc, keep first.
   // Each drop is logged (warn) with a text hash — auditable without echoing
   // customer data. Dropped entries are removed from processed so counts stay
-  // honest.
+  // honest. Guard is > 1: a single-row batch cannot collide with itself.
   if (toInsert.length > 1) {
-    const dedupKey = (row) => `${String(row.text || '').toLowerCase()}:${[...(row.regions || [])].sort().join(',')}`;
+    const dedupKey = (row) => {
+      const t = String(row.text || '').trim().toLowerCase();
+      const r = [...(row.regions || [])].map((x) => String(x).toLowerCase()).sort().join(',');
+      return `${t}:${r}`;
+    };
     const sortedForDedup = [...toInsert].sort((a, b) => {
       const tCmp = String(a.topic_id ?? '').localeCompare(String(b.topic_id ?? ''));
       return tCmp !== 0 ? tCmp : String(a.prompt_id).localeCompare(String(b.prompt_id));

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -919,6 +919,57 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(500);
     });
 
+    it('createPromptsByBrand returns 409 and logs at warn (not error) when INSERT fails with 23505', async () => {
+      const th = (v) => ({ then: (resolve) => resolve(v), catch: () => th(v) });
+      mockDataAccess.services.postgrestClient.from = sandbox.stub().callsFake((table) => {
+        if (table === 'prompts') {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  ...th({ data: [], error: null }),
+                  in: () => th({ data: [], error: null }),
+                }),
+              }),
+            }),
+            insert: () => ({
+              select: () => th({
+                data: null,
+                error: {
+                  code: '23505',
+                  message: 'duplicate key value violates unique constraint "uq_prompt_text_region_per_brand"',
+                },
+              }),
+            }),
+            update: () => ({ eq: () => th({ error: null }) }),
+          };
+        }
+        const chain = {
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          maybeSingle: sandbox.stub().resolves({ data: { id: BRAND_UUID }, error: null }),
+        };
+        if (table === 'llmo_customer_config') {
+          chain.maybeSingle = sandbox.stub()
+            .resolves({ data: { config: { customer: { brands: [] } } }, error: null });
+        }
+        return chain;
+      });
+      loggerStub.warn.resetHistory();
+      loggerStub.error.resetHistory();
+
+      const response = await brandsController.createPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: [{ id: 'p-1', prompt: 'Synthetic test prompt', regions: ['us'] }],
+        dataAccess: mockDataAccess,
+      });
+
+      expect(response.status).to.equal(409);
+      expect(loggerStub.warn).to.have.been.called;
+      expect(loggerStub.error).to.not.have.been.called;
+    });
+
     it('updatePromptByBrandAndId returns 200 when prompt updated', async () => {
       const response = await brandsController.updatePromptByBrandAndId({
         ...context,

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -1923,6 +1923,106 @@ describe('prompts-storage', () => {
       // p-topic-alpha wins: both topic_id=null, 'p-topic-alpha' < 'p-topic-beta' alphabetically
       expect(insertedRows[0].prompt_id).to.equal('p-topic-alpha');
     });
+
+    it('picks winner by (topic_id, promptId) asc regardless of input order', async () => {
+      // Two UUIDs with an unambiguous lexicographic ordering: T_ALPHA < T_BETA.
+      // The dedup sort key is (topic_id, promptId) asc, so T_ALPHA must always win.
+      const T_ALPHA = '00000000-0000-4000-b000-000000000001';
+      const T_BETA = 'ffffffff-ffff-4fff-bfff-fffffffffffe';
+
+      const warnSpy = sandbox.spy(console, 'warn');
+
+      // topics table returns both rows pre-populated so topicMap resolves UUIDs
+      // immediately and ensureLookupEntries makes no upsert calls.
+      // INSERT always succeeds — dedup fires before the row reaches the DB.
+      const makeClient = (insertStub) => ({
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          if (table === 'topics') {
+            return makeChain({
+              data: [{ id: T_ALPHA, name: 'Alpha' }, { id: T_BETA, name: 'Beta' }],
+              error: null,
+            });
+          }
+          return makeChain({ data: [], error: null });
+        },
+      });
+
+      const makeInsertStub = () => sinon.stub().callsFake((rows) => ({
+        select: () => thenable({
+          data: rows.map((r) => ({ prompt_id: r.prompt_id })),
+          error: null,
+        }),
+      }));
+
+      const findDropLog = () => warnSpy.args
+        .find(([msg]) => msg === '[upsertPrompts] dedup-drop')?.[1];
+
+      // Pass 1: feed [alpha, beta]
+      const stub1 = makeInsertStub();
+      const result1 = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [
+          {
+            id: 'p-alpha', prompt: 'Synthetic dedup tie-break text', regions: ['us'], topic: 'Alpha',
+          },
+          {
+            id: 'p-beta', prompt: 'Synthetic dedup tie-break text', regions: ['us'], topic: 'Beta',
+          },
+        ],
+        postgrestClient: makeClient(stub1),
+      });
+
+      // (a) exactly one row reaches INSERT
+      expect(stub1.firstCall.args[0]).to.have.lengthOf(1);
+      // (b) surviving row carries T_ALPHA
+      expect(stub1.firstCall.args[0][0].topic_id).to.equal(T_ALPHA);
+      expect(result1.created).to.equal(1);
+      // (c) log entry correctly identifies winner and dropped topic_id
+      expect(findDropLog()).to.deep.include({
+        winning_topic_id: T_ALPHA,
+        dropped_topic_id: T_BETA,
+      });
+
+      // Pass 2: feed [beta, alpha] — (d) input-order invariance
+      warnSpy.resetHistory();
+      const stub2 = makeInsertStub();
+      const result2 = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [
+          {
+            id: 'p-beta', prompt: 'Synthetic dedup tie-break text', regions: ['us'], topic: 'Beta',
+          },
+          {
+            id: 'p-alpha', prompt: 'Synthetic dedup tie-break text', regions: ['us'], topic: 'Alpha',
+          },
+        ],
+        postgrestClient: makeClient(stub2),
+      });
+
+      expect(stub2.firstCall.args[0]).to.have.lengthOf(1);
+      expect(stub2.firstCall.args[0][0].topic_id).to.equal(T_ALPHA);
+      expect(result2.created).to.equal(1);
+      expect(findDropLog()).to.deep.include({
+        winning_topic_id: T_ALPHA,
+        dropped_topic_id: T_BETA,
+      });
+    });
   });
 
   describe('updatePromptById', () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -2023,6 +2023,56 @@ describe('prompts-storage', () => {
         dropped_topic_id: T_BETA,
       });
     });
+
+    it('routes case-variant text to update not insert when an active row already exists', async () => {
+      // Scenario: DB has "hello world" (lowercase); incoming prompt uses "Hello World" (mixed).
+      // The DB constraint uses lower(text), so they collide. getKey must lowercase the text
+      // component to match existingByKey correctly and route to toUpdate, not toInsert.
+      // RED on current (case-sensitive) getKey: misses existingByKey → INSERT stub is called.
+      // GREEN after fix: matches existingByKey → UPDATE path, INSERT stub never reached.
+      const existingRow = {
+        id: 'row-uuid-existing',
+        prompt_id: 'p-existing',
+        text: 'hello world',
+        regions: ['us'],
+        status: 'active',
+      };
+      const toInsertResult = (rows) => ({
+        select: () => thenable({
+          data: rows.map((r) => ({ prompt_id: r.prompt_id })),
+          error: null,
+        }),
+      });
+      const insertStub = sinon.stub().callsFake(toInsertResult);
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [existingRow], error: null }),
+                    in: () => thenable({ data: [existingRow], error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({ data: [], error: null });
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ prompt: 'Hello World', regions: ['us'] }],
+        postgrestClient: client,
+      });
+      expect(insertStub.notCalled).to.be.true;
+      expect(result.created).to.equal(0);
+      expect(result.updated).to.equal(1);
+    });
   });
 
   describe('updatePromptById', () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -1829,6 +1829,100 @@ describe('prompts-storage', () => {
       expect(result.prompts[0].categoryId).to.be.undefined;
       expect(result.prompts[0].topicId).to.be.undefined;
     });
+
+    it('throws a typed 409 when INSERT returns a 23505 unique-constraint error', async () => {
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
+              insert: () => ({
+                select: () => thenable({
+                  data: null,
+                  error: {
+                    code: '23505',
+                    message: 'duplicate key value violates unique constraint "uq_prompt_text_region_per_brand"',
+                  },
+                }),
+              }),
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({ data: [], error: null });
+        },
+      };
+      const err = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ id: 'p-1', prompt: 'Synthetic prompt text', regions: ['us'] }],
+        postgrestClient: client,
+      }).catch((e) => e);
+      expect(err).to.be.instanceOf(Error);
+      expect(err.status).to.equal(409);
+    });
+
+    it('deduplicates duplicate text+regions in toInsert and does not throw', async () => {
+      // Mock: >1 row in INSERT → 23505 (simulates uq_prompt_text_region_per_brand);
+      // exactly 1 row → success. RED before the intra-batch dedup fix; GREEN after.
+      const insertStub = sinon.stub().callsFake((rows) => ({
+        select: () => thenable(
+          Array.isArray(rows) && rows.length > 1
+            ? {
+              data: null,
+              error: {
+                code: '23505',
+                message: 'duplicate key value violates unique constraint "uq_prompt_text_region_per_brand"',
+              },
+            }
+            : { data: rows.map((r) => ({ prompt_id: r.prompt_id })), error: null },
+        ),
+      }));
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({ data: [], error: null });
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [
+          {
+            id: 'p-topic-alpha', prompt: 'Synthetic test prompt text', regions: ['us'], topic: 'Alpha',
+          },
+          {
+            id: 'p-topic-beta', prompt: 'Synthetic test prompt text', regions: ['us'], topic: 'Beta',
+          },
+        ],
+        postgrestClient: client,
+      });
+      expect(result.created).to.equal(1);
+      expect(result.prompts).to.have.lengthOf(1);
+      const insertedRows = insertStub.firstCall.args[0];
+      expect(insertedRows).to.have.lengthOf(1);
+      // p-topic-alpha wins: both topic_id=null, 'p-topic-alpha' < 'p-topic-beta' alphabetically
+      expect(insertedRows[0].prompt_id).to.equal('p-topic-alpha');
+    });
   });
 
   describe('updatePromptById', () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -1924,6 +1924,60 @@ describe('prompts-storage', () => {
       expect(insertedRows[0].prompt_id).to.equal('p-topic-alpha');
     });
 
+    it('dedup-drop fires once per duplicate and splice reduces toInsert to exactly one row', async () => {
+      // Three prompts with the same synthetic text+regions. Only the winner
+      // (lexicographically first prompt_id when all topic_ids are null) reaches
+      // INSERT. The drop path (lines 740-749) fires twice and the splice mutations
+      // (lines 755-757) reduce toInsert to 1, covering the uncovered block.
+      const warnSpy = sandbox.spy(console, 'warn');
+      const toRow = (r) => ({ prompt_id: r.prompt_id });
+      const insertStub = sinon.stub().callsFake((rows) => ({
+        select: () => thenable({ data: rows.map(toRow), error: null }),
+      }));
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: () => thenable({ data: [], error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({ data: [], error: null });
+        },
+      };
+      // Input order is [p-c, p-a, p-b] — winner is always p-a (lex-first prompt_id)
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [
+          { id: 'p-c', prompt: 'Synthetic triple-dup text', regions: ['us'] },
+          { id: 'p-a', prompt: 'Synthetic triple-dup text', regions: ['us'] },
+          { id: 'p-b', prompt: 'Synthetic triple-dup text', regions: ['us'] },
+        ],
+        postgrestClient: client,
+      });
+
+      // one row inserted, two dropped
+      expect(result.created).to.equal(1);
+      expect(insertStub.firstCall.args[0]).to.have.lengthOf(1);
+      expect(insertStub.firstCall.args[0][0].prompt_id).to.equal('p-a');
+
+      // drop-log fired twice — once for each duplicate
+      const dropLogs = warnSpy.args.filter(([msg]) => msg === '[upsertPrompts] dedup-drop');
+      expect(dropLogs).to.have.lengthOf(2);
+      dropLogs.forEach(([, payload]) => {
+        expect(payload.winning_prompt_id).to.equal('p-a');
+      });
+    });
+
     it('picks winner by (topic_id, promptId) asc regardless of input order', async () => {
       // Two UUIDs with an unambiguous lexicographic ordering: T_ALPHA < T_BETA.
       // The dedup sort key is (topic_id, promptId) asc, so T_ALPHA must always win.


### PR DESCRIPTION
## Summary

POST `/prompts` was returning HTTP 500 for 7 paid-site brandalf-secondaries restores, blocking them indefinitely. Root cause was a chain of three bugs in `upsertPrompts` that together converted a DB constraint violation into an untyped error → always 500.

- [A `b8f5375d`] Classify `23505` INSERT constraint violation as 409 not 500
- [B `650f4567`] Intra-batch dedup of `toInsert` by `(lower(text), sorted_regions)` before bulk INSERT
- [`38ecc0a8`] Test: deterministic distinct-topic tie-break (input-order invariance proof)
- [C `8150ff81`] Lowercase `getKey` text component to match DB `lower(text)` collation

## Root cause

Migration `20260530000003` added `uq_prompt_text_region_per_brand` — a partial unique index on `(brand_id, lower(text), sorted_regions(regions)) WHERE status = 'active'`. For new brands (`existingByKey` empty), V1 configs with cross-topic duplicate prompt text generate two identical `(text, regions)` rows in `toInsert`. The bulk INSERT violates the constraint. PostgREST returns a plain `{ code: '23505' }` error object which had no `.status` set, so `createErrorResponse` always fell through to `internalServerError` → **HTTP 500**.

Three compounding issues:

| # | Gap | Effect |
|---|-----|--------|
| 1 | `upsertPrompts` didn't dedup within `toInsert` | Both rows hit INSERT → constraint fires |
| 2 | `23505` not classified as typed error | `error.status` absent → always 500 |
| 3 | `getKey` used case-sensitive text | Case-variant re-runs would miss `existingByKey` and re-trigger constraint |

## What each commit does

**A `b8f5375d` — classify `23505` INSERT constraint violation as 409 not 500**

Calls `throwOnPgConstraintViolation` on the INSERT error path; maps `23505` → `{ status: 409 }`. Updates `createPromptsByBrand` catch to log at `warn` (not `error`) for 409. Means callers can distinguish a duplicate-input problem from a server fault.

**B `650f4567` — intra-batch dedup of `toInsert` by `(lower(text), sorted_regions)`**

After the `for` loop fully populates `toInsert`, deduplicate before INSERT. Deterministic tie-break: sort `(topic_id, prompt_id)` asc, keep first. Each dropped row is logged at `console.warn` with `brand_id`, `text_hash` (SHA-256 first 12 hex), `winning_prompt_id`/`topic_id`, `dropped_prompt_id`/`topic_id`. Dropped entries removed from `processed` so counts are honest.

The dropped topic association is **by design** (DROP+LOG, not MERGE): brandalf BP executes by brand not topic filter, so the association is latent. MERGE would require direct writes to `topic_prompts`, racing the `sync_prompt_junction_tables` trigger.

**`38ecc0a8` — test: deterministic distinct-topic tie-break**

Two prompts, same `(lower(text), sorted_regions)`, distinct `topic_id` UUIDs (`T_ALPHA < T_BETA`). Asserts: (a) one row to INSERT, (b) `topic_id = T_ALPHA`, (c) drop-log names `winning_topic_id=T_ALPHA` and `dropped_topic_id=T_BETA` (correct assignment), (d) `[beta,alpha]` input yields same winner.

**C `8150ff81` — lowercase `getKey` text to match `lower(text)` constraint**

`getKey` used case-sensitive text — `"Hello World"` ≠ `"hello world"` — so case-variant re-posts missed `existingByKey`, fell through to `toInsert`, and re-triggered the constraint. **Blast radius: changes routing for any case-variant text re-post repo-wide** (not only the 7 dark sites).

## Scope and limits

- Does **not** re-run `restore.py` — the 7 dark sites stay dark until merge + deploy + gated restore.py re-run.
- Does **not** undo existing DB state from previous failed restores.

## Testing

Full suite: **12,392 passing, 0 failing**.

| Test | File | Validates |
|------|------|-----------|
| throws typed 409 on 23505 | `prompts-storage.test.js` | Commit A — error classification |
| createPromptsByBrand returns 409 + warn not error | `brands.test.js` | Commit A — controller catch |
| deduplicates duplicate text+regions in toInsert | `prompts-storage.test.js` | Commit B — dedup fires |
| picks winner by (topic_id, promptId) asc regardless of input order | `prompts-storage.test.js` | Tie-break determinism + drop-log fidelity |
| routes case-variant text to update not insert | `prompts-storage.test.js` | Commit C — collation fix |

## Related

- Epic: SITES-39521 (Mysticat)
- DRS restore.py re-run for the 7 dark sites gated on merge + deploy.

## Known limitation / follow-up

`getKey` lowercases each region value before sorting (`['US'] → ['us']`), but the DB `sorted_regions()` function only sorts without lowercasing. For canonical-lowercase regions — the controlled vocabulary used throughout — this has no effect. If any row or source config ever carries a non-lowercase region string, `getKey` would false-positive match two rows the DB treats as distinct, silently routing an INSERT to UPDATE instead. This is pre-existing, out of scope for this PR, and in the conservative (non-500) direction. Tracked in [LLMO-XXXX](https://jira.corp.adobe.com/browse/LLMO-XXXX). **Reviewer: please confirm whether region values are ever non-canonical case in the data or in V1 source configs.**
