### PR TITLE
chore(deps): bump @adobe/spacecat-shared-cloudflare-client to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
         "@adobe/spacecat-shared-brand-client": "1.4.0",
-        "@adobe/spacecat-shared-cloudflare-client": "1.1.0",
+        "@adobe/spacecat-shared-cloudflare-client": "1.1.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
@@ -2724,9 +2724,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-cloudflare-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.1.0.tgz",
-      "integrity": "sha512-ovXKVB648C5T2NgM6/v7zeu91RXsQLmODPaoAuK+PLBOclhPhdcEhF4/b7Up61ZcKEVfI5Q3/sgkdbML/B4YMg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.1.1.tgz",
+      "integrity": "sha512-JDDT+Bjbn3JuetPkGEERNkQhek9Y6xUHxpMabRiXLkM6dbM55AbioTj6suZWApwEiXj7E5Dd3nBvmLMsZzK4nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.12",
     "@adobe/spacecat-shared-brand-client": "1.4.0",
-    "@adobe/spacecat-shared-cloudflare-client": "1.1.0",
+    "@adobe/spacecat-shared-cloudflare-client": "1.1.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",


### PR DESCRIPTION
## Summary
- Bumps `@adobe/spacecat-shared-cloudflare-client` from `1.1.0` to `1.1.1` in `package.json` and `package-lock.json`.
- Picks up the fix from [spacecat-shared#1736](https://github.com/adobe/spacecat-shared/pull/1736): worker existence check uses **GET** instead of **HEAD** (Cloudflare returns **405** for HEAD on `/workers/scripts/{name}`), which was blocking Cloudflare BYOCDN worker deploy.

## Test plan
- [ ] CI passes
- [ ] After deploy to dev/ci, retry Cloudflare worker deploy from the onboarding wizard and confirm it no longer fails with 405


Made with [Cursor](https://cursor.com)