### PR TITLE
revert: remove temporary cloudflareToken body/query fallback

### DIFF
--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -27,10 +27,6 @@ import {
 const MAX_CONFLICTING_ROUTES = 10;
 
 const CF_TOKEN_HEADER = 'x-cloudflare-token';
-// TEMPORARY: body/query fallback field for the CF token, used only until the
-// x-cloudflare-token header is allowlisted in the CDN/network config (for e2e verification).
-// Intentionally undocumented in the OpenAPI spec. Remove once the header passes through.
-const CF_TOKEN_BODY_FIELD = 'cloudflareToken';
 const CF_TOKEN_MISSING = 'Missing x-cloudflare-token header';
 const EDGE_OPTIMIZE_API_KEY_SECRET = 'EDGE_OPTIMIZE_API_KEY';
 const EDGE_OPTIMIZE_TARGET_HOST_BINDING = 'EDGE_OPTIMIZE_TARGET_HOST';
@@ -152,14 +148,8 @@ function LlmoCloudflareController(ctx) {
   };
 
   const getCfToken = (context) => {
-    const headerToken = context.pathInfo?.headers?.[CF_TOKEN_HEADER];
-    if (hasText(headerToken)) {
-      return headerToken;
-    }
-    // TEMPORARY fallback (see CF_TOKEN_BODY_FIELD): accept the token from the request
-    // body/query while the header is not yet allowlisted in the network config.
-    const fallbackToken = context.data?.[CF_TOKEN_BODY_FIELD];
-    return hasText(fallbackToken) ? fallbackToken : null;
+    const token = context.pathInfo?.headers?.[CF_TOKEN_HEADER];
+    return hasText(token) ? token : null;
   };
 
   /**

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -184,14 +184,6 @@ describe('LlmoCloudflareController', () => {
       expect(res.status).to.equal(400);
     });
 
-    it('falls back to the cloudflareToken in query/body when the header is absent', async () => {
-      mockContext.pathInfo.headers = {};
-      mockContext.data = { cloudflareToken: CF_TOKEN };
-      mockCfClient.listAccounts.resolves([{ id: ACCOUNT_ID, name: 'Test Account' }]);
-      const res = await controller.listAccounts(mockContext);
-      expect(res.status).to.equal(200);
-    });
-
     it('returns 404 when site is not found', async () => {
       mockContext.dataAccess.Site.findById.resolves(null);
       const res = await controller.listAccounts(mockContext);
@@ -425,17 +417,6 @@ describe('LlmoCloudflareController', () => {
         alreadyDeployed: true,
       });
       expect(mockCfClient.setWorkerSecret).to.not.have.been.called;
-    });
-
-    it('accepts the cloudflareToken from the body when the header is absent', async () => {
-      mockContext.pathInfo.headers = {};
-      mockContext.data = {
-        accountId: ACCOUNT_ID, targetHost: TARGET_HOST, cloudflareToken: CF_TOKEN,
-      };
-      mockCfClient.deployWorkerScript.resolves();
-      mockCfClient.setWorkerSecret.resolves();
-      const res = await controller.deployWorker(mockContext);
-      expect(res.status).to.equal(200);
     });
 
     it('fetches the worker script from a pinned commit SHA with a timeout', async () => {


### PR DESCRIPTION
## Summary

- Reverts the temporary `cloudflareToken` body/query fallback introduced in #2701
- The `x-cloudflare-token` header is now allowlisted in the CDN/network config, so the workaround is no longer needed
- Keeps only the `x-cloudflare-token` header as the sole token source in `getCfToken`
- Removes the `CF_TOKEN_BODY_FIELD` constant and associated fallback logic
- Removes the two test cases covering the body/query fallback paths

## Test plan

- [x] All 72 existing tests in `llmo-cloudflare.test.js` pass
- [ ] CI passes