### PR TITLE
chore: bump @adobe/spacecat-shared-cloudflare-client to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
         "@adobe/spacecat-shared-brand-client": "1.4.0",
-        "@adobe/spacecat-shared-cloudflare-client": "1.2.0",
+        "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "3.79.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
@@ -2724,9 +2724,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-cloudflare-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.2.0.tgz",
-      "integrity": "sha512-eyaJAHnX/HLKtchce6l+NcTplhN1kAimA77Ckq5D/B8LtdOz0+xrDH/i83BTgLs3X2hN1hcrfJijPxjSxxnDbw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-cloudflare-client/-/spacecat-shared-cloudflare-client-1.2.1.tgz",
+      "integrity": "sha512-yGGXApQKiYvGp8GI54i4Zu54D+wyPkxQ2/tiPE7hPdD5w3gVXoMLTWScQt8IQ6Z05GNSj/i3UP5NDgv6rvAgYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.12",
     "@adobe/spacecat-shared-brand-client": "1.4.0",
-    "@adobe/spacecat-shared-cloudflare-client": "1.2.0",
+    "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
     "@adobe/spacecat-shared-data-access": "3.79.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",


### PR DESCRIPTION
## Summary

- Bumps `@adobe/spacecat-shared-cloudflare-client` from `1.2.0` → `1.2.1`
- 1.2.1 fixes a bug where the `scripts-search` API response was filtered by `w.id` (an internal UUID) instead of `w.script_name` (the actual worker name), causing the existence check to always return null and silently overwrite an existing Cloudflare worker on every deploy instead of returning a 409 conflict

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)