### PR TITLE
fix(serenity): harden sub-workspace create against failed-provisioning stubs

### DIFF
--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -153,6 +153,18 @@ async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log
   const items = familyItems(family);
   const matches = items.filter((w) => w?.title === title && w?.status === 'created');
   if (matches.length === 0) {
+    // Surface filtered-out non-`created` same-title stubs (Semrush ack-then-fail
+    // zombies) so their accumulation is visible in logs without a manual family
+    // query — they are the exact failure mode this status filter absorbs (#2718).
+    const ignored = items.filter((w) => w?.title === title && w?.status !== 'created');
+    if (ignored.length > 0) {
+      log?.info?.('ensureSubworkspace: ignoring non-created same-title family stub(s)', {
+        parentWorkspaceId,
+        title,
+        ignoredCount: ignored.length,
+        ignoredStatuses: ignored.map((w) => w?.status),
+      });
+    }
     return null;
   }
   if (matches.length > 1) {

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -125,23 +125,38 @@ function familyItems(family) {
 }
 
 /**
- * Ambiguous-create recovery (design §6): a timed-out createSubworkspace is
- * ambiguous (no idempotency key). List the parent's family, match the exact
- * title, and adopt a `created`, project-empty subworkspace. Multiple matches → fail
- * with an alert, never guess.
+ * Finds the one adoptable same-title child in the parent's family, or `null` when
+ * none exists. "Adoptable" means a `created`, project-empty sub-workspace.
+ *
+ * Status filter (issue #2718): a Semrush child create can be 200-acked and then
+ * fail provisioning asynchronously, leaving a stub permanently stuck at
+ * `status: 'not ready'` ("invalid subscription") that we cannot delete. Such a
+ * zombie also has `projectCount 0`, so a title+empty-only match would (a) adopt
+ * it as the brand's workspace (then immediately re-time-out at pollUntilCreated)
+ * and (b) once ≥2 accumulate, inflate the multiple-match `409` and wedge the
+ * brand. Considering ONLY `status === 'created'` entries makes accumulated
+ * zombies invisible to the matcher, breaking that snowball. The live family
+ * endpoint always returns a status, so the strict equality is safe.
+ *
+ * Shared by both adoption paths so the match/ambiguity/empty rules live in one
+ * place: the proactive create-or-adopt check (returns the match to reuse, or
+ * null → create) and the 504 timeout recovery (null → no-match error).
+ *
+ * @param {object} transport
+ * @param {string} parentWorkspaceId
+ * @param {string} title
+ * @param {object} log
+ * @returns {Promise<object|null>} the sole adoptable family entry, or null.
  */
-async function adoptFromFamily(transport, parentWorkspaceId, title, log) {
+async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log) {
   const family = await transport.listWorkspaceFamily(parentWorkspaceId);
   const items = familyItems(family);
-  const matches = items.filter((w) => w?.title === title);
+  const matches = items.filter((w) => w?.title === title && w?.status === 'created');
   if (matches.length === 0) {
-    throw new ErrorWithStatusCode(
-      `Ambiguous subworkspace create for '${title}' and no family match to adopt`,
-      502,
-    );
+    return null;
   }
   if (matches.length > 1) {
-    log?.error?.('ensureSubworkspace: ambiguous create — multiple family matches, refusing to guess', {
+    log?.error?.('ensureSubworkspace: ambiguous create — multiple created family matches, refusing to guess', {
       parentWorkspaceId,
       title,
       matchIds: matches.map((m) => m?.id),
@@ -161,11 +176,11 @@ async function adoptFromFamily(transport, parentWorkspaceId, title, log) {
       502,
     );
   }
-  // Defense-in-depth: adopt ONLY a genuinely empty sub-workspace. A timed-out
-  // create has not yet created any projects (projects are created only after
-  // the workspace settles to `created`), so a non-empty match is NOT our
-  // interrupted create — adopting it would graft this brand onto an
-  // already-provisioned workspace. Refuse rather than risk contamination.
+  // Defense-in-depth: adopt ONLY a genuinely empty sub-workspace. An interrupted
+  // create has not yet created any projects (projects are created only after the
+  // workspace settles to `created`), so a non-empty match is NOT our create —
+  // adopting it would graft this brand onto an already-provisioned workspace.
+  // Refuse rather than risk contamination.
   const adoptedListing = await transport.listProjects(adoptedId);
   const projectCount = Array.isArray(adoptedListing?.items) ? adoptedListing.items.length : 0;
   if (projectCount > 0) {
@@ -180,11 +195,30 @@ async function adoptFromFamily(transport, parentWorkspaceId, title, log) {
       502,
     );
   }
-  log?.info?.('ensureSubworkspace: adopted subworkspace after ambiguous create', {
+  log?.info?.('ensureSubworkspace: adopted same-title family match', {
     parentWorkspaceId,
     title,
     adoptedId,
   });
+  return adopted;
+}
+
+/**
+ * Ambiguous-create recovery (design §6): a timed-out createSubworkspace is
+ * ambiguous (no idempotency key). List the parent's family, match the exact
+ * title, and adopt a `created`, project-empty subworkspace. No match → fail (the
+ * create was attempted, so a missing entry is an error here, unlike the proactive
+ * path where it just means "create one"). Multiple matches → fail with an alert,
+ * never guess.
+ */
+async function adoptFromFamily(transport, parentWorkspaceId, title, log) {
+  const adopted = await findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log);
+  if (!adopted) {
+    throw new ErrorWithStatusCode(
+      `Ambiguous subworkspace create for '${title}' and no family match to adopt`,
+      502,
+    );
+  }
   return adopted;
 }
 
@@ -255,26 +289,35 @@ export async function ensureSubworkspace(
   }
 
   const title = subworkspaceTitle(brand);
-  let created;
-  try {
-    // Carve a fixed allocation (CREATE_ALLOCATION) onto the child so it has the
-    // metered quota to take prompts and publish. marketCount does not size the
-    // create — the allocation is flat (1 project, 500 prompts). If the parent
-    // pool can't cover it the create 422s "insufficient available units".
-    created = await transport.createSubworkspace(
-      parentWorkspaceId,
-      title,
-      CREATE_ALLOCATION,
-    );
-  } catch (e) {
-    // 504 = our transport's timeout signal → ambiguous create, recover by
-    // adoption. The transport timeout is a SerenityTransportError (status 504),
-    // NOT an ErrorWithStatusCode — guard on that so a 504 from our own poll
-    // helper (an ErrorWithStatusCode) re-throws instead of re-entering adoption.
-    if (!(e instanceof ErrorWithStatusCode) && e?.status === 504) {
-      created = await adoptFromFamily(transport, parentWorkspaceId, title, log);
-    } else {
-      throw e;
+  // Idempotent create-or-adopt (issue #2718): a retry after a partial
+  // provisioning failure must NOT spawn a duplicate same-title stub (titles embed
+  // the brand-id suffix, so a retry collides on title). Check the parent family
+  // for an existing `created`, empty same-title child FIRST and reuse it; only
+  // create when none exists. Failed `not ready` zombies are filtered out by the
+  // status check in findAdoptableFamilyMatch, so they are never reused and never
+  // inflate the ambiguity 409.
+  let created = await findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log);
+  if (!created) {
+    try {
+      // Carve a fixed allocation (CREATE_ALLOCATION) onto the child so it has the
+      // metered quota to take prompts and publish. marketCount does not size the
+      // create — the allocation is flat (1 project, 500 prompts). If the parent
+      // pool can't cover it the create 422s "insufficient available units".
+      created = await transport.createSubworkspace(
+        parentWorkspaceId,
+        title,
+        CREATE_ALLOCATION,
+      );
+    } catch (e) {
+      // 504 = our transport's timeout signal → ambiguous create, recover by
+      // adoption. The transport timeout is a SerenityTransportError (status 504),
+      // NOT an ErrorWithStatusCode — guard on that so a 504 from our own poll
+      // helper (an ErrorWithStatusCode) re-throws instead of re-entering adoption.
+      if (!(e instanceof ErrorWithStatusCode) && e?.status === 504) {
+        created = await adoptFromFamily(transport, parentWorkspaceId, title, log);
+      } else {
+        throw e;
+      }
     }
   }
 

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -162,7 +162,7 @@ async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log
         parentWorkspaceId,
         title,
         ignoredCount: ignored.length,
-        ignoredStatuses: ignored.map((w) => w?.status),
+        ignoredStatuses: [...new Set(ignored.map((w) => w?.status))],
       });
     }
     return null;

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -110,49 +110,60 @@ describe('workspace-lifecycle', () => {
       expect(brand.save).to.have.been.calledOnce;
     });
 
-    it('adopts a unique family match after a create timeout (504)', async () => {
-      // GET /v1/workspaces/{id}/family returns a BARE ARRAY (live-verified), not an
-      // { items: [...] } envelope; non-matching entries are skipped and the single
-      // title match is adopted.
+    it('adopts a unique created family match after a create timeout (504 recovery preserved)', async () => {
+      // True 504-recovery: at proactive-check time nothing is adoptable yet, the
+      // create then times out (504) although it actually succeeded upstream, and
+      // the now-`created` child appears in the family on the recovery read. GET
+      // /v1/workspaces/{id}/family returns a BARE ARRAY (live-verified), not an
+      // { items: [...] } envelope; non-matching and non-`created` entries are
+      // skipped and the single title match is adopted.
+      const listWorkspaceFamily = sinon.stub();
+      listWorkspaceFamily.onFirstCall().resolves([]);
+      listWorkspaceFamily.onSecondCall().resolves([
+        { id: 'other-ws', title: 'Some Other Brand [11111111]', status: 'created' },
+        { id: 'adopted-ws', title: EXPECTED_TITLE, status: 'created' },
+      ]);
       const transport = makeTransport({
         createSubworkspace: sinon.stub().rejects(new SerenityTransportError(504, 'timeout')),
-        listWorkspaceFamily: sinon.stub().resolves([
-          { id: 'other-ws', title: 'Some Other Brand [11111111]' },
-          { id: 'adopted-ws', title: EXPECTED_TITLE },
-        ]),
+        listWorkspaceFamily,
       });
       const brand = makeBrand();
 
       const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
 
       expect(result).to.equal('adopted-ws');
+      expect(transport.createSubworkspace).to.have.been.calledOnce;
       expect(brand.setSemrushWorkspaceId).to.have.been.calledWith('adopted-ws');
     });
 
-    it('refuses to adopt a NON-empty family match after a create timeout', async () => {
-      // A timed-out create has no projects yet; a non-empty title match is some
-      // OTHER provisioned workspace, never our interrupted create. Refuse it.
+    it('refuses to adopt a NON-empty created family match (shared empty-check)', async () => {
+      // The empty-check is shared by the proactive and 504 paths. A `created`
+      // title match that already has projects is some OTHER provisioned workspace,
+      // never our interrupted/retried create — refuse rather than graft this brand
+      // onto it.
       const transport = makeTransport({
-        createSubworkspace: sinon.stub().rejects(new SerenityTransportError(504, 'timeout')),
-        listWorkspaceFamily: sinon.stub().resolves([{ id: 'occupied-ws', title: EXPECTED_TITLE }]),
+        listWorkspaceFamily: sinon.stub().resolves([
+          { id: 'occupied-ws', title: EXPECTED_TITLE, status: 'created' },
+        ]),
         listProjects: sinon.stub().resolves({ items: [{ id: 'existing-project' }] }),
       });
       const brand = makeBrand();
 
       await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
         .to.be.rejectedWith(/refusing to adopt/);
+      expect(transport.createSubworkspace).to.not.have.been.called;
       expect(brand.setSemrushWorkspaceId).to.not.have.been.called;
     });
 
-    it('throws when the sole family match has no id', async () => {
+    it('throws when the sole created family match has no id', async () => {
       const transport = makeTransport({
-        createSubworkspace: sinon.stub().rejects(new SerenityTransportError(504, 'timeout')),
-        listWorkspaceFamily: sinon.stub().resolves([{ title: EXPECTED_TITLE }]),
+        listWorkspaceFamily: sinon.stub().resolves([{ title: EXPECTED_TITLE, status: 'created' }]),
       });
       const brand = makeBrand();
 
       await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
         .to.be.rejectedWith(/sole family match has no id/);
+      expect(transport.createSubworkspace).to.not.have.been.called;
       expect(transport.listProjects).to.not.have.been.called;
     });
 
@@ -168,12 +179,13 @@ describe('workspace-lifecycle', () => {
       expect(transport.createSubworkspace).to.not.have.been.called;
     });
 
-    it('fails with an ambiguousWorkspace alert on multiple family matches', async () => {
+    it('fails with an ambiguousWorkspace alert on multiple CREATED family matches', async () => {
+      // Genuine ambiguity preserved: ≥2 `created` same-title children → 409, never
+      // guess. (Non-`created` zombies are filtered out and never reach this count.)
       const transport = makeTransport({
-        createSubworkspace: sinon.stub().rejects(new SerenityTransportError(504, 'timeout')),
         listWorkspaceFamily: sinon.stub().resolves([
-          { id: 'ws-a', title: EXPECTED_TITLE },
-          { id: 'ws-b', title: EXPECTED_TITLE },
+          { id: 'ws-a', title: EXPECTED_TITLE, status: 'created' },
+          { id: 'ws-b', title: EXPECTED_TITLE, status: 'created' },
         ]),
       });
       const brand = makeBrand();
@@ -186,6 +198,7 @@ describe('workspace-lifecycle', () => {
         expect(e.code).to.equal('ambiguousWorkspace');
         expect(e.status).to.equal(409);
       }
+      expect(transport.createSubworkspace).to.not.have.been.called;
       expect(brand.save).to.not.have.been.called;
     });
 
@@ -216,6 +229,77 @@ describe('workspace-lifecycle', () => {
 
       await expect(ensureSubworkspace(transport, brand, '', 1, log, NOOP_TIMING))
         .to.be.rejectedWith(/has no parent workspace/);
+    });
+
+    describe('failed-provisioning stub hardening (issue #2718)', () => {
+      it('idempotent create-or-adopt: reuses an existing created empty same-title child instead of creating a duplicate', async () => {
+        // Mitigation 2: a retry must reuse the good child, not spawn another stub.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'existing-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+
+        expect(result).to.equal('existing-ws');
+        expect(transport.createSubworkspace).to.not.have.been.called;
+        expect(brand.setSemrushWorkspaceId).to.have.been.calledOnceWithExactly('existing-ws');
+        expect(brand.save).to.have.been.calledOnce;
+      });
+
+      it('does NOT adopt a single not-ready zombie stub; creates a fresh workspace', async () => {
+        // Mitigation 1: a failed-provisioning stub (status 'not ready', 0 projects)
+        // is invisible to the matcher, so it is never falsely adopted.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'zombie-ws', title: EXPECTED_TITLE, status: 'not ready' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+
+        expect(result).to.equal(SUB_WS);
+        expect(transport.createSubworkspace).to.have.been.calledOnce;
+        expect(brand.setSemrushWorkspaceId).to.have.been.calledOnceWithExactly(SUB_WS);
+      });
+
+      it('adopts the one created match when a not-ready zombie shares the title', async () => {
+        // Mitigation 1: exactly one `created` among same-title entries → adopt it,
+        // no false 409 from the co-resident zombie.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'zombie-ws', title: EXPECTED_TITLE, status: 'not ready' },
+            { id: 'good-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+
+        expect(result).to.equal('good-ws');
+        expect(transport.createSubworkspace).to.not.have.been.called;
+        expect(brand.setSemrushWorkspaceId).to.have.been.calledWith('good-ws');
+      });
+
+      it('accumulated not-ready zombies do NOT inflate the ambiguity 409; create proceeds', async () => {
+        // Mitigation 1: ≥2 same-title zombies but zero `created` → no false 409;
+        // the snowball is broken and a fresh create proceeds.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'zombie-1', title: EXPECTED_TITLE, status: 'not ready' },
+            { id: 'zombie-2', title: EXPECTED_TITLE, status: 'not ready' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+
+        expect(result).to.equal(SUB_WS);
+        expect(transport.createSubworkspace).to.have.been.calledOnce;
+      });
     });
 
     it('502s when create returns no id', async () => {
@@ -538,12 +622,13 @@ describe('workspace-lifecycle', () => {
       });
     });
 
-    describe('adoptFromFamily adopt path - listProjects resolves non-array', () => {
+    describe('findAdoptableFamilyMatch adopt path - listProjects resolves non-array', () => {
       it('adopts the empty match when listProjects returns {} (projectCount = 0)', async () => {
-        // Line 156: Array.isArray false branch -> projectCount = 0 -> adopts.
+        // Array.isArray false branch -> projectCount = 0 -> adopts.
         const transport = makeTransport({
-          createSubworkspace: sinon.stub().rejects(new SerenityTransportError(504, 'timeout')),
-          listWorkspaceFamily: sinon.stub().resolves([{ id: 'adopted-ws', title: EXPECTED_TITLE }]),
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'adopted-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
           listProjects: sinon.stub().resolves({}),
         });
         const brand = makeBrand();
@@ -551,6 +636,7 @@ describe('workspace-lifecycle', () => {
         const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
 
         expect(result).to.equal('adopted-ws');
+        expect(transport.createSubworkspace).to.not.have.been.called;
         expect(brand.setSemrushWorkspaceId).to.have.been.calledWith('adopted-ws');
       });
     });

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -300,6 +300,53 @@ describe('workspace-lifecycle', () => {
         expect(result).to.equal(SUB_WS);
         expect(transport.createSubworkspace).to.have.been.calledOnce;
       });
+
+      it('logs the count of ignored non-created same-title stubs (operational visibility)', async () => {
+        // Zombies accumulating under a brand should be visible in logs without a
+        // manual family query — the proactive find emits an info line naming the count.
+        const localLog = { info: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'zombie-1', title: EXPECTED_TITLE, status: 'not ready' },
+            { id: 'zombie-2', title: EXPECTED_TITLE, status: 'invalid subscription' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        await ensureSubworkspace(transport, brand, PARENT_WS, 1, localLog, NOOP_TIMING);
+
+        const logged = localLog.info.getCalls()
+          .find((c) => /ignoring non-created same-title/.test(c.args[0]));
+        expect(logged, 'expected an ignored-stub log line').to.exist;
+        expect(logged.args[1]).to.include({ ignoredCount: 2 });
+      });
+
+      it('does NOT log ignored stubs when no same-title stub exists (clean first create)', async () => {
+        // Happy path: empty family → no ignored-stub noise.
+        const localLog = { info: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+        const transport = makeTransport();
+        const brand = makeBrand();
+
+        await ensureSubworkspace(transport, brand, PARENT_WS, 1, localLog, NOOP_TIMING);
+
+        const logged = localLog.info.getCalls()
+          .find((c) => /ignoring non-created same-title/.test(c.args[0]));
+        expect(logged, 'expected no ignored-stub log line').to.not.exist;
+      });
+
+      it('propagates a listWorkspaceFamily error from the proactive check (fail-safe: no blind create)', async () => {
+        // If we cannot read the family we cannot know whether a created child
+        // already exists, so creating blindly would risk the very duplicate-stub
+        // problem this guard prevents. Fail rather than create.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().rejects(new SerenityTransportError(503, 'upstream down')),
+        });
+        const brand = makeBrand();
+
+        await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
+          .to.be.rejectedWith(SerenityTransportError);
+        expect(transport.createSubworkspace).to.not.have.been.called;
+      });
     });
 
     it('502s when create returns no id', async () => {

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -301,14 +301,17 @@ describe('workspace-lifecycle', () => {
         expect(transport.createSubworkspace).to.have.been.calledOnce;
       });
 
-      it('logs the count of ignored non-created same-title stubs (operational visibility)', async () => {
+      it('logs the count of ignored non-created same-title stubs and dedupes their statuses', async () => {
         // Zombies accumulating under a brand should be visible in logs without a
-        // manual family query — the proactive find emits an info line naming the count.
+        // manual family query — the proactive find emits an info line. ignoredCount
+        // conveys volume; ignoredStatuses is deduped so repeated stubs sharing a
+        // status do not bloat the line.
         const localLog = { info: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
         const transport = makeTransport({
           listWorkspaceFamily: sinon.stub().resolves([
             { id: 'zombie-1', title: EXPECTED_TITLE, status: 'not ready' },
-            { id: 'zombie-2', title: EXPECTED_TITLE, status: 'invalid subscription' },
+            { id: 'zombie-2', title: EXPECTED_TITLE, status: 'not ready' },
+            { id: 'zombie-3', title: EXPECTED_TITLE, status: 'invalid subscription' },
           ]),
         });
         const brand = makeBrand();
@@ -318,7 +321,9 @@ describe('workspace-lifecycle', () => {
         const logged = localLog.info.getCalls()
           .find((c) => /ignoring non-created same-title/.test(c.args[0]));
         expect(logged, 'expected an ignored-stub log line').to.exist;
-        expect(logged.args[1]).to.include({ ignoredCount: 2 });
+        expect(logged.args[1]).to.include({ ignoredCount: 3 });
+        expect(logged.args[1].ignoredStatuses).to.have.members(['not ready', 'invalid subscription']);
+        expect(logged.args[1].ignoredStatuses).to.have.lengthOf(2);
       });
 
       it('does NOT log ignored stubs when no same-title stub exists (clean first create)', async () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Hardens serenity's sub-workspace create (`src/support/serenity/workspace-lifecycle.js`) against Semrush "failed-provisioning" stubs by status-filtering adoption and making the create path an idempotent create-or-adopt.

## 2. Reasoning
A Semrush User Manager child-workspace create (`POST .../workspaces/{parent}/child`) can return `200` (accepted) and then fail provisioning asynchronously, leaving the child permanently stuck `status: "not ready"` ("invalid subscription"). Such a stub cannot be removed by us — both `DELETE /v1/workspaces/{id}` and `POST /v2/workspaces/{id}/resources/transfer` return `422 "workspace not ready"` until the workspace reaches `created`, which a failed one never does. Observed live on 2026-06-29 while exercising the User Manager API. The Semrush-side root cause (ack-then-fail with no client reap path) is being raised separately; this change is the client-side hardening so a rare partial failure cannot snowball.

Before this change the snowball was: a non-settling create leaves an undeletable stub in the parent family; a retry creates another same-title child (titles embed the brand-id suffix, so they collide); and adoption matched on `title` + `projectCount === 0` only — never on `status`. A `not ready` zombie also has `projectCount 0`, so it could be falsely adopted (then re-time-out at the next poll), and once ≥2 same-title stubs accumulated the matcher saw multiple matches and returned a false `409 ambiguousWorkspace`, wedging that brand.

## 3. High-level overview of the changes
Two client-side mitigations, both in `ensureSubworkspace` / its family-matching helper:

- **Status-filter adoption.** A new shared helper `findAdoptableFamilyMatch` considers **only** family entries with `status === 'created'` — for both the title match and the multiple-match count. Effect: a failed `not ready` stub is now invisible to the matcher, so it can neither be falsely adopted nor inflate the ambiguity `409`. The existing 504-timeout recovery (`adoptFromFamily`) now delegates to this same helper (no match → `502`), keeping the match/ambiguity/empty rules in one place.
  - Before: single `not ready` same-title stub could be adopted; ≥2 accumulated stubs → false `409`.
  - After: `not ready` stubs ignored; one `created` among same-title entries is adopted with no `409`; a genuinely ambiguous case (≥2 **`created`** same-title) still returns `409 ambiguousWorkspace` (unchanged).

- **Idempotent create-or-adopt.** `ensureSubworkspace` now checks the parent family for an existing **`created`**, empty same-title child **before** calling `createSubworkspace`, and reuses it; it only creates when none exists. Previously adoption ran only on the `504` timeout path, so a retry after a partial failure spawned a duplicate stub. Now a retry reuses the good child.

The `504`/timeout adopt-or-fail behaviour is preserved for the `created` case, and the existing parent-equality guard, the empty-only adoption guard, and the concurrent-activation release/adopt guard are all unchanged.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/2718
- Implementation plan: docs/specs/2026-06-15-serenity-subworkspace-dual-mode-implementation-plan.md (sub-workspace lifecycle design §6 — adoption / ambiguous-create recovery)
- Other: live behaviour + repro https://github.com/adobe/spacecat-shared/issues/1745 ; Semrush-side root cause https://github.com/adobe/serenity-docs/issues/20

## 7. Test plan
(a) Local: this is pure client-side control-flow logic; verification is via the unit suite (`test/support/serenity/workspace-lifecycle.test.js`), which exercises every new branch with injected poll timing (no real delays) — single `not ready` stub not adopted; one `created` among same-title adopted with no `409`; ≥2 `created` still `409`; idempotent reuse instead of duplicate create; and the preserved `504` recovery (two-call family stub proving both the proactive read and the post-timeout recovery read fire).

(b) Per-environment verification (dev): exercise a brand activation/retry for a brand whose org has a parent workspace. Confirm that a retry after a partial-failure create reuses the existing `created` same-title child rather than creating a second one (inspect the parent family listing — no duplicate same-title entries appear from the retry), and that a brand whose family contains only `not ready` stubs proceeds to a fresh create rather than wedging on a `409`. No schema, route, or contract change — no stage/prod-specific steps beyond the standard deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
