### PR TITLE
fix: remove ims user token dependency to create promise token while creating fixes

### DIFF
--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -406,7 +406,13 @@ export class FixesController {
       if (!site || !opportunity) {
         return null;
       }
-      const promiseTokenResponse = await getIMSPromiseToken(this.#ctx);
+      const headerToken = this.#ctx.pathInfo?.headers?.['x-promise-token'];
+      let promiseTokenResponse;
+      if (hasText(headerToken)) {
+        promiseTokenResponse = { promise_token: headerToken };
+      } else {
+        promiseTokenResponse = await getIMSPromiseToken(this.#ctx);
+      }
       const imsAccessToken = await exchangePromiseToken(
         this.#ctx,
         promiseTokenResponse.promise_token,

--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -409,8 +409,10 @@ export class FixesController {
       const headerToken = this.#ctx.pathInfo?.headers?.['x-promise-token'];
       let promiseTokenResponse;
       if (hasText(headerToken)) {
+        log.info('[document-path-enrichment] using promise token from x-promise-token header');
         promiseTokenResponse = { promise_token: headerToken };
       } else {
+        log.info('[document-path-enrichment] no x-promise-token header, creating promise token via IMS');
         promiseTokenResponse = await getIMSPromiseToken(this.#ctx);
       }
       const imsAccessToken = await exchangePromiseToken(

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -1889,6 +1889,88 @@ describe('Fixes Controller', () => {
           sinon.match(/Could not create ContentClient for AEM Edge documentPath enrichment/),
         );
       });
+
+      it('uses x-promise-token header directly and skips getIMSPromiseToken', async () => {
+        getIMSPromiseTokenStub.resetHistory();
+        exchangePromiseTokenStub.resetHistory();
+
+        const mockSite = {
+          getDeliveryType: () => 'aem_cs',
+          getDeliveryConfig: () => ({ authorURL: 'https://author.example.com' }),
+        };
+        const mockOpportunity = { getType: () => 'broken-internal-links', getSiteId: () => siteId };
+        sandbox.stub(dataAccess.Site, 'findById').withArgs(siteId).resolves(mockSite);
+        sandbox.stub(dataAccess.Opportunity, 'findById').withArgs(opportunityId).resolves(mockOpportunity);
+
+        fixesController = new FixesControllerWithStubbedResolver(
+          {
+            dataAccess,
+            pathInfo: { headers: { 'x-promise-token': 'header-promise-token' } },
+            log,
+          },
+          accessControlUtil,
+        );
+
+        requestContext.data = [{
+          origin: 'aso',
+          type: 'CONTENT_UPDATE',
+          opportunityId,
+          changeDetails: { urlFrom: 'https://example.com/page' },
+        }];
+
+        const response = await fixesController.createFixes(requestContext);
+        expect(response).includes({ status: 207 });
+
+        const { fixes, metadata } = await response.json();
+        expect(metadata).deep.equals({ total: 1, success: 1, failed: 0 });
+        expect(fixes[0].fix.changeDetails).to.include({ documentPath: EDIT_URL });
+        expect(getIMSPromiseTokenStub).to.not.have.been.called;
+        expect(exchangePromiseTokenStub).to.have.been.calledWith(
+          sinon.match.any,
+          'header-promise-token',
+        );
+      });
+
+      it('falls back to getIMSPromiseToken when x-promise-token header is absent', async () => {
+        getIMSPromiseTokenStub.resetHistory();
+        exchangePromiseTokenStub.resetHistory();
+
+        const mockSite = {
+          getDeliveryType: () => 'aem_cs',
+          getDeliveryConfig: () => ({ authorURL: 'https://author.example.com' }),
+        };
+        const mockOpportunity = { getType: () => 'broken-internal-links', getSiteId: () => siteId };
+        sandbox.stub(dataAccess.Site, 'findById').withArgs(siteId).resolves(mockSite);
+        sandbox.stub(dataAccess.Opportunity, 'findById').withArgs(opportunityId).resolves(mockOpportunity);
+
+        fixesController = new FixesControllerWithStubbedResolver(
+          {
+            dataAccess,
+            pathInfo: { headers: { authorization: 'Bearer token' } },
+            log,
+          },
+          accessControlUtil,
+        );
+
+        requestContext.data = [{
+          origin: 'aso',
+          type: 'CONTENT_UPDATE',
+          opportunityId,
+          changeDetails: { urlFrom: 'https://example.com/page' },
+        }];
+
+        const response = await fixesController.createFixes(requestContext);
+        expect(response).includes({ status: 207 });
+
+        const { fixes, metadata } = await response.json();
+        expect(metadata).deep.equals({ total: 1, success: 1, failed: 0 });
+        expect(fixes[0].fix.changeDetails).to.include({ documentPath: EDIT_URL });
+        expect(getIMSPromiseTokenStub).to.have.been.calledOnce;
+        expect(exchangePromiseTokenStub).to.have.been.calledWith(
+          sinon.match.any,
+          'mock-promise-token',
+        );
+      });
     });
   });
 

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -1893,6 +1893,7 @@ describe('Fixes Controller', () => {
       it('uses x-promise-token header directly and skips getIMSPromiseToken', async () => {
         getIMSPromiseTokenStub.resetHistory();
         exchangePromiseTokenStub.resetHistory();
+        sandbox.stub(log, 'info');
 
         const mockSite = {
           getDeliveryType: () => 'aem_cs',
@@ -1929,11 +1930,15 @@ describe('Fixes Controller', () => {
           sinon.match.any,
           'header-promise-token',
         );
+        expect(log.info).to.have.been.calledWith(
+          '[document-path-enrichment] using promise token from x-promise-token header',
+        );
       });
 
       it('falls back to getIMSPromiseToken when x-promise-token header is absent', async () => {
         getIMSPromiseTokenStub.resetHistory();
         exchangePromiseTokenStub.resetHistory();
+        sandbox.stub(log, 'info');
 
         const mockSite = {
           getDeliveryType: () => 'aem_cs',
@@ -1969,6 +1974,9 @@ describe('Fixes Controller', () => {
         expect(exchangePromiseTokenStub).to.have.been.calledWith(
           sinon.match.any,
           'mock-promise-token',
+        );
+        expect(log.info).to.have.been.calledWith(
+          '[document-path-enrichment] no x-promise-token header, creating promise token via IMS',
         );
       });
     });


### PR DESCRIPTION
## Summary

- The `#prepareDocumentPathEnrichment` method in `FixesController` always called `getIMSPromiseToken` (which reads the `Authorization: Bearer` header) to obtain a promise token for AEM content API auth when creating manual fixes.
- This change mirrors the pattern already used in the autofix flow (`autofixSuggestions`): if the caller supplies an `x-promise-token` header, it is used directly, bypassing the IMS round-trip entirely.
- Falls back to `getIMSPromiseToken` when the header is absent, preserving existing behaviour.


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
