### PR TITLE
fix(referral-traffic): order Traffic Insights sources cdn-first

### DIFF
--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -750,11 +750,11 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
  * Business Impact (adobe_analytics, ga4) has its own DRS provider check and is
  * intentionally excluded here.
  *
- * Order matters: optel is listed first because it is the preferred source.
+ * Order matters: cdn is listed first because it is the preferred source.
  * The has-data response preserves this order in availableSources so callers
- * can pick the first entry as the active source (optel wins over cdn).
+ * can pick the first entry as the active source (cdn wins over optel).
  */
-const TRAFFIC_INSIGHTS_SOURCES = ['optel', 'cdn'];
+const TRAFFIC_INSIGHTS_SOURCES = ['cdn', 'optel'];
 const TRAFFIC_INSIGHTS_TABLES = TRAFFIC_INSIGHTS_SOURCES.map((s) => SOURCE_TO_TABLE[s]);
 
 /**
@@ -767,8 +767,8 @@ const TRAFFIC_INSIGHTS_TABLES = TRAFFIC_INSIGHTS_SOURCES.map((s) => SOURCE_TO_TA
  *   { hasData: boolean, availableSources: Array<'optel'|'cdn'> }
  *
  * availableSources lists whichever of optel/cdn has at least one row, in
- * priority order (optel first). Callers should use the first entry as the
- * active source so they naturally prefer optel over cdn.
+ * priority order (cdn first). Callers use the first entry as the active
+ * source, which now prefers cdn over optel.
  * hasData is true iff availableSources is non-empty.
  *
  * Both tables are checked in parallel with limit(1) — no RPC required.

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -1087,7 +1087,7 @@ describe('llmo-referral-traffic', () => {
       expect(body.availableSources).to.deep.equal(['cdn']);
     });
 
-    it('returns hasData:true and availableSources:["optel","cdn"] when both have records', async () => {
+    it('returns hasData:true and availableSources:["cdn","optel"] when both have records', async () => {
       const client = makeHasDataChainClient({
         referral_traffic_optel: { data: [ROW], error: null },
         referral_traffic_cdn: { data: [ROW], error: null },
@@ -1098,7 +1098,7 @@ describe('llmo-referral-traffic', () => {
       expect(res.status).to.equal(200);
       const body = await res.json();
       expect(body.hasData).to.equal(true);
-      expect(body.availableSources).to.deep.equal(['optel', 'cdn']);
+      expect(body.availableSources).to.deep.equal(['cdn', 'optel']);
     });
 
     it('returns hasData:false and availableSources:[] when both tables are empty', async () => {


### PR DESCRIPTION
## What

Flips the Traffic Insights source-ordering so the `has-data` endpoint returns `availableSources` **cdn-first** instead of optel-first.

`src/controllers/llmo/llmo-referral-traffic.js`:
- `TRAFFIC_INSIGHTS_SOURCES = ['optel', 'cdn']` → `['cdn', 'optel']` (the derived `TRAFFIC_INSIGHTS_TABLES` follows in lockstep).
- Updated the rationale comment block and the has-data JSDoc to describe cdn as the preferred source.

## Why

Referral Traffic Insights has two mutually-exclusive sources per site (optel & cdn). Product rule: **always prefer cdn over optel**. Clients (referral dashboard, agentic, url-inspector) read `availableSources[0]` as the active source, so ordering `has-data` cdn-first makes all of them seed cdn over optel for free.

AA / GA4 / CJA are **unaffected** — they live in the separate Business Impact tab and use their own DRS provider check. The `has-data` `availableSources` is type-locked to `'optel' | 'cdn'` only.

## Scope / not changed

- The filter-dimensions `availableSources` path is untouched — it comes from the RPC `row.available_sources`, a different code path independent of this constant.

## Merge order

⚠️ **Merge this BEFORE the frontend PR.** The frontend reads `availableSources[0]`; until this lands it degrades gracefully to optel.

## Test

- `npx mocha test/controllers/llmo/llmo-referral-traffic.test.js` → 89 passing (flipped the has-data both-records assertion to `['cdn', 'optel']`).
- `eslint` on changed files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)