### PR TITLE
fix: remove toc and wikipedia-analysis from ASO paid onboarding profile

### DIFF
--- a/static/onboard/profiles.json
+++ b/static/onboard/profiles.json
@@ -132,8 +132,6 @@
 			"security-vulnerabilities-auto-suggest": {},
 			"structured-data": {},
 			"sitemap": {},
-			"toc": {},
-			"wikipedia-analysis": {},
 			"money-pages": {},
 			"cwv-trends-audit": {}
 		},


### PR DESCRIPTION
toc and wikipedia-analysis are LLMO-only audits per the Opportunity Type Catalog. They have no corresponding ASO opportunity types and should not be included in the ASO paid onboarding profile.

Supersedes #2567
Fixes SITES-45864
