### PR TITLE
feat(preflight): swap callMysticatAnalyze headers — Authorization for IMS, x-page-auth for page-auth (SITES-46967)

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -325,7 +325,7 @@ function PreflightController(ctx, log, env) {
    * @param {string} scanId - The AsyncJob ID used as the scan identifier for write-back.
    * @param {string} siteId - The site ID.
    * @param {string} url - The page URL to analyze.
-   * @param {string} [authorizationHeader] - Optional customer-site page-auth header.
+   * @param {string} [pageAuthHeader] - Optional customer-site page-auth header.
    * @param {string} [imsServiceToken] - Optional spacecat IMS v3 service token (raw access_token).
    */
   async function callMysticatAnalyze(
@@ -333,7 +333,7 @@ function PreflightController(ctx, log, env) {
     scanId,
     siteId,
     url,
-    authorizationHeader,
+    pageAuthHeader,
     imsServiceToken,
   ) {
     const controller = new AbortController();
@@ -346,7 +346,7 @@ function PreflightController(ctx, log, env) {
         headers: {
           'Content-Type': 'application/json',
           ...(hasText(imsServiceToken) && { Authorization: `Bearer ${imsServiceToken}` }),
-          ...(hasText(authorizationHeader) && { 'x-page-auth': authorizationHeader }),
+          ...(hasText(pageAuthHeader) && { 'x-page-auth': pageAuthHeader }),
         },
         body: JSON.stringify({
           site_id: siteId,
@@ -464,7 +464,7 @@ function PreflightController(ctx, log, env) {
       log.warn(`checkEnableAuthentication failed for ${previewBaseURL}: ${e.message}`);
       enableAuthentication = false;
     }
-    let authorizationHeader;
+    let pageAuthHeader;
     if (enableAuthentication) {
       let promiseTokenObj;
       try {
@@ -480,7 +480,7 @@ function PreflightController(ctx, log, env) {
         const authOptions = promiseTokenObj ? { promiseToken: promiseTokenObj } : {};
         const accessToken = await retrievePageAuthentication(site, context, authOptions);
         const isBearer = site.getDeliveryType() === DELIVERY_TYPES.AEM_CS && !!promiseTokenObj;
-        authorizationHeader = `${isBearer ? 'Bearer' : 'token'} ${accessToken}`;
+        pageAuthHeader = `${isBearer ? 'Bearer' : 'token'} ${accessToken}`;
       } catch (e) {
         log.error(`Failed to retrieve page authentication: ${e.message}`);
         return preflightError('PREFLIGHT_INTERNAL_ERROR', 'Error retrieving page authentication', 500);
@@ -489,9 +489,11 @@ function PreflightController(ctx, log, env) {
 
     // Mint a spacecat-api-service IMS service token for the Mystique CGW
     // edge gate (SITES-43236 / SITES-46699 / mystique-deploy PR #463). Sent
-    // on the dedicated x-ims-authorization header — separate from
-    // `Authorization` above, which carries the customer site's page-auth
-    // token for DRS upstream.
+    // on the `Authorization` header (SITES-46967 swap — was previously on a
+    // dedicated `x-ims-authorization` header; moved to the default slot so
+    // CGW emits the X-Gw-Ims-Client-Id identity header downstream). The
+    // customer page-auth that previously rode `Authorization` now rides
+    // `x-page-auth` and is forwarded to DRS upstream by mystique.
     //
     // Constructs a custom-env ImsClient with the dedicated PREFLIGHT_IMS_*
     // credentials provisioned in Vault for this S2S use case (SITES-46699).
@@ -594,7 +596,7 @@ function PreflightController(ctx, log, env) {
         asyncJob.getId(),
         siteId,
         url,
-        authorizationHeader,
+        pageAuthHeader,
         imsServiceToken,
       );
     } catch (mysticatError) {

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -309,13 +309,17 @@ function PreflightController(ctx, log, env) {
    * Mysticat processes the analysis asynchronously and writes results directly to the AsyncJob
    * identified by scanId.
    *
-   * Two distinct auth headers are sent (SITES-43236 / mystique-deploy PR #463):
-   *  - `Authorization`: the customer site's page-auth token, forwarded by
-   *    Mysticat to DRS for authenticated page-HTML fetch.
-   *  - `x-ims-authorization`: spacecat-api-service's own IMS service token,
-   *    validated at the Ethos CGW-Flex edge before reaching the Mysticat pod.
-   *    Kept on a dedicated header — not `Authorization` — so the IMS edge gate
-   *    does not collide with the customer's page-auth token above.
+   * Two distinct auth headers are sent (SITES-46967 — header layout swap):
+   *  - `Authorization`: spacecat-api-service's own IMS service token,
+   *    validated at the Ethos CGW-Flex edge before reaching the Mysticat
+   *    pod. On the default header so CGW emits the `X-Gw-Ims-Client-Id`
+   *    identity header downstream (CGW only forwards identity headers when
+   *    the token is read from the default `Authorization` slot — empirically
+   *    confirmed under SITES-46874).
+   *  - `x-page-auth`: the customer site's page-auth token, forwarded by
+   *    Mysticat to DRS for authenticated page-HTML fetch. Moved off
+   *    `Authorization` to make room for the IMS service token (previously
+   *    rode `Authorization`, the IMS token rode `x-ims-authorization`).
    *
    * @param {string} mysticatBaseUrl - The base URL of the Mystique service (MYSTIQUE_API_BASE_URL).
    * @param {string} scanId - The AsyncJob ID used as the scan identifier for write-back.
@@ -341,8 +345,8 @@ function PreflightController(ctx, log, env) {
         signal: controller.signal,
         headers: {
           'Content-Type': 'application/json',
-          ...(hasText(authorizationHeader) && { Authorization: authorizationHeader }),
-          ...(hasText(imsServiceToken) && { 'x-ims-authorization': `Bearer ${imsServiceToken}` }),
+          ...(hasText(imsServiceToken) && { Authorization: `Bearer ${imsServiceToken}` }),
+          ...(hasText(authorizationHeader) && { 'x-page-auth': authorizationHeader }),
         },
         body: JSON.stringify({
           site_id: siteId,

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1589,18 +1589,20 @@ describe('Preflight Controller', () => {
       expect(body.audits).to.be.undefined;
     });
 
-    it('does not include Authorization header when HEAD returns 200 (no auth needed)', async () => {
+    it('does not include x-page-auth header when HEAD returns 200 (no page-auth needed)', async () => {
       await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
       });
       const [, calledOptions] = fetchStub.secondCall.args;
-      expect(calledOptions.headers.Authorization).to.be.undefined;
+      // SITES-46967: page-auth header moved off Authorization onto x-page-auth.
+      // Authorization is now reserved for the IMS service token (always set).
+      expect(calledOptions.headers['x-page-auth']).to.be.undefined;
     });
 
-    // -- IMS service token on x-ims-authorization (SITES-43236) --
+    // -- IMS service token on Authorization, customer page-auth on x-page-auth (SITES-46967) --
 
-    it('attaches the IMS service token on x-ims-authorization (Bearer prefix)', async () => {
+    it('attaches the IMS service token on Authorization (Bearer prefix)', async () => {
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
@@ -1626,21 +1628,21 @@ describe('Preflight Controller', () => {
       );
       expect(mockImsClient.getServiceAccessToken).to.have.been.calledOnce;
       const [, calledOptions] = fetchStub.secondCall.args;
-      // Bearer prefix mirrors the v3-token convention; verified against the
-      // mystique-deploy CGW-Flex validator (Authorization on /v1/apply uses
-      // the same shape).
-      expect(calledOptions.headers['x-ims-authorization']).to.equal(
+      // SITES-46967: IMS service token rides Authorization (default CGW slot)
+      // so the Ethos CGW-Flex edge emits X-Gw-Ims-Client-Id downstream — the
+      // header mystique's require_preflight_service_client dep reads.
+      expect(calledOptions.headers.Authorization).to.equal(
         'Bearer test-ims-service-token',
       );
-      // The customer-site page-auth header lives on a different key and
-      // must not be clobbered or duplicated by the IMS attachment.
-      expect(calledOptions.headers.Authorization).to.be.undefined;
+      // No customer-page-auth header when the page is un-authenticated.
+      expect(calledOptions.headers['x-page-auth']).to.be.undefined;
     });
 
-    it('keeps Authorization (page-auth) and x-ims-authorization (IMS) on separate headers when both are present', async () => {
+    it('keeps Authorization (IMS) and x-page-auth (page-auth) on separate headers when both are present', async () => {
       // HEAD returns 401 → enableAuthentication=true → retrievePageAuthentication
-      // resolves a customer-site token onto Authorization. The IMS token still
-      // rides x-ims-authorization independently.
+      // resolves a customer-site token. SITES-46967: page-auth rides
+      // x-page-auth (was Authorization); IMS service token rides Authorization
+      // (was x-ims-authorization).
       fetchStub.onFirstCall().resolves({ ok: false, status: 401 });
       const aemCsSite = {
         ...mockSite,
@@ -1681,10 +1683,10 @@ describe('Preflight Controller', () => {
       });
       expect(response.status).to.equal(202);
       const [, calledOptions] = fetchStub.secondCall.args;
-      expect(calledOptions.headers.Authorization).to.equal('token customer-site-token');
-      expect(calledOptions.headers['x-ims-authorization']).to.equal(
+      expect(calledOptions.headers.Authorization).to.equal(
         'Bearer test-ims-service-token',
       );
+      expect(calledOptions.headers['x-page-auth']).to.equal('token customer-site-token');
     });
 
     it('returns 500 PREFLIGHT_INTERNAL_ERROR when IMS service-token mint fails', async () => {
@@ -1789,7 +1791,7 @@ describe('Preflight Controller', () => {
 
     // -- enableAuthentication=true path (HEAD returns 401) --
 
-    it('forwards Authorization header to Mysticat for auth-required URL with x-promise-token header', async () => {
+    it('forwards page-auth on x-page-auth to Mysticat for auth-required URL with x-promise-token header', async () => {
       // First fetch (HEAD): 401 → enableAuthentication=true.
       // Use CS_CW so resolvePromiseToken consults the x-promise-token header
       // (PROMISE_BASED_AUTHORING_TYPES = [CS, CS_CW, AMS]).
@@ -1838,8 +1840,11 @@ describe('Preflight Controller', () => {
       });
       expect(response.status).to.equal(202);
       const [, mystiOpts] = fetchStub.secondCall.args;
-      // CS_CW + promiseToken → isBearer false (DeliveryType !== AEM_CS) → 'token <t>'
-      expect(mystiOpts.headers.Authorization).to.equal('token page-access-token');
+      // CS_CW + promiseToken → isBearer false (DeliveryType !== AEM_CS) → 'token <t>'.
+      // SITES-46967: page-auth rides x-page-auth (Authorization now carries
+      // the IMS service token, validated at the CGW-Flex edge).
+      expect(mystiOpts.headers['x-page-auth']).to.equal('token page-access-token');
+      expect(mystiOpts.headers.Authorization).to.equal('Bearer test-ims-service-token');
       expect(mockRetrievePageAuth).to.have.been.calledOnce;
     });
 
@@ -2038,8 +2043,9 @@ describe('Preflight Controller', () => {
       expect(authOptsArg).to.deep.equal({});
     });
 
-    it('uses Bearer prefix for AEM_CS site with x-promise-token header', async () => {
+    it('uses Bearer prefix on x-page-auth for AEM_CS site with x-promise-token header', async () => {
       // Covers the `isBearer` branch where DeliveryType === AEM_CS && promiseTokenObj truthy.
+      // SITES-46967: page-auth header moved to x-page-auth; Bearer prefix logic unchanged.
       fetchStub.resetBehavior();
       fetchStub.onFirstCall().resolves({ ok: false, status: 401 });
       fetchStub.onSecondCall().resolves({ ok: true });
@@ -2083,7 +2089,8 @@ describe('Preflight Controller', () => {
       });
       expect(response.status).to.equal(202);
       const [, mystiOpts] = fetchStub.secondCall.args;
-      expect(mystiOpts.headers.Authorization).to.equal('Bearer cs-token');
+      expect(mystiOpts.headers['x-page-auth']).to.equal('Bearer cs-token');
+      expect(mystiOpts.headers.Authorization).to.equal('Bearer test-ims-service-token');
     });
 
     it('falls back to profile.name and profile.email when first_name/last_name are absent', async () => {
@@ -2133,10 +2140,11 @@ describe('Preflight Controller', () => {
       // We proceeded past the HEAD failure (defaulting to auth-not-required)
       // and Mysticat accepted the call — so 202, not 500.
       expect(response.status).to.equal(202);
-      // The Mysticat call was made without an Authorization header (auth
-      // was skipped because the HEAD probe threw).
+      // The Mysticat call was made without an x-page-auth header (page-auth
+      // was skipped because the HEAD probe threw). Authorization is still
+      // set — SITES-46967 moved the IMS service token onto Authorization.
       const [, mystiOpts] = fetchStub.secondCall.args;
-      expect(mystiOpts.headers.Authorization).to.be.undefined;
+      expect(mystiOpts.headers['x-page-auth']).to.be.undefined;
     });
 
     it('returns 500 and rolls back the AsyncJob when Preflight.create throws', async () => {


### PR DESCRIPTION
## What & why

[SITES-46967](https://jira.corp.adobe.com/browse/SITES-46967) — empirical verification of [SITES-46874](https://jira.corp.adobe.com/browse/SITES-46874) + [SITES-46887](https://jira.corp.adobe.com/browse/SITES-46887) surfaced that CGW-Flex only forwards `X-Gw-Ims-Client-Id` (and other identity headers) when the IMS token is on the **default `Authorization` header**. Our previous custom `x-ims-authorization` header validated correctly at the edge but didn't trigger identity-header forwarding — confirmed by the CGW team via Slack, citing the [headers reference](https://git.corp.adobe.com/adobe-apis/cluster-gateway-docs/blob/main/docs/reference/headers.md) and [FAQ trust-model section](https://git.corp.adobe.com/adobe-apis/cluster-gateway-docs/blob/main/docs/faq.md).

This PR swaps the header layout in `callMysticatAnalyze`:

| | Old | New |
|---|---|---|
| Authorization | `<customer page-auth>` | `Bearer <IMS service token>` |
| Custom header | `x-ims-authorization: Bearer <IMS>` | `x-page-auth: <customer page-auth>` |

## Why we made the original choice — and why we're flipping it

The original layout ([mystique-deploy #463](https://git.corp.adobe.com/experience-platform/mystique-deploy/pull/463)) put IMS on a custom header to avoid colliding with the customer page-auth on `Authorization` that mystique forwards to DRS upstream. Reasonable given what we knew.

What we now know: CGW emits the `X-Gw-Ims-*` identity-header family only for tokens on the default `Authorization` slot. Custom-header validation works (and we proved this — the edge correctly rejects token-less requests under Phase 2), but the pod-side `require_preflight_service_client` dep can't get the identity it needs.

Better factoring: **`Authorization` for the inbound auth that CGW validates; a custom header for the credential mystique forwards upstream.** This is the canonical CGW pattern.

Dev is the right moment to make this swap — we're the only active caller, no prod traffic to migrate.

## Files

- `src/controllers/preflight.js` — `callMysticatAnalyze`: swap the headers + update the docstring rationale
- `test/controllers/preflight.test.js` — flip the assertions on existing tests (rename test titles, swap `Authorization` ↔ `x-page-auth` in expects), update the "no-auth-needed" test to check `x-page-auth` instead of `Authorization`

## Companion PRs (all three needed for the chain to work)

- **mystique** ([SITES-46968](https://jira.corp.adobe.com/browse/SITES-46968)) — read page-auth from `x-page-auth` (was `Authorization`), forward to DRS as `Authorization`
- **mystique-deploy** ([SITES-46969](https://jira.corp.adobe.com/browse/SITES-46969)) — flip CGW config: `header: x-ims-authorization → Authorization`, remove invalid `profileInfo: true`

**Sequencing of merges is not critical** — pelletie is the only active caller on dev today.

## Tests

90/90 pass on `test/controllers/preflight.test.js`.

## Acceptance verification (post-merge of all three repos)

- [ ] spacecat-api-service POSTs IMS service token on `Authorization`, page-auth (when present) on `x-page-auth`
- [ ] CGW edge validates the IMS token, emits `X-Gw-Ims-Client-Id` downstream
- [ ] mystique pod handler runs, fetches page via DRS using forwarded `x-page-auth` → DRS `Authorization`
- [ ] `e_scan_completed` fires, projector flips AsyncJob to terminal

## Related

- [SITES-46874](https://jira.corp.adobe.com/browse/SITES-46874) — pod-side `require_preflight_service_client` dep (the consumer of `X-Gw-Ims-Client-Id`)
- [SITES-46887](https://jira.corp.adobe.com/browse/SITES-46887) — Phase 2 CGW hard-enforce flip
- [SITES-46699](https://jira.corp.adobe.com/browse/SITES-46699) — dedicated IMS client + caller refactor (this PR's lineage)