### PR TITLE
feat: server-side text search for prompt research | LLMO-5216

### DIFF
--- a/docs/openapi/ai-visibility-api.yaml
+++ b/docs/openapi/ai-visibility-api.yaml
@@ -118,6 +118,19 @@ x-ai-vis-search-query: &searchQueryParam
     type: string
     example: coffee
 
+x-ai-vis-text-filter: &textFilterParam
+  name: textFilter
+  in: query
+  required: false
+  description: |
+    Optional free-text filter applied server-side across the full result set (not just the
+    current page), via a `dimension_filter_ql` `CONTAINS` clause on the dataset's primary
+    column (prompts→`prompt`, topics→`topic`, brands→`name`, source-domains→`domain`). When
+    set, `total` reflects the filtered count. Distinct from `searchQuery` (the topic FTS query).
+  schema:
+    type: string
+    example: pdf
+
 x-ai-vis-topic-id: &topicIdParam
   name: topicId
   in: query
@@ -1078,6 +1091,7 @@ ai-visibility-topics-research:
       - *regionParam
       - *engineParam
       - *ftsTopicsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam
@@ -1172,6 +1186,7 @@ ai-visibility-topics-research-prompts:
       - *regionParam
       - *engineParam
       - *ftsPromptsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam
@@ -1206,6 +1221,7 @@ ai-visibility-topics-research-brands:
       - *regionParam
       - *engineParam
       - *ftsBrandsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam
@@ -1242,6 +1258,7 @@ ai-visibility-topics-research-source-domains:
       - *regionParam
       - *engineParam
       - *ftsSourceDomainsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam
@@ -1276,6 +1293,7 @@ ai-visibility-v1-prompt-research-prompts-export:
       - *regionParam
       - *engineParam
       - *ftsPromptsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam
@@ -1309,6 +1327,7 @@ ai-visibility-v1-prompt-research-brands-export:
       - *regionParam
       - *engineParam
       - *ftsBrandsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam
@@ -1342,6 +1361,7 @@ ai-visibility-v1-prompt-research-source-domains-export:
       - *regionParam
       - *engineParam
       - *ftsSourceDomainsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam
@@ -1375,6 +1395,7 @@ ai-visibility-v1-prompt-research-topics-export:
       - *regionParam
       - *engineParam
       - *ftsTopicsSortByParam
+      - *textFilterParam
       - *ftsSortDirectionParam
       - *limitParam
       - *offsetParam

--- a/src/support/ai-visibility/grpc-utils.js
+++ b/src/support/ai-visibility/grpc-utils.js
@@ -218,6 +218,21 @@ export function escapeQlString(s) {
 }
 
 /**
+ * Build a Semrush `dimension_filter_ql` `CONTAINS` clause for a free-text table
+ * search, e.g. `prompt CONTAINS "pdf"`. Returns '' when the filter is empty so
+ * callers can omit the field (leaving the request shape unchanged). The text is
+ * escaped via {@link escapeQlString} so it cannot break out of the QL literal.
+ *
+ * @param {string|null|undefined} textFilter free-text search value
+ * @param {string} column the queryable dimension column (e.g. `prompt`, `topic`, `name`, `domain`)
+ * @returns {string} the QL clause, or '' when no filter
+ */
+export function buildTextFilterQl(textFilter, column) {
+  const t = (textFilter ?? '').trim();
+  return t ? `${column} CONTAINS "${escapeQlString(t)}"` : '';
+}
+
+/**
  * Build a Semrush QL range expression like `volume >= 10 AND volume <= 100`.
  * - both bounds present → `metric >= from AND metric <= to`
  * - only `from` present → `metric >= from`

--- a/src/support/ai-visibility/handlers/topics.js
+++ b/src/support/ai-visibility/handlers/topics.js
@@ -22,7 +22,7 @@ import {
   optionalLlmFromQuery, llmToEngine,
   sourceDomainsByTopicFtsRows,
   LLM_ENUM, FTS_LLMS, TOPIC_INTENT_SLUG,
-  settledValueOrElse, resolveTopicIds,
+  settledValueOrElse, resolveTopicIds, buildTextFilterQl,
 } from '../grpc-utils.js';
 
 /* ------------------------------------------------------------------ */
@@ -143,6 +143,7 @@ export async function countTopicRowsByTopicsByFtsPaging(country, query, llm, cli
   const q = String(query || '').trim();
   if (!q) { return 0; }
   const maxPages = resolveDistinctTopicIdsMaxPages(opts);
+  const dimensionFilterQl = opts?.dimensionFilterQl ?? '';
   async function pull(offset, total, pagesLeft) {
     if (pagesLeft <= 0) {
       return total;
@@ -153,6 +154,7 @@ export async function countTopicRowsByTopicsByFtsPaging(country, query, llm, cli
       query: q,
       order: { by: TOPICS_BY_FTS_REQUEST_ORDER_BY_ENUM.VOLUME },
       range: { limit: DISTINCT_TOPIC_IDS_PAGE, offset },
+      ...(dimensionFilterQl ? { dimensionFilterQl } : {}),
     }).catch(() => ({ topics: [] }));
     const topics = raw.topics || [];
     if (topics.length === 0) {
@@ -168,6 +170,7 @@ export async function countDistinctTopicIdsAcrossFtsLlms(country, query, clients
   const q = String(query || '').trim();
   if (!q) { return 0; }
   const maxPages = resolveDistinctTopicIdsMaxPages(opts);
+  const dimensionFilterQl = opts?.dimensionFilterQl ?? '';
   const seen = new Set();
   async function pullForLlm(llm, offset, pagesLeft) {
     if (pagesLeft <= 0) {
@@ -179,6 +182,7 @@ export async function countDistinctTopicIdsAcrossFtsLlms(country, query, clients
       query: q,
       order: { by: TOPICS_BY_FTS_REQUEST_ORDER_BY_ENUM.VOLUME },
       range: { limit: DISTINCT_TOPIC_IDS_PAGE, offset },
+      ...(dimensionFilterQl ? { dimensionFilterQl } : {}),
     }).catch(() => ({ topics: [] }));
     const topics = raw.topics || [];
     if (topics.length === 0) {
@@ -449,12 +453,13 @@ export async function handleTopicsResearch(sp, clients) {
   const sort = resolveFtsSort(sp, TOPICS_SORT_BY, 'RELEVANCE_SCORE');
   if (sort.error) { return sort.error; }
   const order = { by: sort.by, direction: sort.direction };
+  const dimensionFilterQl = buildTextFilterQl(sp.get('textFilter'), 'topic');
   const llm = optionalLlmFromQuery(sp);
   if (llm) {
     const pair = await Promise.allSettled([
-      countTopicRowsByTopicsByFtsPaging(country, q, llm, clients),
+      countTopicRowsByTopicsByFtsPaging(country, q, llm, clients, { dimensionFilterQl }),
       clients.topicClient.topicsByFTS({
-        country, llm, query: q, order, range: { limit, offset },
+        country, llm, query: q, order, range: { limit, offset }, ...(dimensionFilterQl ? { dimensionFilterQl } : {}),
       }),
     ]);
     const listTotal = settledValueOrElse(pair[0], 0);
@@ -477,9 +482,9 @@ export async function handleTopicsResearch(sp, clients) {
     };
   }
   const pairAll = await Promise.all([
-    countDistinctTopicIdsAcrossFtsLlms(country, q, clients),
+    countDistinctTopicIdsAcrossFtsLlms(country, q, clients, { dimensionFilterQl }),
     Promise.all(FTS_LLMS.map((l) => clients.topicClient.topicsByFTS({
-      country, llm: l, query: q, order, range: { limit, offset },
+      country, llm: l, query: q, order, range: { limit, offset }, ...(dimensionFilterQl ? { dimensionFilterQl } : {}),
     }).catch(() => ({ topics: [] })))),
   ]);
   const topicsTotalDistinct = pairAll[0];
@@ -656,16 +661,19 @@ function mergeMultiLlmPromptRows(listResults, totalsResults, sort, mapRow, limit
  * @returns {Promise<{ data: object[], total: number }>}
  */
 async function promptsByTopicIdsPage({
-  clients, topicIds, country, llm, order, limit, offset,
+  clients, topicIds, country, llm, order, limit, offset, dimensionFilterQl = '',
 }) {
   const llmEnum = llm ?? LLM_ENUM.ALL;
   // For a single-engine request, force the requested engine on every row; for ALL, each row
   // carries its own engine (mapped from `p.llm` in mapTopicIdsPromptRow).
   const singleEngineSlug = llm ? llmToEngine(llm) : '';
+  const filterField = dimensionFilterQl ? { dimensionFilterQl } : {};
   const pr = await Promise.allSettled([
-    clients.promptClient.promptsByTopicIDsTotal({ country, llm: llmEnum, topicIds }),
+    clients.promptClient.promptsByTopicIDsTotal({
+      country, llm: llmEnum, topicIds, ...filterField,
+    }),
     clients.promptClient.promptsByTopicIDs({
-      country, llm: llmEnum, topicIds, order, range: { limit, offset },
+      country, llm: llmEnum, topicIds, order, range: { limit, offset }, ...filterField,
     }),
   ]);
   if (pr[1].status !== 'fulfilled') {
@@ -695,13 +703,15 @@ export async function handleTopicsResearchPrompts(sp, clients) {
   const country = resolveCountryForFts(sp);
   const { limit, offset } = parseLimitOffset(sp);
   const llm = optionalLlmFromQuery(sp);
+  const dimensionFilterQl = buildTextFilterQl(sp.get('textFilter'), 'prompt');
+  const filterField = dimensionFilterQl ? { dimensionFilterQl } : {};
 
   if (hasTopicIds) {
     const sort = resolveFtsSort(sp, PROMPTS_BY_TOPIC_IDS_SORT_BY, 'MENTIONED_BRANDS_COUNT');
     if (sort.error) { return sort.error; }
     const order = { by: sort.by, direction: sort.direction };
     const { data, total } = await promptsByTopicIdsPage({
-      clients, topicIds: topicFilter.topicIds, country, llm, order, limit, offset,
+      clients, topicIds: topicFilter.topicIds, country, llm, order, limit, offset, dimensionFilterQl,
     });
     return {
       status: 200,
@@ -717,9 +727,11 @@ export async function handleTopicsResearchPrompts(sp, clients) {
   if (llm) {
     const engineSlug = llmToEngine(llm);
     const pr = await Promise.allSettled([
-      clients.promptClient.promptsByTopicFTSTotals({ country, llm, query: searchQuery }),
+      clients.promptClient.promptsByTopicFTSTotals({
+        country, llm, query: searchQuery, ...filterField,
+      }),
       clients.promptClient.promptsByTopicFTS({
-        country, llm, query: searchQuery, order, range: { limit, offset },
+        country, llm, query: searchQuery, order, range: { limit, offset }, ...filterField,
       }),
     ]);
     if (pr[1].status !== 'fulfilled') {
@@ -740,9 +752,11 @@ export async function handleTopicsResearchPrompts(sp, clients) {
     };
   }
   const prPair = await Promise.all([
-    Promise.all(FTS_LLMS.map((l) => clients.promptClient.promptsByTopicFTSTotals({ country, llm: l, query: searchQuery }).catch(() => ({ total: 0 })))),
+    Promise.all(FTS_LLMS.map((l) => clients.promptClient.promptsByTopicFTSTotals({
+      country, llm: l, query: searchQuery, ...filterField,
+    }).catch(() => ({ total: 0 })))),
     Promise.all(FTS_LLMS.map((l) => clients.promptClient.promptsByTopicFTS({
-      country, llm: l, query: searchQuery, order, range: { limit, offset },
+      country, llm: l, query: searchQuery, order, range: { limit, offset }, ...filterField,
     }).catch(() => ({ prompts: [] })))),
   ]);
   const { data, total } = mergeMultiLlmPromptRows(prPair[1], prPair[0], sort, mapPromptRow, limit);
@@ -778,12 +792,16 @@ export async function handleTopicsResearchBrands(sp, clients) {
   const order = { by: sort.by, direction: sort.direction };
   const country = resolveCountryForFts(sp);
   const { limit, offset } = parseLimitOffset(sp);
+  const dimensionFilterQl = buildTextFilterQl(sp.get('textFilter'), 'name');
+  const filterField = dimensionFilterQl ? { dimensionFilterQl } : {};
   const llm = optionalLlmFromQuery(sp);
   if (llm) {
     const br = await Promise.allSettled([
-      clients.brandClient.brandsByTopicFTSTotals({ country, llm, query: searchQuery }),
+      clients.brandClient.brandsByTopicFTSTotals({
+        country, llm, query: searchQuery, ...filterField,
+      }),
       clients.brandClient.brandsByTopicFTS({
-        country, llm, query: searchQuery, order, range: { limit, offset },
+        country, llm, query: searchQuery, order, range: { limit, offset }, ...filterField,
       }),
     ]);
     if (br[1].status !== 'fulfilled') {
@@ -800,9 +818,11 @@ export async function handleTopicsResearchBrands(sp, clients) {
     };
   }
   const brPair = await Promise.all([
-    Promise.all(FTS_LLMS.map((l) => clients.brandClient.brandsByTopicFTSTotals({ country, llm: l, query: searchQuery }).catch(() => ({ total: 0 })))),
+    Promise.all(FTS_LLMS.map((l) => clients.brandClient.brandsByTopicFTSTotals({
+      country, llm: l, query: searchQuery, ...filterField,
+    }).catch(() => ({ total: 0 })))),
     Promise.all(FTS_LLMS.map((l) => clients.brandClient.brandsByTopicFTS({
-      country, llm: l, query: searchQuery, order, range: { limit, offset },
+      country, llm: l, query: searchQuery, order, range: { limit, offset }, ...filterField,
     }).catch(() => ({ brands: [] })))),
   ]);
   const totalsResults = brPair[0];
@@ -868,12 +888,16 @@ export async function handleTopicsResearchSourceDomains(sp, clients) {
   const order = { by: sort.by, direction: sort.direction };
   const country = resolveCountryForFts(sp);
   const { limit, offset } = parseLimitOffset(sp);
+  const dimensionFilterQl = buildTextFilterQl(sp.get('textFilter'), 'domain');
+  const filterField = dimensionFilterQl ? { dimensionFilterQl } : {};
   const llm = optionalLlmFromQuery(sp);
   if (llm) {
     const sd = await Promise.allSettled([
-      clients.sourceClient.sourceDomainsByTopicFTSTotals({ country, llm, query: searchQuery }),
+      clients.sourceClient.sourceDomainsByTopicFTSTotals({
+        country, llm, query: searchQuery, ...filterField,
+      }),
       clients.sourceClient.sourceDomainsByTopicFTS({
-        country, llm, query: searchQuery, order, range: { limit, offset },
+        country, llm, query: searchQuery, order, range: { limit, offset }, ...filterField,
       }),
     ]);
     if (sd[1].status !== 'fulfilled') {
@@ -890,9 +914,11 @@ export async function handleTopicsResearchSourceDomains(sp, clients) {
     };
   }
   const sdPair = await Promise.all([
-    Promise.all(FTS_LLMS.map((l) => clients.sourceClient.sourceDomainsByTopicFTSTotals({ country, llm: l, query: searchQuery }).catch(() => ({ total: 0 })))),
+    Promise.all(FTS_LLMS.map((l) => clients.sourceClient.sourceDomainsByTopicFTSTotals({
+      country, llm: l, query: searchQuery, ...filterField,
+    }).catch(() => ({ total: 0 })))),
     Promise.all(FTS_LLMS.map((l) => clients.sourceClient.sourceDomainsByTopicFTS({
-      country, llm: l, query: searchQuery, order, range: { limit, offset },
+      country, llm: l, query: searchQuery, order, range: { limit, offset }, ...filterField,
     }).catch(() => ({ sourceDomains: [] })))),
   ]);
   const totalsResults = sdPair[0];

--- a/src/support/ai-visibility/handlers/v1/prompt-research/brands-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt-research/brands-export.js
@@ -37,6 +37,7 @@ export async function handleBrandsResearchExport(sp, clients) {
     defaultSortKey: 'MENTIONS',
     callExport: (clients_, req) => clients_.brandClient.brandsByTopicFTSExport(req),
     label: 'brands research',
+    textFilterColumn: 'name',
   });
 }
 /* c8 ignore stop */

--- a/src/support/ai-visibility/handlers/v1/prompt-research/fts-research-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt-research/fts-research-export.js
@@ -57,6 +57,9 @@ export async function runFtsResearchExport(sp, clients, config) {
   const {
     requestSchema, exportSchema, sortMap, defaultSortKey, callExport, label, textFilterColumn,
   } = config;
+  if (textFilterColumn === undefined) {
+    throw new Error('runFtsResearchExport: config.textFilterColumn is required');
+  }
 
   const searchQuery = sp.get('searchQuery')?.trim();
   if (!searchQuery) {

--- a/src/support/ai-visibility/handlers/v1/prompt-research/fts-research-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt-research/fts-research-export.js
@@ -21,6 +21,7 @@ import {
   resolveCountryForFts,
   requiredLlmFromQuery,
   responseFromGrpcError,
+  buildTextFilterQl,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -49,11 +50,12 @@ import {
  * @param {string} config.defaultSortKey default sortBy key
  * @param {(clients: object, exportRequest: object) => Promise<object>} config.callExport gRPC call
  * @param {string} config.label human-readable dataset label for error messages
+ * @param {string} config.textFilterColumn dimension column for the optional `textFilter` search
  */
 /* c8 ignore start */
 export async function runFtsResearchExport(sp, clients, config) {
   const {
-    requestSchema, exportSchema, sortMap, defaultSortKey, callExport, label,
+    requestSchema, exportSchema, sortMap, defaultSortKey, callExport, label, textFilterColumn,
   } = config;
 
   const searchQuery = sp.get('searchQuery')?.trim();
@@ -84,6 +86,7 @@ export async function runFtsResearchExport(sp, clients, config) {
   const country = resolveCountryForFts(sp);
   const llm = requiredLlmFromQuery(sp);
   const { limit, offset } = parseLimitOffset(sp);
+  const dimensionFilterQl = buildTextFilterQl(sp.get('textFilter'), textFilterColumn);
 
   let exportRequest;
   try {
@@ -95,6 +98,7 @@ export async function runFtsResearchExport(sp, clients, config) {
         query: searchQuery,
         order: { by: sortBy, direction: sortDirection },
         range: { limit, offset },
+        ...(dimensionFilterQl ? { dimensionFilterQl } : {}),
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/prompt-research/prompts-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt-research/prompts-export.js
@@ -38,6 +38,7 @@ export async function handlePromptsResearchExport(sp, clients) {
     defaultSortKey: 'MENTIONED_BRANDS_COUNT',
     callExport: (clients_, req) => clients_.promptClient.promptsByTopicFTSExport(req),
     label: 'prompts research',
+    textFilterColumn: 'prompt',
   });
 }
 /* c8 ignore stop */

--- a/src/support/ai-visibility/handlers/v1/prompt-research/source-domains-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt-research/source-domains-export.js
@@ -38,6 +38,7 @@ export async function handleSourceDomainsResearchExport(sp, clients) {
     defaultSortKey: 'MENTIONS',
     callExport: (clients_, req) => clients_.sourceClient.sourceDomainsByTopicFTSExport(req),
     label: 'source domains research',
+    textFilterColumn: 'domain',
   });
 }
 /* c8 ignore stop */

--- a/src/support/ai-visibility/handlers/v1/prompt-research/topics-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt-research/topics-export.js
@@ -36,6 +36,7 @@ export async function handleTopicsResearchExport(sp, clients) {
     defaultSortKey: 'RELEVANCE_SCORE',
     callExport: (clients_, req) => clients_.topicClient.topicsByFTSExport(req),
     label: 'topics research',
+    textFilterColumn: 'topic',
   });
 }
 /* c8 ignore stop */

--- a/test/support/ai-visibility/grpc-utils.test.js
+++ b/test/support/ai-visibility/grpc-utils.test.js
@@ -64,6 +64,7 @@ import {
   mergeTopBrandsByDomainResponsesByMax,
   settledValueOrElse,
   settledFulfilledMap,
+  buildTextFilterQl,
 } from '../../../src/support/ai-visibility/grpc-utils.js';
 
 function sp(query) {
@@ -71,6 +72,25 @@ function sp(query) {
 }
 
 describe('grpc-utils', () => {
+  describe('buildTextFilterQl', () => {
+    it('builds a CONTAINS clause for the given column', () => {
+      expect(buildTextFilterQl('pdf', 'prompt')).to.equal('prompt CONTAINS "pdf"');
+      expect(buildTextFilterQl('adobe', 'name')).to.equal('name CONTAINS "adobe"');
+    });
+    it('trims the filter text', () => {
+      expect(buildTextFilterQl('  coffee  ', 'topic')).to.equal('topic CONTAINS "coffee"');
+    });
+    it('escapes embedded quotes and backslashes', () => {
+      expect(buildTextFilterQl('a"b\\c', 'domain')).to.equal('domain CONTAINS "a\\"b\\\\c"');
+    });
+    it('returns empty string for empty / whitespace / nullish input', () => {
+      expect(buildTextFilterQl('', 'prompt')).to.equal('');
+      expect(buildTextFilterQl('   ', 'prompt')).to.equal('');
+      expect(buildTextFilterQl(undefined, 'prompt')).to.equal('');
+      expect(buildTextFilterQl(null, 'prompt')).to.equal('');
+    });
+  });
+
   describe('settledValueOrElse / settledFulfilledMap', () => {
     it('settledValueOrElse returns value when fulfilled', () => {
       expect(settledValueOrElse({ status: 'fulfilled', value: 42 }, 0)).to.equal(42);

--- a/test/support/ai-visibility/handlers/topics.test.js
+++ b/test/support/ai-visibility/handlers/topics.test.js
@@ -273,6 +273,59 @@ describe('AI Visibility – topics handlers', () => {
   /* ------------------------------------------------------------------ */
   /*  handleTopicsResearch                                               */
   /* ------------------------------------------------------------------ */
+  describe('textFilter (server-side search)', () => {
+    it('threads textFilter into topicsByFTS as a topic CONTAINS clause', async () => {
+      clients.topicClient.topicsByFTS.resolves({ topics: [] });
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt&textFilter=pdf');
+      await handleTopicsResearch(sp, clients);
+      expect(clients.topicClient.topicsByFTS.calledWith(
+        sinon.match({ dimensionFilterQl: 'topic CONTAINS "pdf"' }),
+      )).to.equal(true);
+    });
+
+    it('threads textFilter into prompts list + totals as a prompt CONTAINS clause', async () => {
+      clients.promptClient.promptsByTopicFTS.resolves({ prompts: [] });
+      clients.promptClient.promptsByTopicFTSTotals.resolves({ total: 0 });
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt&textFilter=pdf');
+      await handleTopicsResearchPrompts(sp, clients);
+      expect(clients.promptClient.promptsByTopicFTS.calledWith(
+        sinon.match({ dimensionFilterQl: 'prompt CONTAINS "pdf"' }),
+      )).to.equal(true);
+      expect(clients.promptClient.promptsByTopicFTSTotals.calledWith(
+        sinon.match({ dimensionFilterQl: 'prompt CONTAINS "pdf"' }),
+      )).to.equal(true);
+    });
+
+    it('threads textFilter into brands as a name CONTAINS clause', async () => {
+      clients.brandClient.brandsByTopicFTS.resolves({ brands: [] });
+      clients.brandClient.brandsByTopicFTSTotals.resolves({ total: 0 });
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt&textFilter=adobe');
+      await handleTopicsResearchBrands(sp, clients);
+      expect(clients.brandClient.brandsByTopicFTS.calledWith(
+        sinon.match({ dimensionFilterQl: 'name CONTAINS "adobe"' }),
+      )).to.equal(true);
+    });
+
+    it('threads textFilter into source-domains as a domain CONTAINS clause', async () => {
+      clients.sourceClient.sourceDomainsByTopicFTS.resolves({ sourceDomains: [] });
+      clients.sourceClient.sourceDomainsByTopicFTSTotals.resolves({ total: 0 });
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt&textFilter=reddit');
+      await handleTopicsResearchSourceDomains(sp, clients);
+      expect(clients.sourceClient.sourceDomainsByTopicFTS.calledWith(
+        sinon.match({ dimensionFilterQl: 'domain CONTAINS "reddit"' }),
+      )).to.equal(true);
+    });
+
+    it('omits dimensionFilterQl when textFilter is absent', async () => {
+      clients.promptClient.promptsByTopicFTS.resolves({ prompts: [] });
+      clients.promptClient.promptsByTopicFTSTotals.resolves({ total: 0 });
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt');
+      await handleTopicsResearchPrompts(sp, clients);
+      const arg = clients.promptClient.promptsByTopicFTS.lastCall.args[0];
+      expect(arg).to.not.have.property('dimensionFilterQl');
+    });
+  });
+
   describe('handleTopicsResearch', () => {
     it('returns 400 when search_query is missing', async () => {
       const sp = new URLSearchParams('');


### PR DESCRIPTION
## Summary
Adds an optional `textFilter` query param to the four Prompt Research endpoints (`/topics/research`, `/prompts`, `/brands`, `/source-domains`) and their CSV exports. It filters the **full result set server-side** via a `dimension_filter_ql` `CONTAINS` clause — replacing the current client-side, current-page-only table search — so both the table and the export reflect all matching rows, and `total` reflects the filtered count.

## Param + columns
- New param: `textFilter` (distinct from `searchQuery`, which is the topic FTS query).
- `dimension_filter_ql` column per dataset: prompts→`prompt`, topics→`topic`, brands→`name`, source-domains→`domain`.
- Empty/absent `textFilter` → field omitted (request unchanged).

## Changes
- `grpc-utils.js`: new `buildTextFilterQl(textFilter, column)` (reuses `escapeQlString`).
- `topics.js`: threaded onto every gRPC call — list, `*Totals`, each `FTS_LLMS` per-engine call, the topic count helpers, and the prompts `topicId` path — so filtered totals stay consistent.
- Export: `runFtsResearchExport` + 4 wrappers (`textFilterColumn`) set it on the export request.
- OpenAPI: shared `textFilter` param on all 8 ops; rendered docs regenerated.
- No new routes (capability/route/index tests untouched).

## Test plan
- [x] `npx mocha` on touched files: 358 passing (new `buildTextFilterQl` unit tests + per-dataset threading assertions + "omits when absent").
- [x] `npm test`: 12424 passing, coverage 99.95%.
- [x] `npm run docs:lint` valid; `npm run docs:build` regenerated; `eslint` clean.
- Note: brands→`name` is the one column not previously proven against Semrush — validated in manual testing.

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-5216

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits.

If the PR is changing the API implementation or an entity exposed through the API:
- [x] make sure you update the API specification and the examples to reflect the changes.