### PR TITLE
feat(aso-overlay): dual-key overlap for API key rotation (ADR I13)

### DIFF
--- a/src/support/aso-overlay-key-handler.js
+++ b/src/support/aso-overlay-key-handler.js
@@ -35,7 +35,10 @@ function safeEqual(a, b) {
 /**
  * Authenticates the ASO dispatcher-overlay read path
  * (`GET /config/:service/redirects.txt`) via the inbound `X-ASO-API-Key`,
- * validated against `ASO_OVERLAY_API_KEY`.
+ * validated against `ASO_OVERLAY_API_KEY` (current) and optionally
+ * `ASO_OVERLAY_API_KEY_PREVIOUS` (rotation overlap). During a key rotation both
+ * values are populated; in steady state the previous key is empty and only the
+ * current key is checked. See ADR I13 for the rotation playbook.
  *
  * This must live in the auth-handler chain (not the controller): `authWrapper`
  * runs `authenticate()` before any controller, so a route that is neither in
@@ -76,7 +79,9 @@ class AsoOverlayKeyHandler extends AbstractHandler {
       return null;
     }
 
-    if (!safeEqual(providedKey, expectedKey)) {
+    const previousKey = context.env?.ASO_OVERLAY_API_KEY_PREVIOUS;
+    if (!safeEqual(providedKey, expectedKey)
+        && !(previousKey && safeEqual(providedKey, previousKey))) {
       this.log('invalid X-ASO-API-Key', 'warn');
       return null;
     }

--- a/test/support/aso-overlay-key-handler.test.js
+++ b/test/support/aso-overlay-key-handler.test.js
@@ -125,4 +125,52 @@ describe('AsoOverlayKeyHandler', () => {
     expect(authInfo).to.not.be.null;
     expect(authInfo.getType()).to.equal('aso_overlay_key');
   });
+
+  describe('dual-key rotation overlap', () => {
+    const PREVIOUS_KEY = 'old-aso-key-being-rotated';
+
+    it('accepts the previous key during rotation overlap', async () => {
+      const authInfo = await handler.checkAuth(
+        makeRequest({ 'x-aso-api-key': PREVIOUS_KEY }),
+        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY, ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY } }),
+      );
+      expect(authInfo).to.not.be.null;
+      expect(authInfo.isAuthenticated()).to.be.true;
+    });
+
+    it('still accepts the current key when previous is also set', async () => {
+      const authInfo = await handler.checkAuth(
+        makeRequest({ 'x-aso-api-key': API_KEY }),
+        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY, ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY } }),
+      );
+      expect(authInfo).to.not.be.null;
+      expect(authInfo.isAuthenticated()).to.be.true;
+    });
+
+    it('rejects a wrong key even when previous key is set', async () => {
+      const authInfo = await handler.checkAuth(
+        makeRequest({ 'x-aso-api-key': 'totally-wrong' }),
+        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY, ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY } }),
+      );
+      expect(authInfo).to.be.null;
+    });
+
+    it('works in steady state when previous key is empty', async () => {
+      const authInfo = await handler.checkAuth(
+        makeRequest({ 'x-aso-api-key': API_KEY }),
+        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY, ASO_OVERLAY_API_KEY_PREVIOUS: '' } }),
+      );
+      expect(authInfo).to.not.be.null;
+      expect(authInfo.isAuthenticated()).to.be.true;
+    });
+
+    it('works in steady state when previous key is not set at all', async () => {
+      const authInfo = await handler.checkAuth(
+        makeRequest({ 'x-aso-api-key': API_KEY }),
+        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY } }),
+      );
+      expect(authInfo).to.not.be.null;
+      expect(authInfo.isAuthenticated()).to.be.true;
+    });
+  });
 });

--- a/test/support/aso-overlay-key-handler.test.js
+++ b/test/support/aso-overlay-key-handler.test.js
@@ -130,27 +130,39 @@ describe('AsoOverlayKeyHandler', () => {
     const PREVIOUS_KEY = 'old-aso-key-being-rotated';
 
     it('accepts the previous key during rotation overlap', async () => {
+      const env = {
+        ASO_OVERLAY_API_KEY: API_KEY,
+        ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY,
+      };
       const authInfo = await handler.checkAuth(
         makeRequest({ 'x-aso-api-key': PREVIOUS_KEY }),
-        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY, ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY } }),
+        makeContext({ env }),
       );
       expect(authInfo).to.not.be.null;
       expect(authInfo.isAuthenticated()).to.be.true;
     });
 
     it('still accepts the current key when previous is also set', async () => {
+      const env = {
+        ASO_OVERLAY_API_KEY: API_KEY,
+        ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY,
+      };
       const authInfo = await handler.checkAuth(
         makeRequest({ 'x-aso-api-key': API_KEY }),
-        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY, ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY } }),
+        makeContext({ env }),
       );
       expect(authInfo).to.not.be.null;
       expect(authInfo.isAuthenticated()).to.be.true;
     });
 
     it('rejects a wrong key even when previous key is set', async () => {
+      const env = {
+        ASO_OVERLAY_API_KEY: API_KEY,
+        ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY,
+      };
       const authInfo = await handler.checkAuth(
         makeRequest({ 'x-aso-api-key': 'totally-wrong' }),
-        makeContext({ env: { ASO_OVERLAY_API_KEY: API_KEY, ASO_OVERLAY_API_KEY_PREVIOUS: PREVIOUS_KEY } }),
+        makeContext({ env }),
       );
       expect(authInfo).to.be.null;
     });


### PR DESCRIPTION
## Summary

Adds dual-key overlap support to the ASO overlay auth handler so API key rotation doesn't 401 dispatcher pods during the EVO propagation window.

Ports the dual-key pattern from the Fastly VCL side (spacecat-infrastructure #611) to the api-service Lite-E path where the key check now lives (#2638).

## Changes

**`src/support/aso-overlay-key-handler.js`** — check `ASO_OVERLAY_API_KEY` (current) first; if no match, check `ASO_OVERLAY_API_KEY_PREVIOUS` (rotation overlap). Both use the existing constant-time `safeEqual` compare. When `ASO_OVERLAY_API_KEY_PREVIOUS` is empty or unset (steady state), behaviour is identical to today.

## Rotation flow

```
T+0  Copy current ASO_OVERLAY_API_KEY → ASO_OVERLAY_API_KEY_PREVIOUS in Vault
     Write new value into ASO_OVERLAY_API_KEY
     Redeploy api-service → overlap window starts (both keys accepted)

T+N  Wait for all dispatcher pods to roll with new key (EVO propagation)

T+M  Clear ASO_OVERLAY_API_KEY_PREVIOUS in Vault
     Redeploy api-service → only new key accepted
```

## Vault change needed

Add `ASO_OVERLAY_API_KEY_PREVIOUS` (initially empty) to `dx_mysticat/<env>/api-service` for each env.

## Test plan

- [x] 5 new tests covering: previous key accepted during overlap, current key still works, wrong key rejected, empty previous key (steady state), unset previous key (steady state)
- [x] All existing key handler tests unchanged


Made with [Cursor](https://cursor.com)