### PR TITLE
feat(slack): add method/ua/client probe options to detect bot-blocker

### DIFF
--- a/src/support/slack/commands/detect-bot-blocker.js
+++ b/src/support/slack/commands/detect-bot-blocker.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { isValidUrl, detectBotBlocker } from '@adobe/spacecat-shared-utils';
+import {
+  isValidUrl, detectBotBlocker, analyzeBotProtection, tracingFetch, SPACECAT_USER_AGENT,
+} from '@adobe/spacecat-shared-utils';
 
 import BaseCommand from './base.js';
 import { extractURLFromSlackInput, postErrorMessage } from '../../../utils/slack/base.js';
@@ -18,13 +20,100 @@ import { extractURLFromSlackInput, postErrorMessage } from '../../../utils/slack
 const COMMAND_ID = 'detect-bot-blocker';
 const PHRASES = ['detect bot-blocker', 'detect bot blocker', 'check bot blocker'];
 
+const PROBE_TIMEOUT_MS = 15000;
+
+// Named User-Agent presets so a multi-word UA can be selected with a single token
+// (the Slack arg parser splits on spaces, so a raw UA string cannot be passed inline).
+const UA_PRESETS = {
+  default: SPACECAT_USER_AGENT, // what detectBotBlocker uses (mobile Chrome + Spacecat/1.0)
+  standard: SPACECAT_USER_AGENT,
+  audit: 'Mozilla/5.0 (compatible; Spacecat-Audit/1.0)', // CWV liveness check UA
+  bare: 'Spacecat/1.0', // the advertised allowlist token
+  scraper: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Spacecat/1.0',
+};
+
+/**
+ * Normalizes a fetch Response's headers into a plain lower-cased object so the
+ * same analysis works for both the @adobe/fetch and native fetch clients.
+ * @param {*} headers - Response headers (helix-fetch Headers, undici Headers, or plain).
+ * @returns {Object} Plain object of header name -> value.
+ */
+function headersToObject(headers) {
+  if (!headers) {
+    return {};
+  }
+  if (typeof headers.plain === 'function') {
+    return headers.plain();
+  }
+  try {
+    return Object.fromEntries(headers.entries());
+  } catch {
+    try {
+      return Object.fromEntries(headers);
+    } catch {
+      return {};
+    }
+  }
+}
+
+/**
+ * Issues a single bot-blocker probe with an explicit method / User-Agent / client,
+ * then classifies the response with analyzeBotProtection. Used to diagnose whether a
+ * site blocks a specific request shape (e.g. the CWV liveness HEAD + Spacecat-Audit/1.0)
+ * versus the default probe shape.
+ * @param {Object} params
+ * @param {string} params.url - URL to probe.
+ * @param {string} params.method - HTTP method (GET or HEAD).
+ * @param {string} params.userAgent - User-Agent header to send.
+ * @param {string} params.client - 'adobe' (tracingFetch/@adobe/fetch) or 'node' (native fetch).
+ * @returns {Promise<Object>} { status, cfRay, server, analysis }.
+ */
+async function customProbe({
+  url, method, userAgent, client,
+}) {
+  const useNative = client === 'node';
+  const requestOptions = {
+    method,
+    redirect: 'manual',
+    headers: { 'User-Agent': userAgent },
+  };
+  if (useNative) {
+    requestOptions.signal = AbortSignal.timeout(PROBE_TIMEOUT_MS);
+  } else {
+    requestOptions.timeout = PROBE_TIMEOUT_MS;
+  }
+
+  const fetchFn = useNative ? fetch : tracingFetch;
+  const response = await fetchFn(url, requestOptions);
+  const { status } = response;
+  const headersObj = headersToObject(response.headers);
+
+  let html = '';
+  if (method !== 'HEAD') {
+    try {
+      html = await response.text();
+    } catch {
+      html = '';
+    }
+  }
+
+  const analysis = analyzeBotProtection({ status, headers: headersObj, html });
+  return {
+    status,
+    cfRay: headersObj['cf-ray'] || null,
+    server: headersObj.server || null,
+    analysis,
+  };
+}
+
 function DetectBotBlockerCommand(context) {
   const baseCommand = BaseCommand({
     id: COMMAND_ID,
     name: 'Detect Bot Blocker',
-    description: 'Detects bot blocker technology on a website (Cloudflare, Imperva, Akamai, Fastly, CloudFront, HTTP/2 blocks).',
+    description: 'Detects bot blocker technology on a website (Cloudflare, Imperva, Akamai, Fastly, CloudFront, HTTP/2 blocks). '
+      + 'Optionally diagnose a specific request shape with method:/ua:/client: args.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {baseURL}`,
+    usageText: `${PHRASES[0]} {baseURL} [method:GET|HEAD] [ua:default|audit|bare|scraper] [client:adobe|node]`,
   });
 
   const { log } = context;
@@ -85,6 +174,30 @@ function DetectBotBlockerCommand(context) {
     return message;
   };
 
+  /**
+   * Parses optional `method:`/`ua:`/`client:` tokens from the trailing args.
+   * @param {string[]} tokens - args after the URL.
+   * @returns {Object} { hasOverrides, method, client, uaKey, userAgent }.
+   */
+  const parseProbeOptions = (tokens) => {
+    const opts = tokens.reduce((acc, token) => {
+      const idx = token.indexOf(':');
+      if (idx <= 0) {
+        return acc;
+      }
+      return { ...acc, [token.slice(0, idx).toLowerCase()]: token.slice(idx + 1) };
+    }, {});
+
+    const hasOverrides = ['method', 'ua', 'client'].some((key) => key in opts);
+    const method = (opts.method || 'GET').toUpperCase() === 'HEAD' ? 'HEAD' : 'GET';
+    const client = (opts.client || 'adobe').toLowerCase() === 'node' ? 'node' : 'adobe';
+    const uaKey = (opts.ua || 'default').toLowerCase();
+    const userAgent = UA_PRESETS[uaKey] || SPACECAT_USER_AGENT;
+    return {
+      hasOverrides, method, client, uaKey, userAgent,
+    };
+  };
+
   const handleExecution = async (args, slackContext) => {
     const { say } = slackContext;
 
@@ -100,15 +213,37 @@ function DetectBotBlockerCommand(context) {
       return;
     }
 
-    await say(`:mag: Checking bot blocker for \`${baseURL}\`...`);
+    const {
+      hasOverrides, method, client, uaKey, userAgent,
+    } = parseProbeOptions(args.slice(1));
 
+    // Default behavior (no overrides): the standard detectBotBlocker probe.
+    if (!hasOverrides) {
+      await say(`:mag: Checking bot blocker for \`${baseURL}\`...`);
+      try {
+        const result = await detectBotBlocker({ baseUrl: baseURL });
+        await say(`:robot_face: *Bot Blocker Detection Results for* \`${baseURL}\`\n\n${formatResult(result)}`);
+      } catch (error) {
+        log.error(`detect-bot-blocker command: failed for URL ${baseURL}`, error);
+        await postErrorMessage(say, error);
+      }
+      return;
+    }
+
+    // Diagnostic mode: probe with an explicit request shape.
+    await say(`:test_tube: Probing \`${baseURL}\` with client=${client} method=${method} ua=${uaKey}...`);
     try {
-      const result = await detectBotBlocker({ baseUrl: baseURL });
-      const formattedResult = formatResult(result);
-
-      await say(`:robot_face: *Bot Blocker Detection Results for* \`${baseURL}\`\n\n${formattedResult}`);
+      const {
+        status, cfRay, server, analysis,
+      } = await customProbe({
+        url: baseURL, method, userAgent, client,
+      });
+      const header = `:test_tube: *Bot Blocker Probe (custom)* for \`${baseURL}\`\n`
+        + `:gear: client: \`${client}\` | method: \`${method}\` | ua: \`${userAgent}\`\n`
+        + `:bar_chart: HTTP status: \`${status}\` | cf-ray: \`${cfRay || 'n/a'}\` | server: \`${server || 'n/a'}\`\n\n`;
+      await say(header + formatResult(analysis));
     } catch (error) {
-      log.error(`detect-bot-blocker command: failed for URL ${baseURL}`, error);
+      log.error(`detect-bot-blocker command: custom probe failed for URL ${baseURL}`, error);
       await postErrorMessage(say, error);
     }
   };


### PR DESCRIPTION
## ⚠️ Purpose — diagnostic / likely throwaway (please do NOT review)

This is a **temporary diagnostic PR** to investigate a production issue, **not** intended for merge as-is. Kept as **draft** so MysticatBot does not auto-review (its default skip rules skip drafts). Please don't spend review cycles on it.

### What we're investigating
For `datacom.com` (behind Cloudflare Bot Management), SpaceCat audits fail because the site returns **HTTP 403** to our crawlers, **yet `detect bot-blocker` reports `Crawlable: Yes`** — a false positive. We've established:
- The default probe (`@adobe/fetch` GET, `SPACECAT_USER_AGENT`) is **allowed (200)** from prod egress, on homepage *and* deep URLs.
- The **headless scraper** (Chrome) and the **CWV liveness check** (`HEAD` + `Mozilla/5.0 (compatible; Spacecat-Audit/1.0)`) get **403** from the *same* egress IP.
- So the discriminator is **request shape (method / UA / client fingerprint)**, not the URL or the IP.

We confirmed **stage egress passes datacom's Cloudflare IP gate** (stage `detect bot-blocker` → Crawlable: Yes), so a stage probe can cleanly isolate **which axis** (HEAD method vs `Spacecat-Audit/1.0` UA vs client) trips the block — something no existing tool can do, because the probe is hardcoded to GET + the default UA.

### Change
Adds optional args to `detect bot-blocker` (backward-compatible; no options = identical to before):
- `method:GET|HEAD`
- `ua:default|audit|bare|scraper` (named presets; `audit` = the CWV liveness UA)
- `client:adobe|node` (`@adobe/fetch` vs native `fetch`/undici)

When any option is set, it issues one probe with that exact shape and classifies via the shared `analyzeBotProtection()`, also surfacing raw `HTTP status` + `cf-ray`.

### Test plan (on stage, against datacom.com)
Run the matrix and compare statuses:
- [ ] `method:GET ua:default` → baseline (expect 200 / Crawlable: Yes)
- [ ] `method:HEAD ua:default` → isolates HEAD method
- [ ] `method:GET ua:audit` → isolates the `Spacecat-Audit/1.0` UA
- [ ] `method:HEAD ua:audit client:node` → full CWV replica
- [x] Existing unit tests pass (21/21); lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)