### PR TITLE
fix(deps): re-bump spacecat-shared-http-utils 1.30.0 → 1.31.0 (after LD flag fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
-        "@adobe/spacecat-shared-http-utils": "1.30.0",
+        "@adobe/spacecat-shared-http-utils": "1.31.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
         "@adobe/spacecat-shared-project-engine-client": "1.1.1",
@@ -5166,9 +5166,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-http-utils": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.30.0.tgz",
-      "integrity": "sha512-4zqGGk72JuWEhc6MnkOgYTCKJ60DtjETT0C+TY1cIY6qWvEFMqjxGSmmzGM9upUb24Qe0ZcZXojo01grfCnLKw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.31.0.tgz",
+      "integrity": "sha512-TW8MpwUWwGwXo/EYKWjXKb3XOyRmjV+it6fnomRdSjkHYGZfuJySP6ZGbCszpO7PgKtB5ldf4QUq1JypBDrZcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
-    "@adobe/spacecat-shared-http-utils": "1.30.0",
+    "@adobe/spacecat-shared-http-utils": "1.31.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
     "@adobe/spacecat-shared-project-engine-client": "1.1.1",


### PR DESCRIPTION
## Re-bump http-utils 1.30.0 → 1.31.0 (after LD flag fix)

Re-applies the bump reverted in #2691.

**RCA of the back-office outage:** it was **not** a code defect in 1.31.0. The LaunchDarkly FACS flag schema had its **default variation set to `true`**, so 1.31.0's IMS-handler RBAC gate evaluated `true` for *every* org — including ones never targeted — and blocked IMS auth broadly (back office authenticates via IMS). The flag default has now been corrected to `false`, so the gate only blocks orgs that are explicitly targeted.

**Why re-bump:** 1.31.0 restores `AuthInfo.getFacsPermissions()`, which the state-layer controller needs for `GET /user/capabilities` to surface the JWT FACS capability layer.

**Verification plan:** test on the branch's dev (`branch-deploy`, `AWS_ENV=dev`) — confirm IMS auth works (BO-style org, flag now default-`false`) and `/user/capabilities` returns the JWT layer — **before merging**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
