### PR TITLE
fix: exclude soft-deleted brands from name uniqueness check | LLMO-5919

### DIFF
--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -836,14 +836,17 @@ export async function upsertBrand({
   const regions = (brand.region || [])
     .map((r) => (typeof r === 'string' ? r : String(r))).filter(hasText);
 
-  // Check if the brand already exists with a base site set.
-  // This prevents silently downgrading an active brand to pending when a caller
-  // re-upserts by name without passing baseSiteId.
+  // Check if a non-deleted brand already exists with this name. Soft-deleted
+  // brands are excluded (.neq('status', 'deleted')) so that creating a brand
+  // whose name matches a deleted record is treated as a fresh create — the
+  // caller gets the expected new brand instead of a resurrected row that
+  // inherits the deleted brand's site_id and anchoring state (LLMO-5919).
   const { data: existing, error: existingError } = await postgrestClient
     .from('brands')
     .select('id, site_id, status')
     .eq('organization_id', organizationId)
     .eq('name', brand.name)
+    .neq('status', 'deleted')
     .maybeSingle();
 
   // Fail closed (LLMO-5556): PostgREST returns { data: null, error } on a query
@@ -940,17 +943,25 @@ export async function upsertBrand({
   // when the brand has no site_id yet — re-onboarding/re-upserting an existing
   // brand by name must NOT re-point its primary site (LLMO-5556: this silently
   // overwrote mongodb.com -> learn.mongodb.com and merck.com -> keytruda.com).
-  if (!anchoredBySemrush && hasText(brand.baseSiteId) && !hasText(existing?.site_id)) {
-    row.site_id = brand.baseSiteId;
-  } else if (
-    !anchoredBySemrush
-    && hasText(brand.baseSiteId)
-    && hasText(existing?.site_id)
-    && existing.site_id !== brand.baseSiteId
-  ) {
-    log.warn(`upsertBrand: ignoring baseSiteId change for brand "${brand.name}" `
-      + `(org ${organizationId}) — primary site is immutable `
-      + `(existing=${existing.site_id}, attempted=${brand.baseSiteId})`);
+  // LLMO-5919: soft-deleted brands are now excluded from `existing` (see filter
+  // above), so `existing === null` covers both fresh creates and resurrections.
+  // In both cases we always write an explicit site_id — or null to clear the
+  // deleted brand's stale anchor so it cannot survive the ON CONFLICT UPDATE
+  // and collide with whichever brand now owns that site.
+  if (!anchoredBySemrush) {
+    if (existing === null) {
+      row.site_id = hasText(brand.baseSiteId) ? brand.baseSiteId : null;
+    } else if (hasText(brand.baseSiteId) && !hasText(existing.site_id)) {
+      row.site_id = brand.baseSiteId;
+    } else if (
+      hasText(brand.baseSiteId)
+      && hasText(existing.site_id)
+      && existing.site_id !== brand.baseSiteId
+    ) {
+      log.warn(`upsertBrand: ignoring baseSiteId change for brand "${brand.name}" `
+        + `(org ${organizationId}) — primary site is immutable `
+        + `(existing=${existing.site_id}, attempted=${brand.baseSiteId})`);
+    }
   }
 
   const { data: upserted, error } = await postgrestClient

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -790,10 +790,11 @@ describe('brands-storage', () => {
   }
 
   // Like createTableMockClient, but records rows passed to write methods so
-  // tests can assert exactly what was written.
+  // tests can assert exactly what was written. Also records neq() filter calls
+  // so tests can verify which filters were applied to queries.
   function createCapturingClient(tableMap) {
     const calls = {
-      upsert: [], update: [], delete: [], or: [],
+      upsert: [], update: [], delete: [], or: [], neq: [],
     };
     const callCounts = {};
     const makeQuery = (table) => {
@@ -829,6 +830,12 @@ describe('brands-storage', () => {
           if (prop === 'or') {
             return (filter) => {
               calls.or.push({ table, filter });
+              return new Proxy({}, handler);
+            };
+          }
+          if (prop === 'neq') {
+            return (col, val) => {
+              calls.neq.push({ table, col, val });
               return new Proxy({}, handler);
             };
           }
@@ -1409,8 +1416,8 @@ describe('brands-storage', () => {
     });
 
     it('creates a fresh brand when the name matches only a soft-deleted brand (LLMO-5919)', async () => {
-      // The existing-brand lookup returns null because the .neq('status','deleted')
-      // filter excludes the deleted row. The caller's baseSiteId must be applied and
+      // The existing-brand lookup must exclude soft-deleted brands via
+      // .neq('status','deleted'). The caller's baseSiteId must be applied and
       // the brand must be created as active, not resurrected with the old anchor state.
       const client = createCapturingClient({
         brands: [
@@ -1425,6 +1432,10 @@ describe('brands-storage', () => {
         brand: { name: 'Test', baseSiteId: 'new-site' },
         postgrestClient: client,
       });
+
+      // Verify the .neq filter was sent on the existing-brand lookup.
+      const neqFilter = client.capturedCalls.neq.find((c) => c.table === 'brands' && c.col === 'status');
+      expect(neqFilter?.val).to.equal('deleted');
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
       expect(brandsUpsert.row.site_id).to.equal('new-site');

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1408,6 +1408,53 @@ describe('brands-storage', () => {
       expect(log.warn).to.not.have.been.called;
     });
 
+    it('creates a fresh brand when the name matches only a soft-deleted brand (LLMO-5919)', async () => {
+      // The existing-brand lookup returns null because the .neq('status','deleted')
+      // filter excludes the deleted row. The caller's baseSiteId must be applied and
+      // the brand must be created as active, not resurrected with the old anchor state.
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null }, // existing lookup: null (soft-deleted brand excluded)
+          { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
+          { data: makeBrandRow({ name: 'Test', site_id: 'new-site' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'new-site' },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.site_id).to.equal('new-site');
+      expect(brandsUpsert.row.status).to.equal('active');
+    });
+
+    it('sets site_id=null and status=pending when resurrecting a soft-deleted brand without a new baseSiteId (LLMO-5919)', async () => {
+      // Bug scenario: deleted brand had site_id='old-site'. Another brand now owns
+      // that site. A fresh create with no baseSiteId must NOT inherit the stale
+      // site_id — the ON CONFLICT UPDATE would then conflict with the other brand.
+      // The fix writes an explicit null so the stale anchor is cleared.
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null }, // existing lookup: null (soft-deleted brand excluded)
+          { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
+          { data: makeBrandRow({ name: 'Test', status: 'pending' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test' }, // no baseSiteId — should be pending
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.status).to.equal('pending');
+      expect(brandsUpsert.row.site_id).to.equal(null);
+    });
+
     it('fails closed by throwing when the existing-brand lookup errors (LLMO-5556)', async () => {
       // PostgREST returns { data: null, error } instead of throwing — without the
       // guard this would let a transient failure overwrite an existing site_id.


### PR DESCRIPTION
## Summary

Soft-deleted brands were not excluded from the `upsertBrand` name uniqueness check, causing a false \"brand name already exists\" 409 error when a user tried to create a new brand reusing the name of a previously deleted brand.

### Root Cause

`upsertBrand` in `brands-storage.js` queried for existing brands without filtering out soft-deleted rows. The deleted brand's non-null `site_id` made `hasAnchor=true`, silently resurrecting the brand as 'active' with the old site. The `baseSiteId` immutability guard (LLMO-5556) then prevented the new `baseSiteId` from being applied, so the ON CONFLICT UPDATE kept the stale `site_id`. When another brand had since claimed that site, `brands_base_site_unique` fired → 23505 → 409 error.

### Fix

- **`spacecat-api-service/src/support/brands-storage.js`**: Add `.neq('status', 'deleted')` to the existing-brand lookup; restructure `site_id` assignment so `existing===null` (fresh create OR resurrection) always writes an explicit `site_id` or null.
- **`spacecat-api-service/test/support/brands-storage.test.js`**: Extend `createCapturingClient` to capture `.neq()` filter calls; add 2 new `upsertBrand` tests covering LLMO-5919 scenarios including assertion that the deleted-brand filter is applied.

### Test Results

- 165 passing (brands-storage.test.js), 13233 passing (full suite)
- Lint: clean
- IT tests: not run (requires Docker + ECR)

### Known Gaps

- No IT test against a real DB for the soft-deleted-brand resurrection scenario

## Links

- Jira: https://jira.corp.adobe.com/browse/LLMO-5919
- Slack thread: https://adobe.enterprise.slack.com/archives/C0BEJH1SNNL/p1782741378312489

🤖 Generated with [Claude Code](https://claude.com/claude-code)