### PR TITLE
chore: drop Outcome line from CDN/agentic status commands

### DIFF
--- a/src/support/slack/commands/check-agentic-traffic-db-status.js
+++ b/src/support/slack/commands/check-agentic-traffic-db-status.js
@@ -270,7 +270,6 @@ function CheckAgenticTrafficDbStatusCommand(context) {
 
       const lines = [
         `*Agentic Traffic Projection Status — ${dateStr}*`,
-        `Outcome: *${outcome}*`,
         `:white_check_mark: Dashboard-ready: *${dashboardReady.length}/${enabledSites.length}*`,
         `:hourglass_flowing_sand: Missing raw projection: *${rawMissing.length}*`,
         `:arrows_counterclockwise: Missing daily refresh: *${dailyMissing.length}*`,

--- a/src/support/slack/commands/check-cdn-logs-status.js
+++ b/src/support/slack/commands/check-cdn-logs-status.js
@@ -342,13 +342,8 @@ function CheckCdnLogsStatusCommand(context) {
       const partialCoverage = incomplete.filter((r) => r.presentCount > 0);
       const dailyOnlyMissing = incomplete.filter((r) => r.isDailyOnly);
       const hourlyMissing = incomplete.filter((r) => !r.isDailyOnly);
-      const outcome = incomplete.length === 0 && errors.length === 0
-        ? 'READY_FOR_DB_IMPORT'
-        : 'ACTION_REQUIRED';
-
       const lines = [
         `*CDN Logs Aggregate Status — ${dateStr}*`,
-        `Outcome: *${outcome}*`,
         `:white_check_mark: Complete: *${complete.length}*`,
         `:warning: Incomplete: *${incomplete.length}*`,
         `:x: Errors: *${errors.length}*`,

--- a/test/support/slack/commands/check-agentic-traffic-db-status.test.js
+++ b/test/support/slack/commands/check-agentic-traffic-db-status.test.js
@@ -176,7 +176,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     clock.restore();
 
     const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Outcome: *DASHBOARD_READY*');
+    expect(output).to.include('have completed projections');
     expect(output).to.include('Dashboard-ready: *1/1*');
     expect(output).to.include('Missing raw projection: *0*');
     expect(output).to.include('Missing daily refresh: *0*');
@@ -210,7 +210,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     clock.restore();
 
     const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Outcome: *DASHBOARD_READY*');
+    expect(output).to.include('have completed projections');
     expect(output).to.include('Missing raw projection: *0*');
     expect(output).to.include('Missing daily refresh: *0*');
   });
@@ -229,7 +229,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     clock.restore();
 
     const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Outcome: *NO_DB_ROWS_FOR_DATE*');
+    expect(output).to.not.include('have completed projections');
     expect(output).to.include('Missing raw projection: *2*');
   });
 
@@ -381,7 +381,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     clock.restore();
 
     const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Outcome: *DASHBOARD_READY*');
+    expect(output).to.include('have completed projections');
     expect(output).to.not.include('Missing weekly refresh');
   });
 
@@ -500,7 +500,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     clock.restore();
 
     const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Outcome: *DASHBOARD_READY*');
+    expect(output).to.include('have completed projections');
     // daily query: 1 transient failure + 1 retry; then weekly + raw queries.
     expect(flaky.from.callCount).to.equal(4);
   });
@@ -580,7 +580,7 @@ describe('CheckAgenticTrafficDbStatusCommand', () => {
     const calls = postgrest.from.callCount;
     expect(calls).to.equal(6);
     const output = slackContext.say.args.flat().join('\n');
-    expect(output).to.include('Outcome: *DASHBOARD_READY*');
+    expect(output).to.include('have completed projections');
     expect(output).to.include('Dashboard-ready: *250/250*');
   });
 });


### PR DESCRIPTION
## What

Removes the `Outcome: *<state>*` summary line from both LLMO ops status Slack commands:

- `check-agentic-traffic-db-status`
- `check-cdn-logs-status`

The line restated information already conveyed by the per-category counts below it, so it was redundant noise in the Slack output.

## Notes

- The agentic command **keeps** its `outcome` variable — it still drives the actionable-insight branching further down. Only the display line is removed.
- The cdn command's `outcome` variable had no other use, so the variable itself is removed along with the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
