### PR TITLE
feat(llmo): CDN log-forwarding endpoint (BYOCDN CloudFront, step 8)

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -653,6 +653,8 @@ paths:
     $ref: './llmo-api.yaml#/site-llmo-edge-optimize-verify'
   /sites/{siteId}/llmo/edge-optimize/deploy:
     $ref: './llmo-api.yaml#/site-llmo-edge-optimize-deploy'
+  /sites/{siteId}/llmo/cdn-log-delivery:
+    $ref: './llmo-api.yaml#/site-llmo-cdn-log-delivery'
   /sites/{siteId}/llmo/edge-optimize-status:
     $ref: './llmo-api.yaml#/llmo-edge-optimize-status'
   /sites/{siteId}/llmo/probes/edge-optimize:

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -2600,6 +2600,67 @@ site-llmo-edge-optimize-prerequisites:
     security:
       - api_key: [ ]
 
+site-llmo-cdn-log-delivery:
+  post:
+    tags:
+      - llmo
+    summary: Enable CDN access-log forwarding to Adobe
+    description: |
+      Enables CloudFront access-log forwarding to Adobe (BYOCDN). Via the cross-account connector
+      role, creates the customer-account CloudWatch Logs delivery source for the chosen
+      distribution and links it to Adobe's cross-account delivery destination, so the CDN pushes
+      standard logs to the cdn-logs S3 bucket. Idempotent — if forwarding is already configured
+      the call is a no-op and returns `alreadyExisted: true`. Requires Adobe-side cdn-logs
+      provisioning to have created the delivery destination for the organization.
+    operationId: enableCdnLogDelivery
+    parameters:
+      - $ref: './parameters.yaml#/siteId'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/edge-optimize-distribution-request'
+    responses:
+      '200':
+        description: Log forwarding enabled (or already configured).
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - created
+                - alreadyExisted
+                - deliverySourceName
+              properties:
+                created:
+                  type: boolean
+                  description: True when a new delivery was created by this call.
+                alreadyExisted:
+                  type: boolean
+                  description: True when forwarding was already configured (no-op).
+                deliverySourceName:
+                  type: string
+                deliveryId:
+                  type: string
+              example:
+                created: true
+                alreadyExisted: false
+                deliverySourceName: llmo-cf-1234567890abcdef12345678-E2EXAMPLE123
+                deliveryId: abcd1234-5678-90ab-cdef-1234567890ab
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '403':
+        $ref: './responses.yaml#/403'
+      '404':
+        $ref: './responses.yaml#/404'
+      '500':
+        $ref: './responses.yaml#/500'
+    security:
+      - api_key: [ ]
+
 site-llmo-edge-optimize-origins:
   post:
     tags:

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@adobe/spacecat-shared-utils": "1.119.2",
         "@adobe/spacecat-shared-vault-secrets": "1.3.5",
         "@aws-sdk/client-cloudfront": "3.1045.0",
+        "@aws-sdk/client-cloudwatch-logs": "3.1045.0",
         "@aws-sdk/client-iam": "3.1045.0",
         "@aws-sdk/client-lambda": "3.1045.0",
         "@aws-sdk/client-s3": "3.1045.0",
@@ -10620,6 +10621,148 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1045.0.tgz",
+      "integrity": "sha512-8p8jQuiIteWVYF7NhNHTXv4I7w6ZsDUWa4S6F+j8XIu8x5t+f38RKusQCHN4z8YEAzHSmg/8eIXkagP6N4UNMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.24.tgz",
+      "integrity": "sha512-POID/GDbM0tuuKT3IwMw+xnZcz8n8TQT+lOf478erp+QoK5VxI7kPpfIhnDZRJL39SryJvf8Y5BJxBc/+boiIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.23.tgz",
+      "integrity": "sha512-+7IHKSEgEnkbVtM7fP+n0hh5wdOE6yt61kjAec+AXlNei6Xnh3u90Zwu2Amvgx80khpS3+YyUxzMDTBc5s6sew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.25.tgz",
+      "integrity": "sha512-sHrFs/rGno1LGLnQwia6XfWTEumZtZCjeCVOlzP13tdzfLHZ1t4hAe1LLP9jZXndguQjAaJq3QlAtwNVUD2QLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.27.tgz",
+      "integrity": "sha512-1/wB+OZcNXM+OrEGLk3e7uF3xaTeNjWHXvpvMQx6XmL3o8JaJnn25zOTRh0PMWRYRxUQvXda6T1bXO1HVSqnNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.22.tgz",
+      "integrity": "sha512-0KNKzqROyKm+pMqbwCLaQM2spRNsp1FoKWNSf8u6byKu+gsRe3IEHJdz9Otj7CWqALnDSJCsWXRvDTGpGfKzZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@smithy/core": "^3.24.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.24.tgz",
+      "integrity": "sha512-VovINOiescSQAtKW5FMNi4pUr2sOufwuU0oingKLWuFIxIQL8U5qZJEW7/YV8goXRSMLhZ/3u2G2KbGxczAmGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1069.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1069.0.tgz",
@@ -12126,13 +12269,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
-      "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.13",
-        "@aws-sdk/xml-builder": "^3.972.30",
+        "@aws-sdk/xml-builder": "^3.972.31",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/core": "^3.24.6",
         "@smithy/signature-v4": "^5.4.6",
@@ -12158,38 +12301,16 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
-      "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
-        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
@@ -14610,18 +14731,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
@@ -21553,6 +21662,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -29783,6 +29893,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -34429,6 +34540,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@adobe/spacecat-shared-utils": "1.119.2",
     "@adobe/spacecat-shared-vault-secrets": "1.3.5",
     "@aws-sdk/client-cloudfront": "3.1045.0",
+    "@aws-sdk/client-cloudwatch-logs": "3.1045.0",
     "@aws-sdk/client-iam": "3.1045.0",
     "@aws-sdk/client-lambda": "3.1045.0",
     "@aws-sdk/client-s3": "3.1045.0",

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -46,6 +46,10 @@ import {
   verifyEdgeOptimizeRouting,
   runEdgeOptimizeDeployStep,
 } from '../../support/edge-optimize.js';
+import {
+  createCdnLogDelivery,
+  buildDeliveryDestinationArn,
+} from '../../support/cdn-log-delivery.js';
 import { UnauthorizedProductError } from '../../support/errors.js';
 import { cachedOk } from '../../support/cached-response.js';
 import {
@@ -2395,6 +2399,70 @@ function LlmoController(ctx) {
     }
   };
 
+  // Enable CloudFront access-log forwarding to Adobe (diagram step 8) via the connector role.
+  // Idempotent; returns { alreadyExisted: true } when forwarding is already configured.
+  const enableCdnLogDelivery = async (context) => {
+    const { log, dataAccess, env } = context;
+    const { siteId } = context.params;
+    const { Site, Organization } = dataAccess;
+    const accountId = String(context.data?.accountId || '').replace(/\D/g, '');
+    const externalId = String(context.data?.externalId || '').trim();
+    const distributionId = String(context.data?.distributionId || '').trim();
+    const roleName = env?.EDGE_OPTIMIZE_ROLE_NAME || undefined;
+
+    if (accountId.length !== 12) {
+      return badRequest('accountId must be a 12-digit AWS account ID');
+    }
+    if (!hasText(externalId)) {
+      return badRequest('externalId is required');
+    }
+    if (!hasText(distributionId)) {
+      return badRequest('distributionId is required');
+    }
+
+    try {
+      const { error, site } = await gateEdgeOptimizeWizard(siteId, Site, 'enable CDN log forwarding');
+      if (error) {
+        return error;
+      }
+
+      const organization = await Organization.findById(site.getOrganizationId());
+      const imsOrgId = organization?.getImsOrgId();
+      if (!hasText(imsOrgId)) {
+        return badRequest('Site organization has no IMS org ID');
+      }
+
+      const adobeAccountId = env?.CDN_LOG_DELIVERY_DEST_ACCOUNT_ID;
+      if (!hasText(adobeAccountId)) {
+        return badRequest('CDN log delivery destination account is not configured');
+      }
+      const deliveryDestinationArn = buildDeliveryDestinationArn({ imsOrgId, adobeAccountId });
+
+      const { credentials } = await assumeConnectorRole({ accountId, externalId, roleName });
+      let result;
+      try {
+        result = await createCdnLogDelivery(credentials, {
+          provider: 'cloudfront',
+          resourceId: distributionId,
+          accountId,
+          imsOrgId,
+          deliveryDestinationArn,
+        });
+      } catch (deliveryError) {
+        // Adobe destination not provisioned yet → clear error instead of a raw AWS one.
+        if (/ResourceNotFound|delivery.?destination|not.*exist/i.test(deliveryError.message || '')) {
+          return badRequest('Adobe log destination is not provisioned for this organization yet — run cdn-logs provisioning first');
+        }
+        throw deliveryError;
+      }
+      log.info(`[cdn-log-delivery] ${result.alreadyExisted ? 'Already enabled' : 'Enabled'} log forwarding for site ${siteId}, distribution ${distributionId}`);
+      return ok(result);
+    } catch (error) {
+      log.error(`Failed to enable CDN log forwarding for site ${siteId}:`, error);
+      return badRequest(cleanupHeaderValue(error.message));
+    }
+  };
+
   // Add the Edge Optimize origin to the selected distribution (mutation). Idempotent: returns
   // { created: false, alreadyExisted: true } when the origin is already present. Used by the
   // wizard's "Create Edge Optimize origin" step.
@@ -2807,6 +2875,7 @@ function LlmoController(ctx) {
     applyEdgeOptimizeAssociations: applyEdgeOptimizeAssociationsHandler,
     verifyEdgeOptimizeRouting: verifyEdgeOptimizeRoutingHandler,
     deployEdgeOptimize: deployEdgeOptimizeHandler,
+    enableCdnLogDelivery,
     getLlmoSheetData,
     queryLlmoSheetData,
     getLlmoGlobalSheetData,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -497,6 +497,7 @@ export default function getRouteHandlers(
     'POST /sites/:siteId/llmo/edge-optimize/apply-associations': llmoController.applyEdgeOptimizeAssociations,
     'POST /sites/:siteId/llmo/edge-optimize/verify': llmoController.verifyEdgeOptimizeRouting,
     'POST /sites/:siteId/llmo/edge-optimize/deploy': llmoController.deployEdgeOptimize,
+    'POST /sites/:siteId/llmo/cdn-log-delivery': llmoController.enableCdnLogDelivery,
     'GET /sites/:siteId/llmo/strategy': llmoController.getStrategy,
     'PUT /sites/:siteId/llmo/strategy': llmoController.saveStrategy,
     'GET /sites/:siteId/llmo/edge-optimize-status': llmoController.checkEdgeOptimizeStatus,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -144,6 +144,7 @@ export const INTERNAL_ROUTES = [
   'POST /sites/:siteId/llmo/edge-optimize/apply-associations',
   'POST /sites/:siteId/llmo/edge-optimize/verify',
   'POST /sites/:siteId/llmo/edge-optimize/deploy',
+  'POST /sites/:siteId/llmo/cdn-log-delivery',
   'PUT /sites/:siteId/llmo/opportunities-reviewed',
 
   // PLG onboarding - IMS token auth, self-service flow, not S2S

--- a/src/support/cdn-log-delivery.js
+++ b/src/support/cdn-log-delivery.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  CloudWatchLogsClient,
+  PutDeliverySourceCommand,
+  CreateDeliveryCommand,
+  GetDeliverySourceCommand,
+  DescribeDeliveriesCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
+import { hasText } from '@adobe/spacecat-shared-utils';
+
+// CDN vended-log delivery control plane and the Adobe cross-account destination both live in
+// us-east-1 (see spacecat-auth-service cdn-logs provisioning).
+export const CDN_LOG_DELIVERY_REGION = 'us-east-1';
+
+const CDN_LOG_S3_SUFFIX_PATH = '/{yyyy}/{MM}/{dd}/{HH}';
+
+// Supported CDN providers. CloudFront is the first; add a new provider here (resource-ARN shape,
+// CloudWatch log type, source-name prefix, delivered record fields) without touching the
+// delivery flow below.
+export const CDN_PROVIDERS = {
+  cloudfront: {
+    logType: 'ACCESS_LOGS',
+    sourceNamePrefix: 'llmo-cf',
+    buildResourceArn: ({ accountId, resourceId }) => `arn:aws:cloudfront::${accountId}:distribution/${resourceId}`,
+    recordFields: [
+      'date', 'time', 'x-edge-location', 'cs-method', 'cs(Host)', 'cs-uri-stem', 'sc-status',
+      'cs(Referer)', 'cs(User-Agent)', 'time-to-first-byte', 'sc-content-type', 'x-host-header',
+    ],
+  },
+};
+
+export const DEFAULT_CDN_PROVIDER = 'cloudfront';
+
+function getProviderConfig(provider) {
+  const config = CDN_PROVIDERS[provider];
+  if (!config) {
+    throw new Error(`Unsupported CDN provider: ${provider}`);
+  }
+  return config;
+}
+
+/**
+ * Normalize an IMS org id into the AWS-safe token used in cdn-logs resource names. Mirrors
+ * spacecat-auth-service `toSafeAwsName` — must match byte-for-byte so the destination resolves.
+ */
+export function toSafeAwsName(imsOrgId) {
+  return String(imsOrgId).replace(/@AdobeOrg$/, '').replace(/@/g, '').toLowerCase();
+}
+
+/**
+ * Build the cross-account delivery-destination ARN Adobe provisioned for this org's cdn-logs
+ * bucket (`cdn-logs-<org>`). Provider-agnostic.
+ */
+export function buildDeliveryDestinationArn({
+  imsOrgId,
+  adobeAccountId,
+  region = CDN_LOG_DELIVERY_REGION,
+}) {
+  if (!hasText(imsOrgId)) {
+    throw new Error('imsOrgId is required');
+  }
+  if (!/^[0-9]{12}$/.test(String(adobeAccountId))) {
+    throw new Error('adobeAccountId must be a 12-digit AWS account ID');
+  }
+  const name = `cdn-logs-${toSafeAwsName(imsOrgId)}`;
+  return `arn:aws:logs:${region}:${adobeAccountId}:delivery-destination:${name}`;
+}
+
+/** Per-resource delivery-source name, scoped by provider + org + resource. */
+export function buildDeliverySourceName({
+  provider = DEFAULT_CDN_PROVIDER,
+  imsOrgId,
+  resourceId,
+}) {
+  const { sourceNamePrefix } = getProviderConfig(provider);
+  return `${sourceNamePrefix}-${toSafeAwsName(imsOrgId)}-${resourceId}`;
+}
+
+/**
+ * Enable CDN access-log forwarding to Adobe (diagram step 8): create the customer-account
+ * delivery source and link it to Adobe's cross-account destination so the CDN pushes logs to
+ * the cdn-logs S3 bucket.
+ *
+ * Idempotent — returns `{ created: false, alreadyExisted: true }` and mutates nothing when a
+ * delivery from this resource's source already exists.
+ *
+ * @param {object} credentials - temporary credentials from the connector role assume-role.
+ * @param {object} params
+ * @param {string} [params.provider] - CDN provider key (see CDN_PROVIDERS); defaults to cloudfront.
+ * @param {string} params.resourceId - the CDN resource id (e.g. CloudFront distribution id).
+ * @param {string} params.accountId - 12-digit customer AWS account id.
+ * @param {string} params.imsOrgId
+ * @param {string} params.deliveryDestinationArn - Adobe's cross-account destination ARN.
+ * @param {string} [params.region]
+ * @returns {Promise<{created: boolean, alreadyExisted: boolean, deliverySourceName: string,
+ *   deliveryId: string|undefined}>}
+ */
+export async function createCdnLogDelivery(credentials, {
+  provider = DEFAULT_CDN_PROVIDER,
+  resourceId,
+  accountId,
+  imsOrgId,
+  deliveryDestinationArn,
+  region = CDN_LOG_DELIVERY_REGION,
+}) {
+  const config = getProviderConfig(provider);
+  if (!hasText(resourceId)) {
+    throw new Error('resourceId is required');
+  }
+  if (!/^[0-9]{12}$/.test(String(accountId))) {
+    throw new Error('accountId must be a 12-digit AWS account ID');
+  }
+  if (!hasText(imsOrgId)) {
+    throw new Error('imsOrgId is required');
+  }
+  if (!hasText(deliveryDestinationArn)) {
+    throw new Error('deliveryDestinationArn is required');
+  }
+
+  const client = new CloudWatchLogsClient({ region, credentials });
+  const deliverySourceName = buildDeliverySourceName({ provider, imsOrgId, resourceId });
+  const resourceArn = config.buildResourceArn({ accountId, resourceId });
+
+  // No-op if forwarding is already enabled for this resource.
+  let sourceExists = false;
+  try {
+    await client.send(new GetDeliverySourceCommand({ name: deliverySourceName }));
+    sourceExists = true;
+  } catch (err) {
+    if (err?.name !== 'ResourceNotFoundException') {
+      throw err;
+    }
+  }
+
+  if (sourceExists) {
+    const { deliveries = [] } = await client.send(new DescribeDeliveriesCommand({}));
+    const existing = deliveries.find((d) => d.deliverySourceName === deliverySourceName);
+    if (existing) {
+      return {
+        created: false,
+        alreadyExisted: true,
+        deliverySourceName,
+        deliveryId: existing.id,
+      };
+    }
+  }
+
+  await client.send(new PutDeliverySourceCommand({
+    name: deliverySourceName,
+    resourceArn,
+    logType: config.logType,
+  }));
+
+  const response = await client.send(new CreateDeliveryCommand({
+    deliverySourceName,
+    deliveryDestinationArn,
+    s3DeliveryConfiguration: { suffixPath: CDN_LOG_S3_SUFFIX_PATH },
+    recordFields: config.recordFields,
+  }));
+
+  return {
+    created: true,
+    alreadyExisted: false,
+    deliverySourceName,
+    deliveryId: response?.delivery?.id,
+  };
+}

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -97,6 +97,8 @@ describe('LlmoController', () => {
   let applyEdgeOptimizeAssociationsStub;
   let verifyEdgeOptimizeRoutingStub;
   let runEdgeOptimizeDeployStepStub;
+  let createCdnLogDeliveryStub;
+  let buildDeliveryDestinationArnStub;
   let mockTokowakaClient;
   let readStrategyStub;
   let writeStrategyStub;
@@ -298,6 +300,10 @@ describe('LlmoController', () => {
         applyEdgeOptimizeAssociations: (...args) => applyEdgeOptimizeAssociationsStub(...args),
         verifyEdgeOptimizeRouting: (...args) => verifyEdgeOptimizeRoutingStub(...args),
         runEdgeOptimizeDeployStep: (...args) => runEdgeOptimizeDeployStepStub(...args),
+      },
+      '../../../src/support/cdn-log-delivery.js': {
+        createCdnLogDelivery: (...args) => createCdnLogDeliveryStub(...args),
+        buildDeliveryDestinationArn: (...args) => buildDeliveryDestinationArnStub(...args),
       },
       '@adobe/spacecat-shared-ims-client': {
         ImsClient: function MockImsClient() {
@@ -615,6 +621,7 @@ describe('LlmoController', () => {
       setConfig: sinon.stub(),
       save: sinon.stub().resolves(),
       getOrganization: sinon.stub().resolves(mockOrganization),
+      getOrganizationId: sinon.stub().returns(TEST_ORG_ID),
       getBaseURL: sinon.stub().returns('https://www.example.com'),
     };
 
@@ -625,6 +632,7 @@ describe('LlmoController', () => {
 
     mockDataAccess = {
       Site: { findById: sinon.stub().resolves(mockSite) },
+      Organization: { findById: sinon.stub().resolves(mockOrganization) },
       Entitlement: {
         PRODUCT_CODES: { LLMO: 'llmo' },
         findByOrganizationIdAndProductCode: sinon.stub().resolves({
@@ -746,6 +754,9 @@ describe('LlmoController', () => {
     llmoConfigSchemaStub = {
       safeParse: sinon.stub().returns({ success: true, data: {} }),
     };
+    createCdnLogDeliveryStub = sinon.stub();
+    buildDeliveryDestinationArnStub = sinon.stub()
+      .returns('arn:aws:logs:us-east-1:111122223333:delivery-destination:cdn-logs-org');
 
     // Use the global LlmoController from before hook
     controller = LlmoController(mockContext);
@@ -7826,6 +7837,149 @@ describe('LlmoController', () => {
       const deniedController = controllerWithAccessDenied(mockContext);
 
       const result = await deniedController.getEdgeOptimizeDistributions(distributionsContext);
+
+      expect(result.status).to.equal(403);
+    });
+  });
+
+  describe('enableCdnLogDelivery', () => {
+    let logDeliveryContext;
+
+    beforeEach(() => {
+      assumeConnectorRoleStub = sinon.stub().resolves({
+        roleArn: 'arn:aws:iam::120569600543:role/AdobeLLMOptimizerCloudFrontConnectorRole',
+        accountId: '120569600543',
+        credentials: { accessKeyId: 'AKIA', secretAccessKey: 'secret', sessionToken: 'token' },
+      });
+      createCdnLogDeliveryStub = sinon.stub().resolves({
+        created: true,
+        alreadyExisted: false,
+        deliverySourceName: 'llmo-cf-org-E2EXAMPLE123',
+        deliveryId: 'del-1',
+      });
+      buildDeliveryDestinationArnStub = sinon.stub()
+        .returns('arn:aws:logs:us-east-1:111122223333:delivery-destination:cdn-logs-org');
+      logDeliveryContext = {
+        ...mockContext,
+        params: { siteId: TEST_SITE_ID },
+        data: {
+          accountId: '120569600543',
+          externalId: '7ff9518a-cf59-40b4-aa53-68a3cb2e24a5',
+          distributionId: 'E2EXAMPLE123',
+        },
+        env: { CDN_LOG_DELIVERY_DEST_ACCOUNT_ID: '111122223333' },
+      };
+    });
+
+    it('enables log forwarding and returns the delivery result', async () => {
+      const result = await controller.enableCdnLogDelivery(logDeliveryContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.created).to.equal(true);
+      expect(body.deliveryId).to.equal('del-1');
+      expect(assumeConnectorRoleStub.calledOnce).to.equal(true);
+      const callArgs = createCdnLogDeliveryStub.firstCall.args[1];
+      expect(callArgs.provider).to.equal('cloudfront');
+      expect(callArgs.resourceId).to.equal('E2EXAMPLE123');
+    });
+
+    it('is a no-op when forwarding is already enabled', async () => {
+      createCdnLogDeliveryStub.resolves({
+        created: false,
+        alreadyExisted: true,
+        deliverySourceName: 'llmo-cf-org-E2EXAMPLE123',
+        deliveryId: 'del-existing',
+      });
+
+      const result = await controller.enableCdnLogDelivery(logDeliveryContext);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.alreadyExisted).to.equal(true);
+    });
+
+    it('returns 400 for an invalid account id', async () => {
+      const result = await controller.enableCdnLogDelivery({
+        ...logDeliveryContext,
+        data: { ...logDeliveryContext.data, accountId: '123' },
+      });
+
+      expect(result.status).to.equal(400);
+      expect((await result.json()).message).to.include('12-digit');
+    });
+
+    it('returns 400 when the external id is missing', async () => {
+      const result = await controller.enableCdnLogDelivery({
+        ...logDeliveryContext,
+        data: { accountId: '120569600543', distributionId: 'E2EXAMPLE123' },
+      });
+
+      expect(result.status).to.equal(400);
+      expect((await result.json()).message).to.include('externalId');
+    });
+
+    it('returns 400 when the distribution id is missing', async () => {
+      const result = await controller.enableCdnLogDelivery({
+        ...logDeliveryContext,
+        data: { accountId: '120569600543', externalId: 'ext' },
+      });
+
+      expect(result.status).to.equal(400);
+      expect((await result.json()).message).to.include('distributionId');
+    });
+
+    it('returns 400 when the destination account is not configured', async () => {
+      const result = await controller.enableCdnLogDelivery({ ...logDeliveryContext, env: {} });
+
+      expect(result.status).to.equal(400);
+      expect((await result.json()).message).to.include('not configured');
+    });
+
+    it('returns 400 when the site organization has no IMS org id', async () => {
+      mockDataAccess.Organization.findById.resolves({ getImsOrgId: () => undefined });
+
+      const result = await controller.enableCdnLogDelivery(logDeliveryContext);
+
+      expect(result.status).to.equal(400);
+      expect((await result.json()).message).to.include('IMS org');
+    });
+
+    it('returns a clear error when the Adobe destination is not provisioned', async () => {
+      createCdnLogDeliveryStub.rejects(new Error('ResourceNotFoundException: delivery destination not found'));
+
+      const result = await controller.enableCdnLogDelivery(logDeliveryContext);
+
+      expect(result.status).to.equal(400);
+      expect((await result.json()).message).to.include('not provisioned');
+    });
+
+    it('returns 404 when the site is not found', async () => {
+      mockDataAccess.Site.findById.resolves(null);
+
+      const result = await controller.enableCdnLogDelivery(logDeliveryContext);
+
+      expect(result.status).to.equal(404);
+    });
+
+    it('returns 403 when the user lacks access to the site', async () => {
+      const deniedController = controllerWithAccessDenied(mockContext);
+
+      const result = await deniedController.enableCdnLogDelivery(logDeliveryContext);
+
+      expect(result.status).to.equal(403);
+    });
+
+    it('returns 403 when the user is not an LLMO administrator', async () => {
+      const LlmoControllerNoAdmin = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true, true, false),
+        '@adobe/spacecat-shared-http-utils': mockHttpUtils,
+        '../../../src/support/cached-response.js': mockCachedResponse,
+        ...getCommonMocks(),
+      });
+
+      const result = await LlmoControllerNoAdmin(mockContext)
+        .enableCdnLogDelivery(logDeliveryContext);
 
       expect(result.status).to.equal(403);
     });

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1109,6 +1109,7 @@ describe('getRouteHandlers', () => {
       'POST /sites/:siteId/llmo/edge-optimize/apply-associations',
       'POST /sites/:siteId/llmo/edge-optimize/verify',
       'POST /sites/:siteId/llmo/edge-optimize/deploy',
+      'POST /sites/:siteId/llmo/cdn-log-delivery',
       'GET /sites/:siteId/llmo/edge-optimize-status',
       'GET /sites/:siteId/llmo/probes/edge-optimize',
       'GET /sites/:siteId/llmo/strategy',

--- a/test/support/cdn-log-delivery.test.js
+++ b/test/support/cdn-log-delivery.test.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+describe('cdn-log-delivery support', () => {
+  let logsSendStub;
+  let cdnLogDelivery;
+
+  const CREDS = { accessKeyId: 'AK', secretAccessKey: 'SK', sessionToken: 'ST' };
+  const IMS_ORG = '1234567890ABCDEF12345678@AdobeOrg';
+  const SAFE_ORG = '1234567890abcdef12345678';
+  const ACCOUNT = '123456789012';
+  const DIST = 'E1ABCDEF';
+  const DEST_ARN = `arn:aws:logs:us-east-1:111122223333:delivery-destination:cdn-logs-${SAFE_ORG}`;
+
+  before(async function setupEsmock() {
+    this.timeout(120000);
+    const logsCommand = (Name) => function LogsCommand(input) {
+      this.input = input;
+      this.commandName = Name;
+    };
+    cdnLogDelivery = await esmock('../../src/support/cdn-log-delivery.js', {
+      '@aws-sdk/client-cloudwatch-logs': {
+        CloudWatchLogsClient: function CloudWatchLogsClient(config) {
+          this.config = config;
+          this.send = (cmd) => logsSendStub(cmd);
+        },
+        PutDeliverySourceCommand: logsCommand('PutDeliverySource'),
+        CreateDeliveryCommand: logsCommand('CreateDelivery'),
+        GetDeliverySourceCommand: logsCommand('GetDeliverySource'),
+        DescribeDeliveriesCommand: logsCommand('DescribeDeliveries'),
+      },
+    });
+  });
+
+  beforeEach(() => {
+    logsSendStub = sinon.stub();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('toSafeAwsName', () => {
+    it('strips @AdobeOrg, drops @, lowercases', () => {
+      expect(cdnLogDelivery.toSafeAwsName(IMS_ORG)).to.equal(SAFE_ORG);
+    });
+  });
+
+  describe('buildDeliveryDestinationArn', () => {
+    it('builds the cdn-logs-<org> destination ARN (no -ams suffix)', () => {
+      const arn = cdnLogDelivery.buildDeliveryDestinationArn({
+        imsOrgId: IMS_ORG,
+        adobeAccountId: '111122223333',
+      });
+      expect(arn).to.equal(DEST_ARN);
+    });
+
+    it('rejects a non-12-digit Adobe account id', () => {
+      expect(() => cdnLogDelivery.buildDeliveryDestinationArn({
+        imsOrgId: IMS_ORG,
+        adobeAccountId: '123',
+      })).to.throw('adobeAccountId must be a 12-digit AWS account ID');
+    });
+
+    it('rejects a missing imsOrgId', () => {
+      expect(() => cdnLogDelivery.buildDeliveryDestinationArn({
+        adobeAccountId: '111122223333',
+      })).to.throw('imsOrgId is required');
+    });
+  });
+
+  describe('buildDeliverySourceName', () => {
+    it('uses the cloudfront prefix by default', () => {
+      expect(cdnLogDelivery.buildDeliverySourceName({ imsOrgId: IMS_ORG, resourceId: DIST }))
+        .to.equal(`llmo-cf-${SAFE_ORG}-${DIST}`);
+    });
+
+    it('throws on an unsupported provider', () => {
+      expect(() => cdnLogDelivery.buildDeliverySourceName({
+        provider: 'fastly',
+        imsOrgId: IMS_ORG,
+        resourceId: DIST,
+      })).to.throw('Unsupported CDN provider: fastly');
+    });
+  });
+
+  describe('createCdnLogDelivery', () => {
+    const base = {
+      resourceId: DIST,
+      accountId: ACCOUNT,
+      imsOrgId: IMS_ORG,
+      deliveryDestinationArn: DEST_ARN,
+    };
+
+    it('creates source + delivery when none exists', async () => {
+      const notFound = new Error('not found');
+      notFound.name = 'ResourceNotFoundException';
+      logsSendStub.onCall(0).rejects(notFound); // GetDeliverySource
+      logsSendStub.onCall(1).resolves({}); // PutDeliverySource
+      logsSendStub.onCall(2).resolves({ delivery: { id: 'del-1' } }); // CreateDelivery
+
+      const result = await cdnLogDelivery.createCdnLogDelivery(CREDS, base);
+
+      expect(result).to.deep.equal({
+        created: true,
+        alreadyExisted: false,
+        deliverySourceName: `llmo-cf-${SAFE_ORG}-${DIST}`,
+        deliveryId: 'del-1',
+      });
+      const put = logsSendStub.getCall(1).args[0];
+      expect(put.commandName).to.equal('PutDeliverySource');
+      expect(put.input.resourceArn).to.equal(`arn:aws:cloudfront::${ACCOUNT}:distribution/${DIST}`);
+      expect(put.input.logType).to.equal('ACCESS_LOGS');
+      const create = logsSendStub.getCall(2).args[0];
+      expect(create.input.deliveryDestinationArn).to.equal(DEST_ARN);
+      expect(create.input.s3DeliveryConfiguration).to.deep.equal({ suffixPath: '/{yyyy}/{MM}/{dd}/{HH}' });
+      expect(create.input.recordFields).to.include('x-host-header');
+    });
+
+    it('is a no-op when a delivery already exists', async () => {
+      logsSendStub.onCall(0).resolves({ deliverySource: {} }); // GetDeliverySource → exists
+      logsSendStub.onCall(1).resolves({
+        deliveries: [{ id: 'del-existing', deliverySourceName: `llmo-cf-${SAFE_ORG}-${DIST}` }],
+      }); // DescribeDeliveries
+
+      const result = await cdnLogDelivery.createCdnLogDelivery(CREDS, base);
+
+      expect(result).to.deep.equal({
+        created: false,
+        alreadyExisted: true,
+        deliverySourceName: `llmo-cf-${SAFE_ORG}-${DIST}`,
+        deliveryId: 'del-existing',
+      });
+      expect(logsSendStub.callCount).to.equal(2); // no Put/Create
+    });
+
+    it('creates the delivery when the source exists but no delivery is linked', async () => {
+      logsSendStub.onCall(0).resolves({ deliverySource: {} }); // GetDeliverySource → exists
+      logsSendStub.onCall(1).resolves({ deliveries: [] }); // DescribeDeliveries → none
+      logsSendStub.onCall(2).resolves({}); // PutDeliverySource (upsert)
+      logsSendStub.onCall(3).resolves({ delivery: { id: 'del-2' } }); // CreateDelivery
+
+      const result = await cdnLogDelivery.createCdnLogDelivery(CREDS, base);
+      expect(result.created).to.equal(true);
+      expect(result.deliveryId).to.equal('del-2');
+    });
+
+    it('rethrows a non-NotFound error from GetDeliverySource', async () => {
+      logsSendStub.onCall(0).rejects(new Error('AccessDenied'));
+      await expect(cdnLogDelivery.createCdnLogDelivery(CREDS, base))
+        .to.be.rejectedWith('AccessDenied');
+    });
+
+    it('rejects an unsupported provider', async () => {
+      await expect(cdnLogDelivery.createCdnLogDelivery(CREDS, { ...base, provider: 'akamai' }))
+        .to.be.rejectedWith('Unsupported CDN provider: akamai');
+    });
+
+    it('rejects a missing resourceId', async () => {
+      await expect(cdnLogDelivery.createCdnLogDelivery(CREDS, { ...base, resourceId: '' }))
+        .to.be.rejectedWith('resourceId is required');
+    });
+
+    it('rejects a non-12-digit account id', async () => {
+      await expect(cdnLogDelivery.createCdnLogDelivery(CREDS, { ...base, accountId: '1' }))
+        .to.be.rejectedWith('accountId must be a 12-digit AWS account ID');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `POST /sites/:siteId/llmo/cdn-log-delivery` — **diagram step 8** (log forwarding). Via the cross-account connector role from #2654, it creates the customer-account **CloudWatch Logs delivery source** for a CloudFront distribution and links it to **Adobe's cross-account delivery destination**, so CloudFront pushes standard logs to the cdn-logs S3 bucket (step 9, automatic). Maps to the Experience League CLI doc's *"Create the delivery source"* + *"Create the delivery configuration"* (`logs put-delivery-source` + `logs create-delivery`).

**Stacked on #2654** (base branch = `feat/llmo-edge-optimize-cloudfront-wizard`) — it reuses `assumeConnectorRole`, the wizard access gate, and the `{accountId, externalId, distributionId}` request shape. Review only the log-forwarding commit.

## Design

- **Idempotent** — checks `GetDeliverySource` + `DescribeDeliveries` first; if forwarding is already configured it's a **no-op** returning `{ alreadyExisted: true }`.
- **Provider-agnostic** support module `src/support/cdn-log-delivery.js` with a `CDN_PROVIDERS` registry. CloudFront is the first provider; other CDNs slot in without touching the delivery flow.
- **BYOCDN naming**: destination is `cdn-logs-<org>` (**no `-ams` suffix** — that suffix is only for the `ams-cloudfront` source). `toSafeAwsName` mirrors spacecat-auth-service so the destination name matches byte-for-byte.
- Adds `@aws-sdk/client-cloudwatch-logs`. Admin/IMS-only via `INTERNAL_ROUTES` + `required-capabilities`. OpenAPI documented.
- The Adobe destination account comes from `CDN_LOG_DELIVERY_DEST_ACCOUNT_ID` env (**required, no in-code default**).

## Tests

- Support module: 13 (mocked AWS SDK) — create / no-op / source-exists-no-delivery / error passthrough / provider + validation.
- Controller: 11 — happy path, no-op, 400 (invalid account / missing externalId / missing distributionId / dest account not configured / no IMS org / destination not provisioned), 404, 403 ×2.
- Routes + required-capabilities green; `docs:lint` valid; lint clean.

## ⚠️ Cross-service dependencies (to confirm — not in this PR)

1. **Connector-role IAM policy** (`customer-bootstrap-role.yaml`, hosted in the `EDGE_OPTIMIZE_TEMPLATE_BUCKET` S3 bucket — not in any repo) must add `logs:PutDeliverySource`, `logs:CreateDelivery`, `logs:GetDeliverySource`, `logs:DescribeDeliveries`. Today it grants CloudFront perms only — AssumeRole succeeds but the `logs:*` calls would be denied.
2. **Adobe-side cdn-logs provisioning** (spacecat-auth-service) must have created the `cdn-logs-<org>` delivery destination + cross-account policy. The `provision` path currently no-ops for `ams-cloudfront`+UI (`provision.js:1540`) — confirm the BYOCDN path provisions the destination. The handler surfaces a clear "destination not provisioned" error if it's missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)