### PR TITLE
feat(llmo): pass Cloudflare account/zone IDs in body; scope zone listing by account

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -646,8 +646,8 @@ paths:
     $ref: './llmo-api.yaml#/site-llmo-cloudflare-zones'
   /sites/{siteId}/llmo/cdn-onboard/cloudflare/deploy:
     $ref: './llmo-api.yaml#/site-llmo-cloudflare-deploy'
-  /sites/{siteId}/llmo/cdn-onboard/cloudflare/zones/{zoneId}/routes:
-    $ref: './llmo-api.yaml#/site-llmo-cloudflare-zone-routes'
+  /sites/{siteId}/llmo/cdn-onboard/cloudflare/routes:
+    $ref: './llmo-api.yaml#/site-llmo-cloudflare-routes'
   /sites/{siteId}/llmo/strategy:
     $ref: './llmo-api.yaml#/llmo-strategy'
   /sites/{siteId}/reports:

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -4458,6 +4458,15 @@ site-llmo-cloudflare-accounts:
 site-llmo-cloudflare-zones:
   parameters:
     - $ref: './parameters.yaml#/siteId'
+    - name: accountId
+      in: query
+      required: true
+      description: >-
+        Cloudflare account ID (32-character lowercase hex) to scope the listing to — only
+        zones belonging to this account are returned.
+      schema:
+        type: string
+        pattern: '^[0-9a-f]{32}$'
     - name: x-cloudflare-token
       in: header
       required: true
@@ -4466,10 +4475,11 @@ site-llmo-cloudflare-zones:
         type: string
   get:
     operationId: listLlmoCloudflareZones
-    summary: List the Cloudflare zones accessible to the supplied token
+    summary: List the Cloudflare zones for the selected account
     description: |
-      Lists the Cloudflare zones the supplied `x-cloudflare-token` can access. Used by the
-      onboarding UI to let the user pick the zone to attach the Edge Optimize worker route to.
+      Lists the Cloudflare zones belonging to the account given by `accountId` that the supplied
+      `x-cloudflare-token` can access. Used by the onboarding UI to let the user pick the zone to
+      attach the Edge Optimize worker route to.
 
       **Note:** This endpoint requires LLMO administrator access for the site.
     tags:
@@ -4603,16 +4613,9 @@ site-llmo-cloudflare-deploy:
     security:
       - ims_key: [ ]
 
-site-llmo-cloudflare-zone-routes:
+site-llmo-cloudflare-routes:
   parameters:
     - $ref: './parameters.yaml#/siteId'
-    - name: zoneId
-      in: path
-      required: true
-      description: Cloudflare zone ID (32-character lowercase hex)
-      schema:
-        type: string
-        pattern: '^[0-9a-f]{32}$'
     - name: x-cloudflare-token
       in: header
       required: true
@@ -4625,9 +4628,10 @@ site-llmo-cloudflare-zone-routes:
     description: |
       Creates a Cloudflare worker route in the given zone, targeting the service-owned worker
       derived from the site's base URL (`edge-optimize-router-<canonical-host>`) — the worker
-      name is not client-supplied. Before creating the route the service fetches the zone's
-      existing routes and rejects the request with `409` if a route for the same `pattern`
-      already exists, so a deploy can never silently override an existing route.
+      name is not client-supplied. `zoneId` is a Cloudflare identifier (not a SpaceCat entity),
+      so it is supplied in the request body. Before creating the route the service fetches the
+      zone's existing routes and rejects the request with `409` if a route for the same
+      `pattern` already exists, so a deploy can never silently override an existing route.
 
       **Note:** This endpoint requires LLMO administrator access for the site.
     tags:
@@ -4639,8 +4643,14 @@ site-llmo-cloudflare-zone-routes:
           schema:
             type: object
             required:
+              - zoneId
               - pattern
             properties:
+              zoneId:
+                type: string
+                description: Cloudflare zone ID (32-character lowercase hex)
+                pattern: '^[0-9a-f]{32}$'
+                example: '0123456789abcdef0123456789abcdef'
               pattern:
                 type: string
                 description: >-

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -4586,6 +4586,19 @@ site-llmo-cloudflare-deploy:
         $ref: './responses.yaml#/403'
       '404':
         $ref: './responses.yaml#/404'
+      '409':
+        description: A worker with the derived name already exists in the account.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                scriptName:
+                  type: string
+                accountId:
+                  type: string
       '429':
         $ref: './responses.yaml#/429'
       '500':

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
         "@adobe/spacecat-shared-brand-client": "1.4.0",
-        "@adobe/spacecat-shared-cloudflare-client": "1.0.0",
+        "@adobe/spacecat-shared-cloudflare-client": "1.1.0",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
@@ -713,6 +713,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -2724,9 +2725,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-cloudflare-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.0.0.tgz",
-      "integrity": "sha512-HIlWjHSDvhzkRTCZNLgTPu/c9pdNUnEbd0OroyKPVe7IxxDfOOhiPhottT3Plbgwe54bZDsNHNIzzzyiqSn8ag==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.1.0.tgz",
+      "integrity": "sha512-ovXKVB648C5T2NgM6/v7zeu91RXsQLmODPaoAuK+PLBOclhPhdcEhF4/b7Up61ZcKEVfI5Q3/sgkdbML/B4YMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1"
@@ -11019,7 +11020,6 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -12828,7 +12828,6 @@
       "integrity": "sha512-wfAWZ6oIrsDOFyYm9bDQNva/WCmvIrVqP3dSCePN5YYWCGWWXkikn5YC0wPSxF92M8kQFPfdVpMaTTV1mRk4Lw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.21",
         "@smithy/core": "^3.24.6",
@@ -12845,7 +12844,6 @@
       "integrity": "sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -12909,7 +12907,6 @@
       "integrity": "sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
         "@aws-sdk/types": "^3.973.13",
@@ -12927,7 +12924,6 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -13583,7 +13579,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -13607,6 +13604,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -14584,6 +14582,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -14881,6 +14880,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -15087,6 +15087,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -15251,6 +15252,7 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -17268,6 +17270,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -17515,6 +17518,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -17561,6 +17565,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18009,6 +18014,7 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -18758,6 +18764,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20987,6 +20994,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -25323,6 +25331,7 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -26379,7 +26388,6 @@
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -26390,6 +26398,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -28954,6 +28963,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -29427,8 +29437,7 @@
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -29482,6 +29491,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -30684,6 +30694,7 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30694,6 +30705,7 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -31442,6 +31454,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -32806,6 +32819,7 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -33699,6 +33713,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33826,6 +33841,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -34632,6 +34648,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -34923,6 +34940,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -34932,6 +34950,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.12",
     "@adobe/spacecat-shared-brand-client": "1.4.0",
-    "@adobe/spacecat-shared-cloudflare-client": "1.0.0",
+    "@adobe/spacecat-shared-cloudflare-client": "1.1.0",
     "@adobe/spacecat-shared-content-client": "1.8.24",
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",

--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -195,8 +195,9 @@ function LlmoCloudflareController(ctx) {
     }
 
     try {
-      const zones = await client.listZones();
-      return ok((zones || []).filter((zone) => zone?.account?.id === accountId));
+      // The client pushes account.id to the Cloudflare API, so filtering happens server-side.
+      const zones = await client.listZones({ accountId });
+      return ok(zones || []);
     } catch (e) {
       return cfErrorResponse(e, 'zone listing');
     }
@@ -207,7 +208,8 @@ function LlmoCloudflareController(ctx) {
    * Body: { accountId, targetHost }
    * Fetches the Edge Optimize worker script from GitHub and deploys it under a name derived
    * from the site (see deriveWorkerName), then sets the LLMO API key as the
-   * EDGE_OPTIMIZE_API_KEY secret on the worker.
+   * EDGE_OPTIMIZE_API_KEY secret on the worker. Returns 409 if a worker with the derived name
+   * already exists in the account (the client refuses to overwrite).
    */
   const deployWorker = async (context) => {
     const result = await getSiteAndCheckAccess(context);
@@ -269,8 +271,18 @@ function LlmoCloudflareController(ctx) {
     ];
 
     try {
+      // overwrite defaults to false, so the client rejects if the worker already exists,
+      // preventing an onboarding deploy from silently replacing one.
       await cfClient.deployWorkerScript(accountId, scriptName, workerScript, bindings);
     } catch (e) {
+      if (/already exists/i.test(e.message)) {
+        log.info(`Worker '${scriptName}' already exists in account ${accountId}; refusing to overwrite`);
+        return createResponse({
+          message: `A worker named '${scriptName}' already exists in this Cloudflare account`,
+          scriptName,
+          accountId,
+        }, 409);
+      }
       return cfErrorResponse(e, 'worker deployment');
     }
 

--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -170,8 +170,37 @@ function LlmoCloudflareController(ctx) {
   // GET /sites/:siteId/llmo/cdn-onboard/cloudflare/accounts
   const listAccounts = cfListProxy('listAccounts', 'account listing');
 
-  // GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones
-  const listZones = cfListProxy('listZones', 'zone listing');
+  /**
+   * GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones?accountId=<id>
+   * Lists only the zones belonging to the selected Cloudflare account. `accountId` is a
+   * Cloudflare identifier (not a SpaceCat entity), supplied as a query parameter.
+   */
+  const listZones = async (context) => {
+    const result = await getSiteAndCheckAccess(context);
+    if (result.status) {
+      return result;
+    }
+
+    const { client, error } = requireCfClient(context);
+    if (error) {
+      return error;
+    }
+
+    const { accountId } = context.data || {};
+    if (!hasText(accountId)) {
+      return badRequest('Missing accountId query parameter');
+    }
+    if (!CF_ID_RE.test(accountId)) {
+      return badRequest('accountId must be a 32-character hexadecimal Cloudflare account ID');
+    }
+
+    try {
+      const zones = await client.listZones();
+      return ok((zones || []).filter((zone) => zone?.account?.id === accountId));
+    } catch (e) {
+      return cfErrorResponse(e, 'zone listing');
+    }
+  };
 
   /**
    * POST /sites/:siteId/llmo/cdn-onboard/cloudflare/deploy
@@ -276,11 +305,12 @@ function LlmoCloudflareController(ctx) {
   };
 
   /**
-   * POST /sites/:siteId/llmo/cdn-onboard/cloudflare/zones/:zoneId/routes
-   * Body: { pattern }
+   * POST /sites/:siteId/llmo/cdn-onboard/cloudflare/routes
+   * Body: { zoneId, pattern }
    * Verifies server-side that the pattern targets the site's own domain and does not collide
    * with an existing route in the zone before creating it, so a deploy cannot silently override
-   * a route the customer already has.
+   * a route the customer already has. `zoneId` is a Cloudflare identifier (not a SpaceCat
+   * entity), so it is supplied in the body rather than the path.
    */
   const addRoute = async (context) => {
     const result = await getSiteAndCheckAccess(context);
@@ -300,16 +330,14 @@ function LlmoCloudflareController(ctx) {
       return nameError;
     }
 
-    const { zoneId } = context.params;
+    const { zoneId, pattern } = context.data || {};
+
     if (!hasText(zoneId)) {
-      return badRequest('Missing zoneId');
+      return badRequest('Missing zoneId in request body');
     }
     if (!CF_ID_RE.test(zoneId)) {
       return badRequest('zoneId must be a 32-character hexadecimal Cloudflare zone ID');
     }
-
-    const { pattern } = context.data || {};
-
     if (!hasText(pattern)) {
       return badRequest('Missing pattern in request body');
     }

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -145,7 +145,7 @@ const routeFacsCapabilities = {
     'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/accounts',
     'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones',
     'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/deploy',
-    'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/zones/:zoneId/routes',
+    'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/routes',
     // Admin-only writes
     'POST /sites', // hasAdminAccess
     'DELETE /sites/:siteId', // restricted (always 403)
@@ -1146,9 +1146,6 @@ const routeFacsCapabilities = {
     // External / shared identifiers:
     'accessId', 'batchId', 'clientId', 'consumerId', 'contactSalesLeadId',
     'externalUserId', 'imsOrgId', 'grantId', 'userId',
-    // Cloudflare zone identifier (LLMO Cloudflare onboarding route-create endpoint) —
-    // an upstream Cloudflare ID, not a SpaceCat ReBAC entity.
-    'zoneId',
     // ASO dispatcher-overlay service name (GET /config/:service/redirects.txt) —
     // an X-ASO-API-Key-authenticated internal route, not a FACS resource.
     'service',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -517,7 +517,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/accounts': llmoCloudflareController.listAccounts,
     'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones': llmoCloudflareController.listZones,
     'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/deploy': llmoCloudflareController.deployWorker,
-    'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/zones/:zoneId/routes': llmoCloudflareController.addRoute,
+    'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/routes': llmoCloudflareController.addRoute,
 
     'GET /llmo/agentic-traffic/global': llmoMysticatController.getAgenticTrafficGlobal,
     'POST /llmo/agentic-traffic/global': llmoMysticatController.postAgenticTrafficGlobal,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -138,7 +138,7 @@ export const INTERNAL_ROUTES = [
   'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/accounts',
   'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones',
   'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/deploy',
-  'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/zones/:zoneId/routes',
+  'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/routes',
 
   // PLG onboarding - IMS token auth, self-service flow, not S2S
   'POST /plg/onboard',

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -218,18 +218,52 @@ describe('LlmoCloudflareController', () => {
   // ── listZones ────────────────────────────────────────────────────────────
 
   describe('listZones', () => {
-    it('returns zones list', async () => {
-      const zones = [{ id: ZONE_ID, name: 'example.com' }];
-      mockCfClient.listZones.resolves(zones);
+    beforeEach(() => {
+      mockContext.data = { accountId: ACCOUNT_ID };
+    });
+
+    it('returns only the zones belonging to the selected account', async () => {
+      const selected = { id: ZONE_ID, name: 'example.com', account: { id: ACCOUNT_ID } };
+      const other = { id: 'z2', name: 'other.com', account: { id: 'ffffffffffffffffffffffffffffffff' } };
+      const noAccount = { id: 'z3', name: 'noacct.com' };
+      // null + account-less entries exercise the zone?.account?.id guard.
+      mockCfClient.listZones.resolves([selected, other, noAccount, null]);
 
       const res = await controller.listZones(mockContext);
       expect(res.status).to.equal(200);
       const body = await res.json();
-      expect(body).to.deep.equal(zones);
+      expect(body).to.deep.equal([selected]);
+    });
+
+    it('treats a null zone list as empty', async () => {
+      mockCfClient.listZones.resolves(null);
+      const res = await controller.listZones(mockContext);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body).to.deep.equal([]);
     });
 
     it('returns 400 when CF token is missing', async () => {
       mockContext.pathInfo.headers = {};
+      const res = await controller.listZones(mockContext);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when the request has no query data', async () => {
+      mockContext.data = undefined;
+      const res = await controller.listZones(mockContext);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when accountId is missing', async () => {
+      mockContext.data = {};
+      const res = await controller.listZones(mockContext);
+      expect(res.status).to.equal(400);
+      expect(mockCfClient.listZones).to.not.have.been.called;
+    });
+
+    it('returns 400 when accountId is not a 32-char hex id', async () => {
+      mockContext.data = { accountId: 'acc-123' };
       const res = await controller.listZones(mockContext);
       expect(res.status).to.equal(400);
     });
@@ -418,8 +452,8 @@ describe('LlmoCloudflareController', () => {
 
   describe('addRoute', () => {
     beforeEach(() => {
-      mockContext.params = { siteId: SITE_ID, zoneId: ZONE_ID };
-      mockContext.data = { pattern: 'example.com/*' };
+      mockContext.params = { siteId: SITE_ID };
+      mockContext.data = { zoneId: ZONE_ID, pattern: 'example.com/*' };
       mockCfClient.listRoutes.resolves([]);
     });
 
@@ -464,13 +498,13 @@ describe('LlmoCloudflareController', () => {
     });
 
     it('returns 400 when pattern is missing', async () => {
-      mockContext.data = {};
+      mockContext.data = { zoneId: ZONE_ID };
       const res = await controller.addRoute(mockContext);
       expect(res.status).to.equal(400);
     });
 
     it('returns 400 when the pattern does not target the site domain', async () => {
-      mockContext.data = { pattern: 'evil.com/*' };
+      mockContext.data = { zoneId: ZONE_ID, pattern: 'evil.com/*' };
       const res = await controller.addRoute(mockContext);
       expect(res.status).to.equal(400);
       expect(mockCfClient.listRoutes).to.not.have.been.called;
@@ -478,7 +512,7 @@ describe('LlmoCloudflareController', () => {
     });
 
     it('accepts a wildcard subdomain pattern within the site domain', async () => {
-      mockContext.data = { pattern: '*.example.com/*' };
+      mockContext.data = { zoneId: ZONE_ID, pattern: '*.example.com/*' };
       const route = { id: ROUTE_ID, pattern: '*.example.com/*', script: DERIVED_SCRIPT_NAME };
       mockCfClient.addRoute.resolves(route);
       const res = await controller.addRoute(mockContext);
@@ -500,13 +534,13 @@ describe('LlmoCloudflareController', () => {
     });
 
     it('returns 400 when zoneId is missing', async () => {
-      mockContext.params = { siteId: SITE_ID, zoneId: '' };
+      mockContext.data = { pattern: 'example.com/*' };
       const res = await controller.addRoute(mockContext);
       expect(res.status).to.equal(400);
     });
 
     it('returns 400 when zoneId is not a 32-char hex id', async () => {
-      mockContext.params = { siteId: SITE_ID, zoneId: 'zone-456' };
+      mockContext.data = { zoneId: 'zone-456', pattern: 'example.com/*' };
       const res = await controller.addRoute(mockContext);
       expect(res.status).to.equal(400);
     });

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -222,17 +222,15 @@ describe('LlmoCloudflareController', () => {
       mockContext.data = { accountId: ACCOUNT_ID };
     });
 
-    it('returns only the zones belonging to the selected account', async () => {
-      const selected = { id: ZONE_ID, name: 'example.com', account: { id: ACCOUNT_ID } };
-      const other = { id: 'z2', name: 'other.com', account: { id: 'ffffffffffffffffffffffffffffffff' } };
-      const noAccount = { id: 'z3', name: 'noacct.com' };
-      // null + account-less entries exercise the zone?.account?.id guard.
-      mockCfClient.listZones.resolves([selected, other, noAccount, null]);
+    it('passes the accountId to the client and returns the account-scoped zones', async () => {
+      const zones = [{ id: ZONE_ID, name: 'example.com', account: { id: ACCOUNT_ID } }];
+      mockCfClient.listZones.resolves(zones);
 
       const res = await controller.listZones(mockContext);
       expect(res.status).to.equal(200);
+      expect(mockCfClient.listZones).to.have.been.calledWith({ accountId: ACCOUNT_ID });
       const body = await res.json();
-      expect(body).to.deep.equal([selected]);
+      expect(body).to.deep.equal(zones);
     });
 
     it('treats a null zone list as empty', async () => {
@@ -433,6 +431,17 @@ describe('LlmoCloudflareController', () => {
       mockCfClient.deployWorkerScript.rejects(new Error('Cloudflare API returned 500 on /workers: boom'));
       const res = await controller.deployWorker(mockContext);
       expect(res.status).to.equal(502);
+      expect(mockCfClient.setWorkerSecret).to.not.have.been.called;
+    });
+
+    it('returns 409 when a worker with the derived name already exists', async () => {
+      mockCfClient.deployWorkerScript.rejects(
+        new Error(`Worker script '${DERIVED_SCRIPT_NAME}' already exists in account ${ACCOUNT_ID}. Set overwrite: true to replace it.`),
+      );
+      const res = await controller.deployWorker(mockContext);
+      expect(res.status).to.equal(409);
+      const body = await res.json();
+      expect(body.scriptName).to.equal(DERIVED_SCRIPT_NAME);
       expect(mockCfClient.setWorkerSecret).to.not.have.been.called;
     });
 

--- a/test/it/shared/tests/llmo-cloudflare-onboarding.js
+++ b/test/it/shared/tests/llmo-cloudflare-onboarding.js
@@ -24,9 +24,9 @@ import {
  * Endpoints under test (src/controllers/llmo/llmo-cloudflare.js):
  *   GET  /sites/:siteId/llmo/cdn-onboard/cloudflare/config
  *   GET  /sites/:siteId/llmo/cdn-onboard/cloudflare/accounts
- *   GET  /sites/:siteId/llmo/cdn-onboard/cloudflare/zones
+ *   GET  /sites/:siteId/llmo/cdn-onboard/cloudflare/zones?accountId=<id>
  *   POST /sites/:siteId/llmo/cdn-onboard/cloudflare/deploy
- *   POST /sites/:siteId/llmo/cdn-onboard/cloudflare/zones/:zoneId/routes
+ *   POST /sites/:siteId/llmo/cdn-onboard/cloudflare/routes
  *
  * SCOPE — IT only exercises code paths that short-circuit BEFORE any external call.
  * The accounts/zones/deploy/route-create handlers ultimately call the external Cloudflare
@@ -120,7 +120,16 @@ export default function llmoCloudflareOnboardingTests(getHttpClient, resetData) 
       it('llmoAdmin: returns 400 when x-cloudflare-token header is missing', async () => {
         const http = getHttpClient();
         const res = await http.llmoAdmin.get(
+          `/sites/${SITE_1_ID}/llmo/cdn-onboard/cloudflare/zones?accountId=${VALID_ACCOUNT_ID}`,
+        );
+        expect(res.status).to.equal(400);
+      });
+
+      it('llmoAdmin: returns 400 when accountId query param is missing', async () => {
+        const http = getHttpClient();
+        const res = await http.llmoAdmin.get(
           `/sites/${SITE_1_ID}/llmo/cdn-onboard/cloudflare/zones`,
+          CF_TOKEN_HEADERS,
         );
         expect(res.status).to.equal(400);
       });
@@ -180,24 +189,34 @@ export default function llmoCloudflareOnboardingTests(getHttpClient, resetData) 
       });
     });
 
-    // ── POST route create — token, zoneId and body validation precede external calls ─
+    // ── POST route create — token + body validation precede external calls ─────────
 
-    describe('POST .../cloudflare/zones/:zoneId/routes', () => {
-      const routesPath = (zoneId) => `/sites/${SITE_1_ID}/llmo/cdn-onboard/cloudflare/zones/${zoneId}/routes`;
+    describe('POST .../cloudflare/routes', () => {
+      const routesPath = `/sites/${SITE_1_ID}/llmo/cdn-onboard/cloudflare/routes`;
 
       it('returns 400 when x-cloudflare-token header is missing', async () => {
         const http = getHttpClient();
-        const res = await http.llmoAdmin.post(routesPath(VALID_ZONE_ID), {
-          pattern: 'example.com/*',
+        const res = await http.llmoAdmin.post(routesPath, {
+          zoneId: VALID_ZONE_ID, pattern: 'example.com/*',
         });
+        expect(res.status).to.equal(400);
+      });
+
+      it('returns 400 when zoneId is missing from the body', async () => {
+        const http = getHttpClient();
+        const res = await http.llmoAdmin.post(
+          routesPath,
+          { pattern: 'example.com/*' },
+          CF_TOKEN_HEADERS,
+        );
         expect(res.status).to.equal(400);
       });
 
       it('returns 400 when zoneId is not a 32-char hex id', async () => {
         const http = getHttpClient();
         const res = await http.llmoAdmin.post(
-          routesPath('zone-456'),
-          { pattern: 'example.com/*' },
+          routesPath,
+          { zoneId: 'zone-456', pattern: 'example.com/*' },
           CF_TOKEN_HEADERS,
         );
         expect(res.status).to.equal(400);
@@ -206,8 +225,8 @@ export default function llmoCloudflareOnboardingTests(getHttpClient, resetData) 
       it('returns 400 when pattern is missing', async () => {
         const http = getHttpClient();
         const res = await http.llmoAdmin.post(
-          routesPath(VALID_ZONE_ID),
-          {},
+          routesPath,
+          { zoneId: VALID_ZONE_ID },
           CF_TOKEN_HEADERS,
         );
         expect(res.status).to.equal(400);
@@ -216,8 +235,8 @@ export default function llmoCloudflareOnboardingTests(getHttpClient, resetData) 
       it('returns 400 when the pattern targets a domain outside the site', async () => {
         const http = getHttpClient();
         const res = await http.llmoAdmin.post(
-          routesPath(VALID_ZONE_ID),
-          { pattern: 'evil.com/*' },
+          routesPath,
+          { zoneId: VALID_ZONE_ID, pattern: 'evil.com/*' },
           CF_TOKEN_HEADERS,
         );
         expect(res.status).to.equal(400);

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1121,7 +1121,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/accounts',
       'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones',
       'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/deploy',
-      'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/zones/:zoneId/routes',
+      'POST /sites/:siteId/llmo/cdn-onboard/cloudflare/routes',
       'GET /sites/:siteId/user-activities',
       'POST /sites/:siteId/user-activities',
       'GET /sites/:siteId/site-enrollments',


### PR DESCRIPTION
Follow-up to #2681 (merged). Cloudflare identifiers are not SpaceCat ReBAC entities, so they should not appear as path segments.

## Changes

- **Route-create endpoint** is now `POST /sites/{siteId}/llmo/cdn-onboard/cloudflare/routes` with `{ zoneId, pattern }` in the **request body** (previously `.../zones/{zoneId}/routes`). This drops the `:zoneId` path param and its `FACS_NON_RESOURCE_PARAMS` classification.
- **`GET /sites/{siteId}/llmo/cdn-onboard/cloudflare/zones`** now requires an **`accountId` query param** and returns only the zones belonging to that Cloudflare account (filtered server-side on the zone's `account.id`).

`accountId` was already supplied in the deploy request body, so no change was needed there.

## Notes

- The published `@adobe/spacecat-shared-cloudflare-client@1.0.0` `listZones()` can't push `account.id` to the Cloudflare API, so the account scoping is applied in the controller. Pushing the filter down into the client (so the CF API does it) is a reasonable follow-up if/when that client gains the capability — same bucket as the deferred worker-existence pre-check.

## Testing

- Updated routes, capability classification (`required-capabilities.js` + `facs-capabilities.js`), OpenAPI specs, and unit + integration tests.
- `src/controllers/llmo/llmo-cloudflare.js` stays at **100% coverage**; full unit suite green; `docs:lint` / `docs:build` clean.

## Related Issues

_None linked._
