### PR TITLE
feat: return per-prompt userIntent in topic-prompts endpoint | LLMO-5950

### DIFF
--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -2181,13 +2181,7 @@ export function createTopicPromptsHandler(getOrgAndValidateAccess) {
       const rawRows = data || [];
       const topicResponseLabel = topicLabelForDetailResponse(rawRows, topicName);
       const topicIdResponse = topicIdForDetailResponse(rawRows, topicName);
-      // Enrich with per-prompt intent from the prompts table (1:1 with prompt_id;
-      // executions carry only prompt_id). Non-fatal + intent-column-absent safe.
-      const intentByPromptId = await getIntentsByPromptIds({
-        promptIds: rawRows.map((r) => r.prompt_id),
-        postgrestClient: client,
-      });
-      let items = buildPromptDetails(rawRows, intentByPromptId);
+      let items = buildPromptDetails(rawRows);
 
       // When a search query is provided, filter to only prompts whose text
       // matches — mirroring the original brand presence client-side behaviour
@@ -2204,8 +2198,21 @@ export function createTopicPromptsHandler(getOrgAndValidateAccess) {
       const start = pagination.page * pagination.pageSize;
       const paged = items.slice(start, start + pagination.pageSize);
 
+      // Enrich only the returned page with per-prompt intent from the prompts
+      // table (1:1 with prompt_id; executions carry only prompt_id). Done after
+      // pagination so the .in() lookup is bounded to the page (≤ pageSize),
+      // never the full rawRows set. Non-fatal + intent-column-absent safe.
+      const intentByPromptId = await getIntentsByPromptIds({
+        promptIds: paged.map((item) => item.promptId),
+        postgrestClient: client,
+      });
+      const pagedItems = paged.map((item) => ({
+        ...item,
+        userIntent: intentByPromptId.get(item.promptId) || '',
+      }));
+
       return cachedOk({
-        items: paged,
+        items: pagedItems,
         totalCount,
         topic: topicResponseLabel,
         topicId: topicIdResponse,

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -18,6 +18,7 @@ import {
 } from '@adobe/spacecat-shared-http-utils';
 import { hasText, isValidUUID } from '@adobe/spacecat-shared-utils';
 import { cachedOk } from '../../support/cached-response.js';
+import { getIntentsByPromptIds } from '../../support/prompts-storage.js';
 
 /**
  * Brand Presence filter-dimensions handler for org-based routes.
@@ -1939,7 +1940,7 @@ export function aggregateTopicData(rows) {
  * @returns {Array<Object>} PromptDetail-compatible objects
  * @internal Exported for testing
  */
-export function buildPromptDetails(rows) {
+export function buildPromptDetails(rows, intentByPromptId = new Map()) {
   const promptMap = new Map();
 
   rows.forEach((row) => {
@@ -1985,6 +1986,7 @@ export function buildPromptDetails(rows) {
       sentiment: r.sentiment || '',
       errorCode: r.error_code || '',
       origin: r.origin || '',
+      userIntent: (r.prompt_id != null && intentByPromptId.get(String(r.prompt_id))) || '',
     };
   });
 }
@@ -2179,7 +2181,13 @@ export function createTopicPromptsHandler(getOrgAndValidateAccess) {
       const rawRows = data || [];
       const topicResponseLabel = topicLabelForDetailResponse(rawRows, topicName);
       const topicIdResponse = topicIdForDetailResponse(rawRows, topicName);
-      let items = buildPromptDetails(rawRows);
+      // Enrich with per-prompt intent from the prompts table (1:1 with prompt_id;
+      // executions carry only prompt_id). Non-fatal + intent-column-absent safe.
+      const intentByPromptId = await getIntentsByPromptIds({
+        promptIds: rawRows.map((r) => r.prompt_id),
+        postgrestClient: client,
+      });
+      let items = buildPromptDetails(rawRows, intentByPromptId);
 
       // When a search query is provided, filter to only prompts whose text
       // matches — mirroring the original brand presence client-side behaviour

--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -1940,7 +1940,7 @@ export function aggregateTopicData(rows) {
  * @returns {Array<Object>} PromptDetail-compatible objects
  * @internal Exported for testing
  */
-export function buildPromptDetails(rows, intentByPromptId = new Map()) {
+export function buildPromptDetails(rows) {
   const promptMap = new Map();
 
   rows.forEach((row) => {
@@ -1986,7 +1986,6 @@ export function buildPromptDetails(rows, intentByPromptId = new Map()) {
       sentiment: r.sentiment || '',
       errorCode: r.error_code || '',
       origin: r.origin || '',
-      userIntent: (r.prompt_id != null && intentByPromptId.get(String(r.prompt_id))) || '',
     };
   });
 }
@@ -2204,7 +2203,9 @@ export function createTopicPromptsHandler(getOrgAndValidateAccess) {
       // never the full rawRows set. Non-fatal + intent-column-absent safe.
       const intentByPromptId = await getIntentsByPromptIds({
         promptIds: paged.map((item) => item.promptId),
+        organizationId,
         postgrestClient: client,
+        log: ctx.log,
       });
       const pagedItems = paged.map((item) => ({
         ...item,

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -104,6 +104,40 @@ async function withMissingIntentFallback(postgrestClient, run) {
 }
 
 /**
+ * Loads `intent` for a set of prompts by their `prompts.id` (uuid) values.
+ * Used to enrich reads (e.g. brand-presence executions) that carry a `prompt_id`
+ * FK but not intent itself. Degrades gracefully in intent-column-absent
+ * environments via withMissingIntentFallback, and treats any other error as a
+ * non-fatal miss (empty Map) so callers never fail a request over this enrichment.
+ *
+ * @param {object} params
+ * @param {Array<string>} params.promptIds - prompts.id (uuid) values; nullish/dupes are ignored
+ * @param {object} params.postgrestClient - PostgREST client
+ * @returns {Promise<Map<string, string>>} Map of promptId -> intent (only non-empty intents)
+ */
+export async function getIntentsByPromptIds({ promptIds, postgrestClient }) {
+  const ids = [...new Set((promptIds || []).filter(Boolean))];
+  if (!ids.length || !postgrestClient?.from) {
+    return new Map();
+  }
+  const run = (includeIntent) => postgrestClient
+    .from('prompts')
+    .select(includeIntent ? 'id, intent' : 'id')
+    .in('id', ids);
+  const { data, error } = await withMissingIntentFallback(postgrestClient, run);
+  if (error) {
+    return new Map();
+  }
+  const map = new Map();
+  (data || []).forEach((r) => {
+    if (r.intent) {
+      map.set(String(r.id), r.intent);
+    }
+  });
+  return map;
+}
+
+/**
  * Resolves brandId (path param) to Postgres brands.id (uuid).
  * Tries: 1) valid uuid lookup, 2) case-insensitive name lookup.
  *

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -106,9 +106,10 @@ async function withMissingIntentFallback(postgrestClient, run) {
 /**
  * Loads `intent` for a set of prompts by their `prompts.id` (uuid) values.
  * Used to enrich reads (e.g. brand-presence executions) that carry a `prompt_id`
- * FK but not intent itself. Degrades gracefully in intent-column-absent
- * environments via withMissingIntentFallback, and treats any other error as a
+ * FK but not intent itself. Any error — including a missing `intent` column — is a
  * non-fatal miss (empty Map) so callers never fail a request over this enrichment.
+ * No missing-column retry is needed here: this helper's only output is intent, so a
+ * column-absent environment simply yields an empty Map, same as the error path.
  *
  * @param {object} params
  * @param {Array<string>} params.promptIds - prompts.id (uuid) values; nullish/dupes are ignored
@@ -120,11 +121,10 @@ export async function getIntentsByPromptIds({ promptIds, postgrestClient }) {
   if (!ids.length || !postgrestClient?.from) {
     return new Map();
   }
-  const run = (includeIntent) => postgrestClient
+  const { data, error } = await postgrestClient
     .from('prompts')
-    .select(includeIntent ? 'id, intent' : 'id')
+    .select('id, intent')
     .in('id', ids);
-  const { data, error } = await withMissingIntentFallback(postgrestClient, run);
   if (error) {
     return new Map();
   }

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -103,6 +103,19 @@ async function withMissingIntentFallback(postgrestClient, run) {
   return result;
 }
 
+// Bound the number of ids per `id=in.(...)` PostgREST GET so the query string
+// stays well under proxy/header URL-length limits: a full page (pageSize caps at
+// 1000) of ~36-char UUIDs would be ~37KB and risk a 414. 100 ids ≈ 3.7KB.
+const INTENT_LOOKUP_CHUNK_SIZE = 100;
+
+function chunkArray(arr, size) {
+  const chunks = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
 /**
  * Loads `intent` for a set of prompts by their `prompts.id` (uuid) values.
  * Used to enrich reads (e.g. brand-presence executions) that carry a `prompt_id`
@@ -111,28 +124,52 @@ async function withMissingIntentFallback(postgrestClient, run) {
  * No missing-column retry is needed here: this helper's only output is intent, so a
  * column-absent environment simply yields an empty Map, same as the error path.
  *
+ * The id list is chunked across parallel queries to bound the IN-clause URL length,
+ * and an optional `organizationId` predicate scopes the lookup for defense-in-depth
+ * (callers already pass tenant-scoped ids). A missing-`intent`-column error logs at
+ * debug (benign, older DB image); any other error logs at warn so blank intent is
+ * diagnosable — neither fails the caller.
+ *
  * @param {object} params
  * @param {Array<string>} params.promptIds - prompts.id (uuid) values; nullish/dupes are ignored
+ * @param {string} [params.organizationId] - scopes the lookup to this org (defense-in-depth)
  * @param {object} params.postgrestClient - PostgREST client
+ * @param {object} [params.log] - logger; `debug` for benign missing-column, `warn` otherwise
  * @returns {Promise<Map<string, string>>} Map of promptId -> intent (only non-empty intents)
  */
-export async function getIntentsByPromptIds({ promptIds, postgrestClient }) {
+export async function getIntentsByPromptIds({
+  promptIds, organizationId, postgrestClient, log,
+}) {
   const ids = [...new Set((promptIds || []).filter(Boolean))];
   if (!ids.length || !postgrestClient?.from) {
     return new Map();
   }
-  const { data, error } = await postgrestClient
-    .from('prompts')
-    .select('id, intent')
-    .in('id', ids);
-  if (error) {
-    return new Map();
-  }
+
+  const results = await Promise.all(
+    chunkArray(ids, INTENT_LOOKUP_CHUNK_SIZE).map((batch) => {
+      let query = postgrestClient.from('prompts').select('id, intent').in('id', batch);
+      if (organizationId) {
+        query = query.eq('organization_id', organizationId);
+      }
+      return query;
+    }),
+  );
+
   const map = new Map();
-  (data || []).forEach((r) => {
-    if (r.intent) {
-      map.set(String(r.id), r.intent);
+  results.forEach(({ data, error }) => {
+    if (error) {
+      if (isMissingIntentColumnError(error)) {
+        log?.debug?.(`getIntentsByPromptIds: prompts.intent unavailable (${error.message}); returning no intent`);
+      } else {
+        log?.warn?.(`getIntentsByPromptIds: intent lookup failed (${error.message}); returning no intent`);
+      }
+      return;
     }
+    (data || []).forEach((r) => {
+      if (r.intent) {
+        map.set(String(r.id), r.intent);
+      }
+    });
   });
   return map;
 }

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -5074,27 +5074,6 @@ describe('llmo-brand-presence', () => {
       expect(item.promptId).to.equal('');
     });
 
-    it('defaults userIntent to empty string when no intent map is provided', () => {
-      const rows = [makeExecRow({ prompt_id: 'p1' })];
-      expect(buildPromptDetails(rows)[0].userIntent).to.equal('');
-    });
-
-    it('maps userIntent from the intent map keyed by prompt_id', () => {
-      const rows = [makeExecRow({ prompt_id: 'p1' })];
-      const intentByPromptId = new Map([['p1', 'Informational']]);
-      expect(buildPromptDetails(rows, intentByPromptId)[0].userIntent).to.equal('Informational');
-    });
-
-    it('leaves userIntent empty when prompt_id is absent from the intent map or null', () => {
-      const rows = [
-        makeExecRow({ prompt: 'q1', prompt_id: 'missing' }),
-        makeExecRow({ prompt: 'q2', prompt_id: null }),
-      ];
-      const intentByPromptId = new Map([['p1', 'Informational']]);
-      const result = buildPromptDetails(rows, intentByPromptId);
-      expect(result.every((i) => i.userIntent === '')).to.equal(true);
-    });
-
     it('deduplicates by prompt|region_code keeping latest execution', () => {
       const rows = [
         makeExecRow({
@@ -5589,6 +5568,32 @@ describe('llmo-brand-presence', () => {
 
       const body = await result.json();
       expect(body.items[0].userIntent).to.equal('Commercial');
+    });
+
+    it('bounds the intent lookup to the paginated page, not all rows', async () => {
+      // 5 distinct prompts, pageSize 2 → only the 2 returned prompt_ids should be
+      // looked up (proves enrichment runs after pagination, not over all rawRows).
+      const rows = [];
+      for (let i = 0; i < 5; i += 1) {
+        rows.push(makeDetailRow({
+          prompt: `q${i}`, prompt_id: `p${i}`, id: `p${i}`, intent: `intent${i}`,
+        }));
+      }
+      mockContext.params.topicId = 'T';
+      mockContext.data = { page: '0', pageSize: '2' };
+      const client = createChainableMock({ data: rows, error: null });
+      mockContext.dataAccess.Site.postgrestService = client;
+
+      const handler = createTopicPromptsHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      const body = await result.json();
+      expect(body.items).to.have.lengthOf(2);
+      expect(body.items.map((i) => i.userIntent)).to.deep.equal(['intent0', 'intent1']);
+      // Only the intent lookup uses `.in('id', ...)`; assert it received just the
+      // page's prompt_ids, not all 5.
+      const inCall = client.in.getCalls().find((c) => c.args[0] === 'id');
+      expect(inCall.args[1]).to.deep.equal(['p0', 'p1']);
     });
 
     it('returns empty items when no data', async () => {

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -5074,6 +5074,27 @@ describe('llmo-brand-presence', () => {
       expect(item.promptId).to.equal('');
     });
 
+    it('defaults userIntent to empty string when no intent map is provided', () => {
+      const rows = [makeExecRow({ prompt_id: 'p1' })];
+      expect(buildPromptDetails(rows)[0].userIntent).to.equal('');
+    });
+
+    it('maps userIntent from the intent map keyed by prompt_id', () => {
+      const rows = [makeExecRow({ prompt_id: 'p1' })];
+      const intentByPromptId = new Map([['p1', 'Informational']]);
+      expect(buildPromptDetails(rows, intentByPromptId)[0].userIntent).to.equal('Informational');
+    });
+
+    it('leaves userIntent empty when prompt_id is absent from the intent map or null', () => {
+      const rows = [
+        makeExecRow({ prompt: 'q1', prompt_id: 'missing' }),
+        makeExecRow({ prompt: 'q2', prompt_id: null }),
+      ];
+      const intentByPromptId = new Map([['p1', 'Informational']]);
+      const result = buildPromptDetails(rows, intentByPromptId);
+      expect(result.every((i) => i.userIntent === '')).to.equal(true);
+    });
+
     it('deduplicates by prompt|region_code keeping latest execution', () => {
       const rows = [
         makeExecRow({
@@ -5546,6 +5567,28 @@ describe('llmo-brand-presence', () => {
       expect(body.items[0].topicId).to.equal(topicUuid);
       expect(body.items[0].promptId).to.equal('prompt-row-uuid');
       expect(body.totalCount).to.equal(1);
+    });
+
+    it('enriches items with userIntent looked up by prompt_id', async () => {
+      // The chainable mock returns the same rows for both the executions query
+      // and the prompts intent lookup, so a row whose id === prompt_id and which
+      // carries `intent` exercises the getIntentsByPromptIds -> DTO join.
+      const rows = [
+        makeDetailRow({
+          prompt: 'q1', prompt_id: 'p1', id: 'p1', intent: 'Commercial',
+        }),
+      ];
+      mockContext.params.topicId = 'T';
+      mockContext.dataAccess.Site.postgrestService = createChainableMock({
+        data: rows,
+        error: null,
+      });
+
+      const handler = createTopicPromptsHandler(getOrgAndValidateAccess);
+      const result = await handler(mockContext);
+
+      const body = await result.json();
+      expect(body.items[0].userIntent).to.equal('Commercial');
     });
 
     it('returns empty items when no data', async () => {

--- a/test/it/postgres/brand-presence-topic-prompts.test.js
+++ b/test/it/postgres/brand-presence-topic-prompts.test.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ctx } from './harness.js';
+import { resetPostgres } from './seed.js';
+import brandPresenceTopicPromptsTests from '../shared/tests/brand-presence-topic-prompts.js';
+
+brandPresenceTopicPromptsTests(() => ctx.httpClient, resetPostgres);

--- a/test/it/postgres/brand-presence-topic-prompts.test.js
+++ b/test/it/postgres/brand-presence-topic-prompts.test.js
@@ -11,7 +11,7 @@
  */
 
 import { ctx } from './harness.js';
-import { resetPostgres } from './seed.js';
+import { resetPostgres, seedBrandPresenceIntentFixture } from './seed.js';
 import brandPresenceTopicPromptsTests from '../shared/tests/brand-presence-topic-prompts.js';
 
-brandPresenceTopicPromptsTests(() => ctx.httpClient, resetPostgres);
+brandPresenceTopicPromptsTests(() => ctx.httpClient, resetPostgres, seedBrandPresenceIntentFixture);

--- a/test/it/postgres/seed-data/brand-presence-executions.js
+++ b/test/it/postgres/seed-data/brand-presence-executions.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  ORG_1_ID,
+  BRAND_1_ID,
+  SITE_1_ID,
+  BP_PROMPT_1_ID,
+  BP_EXECUTION_1_ID,
+  BP_TOPIC_1_NAME,
+} from '../../shared/seed-ids.js';
+
+// One execution row for BRAND_1 under topic BP_TOPIC_1_NAME, referencing the
+// seeded prompt (BP_PROMPT_1_ID) via prompt_id. execution_date lands in the
+// 2026_06 partition (present in the pinned mysticat-data-service IT image) and
+// the test queries an explicit startDate/endDate around it so the assertion is
+// not time-dependent. model matches the endpoint's DEFAULT_MODEL ('chatgpt-free').
+export const brandPresenceExecutions = [
+  {
+    id: BP_EXECUTION_1_ID,
+    organization_id: ORG_1_ID,
+    brand_id: BRAND_1_ID,
+    site_id: SITE_1_ID,
+    prompt_id: BP_PROMPT_1_ID,
+    model: 'chatgpt-free',
+    execution_date: '2026-06-15',
+    brand_name: 'Test Brand',
+    category_name: 'Discovery',
+    topics: BP_TOPIC_1_NAME,
+    prompt: 'best pdf editor for mac',
+    region_code: 'us',
+    origin: 'human',
+    mentions: true,
+    citations: false,
+    visibility_score: 80,
+    sentiment: 'positive',
+    dedupe_hash: 'bp-intent-it-dedupe-1',
+  },
+];

--- a/test/it/postgres/seed-data/brand-presence-executions.js
+++ b/test/it/postgres/seed-data/brand-presence-executions.js
@@ -11,7 +11,6 @@
  */
 
 import {
-  ORG_1_ID,
   BRAND_1_ID,
   SITE_1_ID,
   BP_PROMPT_1_ID,
@@ -24,10 +23,13 @@ import {
 // 2026_06 partition (present in the pinned mysticat-data-service IT image) and
 // the test queries an explicit startDate/endDate around it so the assertion is
 // not time-dependent. model matches the endpoint's DEFAULT_MODEL ('chatgpt-free').
+//
+// organization_id and dedupe_hash are intentionally omitted: BEFORE INSERT
+// triggers derive them (bpe_set_organization_id from site_id; trg_bpe_dedupe_hash
+// computes the md5 dedupe_hash), so any values supplied here would be dead.
 export const brandPresenceExecutions = [
   {
     id: BP_EXECUTION_1_ID,
-    organization_id: ORG_1_ID,
     brand_id: BRAND_1_ID,
     site_id: SITE_1_ID,
     prompt_id: BP_PROMPT_1_ID,
@@ -43,6 +45,5 @@ export const brandPresenceExecutions = [
     citations: false,
     visibility_score: 80,
     sentiment: 'positive',
-    dedupe_hash: 'bp-intent-it-dedupe-1',
   },
 ];

--- a/test/it/postgres/seed-data/prompts.js
+++ b/test/it/postgres/seed-data/prompts.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  ORG_1_ID,
+  BRAND_1_ID,
+  BP_PROMPT_1_ID,
+  BP_PROMPT_1_INTENT,
+} from '../../shared/seed-ids.js';
+
+// A single active prompt carrying an `intent`, referenced by the seeded
+// brand_presence_executions row so the topic-prompts endpoint can enrich
+// `userIntent` from the prompts table.
+export const prompts = [
+  {
+    id: BP_PROMPT_1_ID,
+    organization_id: ORG_1_ID,
+    brand_id: BRAND_1_ID,
+    prompt_id: 'bp-intent-it',
+    name: 'Intent IT Prompt',
+    text: 'best pdf editor for mac',
+    regions: ['us'],
+    status: 'active',
+    origin: 'human',
+    source: 'config',
+    intent: BP_PROMPT_1_INTENT,
+  },
+];

--- a/test/it/postgres/seed.js
+++ b/test/it/postgres/seed.js
@@ -40,6 +40,8 @@ import { brands } from './seed-data/brands.js';
 import { brandSites } from './seed-data/brand-sites.js';
 import { projectionAudits } from './seed-data/projection-audits.js';
 import { featureFlags } from './seed-data/feature-flags.js';
+import { prompts } from './seed-data/prompts.js';
+import { brandPresenceExecutions } from './seed-data/brand-presence-executions.js';
 
 const POSTGREST_PORT = process.env.IT_POSTGREST_PORT || '3300';
 const POSTGREST_URL = `http://localhost:${POSTGREST_PORT}`;
@@ -163,10 +165,15 @@ async function seed() {
     insertRows('audit_urls', auditUrls),
     insertRows('sentiment_guidelines', sentimentGuidelines),
     insertRows('brand_sites', brandSites),
+    // prompts.brand_id → brands.id, organization_id → organizations.id
+    insertRows('prompts', prompts),
   ]);
 
-  // Level 4: depend on fix_entities + suggestions
-  await insertRows('fix_entity_suggestions', fixEntitySuggestions);
+  // Level 4: depend on fix_entities + suggestions, and prompts (BPE.prompt_id → prompts.id)
+  await Promise.all([
+    insertRows('fix_entity_suggestions', fixEntitySuggestions),
+    insertRows('brand_presence_executions', brandPresenceExecutions),
+  ]);
 }
 
 /**

--- a/test/it/postgres/seed.js
+++ b/test/it/postgres/seed.js
@@ -165,15 +165,22 @@ async function seed() {
     insertRows('audit_urls', auditUrls),
     insertRows('sentiment_guidelines', sentimentGuidelines),
     insertRows('brand_sites', brandSites),
-    // prompts.brand_id → brands.id, organization_id → organizations.id
-    insertRows('prompts', prompts),
   ]);
 
-  // Level 4: depend on fix_entities + suggestions, and prompts (BPE.prompt_id → prompts.id)
-  await Promise.all([
-    insertRows('fix_entity_suggestions', fixEntitySuggestions),
-    insertRows('brand_presence_executions', brandPresenceExecutions),
-  ]);
+  // Level 4: depend on fix_entities + suggestions
+  await insertRows('fix_entity_suggestions', fixEntitySuggestions);
+}
+
+/**
+ * Optional per-test fixture: a prompt carrying an `intent` plus a
+ * brand_presence_executions row referencing it. NOT part of the baseline seed —
+ * other suites (e.g. categories-prompts) count prompts under ORG_1/BRAND_1 and
+ * assume an empty baseline, so this is seeded only by the topic-prompts IT after
+ * resetPostgres(). Cleared by the next suite's clearData (organizations CASCADE).
+ */
+export async function seedBrandPresenceIntentFixture() {
+  await insertRows('prompts', prompts); // FK: BPE.prompt_id → prompts.id
+  await insertRows('brand_presence_executions', brandPresenceExecutions);
 }
 
 /**

--- a/test/it/shared/seed-ids.js
+++ b/test/it/shared/seed-ids.js
@@ -47,6 +47,16 @@ export const MARKET_SITE_1_BASE_URL = 'https://semrush-market.example.fr';
 
 export const BRAND_1_ID = 'ab111111-1111-4111-b111-111111111111'; // ORG_1, "Test Brand"
 
+// ── Brand Presence (topic-prompts intent enrichment) ──
+// A prompt row carrying an `intent`, plus a brand_presence_executions row that
+// references it, so the topic-prompts endpoint can be asserted to enrich
+// `userIntent` from the prompts table. See seed-data/prompts.js +
+// seed-data/brand-presence-executions.js.
+export const BP_PROMPT_1_ID = 'b9111111-1111-4111-b111-111111111111';
+export const BP_EXECUTION_1_ID = 'be111111-1111-4111-b111-111111111111';
+export const BP_TOPIC_1_NAME = 'IntentITTopic';
+export const BP_PROMPT_1_INTENT = 'informational';
+
 // Serenity Semrush vendor-mock seed alignment. BRAND_1 is in subworkspace mode
 // (brands.semrush_workspace_id set); pointing it at the workspace the Project
 // Engine / User Manager mocks seed (`MOCK_SEED=workspace-with-data` /

--- a/test/it/shared/tests/brand-presence-topic-prompts.js
+++ b/test/it/shared/tests/brand-presence-topic-prompts.js
@@ -34,10 +34,15 @@ import {
  *
  * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
  * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
+ * @param {() => Promise<void>} seedFixture - Seeds the prompt + execution fixture
+ *   (kept out of the baseline so other suites' prompt counts are unaffected)
  */
-export default function brandPresenceTopicPromptsTests(getHttpClient, resetData) {
+export default function brandPresenceTopicPromptsTests(getHttpClient, resetData, seedFixture) {
   describe('Brand Presence — topic-prompts intent enrichment', () => {
-    before(() => resetData());
+    before(async () => {
+      await resetData();
+      await seedFixture();
+    });
 
     const topicPromptsPath = (query) => {
       const qs = new URLSearchParams(query).toString();

--- a/test/it/shared/tests/brand-presence-topic-prompts.js
+++ b/test/it/shared/tests/brand-presence-topic-prompts.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import {
+  ORG_1_ID,
+  BRAND_1_ID,
+  BP_PROMPT_1_ID,
+  BP_TOPIC_1_NAME,
+  BP_PROMPT_1_INTENT,
+} from '../seed-ids.js';
+
+/**
+ * Shared brand-presence topic-prompts endpoint tests.
+ *
+ *   GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/prompts
+ *
+ * Covers the per-prompt `userIntent` enrichment: the executions source carries
+ * only a `prompt_id`, and the handler looks up `intent` from the `prompts`
+ * table (bounded to the returned page) and maps it onto each item. The seeded
+ * data (seed-data/prompts.js + seed-data/brand-presence-executions.js) provides
+ * one execution under BP_TOPIC_1_NAME referencing a prompt whose intent is
+ * BP_PROMPT_1_INTENT, so we can assert the enriched value end-to-end.
+ *
+ * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
+ * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
+ */
+export default function brandPresenceTopicPromptsTests(getHttpClient, resetData) {
+  describe('Brand Presence — topic-prompts intent enrichment', () => {
+    before(() => resetData());
+
+    const topicPromptsPath = (query) => {
+      const qs = new URLSearchParams(query).toString();
+      const topic = encodeURIComponent(BP_TOPIC_1_NAME);
+      return `/org/${ORG_1_ID}/brands/${BRAND_1_ID}/brand-presence/topics/${topic}/prompts?${qs}`;
+    };
+
+    it('enriches each prompt with userIntent looked up from the prompts table', async () => {
+      const http = getHttpClient();
+      // Explicit date window around the seeded execution_date (2026-06-15) so the
+      // assertion does not depend on the current date / default 28-day range.
+      const res = await http.admin.get(topicPromptsPath({
+        startDate: '2026-06-01',
+        endDate: '2026-06-30',
+      }));
+
+      // Env-independent guard (mirrors llmo-url-inspector): pin the contract on
+      // the 200 case; other branches only assert the endpoint is reachable.
+      //   - 200 with the seeded prompt + enriched userIntent   (happy path)
+      //   - 401/403 if the auth chain does not grant LLMO       (env-dependent)
+      //   - 503 if PostgREST is not configured                 (LOCAL_DEV off)
+      expect(res.status).to.be.oneOf([200, 401, 403, 503]);
+      if (res.status !== 200) {
+        return;
+      }
+
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.property('topic', BP_TOPIC_1_NAME);
+      expect(res.body).to.have.property('totalCount', 1);
+      expect(res.body).to.have.property('items').that.is.an('array').with.lengthOf(1);
+
+      const [item] = res.body.items;
+      expect(item).to.have.property('promptId', BP_PROMPT_1_ID);
+      expect(item).to.have.property('prompt', 'best pdf editor for mac');
+      // The behaviour under test: userIntent enriched from prompts.intent,
+      // joined on prompt_id after pagination.
+      expect(item).to.have.property('userIntent', BP_PROMPT_1_INTENT);
+    });
+  });
+}

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -3293,14 +3293,12 @@ describe('prompts-storage', () => {
       expect(map.size).to.equal(0);
     });
 
-    it('degrades without throwing when the intent column is absent', async () => {
-      const inStub = sinon.stub();
-      inStub.onFirstCall().returns(thenable({ data: null, error: MISSING_INTENT }));
-      inStub.onSecondCall().returns(thenable({ data: [{ id: 'p1' }], error: null }));
+    it('returns an empty Map when the intent column is absent (no retry)', async () => {
+      const inStub = sinon.stub().returns(thenable({ data: null, error: MISSING_INTENT }));
       const client = { from: () => ({ select: () => ({ in: inStub }) }) };
       const map = await getIntentsByPromptIds({ promptIds: ['p1'], postgrestClient: client });
       expect(map.size).to.equal(0);
-      expect(inStub.callCount).to.equal(2);
+      expect(inStub.callCount).to.equal(1);
     });
   });
 

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -3255,12 +3255,17 @@ describe('prompts-storage', () => {
   // retries without intent so prompts still persist/read.
   describe('getIntentsByPromptIds', () => {
     const MISSING_INTENT = { code: '42703', message: 'column prompts.intent does not exist' };
-    const makeClient = (result) => ({
-      from: () => ({ select: () => ({ in: () => thenable(result) }) }),
+    // `.in()` result is awaitable and also chains `.eq()` (for the org predicate).
+    const clientReturning = (result, inStub) => ({
+      from: () => ({
+        select: () => ({
+          in: inStub || (() => ({ ...thenable(result), eq: () => thenable(result) })),
+        }),
+      }),
     });
 
     it('returns an empty Map for empty/nullish ids or no client', async () => {
-      const client = makeClient({});
+      const client = clientReturning({ data: [], error: null });
       const sizeFor = async (args) => (await getIntentsByPromptIds(args)).size;
       expect(await sizeFor({ promptIds: [], postgrestClient: client })).to.equal(0);
       expect(await sizeFor({ promptIds: [null, undefined], postgrestClient: client })).to.equal(0);
@@ -3276,7 +3281,7 @@ describe('prompts-storage', () => {
         ],
         error: null,
       }));
-      const client = { from: () => ({ select: () => ({ in: inStub }) }) };
+      const client = clientReturning(null, inStub);
       const map = await getIntentsByPromptIds({
         promptIds: ['p1', 'p1', 'p2', 'p3', null], postgrestClient: client,
       });
@@ -3287,18 +3292,48 @@ describe('prompts-storage', () => {
       expect(inStub.firstCall.args[1]).to.deep.equal(['p1', 'p2', 'p3']);
     });
 
-    it('returns an empty Map (non-fatal) on a generic query error', async () => {
-      const client = makeClient({ data: null, error: { message: 'DB exploded' } });
-      const map = await getIntentsByPromptIds({ promptIds: ['p1'], postgrestClient: client });
-      expect(map.size).to.equal(0);
+    it('scopes the lookup by organizationId when provided', async () => {
+      const eqStub = sinon.stub().returns(
+        thenable({ data: [{ id: 'p1', intent: 'Commercial' }], error: null }),
+      );
+      const inStub = sinon.stub().returns({ eq: eqStub });
+      const client = clientReturning(null, inStub);
+      const map = await getIntentsByPromptIds({
+        promptIds: ['p1'], organizationId: 'org-1', postgrestClient: client,
+      });
+      expect(map.get('p1')).to.equal('Commercial');
+      expect(eqStub.calledOnceWithExactly('organization_id', 'org-1')).to.equal(true);
     });
 
-    it('returns an empty Map when the intent column is absent (no retry)', async () => {
+    it('chunks large id lists into multiple bounded queries', async () => {
+      const inStub = sinon.stub().returns(thenable({ data: [], error: null }));
+      const client = clientReturning(null, inStub);
+      const ids = Array.from({ length: 250 }, (_, i) => `p${i}`);
+      await getIntentsByPromptIds({ promptIds: ids, postgrestClient: client });
+      // 250 ids / 100 per batch → 3 queries, each within the chunk size.
+      expect(inStub.callCount).to.equal(3);
+      expect(inStub.getCalls().map((c) => c.args[1].length)).to.deep.equal([100, 100, 50]);
+    });
+
+    it('logs at debug (not warn) when the intent column is absent, and does not retry', async () => {
       const inStub = sinon.stub().returns(thenable({ data: null, error: MISSING_INTENT }));
-      const client = { from: () => ({ select: () => ({ in: inStub }) }) };
-      const map = await getIntentsByPromptIds({ promptIds: ['p1'], postgrestClient: client });
+      const client = clientReturning(null, inStub);
+      const log = { debug: sinon.stub(), warn: sinon.stub() };
+      const map = await getIntentsByPromptIds({ promptIds: ['p1'], postgrestClient: client, log });
       expect(map.size).to.equal(0);
       expect(inStub.callCount).to.equal(1);
+      expect(log.debug.called).to.equal(true);
+      expect(log.warn.called).to.equal(false);
+    });
+
+    it('logs at warn (not debug) on a non-missing-column error, returning empty', async () => {
+      const inStub = sinon.stub().returns(thenable({ data: null, error: { message: 'timeout' } }));
+      const client = clientReturning(null, inStub);
+      const log = { debug: sinon.stub(), warn: sinon.stub() };
+      const map = await getIntentsByPromptIds({ promptIds: ['p1'], postgrestClient: client, log });
+      expect(map.size).to.equal(0);
+      expect(log.warn.called).to.equal(true);
+      expect(log.debug.called).to.equal(false);
     });
   });
 

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -29,6 +29,7 @@ import {
   normalizeIntent,
   isMissingIntentColumnError,
   findPromptsBlockingRegionRemoval,
+  getIntentsByPromptIds,
 } from '../../src/support/prompts-storage.js';
 
 use(chaiAsPromised);
@@ -3252,6 +3253,57 @@ describe('prompts-storage', () => {
   // intent migration). Writing/reading `intent` there 500s with a missing-
   // column error; the storage layer detects this per-client (WeakMap) and
   // retries without intent so prompts still persist/read.
+  describe('getIntentsByPromptIds', () => {
+    const MISSING_INTENT = { code: '42703', message: 'column prompts.intent does not exist' };
+    const makeClient = (result) => ({
+      from: () => ({ select: () => ({ in: () => thenable(result) }) }),
+    });
+
+    it('returns an empty Map for empty/nullish ids or no client', async () => {
+      const client = makeClient({});
+      const sizeFor = async (args) => (await getIntentsByPromptIds(args)).size;
+      expect(await sizeFor({ promptIds: [], postgrestClient: client })).to.equal(0);
+      expect(await sizeFor({ promptIds: [null, undefined], postgrestClient: client })).to.equal(0);
+      expect(await sizeFor({ promptIds: ['p1'], postgrestClient: {} })).to.equal(0);
+    });
+
+    it('maps intent by id, dedupes ids, and skips null/empty intents', async () => {
+      const inStub = sinon.stub().returns(thenable({
+        data: [
+          { id: 'p1', intent: 'Commercial' },
+          { id: 'p2', intent: null },
+          { id: 'p3', intent: '' },
+        ],
+        error: null,
+      }));
+      const client = { from: () => ({ select: () => ({ in: inStub }) }) };
+      const map = await getIntentsByPromptIds({
+        promptIds: ['p1', 'p1', 'p2', 'p3', null], postgrestClient: client,
+      });
+      expect(map.get('p1')).to.equal('Commercial');
+      expect(map.has('p2')).to.equal(false);
+      expect(map.has('p3')).to.equal(false);
+      // Deduped to the 3 distinct non-null ids.
+      expect(inStub.firstCall.args[1]).to.deep.equal(['p1', 'p2', 'p3']);
+    });
+
+    it('returns an empty Map (non-fatal) on a generic query error', async () => {
+      const client = makeClient({ data: null, error: { message: 'DB exploded' } });
+      const map = await getIntentsByPromptIds({ promptIds: ['p1'], postgrestClient: client });
+      expect(map.size).to.equal(0);
+    });
+
+    it('degrades without throwing when the intent column is absent', async () => {
+      const inStub = sinon.stub();
+      inStub.onFirstCall().returns(thenable({ data: null, error: MISSING_INTENT }));
+      inStub.onSecondCall().returns(thenable({ data: [{ id: 'p1' }], error: null }));
+      const client = { from: () => ({ select: () => ({ in: inStub }) }) };
+      const map = await getIntentsByPromptIds({ promptIds: ['p1'], postgrestClient: client });
+      expect(map.size).to.equal(0);
+      expect(inStub.callCount).to.equal(2);
+    });
+  });
+
   describe('intent column best-effort fallback', () => {
     const MISSING_INTENT_INSERT = {
       code: 'PGRST204',


### PR DESCRIPTION
## What & why

The brand-presence **topic-prompts** listing (`GET /org/:spaceCatId/brands/:brandId/brand-presence/topics/:topicId/prompts`) returned no per-prompt intent, so downstream the Data Insights export's **User Intent** column was always blank. Intent lives only on `prompts.intent`; the executions source carries just a `prompt_id` FK.

## Change

- **`src/support/prompts-storage.js`** — new exported `getIntentsByPromptIds({ promptIds, postgrestClient })`: a targeted `prompts.select('id, intent').in('id', ids)` lookup returning a `Map<promptId, intent>`. Reuses the existing `withMissingIntentFallback`, so **intent-column-absent environments degrade gracefully** instead of throwing. Any other query error → empty Map (non-fatal enrichment; never fails the request).
- **`src/controllers/llmo/llmo-brand-presence.js`** — `createTopicPromptsHandler` collects the executions' distinct `prompt_id`s, calls the helper with the handler's PostgREST client, and threads the map into `buildPromptDetails`, which now emits `userIntent`. Intent is 1:1 with `prompt_id`, so no row fan-out; `null` prompt_id → `''`.

### Why a handler-side lookup (not a view change or RPC)
The shared `brand_presence_executions_active` view has ~40+ consumers including perf-tuned, partition-pruned RPCs; adding a `prompts` join there risks regressing all of them. A dedicated RPC is over-engineered for a single 1:1 column on an endpoint that isn't RPC-backed today. The handler-side lookup has **zero blast radius and needs no migration**, at the cost of one bounded extra round-trip per topic expansion.

## Scope / follow-ups
- **Backend only.** The elmo-ui export cell for User Intent is still hardcoded empty — now a one-line read since the API returns `userIntent`.
- The `userIntent` **filter** query param remains parsed-but-unused (server-side filtering not wired).
- Blank `userIntent` is expected where `prompts.intent` is `null` (best-effort classification + manual backfill) — this surfaces intent, it doesn't populate it.

## Testing
- Added unit tests: `getIntentsByPromptIds` (empty/no-client, mapping+dedupe+null-skip, generic-error degrade, column-absent retry) and `buildPromptDetails`/handler enrichment.
- `npx mocha` on the affected suites: **670 passing, 0 failing**. eslint clean on all changed files.

## Related issue
https://jira.corp.adobe.com/browse/LLMO-5950