### PR TITLE
feat:  (SITES-46688) log PF run summary with per-audit issue counts

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -32,6 +32,35 @@ import {
 export const AUDIT_STEP_IDENTIFY = 'identify';
 export const AUDIT_STEP_SUGGEST = 'suggest';
 
+const ACCESSIBILITY_AUDIT_NAME = 'accessibility';
+
+/**
+ * Counts the number of issues for a single preflight audit. Three counting modes:
+ *  - accessibility: sum of the integer `occurrences` across opportunities
+ *    (each opportunity is an issue "type" with N occurrences).
+ *  - opportunities whose `issue` is an array (e.g. links): sum of the issue-array
+ *    lengths (each entry is one issue).
+ *  - all others: one issue per opportunity that has a truthy `issue` (exactly one
+ *    issue per opportunity).
+ * @param {Object} audit - A PreflightAudit: { name, type, opportunities }
+ * @returns {number} Total issue count for the audit
+ */
+export function countIssuesForAudit(audit) {
+  const opportunities = Array.isArray(audit?.opportunities) ? audit.opportunities : [];
+  if (audit?.name === ACCESSIBILITY_AUDIT_NAME) {
+    return opportunities.reduce((sum, opp) => sum + (opp?.occurrences ?? 0), 0);
+  }
+  return opportunities.reduce((count, opp) => {
+    if (Array.isArray(opp?.issue)) {
+      return count + opp.issue.length;
+    }
+    if (opp?.issue) {
+      return count + 1;
+    }
+    return count;
+  }, 0);
+}
+
 /**
  * Creates a preflight controller instance
  * @param {Object} ctx - The context object containing dataAccess and sqs
@@ -280,9 +309,27 @@ function PreflightController(ctx, log, env) {
 
       log.debug(`getPreflightJobStatusAndResult returning job: ${JSON.stringify(job)}`);
 
+      const result = job.getResult();
+      const status = job.getStatus();
+
+      // Log a compact summary of the audit-worker results once the job is completed.
+      if (status === AsyncJob.Status.COMPLETED && isNonEmptyArray(result)) {
+        const summary = result.map((r) => ({
+          pageUrl: r?.pageUrl,
+          step: r?.step,
+          audits: (Array.isArray(r?.audits) ? r.audits : []).map((a) => ({
+            name: a?.name,
+            type: a?.type,
+            opportunities: Array.isArray(a?.opportunities) ? a.opportunities.length : 0,
+            issues: countIssuesForAudit(a),
+          })),
+        }));
+        log.info(`[Preflight] Run complete. jobId=${jobId} status=${status} results=${JSON.stringify(summary)}`);
+      }
+
       return ok({
         jobId: job.getId(),
-        status: job.getStatus(),
+        status,
         createdAt: job.getCreatedAt(),
         updatedAt: job.getUpdatedAt(),
         startedAt: job.getStartedAt(),
@@ -290,7 +337,7 @@ function PreflightController(ctx, log, env) {
         recordExpiresAt: job.getRecordExpiresAt(),
         resultLocation: job.getResultLocation(),
         resultType: job.getResultType(),
-        result: job.getResult(),
+        result,
         error: job.getError(),
         metadata: job.getMetadata(),
       });

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -21,7 +21,7 @@ import { Site as SiteModel } from '@adobe/spacecat-shared-data-access';
 import esmock from 'esmock';
 
 import * as utils from '../../src/support/utils.js';
-import PreflightController from '../../src/controllers/preflight.js';
+import PreflightController, { countIssuesForAudit } from '../../src/controllers/preflight.js';
 
 // Make fetch available globally
 global.fetch = fetch;
@@ -2201,6 +2201,145 @@ describe('Preflight Controller', () => {
       });
     });
 
+    it('logs a compact summary with issue counts (all three counting modes)', async () => {
+      loggerStub.info.resetHistory();
+      const resultJob = {
+        ...mockJob,
+        getStatus: () => 'COMPLETED',
+        getResult: () => [
+          {
+            pageUrl: 'https://main--example-site.aem.page/test.html',
+            step: 'suggest',
+            audits: [
+              // empty audit -> 0
+              { name: 'body-size', type: 'seo', opportunities: [] },
+              // single-issue-per-opportunity -> 2
+              {
+                name: 'metatags',
+                type: 'seo',
+                opportunities: [{ issue: 'Title too short' }, { issue: 'Description too short' }],
+              },
+              // issue-is-an-array (links) -> 3 + 1 = 4
+              {
+                name: 'links',
+                type: 'seo',
+                opportunities: [
+                  { check: 'broken-internal-links', issue: [{}, {}, {}] },
+                  { check: 'broken-external-links', issue: [{}] },
+                ],
+              },
+              // accessibility -> sum of occurrences = 5 + 40 = 45
+              {
+                name: 'accessibility',
+                type: 'a11y',
+                opportunities: [
+                  { type: 'aria-allowed-attr', occurrences: 5 },
+                  { type: 'color-contrast', occurrences: 40 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      mockDataAccess.AsyncJob.findById.resolves(resultJob);
+
+      const context = { params: { jobId } };
+
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const infoCall = loggerStub.info.getCalls()
+        .find((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes(`[Preflight] Run complete. jobId=${jobId}`)
+          && c.args[0].includes('status=COMPLETED'));
+      expect(infoCall, 'expected a [Preflight] jobId info log').to.not.be.undefined;
+      const logged = JSON.parse(infoCall.args[0].split('results=')[1]);
+      expect(logged).to.deep.equal([
+        {
+          pageUrl: 'https://main--example-site.aem.page/test.html',
+          step: 'suggest',
+          audits: [
+            {
+              name: 'body-size', type: 'seo', opportunities: 0, issues: 0,
+            },
+            {
+              name: 'metatags', type: 'seo', opportunities: 2, issues: 2,
+            },
+            {
+              name: 'links', type: 'seo', opportunities: 2, issues: 4,
+            },
+            {
+              name: 'accessibility', type: 'a11y', opportunities: 2, issues: 45,
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('handles malformed result entries (non-array audits / opportunities)', async () => {
+      loggerStub.info.resetHistory();
+      const resultJob = {
+        ...mockJob,
+        getStatus: () => 'COMPLETED',
+        getResult: () => [
+          // audits is not an array -> falls back to []
+          { pageUrl: 'https://main--example-site.aem.page/a.html', step: 'identify', audits: undefined },
+          // audit present but opportunities is not an array -> opportunities count falls back to 0
+          {
+            pageUrl: 'https://main--example-site.aem.page/b.html',
+            step: 'identify',
+            audits: [{ name: 'metatags', type: 'seo', opportunities: undefined }],
+          },
+        ],
+      };
+      mockDataAccess.AsyncJob.findById.resolves(resultJob);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const infoCall = loggerStub.info.getCalls()
+        .find((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes(`[Preflight] Run complete. jobId=${jobId}`)
+          && c.args[0].includes('status=COMPLETED'));
+      expect(infoCall, 'expected a [Preflight] jobId info log').to.not.be.undefined;
+      const logged = JSON.parse(infoCall.args[0].split('results=')[1]);
+      expect(logged).to.deep.equal([
+        { pageUrl: 'https://main--example-site.aem.page/a.html', step: 'identify', audits: [] },
+        {
+          pageUrl: 'https://main--example-site.aem.page/b.html',
+          step: 'identify',
+          audits: [{
+            name: 'metatags', type: 'seo', opportunities: 0, issues: 0,
+          }],
+        },
+      ]);
+    });
+
+    it('does not log results while the job is still IN_PROGRESS', async () => {
+      loggerStub.info.resetHistory();
+      const inProgressJob = {
+        ...mockJob,
+        getStatus: () => 'IN_PROGRESS',
+        getResult: () => [
+          {
+            pageUrl: 'https://main--example-site.aem.page/test.html',
+            step: 'identify',
+            audits: [{ name: 'Meta Tags', type: 'meta-tags', opportunities: [{}] }],
+          },
+        ],
+      };
+      mockDataAccess.AsyncJob.findById.resolves(inProgressJob);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const infoCall = loggerStub.info.getCalls()
+        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes(`[Preflight] Run complete. jobId=${jobId}`));
+      expect(infoCall, 'expected no [Preflight] jobId info log while IN_PROGRESS').to.be.undefined;
+    });
+
     it('returns 400 Bad Request for invalid job ID', async () => {
       const context = {
         params: {
@@ -2467,5 +2606,57 @@ describe('Preflight Controller', () => {
       const result = await response.json();
       expect(result.errorCode).to.equal('PREFLIGHT_INTERNAL_ERROR');
     });
+  });
+});
+
+describe('countIssuesForAudit', () => {
+  it('returns 0 for an audit with no opportunities', () => {
+    expect(countIssuesForAudit({ name: 'body-size', opportunities: [] })).to.equal(0);
+  });
+
+  it('returns 0 when opportunities is missing or not an array', () => {
+    expect(countIssuesForAudit({ name: 'h1-count' })).to.equal(0);
+    expect(countIssuesForAudit({ name: 'h1-count', opportunities: null })).to.equal(0);
+    expect(countIssuesForAudit(undefined)).to.equal(0);
+  });
+
+  it('counts one issue per opportunity with a scalar issue (metatags/headings)', () => {
+    const audit = {
+      name: 'metatags',
+      opportunities: [{ issue: 'Title too short' }, { issue: 'Description too short' }],
+    };
+    expect(countIssuesForAudit(audit)).to.equal(2);
+  });
+
+  it('ignores opportunities without an issue in the default mode', () => {
+    const audit = {
+      name: 'headings',
+      opportunities: [{ issue: 'Empty Heading' }, { check: 'no-issue-field' }],
+    };
+    expect(countIssuesForAudit(audit)).to.equal(1);
+  });
+
+  it('sums issue-array lengths for links audits', () => {
+    const audit = {
+      name: 'links',
+      opportunities: [
+        { check: 'broken-internal-links', issue: [{}, {}, {}] },
+        { check: 'broken-external-links', issue: [{}] },
+        { check: 'bad-links', issue: [{}] },
+      ],
+    };
+    expect(countIssuesForAudit(audit)).to.equal(5);
+  });
+
+  it('sums occurrences for accessibility audits (not htmlWithIssues length)', () => {
+    const audit = {
+      name: 'accessibility',
+      opportunities: [
+        { type: 'aria-allowed-attr', occurrences: 5, htmlWithIssues: [{}, {}] },
+        { type: 'color-contrast', occurrences: 40 },
+        { type: 'missing-occurrences' },
+      ],
+    };
+    expect(countIssuesForAudit(audit)).to.equal(45);
   });
 });


### PR DESCRIPTION
Adds a compact run-complete summary log to the preflight job status endpoint (jobId, status, and per-audit opportunity/issue counts) to support dashboarding. Includes a countIssuesForAudit helper mirroring the preflight MFE's counting logic, and unit tests.
https://jira.corp.adobe.com/browse/SITES-46688

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
