### PR TITLE
feat(llmo): support stage-domain Cloudflare deploy and routing

### DIFF
--- a/src/controllers/llmo/llmo-cloudflare-utils.js
+++ b/src/controllers/llmo/llmo-cloudflare-utils.js
@@ -16,6 +16,8 @@
  * unit-tested in isolation.
  */
 
+import { getDomain } from 'tldts';
+
 const WORKER_NAME_PREFIX = 'edge-optimize-router';
 const CF_MAX_SCRIPT_NAME_LEN = 63; // Cloudflare worker script name max length
 
@@ -35,6 +37,23 @@ export const deriveWorkerName = (baseURL) => {
   return `${WORKER_NAME_PREFIX}-${slug}`.slice(0, CF_MAX_SCRIPT_NAME_LEN).replace(/-+$/g, '');
 };
 
+/** Canonical hostname (no leading www, lowercased). */
+export const canonicalHostname = (host) => host.replace(/^www\./i, '').toLowerCase();
+
+/**
+ * Base URL used to derive the worker name and resolve the Edge Optimize API key for deploy.
+ * Production target hosts reuse the site base URL; staging / other subdomains use https://{targetHost}/.
+ */
+export const deployWorkerBaseURL = (siteBaseURL, targetHost) => {
+  const siteHost = canonicalHostname(new URL(siteBaseURL).hostname);
+  const targetHostOnly = targetHost.trim().replace(/^https?:\/\//i, '').split('/')[0];
+  const targetCanon = canonicalHostname(targetHostOnly);
+  if (targetCanon === siteHost) {
+    return siteBaseURL;
+  }
+  return `https://${targetHostOnly}/`;
+};
+
 /**
  * Whether `host` belongs to the onboarded site's domain: it must equal the site's canonical
  * host (base URL host minus leading "www.") or be a subdomain of it. Prevents pointing the
@@ -45,6 +64,26 @@ export const hostInSiteDomain = (host, baseURL) => {
   const h = host.toLowerCase();
   return h === siteHost || h.endsWith(`.${siteHost}`);
 };
+
+/**
+ * Whether `host` shares the same registrable domain as the production site (matches stage
+ * domain onboarding rules — sibling subdomains on the same zone).
+ */
+export const hostSharesSiteRegistrableDomain = (host, baseURL) => {
+  try {
+    const prodDomain = getDomain(new URL(baseURL).hostname);
+    const hostOnly = host.replace(/^https?:\/\//i, '').split('/')[0];
+    const targetDomain = getDomain(hostOnly);
+    return Boolean(prodDomain && targetDomain && prodDomain === targetDomain);
+  } catch {
+    return false;
+  }
+};
+
+/** Accept production subdomains or registrable-domain siblings (stage hosts). */
+export const isCloudflareTargetHostAllowed = (host, baseURL) => (
+  hostInSiteDomain(host, baseURL) || hostSharesSiteRegistrableDomain(host, baseURL)
+);
 
 /**
  * Extracts the host from a Cloudflare route pattern (e.g. "*.example.com/path*" -> "example.com",

--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -17,7 +17,9 @@ import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 import TokowakaClient from '@adobe/spacecat-shared-tokowaka-client';
 import CloudflareClient from '@adobe/spacecat-shared-cloudflare-client';
 import AccessControlUtil from '../../support/access-control-util.js';
-import { deriveWorkerName, hostInSiteDomain, routePatternHost } from './llmo-cloudflare-utils.js';
+import {
+  deriveWorkerName, deployWorkerBaseURL, isCloudflareTargetHostAllowed, routePatternHost,
+} from './llmo-cloudflare-utils.js';
 
 const CF_TOKEN_HEADER = 'x-cloudflare-token';
 // TEMPORARY: body/query fallback field for the CF token, used only until the
@@ -96,9 +98,9 @@ function LlmoCloudflareController(ctx) {
     return createResponse({ message: `Cloudflare ${action} failed` }, 502);
   };
 
-  const getLlmoApiKey = async (site, context) => {
+  const getLlmoApiKey = async (metaconfigBaseURL, context) => {
     const tokowaka = TokowakaClient.createFrom(context);
-    const metaconfig = await tokowaka.fetchMetaconfig(site.getBaseURL());
+    const metaconfig = await tokowaka.fetchMetaconfig(metaconfigBaseURL);
     return metaconfig?.apiKeys?.[0] ?? null;
   };
 
@@ -126,14 +128,15 @@ function LlmoCloudflareController(ctx) {
   };
 
   /**
-   * Derives the service-owned worker name for a site, or a badRequest when the site base URL
-   * yields no usable slug.
+   * Derives the service-owned worker name for a deploy target, or a badRequest when the
+   * resolved base URL yields no usable slug.
    * @returns {{ scriptName: string } | { error: Response }}
    */
-  const requireScriptName = (site) => {
-    const scriptName = deriveWorkerName(site.getBaseURL());
+  const requireScriptNameForDeploy = (site, targetHost) => {
+    const deployBaseURL = deployWorkerBaseURL(site.getBaseURL(), targetHost);
+    const scriptName = deriveWorkerName(deployBaseURL);
     if (!scriptName) {
-      log.error(`Unable to derive a worker name from site base URL ${site.getBaseURL()}`);
+      log.error(`Unable to derive a worker name from deploy base URL ${deployBaseURL}`);
       return { error: badRequest('Unable to derive a worker name from the site base URL') };
     }
     return { scriptName };
@@ -233,12 +236,6 @@ function LlmoCloudflareController(ctx) {
       return cfError;
     }
 
-    // The worker name is owned by the service and derived from the site, not client-supplied.
-    const { scriptName, error: nameError } = requireScriptName(site);
-    if (nameError) {
-      return nameError;
-    }
-
     const { accountId, targetHost } = context.data || {};
 
     if (!hasText(accountId)) {
@@ -253,13 +250,21 @@ function LlmoCloudflareController(ctx) {
     if (!HOSTNAME_RE.test(targetHost)) {
       return badRequest('targetHost must be a valid hostname');
     }
-    if (!hostInSiteDomain(targetHost, site.getBaseURL())) {
+    if (!isCloudflareTargetHostAllowed(targetHost, site.getBaseURL())) {
       return badRequest('targetHost must belong to the site\'s domain');
     }
 
+    // Worker name + API key follow targetHost (stage hosts use their own worker + key).
+    const { scriptName, error: nameError } = requireScriptNameForDeploy(site, targetHost);
+    if (nameError) {
+      return nameError;
+    }
+
+    const metaconfigBaseURL = deployWorkerBaseURL(site.getBaseURL(), targetHost);
+
     let llmoApiKey;
     try {
-      llmoApiKey = await getLlmoApiKey(site, context);
+      llmoApiKey = await getLlmoApiKey(metaconfigBaseURL, context);
     } catch (e) {
       log.error(`Failed to fetch LLMO metaconfig for site ${site.getId()}: ${e.message}`);
       return createResponse({ message: 'Failed to fetch site metaconfig' }, 502);
@@ -346,12 +351,6 @@ function LlmoCloudflareController(ctx) {
       return cfError;
     }
 
-    // The route targets the service-owned worker derived from the site, not a client value.
-    const { scriptName, error: nameError } = requireScriptName(site);
-    if (nameError) {
-      return nameError;
-    }
-
     const { zoneId, pattern } = context.data || {};
 
     if (!hasText(zoneId)) {
@@ -363,8 +362,15 @@ function LlmoCloudflareController(ctx) {
     if (!hasText(pattern)) {
       return badRequest('Missing pattern in request body');
     }
-    if (!hostInSiteDomain(routePatternHost(pattern), site.getBaseURL())) {
+    if (!isCloudflareTargetHostAllowed(routePatternHost(pattern), site.getBaseURL())) {
       return badRequest('route pattern must target the site\'s domain');
+    }
+
+    // The route targets the service-owned worker for the pattern host (stage vs production).
+    const routeHost = routePatternHost(pattern);
+    const { scriptName, error: nameError } = requireScriptNameForDeploy(site, routeHost);
+    if (nameError) {
+      return nameError;
     }
 
     // Guard against overriding an existing route: fetch the zone's current routes and reject

--- a/test/controllers/llmo/llmo-cloudflare-utils.test.js
+++ b/test/controllers/llmo/llmo-cloudflare-utils.test.js
@@ -14,7 +14,10 @@ import { expect } from 'chai';
 
 import {
   deriveWorkerName,
+  deployWorkerBaseURL,
   hostInSiteDomain,
+  hostSharesSiteRegistrableDomain,
+  isCloudflareTargetHostAllowed,
   routePatternHost,
 } from '../../../src/controllers/llmo/llmo-cloudflare-utils.js';
 
@@ -73,6 +76,36 @@ describe('llmo-cloudflare-utils', () => {
 
     it('strips a scheme when present', () => {
       expect(routePatternHost('https://www.example.com/*')).to.equal('www.example.com');
+    });
+  });
+
+  describe('deployWorkerBaseURL', () => {
+    it('reuses the site base URL for the production host', () => {
+      expect(deployWorkerBaseURL('https://www.example.com', 'www.example.com')).to.equal('https://www.example.com');
+    });
+
+    it('uses https://{targetHost}/ for staging subdomains', () => {
+      expect(deployWorkerBaseURL('https://www.example.com', 'staging.example.com')).to.equal('https://staging.example.com/');
+    });
+  });
+
+  describe('hostSharesSiteRegistrableDomain', () => {
+    it('accepts sibling subdomains on the same registrable domain', () => {
+      expect(hostSharesSiteRegistrableDomain('tokowaka.aem-screens.net', 'https://frescopa.aem-screens.net')).to.equal(true);
+    });
+
+    it('rejects unrelated domains', () => {
+      expect(hostSharesSiteRegistrableDomain('evil.com', 'https://frescopa.aem-screens.net')).to.equal(false);
+    });
+  });
+
+  describe('isCloudflareTargetHostAllowed', () => {
+    it('accepts production subdomains', () => {
+      expect(isCloudflareTargetHostAllowed('cdn.example.com', 'https://www.example.com')).to.equal(true);
+    });
+
+    it('accepts registrable-domain siblings for stage-style hosts', () => {
+      expect(isCloudflareTargetHostAllowed('tokowaka.aem-screens.net', 'https://frescopa.aem-screens.net')).to.equal(true);
     });
   });
 });

--- a/test/controllers/llmo/llmo-cloudflare-utils.test.js
+++ b/test/controllers/llmo/llmo-cloudflare-utils.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 
 import {
+  canonicalHostname,
   deriveWorkerName,
   deployWorkerBaseURL,
   hostInSiteDomain,
@@ -22,6 +23,24 @@ import {
 } from '../../../src/controllers/llmo/llmo-cloudflare-utils.js';
 
 describe('llmo-cloudflare-utils', () => {
+  describe('canonicalHostname', () => {
+    it('strips a leading www.', () => {
+      expect(canonicalHostname('www.example.com')).to.equal('example.com');
+    });
+
+    it('lowercases the result', () => {
+      expect(canonicalHostname('CDN.EXAMPLE.COM')).to.equal('cdn.example.com');
+    });
+
+    it('leaves an already-canonical hostname unchanged', () => {
+      expect(canonicalHostname('example.com')).to.equal('example.com');
+    });
+
+    it('strips www case-insensitively', () => {
+      expect(canonicalHostname('WWW.Example.Com')).to.equal('example.com');
+    });
+  });
+
   describe('deriveWorkerName', () => {
     it('strips leading www and maps dots to hyphens', () => {
       expect(deriveWorkerName('https://www.example.com')).to.equal('edge-optimize-router-example-com');
@@ -80,12 +99,28 @@ describe('llmo-cloudflare-utils', () => {
   });
 
   describe('deployWorkerBaseURL', () => {
-    it('reuses the site base URL for the production host', () => {
+    it('reuses the site base URL for the production host (with www)', () => {
       expect(deployWorkerBaseURL('https://www.example.com', 'www.example.com')).to.equal('https://www.example.com');
     });
 
-    it('uses https://{targetHost}/ for staging subdomains', () => {
+    it('reuses the site base URL for the canonical production host (no www)', () => {
+      expect(deployWorkerBaseURL('https://www.example.com', 'example.com')).to.equal('https://www.example.com');
+    });
+
+    it('uses https://{targetHost}/ for a subdomain that is not the production host', () => {
       expect(deployWorkerBaseURL('https://www.example.com', 'staging.example.com')).to.equal('https://staging.example.com/');
+    });
+
+    it('uses https://{targetHost}/ for a sibling subdomain on the same registrable domain', () => {
+      expect(deployWorkerBaseURL('https://frescopa.aem-screens.net', 'tokowaka.aem-screens.net')).to.equal('https://tokowaka.aem-screens.net/');
+    });
+
+    it('strips a scheme prefix from targetHost before comparison', () => {
+      expect(deployWorkerBaseURL('https://www.example.com', 'https://www.example.com')).to.equal('https://www.example.com');
+    });
+
+    it('strips a path suffix from targetHost before comparison', () => {
+      expect(deployWorkerBaseURL('https://www.example.com', 'www.example.com/some/path')).to.equal('https://www.example.com');
     });
   });
 
@@ -94,18 +129,46 @@ describe('llmo-cloudflare-utils', () => {
       expect(hostSharesSiteRegistrableDomain('tokowaka.aem-screens.net', 'https://frescopa.aem-screens.net')).to.equal(true);
     });
 
+    it('accepts the exact same host as the site', () => {
+      expect(hostSharesSiteRegistrableDomain('frescopa.aem-screens.net', 'https://frescopa.aem-screens.net')).to.equal(true);
+    });
+
     it('rejects unrelated domains', () => {
       expect(hostSharesSiteRegistrableDomain('evil.com', 'https://frescopa.aem-screens.net')).to.equal(false);
+    });
+
+    it('rejects a look-alike suffix that is not the same registrable domain', () => {
+      expect(hostSharesSiteRegistrableDomain('notaem-screens.net', 'https://frescopa.aem-screens.net')).to.equal(false);
+    });
+
+    it('strips a scheme prefix from host before parsing', () => {
+      expect(hostSharesSiteRegistrableDomain('https://tokowaka.aem-screens.net', 'https://frescopa.aem-screens.net')).to.equal(true);
+    });
+
+    it('returns false when baseURL is not a valid URL', () => {
+      expect(hostSharesSiteRegistrableDomain('tokowaka.aem-screens.net', 'not-a-url')).to.equal(false);
     });
   });
 
   describe('isCloudflareTargetHostAllowed', () => {
+    it('accepts the exact canonical site host', () => {
+      expect(isCloudflareTargetHostAllowed('example.com', 'https://www.example.com')).to.equal(true);
+    });
+
     it('accepts production subdomains', () => {
       expect(isCloudflareTargetHostAllowed('cdn.example.com', 'https://www.example.com')).to.equal(true);
     });
 
     it('accepts registrable-domain siblings for stage-style hosts', () => {
       expect(isCloudflareTargetHostAllowed('tokowaka.aem-screens.net', 'https://frescopa.aem-screens.net')).to.equal(true);
+    });
+
+    it('rejects a completely unrelated domain', () => {
+      expect(isCloudflareTargetHostAllowed('evil.com', 'https://www.example.com')).to.equal(false);
+    });
+
+    it('rejects a look-alike suffix that shares neither the site domain nor registrable domain', () => {
+      expect(isCloudflareTargetHostAllowed('notexample.com', 'https://www.example.com')).to.equal(false);
     });
   });
 });

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -414,6 +414,27 @@ describe('LlmoCloudflareController', () => {
       expect(res.status).to.equal(200);
     });
 
+    it('uses staging metaconfig and a stage-specific worker name for stage subdomains', async () => {
+      const STAGE_HOST = 'staging.example.com';
+      const STAGE_SCRIPT = 'edge-optimize-router-staging-example-com';
+      mockContext.data = { accountId: ACCOUNT_ID, targetHost: STAGE_HOST };
+      mockCfClient.deployWorkerScript.resolves();
+      mockCfClient.setWorkerSecret.resolves();
+
+      const res = await controller.deployWorker(mockContext);
+      expect(res.status).to.equal(200);
+
+      expect(mockTokowakaClient.fetchMetaconfig).to.have.been.calledWith('https://staging.example.com/');
+      expect(mockCfClient.deployWorkerScript).to.have.been.calledWith(
+        ACCOUNT_ID,
+        STAGE_SCRIPT,
+        WORKER_SCRIPT_TEXT,
+        [{ name: 'EDGE_OPTIMIZE_TARGET_HOST', type: 'plain_text', text: STAGE_HOST }],
+      );
+      const body = await res.json();
+      expect(body.scriptName).to.equal(STAGE_SCRIPT);
+    });
+
     it('returns 400 when CF token is missing', async () => {
       mockContext.pathInfo.headers = {};
       const res = await controller.deployWorker(mockContext);

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -435,6 +435,42 @@ describe('LlmoCloudflareController', () => {
       expect(body.scriptName).to.equal(STAGE_SCRIPT);
     });
 
+    it('accepts a sibling subdomain and uses its own worker name and metaconfig URL', async () => {
+      const SIBLING_HOST = 'tokowaka.aem-screens.net';
+      const SIBLING_SCRIPT = 'edge-optimize-router-tokowaka-aem-screens-net';
+      mockSite.getBaseURL = () => 'https://frescopa.aem-screens.net';
+      mockContext.data = { accountId: ACCOUNT_ID, targetHost: SIBLING_HOST };
+      mockCfClient.deployWorkerScript.resolves();
+      mockCfClient.setWorkerSecret.resolves();
+
+      const res = await controller.deployWorker(mockContext);
+      expect(res.status).to.equal(200);
+
+      expect(mockTokowakaClient.fetchMetaconfig).to.have.been.calledWith('https://tokowaka.aem-screens.net/');
+      expect(mockCfClient.deployWorkerScript).to.have.been.calledWith(
+        ACCOUNT_ID,
+        SIBLING_SCRIPT,
+        WORKER_SCRIPT_TEXT,
+        [{ name: 'EDGE_OPTIMIZE_TARGET_HOST', type: 'plain_text', text: SIBLING_HOST }],
+      );
+      const body = await res.json();
+      expect(body.scriptName).to.equal(SIBLING_SCRIPT);
+    });
+
+    it('uses the site base URL for metaconfig when targetHost is the canonical production host', async () => {
+      mockContext.data = { accountId: ACCOUNT_ID, targetHost: 'example.com' };
+      mockCfClient.deployWorkerScript.resolves();
+      mockCfClient.setWorkerSecret.resolves();
+
+      const res = await controller.deployWorker(mockContext);
+      expect(res.status).to.equal(200);
+
+      // Canonical host matches www.example.com → site base URL is reused for metaconfig.
+      expect(mockTokowakaClient.fetchMetaconfig).to.have.been.calledWith('https://www.example.com');
+      const body = await res.json();
+      expect(body.scriptName).to.equal(DERIVED_SCRIPT_NAME);
+    });
+
     it('returns 400 when CF token is missing', async () => {
       mockContext.pathInfo.headers = {};
       const res = await controller.deployWorker(mockContext);
@@ -566,6 +602,20 @@ describe('LlmoCloudflareController', () => {
       mockCfClient.addRoute.resolves(route);
       const res = await controller.addRoute(mockContext);
       expect(res.status).to.equal(200);
+    });
+
+    it('accepts a sibling-subdomain pattern and targets a stage-specific worker', async () => {
+      const SIBLING_PATTERN = 'tokowaka.aem-screens.net/*';
+      const SIBLING_SCRIPT = 'edge-optimize-router-tokowaka-aem-screens-net';
+      mockSite.getBaseURL = () => 'https://frescopa.aem-screens.net';
+      mockContext.data = { zoneId: ZONE_ID, pattern: SIBLING_PATTERN };
+      const route = { id: ROUTE_ID, pattern: SIBLING_PATTERN, script: SIBLING_SCRIPT };
+      mockCfClient.addRoute.resolves(route);
+
+      const res = await controller.addRoute(mockContext);
+      expect(res.status).to.equal(200);
+      // eslint-disable-next-line max-len
+      expect(mockCfClient.addRoute).to.have.been.calledWith(ZONE_ID, SIBLING_PATTERN, SIBLING_SCRIPT);
     });
 
     it('returns 400 when a worker name cannot be derived from the site base URL', async () => {


### PR DESCRIPTION
## Summary
- Allow Cloudflare deploy/route `targetHost` validation for stage domains that share the production site's registrable domain (sibling subdomains, e.g. `tokowaka.aem-screens.net` vs `frescopa.aem-screens.net`), matching stage-domain onboarding in the UI.
- Resolve worker script name and Edge Optimize API key from the deploy target host via `deployWorkerBaseURL` so stage hosts get their own worker name and staging metaconfig key.

Replaces #2711 (cloudflare-client 1.1.1 bump is already on main via #2704).

Pairs with [project-elmo-ui#2173](https://github.com/adobe/project-elmo-ui/pull/2173).

## Test plan
- [x] `llmo-cloudflare` utils + controller unit tests pass
- [ ] Deploy worker from stage-domain wizard with a sibling subdomain host — expect 200 (not `targetHost must belong to the site's domain`)
- [ ] Deploy worker for production host — unchanged behavior
- [ ] Add route for stage host pattern — worker name matches stage-specific script


Made with [Cursor](https://cursor.com)