### PR TITLE
fix(agentic-traffic): map google-ai-mode and copilot platform codes to DB values

### DIFF
--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -60,6 +60,8 @@ const PLATFORM_CODE_TO_DB = {
   perplexity: 'Perplexity',
   gemini: 'Gemini',
   google: 'Google',
+  'google-ai-mode': 'Google AI Mode',
+  copilot: 'Copilot',
   amazon: 'Amazon',
 };
 

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -289,6 +289,8 @@ describe('llmo-agentic-traffic', () => {
       ['perplexity', 'Perplexity'],
       ['gemini', 'Gemini'],
       ['google', 'Google'],
+      ['google-ai-mode', 'Google AI Mode'],
+      ['copilot', 'Copilot'],
       ['amazon', 'Amazon'],
       ['all', null],
       [undefined, null],


### PR DESCRIPTION
## Problem

In the Agentic Traffic dashboard, filtering by **Google AI Mode** returned the same totals as **All**

## Root cause

`PLATFORM_CODE_TO_DB` in `src/controllers/llmo/llmo-agentic-traffic.js` translates UI platform codes into the DB `platform` value used by the SQL filter (`lower(s.platform) = lower($4)`). The map was missing `google-ai-mode` (and `copilot`), so:

```
platform=google-ai-mode → PLATFORM_CODE_TO_DB['google-ai-mode'] = undefined → ?? null → no filter → ALL traffic
```

Working codes like `chatgpt`→`ChatGPT` and `mistral`→`MistralAI` already had entries, which is why only GAIM (and Copilot) misbehaved. The UI was already sending the correct code; only the server-side mapping was incomplete.

## Fix

Add the two missing entries (DB values verified against the audit-worker's `inferProviderFromUserAgent`):

- `google-ai-mode` → `Google AI Mode`
- `copilot` → `Copilot` (same latent bug — dropdown offers it but it fell through to All)

Extended the platform-code translation test cases to cover both.

## Testing

- `npx mocha test/controllers/llmo/llmo-agentic-traffic.test.js` — 134 passing
- lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)