### PR TITLE
feat(llmo): filter Cloudflare onboarding zones to the site's registrable domain (PSL)

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -5692,8 +5692,11 @@ site-llmo-cloudflare-zones:
     summary: List the Cloudflare zones for the selected account
     description: |
       Lists the Cloudflare zones belonging to the account given by `accountId` that the supplied
-      `x-cloudflare-token` can access. Used by the onboarding UI to let the user pick the zone to
-      attach the Edge Optimize worker route to.
+      `x-cloudflare-token` can access, filtered to the zones relevant to the site: only zones whose
+      registrable apex (the last two hostname labels, e.g. `example.com`) matches the site's
+      base-URL host are returned, so the onboarding UI offers only zones for the site's own domain.
+      Used by the onboarding UI to let the user pick the zone to attach the Edge Optimize worker
+      route to.
 
       **Note:** This endpoint requires LLMO administrator access for the site.
     tags:

--- a/src/controllers/llmo/llmo-cloudflare-utils.js
+++ b/src/controllers/llmo/llmo-cloudflare-utils.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { getDomain } from 'tldts';
+
 /**
  * Pure, controller-independent helpers for the LLMO Cloudflare onboarding endpoints
  * (see llmo-cloudflare.js). Kept here so the controller stays minimal and these can be
@@ -34,6 +36,14 @@ export const deriveWorkerName = (baseURL) => {
   }
   return `${WORKER_NAME_PREFIX}-${slug}`.slice(0, CF_MAX_SCRIPT_NAME_LEN).replace(/-+$/g, '');
 };
+
+/**
+ * The registrable domain ("apex") of a hostname, resolved via the Public Suffix List (tldts), so
+ * multi-part TLDs are handled correctly: "www.shop.example.com" -> "example.com",
+ * "shop.example.co.uk" -> "example.co.uk", "example.com" -> "example.com". Returns null when the
+ * host has no registrable domain under the PSL (e.g. "localhost", a bare TLD, or an IP address).
+ */
+export const registrableDomain = (host) => getDomain(host);
 
 /**
  * Whether `host` belongs to the onboarded site's domain: it must equal the site's canonical

--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -18,7 +18,8 @@ import TokowakaClient from '@adobe/spacecat-shared-tokowaka-client';
 import CloudflareClient from '@adobe/spacecat-shared-cloudflare-client';
 import AccessControlUtil from '../../support/access-control-util.js';
 import {
-  deriveWorkerName, hostInSiteDomain, routePatternHost, routePatternHostGlob, routePatternsOverlap,
+  deriveWorkerName, hostInSiteDomain, registrableDomain, routePatternHost, routePatternHostGlob,
+  routePatternsOverlap,
 } from './llmo-cloudflare-utils.js';
 
 // Cap the conflicting-routes list returned in a 409 so a zone with many overlapping routes can't
@@ -268,14 +269,17 @@ function LlmoCloudflareController(ctx) {
 
   /**
    * GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones?accountId=<id>
-   * Lists only the zones belonging to the selected Cloudflare account. `accountId` is a
-   * Cloudflare identifier (not a SpaceCat entity), supplied as a query parameter.
+   * Lists the zones belonging to the selected Cloudflare account that are relevant to the site —
+   * i.e. whose registrable domain (resolved via the Public Suffix List) matches the site's
+   * base-URL host, so the onboarding UI only offers zones for the site's own domain. `accountId`
+   * is a Cloudflare identifier (not a SpaceCat entity), supplied as a query parameter.
    */
   const listZones = async (context) => {
     const result = await getSiteAndCheckAccess(context);
     if (result.status) {
       return result;
     }
+    const { site } = result;
 
     const { client, error } = requireCfClient(context);
     if (error) {
@@ -291,9 +295,14 @@ function LlmoCloudflareController(ctx) {
     }
 
     try {
-      // The client pushes account.id to the Cloudflare API, so filtering happens server-side.
+      // The client pushes account.id to the Cloudflare API, so account filtering happens
+      // server-side; we then keep only the zones on the site's own registrable domain (PSL).
       const zones = await client.listZones({ accountId });
-      return ok(zones || []);
+      const siteApex = registrableDomain(new URL(site.getBaseURL()).hostname);
+      const matching = (zones || []).filter(
+        (zone) => hasText(zone?.name) && !!siteApex && registrableDomain(zone.name) === siteApex,
+      );
+      return ok(matching);
     } catch (e) {
       return cfErrorResponse(e, 'zone listing', context, {
         siteId: context.params?.siteId,

--- a/test/controllers/llmo/llmo-cloudflare-utils.test.js
+++ b/test/controllers/llmo/llmo-cloudflare-utils.test.js
@@ -15,6 +15,7 @@ import { expect } from 'chai';
 import {
   deriveWorkerName,
   hostInSiteDomain,
+  registrableDomain,
   routePatternHost,
   routePatternHostGlob,
   globsIntersect,
@@ -62,6 +63,23 @@ describe('llmo-cloudflare-utils', () => {
     it('rejects an unrelated domain and look-alike suffixes', () => {
       expect(hostInSiteDomain('evil.com', baseURL)).to.equal(false);
       expect(hostInSiteDomain('notexample.com', baseURL)).to.equal(false);
+    });
+  });
+
+  describe('registrableDomain', () => {
+    it('resolves the registrable domain for a simple TLD', () => {
+      expect(registrableDomain('www.shop.example.com')).to.equal('example.com');
+      expect(registrableDomain('example.com')).to.equal('example.com');
+    });
+
+    it('handles multi-part public suffixes via the PSL', () => {
+      expect(registrableDomain('shop.example.co.uk')).to.equal('example.co.uk');
+      expect(registrableDomain('example.com.au')).to.equal('example.com.au');
+    });
+
+    it('returns null when there is no registrable domain (localhost, bare TLD)', () => {
+      expect(registrableDomain('localhost')).to.equal(null);
+      expect(registrableDomain('com')).to.equal(null);
     });
   });
 

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -249,6 +249,31 @@ describe('LlmoCloudflareController', () => {
       expect(body).to.deep.equal([]);
     });
 
+    it('returns only zones whose registrable domain matches the site domain', async () => {
+      // Site base URL is https://www.example.com -> registrable domain example.com.
+      const match = { id: ZONE_ID, name: 'example.com' };
+      const subdomainZone = { id: 'z2', name: 'shop.example.com' }; // registrable = example.com
+      const otherTld = { id: 'z3', name: 'example.net' };
+      const unrelated = { id: 'z4', name: 'other.com' };
+      const noName = { id: 'z5' }; // exercises the hasText(zone.name) guard
+      mockCfClient.listZones.resolves([match, subdomainZone, otherTld, unrelated, noName]);
+
+      const res = await controller.listZones(mockContext);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body).to.deep.equal([match, subdomainZone]);
+    });
+
+    it('returns no zones when the site host has no registrable domain (PSL miss)', async () => {
+      mockSite.getBaseURL = () => 'http://localhost';
+      mockCfClient.listZones.resolves([{ id: ZONE_ID, name: 'example.com' }, { id: 'z2', name: 'localhost' }]);
+
+      const res = await controller.listZones(mockContext);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body).to.deep.equal([]);
+    });
+
     it('returns 400 when CF token is missing', async () => {
       mockContext.pathInfo.headers = {};
       const res = await controller.listZones(mockContext);


### PR DESCRIPTION
## Summary

Follow-up to #2716 (now merged). Filters the Cloudflare **zones** onboarding endpoint to only the zones relevant to the site, so the onboarding UI offers just the zones for the site's own domain.

- `GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones` now returns only zones whose **registrable domain matches the site's base-URL host**.
- The apex is resolved via the **Public Suffix List** (`tldts.getDomain`, already a repo dependency — used in `import.js`), so multi-part TLDs resolve correctly: `shop.example.co.uk` → `example.co.uk`, `www.example.com` → `example.com`.
- Guards a null PSL result (e.g. `localhost`, a bare TLD, or an IP): if the site host has no registrable domain, no zones match.
- OpenAPI description for the zones endpoint updated to document the filtering.

## Test plan
- [x] `npm test` — full suite green (13044 passing)
- [x] Unit tests: zones filtered to matching registrable domain (incl. subdomain zone kept, other-TLD/unrelated dropped, no-name guard); null-apex (`localhost`) returns no zones; `registrableDomain` PSL cases (`co.uk`, `com.au`, `localhost`→null)
- [x] `npm run lint` clean; 100% coverage on both touched files
- [ ] Verify against a real Cloudflare account that the zone picker shows only the site's domain zones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```