### PR TITLE
fix: match prompts region filter case-insensitively | LLMO-5755

### DIFF
--- a/docs/openapi/prompts-v2-api.yaml
+++ b/docs/openapi/prompts-v2-api.yaml
@@ -66,7 +66,11 @@ v2-prompts-by-brand:
       required: false
       schema:
         type: string
-      description: Filter by region (matches prompts whose regions array contains this value)
+      description: >-
+        Filter by region code (e.g. `us`). Matches prompts whose `regions`
+        array contains the value, case-insensitively — region codes are stored
+        with inconsistent casing depending on the onboarding path, so both
+        lower- and upper-case variants are matched.
     - name: origin
       in: query
       required: false

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -509,7 +509,16 @@ export async function listPrompts({
     }
 
     if (hasText(region)) {
-      baseQuery = baseQuery.contains('regions', [region]);
+      // Region codes are persisted with inconsistent casing depending on the
+      // onboarding path: `onboard-llmo` and Serenity provisioning store them
+      // UPPERCASE (e.g. ['US','NO']), while CSV / config-mapper imports store
+      // them lowercase. The UI sends the code lowercased, so a case-sensitive
+      // `.contains` (regions @> ARRAY['us']) silently matches nothing for the
+      // uppercase brands. Match an array overlap against both case variants so
+      // the filter is case-insensitive without rewriting stored values.
+      // (LLMO-5755)
+      const regionVariants = [...new Set([region.toLowerCase(), region.toUpperCase()])];
+      baseQuery = baseQuery.overlaps('regions', regionVariants);
     }
 
     if (hasText(search)) {

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -509,14 +509,8 @@ export async function listPrompts({
     }
 
     if (hasText(region)) {
-      // Region codes are persisted with inconsistent casing depending on the
-      // onboarding path: `onboard-llmo` and Serenity provisioning store them
-      // UPPERCASE (e.g. ['US','NO']), while CSV / config-mapper imports store
-      // them lowercase. The UI sends the code lowercased, so a case-sensitive
-      // `.contains` (regions @> ARRAY['us']) silently matches nothing for the
-      // uppercase brands. Match an array overlap against both case variants so
-      // the filter is case-insensitive without rewriting stored values.
-      // (LLMO-5755)
+      // Stored region codes can be lower- or upper-case, so match both
+      // variants — a case-sensitive `.contains` would miss the other. (LLMO-5755)
       const regionVariants = [...new Set([region.toLowerCase(), region.toUpperCase()])];
       baseQuery = baseQuery.overlaps('regions', regionVariants);
     }

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -457,6 +457,7 @@ describe('Brands Controller', () => {
             update: sandbox.stub().returnsThis(),
             or: sandbox.stub().returnsThis(),
             contains: sandbox.stub().returnsThis(),
+            overlaps: sandbox.stub().returnsThis(),
             range: sandbox.stub().resolves({
               data: table === 'prompts' ? [promptRow] : [],
               error: null,
@@ -613,6 +614,7 @@ describe('Brands Controller', () => {
           update: sandbox.stub().returnsThis(),
           or: sandbox.stub().returnsThis(),
           contains: sandbox.stub().returnsThis(),
+          overlaps: sandbox.stub().returnsThis(),
           range: sandbox.stub().rejects(new Error('DB connection lost')),
           maybeSingle: sandbox.stub().callsFake(() => {
             if (table === 'brands') {
@@ -4275,6 +4277,7 @@ describe('Brands Controller', () => {
             update: sandbox.stub().returnsThis(),
             or: sandbox.stub().returnsThis(),
             contains: sandbox.stub().returnsThis(),
+            overlaps: sandbox.stub().returnsThis(),
             range: sandbox.stub().resolves({
               data: table === 'prompts' ? [promptRow] : [],
               error: null,

--- a/test/it/shared/tests/categories-prompts.js
+++ b/test/it/shared/tests/categories-prompts.js
@@ -191,13 +191,9 @@ export default function categoriesPromptsTests(getHttpClient, resetData) {
       it('matches prompts whose stored region casing differs from the query', async () => {
         const http = getHttpClient();
 
-        // Region codes are persisted with mixed casing: onboard-llmo and
-        // Serenity provisioning store them UPPERCASE, while CSV / config-mapper
-        // imports store them lowercase. The UI always sends the code lowercased.
-        // Store one prompt UPPERCASE and one lowercase, then filter with the
-        // lowercased code — both must come back. A case-sensitive containment
-        // (the pre-LLMO-5755 behaviour) returned nothing for the uppercase row,
-        // which is what made the Creditsafe market filter look broken.
+        // Stored region codes can be lower- or upper-case. Store one prompt
+        // each way, then filter with the lowercased code — both must come back
+        // (a case-sensitive contains would miss the upper-case row). (LLMO-5755)
         const created = await http.admin.post(
           `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
           [

--- a/test/it/shared/tests/categories-prompts.js
+++ b/test/it/shared/tests/categories-prompts.js
@@ -183,6 +183,57 @@ export default function categoriesPromptsTests(getHttpClient, resetData) {
       });
     });
 
+    // ── The region/market filter is case-insensitive (LLMO-5755) ──
+
+    describe('Prompt-list region filter matches case-insensitively', () => {
+      before(() => resetData());
+
+      it('matches prompts whose stored region casing differs from the query', async () => {
+        const http = getHttpClient();
+
+        // Region codes are persisted with mixed casing: onboard-llmo and
+        // Serenity provisioning store them UPPERCASE, while CSV / config-mapper
+        // imports store them lowercase. The UI always sends the code lowercased.
+        // Store one prompt UPPERCASE and one lowercase, then filter with the
+        // lowercased code — both must come back. A case-sensitive containment
+        // (the pre-LLMO-5755 behaviour) returned nothing for the uppercase row,
+        // which is what made the Creditsafe market filter look broken.
+        const created = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
+          [
+            { prompt: 'Uppercase region prompt', regions: ['US'] },
+            { prompt: 'Lowercase region prompt', regions: ['us'] },
+            { prompt: 'Other region prompt', regions: ['gb'] },
+          ],
+        );
+        expect(created.status).to.equal(201);
+        expect(created.body.created).to.equal(3);
+
+        // Lowercase query returns BOTH the US and us rows, not the gb one.
+        const filtered = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts?region=us`,
+        );
+        expect(filtered.status).to.equal(200);
+        expect(filtered.body.total).to.equal(2);
+        expect(filtered.body.items).to.have.lengthOf(2);
+
+        // Uppercase query is symmetric — also returns both rows.
+        const filteredUpper = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts?region=US`,
+        );
+        expect(filteredUpper.status).to.equal(200);
+        expect(filteredUpper.body.total).to.equal(2);
+
+        // No filter returns all three — proving the filter narrowed the set
+        // rather than the brand simply having those prompts.
+        const unfiltered = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
+        );
+        expect(unfiltered.status).to.equal(200);
+        expect(unfiltered.body.total).to.equal(3);
+      });
+    });
+
     // ── Multibyte / non-ASCII-only names (LLMO-5515) ──
 
     describe('Category creation with an all-multibyte name (no explicit id)', () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -350,12 +350,9 @@ describe('prompts-storage', () => {
     });
 
     it('filters by region case-insensitively via array overlap (LLMO-5755)', async () => {
-      // Region codes are persisted UPPERCASE by some onboarding paths
-      // (onboard-llmo / Serenity provisioning) and lowercase by others
-      // (CSV / config-mapper). The UI sends the code lowercased, so the filter
-      // must match either case variant with an array-overlap query; a
-      // case-sensitive `.contains(['us'])` matched nothing for uppercase brands
-      // (e.g. Creditsafe), which is what made the market filter appear broken.
+      // Stored region codes can be lower- or upper-case, so the filter must
+      // match both variants via array overlap rather than a case-sensitive
+      // contains. (LLMO-5755)
       let overlapsCall = null;
       const recordingChain = (result) => {
         const chain = {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -51,6 +51,7 @@ describe('prompts-storage', () => {
       ilike: () => chain,
       or: () => chain,
       contains: () => chain,
+      overlaps: () => chain,
       in: () => chain,
       upsert: () => chain,
       insert: () => ({ select: () => thenable(result) }),
@@ -346,6 +347,51 @@ describe('prompts-storage', () => {
       });
       expect(result.limit).to.equal(100);
       expect(result.page).to.equal(1);
+    });
+
+    it('filters by region case-insensitively via array overlap (LLMO-5755)', async () => {
+      // Region codes are persisted UPPERCASE by some onboarding paths
+      // (onboard-llmo / Serenity provisioning) and lowercase by others
+      // (CSV / config-mapper). The UI sends the code lowercased, so the filter
+      // must match either case variant with an array-overlap query; a
+      // case-sensitive `.contains(['us'])` matched nothing for uppercase brands
+      // (e.g. Creditsafe), which is what made the market filter appear broken.
+      let overlapsCall = null;
+      const recordingChain = (result) => {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          neq: () => chain,
+          order: () => chain,
+          or: () => chain,
+          contains: () => chain,
+          overlaps: (column, value) => {
+            overlapsCall = { column, value };
+            return chain;
+          },
+          in: () => chain,
+          range: () => thenable(result),
+          maybeSingle: () => thenable(result),
+          single: () => thenable(result),
+          then: (resolve) => resolve(result),
+        };
+        return chain;
+      };
+      const client = {
+        from: (table) => (table === 'brands'
+          ? recordingChain({ data: { id: BRAND_UUID }, error: null })
+          : recordingChain({ data: [], error: null, count: 0 })),
+      };
+      await listPrompts({
+        organizationId: ORG_ID,
+        brandId: BRAND_UUID,
+        region: 'us',
+        postgrestClient: client,
+      });
+      expect(overlapsCall).to.not.be.null;
+      expect(overlapsCall.column).to.equal('regions');
+      expect(overlapsCall.value).to.have.members(['us', 'US']);
+      expect(overlapsCall.value).to.have.lengthOf(2);
     });
 
     it('uses explicit limit and page values', async () => {


### PR DESCRIPTION
## Problem

The brand-scoped prompts list endpoint (`GET /v2/orgs/{orgId}/brands/{brandId}/prompts?region=…`) filtered by region using a **case-sensitive** Postgres array containment:

```js
baseQuery = baseQuery.contains('regions', [region]); // regions @> ARRAY['us']
```

Region codes are persisted with **inconsistent casing** depending on the onboarding path:
- `onboard-llmo` (Slack) and Serenity brand-provisioning store them **UPPERCASE** (`['US','NO',…]`).
- CSV upload and the customer-config-mapper store them **lowercase** (`['us',…]`).

The UI always sends the filter value lowercased (`code.toLowerCase()`). So for uppercase-onboarded brands — e.g. **Creditsafe**, which was onboarded via `onboard-llmo` — `ARRAY['US'] @> ARRAY['us']` is `false`, every prompt is filtered out, and the market filter appears "completely bugged out." Lowercase-onboarded brands were unaffected, which is why this looked Creditsafe-specific.

Reported in the LLMO support thread → ticket **LLMO-5755**.

## Fix

Match an array **overlap** against both case variants instead of a single case-sensitive containment:

```js
const regionVariants = [...new Set([region.toLowerCase(), region.toUpperCase()])];
baseQuery = baseQuery.overlaps('regions', regionVariants); // regions && ARRAY['us','US']
```

The filter is now case-insensitive and works regardless of how regions were stored. **No stored data is rewritten** — this is a read-path-only change, so no migration/backfill is required. The frontend needs no change (it already sends the lowercased code).

## Tests / docs

- **Unit** (`test/support/prompts-storage.test.js`): asserts the region filter calls `.overlaps('regions', ['us','US'])`. Suite: 148 passing.
- **Integration** (`test/it/shared/tests/categories-prompts.js`): stores prompts with UPPERCASE regions, filters with a lowercase `?region=us`, and expects both case-variant rows back (and that filtering still narrows the set).
- **OpenAPI** (`docs/openapi/prompts-v2-api.yaml`): documented the case-insensitive matching; `npm run docs:lint` passes.

## Verification still to do

End-to-end Playwright verification of the Prompts Management market filter against a deployed env with the Creditsafe brand (pending deploy of this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)