### PR TITLE
fix(llmo): return 409 when Cloudflare deploy worker already exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
         "@adobe/spacecat-shared-brand-client": "1.4.0",
-        "@adobe/spacecat-shared-cloudflare-client": "1.1.1",
+        "@adobe/spacecat-shared-cloudflare-client": "1.2.0",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
@@ -2724,9 +2724,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-cloudflare-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.1.1.tgz",
-      "integrity": "sha512-JDDT+Bjbn3JuetPkGEERNkQhek9Y6xUHxpMabRiXLkM6dbM55AbioTj6suZWApwEiXj7E5Dd3nBvmLMsZzK4nQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.2.0.tgz",
+      "integrity": "sha512-eyaJAHnX/HLKtchce6l+NcTplhN1kAimA77Ckq5D/B8LtdOz0+xrDH/i83BTgLs3X2hN1hcrfJijPxjSxxnDbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.12",
     "@adobe/spacecat-shared-brand-client": "1.4.0",
-    "@adobe/spacecat-shared-cloudflare-client": "1.1.1",
+    "@adobe/spacecat-shared-cloudflare-client": "1.2.0",
     "@adobe/spacecat-shared-content-client": "1.8.24",
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",

--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -39,6 +39,25 @@ const WORKER_SCRIPT_FETCH_TIMEOUT_MS = 10_000;
 const CF_ID_RE = /^[0-9a-f]{32}$/; // Cloudflare account/zone IDs are 32-char lowercase hex
 const HOSTNAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/i;
 
+/**
+ * Whether a deployWorkerScript failure indicates the target worker name is already taken.
+ * CloudflareClient 1.1.x probed existence via GET /workers/scripts/:name, which returns
+ * script source (not JSON) when the worker exists — that surfaced as a generic 502 upstream.
+ */
+const isWorkerDeployConflictError = (error) => {
+  const message = error?.message || String(error);
+  if (/already exists/i.test(message)) {
+    return true;
+  }
+  return /non-JSON response on \/accounts\/[^/]+\/workers\/scripts\//i.test(message);
+};
+
+const workerAlreadyExistsResponse = (scriptName, accountId) => createResponse({
+  message: `A worker named '${scriptName}' already exists in this Cloudflare account`,
+  scriptName,
+  accountId,
+}, 409);
+
 function LlmoCloudflareController(ctx) {
   const { log, env } = ctx;
   const accessControlUtil = AccessControlUtil.fromContext(ctx);
@@ -285,13 +304,9 @@ function LlmoCloudflareController(ctx) {
       // preventing an onboarding deploy from silently replacing one.
       await cfClient.deployWorkerScript(accountId, scriptName, workerScript, bindings);
     } catch (e) {
-      if (/already exists/i.test(e.message)) {
+      if (isWorkerDeployConflictError(e)) {
         log.info(`Worker '${scriptName}' already exists in account ${accountId}; refusing to overwrite`);
-        return createResponse({
-          message: `A worker named '${scriptName}' already exists in this Cloudflare account`,
-          scriptName,
-          accountId,
-        }, 409);
+        return workerAlreadyExistsResponse(scriptName, accountId);
       }
       return cfErrorResponse(e, 'worker deployment');
     }

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -461,6 +461,23 @@ describe('LlmoCloudflareController', () => {
       expect(res.status).to.equal(409);
       const body = await res.json();
       expect(body.scriptName).to.equal(DERIVED_SCRIPT_NAME);
+      expect(body.message).to.equal(
+        `A worker named '${DERIVED_SCRIPT_NAME}' already exists in this Cloudflare account`,
+      );
+      expect(mockCfClient.setWorkerSecret).to.not.have.been.called;
+    });
+
+    it('returns 409 when existence check fails with non-JSON worker script GET (legacy client)', async () => {
+      mockCfClient.deployWorkerScript.rejects(
+        new Error(`Cloudflare API returned a non-JSON response on /accounts/${ACCOUNT_ID}/workers/scripts/${DERIVED_SCRIPT_NAME}`),
+      );
+      const res = await controller.deployWorker(mockContext);
+      expect(res.status).to.equal(409);
+      const body = await res.json();
+      expect(body.scriptName).to.equal(DERIVED_SCRIPT_NAME);
+      expect(body.message).to.equal(
+        `A worker named '${DERIVED_SCRIPT_NAME}' already exists in this Cloudflare account`,
+      );
       expect(mockCfClient.setWorkerSecret).to.not.have.been.called;
     });
 


### PR DESCRIPTION
## Summary
- Bumps `@adobe/spacecat-shared-cloudflare-client` to 1.2.0, which checks worker existence via `scripts-search` (JSON) instead of GET on the script endpoint (returns worker source, not JSON).
- Maps worker deploy conflicts to HTTP 409 with `message`, `scriptName`, and `accountId` so ELMO UI can surface `CloudflareWorkerAlreadyExistsError`.
- Adds a fallback mapping for legacy client errors (`non-JSON response on /workers/scripts/...`) that previously surfaced as a generic 502.

## Test plan
- [x] `npm test` (full suite green)
- [x] Unit tests for 409 on explicit `already exists` and legacy non-JSON worker GET errors
- [ ] Deploy to a Cloudflare account that already has the derived worker name and confirm the deploy endpoint returns 409 with the expected message body


Made with [Cursor](https://cursor.com)