### PR TITLE
fix: gap-topics empty on first day of month | LLMO-5963

### DIFF
--- a/src/support/ai-visibility/grpc-utils.js
+++ b/src/support/ai-visibility/grpc-utils.js
@@ -434,6 +434,19 @@ export function parseMonthYM(sp) {
   return { year: Number(m[1]), month: Number(m[2]) };
 }
 
+/**
+ * Returns the `date` query param only when it is an exact `YYYY-MM-DD` snapshot date,
+ * otherwise `undefined`. A month-only `YYYY-MM` (the value the UI currently sends, since
+ * Competitor Research has no date filter) is intentionally dropped so the upstream service
+ * defaults to the latest available snapshot — mirroring `competitors/metrics`. Pinning a
+ * month-only `target_date` makes the gRPC TopicService return NotFound on the first day of a
+ * month, before that month has any data. See LLMO-5963.
+ */
+export function exactSnapshotDate(sp) {
+  const raw = sp.get('date')?.trim();
+  return raw && /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw : undefined;
+}
+
 export function statsByLLMDateRange(endYear, endMonth, windowMonths) {
   let fromMonth = endMonth - (windowMonths - 1);
   let fromYear = endYear;

--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics-export.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics-export.js
@@ -33,6 +33,7 @@ import {
   brandTarget,
   parseCompetitorDomainsList,
   responseFromGrpcError,
+  exactSnapshotDate,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -49,7 +50,7 @@ export async function handleGapTopicsExport(sp, clients) {
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const sortBy = sp.get('sortBy') || TOPICS_REQUEST_ORDER_BY_ENUM.TOTAL_COMPETITOR_MENTIONS;
   const sortDirection = sp.get('sortDirection') || ORDER_DIRECTION_ENUM.DESC;
-  const date = sp.get('date');
+  const targetDate = exactSnapshotDate(sp);
   const { limit, offset } = parseLimitOffset(sp);
 
   const gapKindsRaw = sp.get('gapKinds');
@@ -78,7 +79,7 @@ export async function handleGapTopicsExport(sp, clients) {
         range: { limit, offset },
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterResult.metricFilterQl,
-        target_date: date,
+        ...(targetDate ? { target_date: targetDate } : {}),
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics-totals.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics-totals.js
@@ -25,6 +25,7 @@ import {
   brandTarget,
   parseCompetitorDomainsList,
   responseFromGrpcError,
+  exactSnapshotDate,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -39,7 +40,7 @@ export async function handleGapTopicsTotals(sp, clients) {
   const competitorDomains = parseCompetitorDomainsList(sp);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
-  const date = sp.get('date');
+  const targetDate = exactSnapshotDate(sp);
 
   const dimensionFilterQl = buildGapTopicsDimensionFilterQl(sp);
   const metricFilterResult = buildGapTopicsMetricFilterQl(sp);
@@ -58,7 +59,7 @@ export async function handleGapTopicsTotals(sp, clients) {
         competitors: competitorDomains.map(brandTarget),
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterResult.metricFilterQl,
-        target_date: date,
+        ...(targetDate ? { target_date: targetDate } : {}),
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
+++ b/src/support/ai-visibility/handlers/v1/topic/gap-topics.js
@@ -32,6 +32,7 @@ import {
   buildRangeExpr,
   escapeQlString,
   isValidVolume,
+  exactSnapshotDate,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -73,7 +74,7 @@ export async function handleGapTopics(sp, clients) {
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const sortBy = sp.get('sortBy') || TOPICS_REQUEST_ORDER_BY_ENUM.TOTAL_COMPETITOR_MENTIONS;
   const sortDirection = sp.get('sortDirection') || ORDER_DIRECTION_ENUM.DESC;
-  const date = sp.get('date');
+  const targetDate = exactSnapshotDate(sp);
   const { limit, offset } = parseLimitOffset(sp);
 
   const gapKindsRaw = sp.get('gapKinds');
@@ -102,7 +103,7 @@ export async function handleGapTopics(sp, clients) {
         range: { limit, offset },
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterResult.metricFilterQl,
-        target_date: date,
+        ...(targetDate ? { target_date: targetDate } : {}),
       },
       PROTO_FROM_JSON,
     );

--- a/test/support/ai-visibility/grpc-utils.test.js
+++ b/test/support/ai-visibility/grpc-utils.test.js
@@ -39,6 +39,7 @@ import {
   requiredLlmFromQuery,
   optionalLlmFromQuery,
   parseMonthYM,
+  exactSnapshotDate,
   statsByLLMDateRange,
   slugHostFromBrandName,
   normalizeTopBrandsByDomainNameKey,
@@ -609,6 +610,30 @@ describe('grpc-utils', () => {
 
     it('returns null for whitespace-only month', () => {
       expect(parseMonthYM(sp('month=%20'))).to.be.null;
+    });
+  });
+
+  describe('exactSnapshotDate', () => {
+    it('returns the value for an exact YYYY-MM-DD date', () => {
+      expect(exactSnapshotDate(sp('date=2026-07-01'))).to.equal('2026-07-01');
+    });
+
+    it('returns undefined for a month-only YYYY-MM date', () => {
+      expect(exactSnapshotDate(sp('date=2026-07'))).to.be.undefined;
+    });
+
+    it('returns undefined when date param is missing', () => {
+      expect(exactSnapshotDate(sp(''))).to.be.undefined;
+    });
+
+    it('returns undefined for empty or whitespace-only date', () => {
+      expect(exactSnapshotDate(sp('date='))).to.be.undefined;
+      expect(exactSnapshotDate(sp('date=%20'))).to.be.undefined;
+    });
+
+    it('returns undefined for malformed dates', () => {
+      expect(exactSnapshotDate(sp('date=2026-7-1'))).to.be.undefined;
+      expect(exactSnapshotDate(sp('date=abc'))).to.be.undefined;
     });
   });
 

--- a/test/support/ai-visibility/handlers/v1/topic/gap-topics.test.js
+++ b/test/support/ai-visibility/handlers/v1/topic/gap-topics.test.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable max-len -- AI Visibility gap-topics target_date tests */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import {
+  GapTopicsResponseSchema,
+  GapTopicsTotalsResponseSchema,
+} from '@quazar/ai-seo-ts/v2/topic/messages_pb.js';
+import { ExportResponseSchema } from '@quazar/ai-seo-ts/v2/common/messages_pb.js';
+import { handleGapTopics } from '../../../../../../src/support/ai-visibility/handlers/v1/topic/gap-topics.js';
+import { handleGapTopicsTotals } from '../../../../../../src/support/ai-visibility/handlers/v1/topic/gap-topics-totals.js';
+import { handleGapTopicsExport } from '../../../../../../src/support/ai-visibility/handlers/v1/topic/gap-topics-export.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+// Shared params so the only thing varying between cases is the `date` snapshot value.
+const BASE = 'domain=example.com&competitors=rival.com';
+
+describe('AI Visibility – v1 gap-topics target_date (LLMO-5963)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      topicClient: {
+        gapTopics: sandbox.stub().resolves(create(GapTopicsResponseSchema, { topics: [] })),
+        gapTopicsTotals: sandbox.stub().resolves(create(GapTopicsTotalsResponseSchema, { totals: [] })),
+        gapTopicsExport: sandbox.stub().resolves(create(ExportResponseSchema, {})),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleGapTopics', () => {
+    it('forwards an exact YYYY-MM-DD date as target_date', async () => {
+      await handleGapTopics(sp(`${BASE}&date=2026-06-30`), clients);
+      expect(clients.topicClient.gapTopics.firstCall.args[0].targetDate).to.equal('2026-06-30');
+    });
+
+    it('drops a month-only YYYY-MM date so upstream uses the latest snapshot', async () => {
+      await handleGapTopics(sp(`${BASE}&date=2026-07`), clients);
+      expect(clients.topicClient.gapTopics.firstCall.args[0].targetDate).to.be.undefined;
+    });
+  });
+
+  describe('handleGapTopicsTotals', () => {
+    it('forwards an exact YYYY-MM-DD date as target_date', async () => {
+      await handleGapTopicsTotals(sp(`${BASE}&date=2026-06-30`), clients);
+      expect(clients.topicClient.gapTopicsTotals.firstCall.args[0].targetDate).to.equal('2026-06-30');
+    });
+
+    it('drops a month-only YYYY-MM date', async () => {
+      await handleGapTopicsTotals(sp(`${BASE}&date=2026-07`), clients);
+      expect(clients.topicClient.gapTopicsTotals.firstCall.args[0].targetDate).to.be.undefined;
+    });
+  });
+
+  describe('handleGapTopicsExport', () => {
+    it('forwards an exact YYYY-MM-DD date as target_date on the nested request', async () => {
+      await handleGapTopicsExport(sp(`${BASE}&date=2026-06-30`), clients);
+      expect(clients.topicClient.gapTopicsExport.firstCall.args[0].request.targetDate).to.equal('2026-06-30');
+    });
+
+    it('drops a month-only YYYY-MM date', async () => {
+      await handleGapTopicsExport(sp(`${BASE}&date=2026-07`), clients);
+      expect(clients.topicClient.gapTopicsExport.firstCall.args[0].request.targetDate).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

On the first day of a month the Competitor Research **Gap Topics** tab renders empty while the comparison chart, historical comparison, and Gap Source Domains tab all work. The v1 gap-topics handlers forwarded the UI's month-only `date` (`YYYY-MM`) verbatim as `target_date` to the Semrush gRPC `TopicService`, which has no snapshot for the current month yet on day 1 and returns NotFound/empty. This fixes it backend-side (no UI change) so it's corrected for all clients.

## Changes

- Add `exactSnapshotDate(sp)` to `grpc-utils.js` — returns the `date` param only when it is an exact `YYYY-MM-DD`, else `undefined`.
- `gap-topics.js`, `gap-topics-totals.js`, `gap-topics-export.js` now forward `target_date` **only when it is an exact date**; a month-only `YYYY-MM` is omitted so upstream `TopicService` defaults to the latest available snapshot (matching `competitors/metrics`).
- The key is omitted (not set to `undefined`) because `fromJson` rejects an `undefined` `target_date` and would otherwise return HTTP 400.
- Source-domains handlers left unchanged — they already work.

## Test plan

- [x] `npx mocha test/support/ai-visibility/grpc-utils.test.js` — new `exactSnapshotDate` cases (exact / month-only / missing / empty / malformed).
- [x] `npx mocha test/support/ai-visibility/handlers/v1/topic/gap-topics.test.js` — all three handlers forward an exact date and omit a month-only one (249 passing).
- [x] `npx eslint` clean on all touched files.
- [ ] **QA (blocked by stage auth outage):** confirm on the first of a month that Gap Topics shows the latest snapshot and Source Domains/comparison are unregressed. Rests on the assumption that `TopicService` returns latest when `target_date` is omitted.

## Related Issues

https://jira.corp.adobe.com/browse/LLMO-5963