### PR TITLE
feat(serenity): bump project-engine-client to 1.2.0 and document v1/v2 read drift

### DIFF
--- a/docs/decisions/006-serenity-v1-v2-read-drift.md
+++ b/docs/decisions/006-serenity-v1-v2-read-drift.md
@@ -41,7 +41,17 @@ by a blanket "use the newest version" rule:
 | `getProject` (`GET /projects/{id}?draft=true&type=ai`) | **v1** | draft | single-project draft settings; `draft` query is required upstream |
 | `listPromptsByTags` (`POST /aio/prompts/by_tags`) | **v2** | live | no v1 variant exists; prompt layer is live-only |
 | `getInitStatus` (`GET /aio/init_status`) | **v2** | n/a | readiness boolean; v1 route removed in client 1.2.0 |
-| writes that need to go live (`addAiModel`, `createTaggedPrompts`, …) | mixed | draft → publish | mutations stage in draft; `publishProject` commits them |
+| writes that need to go live (`addAiModel`, `createTaggedPrompts`, …) | per-op¹ | draft → publish | mutations stage in draft; `publishProject` commits them |
+
+¹ Writes are out of this ADR's scope (it is about which layer each *read*
+observes). For a write, the API **version does not affect draft-faithfulness** —
+every mutation stages in the draft layer regardless of v1/v2 and only reaches
+live on `publishProject`, so picking the version is a pure contract question, not
+a layer question. The authoritative per-method v1/v2 map for writes lives in the
+transport method JSDoc (`src/support/serenity/rest-transport.js`) and the
+serenity transport-endpoint audit (rule: prefer v2 where a compatible v2 variant
+exists). A developer adding a write picks the version from that map; this ADR
+governs only the read side, where the version determines the layer.
 
 Consequences for **migration-verification / UI-enrichment reads**:
 

--- a/docs/decisions/006-serenity-v1-v2-read-drift.md
+++ b/docs/decisions/006-serenity-v1-v2-read-drift.md
@@ -1,0 +1,65 @@
+# ADR-006: Serenity (Semrush) v1/v2 read drift — which layer each read sees
+
+## Context
+
+The Serenity transport (`src/support/serenity/rest-transport.js`) talks to the
+Semrush Project Engine through two API versions, `/v1` and `/v2`, and the choice
+is **not** "prefer v2 everywhere". The two versions read **different layers of a
+project's state**, and getting the version wrong silently misreads an unpublished
+draft as empty or as the wrong geo. This was surfaced while reviewing the
+all-PAID Semrush migration readiness (serenity-docs#18) and is tracked as one of
+the implementation adjustments in
+https://github.com/adobe/spacecat-api-service/issues/2687 .
+
+A Semrush AIO project has a **draft layer** and a **live (published) layer**.
+Mutations (settings, AI-model assignments, prompts) stage in the draft layer and
+only reach the live layer on `publishProject`. The two API versions expose these
+layers differently:
+
+- **Project SETTINGS** (name, brand_names, language, country, location, model
+  set): the **v1 default view is draft-faithful**. The v2 list (and v1 with
+  `live=true`) returns a **live-view materialisation** — for a never-published
+  draft it defaults the location to US/2840 and nulls `brand_names`, giving the
+  wrong slice identity. Verified live 2026-06-11 against the prod tenant.
+- **Prompt layer** (counts, lists, tags): reads **only the live layer**, and
+  there is **no v1 variant at all** — `aio/prompts/by_tags` exists only on
+  `/v2`. A populated-but-unpublished draft reads **empty**. This is the source of
+  every "201-but-count-0" symptom.
+- **Init status** (`aio/init_status`, an AIO-readiness boolean): moved from `/v1`
+  to `/v2` in `@adobe/spacecat-shared-project-engine-client` **1.2.0** (the v1
+  route was removed from the generated contract). It is a readiness flag, not
+  draft settings, so the v2 live-view carries no draft-faithfulness concern.
+
+## Decision
+
+Each Serenity read picks its API version by **which layer it must observe**, not
+by a blanket "use the newest version" rule:
+
+| Read | Version | Layer | Why |
+|------|---------|-------|-----|
+| `listProjects` (`GET /projects?type=ai`) | **v1** | draft | draft-faithful settings; v2 list returns live-view with wrong location/null brand_names |
+| `getProject` (`GET /projects/{id}?draft=true&type=ai`) | **v1** | draft | single-project draft settings; `draft` query is required upstream |
+| `listPromptsByTags` (`POST /aio/prompts/by_tags`) | **v2** | live | no v1 variant exists; prompt layer is live-only |
+| `getInitStatus` (`GET /aio/init_status`) | **v2** | n/a | readiness boolean; v1 route removed in client 1.2.0 |
+| writes that need to go live (`addAiModel`, `createTaggedPrompts`, …) | mixed | draft → publish | mutations stage in draft; `publishProject` commits them |
+
+Consequences for **migration-verification / UI-enrichment reads**:
+
+- Treat a v2 prompt/tag read of **0** on an **unpublished** project as
+  "not yet published", **never** as "migration didn't land". Publish first (or
+  read after the known publish), then re-read.
+- Never read draft project **settings** through the v2 project list — its
+  location/brand_names are a live-view default, not the draft's real values.
+- Model-set edits via `PUT /serenity/models` republish by default
+  (`syncModelsForProject({ publish: true })`) precisely so the new set reaches
+  the live layer that subsequent reads observe; the only `publish: false` caller
+  is brand-create, which batches one final publish itself.
+
+## Status
+
+Accepted. The transport already reads settings via v1 (`listProjects`,
+`getProject`) and prompts via v2 (`listPromptsByTags`); this ADR records the
+**reason** so the choice is not "corrected" into a uniform v2 swap. The
+per-method v1/v2 audit map lives alongside the transport methods' JSDoc. Future
+prompt-layer reads inherit the live-only constraint until/unless Semrush ships a
+draft-faithful prompt read.

--- a/docs/specs/2026-06-15-serenity-subworkspace-dual-mode-implementation-plan.md
+++ b/docs/specs/2026-06-15-serenity-subworkspace-dual-mode-implementation-plan.md
@@ -144,7 +144,7 @@ Add thin wrappers (all under `API_PREFIX`, all via the existing `request()` help
 | `deleteWorkspace(wsId)` | DELETE `…/v1/workspaces/{id}` | **test cleanup only** — guard comment; production flows never call it |
 | `listProjects(wsId)` | GET `…/v1/workspaces/{id}/projects` | v1 **default view** (draft‑faithful) |
 | `getProject(wsId, projectId)` | GET `…/v1/workspaces/{id}/projects/{id}` | v1 by‑id read |
-| `getInitStatus(wsId, projectId)` | GET `…/v1/workspaces/{id}/projects/{id}/aio/init_status` | detail‑read enrichment only |
+| `getInitStatus(wsId, projectId)` | GET `…/v2/workspaces/{id}/projects/{id}/aio/init_status` | detail‑read enrichment only (moved v1→v2 in project-engine-client 1.2.0; v1 route removed — see ADR-006) |
 
 Extend **`errors.js`** with normative classification (design §6) and new `ERROR_CODES`:
 - `405` + `text/html` body on publish → **permanent allocation failure** (`allocationFailure`) — never retried as transient.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.30.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.1.1",
+        "@adobe/spacecat-shared-project-engine-client": "^1.2.0",
         "@adobe/spacecat-shared-rum-api-client": "2.40.13",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -713,7 +713,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -6926,9 +6925,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.1.1.tgz",
-      "integrity": "sha512-LAlbiGeWvweB9wXpp2MTw8op2fVw/wvexQBzBoyuG3Vb9cGePretczyiQV8yyBOo+b7k+GXUL0PEKwSIlrlKjw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.2.0.tgz",
+      "integrity": "sha512-WOcTN//+8wVTGvtG7w7b38bftUr+nKjPkDAHbwNpZ/bdIO65V2GQKXXXBAE8cCOkzi26mxedFkIaP/Qoqu9BCA==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"
@@ -11020,6 +11019,7 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -12828,6 +12828,7 @@
       "integrity": "sha512-wfAWZ6oIrsDOFyYm9bDQNva/WCmvIrVqP3dSCePN5YYWCGWWXkikn5YC0wPSxF92M8kQFPfdVpMaTTV1mRk4Lw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.21",
         "@smithy/core": "^3.24.6",
@@ -12844,6 +12845,7 @@
       "integrity": "sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -12907,6 +12909,7 @@
       "integrity": "sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
         "@aws-sdk/types": "^3.973.13",
@@ -12924,6 +12927,7 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -13579,8 +13583,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -13604,7 +13607,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -14582,7 +14584,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -14880,7 +14881,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -15087,7 +15087,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -15252,7 +15251,6 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -17270,7 +17268,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -17518,7 +17515,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -17565,7 +17561,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18014,7 +18009,6 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -18764,7 +18758,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20994,7 +20987,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -25331,7 +25323,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -26388,6 +26379,7 @@
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -26398,7 +26390,6 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -28963,7 +28954,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -29437,7 +29427,8 @@
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -29491,7 +29482,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -30694,7 +30684,6 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -30705,7 +30694,6 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -31454,7 +31442,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -32819,7 +32806,6 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -33713,7 +33699,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33841,7 +33826,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -34648,7 +34632,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -34940,7 +34923,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -34950,7 +34932,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.31.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "^1.2.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.2.0",
         "@adobe/spacecat-shared-rum-api-client": "2.40.13",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.30.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.1.1",
+    "@adobe/spacecat-shared-project-engine-client": "1.2.0",
     "@adobe/spacecat-shared-rum-api-client": "2.40.13",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -557,6 +557,12 @@ function evictTagCacheIfNeeded() {
  * how the slice resolves to a `projectId` (DB row vs live listing); the cache,
  * pagination, truncation guard, and sort are identical, so they live here once.
  * `logCtx` is spread into the truncation warning for diagnosability.
+ *
+ * LIVE-LAYER READ: tags are derived by paginating `transport.listPromptsByTags`,
+ * which reads the LIVE (published) prompt layer (no v1 draft variant exists — see
+ * docs/decisions/006-serenity-v1-v2-read-drift.md). A slice whose prompts are
+ * staged in an unpublished draft therefore yields an EMPTY tag set here until the
+ * project is published — that is correct, not a missing-data bug.
  */
 export async function listTagsForProject(transport, semrushWorkspaceId, projectId, logCtx, log) {
   const cacheKey = tagCacheKey(semrushWorkspaceId, projectId);

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -23,6 +23,13 @@ import { ErrorWithStatusCode } from '../utils.js';
 //    (create child / status / family / resources transfer / delete). A DIFFERENT
 //    gateway than project ops (verified live 2026-06-15: the project prefix 404s
 //    these routes); the typed client appends the prefix internally.
+//
+// v1/v2 read-layer choice: each read method below picks its API version by which
+// project layer it must observe (v1 = draft-faithful settings; v2 prompts = live
+// layer; init_status = v2-only). When ADDING a read endpoint, see
+// docs/decisions/006-serenity-v1-v2-read-drift.md before defaulting to v2 — a
+// draft-settings read on the v2 list returns a wrong-location/null-brand live
+// view. The per-method JSDoc on each method states which layer it reads and why.
 // Cap upstream calls so a slow Semrush response doesn't pin the Lambda for its
 // full wall budget. Semrush returns well under 5s in practice; 15s is a safe
 // ceiling that still gives the user a clean error rather than a Lambda timeout.

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -232,6 +232,17 @@ export function createSerenityTransport({ env, imsToken }) {
      * Multiple tag IDs use OR semantics: any prompt carrying at least one of
      * the supplied IDs is included. AND filtering must be done by the caller.
      *
+     * LIVE-LAYER READ (v1/v2 read drift — see docs/decisions/006-serenity-v1-v2-read-drift.md):
+     * prompt reads have NO v1 variant — `by_tags` exists only on /v2, and the v2
+     * prompt layer materialises the LIVE (published) view. A populated-but-
+     * unpublished draft therefore reads EMPTY here (the source of every "201 but
+     * count 0"). Counts/lists derived from this call (e.g. listTagsForProject)
+     * only reflect a slice's prompts AFTER the project is published. This differs
+     * from listProjects/getProject (above), which read draft-faithful project
+     * SETTINGS via /v1; the prompt layer cannot be read draft-faithfully at all.
+     * Migration-verification "did it land?" checks must publish first (or accept
+     * that an unpublished draft reads as 0 prompts), never treat empty as missing.
+     *
      * Note: Semrush rejects `sort_field` / `sort_dir` on this endpoint (see
      * commit history on the prior `serenity` handler). Body is restricted to
      * the fields the upstream documents as accepted.
@@ -596,13 +607,20 @@ export function createSerenityTransport({ env, imsToken }) {
     },
 
     /**
-     * GET /v1/workspaces/{ws}/projects/{pid}/aio/init_status — AIO readiness
+     * GET /v2/workspaces/{ws}/projects/{pid}/aio/init_status — AIO readiness
      * for a live project (`{ initialized: bool }`). Surfaced on the single
      * market-detail read only, never per-item in the list (would be N+1).
+     *
+     * v2 (not v1): project-engine-client 1.2.0 moved init_status to /v2 and
+     * removed the /v1 route entirely (the v1 path no longer exists in the
+     * generated types). This is unrelated to the v1-draft / v2-live read split
+     * (see listProjects/getProject above) — init_status is a readiness boolean,
+     * not draft-settings, so the live-view materialisation v2 reads carries no
+     * draft-faithfulness concern here.
      */
     async getInitStatus(workspaceId, projectId) {
       return unwrap('GET', await projects.GET(
-        '/v1/workspaces/{id}/projects/{project_id}/aio/init_status',
+        '/v2/workspaces/{id}/projects/{project_id}/aio/init_status',
         { params: { path: { id: workspaceId, project_id: projectId } } },
       ));
     },

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -1322,6 +1322,45 @@ describe('handlers/markets.js — handleUpdateModels', () => {
     expect(transport.publishProject).to.have.been.calledOnceWith(WORKSPACE, 'proj-1');
   });
 
+  // Guard for issue #2687 item 1: the standalone PUT /serenity/models path must
+  // ALWAYS republish a real model-set change to the live layer — the only
+  // `publish: false` caller is brand-create (which batches its own publish). The
+  // handler signature exposes no publish-control option, so a caller cannot turn
+  // republish off. This test pins that contract: a `publish`/`publishMode` field
+  // smuggled into the request body is IGNORED and the project still publishes.
+  it('always republishes on a model-set change — body publish flags cannot suppress it', async () => {
+    const project = makeProject({ semrushProjectId: 'proj-1', geoTargetId: 2840, languageCode: 'en' });
+    const da = makeDataAccess([]);
+    da.BrandSemrushProject.findBySlice.resolves(project);
+    const transport = makeTransport({ currentItems: [] });
+    transport.listAiModels.onSecondCall().resolves({
+      items: [{
+        id: 'assign-1',
+        model: {
+          id: 'cat-gpt', key: 'chatgpt', name: 'ChatGPT', icon: null,
+        },
+      }],
+    });
+
+    await handleUpdateModels(
+      transport,
+      da,
+      BRAND,
+      WORKSPACE,
+      {
+        geoTargetId: 2840,
+        languageCode: 'en',
+        modelIds: ['cat-gpt'],
+        // Hostile extras: neither must reach syncModelsForProject's publish gate.
+        publish: false,
+        publishMode: 'skip',
+      },
+      fakeLog(),
+    );
+
+    expect(transport.publishProject).to.have.been.calledOnceWith(WORKSPACE, 'proj-1');
+  });
+
   it('propagates transport errors from deleteAiModelsByIds', async () => {
     const project = makeProject({ semrushProjectId: 'proj-1', geoTargetId: 2840, languageCode: 'en' });
     const da = makeDataAccess([]);

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -880,7 +880,7 @@ describe('Semrush REST transport', () => {
   });
 
   describe('getInitStatus', () => {
-    it('GETs /v1/workspaces/{ws}/projects/{pid}/aio/init_status', async () => {
+    it('GETs /v2/workspaces/{ws}/projects/{pid}/aio/init_status', async () => {
       fetchStub.resolves(fetchOk({ initialized: false }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
@@ -888,8 +888,10 @@ describe('Semrush REST transport', () => {
 
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
+      // v2 (not v1): project-engine-client 1.2.0 moved init_status to /v2 and
+      // dropped the /v1 route.
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/init_status`,
+        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/init_status`,
       );
       expect(result.initialized).to.equal(false);
     });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Bumps `@adobe/spacecat-shared-project-engine-client` from 1.1.1 to 1.2.0 and lands two Serenity/Semrush implementation adjustments tracked in the running issue: documentation of the v1/v2 read-layer split, and a guard test for the model-edit republish contract.

## 2. Reasoning
1.2.0 is `latest` on npm and moves the Semrush `aio/init_status` route from `/v1` to `/v2`, removing the `/v1` route from the generated contract — so the transport must follow or it no longer type-checks. While in this code, two adjustments from the migration-readiness review (serenity-docs risk analysis) were closed: the v1/v2 read-drift that silently misreads an unpublished draft as empty/US, and locking in that a standalone model-set edit always republishes to the live layer.

## 3. High-level overview of the changes
- **Client bump 1.1.1 → 1.2.0.** The only behavioural consequence for us is `getInitStatus`, which now calls `GET /v2/workspaces/{id}/projects/{id}/aio/init_status` (the `/v1` route was removed upstream). `init_status` is an AIO-readiness boolean, not draft settings, so reading it from v2's live-view carries no draft-faithfulness concern. The other 1.2.0 changes (several response fields tightened to required; `addAiModel` 200→201; `createProjectTags` response object→array) are inert here — those consumers discard the response body and the transport's `unwrap` accepts any `response.ok`.
- **v1/v2 read-drift documentation (issue item 2).** No code move — the only prompt read (`listPromptsByTags`) has no v1 variant, so it inherently reads the live (published) layer; an unpublished draft therefore reads empty (the "201-but-count-0" source). Added explaining comments on `listPromptsByTags` and `listTagsForProject`, and a new ADR recording which layer each Serenity read observes (v1 = draft settings, v2 prompts = live-only).
- **Model-edit republish guard (issue item 1).** Behaviour was already correct (the standalone `PUT /serenity/models` path defaults `publish: true`; only brand-create batches its own publish). Added a guard test pinning that a `publish`/`publishMode` flag smuggled into the request body cannot suppress the republish.

No customer-visible API shape change; the `/serenity/*` surface consumed by elmo is unchanged.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/2687
- Implementation plan: docs/specs/2026-06-15-serenity-subworkspace-dual-mode-implementation-plan.md (transport table row updated for the init_status v1→v2 move)
- ADR(s): docs/decisions/006-serenity-v1-v2-read-drift.md (new)

## 6. Additional information outside the code
- Diffed the published 1.1.1 vs 1.2.0 client `paths` types to scope the bump: confirmed `aio/init_status` is the only route that moved (v1 removed, v2 added) and that prompts remain v2-only in 1.2.0 (no v1 `by_tags` variant exists), which is why issue item 2 is documentation rather than a version swap.
- Verified the two 1.2.0 runtime response-shape changes are inert by reading every consumer: `addAiModel` (markets.js) and `createProjectTags` (markets-subworkspace.js) both discard the response body, and `unwrap` gates on `response.ok` rather than a literal `200`.

## 7. Test plan
- (a) Ran the affected Serenity unit suites and the Serenity controller + OpenAPI-contract suites locally against the installed 1.2.0 client; the new model-edit guard test and the updated init_status assertion exercise the changed paths.
- (b) **dev:** for a live (published) subworkspace brand, call the market-detail read (`GET /serenity/markets/:geoTargetId/:languageCode`) which triggers `getInitStatus`, and confirm `initialized` still resolves (now served by the v2 route). No prod/stage-specific steps — the change is an internal upstream-contract follow + docs/tests.

## 8. Deployment & merge order
- https://github.com/adobe/spacecat-api-service/pull/2584 — related (not a hard dependency). Issue item 1 also asks to ensure that publish-split refactor preserves the live-edit republish; #2584 is still open, so that confirmation remains open and should be re-checked when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
