### PR TITLE
feat(serenity): brand categories (generic createTag + standalone-tag read-back) + edit-flow fixes

### DIFF
--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -447,6 +447,70 @@ v2-serenity-tags:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
       '500': { $ref: './responses.yaml#/500' }
+  post:
+    tags: [serenity]
+    summary: Create a tag on one market
+    description: |
+      Registers a `<type>:<name>` prompt tag on the market addressed by the
+      `(geoTargetId, languageCode)` slice. `type` must be one of the OPEN tag
+      dimensions — `category` or `topic` — that accept customer-authored values;
+      the closed taxonomies (`source` / `intent` / `type`) have a fixed value
+      enum and are not freely creatable. The "Categories" view, for example, is
+      the `category:` slice of these tags across a brand's markets.
+    operationId: createSerenityTag
+    security:
+      - ims_key: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [type, name, geoTargetId, languageCode]
+            additionalProperties: false
+            properties:
+              type:
+                type: string
+                enum: [category, topic]
+                description: The open tag dimension to create a value under.
+              name:
+                type: string
+                minLength: 1
+                maxLength: 100
+                description: Free-form tag value. Must not contain ':'.
+              geoTargetId:
+                type: integer
+                minimum: 1
+                description: Google Ads Geo Target ID of the market slice.
+              languageCode:
+                type: string
+                pattern: '^[a-z]{2,3}(-[a-z]{2,4})?$'
+                description: BCP-47 primary subtag of the market slice.
+    responses:
+      '201':
+        description: Tag registered on the market's project.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                brandId: { type: string, format: uuid }
+                geoTargetId: { type: integer }
+                languageCode: { type: string }
+                type: { type: string, enum: [category, topic] }
+                name: { type: string }
+                tag:
+                  type: string
+                  description: The full `<type>:<name>` tag string registered upstream.
+      '400': { $ref: './responses.yaml#/400' }
+      '404':
+        description: Organization, brand, or the (geoTargetId, languageCode) market not found.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
 
 # ─── Brand activation (sub-workspace mode) ────────────────────────────
 

--- a/docs/serenity.md
+++ b/docs/serenity.md
@@ -144,6 +144,7 @@ All endpoints require `Authorization: Bearer <ims_user_token>` and `organization
 | POST | `/serenity/markets` | Onboard a new (brand, geoTargetId, languageCode) slice | `createSerenityMarket` |
 | DELETE | `/serenity/markets/:geoTargetId/:languageCode` | Remove a slice (idempotent; upstream-first, DB-second) | `deleteSerenityMarket` |
 | GET | `/serenity/tags?geoTargetId=&languageCode=` | Unique tag names for one slice | `listSerenityTags` |
+| POST | `/serenity/tags` | Register an open-dimension (`category`/`topic`) tag on one slice; body is `{ type, name, geoTargetId, languageCode }` | `createSerenityTag` |
 | GET | `/serenity/models?geoTargetId=&languageCode=` | AI models for one slice (catalog mode when no params) | `listSerenityModels` |
 | PUT | `/serenity/models` | Replace the AI-model set for one slice (publishes after change) | `updateSerenityModels` |
 | POST | `/serenity/activate` | Activate the brand into sub-workspace mode (ensure sub-workspace + publish supplied markets) | `activateSerenityBrand` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.31.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.3.2",
+        "@adobe/spacecat-shared-project-engine-client": "1.4.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -7037,9 +7037,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.3.2.tgz",
-      "integrity": "sha512-AMAfXvXh9lb+Z36oLWjJMwcHcAqvmbsSHQB+TB/EqEGKUStQud+Mbno4w3uLcwevRrfg91jtYCm/DSJKciCMvw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.4.0.tgz",
+      "integrity": "sha512-05G7JdpGP7ujJt+bbWPAqdY1oH9pZ4ehPtma6wEI+1+z+TB/ODSnm0LZjXCLSSe2Xf6El5wxQWzceFMmTiJLbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.31.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.3.2",
+    "@adobe/spacecat-shared-project-engine-client": "1.4.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -193,8 +193,9 @@ function mapError(e, log) {
  * fail-fast + shape guard so we do not forward a token Semrush will obviously
  * reject; it never substitutes for the upstream's own validation.
  *
- * Test-only escape hatch: when `SERENITY_ALLOW_NON_IMS_AUTH === 'true'` the
- * IMS-type check is skipped so an authenticated NON-IMS caller (e.g. the
+ * Test-only escape hatch: when `SERENITY_ALLOW_NON_IMS_AUTH === 'true'` AND the
+ * runtime is not production, the IMS-type check is skipped so an authenticated
+ * NON-IMS caller (e.g. the
  * locally-signed JWT the integration-test harness mints) can reach the
  * handlers. This is sound because (a) production auth is unaffected — Semrush
  * still validates the forwarded token end to end — and (b) the integration
@@ -208,7 +209,11 @@ function mapError(e, log) {
  */
 function requireImsBearer(ctx) {
   const authInfo = ctx?.attributes?.authInfo;
-  const allowNonIms = ctx?.env?.SERENITY_ALLOW_NON_IMS_AUTH === 'true';
+  // Hard-disable the escape hatch in production, mirroring getImsUserTokenStrict:
+  // even if SERENITY_ALLOW_NON_IMS_AUTH were somehow set in a prod env, a non-IMS
+  // caller must never reach the handlers there.
+  const isProd = ctx?.env?.AWS_ENV === 'prod' || ctx?.env?.ENV === 'prod';
+  const allowNonIms = !isProd && ctx?.env?.SERENITY_ALLOW_NON_IMS_AUTH === 'true';
   if (!allowNonIms && authInfo?.getType && authInfo.getType() !== 'ims') {
     throw new ErrorWithStatusCode(
       'Serenity proxy requires IMS authentication',

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -55,6 +55,10 @@ import {
   handleUpdatePromptSubworkspace,
   handleBulkDeletePromptsSubworkspace,
 } from '../support/serenity/handlers/prompts-subworkspace.js';
+import {
+  handleCreateTag,
+  handleCreateTagSubworkspace,
+} from '../support/serenity/handlers/tags.js';
 import { ensureSubworkspace, decommissionBrandWorkspace } from '../support/serenity/workspace-lifecycle.js';
 import { MAX_TOPICS_ON_CREATE } from '../support/serenity/brand-provisioning.js';
 import { STANDARD_PROMPT_TAGS, PROJECT_STANDARD_TAGS } from '../support/serenity/prompt-tags.js';
@@ -674,6 +678,46 @@ function SerenityController(context, log, env) {
     }
   };
 
+  /**
+   * POST /serenity/tags — register a `<type>:<NAME>` prompt tag on a single
+   * market (the (geoTargetId, languageCode) slice in the body). `type` is one of
+   * the open tag dimensions (CREATABLE_TAG_DIMENSIONS — `category` / `topic`);
+   * the closed taxonomies are not freely creatable. The UI's "Categories" view,
+   * for one, is derived from the `category:` tags across a brand's markets.
+   * Dispatches by workspace mode, mirroring the tags/markets handlers.
+   */
+  const createTag = async (ctx) => {
+    try {
+      const imsToken = requireImsBearer(ctx);
+      const auth = await authorize(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const transport = buildTransport(ctx, imsToken);
+      // authorize() guarantees brandUuid (404s a missing brand) and, in flat
+      // mode, a non-null workspaceId (404s 'no semrush_workspace_id'); assert
+      // the invariant for the typed handler, mirroring activate().
+      const result = auth.mode === 'subworkspace'
+        ? await handleCreateTagSubworkspace(
+          transport,
+          /** @type {string} */ (auth.workspaceId),
+          ctx.data || {},
+          log,
+        )
+        : await handleCreateTag(
+          transport,
+          ctx.dataAccess,
+          /** @type {string} */ (auth.brandUuid),
+          /** @type {string} */ (auth.workspaceId),
+          ctx.data || {},
+          log,
+        );
+      return createResponse(result.body, result.status);
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+
   const listModels = async (ctx) => {
     try {
       const imsToken = requireImsBearer(ctx);
@@ -1254,6 +1298,7 @@ function SerenityController(context, log, env) {
     createMarket,
     deleteMarket,
     listTags,
+    createTag,
     listModels,
     listOrgModels,
     listOrgLanguages,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -577,6 +577,7 @@ const routeFacsCapabilities = {
       'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:semrushPromptId': 'llmo/can_configure',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets': 'llmo/can_configure',
       'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': 'llmo/can_configure',
+      'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'llmo/can_configure',
       'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': 'llmo/can_configure',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': 'llmo/can_configure',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate': 'llmo/can_configure',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -228,6 +228,7 @@ export default function getRouteHandlers(
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': serenityController.getMarket,
     'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': serenityController.deleteMarket,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': serenityController.listTags,
+    'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': serenityController.createTag,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': serenityController.listModels,
     'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': serenityController.updateModels,
     // Brand-independent global model catalog (add-brand wizard, before a brand exists).

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -325,6 +325,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': 'organization:read',
   'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': 'organization:write',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'organization:read',
+  'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'organization:write',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': 'organization:read',
   'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': 'organization:write',
   // Org-level Semrush catalogue lookups (brand-independent): read-only, org

--- a/src/support/serenity/competitor-benchmarks.js
+++ b/src/support/serenity/competitor-benchmarks.js
@@ -216,16 +216,27 @@ export async function syncCompetitorBenchmarksForProject(
     if (b?.main_brand !== true && hasText(b?.id)) {
       competitorByDomain.set(domain, {
         id: String(b.id),
+        name: hasText(b?.brand_name) ? b.brand_name : '',
         aliases: Array.isArray(b?.brand_aliases) ? b.brand_aliases : [],
       });
     }
   }
 
   const toCreate = desired.filter((c) => !presentDomains.has(c.domain));
-  // Update an existing competitor benchmark only when its alias set drifted.
+  // Update an existing competitor benchmark when its display name OR its alias
+  // set drifted. The benchmark is keyed by domain, so a rename that keeps the
+  // same URL (e.g. "test1234" → "test12345" on test1234.de) would otherwise
+  // never re-sync — leaving the upstream brand_name stale vs the brand row.
   const toUpdate = desired.filter((c) => {
     const existing = competitorByDomain.get(c.domain);
-    return existing && !sameAliasSet(existing.aliases, c.aliases);
+    if (!existing) {
+      return false;
+    }
+    // Re-sync only when the upstream benchmark carries a name that differs from
+    // the desired one (a genuine rename). An absent upstream name is left alone
+    // rather than backfilled, so a benchmark we did not name is never touched.
+    const nameDrifted = existing.name !== '' && existing.name !== c.name;
+    return nameDrifted || !sameAliasSet(existing.aliases, c.aliases);
   });
   const toDelete = [...removedSet]
     .map((d) => competitorByDomain.get(d)?.id)

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -538,6 +538,36 @@ export async function handleDeleteMarketSubworkspace(
 }
 
 /**
+ * Page through a project's STANDALONE AIO tags (registered via createProjectTags,
+ * not necessarily carried by any prompt). `listProjectTags` is page-based
+ * (page/limit); walk until a short page ends it, bounded by a page ceiling for an
+ * unexpectedly huge set — mirroring `listTagsForProject`'s prompt-page walk so
+ * standalone categories beyond the first page are not silently dropped.
+ *
+ * @param {any} transport - Serenity transport.
+ * @param {string} workspaceId - Semrush (sub-)workspace id.
+ * @param {string} projectId - AIO project id.
+ * @returns {Promise<{ items: Array<{ id?: string, name?: string }> }>}
+ */
+async function listStandaloneProjectTags(transport, workspaceId, projectId) {
+  const items = [];
+  const LIMIT = 100;
+  const PAGE_LIMIT = 50;
+  let page = 1;
+  while (page <= PAGE_LIMIT) {
+    // eslint-disable-next-line no-await-in-loop
+    const resp = await transport.listProjectTags(workspaceId, projectId, { page, limit: LIMIT });
+    const batch = Array.isArray(resp?.items) ? resp.items : [];
+    items.push(...batch);
+    if (batch.length < LIMIT) {
+      break;
+    }
+    page += 1;
+  }
+  return { items };
+}
+
+/**
  * GET /serenity/tags (subworkspace) — unique tag names across the slice's prompts.
  * Resolves the slice's project from the live listing, then reuses the shared
  * project-keyed tag aggregation (cache + pagination + truncation guard). A
@@ -566,7 +596,7 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
   const [fromPrompts, standalone] = await Promise.all([
     listTagsForProject(transport, workspaceId, projectId, { geoTargetId, languageCode }, log),
     Promise.resolve()
-      .then(() => transport.listProjectTags(workspaceId, projectId))
+      .then(() => listStandaloneProjectTags(transport, workspaceId, projectId))
       .catch((e) => {
         log?.warn?.('handleListTagsSubworkspace: standalone tag list failed (non-fatal)', {
           workspaceId, projectId, error: e?.message,
@@ -577,8 +607,19 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
   const byName = new Map();
   const all = [...(fromPrompts?.items || []), ...(standalone?.items || [])];
   for (const t of all) {
-    if (t && hasText(t.name) && !byName.has(t.name)) {
-      byName.set(t.name, { id: hasText(t.id) ? String(t.id) : t.name, name: t.name });
+    if (t && hasText(t.name)) {
+      const id = hasText(t.id) ? String(t.id) : t.name;
+      const existing = byName.get(t.name);
+      if (!existing) {
+        byName.set(t.name, { id, name: t.name });
+      } else if (existing.id === existing.name && id !== t.name) {
+        // Upgrade a synthetic (id === name) entry — e.g. a prompt-derived tag that
+        // arrived as a bare string — to the canonical upstream id once the
+        // standalone listing supplies it, regardless of merge order. Prevents a
+        // synthetic id from shadowing the real one just because the prompt-derived
+        // entry was seen first.
+        existing.id = id;
+      }
     }
   }
   return { items: [...byName.values()] };

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -547,9 +547,10 @@ export async function handleDeleteMarketSubworkspace(
  * @param {any} transport - Serenity transport.
  * @param {string} workspaceId - Semrush (sub-)workspace id.
  * @param {string} projectId - AIO project id.
+ * @param {any} [log] - logger, used to surface a ceiling-hit truncation warning.
  * @returns {Promise<{ items: Array<{ id?: string, name?: string }> }>}
  */
-async function listStandaloneProjectTags(transport, workspaceId, projectId) {
+async function listStandaloneProjectTags(transport, workspaceId, projectId, log) {
   const items = [];
   const LIMIT = 100;
   const PAGE_LIMIT = 50;
@@ -560,6 +561,15 @@ async function listStandaloneProjectTags(transport, workspaceId, projectId) {
     const batch = Array.isArray(resp?.items) ? resp.items : [];
     items.push(...batch);
     if (batch.length < LIMIT) {
+      break;
+    }
+    if (page === PAGE_LIMIT) {
+      // Ceiling reached with a still-full last page: at least one more page went
+      // unread, so the standalone set may be truncated. A missing category in the
+      // UI is a real symptom, so log it rather than stop silently.
+      log?.warn?.('listStandaloneProjectTags: page ceiling hit; standalone tag set may be truncated', {
+        workspaceId, projectId, pages: PAGE_LIMIT, limit: LIMIT,
+      });
       break;
     }
     page += 1;
@@ -596,7 +606,7 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
   const [fromPrompts, standalone] = await Promise.all([
     listTagsForProject(transport, workspaceId, projectId, { geoTargetId, languageCode }, log),
     Promise.resolve()
-      .then(() => listStandaloneProjectTags(transport, workspaceId, projectId))
+      .then(() => listStandaloneProjectTags(transport, workspaceId, projectId, log))
       .catch((e) => {
         log?.warn?.('handleListTagsSubworkspace: standalone tag list failed (non-fatal)', {
           workspaceId, projectId, error: e?.message,
@@ -605,7 +615,9 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
       }),
   ]);
   const byName = new Map();
-  const all = [...(fromPrompts?.items || []), ...(standalone?.items || [])];
+  // listTagsForProject and listStandaloneProjectTags (and its catch) each always
+  // resolve `{ items: [...] }`, so no defensive `?.`/`|| []` is needed here.
+  const all = [...fromPrompts.items, ...standalone.items];
   for (const t of all) {
     if (t && hasText(t.name)) {
       const id = hasText(t.id) ? String(t.id) : t.name;

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -556,13 +556,32 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
   if (!project) {
     return { items: [] };
   }
-  return listTagsForProject(
-    transport,
-    workspaceId,
-    String(project.id),
-    { geoTargetId, languageCode },
-    log,
-  );
+  const projectId = String(project.id);
+  // A tag exists in two forms: attached to ≥1 prompt (listTagsForProject scans the
+  // prompt vocabulary) OR standalone (registered via createProjectTags but not yet
+  // carried by any prompt — e.g. a just-created, still-empty `category:<NAME>`).
+  // The Categories surface must round-trip BOTH, so merge them by tag name. The
+  // standalone list is best-effort: a hiccup there must not regress the
+  // prompt-derived behavior that already worked.
+  const [fromPrompts, standalone] = await Promise.all([
+    listTagsForProject(transport, workspaceId, projectId, { geoTargetId, languageCode }, log),
+    Promise.resolve()
+      .then(() => transport.listProjectTags(workspaceId, projectId))
+      .catch((e) => {
+        log?.warn?.('handleListTagsSubworkspace: standalone tag list failed (non-fatal)', {
+          workspaceId, projectId, error: e?.message,
+        });
+        return { items: [] };
+      }),
+  ]);
+  const byName = new Map();
+  const all = [...(fromPrompts?.items || []), ...(standalone?.items || [])];
+  for (const t of all) {
+    if (t && hasText(t.name) && !byName.has(t.name)) {
+      byName.set(t.name, { id: hasText(t.id) ? String(t.id) : t.name, name: t.name });
+    }
+  }
+  return { items: [...byName.values()] };
 }
 
 /**

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+import { hasText } from '@adobe/spacecat-shared-utils';
+
+import { ErrorWithStatusCode } from '../../utils.js';
+import { ERROR_CODES } from '../errors.js';
+import { normalizeGeoTargetId, normalizeLanguageCode } from '../validation.js';
+import { resolveProject } from '../subworkspace-projects.js';
+import { tagFor, CREATABLE_TAG_DIMENSIONS } from '../prompt-tags.js';
+
+/**
+ * POST /serenity/tags — create a prompt TAG on a single market.
+ *
+ * Tags are `dimension:<NAME>` strings registered on a market's project (the
+ * `aio/tags` surface, via {@link createProjectTags}). This endpoint creates a
+ * tag under one of the OPEN dimensions ({@link CREATABLE_TAG_DIMENSIONS} —
+ * `category` / `topic`); the closed taxonomies (`source` / `intent` / `type`)
+ * have a fixed value enum and are not freely creatable, so the `type` is
+ * validated against the allow-list (this is what bounds the allowed prefixes).
+ * The UI's "Categories" view, for instance, is the `category:` slice of these
+ * tags across the brand's markets.
+ *
+ * Both the flat-mode and subworkspace-mode handlers resolve the market's project
+ * id from the `(geoTargetId, languageCode)` slice and register one tag.
+ */
+
+const MAX_TAG_NAME_LEN = 100;
+
+/**
+ * Validates + normalizes the create-tag body, throwing a 400
+ * {@link ErrorWithStatusCode} on the first problem. Returns the parsed
+ * `{ type, name, geoTargetId, languageCode }`.
+ *
+ * @param {object} body - request body.
+ * @returns {{ type: string, name: string, geoTargetId: number, languageCode: string }}
+ */
+function parseCreateTagBody(body) {
+  const type = hasText(body?.type) ? String(body.type).trim().toLowerCase() : '';
+  // CREATABLE_TAG_DIMENSIONS is a frozen literal tuple; widen to string[] so
+  // `.includes(type)` accepts an arbitrary runtime string for the membership test.
+  if (!(/** @type {readonly string[]} */ (CREATABLE_TAG_DIMENSIONS)).includes(type)) {
+    throw new ErrorWithStatusCode(
+      `type must be one of: ${CREATABLE_TAG_DIMENSIONS.join(', ')}`,
+      400,
+    );
+  }
+  const rawName = hasText(body?.name) ? String(body.name).trim() : '';
+  if (!rawName) {
+    throw new ErrorWithStatusCode('name is required', 400);
+  }
+  if (rawName.length > MAX_TAG_NAME_LEN) {
+    throw new ErrorWithStatusCode(
+      `name must not exceed ${MAX_TAG_NAME_LEN} characters`,
+      400,
+    );
+  }
+  // The `<type>:` prefix is added by tagFor(); a `:` in the name would either
+  // double-prefix or smuggle a different dimension (e.g. type=category,
+  // name='topic:x' → 'category:topic:x'). Reject rather than silently rewrite.
+  if (rawName.includes(':')) {
+    throw new ErrorWithStatusCode('name must not contain ":"', 400);
+  }
+  const geoTargetId = normalizeGeoTargetId(Number(body?.geoTargetId));
+  if (geoTargetId === null) {
+    throw new ErrorWithStatusCode('geoTargetId must be a positive integer', 400);
+  }
+  const languageCode = normalizeLanguageCode(body?.languageCode);
+  if (languageCode === null) {
+    throw new ErrorWithStatusCode(
+      'languageCode must match ^[a-z]{2,3}(-[a-z]{2,4})?$',
+      400,
+    );
+  }
+  return {
+    type, name: rawName, geoTargetId, languageCode,
+  };
+}
+
+/** Throws a 404 `marketNotFound` for a slice with no backing project. */
+function marketNotFound() {
+  const err = new ErrorWithStatusCode(
+    'No market for this brand and (geoTargetId, languageCode) slice',
+    404,
+  );
+  err.code = ERROR_CODES.MARKET_NOT_FOUND;
+  return err;
+}
+
+/**
+ * Flat mode — the market's project id comes from the persisted
+ * `BrandSemrushProject` mapping (same resolution as handleListTags).
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {object} dataAccess - data-access layer (BrandSemrushProject).
+ * @param {string} brandId - brand UUID.
+ * @param {string} semrushWorkspaceId - the org's (parent) workspace id.
+ * @param {object} body - request body ({ type, name, geoTargetId, languageCode }).
+ * @param {object} log - logger.
+ * @returns {Promise<{status: number, body: object}>}
+ */
+export async function handleCreateTag(
+  transport,
+  dataAccess,
+  brandId,
+  semrushWorkspaceId,
+  body,
+  log,
+) {
+  const {
+    type, name, geoTargetId, languageCode,
+  } = parseCreateTagBody(body);
+  const row = await dataAccess.BrandSemrushProject.findBySlice(
+    brandId,
+    geoTargetId,
+    languageCode,
+  );
+  if (!row) {
+    throw marketNotFound();
+  }
+  const tag = tagFor(type, name);
+  await transport.createProjectTags(semrushWorkspaceId, row.getSemrushProjectId(), [tag]);
+  log?.info?.('handleCreateTag: registered tag', {
+    brandId, geoTargetId, languageCode, tag,
+  });
+  return {
+    status: 201,
+    body: {
+      brandId, geoTargetId, languageCode, type, name, tag,
+    },
+  };
+}
+
+/**
+ * Subworkspace mode — the market's project is resolved live from the brand's
+ * own subworkspace listing (same resolution as handleListTagsSubworkspace).
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {string} workspaceId - the brand's subworkspace id.
+ * @param {object} body - request body ({ type, name, geoTargetId, languageCode }).
+ * @param {object} log - logger.
+ * @returns {Promise<{status: number, body: object}>}
+ */
+export async function handleCreateTagSubworkspace(
+  transport,
+  workspaceId,
+  body,
+  log,
+) {
+  const {
+    type, name, geoTargetId, languageCode,
+  } = parseCreateTagBody(body);
+  const project = await resolveProject(transport, workspaceId, geoTargetId, languageCode, log);
+  if (!project) {
+    throw marketNotFound();
+  }
+  const tag = tagFor(type, name);
+  await transport.createProjectTags(workspaceId, String(project.id), [tag]);
+  log?.info?.('handleCreateTagSubworkspace: registered tag', {
+    geoTargetId, languageCode, tag,
+  });
+  return {
+    status: 201,
+    body: {
+      geoTargetId, languageCode, type, name, tag,
+    },
+  };
+}

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -72,6 +72,14 @@ function parseCreateTagBody(body) {
   if (rawName.includes(':')) {
     throw new ErrorWithStatusCode('name must not contain ":"', 400);
   }
+  // Reject C0/C1-adjacent control characters (incl. DEL): unprintable chars have
+  // no legitimate place in a customer-authored tag value and cause UI + upstream
+  // confusion. Zero-width joiners (U+200C/U+200D) are intentionally NOT banned —
+  // they are legitimate in some scripts and emoji sequences.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001F\u007F]/.test(rawName)) {
+    throw new ErrorWithStatusCode('name must not contain control characters', 400);
+  }
   const geoTargetId = normalizeGeoTargetId(Number(body?.geoTargetId));
   if (geoTargetId === null) {
     throw new ErrorWithStatusCode('geoTargetId must be a positive integer', 400);

--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -25,6 +25,7 @@ export const TAG_DIMENSION = Object.freeze({
   SOURCE: 'source',
   INTENT: 'intent',
   TYPE: 'type',
+  CATEGORY: 'category',
 });
 
 // `source:<value>` — who authored the prompt.
@@ -59,10 +60,28 @@ export const TYPE_TAG = Object.freeze({
   NON_BRANDED: 'type:non-branded',
 });
 
+/** Builds the `<dimension>:<NAME>` tag string for a dimension + free-form value. */
+export function tagFor(dimension, name) {
+  return `${dimension}:${name}`;
+}
+
 /** Builds the `topic:<NAME>` tag for a topic name. */
 export function topicTag(name) {
-  return `${TAG_DIMENSION.TOPIC}:${name}`;
+  return tagFor(TAG_DIMENSION.TOPIC, name);
 }
+
+/**
+ * The tag dimensions a caller may freely create values under (the open
+ * taxonomies). The closed taxonomies — `source` / `intent` / `type` — have a
+ * fixed value enum registered as {@link PROJECT_STANDARD_TAGS}, so callers must
+ * NOT mint arbitrary values under them; only `topic` and `category` accept
+ * customer-authored values. The create-tag endpoint validates the requested
+ * `type` against this list, which is what bounds the allowed tag prefixes.
+ */
+export const CREATABLE_TAG_DIMENSIONS = Object.freeze([
+  TAG_DIMENSION.CATEGORY,
+  TAG_DIMENSION.TOPIC,
+]);
 
 // Tags applied to EVERY AI-generated prompt on top of its `topic:<NAME>` tag:
 // `source:ai` (AI-authored) plus the default `intent:Informational` (the most

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -414,6 +414,28 @@ export function createSerenityTransport({ env, imsToken }) {
     },
 
     /**
+     * GET /v2/workspaces/{ws}/projects/{pid}/aio/tags — lists the project's
+     * STANDALONE AIO tags (the ones `createProjectTags` registers), independent of
+     * whether any prompt carries them. This is the only read that surfaces a tag
+     * with no carrying prompt — e.g. a freshly-created, still-empty `category:<NAME>`
+     * — so the Categories surface can round-trip it. `parent_id` + `search` are
+     * required by the upstream contract; pass empty strings to list all (flat).
+     */
+    async listProjectTags(semrushWorkspaceId, projectId, { search = '', page = 1, limit = 100 } = {}) {
+      return unwrap('GET', await projects.GET(
+        '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+        {
+          params: {
+            path: { id: semrushWorkspaceId, project_id: projectId },
+            query: {
+              parent_id: '', search, page, limit,
+            },
+          },
+        },
+      ));
+    },
+
+    /**
      * POST /v1/workspaces/{ws}/projects — creates a new Semrush AIO project.
      */
     async createProject(semrushWorkspaceId, body) {

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -693,7 +693,13 @@ export function getImsUserTokenStrict(context) {
   // to the Semrush vendor MOCK, which ignores it. NO deployed environment sets
   // this flag (it is never written to Vault), so production auth is unaffected —
   // the real Semrush gateway still validates the forwarded token end to end.
-  const allowNonIms = context?.env?.SERENITY_ALLOW_NON_IMS_AUTH === 'true';
+  //
+  // Defense-in-depth: the hatch is HARD-DISABLED in production regardless of the
+  // flag, so an accidental SERENITY_ALLOW_NON_IMS_AUTH in prod can never open the
+  // gate — prod always fails closed and requires real IMS auth. Both AWS_ENV and
+  // ENV are checked because the codebase reads prod from either.
+  const isProd = context?.env?.AWS_ENV === 'prod' || context?.env?.ENV === 'prod';
+  const allowNonIms = !isProd && context?.env?.SERENITY_ALLOW_NON_IMS_AUTH === 'true';
   // Fail closed: forward the bearer upstream ONLY for a caller we can positively
   // confirm authenticated via IMS (or when the escape hatch is explicitly set).
   // A missing/non-standard authInfo (no getType) is treated as "not IMS" and

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -686,11 +686,20 @@ export function getImsUserToken(context) {
  */
 export function getImsUserTokenStrict(context) {
   const authInfo = context?.attributes?.authInfo;
+  // Local/automated-E2E escape hatch — mirrors the serenity controller's
+  // requireImsBearer. When SERENITY_ALLOW_NON_IMS_AUTH is set, trust the present
+  // bearer even if the authInfo is not IMS-typed: locally `SKIP_AUTH=true`
+  // injects a mock (non-IMS) admin authInfo, and these flows forward the bearer
+  // to the Semrush vendor MOCK, which ignores it. NO deployed environment sets
+  // this flag (it is never written to Vault), so production auth is unaffected —
+  // the real Semrush gateway still validates the forwarded token end to end.
+  const allowNonIms = context?.env?.SERENITY_ALLOW_NON_IMS_AUTH === 'true';
   // Fail closed: forward the bearer upstream ONLY for a caller we can positively
-  // confirm authenticated via IMS. A missing/non-standard authInfo (no getType)
-  // is treated as "not IMS" and refused, rather than falling through to proxy an
-  // unverified bearer to the Semrush gateway.
-  if (typeof authInfo?.getType !== 'function' || authInfo.getType() !== 'ims') {
+  // confirm authenticated via IMS (or when the escape hatch is explicitly set).
+  // A missing/non-standard authInfo (no getType) is treated as "not IMS" and
+  // refused, rather than falling through to proxy an unverified bearer to the
+  // Semrush gateway.
+  if (!allowNonIms && (typeof authInfo?.getType !== 'function' || authInfo.getType() !== 'ims')) {
     throw new ErrorWithStatusCode('IMS authentication required', STATUS_UNAUTHORIZED);
   }
   return getImsUserToken(context);

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -120,6 +120,8 @@ describe('SerenityController', () => {
     handleCreatePromptsSubworkspace: sinon.stub(),
     handleUpdatePromptSubworkspace: sinon.stub(),
     handleBulkDeletePromptsSubworkspace: sinon.stub(),
+    handleCreateTag: sinon.stub(),
+    handleCreateTagSubworkspace: sinon.stub(),
   };
   let decommissionStub;
   let ensureSubworkspaceStub;
@@ -211,6 +213,10 @@ describe('SerenityController', () => {
         handleCreatePromptsSubworkspace: handlers.handleCreatePromptsSubworkspace,
         handleUpdatePromptSubworkspace: handlers.handleUpdatePromptSubworkspace,
         handleBulkDeletePromptsSubworkspace: handlers.handleBulkDeletePromptsSubworkspace,
+      },
+      '../../src/support/serenity/handlers/tags.js': {
+        handleCreateTag: handlers.handleCreateTag,
+        handleCreateTagSubworkspace: handlers.handleCreateTagSubworkspace,
       },
       '../../src/support/serenity/workspace-lifecycle.js': {
         ensureSubworkspace: ensureSubworkspaceStub,
@@ -855,6 +861,37 @@ describe('SerenityController', () => {
       expect(handlers.handleBulkDeletePrompts).to.have.been.calledOnce;
       expect(handlers.handleBulkDeletePromptsSubworkspace).to.not.have.been.called;
     });
+
+    it('createTag routes to the flat handler in flat mode and returns its status', async () => {
+      handlers.handleCreateTag.resolves({
+        status: 201,
+        body: {
+          brandId: BRAND, geoTargetId: 2840, languageCode: 'en', type: 'category', name: 'Footwear', tag: 'category:Footwear',
+        },
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.createTag(fakeContext({
+        data: {
+          type: 'category', name: 'Footwear', geoTargetId: 2840, languageCode: 'en',
+        },
+      }));
+      expect(response.status).to.equal(201);
+      const body = await readBody(response);
+      expect(body.tag).to.equal('category:Footwear');
+      expect(handlers.handleCreateTag).to.have.been.calledOnce;
+      expect(handlers.handleCreateTagSubworkspace).to.not.have.been.called;
+    });
+
+    it('createTag maps a handler 400 (bad body) through mapError', async () => {
+      handlers.handleCreateTag.rejects(new ErrorWithStatusCode('name is required', 400));
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.createTag(fakeContext({
+        data: { type: 'category', geoTargetId: 2840, languageCode: 'en' },
+      }));
+      expect(response.status).to.equal(400);
+      const body = await readBody(response);
+      expect(body.message).to.match(/name is required/);
+    });
   });
 
   describe('controller surface', () => {
@@ -869,6 +906,7 @@ describe('SerenityController', () => {
       expect(controller.createMarket).to.be.a('function');
       expect(controller.deleteMarket).to.be.a('function');
       expect(controller.listTags).to.be.a('function');
+      expect(controller.createTag).to.be.a('function');
       expect(controller.listModels).to.be.a('function');
       expect(controller.updateModels).to.be.a('function');
 
@@ -1114,6 +1152,25 @@ describe('SerenityController', () => {
       expect(response.status).to.equal(200);
       expect(handlers.handleUpdatePromptSubworkspace).to.have.been.calledOnce;
       expect(handlers.handleUpdatePrompt).to.not.have.been.called;
+    });
+
+    it('createTag routes to the subworkspace handler in subworkspace mode', async () => {
+      handlers.handleCreateTagSubworkspace.resolves({
+        status: 201,
+        body: {
+          geoTargetId: 2840, languageCode: 'en', type: 'category', name: 'Footwear', tag: 'category:Footwear',
+        },
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.createTag(fakeContext({
+        data: {
+          type: 'category', name: 'Footwear', geoTargetId: 2840, languageCode: 'en',
+        },
+      }));
+      expect(response.status).to.equal(201);
+      expect(handlers.handleCreateTagSubworkspace).to.have.been.calledOnce;
+      expect(handlers.handleCreateTagSubworkspace.firstCall.args[1]).to.equal('subworkspace-ws-1');
+      expect(handlers.handleCreateTag).to.not.have.been.called;
     });
 
     it('bulkDeletePrompts routes to the subworkspace handler in subworkspace mode', async () => {

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -314,6 +314,27 @@ describe('SerenityController', () => {
       expect(response.status).to.equal(401);
     });
 
+    // The escape hatch is hard-disabled in production (AWS_ENV or ENV === 'prod'),
+    // mirroring getImsUserTokenStrict — a non-IMS caller must never slip through
+    // even if SERENITY_ALLOW_NON_IMS_AUTH were somehow set in a prod env.
+    it('401s a non-IMS caller with the flag set when AWS_ENV is prod', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const ctx = fakeContext({
+        authType: 'jwt', env: { SERENITY_ALLOW_NON_IMS_AUTH: 'true', AWS_ENV: 'prod' },
+      });
+      const response = await controller.listPrompts(ctx);
+      expect(response.status).to.equal(401);
+    });
+
+    it('401s a non-IMS caller with the flag set when ENV is prod', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const ctx = fakeContext({
+        authType: 'jwt', env: { SERENITY_ALLOW_NON_IMS_AUTH: 'true', ENV: 'prod' },
+      });
+      const response = await controller.listPrompts(ctx);
+      expect(response.status).to.equal(401);
+    });
+
     it('400s when :brandId is not a UUID (the new guard)', async () => {
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const ctx = fakeContext({ brandId: 'adobe-brand-name' });
@@ -904,15 +925,26 @@ describe('SerenityController', () => {
         },
       });
       const controller = SerenityController({ env: {} }, fakeLog(), {});
+      // No ctx.data → exercises the `ctx.data || {}` body-defaulting fallback.
+      const response = await controller.createTag(fakeContext());
+      expect(response.status).to.equal(201);
+      const body = await readBody(response);
+      expect(body.tag).to.equal('category:Footwear');
+      expect(handlers.handleCreateTag).to.have.been.calledOnce;
+      expect(handlers.handleCreateTag.firstCall.args[4]).to.deep.equal({});
+      expect(handlers.handleCreateTagSubworkspace).to.not.have.been.called;
+    });
+
+    it('createTag returns the authorize() error (403) and does not dispatch when the caller lacks org access', async () => {
+      accessControlHasAccessStub.resolves(false);
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
       const response = await controller.createTag(fakeContext({
         data: {
           type: 'category', name: 'Footwear', geoTargetId: 2840, languageCode: 'en',
         },
       }));
-      expect(response.status).to.equal(201);
-      const body = await readBody(response);
-      expect(body.tag).to.equal('category:Footwear');
-      expect(handlers.handleCreateTag).to.have.been.calledOnce;
+      expect(response.status).to.equal(403);
+      expect(handlers.handleCreateTag).to.not.have.been.called;
       expect(handlers.handleCreateTagSubworkspace).to.not.have.been.called;
     });
 
@@ -1196,14 +1228,12 @@ describe('SerenityController', () => {
         },
       });
       const controller = SerenityController({ env: {} }, fakeLog(), {});
-      const response = await controller.createTag(fakeContext({
-        data: {
-          type: 'category', name: 'Footwear', geoTargetId: 2840, languageCode: 'en',
-        },
-      }));
+      // No ctx.data → exercises the `ctx.data || {}` body-defaulting fallback.
+      const response = await controller.createTag(fakeContext());
       expect(response.status).to.equal(201);
       expect(handlers.handleCreateTagSubworkspace).to.have.been.calledOnce;
       expect(handlers.handleCreateTagSubworkspace.firstCall.args[1]).to.equal('subworkspace-ws-1');
+      expect(handlers.handleCreateTagSubworkspace.firstCall.args[2]).to.deep.equal({});
       expect(handlers.handleCreateTag).to.not.have.been.called;
     });
 

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -235,6 +235,14 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
       expect(res.status).to.equal(400);
       expect(res.body.error).to.equal('invalidRequest');
     });
+
+    it('POST /serenity/tags 400s when type is not a creatable dimension', async () => {
+      const res = await getHttpClient().admin.post(`${base}/tags`, {
+        type: 'intent', name: 'Whatever', geoTargetId: 2840, languageCode: 'en',
+      });
+      expect(res.status).to.equal(400);
+      expect(res.body.message).to.match(/type must be one of/i);
+    });
   });
 
   describe('Serenity API — sub-workspace lifecycle (mutating, live mock)', () => {
@@ -280,6 +288,18 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
       const res = await getHttpClient().admin.get(`${base}/tags?geoTargetId=${US_GEO}&languageCode=en`);
       expect(res.status).to.equal(200);
       expect(res.body.items).to.be.an('array');
+    });
+
+    it('POST /serenity/tags registers a category tag on the market (201)', async () => {
+      await createUsMarket();
+      const res = await getHttpClient().admin.post(`${base}/tags`, {
+        type: 'category', name: 'Footwear', geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(res.status).to.equal(201);
+      expect(res.body.type).to.equal('category');
+      expect(res.body.tag).to.equal('category:Footwear');
+      expect(res.body.geoTargetId).to.equal(US_GEO);
+      expect(res.body.languageCode).to.equal('en');
     });
 
     it('POST /serenity/activate provisions + publishes, then deactivate decommissions', async () => {

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -199,6 +199,25 @@ const FIXTURES = {
     handlerResult: { items: [{ id: 't1', name: 'Topic A' }] },
     query: { geoTargetId: '2840', languageCode: 'en' },
   },
+  createSerenityTag: {
+    expectedStatus: 201,
+    controllerMethod: 'createTag',
+    handlerName: 'handleCreateTag',
+    handlerResult: {
+      status: 201,
+      body: {
+        brandId: BRAND,
+        geoTargetId: 2840,
+        languageCode: 'en',
+        type: 'category',
+        name: 'Running Shoes',
+        tag: 'category:Running Shoes',
+      },
+    },
+    data: {
+      type: 'category', name: 'Running Shoes', geoTargetId: 2840, languageCode: 'en',
+    },
+  },
   listSerenityModels: {
     expectedStatus: 200,
     controllerMethod: 'listModels',
@@ -315,6 +334,7 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
         handleCreateMarket: sinon.stub(),
         handleDeleteMarket: sinon.stub(),
         handleListTags: sinon.stub(),
+        handleCreateTag: sinon.stub(),
         handleListModels: sinon.stub(),
         handleUpdateModels: sinon.stub(),
         handleCreateMarketSubworkspace: sinon.stub(),
@@ -360,6 +380,10 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
             handleUpdateModels: handlerStubs.handleUpdateModels,
             listGlobalModelCatalog: handlerStubs.listGlobalModelCatalog,
             listLanguageCatalog: handlerStubs.listLanguageCatalog,
+          },
+          '../../src/support/serenity/handlers/tags.js': {
+            handleCreateTag: handlerStubs.handleCreateTag,
+            handleCreateTagSubworkspace: sinon.stub(),
           },
           '../../src/support/serenity/handlers/markets-subworkspace.js': {
             handleListMarketsSubworkspace: sinon.stub(),

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -872,6 +872,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode',
       'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags',
+      'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/models',
       'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models',
       'GET /v2/orgs/:spaceCatId/serenity/models',

--- a/test/support/serenity/competitor-benchmarks.test.js
+++ b/test/support/serenity/competitor-benchmarks.test.js
@@ -253,6 +253,25 @@ describe('competitor-benchmarks helpers', () => {
       });
     });
 
+    it('does NOT re-sync when the upstream brand_name is empty, even if the desired name differs', async () => {
+      // An absent upstream name is left alone rather than backfilled — a benchmark
+      // we did not name is never touched, so an operator's direct upstream rename
+      // is not clobbered by a drifting desired name.
+      const transport = makeTransport([
+        {
+          id: 'rival', main_brand: false, domain: 'test1234.de', brand_name: '',
+        },
+      ]);
+      const competitors = [
+        { name: 'test12345', url: 'https://www.test1234.de', regions: ['us'] },
+      ];
+      const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
+      expect(transport.updateBenchmark).to.not.have.been.called;
+      expect(transport.createBenchmarks).to.not.have.been.called;
+      expect(result.changed).to.equal(false);
+      expect(result.updated).to.equal(0);
+    });
+
     it('does NOT update when the name and alias set are unchanged', async () => {
       const transport = makeTransport([
         {

--- a/test/support/serenity/competitor-benchmarks.test.js
+++ b/test/support/serenity/competitor-benchmarks.test.js
@@ -232,6 +232,41 @@ describe('competitor-benchmarks helpers', () => {
       });
     });
 
+    it('updates an existing competitor benchmark when only its name drifts (same domain)', async () => {
+      // Renaming a competitor while keeping its URL (e.g. test1234 → test12345 on
+      // test1234.de) must re-sync the upstream brand_name — it is keyed by domain.
+      const transport = makeTransport([
+        {
+          id: 'rival', main_brand: false, domain: 'test1234.de', brand_name: 'test1234',
+        },
+      ]);
+      const competitors = [
+        { name: 'test12345', url: 'https://www.test1234.de', regions: ['us'] },
+      ];
+      const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
+      expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, PID, 'rival', {
+        brand_name: 'test12345', domain: 'test1234.de',
+      });
+      expect(transport.createBenchmarks).to.not.have.been.called;
+      expect(result).to.deep.equal({
+        created: 0, updated: 1, deleted: 0, changed: true, rejected: [],
+      });
+    });
+
+    it('does NOT update when the name and alias set are unchanged', async () => {
+      const transport = makeTransport([
+        {
+          id: 'rival', main_brand: false, domain: 'test1234.de', brand_name: 'test1234',
+        },
+      ]);
+      const competitors = [
+        { name: 'test1234', url: 'https://www.test1234.de', regions: ['us'] },
+      ];
+      const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
+      expect(transport.updateBenchmark).to.not.have.been.called;
+      expect(result.changed).to.equal(false);
+    });
+
     it('does NOT update when the alias set is unchanged (order/case-insensitive)', async () => {
       const transport = makeTransport([
         {

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -673,6 +673,41 @@ describe('markets-subworkspace handlers', () => {
       expect(transport.listPromptsByTags).to.have.been.calledWith(WS, 'p-tag');
     });
 
+    it('merges standalone tags (prompt-less categories) with prompt-derived ones, deduped by name', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub().resolves({
+          items: [{ id: 'q1', tags: [{ id: 't-1', name: 'category:Running Shoes' }] }],
+        }),
+        // A standalone category created via createProjectTags that no prompt carries
+        // yet, plus one that IS already on a prompt (must not duplicate).
+        listProjectTags: sinon.stub().resolves({
+          items: [
+            { id: 't-9', name: 'category:Hiking Boots' },
+            { id: 't-1', name: 'category:Running Shoes' },
+          ],
+        }),
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);
+      expect(result.items).to.deep.equal([
+        { id: 't-1', name: 'category:Running Shoes' },
+        { id: 't-9', name: 'category:Hiking Boots' },
+      ]);
+      expect(transport.listProjectTags).to.have.been.calledWith(WS, 'p-tag');
+    });
+
+    it('keeps prompt-derived tags when the standalone tag list call fails (best-effort)', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub().resolves({
+          items: [{ id: 'q1', tags: [{ id: 't-1', name: 'category:Running Shoes' }] }],
+        }),
+        listProjectTags: sinon.stub().rejects(new Error('boom')),
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);
+      expect(result.items).to.deep.equal([{ id: 't-1', name: 'category:Running Shoes' }]);
+    });
+
     it('returns an empty set when no slice matches (no upstream prompt call)', async () => {
       const transport = makeTransport();
       const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -725,11 +725,70 @@ describe('markets-subworkspace handlers', () => {
       expect(result.items).to.deep.equal([{ id: 't-1', name: 'category:Running Shoes' }]);
     });
 
+    it('keeps the first (prompt-derived) real id when both sources supply different real ids for a name', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub().resolves({
+          items: [{ id: 'q1', tags: [{ id: 'prompt-id', name: 'category:Running Shoes' }] }],
+        }),
+        listProjectTags: sinon.stub().resolves({
+          items: [{ id: 'standalone-id', name: 'category:Running Shoes' }],
+        }),
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);
+      // Both ids are real (≠ name), so the synthetic-id upgrade does not fire and
+      // first-writer-wins holds: the prompt-derived id is kept deterministically.
+      expect(result.items).to.deep.equal([{ id: 'prompt-id', name: 'category:Running Shoes' }]);
+    });
+
+    it('warns when the standalone tag page ceiling is hit (possible truncation)', async () => {
+      const fullPage = Array.from({ length: 100 }, (_, i) => ({ id: `t${i}`, name: `category:C${i}` }));
+      const warnLog = { info: () => {}, error: () => {}, warn: sinon.stub() };
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub().resolves({ items: [] }),
+        // Every page is full → the walk never short-circuits and runs to the ceiling.
+        listProjectTags: sinon.stub().resolves({ items: fullPage }),
+      });
+      await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, warnLog);
+      expect(warnLog.warn).to.have.been.calledWithMatch(/page ceiling hit/);
+      expect(transport.listProjectTags.callCount).to.equal(50);
+    });
+
+    it('treats a standalone tag page with no items array as empty (defensive)', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub().resolves({
+          items: [{ id: 'q1', tags: [{ id: 't-1', name: 'category:Running Shoes' }] }],
+        }),
+        // Upstream page carries no items array — must be coerced to empty, not throw.
+        listProjectTags: sinon.stub().resolves(null),
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);
+      expect(result.items).to.deep.equal([{ id: 't-1', name: 'category:Running Shoes' }]);
+    });
+
+    it('falls back to the tag name as id when a standalone tag has no id', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub().resolves({ items: [] }),
+        listProjectTags: sinon.stub().resolves({
+          items: [{ name: 'category:No Id Yet' }],
+        }),
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);
+      expect(result.items).to.deep.equal([{ id: 'category:No Id Yet', name: 'category:No Id Yet' }]);
+    });
+
     it('paginates the standalone tag listing so categories beyond the first page are not dropped', async () => {
       const page1 = Array.from({ length: 100 }, (_, i) => ({ id: `t${i}`, name: `category:C${i}` }));
       const listProjectTags = sinon.stub();
       listProjectTags.onFirstCall().resolves({ items: page1 });
       listProjectTags.onSecondCall().resolves({ items: [{ id: 't-last', name: 'category:Last' }] });
+      // A short second page must end the walk; a third fetch would be an
+      // over-fetch bug — make it throw so the assertions below fail loudly
+      // rather than silently getting sinon's default undefined.
+      listProjectTags.onThirdCall().rejects(new Error('unexpected 3rd standalone page fetch'));
       const transport = makeTransport({
         listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
         listPromptsByTags: sinon.stub().resolves({ items: [] }),

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -708,6 +708,41 @@ describe('markets-subworkspace handlers', () => {
       expect(result.items).to.deep.equal([{ id: 't-1', name: 'category:Running Shoes' }]);
     });
 
+    it('upgrades a synthetic prompt-derived id to the canonical standalone id (no shadowing)', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        // Prompt-derived tag arrives as a BARE STRING → synthetic id === name.
+        listPromptsByTags: sinon.stub().resolves({
+          items: [{ id: 'q1', tags: ['category:Running Shoes'] }],
+        }),
+        // Standalone listing carries the canonical upstream id for the same name;
+        // it must win over the synthetic id even though prompts are merged first.
+        listProjectTags: sinon.stub().resolves({
+          items: [{ id: 't-1', name: 'category:Running Shoes' }],
+        }),
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);
+      expect(result.items).to.deep.equal([{ id: 't-1', name: 'category:Running Shoes' }]);
+    });
+
+    it('paginates the standalone tag listing so categories beyond the first page are not dropped', async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) => ({ id: `t${i}`, name: `category:C${i}` }));
+      const listProjectTags = sinon.stub();
+      listProjectTags.onFirstCall().resolves({ items: page1 });
+      listProjectTags.onSecondCall().resolves({ items: [{ id: 't-last', name: 'category:Last' }] });
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub().resolves({ items: [] }),
+        listProjectTags,
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);
+      // A full first page (=== limit) forces a second fetch; a short page ends it.
+      expect(listProjectTags.callCount).to.equal(2);
+      expect(listProjectTags.secondCall.args).to.deep.equal([WS, 'p-tag', { page: 2, limit: 100 }]);
+      expect(result.items).to.have.lengthOf(101);
+      expect(result.items).to.deep.include({ id: 't-last', name: 'category:Last' });
+    });
+
     it('returns an empty set when no slice matches (no upstream prompt call)', async () => {
       const transport = makeTransport();
       const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en' }, log);

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+const BRAND = '11111111-2222-3333-4444-555555555555';
+const WORKSPACE = '22222222-3333-4444-5555-666666666666';
+
+function fakeLog() {
+  return {
+    info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+  };
+}
+
+function makeTransport(overrides = {}) {
+  return {
+    createProjectTags: sinon.stub().resolves([{ id: 'tag-1', name: 'category:Footwear' }]),
+    ...overrides,
+  };
+}
+
+function makeDataAccess(findBySliceResult) {
+  return {
+    BrandSemrushProject: {
+      findBySlice: sinon.stub().resolves(findBySliceResult),
+    },
+  };
+}
+
+const validBody = {
+  type: 'category', name: 'Footwear', geoTargetId: 2840, languageCode: 'en',
+};
+
+describe('serenity tags handler (POST /serenity/tags)', () => {
+  afterEach(() => sinon.restore());
+
+  describe('handleCreateTag (flat mode)', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    it('registers a category:<NAME> tag on the slice project and returns 201', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        validBody,
+        fakeLog(),
+      );
+      expect(res.status).to.equal(201);
+      expect(res.body).to.include({
+        brandId: BRAND,
+        geoTargetId: 2840,
+        languageCode: 'en',
+        type: 'category',
+        name: 'Footwear',
+        tag: 'category:Footwear',
+      });
+      expect(transport.createProjectTags)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['category:Footwear']);
+    });
+
+    it('supports the topic dimension (also free-form)', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        { ...validBody, type: 'topic', name: 'Running Shoes' },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(201);
+      expect(res.body.tag).to.equal('topic:Running Shoes');
+      expect(transport.createProjectTags.firstCall.args[2]).to.deep.equal(['topic:Running Shoes']);
+    });
+
+    it('404s (marketNotFound) when no project backs the slice', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess(null);
+      await expect(
+        handler.handleCreateTag(transport, dataAccess, BRAND, WORKSPACE, validBody, fakeLog()),
+      ).to.be.rejected.then((err) => {
+        expect(err.status).to.equal(404);
+        expect(err.code).to.equal('marketNotFound');
+      });
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('400s when type is not in the creatable allow-list (closed taxonomy)', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      for (const type of ['intent', 'source', 'type', 'bogus', '', undefined]) {
+        // eslint-disable-next-line no-await-in-loop
+        await expect(handler.handleCreateTag(
+          transport,
+          dataAccess,
+          BRAND,
+          WORKSPACE,
+          { ...validBody, type },
+          fakeLog(),
+        )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      }
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('400s when name is missing, too long, or contains a colon', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const bad = [
+        { ...validBody, name: '   ' },
+        { ...validBody, name: 'x'.repeat(101) },
+        { ...validBody, name: 'topic:smuggled' },
+      ];
+      for (const body of bad) {
+        // eslint-disable-next-line no-await-in-loop
+        await expect(
+          handler.handleCreateTag(transport, dataAccess, BRAND, WORKSPACE, body, fakeLog()),
+        ).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      }
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('400s on a non-positive geoTargetId or malformed languageCode', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const bad = [
+        { ...validBody, geoTargetId: 0 },
+        { ...validBody, geoTargetId: 'abc' },
+        { ...validBody, languageCode: 'EN_US!' },
+        { ...validBody, languageCode: '' },
+      ];
+      for (const body of bad) {
+        // eslint-disable-next-line no-await-in-loop
+        await expect(
+          handler.handleCreateTag(transport, dataAccess, BRAND, WORKSPACE, body, fakeLog()),
+        ).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      }
+    });
+  });
+
+  describe('handleCreateTagSubworkspace', () => {
+    it('resolves the project from the live listing and registers the tag', async () => {
+      const resolveProjectStub = sinon.stub().resolves({ id: 'proj-sub-1' });
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeTransport();
+      const res = await handler.handleCreateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        validBody,
+        fakeLog(),
+      );
+      expect(res.status).to.equal(201);
+      expect(res.body).to.include({ type: 'category', name: 'Footwear', tag: 'category:Footwear' });
+      expect(res.body).to.not.have.property('brandId');
+      expect(resolveProjectStub).to.have.been.calledOnceWithExactly(
+        transport,
+        WORKSPACE,
+        2840,
+        'en',
+        sinon.match.any,
+      );
+      expect(transport.createProjectTags)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', ['category:Footwear']);
+    });
+
+    it('404s (marketNotFound) when the slice has no live project', async () => {
+      const resolveProjectStub = sinon.stub().resolves(null);
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeTransport();
+      await expect(handler.handleCreateTagSubworkspace(transport, WORKSPACE, validBody, fakeLog()))
+        .to.be.rejected.then((err) => {
+          expect(err.status).to.equal(404);
+          expect(err.code).to.equal('marketNotFound');
+        });
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('400s on a bad body before resolving any project', async () => {
+      const resolveProjectStub = sinon.stub().resolves({ id: 'proj-sub-1' });
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeTransport();
+      await expect(handler.handleCreateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        { ...validBody, type: 'intent' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(resolveProjectStub).to.not.have.been.called;
+    });
+  });
+});

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -129,6 +129,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
       const bad = [
+        { ...validBody, name: undefined },
         { ...validBody, name: '   ' },
         { ...validBody, name: 'x'.repeat(101) },
         { ...validBody, name: 'topic:smuggled' },

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -125,13 +125,15 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(transport.createProjectTags).to.not.have.been.called;
     });
 
-    it('400s when name is missing, too long, or contains a colon', async () => {
+    it('400s when name is missing, too long, contains a colon, or has control characters', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
       const bad = [
         { ...validBody, name: '   ' },
         { ...validBody, name: 'x'.repeat(101) },
         { ...validBody, name: 'topic:smuggled' },
+        { ...validBody, name: 'bad\u0000name' },
+        { ...validBody, name: 'tab\there' },
       ];
       for (const body of bad) {
         // eslint-disable-next-line no-await-in-loop

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -785,6 +785,24 @@ describe('Semrush REST transport', () => {
     });
   });
 
+  describe('listProjectTags', () => {
+    it('GETs /v2/workspaces/{ws}/projects/{pid}/aio/tags with parent_id + search', async () => {
+      fetchStub.resolves(fetchOk({ items: [{ id: 't-1', name: 'category:Running Shoes' }], page: 1, total: 1 }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const result = await transport.listProjectTags(WORKSPACE_ID, PROJECT_ID);
+
+      const call = await callOf(fetchStub);
+      expect(call.method).to.equal('GET');
+      expect(call.url).to.contain(
+        `/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/tags`,
+      );
+      expect(call.url).to.contain('parent_id=');
+      expect(call.url).to.contain('search=');
+      expect(result.items).to.deep.equal([{ id: 't-1', name: 'category:Running Shoes' }]);
+    });
+  });
+
   describe('getBrandTopics', () => {
     it('GETs /v1/workspaces/{ws}/brand-topics with domain + country query', async () => {
       fetchStub.resolves(fetchOk([

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -1553,5 +1553,15 @@ describe('utils', () => {
         .to.throw('IMS authentication required')
         .with.property('status', 401);
     });
+
+    it('returns the bearer for a non-IMS caller when SERENITY_ALLOW_NON_IMS_AUTH is set (local/E2E escape hatch)', () => {
+      const context = { ...buildContext({ getType: () => 'jwt' }), env: { SERENITY_ALLOW_NON_IMS_AUTH: 'true' } };
+      expect(getImsUserTokenStrict(context)).to.equal('ims-user-token');
+    });
+
+    it('still requires an Authorization header even with the escape hatch set', () => {
+      const context = { attributes: { authInfo: {} }, pathInfo: { headers: {} }, env: { SERENITY_ALLOW_NON_IMS_AUTH: 'true' } };
+      expect(() => getImsUserTokenStrict(context)).to.throw('Missing Authorization header');
+    });
   });
 });

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -1563,5 +1563,25 @@ describe('utils', () => {
       const context = { attributes: { authInfo: {} }, pathInfo: { headers: {} }, env: { SERENITY_ALLOW_NON_IMS_AUTH: 'true' } };
       expect(() => getImsUserTokenStrict(context)).to.throw('Missing Authorization header');
     });
+
+    it('hard-disables the escape hatch in production (AWS_ENV=prod) — a non-IMS caller 401s', () => {
+      const context = {
+        ...buildContext({ getType: () => 'jwt' }),
+        env: { SERENITY_ALLOW_NON_IMS_AUTH: 'true', AWS_ENV: 'prod' },
+      };
+      expect(() => getImsUserTokenStrict(context))
+        .to.throw('IMS authentication required')
+        .with.property('status', 401);
+    });
+
+    it('hard-disables the escape hatch in production (ENV=prod) — a non-IMS caller 401s', () => {
+      const context = {
+        ...buildContext({ getType: () => 'jwt' }),
+        env: { SERENITY_ALLOW_NON_IMS_AUTH: 'true', ENV: 'prod' },
+      };
+      expect(() => getImsUserTokenStrict(context))
+        .to.throw('IMS authentication required')
+        .with.property('status', 401);
+    });
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds the brand **Categories** surface for Semrush sub-workspace brands — a generic create-tag endpoint plus a standalone-tag read-back so categories persist — and the fixes found while testing the serenity brand-edit flow.

## 2. Reasoning
In the Serenity model a "category" is a `category:<NAME>` tag. The UI needs to create a category (name + market) and have it persist. The original create wrote a standalone tag, but every read derived categories from prompt-tags only, so a prompt-less category vanished on reload. Testing the brand-edit flow also surfaced a competitor-name propagation gap and a 401 on the local re-sync path.

## 3. High-level overview of the changes
Categories / tags:
- Generic create-tag: `prompt-tags.js` gains a `category` dimension + a `CREATABLE_TAG_DIMENSIONS` allow-list; new `handlers/tags.js` validates `type` against it and registers `<type>:<name>` on a market's project. Exposed as `POST /serenity/tags` (+ OpenAPI).
- New `listProjectTags` transport (`GET /aio/tags`); `handleListTagsSubworkspace` now **merges** standalone tags with prompt-derived ones (deduped by name, best-effort), so a freshly-created empty `category:<NAME>` round-trips instead of disappearing.
- Bumps `@adobe/spacecat-shared-project-engine-client` 1.3.2 → 1.4.0 (the release that makes AIO tags a stateful mock resource).

Edit-flow fixes:
- `competitor-benchmarks`: re-sync when a competitor's **name** drifts (not only its alias set), so a renamed competitor propagates to the Semrush benchmark.
- `getImsUserTokenStrict`: honor `SERENITY_ALLOW_NON_IMS_AUTH` so the local admin / non-IMS caller isn't 401'd on the brand re-sync path (test-only escape hatch; no deployed env sets it).

## 4. Required information
- Other: builds on  https://github.com/adobe/spacecat-shared/pull/1752  (project-engine-client 1.4.0); the mock model-name fidelity fix is  https://github.com/adobe/spacecat-shared/pull/1753

## 5. Affected / used mysticat-workspace projects
- project-elmo-ui — consumes the new `/serenity/tags` create + list (the Categories UI):  https://github.com/adobe/project-elmo-ui/pull/2078
- mysticat-data-service — local serenity dev needs the `LLMO/serenity` flag seeded:  https://github.com/adobe/mysticat-data-service/pull/758

## 6. Additional information outside the code
Verified end-to-end on the local stack against the 1.4.0 mock: `POST /serenity/tags` creates a `category:` tag and `GET /serenity/tags` reads it back **even with no carrying prompt** (the exact reload bug), and a renamed competitor propagates to the project benchmark (confirmed via the mock `__dump`).

## 7. Test plan
(a) Local: with the 1.4.0 Semrush mocks up and the `LLMO/serenity` flag enabled, create a category in elmo and confirm it survives a reload; rename a competitor and confirm it reaches the Semrush benchmark.
(b) Deployed envs: behind the existing serenity gate; no env-specific steps beyond the normal serenity surface.

## 8. Deployment & merge order
- Related:  https://github.com/adobe/project-elmo-ui/pull/2078  (UI consumer),  https://github.com/adobe/mysticat-data-service/pull/758  (seed flag),  https://github.com/adobe/spacecat-shared/pull/1753  (mock model-name fix).

The 1.4.0 client bump depends only on the already-released  https://github.com/adobe/spacecat-shared/pull/1752 . Merge order is not strict, but the elmo UI PR should land with or after this so the `/serenity/tags` endpoints exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
