### PR TITLE
fix(llmo): use canonical baseURL for DRS prompt generation — override…

### DIFF
--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1402,7 +1402,7 @@ export async function activateBrandAndGeneratePrompts({
     try {
       const drsClient = DrsClient.createFrom(context);
       if (drsClient.isConfigured()) {
-        const companyWebsite = siteConfig.getFetchConfig?.()?.overrideBaseURL || baseURL;
+        const companyWebsite = baseURL;
         await triggerBrandalfOnboardingJob({
           drsClient,
           organizationId: organization.getId(),
@@ -1448,7 +1448,7 @@ export async function activateBrandAndGeneratePrompts({
           log.info(`Using operator-supplied region "${region}" for v1 DRS prompt generation`);
         }
         const drsJob = await drsClient.submitPromptGenerationJob({
-          baseUrl: siteConfig.getFetchConfig?.()?.overrideBaseURL || baseURL,
+          baseUrl: baseURL,
           brandName: trimmedBrand,
           audience,
           siteId: site.getId(),

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -313,7 +313,7 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
  * Fully replaces brand_sites for a brand. Groups submitted URLs by normalized base URL
  * (via composeBaseURL) so that multiple paths under the same site share one brand_sites row.
  */
-async function syncBrandSites(organizationId, brandId, urls, postgrestClient, updatedBy) {
+async function syncBrandSites(organizationId, brandId, urls, postgrestClient, updatedBy, log = console) {
   // Serenity market-site rows (type='serenity') are owned by the serenity market
   // lifecycle, NOT by the brand's URL list. A market's domain is generally not in
   // brand.urls, so the delete-all-then-reinsert below would wipe these links on
@@ -395,6 +395,7 @@ async function syncBrandSites(organizationId, brandId, urls, postgrestClient, up
   }
 
   if (!sites || sites.length === 0) {
+    log.warn(`syncBrandSites: no sites found for org ${organizationId} matching URLs [${[...pathsByBase.keys()].join(', ')}]`);
     return;
   }
 
@@ -990,7 +991,7 @@ export async function upsertBrand({
 
   if (brand.urls !== undefined) {
     await Promise.all([
-      syncBrandSites(organizationId, brandId, brand.urls, postgrestClient, updatedBy),
+      syncBrandSites(organizationId, brandId, brand.urls, postgrestClient, updatedBy, log),
       syncBrandUrls(organizationId, brandId, brand.urls, postgrestClient, updatedBy),
     ]);
   }
@@ -1015,6 +1016,7 @@ export async function updateBrand({
   updates,
   postgrestClient,
   updatedBy = 'system',
+  log = console,
 }) {
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
@@ -1193,7 +1195,7 @@ export async function updateBrand({
 
   if (updates.urls !== undefined) {
     await Promise.all([
-      syncBrandSites(organizationId, brandId, updates.urls, postgrestClient, updatedBy),
+      syncBrandSites(organizationId, brandId, updates.urls, postgrestClient, updatedBy, log),
       syncBrandUrls(organizationId, brandId, updates.urls, postgrestClient, updatedBy),
     ]);
   }


### PR DESCRIPTION
## Problem

The V1 DRS prompt generation path passes `overrideBaseURL` (e.g., `https://www.example.com`) as `baseUrl` to `submitPromptGenerationJob`. The downstream handler uses this URL for brand-to-site resolution, but the brand/site tables store the canonical `baseURL` (e.g., `https://example.com`). The mismatch causes:

> `Error: No brand matching site {siteId} in org {orgId}`

This is an org-wide failure for any V1 org where Ahrefs auto-detected a www-variant override, e.g., Paramount org (`296fefc8-1e54-46dd-aee4-a0f94621deaf`) — 3/3 sites failed with 100% failure rate.

The `overrideBaseURL` is meant exclusively for **fetch/audit configuration** (telling the scraper which URL to fetch when the apex doesn't resolve). It should never be used for brand-to-site resolution lookups, as the comment on `llmo-onboarding.js:1344` explicitly warns.

## Changes

| File | Change |
|---|---|
| `src/controllers/llmo/llmo-onboarding.js` | **V1 DRS path** — `baseUrl` now uses canonical `baseURL` instead of `overrideBaseURL \|\| baseURL` |
| `src/controllers/llmo/llmo-onboarding.js` | **V2 Brandalf path** — `companyWebsite` now uses canonical `baseURL` for consistency |
| `src/support/brands-storage.js` | Added `log` parameter to `syncBrandSites` with diagnostic warning when no sites match, making future brand lookup failures discoverable |

## Related
- Closes #2373
- Root cause analysis: Paramount org V1→V2 migration left brand-sites linkage broken; this fix prevents the `overrideBaseURL` from causing the brand lookup to fail on top of that