### PR TITLE
feat(llmo): temporary cloudflareToken body/query fallback for CF token

### DIFF
--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -20,6 +20,10 @@ import AccessControlUtil from '../../support/access-control-util.js';
 import { deriveWorkerName, hostInSiteDomain, routePatternHost } from './llmo-cloudflare-utils.js';
 
 const CF_TOKEN_HEADER = 'x-cloudflare-token';
+// TEMPORARY: body/query fallback field for the CF token, used only until the
+// x-cloudflare-token header is allowlisted in the CDN/network config (for e2e verification).
+// Intentionally undocumented in the OpenAPI spec. Remove once the header passes through.
+const CF_TOKEN_BODY_FIELD = 'cloudflareToken';
 const CF_TOKEN_MISSING = 'Missing x-cloudflare-token header';
 const EDGE_OPTIMIZE_API_KEY_SECRET = 'EDGE_OPTIMIZE_API_KEY';
 const EDGE_OPTIMIZE_TARGET_HOST_BINDING = 'EDGE_OPTIMIZE_TARGET_HOST';
@@ -61,8 +65,14 @@ function LlmoCloudflareController(ctx) {
   };
 
   const getCfToken = (context) => {
-    const token = context.pathInfo?.headers?.[CF_TOKEN_HEADER];
-    return hasText(token) ? token : null;
+    const headerToken = context.pathInfo?.headers?.[CF_TOKEN_HEADER];
+    if (hasText(headerToken)) {
+      return headerToken;
+    }
+    // TEMPORARY fallback (see CF_TOKEN_BODY_FIELD): accept the token from the request
+    // body/query while the header is not yet allowlisted in the network config.
+    const fallbackToken = context.data?.[CF_TOKEN_BODY_FIELD];
+    return hasText(fallbackToken) ? fallbackToken : null;
   };
 
   /**

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -184,6 +184,14 @@ describe('LlmoCloudflareController', () => {
       expect(res.status).to.equal(400);
     });
 
+    it('falls back to the cloudflareToken in query/body when the header is absent', async () => {
+      mockContext.pathInfo.headers = {};
+      mockContext.data = { cloudflareToken: CF_TOKEN };
+      mockCfClient.listAccounts.resolves([{ id: ACCOUNT_ID, name: 'Test Account' }]);
+      const res = await controller.listAccounts(mockContext);
+      expect(res.status).to.equal(200);
+    });
+
     it('returns 404 when site is not found', async () => {
       mockContext.dataAccess.Site.findById.resolves(null);
       const res = await controller.listAccounts(mockContext);
@@ -311,6 +319,17 @@ describe('LlmoCloudflareController', () => {
       expect(body).to.deep.equal({
         scriptName: DERIVED_SCRIPT_NAME, accountId: ACCOUNT_ID, targetHost: TARGET_HOST,
       });
+    });
+
+    it('accepts the cloudflareToken from the body when the header is absent', async () => {
+      mockContext.pathInfo.headers = {};
+      mockContext.data = {
+        accountId: ACCOUNT_ID, targetHost: TARGET_HOST, cloudflareToken: CF_TOKEN,
+      };
+      mockCfClient.deployWorkerScript.resolves();
+      mockCfClient.setWorkerSecret.resolves();
+      const res = await controller.deployWorker(mockContext);
+      expect(res.status).to.equal(200);
     });
 
     it('fetches the worker script from a pinned commit SHA with a timeout', async () => {


### PR DESCRIPTION
## Temporary workaround — revert before/after header allowlisting

The Cloudflare onboarding endpoints expect the Cloudflare token in the `x-cloudflare-token` header, but that custom header is **not yet allowlisted in the CDN/network config**, so it's stripped before reaching the service — blocking end-to-end verification.

This change adds a **temporary fallback**: `getCfToken` accepts the token from a `cloudflareToken` field in the request **body** (POST: deploy / routes) or **query string** (GET: accounts / zones) when the header is absent. The header still takes precedence.

### Notes
- **Intentionally NOT documented in the OpenAPI spec** — it's a temporary workaround, not part of the contract.
- ⚠️ **Revert this once `x-cloudflare-token` is allowlisted** in the network config. A token in a URL query is visible in access logs, so the query path in particular should not outlive the workaround.
- Controller stays at **100% coverage** (unit tests cover both the GET/query and POST/body fallback paths); full suite green.

Follow-up to the merged Cloudflare onboarding work (#2681, #2697).

## Related Issues

_None linked._
