### PR TITLE
fix: ChatGPT missing from AI Visibility Model filter | LLMO-5933

### DIFF
--- a/src/support/ai-visibility/visibility-filters.js
+++ b/src/support/ai-visibility/visibility-filters.js
@@ -50,6 +50,7 @@ export function resolveVisibilityMarketFromSearchParams(sp) {
 
 const ENGINE_QUERY_MAP = {
   chatgpt: 'chatgpt',
+  chat_gpt: 'chatgpt',
   gemini: 'gemini',
   aimode: 'googleAiMode',
   overview: 'googleAiOverview',
@@ -60,9 +61,12 @@ const ENGINE_QUERY_MAP = {
 };
 
 export function normalizeEngineFromQuery(engine) {
-  if (engine == null || engine === '' || engine === 'all') { return null; }
+  if (engine == null || engine === '') { return null; }
   const t = engine.trim();
   const e = t.toLowerCase();
+  // Drop aggregate / non-engine tokens: `all` (query) and `unspecified` (the
+  // SR `stats-by-llm` cross-engine total row's `llm` enum) are not selectable models.
+  if (e === 'all' || e === 'unspecified') { return null; }
   return ENGINE_QUERY_MAP[e] ?? t;
 }
 

--- a/test/support/ai-visibility/visibility-filters.test.js
+++ b/test/support/ai-visibility/visibility-filters.test.js
@@ -145,6 +145,11 @@ describe('visibility-filters', () => {
       expect(normalizeEngineFromQuery('all')).to.be.null;
     });
 
+    it('returns null for "unspecified" (SR cross-engine total row, not a real model)', () => {
+      expect(normalizeEngineFromQuery('unspecified')).to.be.null;
+      expect(normalizeEngineFromQuery('UNSPECIFIED')).to.be.null;
+    });
+
     it('maps known engines', () => {
       expect(normalizeEngineFromQuery('chatgpt')).to.equal('chatgpt');
       expect(normalizeEngineFromQuery('gemini')).to.equal('gemini');
@@ -154,6 +159,11 @@ describe('visibility-filters', () => {
       expect(normalizeEngineFromQuery('googleAiOverview')).to.equal('googleAiOverview');
       expect(normalizeEngineFromQuery('google_ai_mode')).to.equal('googleAiMode');
       expect(normalizeEngineFromQuery('google_ai_overview')).to.equal('googleAiOverview');
+    });
+
+    it('maps the SR `llm` enum form CHAT_GPT to chatgpt', () => {
+      expect(normalizeEngineFromQuery('CHAT_GPT')).to.equal('chatgpt');
+      expect(normalizeEngineFromQuery('chat_gpt')).to.equal('chatgpt');
     });
 
     it('is case-insensitive for known engines', () => {
@@ -219,6 +229,27 @@ describe('visibility-filters', () => {
       const body = { data: [{ llm: 'chatgpt' }] };
       const result = attachSrFiltersToSuccessfulBody(200, body);
       expect(result.srFilters.models).to.include('chatgpt');
+    });
+
+    it('normalizes the stats-by-llm enum rows: CHAT_GPT -> chatgpt, drops UNSPECIFIED', () => {
+      // Mirrors the real `/v1/brand/stats-by-llm` body: one row per engine plus the
+      // cross-engine total row labelled `UNSPECIFIED`. Engines arrive as SR enum strings.
+      const body = {
+        llm: [
+          { llm: 'UNSPECIFIED', mentions: '932' },
+          { llm: 'GEMINI', mentions: '295' },
+          { llm: 'GOOGLE_AI_OVERVIEW', mentions: '180' },
+          { llm: 'GOOGLE_AI_MODE', mentions: '284' },
+          { llm: 'CHAT_GPT', mentions: '173' },
+        ],
+      };
+      const result = attachSrFiltersToSuccessfulBody(200, body);
+      expect(result.srFilters.models).to.include('chatgpt');
+      expect(result.srFilters.models).to.have.members([
+        'chatgpt', 'gemini', 'googleAiMode', 'googleAiOverview',
+      ]);
+      expect(result.srFilters.models).to.not.include('CHAT_GPT');
+      expect(result.srFilters.models).to.not.include('UNSPECIFIED');
     });
 
     it('includes searchParams country in filters', () => {


### PR DESCRIPTION
## Summary
The AI Visibility results Model filter dropped ChatGPT even though ChatGPT had data. The filter is built from `/v1/brand/stats-by-llm`'s `srFilters.models`, which emitted ChatGPT as the raw SR enum `CHAT_GPT` (and the cross-engine total as `UNSPECIFIED`) while other engines were camelCase slugs. `normalizeEngineFromQuery`'s lowercase lookup had no `chat_gpt` key, so it passed `CHAT_GPT` through raw; the UI's slug→platform lookup then silently dropped it.

This adds `chat_gpt → chatgpt` to `ENGINE_QUERY_MAP` and drops the non-selectable `unspecified` aggregate token, so `srFilters.models` matches `modelsCatalog` (and the other endpoints). A companion defensive fix lands in project-elmo-ui.

## Changes
- `ENGINE_QUERY_MAP`: add `chat_gpt: 'chatgpt'`.
- `normalizeEngineFromQuery`: drop `unspecified` (alongside `all`) — it's the cross-engine total row, not a selectable model.
- Unit tests: `CHAT_GPT → chatgpt`, `UNSPECIFIED` dropped, and a full `stats-by-llm`-shaped body.

## Test plan
- [x] `npx mocha test/support/ai-visibility/visibility-filters.test.js` — 57 passing.
- [x] `npx eslint` on both changed files — clean.
- [x] Verified live: the AI Visibility Model filter now lists ChatGPT.

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-5933

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Igor Grubic", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```