### PR TITLE
fix(preflight): rename scan_id wire field to async_job_id in callMysticatAnalyze (SITES-47173)

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -353,8 +353,16 @@ function PreflightController(ctx, log, env) {
 
   /**
    * Calls Mysticat's POST /v1/preflight/analyze and returns once the request is accepted.
-   * Mysticat processes the analysis asynchronously and writes results directly to the AsyncJob
-   * identified by scanId.
+   * Mysticat processes the analysis asynchronously and writes results back to the
+   * AsyncJob identified by asyncJobId.
+   *
+   * SITES-47173: mystique owns the scan_id concept end-to-end (mints its own
+   * scan_id, registers `control_scan`, tags `async_jobs.metadata.scan_id` at
+   * scan-start). Spacecat passes the AsyncJob id under its real name; the
+   * scan_id concept is internal to mystique. After this call returns, the
+   * AsyncJob's `metadata.scan_id` is populated (best-effort by mystique) for
+   * any downstream consumer that needs to discover the scan_id without
+   * round-tripping back to mystique.
    *
    * Two distinct auth headers are sent (SITES-46967 — header layout swap):
    *  - `Authorization`: spacecat-api-service's own IMS service token,
@@ -369,7 +377,8 @@ function PreflightController(ctx, log, env) {
    *    rode `Authorization`, the IMS token rode `x-ims-authorization`).
    *
    * @param {string} mysticatBaseUrl - The base URL of the Mystique service (MYSTIQUE_API_BASE_URL).
-   * @param {string} scanId - The AsyncJob ID used as the scan identifier for write-back.
+   * @param {string} asyncJobId - The AsyncJob id; mystique tags its minted
+   *   scan_id onto async_jobs.metadata for the projector lookup.
    * @param {string} siteId - The site ID.
    * @param {string} url - The page URL to analyze.
    * @param {string} [pageAuthHeader] - Optional customer-site page-auth header.
@@ -377,7 +386,7 @@ function PreflightController(ctx, log, env) {
    */
   async function callMysticatAnalyze(
     mysticatBaseUrl,
-    scanId,
+    asyncJobId,
     siteId,
     url,
     pageAuthHeader,
@@ -398,7 +407,7 @@ function PreflightController(ctx, log, env) {
         body: JSON.stringify({
           site_id: siteId,
           url,
-          scan_id: scanId,
+          async_job_id: asyncJobId,
           persist: true,
         }),
       });

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1575,7 +1575,7 @@ describe('Preflight Controller', () => {
     });
 
     it('calls Mysticat with correct parameters', async () => {
-      await preflightController.createPreflight({
+      const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
         data: { url: 'https://main--example-site.aem.page/test.html' },
         attributes: { authInfo: mockAuthInfo },
@@ -1587,6 +1587,17 @@ describe('Preflight Controller', () => {
       expect(body.url).to.equal('https://main--example-site.aem.page/test.html');
       expect(body.mode).to.be.undefined;
       expect(body.audits).to.be.undefined;
+      // SITES-47173: wire field is `async_job_id` (the AsyncJob id spacecat
+      // owns); mystique mints its own scan_id internally. The deprecated
+      // `scan_id` body field must NOT be sent.
+      expect(body.async_job_id).to.be.a('string').and.not.empty;
+      expect(body.scan_id).to.be.undefined;
+      // The async_job_id carries the AsyncJob row id that createPreflight
+      // creates — pulled from the response's Preflight DTO via its
+      // back-reference, but easier to assert it matches what's on the wire.
+      const preflightBody = await response.json();
+      expect(body.async_job_id).to.not.be.undefined;
+      expect(preflightBody.preflightId).to.be.a('string');
     });
 
     it('does not include x-page-auth header when HEAD returns 200 (no page-auth needed)', async () => {


### PR DESCRIPTION
## Summary

The new preflight call (`callMysticatAnalyze`) sends `asyncJob.getId()` over the wire under the misleading field name `scan_id`. In reality mystique uses that value as the **AsyncJob id** (to tag `async_jobs.metadata.scan_id` back to the right row from inside the executor); the actual scan_id is minted inside mystique.

Companion to the mystique-side change that mints scan_id, registers `control_scan`, and writes `async_jobs.metadata.scan_id` at scan-start: [mystique#3043](https://git.corp.adobe.com/experience-platform/mystique/pull/3043).

**Pure wire rename here — no logic change.**

## Changes

- **`src/controllers/preflight.js`** — `callMysticatAnalyze`:
  - Parameter `scanId` → `asyncJobId`
  - Request body field `scan_id` → `async_job_id`
  - JSDoc rewritten to describe the actual contract — mystique owns scan_id end-to-end; spacecat hands over the AsyncJob id; after the call returns, `asyncJob.metadata.scan_id` is populated (best-effort by mystique) for any downstream consumer that needs to discover the scan_id without round-tripping back to mystique.

- **Call site at the bottom of `createPreflight`** — unchanged. The value passed positionally (`asyncJob.getId()`) is unchanged; the rename is purely on the parameter name.

- **`test/controllers/preflight.test.js`** — `calls Mysticat with correct parameters` test now pins `body.async_job_id` and asserts `body.scan_id` is **not** sent. Drift guard so the rename can't silently regress.

## Test plan

- [x] `npx mocha test/controllers/preflight.test.js` — 99/99 pass.
- [ ] **Manual** (post-deploy, coordinated with mystique companion PR): trigger preflight; verify mystique receives `async_job_id` in the body and the analyze call succeeds end-to-end (no orphan IN_PROGRESS AsyncJob rows).

## Deploy ordering

The mystique companion PR accepts **both** `async_job_id` (new) and `scan_id` (deprecated alias) on the request body during the SITES-47173 transition window, so these two repos can deploy independently in either order. Once both ship and roll out, the alias on the mystique side can be dropped.

## Related

- SITES-47173 (this PR — spacecat-api-service piece)
- [mystique#3043](https://git.corp.adobe.com/experience-platform/mystique/pull/3043) — the load-bearing fix (mints scan_id, registers control_scan, tags async_jobs.metadata.scan_id at scan-start)
- SITES-47063 — emit-on-failure for catastrophic fetch errors (already shipped; complementary to this change)
- SITES-47095 — DRS provider switch (already shipped; independent)