### PR TITLE
fix: timebox overrideBaseURL detection so onboarding beats the CDN timeout | LLMO-5606

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -63,6 +63,36 @@ export const ASO_DEMO_ORG = '66331367-70e6-4a49-8445-4f6d9c265af9';
 export const ASO_CRITICAL_SITES = [];
 const LLMO_ONBOARDING_PUBLISH_TRIGGER = 'trigger:llmo-onboarding-publish';
 
+// Cap for the best-effort Ahrefs/SEO overrideBaseURL detection during onboarding.
+// It can fire many slow SEO API calls (~10s observed) and, on the synchronous
+// onboarding path, push the response past the CDN first-byte timeout (~15s) — the
+// client gets a 503 even though onboarding succeeded. (LLMO-5606 follow-up.)
+const OVERRIDE_DETECT_TIMEOUT_MS = 5000;
+
+/**
+ * Awaits `promise`, but resolves to `fallback` if it rejects or doesn't settle
+ * within `timeoutMs`. The underlying promise is left running and any late
+ * rejection is swallowed, so a slow/flaky best-effort step can neither block past
+ * the cap nor surface as an unhandled rejection.
+ * @param {Promise<*>} promise - The in-flight work.
+ * @param {number} timeoutMs - Max time to wait before giving up.
+ * @param {*} fallback - Value to resolve to on timeout or rejection.
+ * @returns {Promise<*>} The promise's value, or `fallback`.
+ */
+export async function settleWithin(promise, timeoutMs, fallback) {
+  let timer;
+  try {
+    return await Promise.race([
+      Promise.resolve(promise).catch(() => fallback),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve(fallback), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function resolveUpdatedBy(context) {
   return context.attributes?.authInfo?.profile?.email
     || context.attributes?.authInfo?.getProfile?.()?.email
@@ -1526,7 +1556,15 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
 
     // Only determine override if one doesn't already exist
     if (!currentFetchConfig.overrideBaseURL) {
-      const overrideBaseURL = await determineOverrideBaseURL(baseURL, context);
+      // Timebox the best-effort SEO override detection: it only tunes which host
+      // audits scrape (www vs apex), but can run ~10s (dozens of SEO calls) and push
+      // the synchronous response past the CDN first-byte timeout (~15s) → client 503
+      // even though onboarding succeeded. On timeout/error we skip it. (LLMO-5606.)
+      const overrideBaseURL = await settleWithin(
+        determineOverrideBaseURL(baseURL, context),
+        OVERRIDE_DETECT_TIMEOUT_MS,
+        null,
+      );
       if (overrideBaseURL) {
         siteConfig.updateFetchConfig({
           ...currentFetchConfig,

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -319,6 +319,29 @@ describe('LLMO Onboarding Functions', () => {
     });
   };
 
+  describe('settleWithin', () => {
+    let settleWithin;
+
+    before(async () => {
+      ({ settleWithin } = await esmock('../../../src/controllers/llmo/llmo-onboarding.js', {}));
+    });
+
+    it('resolves to the value when the promise settles within the timeout', async () => {
+      expect(await settleWithin(Promise.resolve('detected'), 1000, null)).to.equal('detected');
+    });
+
+    it('resolves to the fallback when the promise rejects (non-fatal)', async () => {
+      expect(await settleWithin(Promise.reject(new Error('boom')), 1000, null)).to.equal(null);
+    });
+
+    it('resolves to the fallback when the promise exceeds the timeout', async () => {
+      const slow = new Promise((resolve) => {
+        setTimeout(() => resolve('late'), 200);
+      });
+      expect(await settleWithin(slow, 20, 'fallback')).to.equal('fallback');
+    });
+  });
+
   describe('generateDataFolder', () => {
     let generateDataFolder;
 
@@ -3902,7 +3925,9 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
       const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
+      // NB: do NOT mock setTimeout to fire immediately here — override detection is
+      // now timeboxed via settleWithin(), and an immediate-firing timer would trip
+      // the timeout before the (instant, mocked) detection wins the race.
       const mockComposeBaseURL = createMockComposeBaseURL();
       const { mockClient: sharePointClient } = createMockSharePointClient(
         sinon,


### PR DESCRIPTION
## Problem

The first real call to the paid site-only onboarding endpoint ([LLMO-5606], `POST /v2/orgs/:spaceCatId/llmo/onboard-site`) returned a **503** to the client. CloudWatch shows the request actually **succeeded server-side in ~15.2s** — but Fastly's **first-byte timeout (~15s)** fired first, so the client got a `503 first byte timeout` even though the site was created.

Per-step timing of the invocation:

| Step | Elapsed |
|---|---|
| cold start + auth + org + site + entitlement | ~1.1s |
| SharePoint copy | ~2.5s |
| GitHub `helix-query.yaml` | ~1.0s |
| **`determineOverrideBaseURL` (Ahrefs/SEO) + CDN detect** | **~10s ⟵ dominant** |
| brandalf flag + triggerAudits + return | ~0.4s |

The `determineOverrideBaseURL` step fired **dozens of slow Semrush/SEO API calls** (~10s) — that's the budget-blower.

## Fix

`overrideBaseURL` detection is a **best-effort refinement** (it only tunes which host audits scrape — www vs apex), so it shouldn't block the response. This timeboxes it via a small `settleWithin(promise, timeoutMs, fallback)` helper: the detection is capped at **5s** and resolves to `null` on timeout **or** error, so it's skipped (non-fatal) rather than blocking or failing onboarding. The synchronous path drops to ~6–7s, comfortably under Fastly's window; the override is still applied in the common fast case.

It's in the shared `performLlmoOnboarding`, so the admin/Slack onboarding paths get the same protection.

## Notes
- Not a deferral/architecture change — stays fully synchronous (the LLMO-5606 execution model), just bounded.
- Secondary follow-up worth filing: the **dozens of SEO calls** for one detection look inefficient and could be reduced independently.

## Testing
- New unit tests for `settleWithin` (resolves fast → value; rejects → fallback; exceeds timeout → fallback).
- Existing `performLlmoOnboarding` override tests still pass (the "override is set" test no longer mocks `setTimeout` to fire immediately, which would trip the new timebox).
- Full suite green (12,467 passing); `llmo-onboarding.js` at 100% line/branch coverage.

[LLMO-5606]: https://jira.corp.adobe.com/browse/LLMO-5606

🤖 Generated with [Claude Code](https://claude.com/claude-code)