### PR TITLE
fix(deps): bump spacecat-shared-http-utils 1.30.0 → 1.31.0 (FACS getFacsPermissions)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,12 @@
         "@adobe/mysticat-shared-seo-client": "1.3.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
-        "@adobe/spacecat-shared-brand-client": "^1.4.0",
+        "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
-        "@adobe/spacecat-shared-http-utils": "1.30.0",
+        "@adobe/spacecat-shared-http-utils": "1.31.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
         "@adobe/spacecat-shared-project-engine-client": "1.1.1",
@@ -4585,9 +4585,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-http-utils": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.30.0.tgz",
-      "integrity": "sha512-4zqGGk72JuWEhc6MnkOgYTCKJ60DtjETT0C+TY1cIY6qWvEFMqjxGSmmzGM9upUb24Qe0ZcZXojo01grfCnLKw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.31.0.tgz",
+      "integrity": "sha512-TW8MpwUWwGwXo/EYKWjXKb3XOyRmjV+it6fnomRdSjkHYGZfuJySP6ZGbCszpO7PgKtB5ldf4QUq1JypBDrZcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
-    "@adobe/spacecat-shared-http-utils": "1.30.0",
+    "@adobe/spacecat-shared-http-utils": "1.31.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
     "@adobe/spacecat-shared-project-engine-client": "1.1.1",


### PR DESCRIPTION
## Why

`GET /user/capabilities/:resourceId` (and the FACS-layer authorization gates) were dropping all JWT-granted capabilities. Root cause: api-service depends on **http-utils 1.30.0**, but `AuthInfo.getFacsPermissions()` was only added in **1.31.0** (#1712). The controller reads the JWT layer with an optional call:

```js
const jwtPermissions = ctx.attributes?.authInfo?.getFacsPermissions?.() ?? [];
```

On 1.30.0 that method doesn't exist → `?.()` → `undefined` → `?? []` → **empty JWT layer**. A token carrying `facs_permissions: ["llmo/can_view", "llmo/can_manage_users", …]` therefore returned no `jwt`-tagged capabilities.

## What

Bump `@adobe/spacecat-shared-http-utils` `1.30.0` → `1.31.0` (latest published) + lockfile. With 1.31.0, `getFacsPermissions()` resolves and `/user/capabilities` surfaces the JWT FACS layer (∪ state layer) as designed.

## Heads-up

1.31.0 also ships the **IMS-handler RBAC block** from the same release (blocks IMS auth for RBAC-enabled orgs, forcing the JWT path). It's LaunchDarkly-gated and fail-open, so inert unless the flag is enabled — intended hybrid-model behavior, noted here since it rides along with the bump.

## Testing

`npm test` → **12849 passing**, 0 failing, coverage gate met. Dependency + lockfile only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)