### PR TITLE
feat(serenity): consume nested AIO tags (parentId create, tree read, PATCH re-parent)

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -160,6 +160,8 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-market-by-slice'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/tags:
     $ref: './serenity-api.yaml#/v2-serenity-tags'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/tags/{tagId}:
+    $ref: './serenity-api.yaml#/v2-serenity-tag-by-id'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/models:
     $ref: './serenity-api.yaml#/v2-serenity-models'
   /v2/orgs/{spaceCatId}/serenity/models:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11255,6 +11255,27 @@ SerenityTag:
   properties:
     id: { type: string }
     name: { type: string }
+    parentId:
+      type: [string, 'null']
+      description: |
+        Parent tag id when this tag is a nested child, else null. Only populated
+        by the nested TREE read (GET /serenity/tags?parentId=...); absent on the
+        flat, prompt-derived listing.
+    childrenCount:
+      type: integer
+      description: |
+        Number of direct children under this tag. Populated by the TREE read
+        (typically non-zero only on root categories).
+    path:
+      type: [array, 'null']
+      description: |
+        Ancestor breadcrumb (root → ... ) for a nested child, populated by the
+        TREE read when listing a parent's children; null for a root/flat tag.
+      items:
+        type: object
+        properties:
+          id: { type: string }
+          name: { type: string }
 
 SerenityTagListResponse:
   type: object

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -419,7 +419,13 @@ v2-serenity-tags:
   get:
     tags: [serenity]
     summary: List tags for one slice
-    description: Unique tag set across the slice's prompts.
+    description: |
+      Unique tag set across the slice's prompts. When the `parentId` query param
+      is present (even empty), the read instead returns one level of the nested
+      category TREE: `parentId=''` returns the root categories (each with
+      `childrenCount`), a tag id returns that category's children (each with a
+      `path[]` breadcrumb). The tree view reads the draft layer so a just-created
+      category is visible before the project is published.
     operationId: listSerenityTags
     security:
       - ims_key: []
@@ -432,6 +438,14 @@ v2-serenity-tags:
         in: query
         required: true
         schema: { type: string, pattern: '^[a-z]{2,3}(-[a-z]{2,4})?$' }
+      - name: parentId
+        in: query
+        required: false
+        description: |
+          Present (even empty) → nested TREE read at this level: `''` lists the
+          roots, an upstream tag id lists that tag's children. Absent → the flat,
+          prompt-derived tag set.
+        schema: { type: string }
     responses:
       '200':
         description: Tags retrieved.
@@ -457,6 +471,9 @@ v2-serenity-tags:
       the closed taxonomies (`source` / `intent` / `type`) have a fixed value
       enum and are not freely creatable. The "Categories" view, for example, is
       the `category:` slice of these tags across a brand's markets.
+
+      Pass `parentId` (an upstream tag id from a prior list) to create the tag as
+      a 1-level nested child of that category; omit it for a root/flat tag.
     operationId: createSerenityTag
     security:
       - ims_key: []
@@ -486,6 +503,11 @@ v2-serenity-tags:
                 type: string
                 pattern: '^[a-z]{2,3}(-[a-z]{2,4})?$'
                 description: BCP-47 primary subtag of the market slice.
+              parentId:
+                type: string
+                description: |
+                  Optional upstream tag id (from a prior tags list) to nest the
+                  new tag under as a 1-level child. Omit for a root/flat tag.
     responses:
       '201':
         description: Tag registered on the market's project.
@@ -502,11 +524,114 @@ v2-serenity-tags:
                 tag:
                   type: string
                   description: The full `<type>:<name>` tag string registered upstream.
+                id:
+                  type: string
+                  description: The created tag's upstream id.
+                parentId:
+                  type: [string, 'null']
+                  description: The parent tag id when nested, otherwise null.
       '400': { $ref: './responses.yaml#/400' }
       '404':
         description: Organization, brand, or the (geoTargetId, languageCode) market not found.
       '502':
         description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
+# ─── Nested-tag edit (rename / re-parent) ─────────────────────────────
+
+v2-serenity-tag-by-id:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+    - name: tagId
+      in: path
+      required: true
+      description: Upstream AIO tag id (from a prior tags list).
+      schema:
+        type: string
+  patch:
+    tags: [serenity]
+    summary: Rename and/or re-parent a tag
+    description: |
+      Updates a single AIO tag in place on the market addressed by the
+      `(geoTargetId, languageCode)` slice — renames it and/or re-parents it under
+      another category (1-level nesting). `name` is the tag's full
+      `<dimension>:<value>` string and is always required by the upstream
+      contract, so a pure re-parent still carries the (unchanged) name. `parentId`
+      re-parents when present; note that promoting a child back to a root is not
+      supported upstream. An unknown `tagId` returns 404.
+    operationId: updateSerenityTag
+    security:
+      - ims_key: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [name, geoTargetId, languageCode]
+            additionalProperties: false
+            properties:
+              name:
+                type: string
+                minLength: 1
+                description: |
+                  The tag's full `<dimension>:<value>` string (dimension one of
+                  `category` / `topic`). Rename by changing the value.
+              parentId:
+                type: string
+                description: |
+                  Optional upstream tag id to re-parent this tag under. Omit to
+                  leave the parent unchanged.
+              geoTargetId:
+                type: integer
+                minimum: 1
+                description: Google Ads Geo Target ID of the market slice.
+              languageCode:
+                type: string
+                pattern: '^[a-z]{2,3}(-[a-z]{2,4})?$'
+                description: BCP-47 primary subtag of the market slice.
+    responses:
+      '200':
+        description: Tag updated.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                brandId: { type: string, format: uuid }
+                geoTargetId: { type: integer }
+                languageCode: { type: string }
+                tagId: { type: string }
+                tag:
+                  type: string
+                  description: The tag's full `<dimension>:<value>` string after update.
+                parentId:
+                  type: [string, 'null']
+                  description: The parent tag id when nested, otherwise null.
+      '400': { $ref: './responses.yaml#/400' }
+      '404':
+        description: |
+          Organization, brand, or the (geoTargetId, languageCode) market not found
+          (local checks). An unknown upstream tag id is NOT a 404 — like every
+          serenity proxy write, an upstream error surfaces as 502.
+      '502':
+        description: Upstream returned a non-2xx response (including an unknown tag id).
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -581,7 +581,8 @@ v2-serenity-tag-by-id:
       CURRENT `parentId` itself (never omits it for a child — omission silently
       promotes a child to root upstream), so the parent is safely left
       unchanged either way. Note that promoting a child back to a root is not
-      supported upstream. An unknown `tagId` returns 404.
+      supported upstream. An unknown `tagId` is NOT a 404 — it surfaces as 502,
+      like every serenity proxy write against an upstream error.
     operationId: updateSerenityTag
     security:
       - ims_key: []

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -523,7 +523,10 @@ v2-serenity-tags:
                 name: { type: string }
                 tag:
                   type: string
-                  description: The full `<type>:<name>` tag string registered upstream.
+                  description: |
+                    The registered tag string: the full `<type>:<name>` for a
+                    root/flat tag (no `parentId`), or the BARE `<name>` (no
+                    dimension prefix) for a 1-level nested child.
                 id:
                   type: string
                   description: The created tag's upstream id.
@@ -570,10 +573,14 @@ v2-serenity-tag-by-id:
     description: |
       Updates a single AIO tag in place on the market addressed by the
       `(geoTargetId, languageCode)` slice — renames it and/or re-parents it under
-      another category (1-level nesting). `name` is the tag's full
-      `<dimension>:<value>` string and is always required by the upstream
-      contract, so a pure re-parent still carries the (unchanged) name. `parentId`
-      re-parents when present; note that promoting a child back to a root is not
+      another category (1-level nesting). `name` is required on every call; its
+      shape depends on the CURRENT tag: a root takes the full
+      `<dimension>:<value>` string, a child takes a BARE value (no dimension
+      prefix — mirrors tag creation). `parentId` re-parents when present; when
+      omitted on a child rename, the proxy resolves and re-sends the child's
+      CURRENT `parentId` itself (never omits it for a child — omission silently
+      promotes a child to root upstream), so the parent is safely left
+      unchanged either way. Note that promoting a child back to a root is not
       supported upstream. An unknown `tagId` returns 404.
     operationId: updateSerenityTag
     security:
@@ -591,13 +598,18 @@ v2-serenity-tag-by-id:
                 type: string
                 minLength: 1
                 description: |
-                  The tag's full `<dimension>:<value>` string (dimension one of
-                  `category` / `topic`). Rename by changing the value.
+                  The tag's new name. For a ROOT tag, the full
+                  `<dimension>:<value>` string (dimension one of `category` /
+                  `topic`) — rename by changing the value. For a CHILD tag
+                  (currently nested under a parent), a BARE value with no
+                  dimension prefix, mirroring how children are created.
               parentId:
                 type: string
                 description: |
                   Optional upstream tag id to re-parent this tag under. Omit to
-                  leave the parent unchanged.
+                  leave the parent unchanged (safe for both a root and a child
+                  — the proxy resolves and preserves a child's current parent
+                  server-side rather than omitting it from the upstream call).
               geoTargetId:
                 type: integer
                 minimum: 1
@@ -620,7 +632,9 @@ v2-serenity-tag-by-id:
                 tagId: { type: string }
                 tag:
                   type: string
-                  description: The tag's full `<dimension>:<value>` string after update.
+                  description: |
+                    The tag's name after update: the full `<dimension>:<value>`
+                    string for a root, or the BARE value for a child.
                 parentId:
                   type: [string, 'null']
                   description: The parent tag id when nested, otherwise null.

--- a/docs/serenity.md
+++ b/docs/serenity.md
@@ -143,8 +143,9 @@ All endpoints require `Authorization: Bearer <ims_user_token>` and `organization
 | GET | `/serenity/markets` | List markets configured for the brand (incl. live `status`) | `listSerenityMarkets` |
 | POST | `/serenity/markets` | Onboard a new (brand, geoTargetId, languageCode) slice | `createSerenityMarket` |
 | DELETE | `/serenity/markets/:geoTargetId/:languageCode` | Remove a slice (idempotent; upstream-first, DB-second) | `deleteSerenityMarket` |
-| GET | `/serenity/tags?geoTargetId=&languageCode=` | Unique tag names for one slice | `listSerenityTags` |
-| POST | `/serenity/tags` | Register an open-dimension (`category`/`topic`) tag on one slice; body is `{ type, name, geoTargetId, languageCode }` | `createSerenityTag` |
+| GET | `/serenity/tags?geoTargetId=&languageCode=` | Unique tag names for one slice. Add `parentId` (present, even empty) to switch to the nested-tree read instead: `parentId=''` returns root categories with `childrenCount`, `parentId=<tagId>` returns that root's children with a `path` breadcrumb. | `listSerenityTags` |
+| POST | `/serenity/tags` | Register an open-dimension (`category`/`topic`) tag on one slice; body is `{ type, name, geoTargetId, languageCode, parentId? }`. `parentId` nests the tag as a 1-level child (bare name, no dimension prefix) under an existing root. | `createSerenityTag` |
+| PATCH | `/serenity/tags/:tagId` | Rename and/or re-parent a tag by its upstream id. `name` is the full `<dimension>:<value>` string for a root, or a bare value for a child; `parentId` re-parents when present, otherwise the proxy preserves a child's current parent server-side. | `updateSerenityTag` |
 | GET | `/serenity/models?geoTargetId=&languageCode=` | AI models for one slice (catalog mode when no params) | `listSerenityModels` |
 | PUT | `/serenity/models` | Replace the AI-model set for one slice (publishes after change) | `updateSerenityModels` |
 | POST | `/serenity/activate` | Activate the brand into sub-workspace mode (ensure sub-workspace + publish supplied markets) | `activateSerenityBrand` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.31.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.4.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.6.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -7037,9 +7037,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.4.0.tgz",
-      "integrity": "sha512-05G7JdpGP7ujJt+bbWPAqdY1oH9pZ4ehPtma6wEI+1+z+TB/ODSnm0LZjXCLSSe2Xf6El5wxQWzceFMmTiJLbw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.6.0.tgz",
+      "integrity": "sha512-FU8vrvGxen7PtYHzW+aI7ErHG7RMOHDODrJ5zs/qgAr8TFV4BSa1kAWar3fuZcxU6XfPipAfyTjKVRjnrDQhKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.31.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.4.0",
+    "@adobe/spacecat-shared-project-engine-client": "1.6.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -58,6 +58,8 @@ import {
 import {
   handleCreateTag,
   handleCreateTagSubworkspace,
+  handleUpdateTag,
+  handleUpdateTagSubworkspace,
 } from '../support/serenity/handlers/tags.js';
 import { ensureSubworkspace, decommissionBrandWorkspace } from '../support/serenity/workspace-lifecycle.js';
 import { isSerenityActiveForOrg } from '../support/serenity/serenity-active.js';
@@ -736,6 +738,48 @@ function SerenityController(context, log, env) {
     }
   };
 
+  /**
+   * PATCH /serenity/tags/:tagId — rename and/or re-parent a single AIO tag in
+   * place (the nested Categories edit path). `tagId` is the upstream tag id from a
+   * prior tags list; the body carries the tag's full `name` (required upstream)
+   * and an optional `parentId` to re-parent. An unknown tagId surfaces upstream as
+   * a 404. Dispatches by workspace mode, mirroring createTag / updatePrompt.
+   */
+  const updateTag = async (ctx) => {
+    try {
+      const imsToken = requireImsBearer(ctx);
+      const { tagId } = ctx?.params || {};
+      if (!hasText(tagId)) {
+        throw new ErrorWithStatusCode('Missing tagId', 400);
+      }
+      const auth = await authorize(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const transport = buildTransport(ctx, imsToken);
+      const result = auth.mode === 'subworkspace'
+        ? await handleUpdateTagSubworkspace(
+          transport,
+          /** @type {string} */ (auth.workspaceId),
+          tagId,
+          ctx.data || {},
+          log,
+        )
+        : await handleUpdateTag(
+          transport,
+          ctx.dataAccess,
+          /** @type {string} */ (auth.brandUuid),
+          /** @type {string} */ (auth.workspaceId),
+          tagId,
+          ctx.data || {},
+          log,
+        );
+      return createResponse(result.body, result.status);
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+
   const listModels = async (ctx) => {
     try {
       const imsToken = requireImsBearer(ctx);
@@ -1317,6 +1361,7 @@ function SerenityController(context, log, env) {
     deleteMarket,
     listTags,
     createTag,
+    updateTag,
     listModels,
     listOrgModels,
     listOrgLanguages,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -578,6 +578,7 @@ const routeFacsCapabilities = {
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets': 'llmo/can_configure',
       'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': 'llmo/can_configure',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'llmo/can_configure',
+      'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags/:tagId': 'llmo/can_configure',
       'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': 'llmo/can_configure',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': 'llmo/can_configure',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate': 'llmo/can_configure',
@@ -1173,9 +1174,9 @@ const routeFacsCapabilities = {
     // an X-ASO-API-Key-authenticated internal route, not a FACS resource.
     'service',
     // Serenity proxy params — identifiers from the upstream API (geo
-    // target / language / semrush prompt id), not SpaceCat resources. The
-    // enclosing :brandId is the FACS resource for these routes.
-    'semrushPromptId', 'geoTargetId', 'languageCode',
+    // target / language / semrush prompt id / aio tag id), not SpaceCat
+    // resources. The enclosing :brandId is the FACS resource for these routes.
+    'semrushPromptId', 'geoTargetId', 'languageCode', 'tagId',
     // Preflight job id — sub-resource of the enclosing :siteId.
     'preflightId',
     // Filter / pagination / format params (not entities):

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -229,6 +229,7 @@ export default function getRouteHandlers(
     'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': serenityController.deleteMarket,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': serenityController.listTags,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': serenityController.createTag,
+    'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags/:tagId': serenityController.updateTag,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': serenityController.listModels,
     'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': serenityController.updateModels,
     // Brand-independent global model catalog (add-brand wizard, before a brand exists).

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -326,6 +326,7 @@ const routeRequiredCapabilities = {
   'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': 'organization:write',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'organization:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'organization:write',
+  'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags/:tagId': 'organization:write',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': 'organization:read',
   'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models': 'organization:write',
   // Org-level Semrush catalogue lookups (brand-independent): read-only, org

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -23,6 +23,7 @@ import {
   resolveLanguageId,
   defaultMarketName,
   listTagsForProject,
+  listProjectTagTree,
   listGlobalModelCatalog,
   listSliceModels,
   syncModelsForProject,
@@ -597,6 +598,11 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
     return { items: [] };
   }
   const projectId = String(project.id);
+  // NESTED-TREE MODE (parity with flat handleListTags): a `parentId` query param
+  // drills the standalone AIO tag tree instead of the prompt-derived merge below.
+  if (query?.parentId !== undefined) {
+    return listProjectTagTree(transport, workspaceId, projectId, String(query.parentId), log);
+  }
   // A tag exists in two forms: attached to ≥1 prompt (listTagsForProject scans the
   // prompt vocabulary) OR standalone (registered via createProjectTags but not yet
   // carried by any prompt — e.g. a just-created, still-empty `category:<NAME>`).

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -28,6 +28,7 @@ import {
   listSliceModels,
   syncModelsForProject,
   MAX_MODEL_IDS,
+  validateParentIdQuery,
 } from './markets.js';
 import {
   listMarkets, resolveProject, mapPublishStatus, projectToSlice,
@@ -601,7 +602,13 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
   // NESTED-TREE MODE (parity with flat handleListTags): a `parentId` query param
   // drills the standalone AIO tag tree instead of the prompt-derived merge below.
   if (query?.parentId !== undefined) {
-    return listProjectTagTree(transport, workspaceId, projectId, String(query.parentId), log);
+    return listProjectTagTree(
+      transport,
+      workspaceId,
+      projectId,
+      validateParentIdQuery(String(query.parentId)),
+      log,
+    );
   }
   // A tag exists in two forms: attached to ≥1 prompt (listTagsForProject scans the
   // prompt vocabulary) OR standalone (registered via createProjectTags but not yet

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -641,14 +641,91 @@ export async function listTagsForProject(transport, semrushWorkspaceId, projectI
 }
 
 /**
+ * Read one LEVEL of a project's STANDALONE AIO tag tree (the `/aio/tags` surface),
+ * shaped for the nested Categories view. `parentId === ''` returns the ROOTS (each
+ * carrying `childrenCount`); a non-empty `parentId` returns that tag's CHILDREN
+ * (each carrying a `path[]` breadcrumb up to its root). Reads the DRAFT view so a
+ * just-created, still-unpublished category is visible — the live view hides it
+ * until the project is published (verified live 2026-07-01). Pages through the
+ * level bounded by a ceiling, mirroring the standalone-tag walk.
+ *
+ * Unlike {@link listTagsForProject} (prompt-derived, flat, cached), this reads the
+ * registered standalone tags keyed by their upstream ids — the ids the nested
+ * create + re-parent endpoints operate on — so it is NOT cached (a just-created or
+ * re-parented tag must show immediately).
+ *
+ * @param {any} transport - Serenity transport.
+ * @param {string} semrushWorkspaceId - Semrush (sub-)workspace id.
+ * @param {string} projectId - AIO project id.
+ * @param {string} parentId - '' for roots, an upstream tag id for its children.
+ * @param {any} [log] - logger, used to surface a ceiling-hit truncation warning.
+ * @returns {Promise<{ items: Array<{
+ *   id: string, name: string, parentId: string | null,
+ *   childrenCount: number, path: Array<{ id: string, name: string }> | null,
+ * }> }>}
+ */
+export async function listProjectTagTree(transport, semrushWorkspaceId, projectId, parentId, log) {
+  const items = [];
+  const LIMIT = 100;
+  const PAGE_LIMIT = 50;
+  let page = 1;
+  while (page <= PAGE_LIMIT) {
+    // eslint-disable-next-line no-await-in-loop
+    const resp = await transport.listProjectTags(semrushWorkspaceId, projectId, {
+      parentId, page, limit: LIMIT, draft: true,
+    });
+    const batch = Array.isArray(resp?.items) ? resp.items : [];
+    for (const t of batch) {
+      // AIOTag.id is required upstream; guard defensively and skip a malformed row.
+      if (t && typeof t.id === 'string' && t.id) {
+        items.push({
+          id: t.id,
+          name: typeof t.name === 'string' ? t.name : '',
+          parentId: typeof t.parent_id === 'string' && t.parent_id ? t.parent_id : null,
+          childrenCount: typeof t.children_count === 'number' ? t.children_count : 0,
+          path: Array.isArray(t.path)
+            ? t.path.map((p) => ({
+              id: typeof p?.id === 'string' ? p.id : '',
+              name: typeof p?.name === 'string' ? p.name : '',
+            }))
+            : null,
+        });
+      }
+    }
+    if (batch.length < LIMIT) {
+      break;
+    }
+    if (page === PAGE_LIMIT) {
+      // Ceiling reached with a still-full last page: at least one more page went
+      // unread, so this tag level may be truncated. A missing category in the UI
+      // is a real symptom, so log it rather than stop silently.
+      log?.warn?.('listProjectTagTree: page ceiling hit; tag level may be truncated', {
+        semrushWorkspaceId, projectId, parentId, pages: PAGE_LIMIT, limit: LIMIT,
+      });
+      break;
+    }
+    page += 1;
+  }
+  return { items };
+}
+
+/**
  * GET /serenity/tags?geoTargetId=&languageCode= — unique tag names across
  * the slice's prompts. Required filters; one slice → one upstream call set.
  * Short-TTL cache to keep dashboard polling cheap.
  *
- * TODO: the tag set is computed by paginating the project's prompts and
- * aggregating distinct tag names in JS. This is an O(N) approximation —
- * for a project with N prompts we do ceil(N/200) upstream calls. Capped
- * at 50 pages (10k prompts); beyond that the tag set is silently
+ * NESTED-TREE MODE: when the request carries a `parentId` query param (present,
+ * even empty), the read switches to the standalone AIO tag TREE instead of the
+ * prompt-derived list — `parentId=''` returns the root categories (each with
+ * `childrenCount`), a tag id returns that category's children (each with a
+ * `path[]` breadcrumb). This is the read the nested Categories view drills with,
+ * and the level the id-keyed create/re-parent endpoints operate on. Absent
+ * `parentId` preserves the legacy flat, prompt-derived behavior below.
+ *
+ * TODO: the (legacy) prompt-derived tag set is computed by paginating the
+ * project's prompts and aggregating distinct tag names in JS. This is an O(N)
+ * approximation — for a project with N prompts we do ceil(N/200) upstream calls.
+ * Capped at 50 pages (10k prompts); beyond that the tag set is silently
  * truncated and a `warn` log fires (see TAG_PAGE_LIMIT in
  * `listTagsForProject`). When/if Semrush exposes a dedicated tags endpoint
  * (`GET /v1/workspaces/{ws}/projects/{pid}/tags`), this whole loop
@@ -679,10 +756,20 @@ export async function handleListTags(
   if (!row) {
     return { items: [] };
   }
+  const projectId = row.getSemrushProjectId();
+  if (query?.parentId !== undefined) {
+    return listProjectTagTree(
+      transport,
+      semrushWorkspaceId,
+      projectId,
+      String(query.parentId),
+      log,
+    );
+  }
   return listTagsForProject(
     transport,
     semrushWorkspaceId,
-    row.getSemrushProjectId(),
+    projectId,
     { brandId, geoTargetId, languageCode },
     log,
   );

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -23,6 +23,31 @@ import { resolveLocation } from '../locations.js';
 
 const LANGUAGE_CACHE_TTL_MS = 60 * 60 * 1000;
 export const MAX_MODEL_IDS = 50;
+const MAX_PARENT_ID_QUERY_LEN = 200;
+
+/**
+ * Validates the `parentId` query param for the nested-tree tag read (`''` = roots,
+ * an upstream tag id = that tag's children). Mirrors handlers/tags.js's
+ * `parseParentId` create/PATCH-body validation for a consistent posture across
+ * every path that accepts a parentId, but keeps `''` as a meaningful value here
+ * (it is not omitted/absent — see {@link listProjectTagTree}).
+ *
+ * @param {string} raw - `String(query.parentId)`.
+ * @returns {string} the value, unchanged, once validated.
+ */
+export function validateParentIdQuery(raw) {
+  if (raw.length > MAX_PARENT_ID_QUERY_LEN) {
+    throw new ErrorWithStatusCode(
+      `parentId must not exceed ${MAX_PARENT_ID_QUERY_LEN} characters`,
+      400,
+    );
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\s\u0000-\u001F\u007F]/.test(raw)) {
+    throw new ErrorWithStatusCode('parentId must not contain whitespace or control characters', 400);
+  }
+  return raw;
+}
 
 // Re-exported so existing importers (handlers/markets-subworkspace.js, tests)
 // keep resolving it from here; the implementation now lives in ../locations.js
@@ -762,7 +787,7 @@ export async function handleListTags(
       transport,
       semrushWorkspaceId,
       projectId,
-      String(query.parentId),
+      validateParentIdQuery(String(query.parentId)),
       log,
     );
   }

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -436,9 +436,12 @@ function buildUpdatePayload(parsed, target) {
     if (hasDimensionPrefix) {
       throw new ErrorWithStatusCode('a child tag name must not contain ":"', 400);
     }
+    // target.parentId is never null here: resolveTagTarget's child branch always
+    // resolves it (falling back to the child's own root id), so no `?? undefined`
+    // is needed the way the root/unknown branch below needs one.
     return {
       tag: value,
-      parentIdToSend: parentId !== undefined ? parentId : (target.parentId ?? undefined),
+      parentIdToSend: parentId !== undefined ? parentId : /** @type {string} */ (target.parentId),
     };
   }
   // Root, or an id we could not resolve in the tree walk -- legacy behavior:

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -19,18 +19,21 @@ import { ERROR_CODES } from '../errors.js';
 import { normalizeGeoTargetId, normalizeLanguageCode } from '../validation.js';
 import { resolveProject } from '../subworkspace-projects.js';
 import { tagFor, CREATABLE_TAG_DIMENSIONS } from '../prompt-tags.js';
+import { listProjectTagTree } from './markets.js';
 
 /**
  * POST /serenity/tags — create a prompt TAG on a single market.
  *
- * Tags are `dimension:<NAME>` strings registered on a market's project (the
- * `aio/tags` surface, via {@link createProjectTags}). This endpoint creates a
- * tag under one of the OPEN dimensions ({@link CREATABLE_TAG_DIMENSIONS} —
- * `category` / `topic`); the closed taxonomies (`source` / `intent` / `type`)
- * have a fixed value enum and are not freely creatable, so the `type` is
- * validated against the allow-list (this is what bounds the allowed prefixes).
- * The UI's "Categories" view, for instance, is the `category:` slice of these
- * tags across the brand's markets.
+ * A ROOT tag is a `dimension:<NAME>` string registered on a market's project
+ * (the `aio/tags` surface, via {@link createProjectTags}) under one of the
+ * OPEN dimensions ({@link CREATABLE_TAG_DIMENSIONS} — `category` / `topic`);
+ * the closed taxonomies (`source` / `intent` / `type`) have a fixed value enum
+ * and are not freely creatable, so the `type` is validated against the
+ * allow-list (this is what bounds the allowed prefixes). A CHILD tag (created
+ * with `parentId`, 1-level nesting) is BARE — no dimension prefix — matching
+ * the migration CLI's write shape (serenity-docs#24 §2). The UI's
+ * "Categories" view is the `category:` slice of these root tags, plus their
+ * bare children, across the brand's markets.
  *
  * Both the flat-mode and subworkspace-mode handlers resolve the market's project
  * id from the `(geoTargetId, languageCode)` slice and register one tag.
@@ -204,7 +207,9 @@ export async function handleCreateTag(
   if (!row) {
     throw marketNotFound();
   }
-  const tag = tagFor(type, name);
+  // A nested child is created BARE (no dimension prefix) — only a root gets the
+  // `<dimension>:<value>` name. See issue 21 §1 / serenity-docs#24 §2.
+  const tag = parentId ? name : tagFor(type, name);
   const created = await transport.createProjectTags(
     semrushWorkspaceId,
     row.getSemrushProjectId(),
@@ -246,7 +251,9 @@ export async function handleCreateTagSubworkspace(
   if (!project) {
     throw marketNotFound();
   }
-  const tag = tagFor(type, name);
+  // A nested child is created BARE (no dimension prefix) — only a root gets the
+  // `<dimension>:<value>` name. See issue 21 §1 / serenity-docs#24 §2.
+  const tag = parentId ? name : tagFor(type, name);
   const created = await transport.createProjectTags(
     workspaceId,
     String(project.id),
@@ -274,18 +281,17 @@ function requireTagId(tagId) {
 }
 
 /**
- * Validates + normalizes the update-tag body, throwing a 400 on the first
- * problem. Unlike create, `name` here is the FULL `<dimension>:<value>` tag
- * string (upstream requires `name` on every PATCH, so a pure re-parent still
- * carries the tag's current full name — the caller has it from a prior list). The
- * dimension must be one of {@link CREATABLE_TAG_DIMENSIONS}, so a PATCH can never
- * smuggle a tag into a closed taxonomy (`intent`/`source`/`type`). `parentId`
- * (optional) re-parents when non-empty.
+ * Validates + normalizes the update-tag body's SYNTAX only, throwing a 400 on
+ * the first problem. Deliberately does NOT judge whether a bare (no dimension
+ * prefix) name is legal -- that depends on whether the PATCH target is
+ * currently a root or a child, which only {@link resolveTagTarget} can answer
+ * (it needs transport access this pure parser doesn't have). See
+ * {@link buildUpdatePayload} for that cross-check.
  *
  * @param {object} body - request body ({ name, parentId?, geoTargetId, languageCode }).
  * @returns {{
- *   tag: string, parentId: string | undefined,
- *   geoTargetId: number, languageCode: string,
+ *   dimension: string, value: string, hasDimensionPrefix: boolean,
+ *   parentId: string | undefined, geoTargetId: number, languageCode: string,
  * }}
  */
 function parseUpdateTagBody(body) {
@@ -294,16 +300,11 @@ function parseUpdateTagBody(body) {
     throw new ErrorWithStatusCode('name is required', 400);
   }
   const colon = rawName.indexOf(':');
-  const dimension = colon > 0 ? rawName.slice(0, colon).toLowerCase() : '';
-  const value = colon > 0 ? rawName.slice(colon + 1) : '';
-  // Widen the frozen tuple to string[] for the runtime membership test (see the
-  // same idiom in parseCreateTagBody).
-  const creatable = /** @type {readonly string[]} */ (CREATABLE_TAG_DIMENSIONS);
-  if (!creatable.includes(dimension) || !value) {
-    throw new ErrorWithStatusCode(
-      `name must be a "<dimension>:<value>" tag where dimension is one of: ${CREATABLE_TAG_DIMENSIONS.join(', ')}`,
-      400,
-    );
+  const hasDimensionPrefix = colon > 0;
+  const dimension = hasDimensionPrefix ? rawName.slice(0, colon).toLowerCase() : '';
+  const value = hasDimensionPrefix ? rawName.slice(colon + 1) : rawName;
+  if (!value) {
+    throw new ErrorWithStatusCode('name must not be empty', 400);
   }
   if (value.length > MAX_TAG_NAME_LEN) {
     throw new ErrorWithStatusCode(
@@ -311,9 +312,10 @@ function parseUpdateTagBody(body) {
       400,
     );
   }
-  // Exactly one ':' — a second colon would smuggle a nested dimension.
+  // At most one ':' -- a second colon would smuggle a nested dimension, whether
+  // the target turns out to be a root (one ':' expected) or a child (none).
   if (value.includes(':')) {
-    throw new ErrorWithStatusCode('name must contain exactly one ":"', 400);
+    throw new ErrorWithStatusCode('name must contain at most one ":"', 400);
   }
   // eslint-disable-next-line no-control-regex
   if (/[\u0000-\u001F\u007F]/.test(value)) {
@@ -332,15 +334,117 @@ function parseUpdateTagBody(body) {
     );
   }
   return {
-    tag: `${dimension}:${value}`, parentId, geoTargetId, languageCode,
+    dimension, value, hasDimensionPrefix, parentId, geoTargetId, languageCode,
   };
 }
 
 /**
- * PATCH /serenity/tags/:tagId (flat mode) — rename and/or re-parent a single tag
- * in place. The market's project id comes from the persisted `BrandSemrushProject`
- * mapping (same resolution as handleCreateTag). An unknown `tagId` surfaces as the
- * upstream 404 (SerenityTransportError) via the controller's mapError.
+ * Resolves whether `tagId` is currently a ROOT or a CHILD in the project's
+ * standalone AIO tag tree, and -- when a child -- its current parent id. There
+ * is no upstream "get tag by id" endpoint, so this walks the draft tree: the
+ * roots first, then (if not found there) each root's children in turn until
+ * `tagId` is found. Bounded by the project's root-category count (O(1 +
+ * numRoots) upstream calls) -- acceptable for an admin-frequency rename/
+ * re-parent action, not a hot path.
+ *
+ * Exists to close a live-verified gap (serenity-docs#24 section 3.1 gate 5,
+ * probed 2026-07-02): PATCHing a child with `parent_id` omitted from the
+ * upstream body silently PROMOTES it to root -- omission is only safe when the
+ * target is already a root. Every PATCH to a child must therefore explicitly
+ * re-send its current `parent_id`, even when only the name is changing (see
+ * {@link buildUpdatePayload}).
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {string} semrushWorkspaceId
+ * @param {string} projectId
+ * @param {string} tagId - the PATCH target's upstream id.
+ * @param {object} [log] - logger.
+ * @returns {Promise<{ kind: 'root' | 'child' | 'unknown', parentId: string | null }>}
+ */
+async function resolveTagTarget(transport, semrushWorkspaceId, projectId, tagId, log) {
+  const roots = await listProjectTagTree(transport, semrushWorkspaceId, projectId, '', log);
+  if (roots.items.some((t) => t.id === tagId)) {
+    return { kind: 'root', parentId: null };
+  }
+  for (const root of roots.items) {
+    // Sequential by design: stop at the first root whose children contain the
+    // target, rather than fanning out every root's children concurrently for
+    // what is expected to resolve within the first few roots in practice.
+    // eslint-disable-next-line no-await-in-loop
+    const children = await listProjectTagTree(
+      transport,
+      semrushWorkspaceId,
+      projectId,
+      root.id,
+      log,
+    );
+    const found = children.items.find((t) => t.id === tagId);
+    if (found) {
+      return { kind: 'child', parentId: found.parentId ?? root.id };
+    }
+  }
+  return { kind: 'unknown', parentId: null };
+}
+
+/**
+ * Cross-checks the parsed update body's name shape against the PATCH target's
+ * resolved tree position (see {@link resolveTagTarget}), and decides what
+ * `parentId` to forward upstream. A root keeps the legacy
+ * `<dimension>:<value>` requirement (dimension validated against
+ * {@link CREATABLE_TAG_DIMENSIONS}, unchanged); a child takes a bare name
+ * (no dimension prefix -- mirrors {@link handleCreateTag}'s create-side rule)
+ * and ALWAYS gets an explicit `parentId` in the outgoing PATCH: the caller's
+ * requested `parentId` when re-parenting, otherwise the child's own CURRENT
+ * parent so a rename-only PATCH never omits it (gate 5). An unresolvable
+ * (`unknown`) target falls back to the pre-existing full-name requirement and
+ * an omitted `parentId` -- the upstream 404 on the `tag_id` path segment is
+ * what actually catches a genuinely unknown id, not this validation.
+ *
+ * @param {{
+ *   hasDimensionPrefix: boolean, dimension: string, value: string,
+ *   parentId: string | undefined,
+ * }} parsed
+ * @param {{ kind: 'root' | 'child' | 'unknown', parentId: string | null }} target
+ * @returns {{ tag: string, parentIdToSend: string | undefined }}
+ */
+function buildUpdatePayload(parsed, target) {
+  const {
+    hasDimensionPrefix, dimension, value, parentId,
+  } = parsed;
+  if (target.kind === 'child') {
+    if (hasDimensionPrefix) {
+      throw new ErrorWithStatusCode('a child tag name must not contain ":"', 400);
+    }
+    return {
+      tag: value,
+      parentIdToSend: parentId !== undefined ? parentId : (target.parentId ?? undefined),
+    };
+  }
+  // Root, or an id we could not resolve in the tree walk -- legacy behavior:
+  // require the full "<dimension>:<value>" shape.
+  const creatable = /** @type {readonly string[]} */ (CREATABLE_TAG_DIMENSIONS);
+  if (!hasDimensionPrefix || !creatable.includes(dimension)) {
+    throw new ErrorWithStatusCode(
+      `name must be a "<dimension>:<value>" tag where dimension is one of: ${CREATABLE_TAG_DIMENSIONS.join(', ')}`,
+      400,
+    );
+  }
+  return { tag: `${dimension}:${value}`, parentIdToSend: parentId };
+}
+
+/**
+ * PATCH /serenity/tags/:tagId (flat mode) -- rename and/or re-parent a single
+ * tag in place. The market's project id comes from the persisted
+ * `BrandSemrushProject` mapping (same resolution as handleCreateTag).
+ *
+ * Resolves the target's current tree position first (see
+ * {@link resolveTagTarget}) so a child rename never omits `parent_id` (which
+ * would silently promote it to root, serenity-docs#24 section 3.1 gate 5) and
+ * so a bare (no dimension prefix) name is only accepted for a child, mirroring
+ * {@link handleCreateTag}'s create-side rule. An id we cannot resolve in the
+ * tree walk falls back to the pre-existing full-name requirement; the
+ * upstream 404 on the `tag_id` path segment (surfaced via the controller's
+ * mapError) is what actually catches a genuinely unknown id.
  *
  * @param {object} transport - Serenity transport (Semrush proxy client).
  * @param {object} dataAccess - data-access layer (BrandSemrushProject).
@@ -361,9 +465,8 @@ export async function handleUpdateTag(
   log,
 ) {
   const id = requireTagId(tagId);
-  const {
-    tag, parentId, geoTargetId, languageCode,
-  } = parseUpdateTagBody(body);
+  const parsed = parseUpdateTagBody(body);
+  const { geoTargetId, languageCode } = parsed;
   const row = await dataAccess.BrandSemrushProject.findBySlice(
     brandId,
     geoTargetId,
@@ -372,15 +475,18 @@ export async function handleUpdateTag(
   if (!row) {
     throw marketNotFound();
   }
+  const projectId = row.getSemrushProjectId();
+  const target = await resolveTagTarget(transport, semrushWorkspaceId, projectId, id, log);
+  const { tag, parentIdToSend } = buildUpdatePayload(parsed, target);
   const updated = await transport.updateProjectTag(
     semrushWorkspaceId,
-    row.getSemrushProjectId(),
+    projectId,
     id,
-    { name: tag, parentId },
+    { name: tag, parentId: parentIdToSend },
   );
-  const { parentId: updatedParentId } = pickTagIds(updated, parentId);
+  const { parentId: updatedParentId } = pickTagIds(updated, parentIdToSend);
   log?.info?.('handleUpdateTag: updated tag', {
-    brandId, geoTargetId, languageCode, tagId: id, tag, parentId,
+    brandId, geoTargetId, languageCode, tagId: id, tag, parentId: parentIdToSend,
   });
   return {
     status: 200,
@@ -391,9 +497,10 @@ export async function handleUpdateTag(
 }
 
 /**
- * PATCH /serenity/tags/:tagId (subworkspace mode) — the market's project is
+ * PATCH /serenity/tags/:tagId (subworkspace mode) -- the market's project is
  * resolved live from the brand's own subworkspace listing (same resolution as
- * handleCreateTagSubworkspace).
+ * handleCreateTagSubworkspace). See {@link handleUpdateTag} for the
+ * child-target resolution / bare-name / parent_id-echo rules this shares.
  *
  * @param {object} transport - Serenity transport (Semrush proxy client).
  * @param {string} workspaceId - the brand's subworkspace id.
@@ -410,22 +517,24 @@ export async function handleUpdateTagSubworkspace(
   log,
 ) {
   const id = requireTagId(tagId);
-  const {
-    tag, parentId, geoTargetId, languageCode,
-  } = parseUpdateTagBody(body);
+  const parsed = parseUpdateTagBody(body);
+  const { geoTargetId, languageCode } = parsed;
   const project = await resolveProject(transport, workspaceId, geoTargetId, languageCode, log);
   if (!project) {
     throw marketNotFound();
   }
+  const projectId = String(project.id);
+  const target = await resolveTagTarget(transport, workspaceId, projectId, id, log);
+  const { tag, parentIdToSend } = buildUpdatePayload(parsed, target);
   const updated = await transport.updateProjectTag(
     workspaceId,
-    String(project.id),
+    projectId,
     id,
-    { name: tag, parentId },
+    { name: tag, parentId: parentIdToSend },
   );
-  const { parentId: updatedParentId } = pickTagIds(updated, parentId);
+  const { parentId: updatedParentId } = pickTagIds(updated, parentIdToSend);
   log?.info?.('handleUpdateTagSubworkspace: updated tag', {
-    geoTargetId, languageCode, tagId: id, tag, parentId,
+    geoTargetId, languageCode, tagId: id, tag, parentId: parentIdToSend,
   });
   return {
     status: 200,

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -43,6 +43,9 @@ const MAX_TAG_NAME_LEN = 100;
 // Upstream tag ids are opaque (UUIDs in practice); this only bounds an absurd
 // value, not a strict format — the id must round-trip from a prior list.
 const MAX_TAG_ID_LEN = 200;
+// Bounds resolveTagTarget's per-root fan-out for an unresolvable tagId — well
+// above any real project's root-category count, just a ceiling on amplification.
+const MAX_ROOTS_TO_SEARCH = 100;
 
 /**
  * Validates an optional upstream parent tag id (an `id` from a prior tags list).
@@ -272,12 +275,25 @@ export async function handleCreateTagSubworkspace(
   };
 }
 
-/** Throws a 400 for a missing/blank tagId path param. Returns the trimmed id. */
+/**
+ * Throws a 400 for a missing/blank tagId path param, or one too long or
+ * carrying whitespace/control characters -- mirrors {@link parseParentId}'s
+ * validation for consistency; openapi-fetch already encodes path params, so
+ * this is defense-in-depth rather than a live exploit. Returns the trimmed id.
+ */
 function requireTagId(tagId) {
   if (!hasText(tagId)) {
     throw new ErrorWithStatusCode('tagId is required', 400);
   }
-  return String(tagId).trim();
+  const id = String(tagId).trim();
+  if (id.length > MAX_TAG_ID_LEN) {
+    throw new ErrorWithStatusCode(`tagId must not exceed ${MAX_TAG_ID_LEN} characters`, 400);
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\s\u0000-\u001F\u007F]/.test(id)) {
+    throw new ErrorWithStatusCode('tagId must not contain whitespace or control characters', 400);
+  }
+  return id;
 }
 
 /**
@@ -345,7 +361,10 @@ function parseUpdateTagBody(body) {
  * roots first, then (if not found there) each root's children in turn until
  * `tagId` is found. Bounded by the project's root-category count (O(1 +
  * numRoots) upstream calls) -- acceptable for an admin-frequency rename/
- * re-parent action, not a hot path.
+ * re-parent action, not a hot path. Roots with no children are skipped (their
+ * `childrenCount` is 0, so a child lookup can never match), and the walk is
+ * capped at {@link MAX_ROOTS_TO_SEARCH} roots so a bogus `tagId` against a
+ * project with many root categories can't fan out unboundedly.
  *
  * Exists to close a live-verified gap (serenity-docs#24 section 3.1 gate 5,
  * probed 2026-07-02): PATCHing a child with `parent_id` omitted from the
@@ -366,7 +385,9 @@ async function resolveTagTarget(transport, semrushWorkspaceId, projectId, tagId,
   if (roots.items.some((t) => t.id === tagId)) {
     return { kind: 'root', parentId: null };
   }
-  for (const root of roots.items) {
+  const candidates = roots.items.filter((root) => root.childrenCount > 0);
+  const searched = candidates.slice(0, MAX_ROOTS_TO_SEARCH);
+  for (const root of searched) {
     // Sequential by design: stop at the first root whose children contain the
     // target, rather than fanning out every root's children concurrently for
     // what is expected to resolve within the first few roots in practice.

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -37,14 +37,60 @@ import { tagFor, CREATABLE_TAG_DIMENSIONS } from '../prompt-tags.js';
  */
 
 const MAX_TAG_NAME_LEN = 100;
+// Upstream tag ids are opaque (UUIDs in practice); this only bounds an absurd
+// value, not a strict format — the id must round-trip from a prior list.
+const MAX_TAG_ID_LEN = 200;
+
+/**
+ * Validates an optional upstream parent tag id (an `id` from a prior tags list).
+ * Returns the trimmed id, or `undefined` when absent/empty — an empty parent is a
+ * no-op upstream (a flat/root create), so it is normalized away rather than sent.
+ * Throws a 400 {@link ErrorWithStatusCode} on a malformed value.
+ *
+ * @param {unknown} raw - the request's `parentId`.
+ * @returns {string | undefined}
+ */
+function parseParentId(raw) {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+  if (typeof raw !== 'string') {
+    throw new ErrorWithStatusCode('parentId must be a string', 400);
+  }
+  const id = raw.trim();
+  if (!id) {
+    return undefined;
+  }
+  if (id.length > MAX_TAG_ID_LEN) {
+    throw new ErrorWithStatusCode(
+      `parentId must not exceed ${MAX_TAG_ID_LEN} characters`,
+      400,
+    );
+  }
+  // Whitespace / control chars can never be a valid upstream id and would corrupt
+  // the request (query value on create, path segment on PATCH). Reject them; leave
+  // the id otherwise opaque (do not assume a strict UUID shape).
+  // eslint-disable-next-line no-control-regex
+  if (/[\s\u0000-\u001F\u007F]/.test(id)) {
+    throw new ErrorWithStatusCode(
+      'parentId must not contain whitespace or control characters',
+      400,
+    );
+  }
+  return id;
+}
 
 /**
  * Validates + normalizes the create-tag body, throwing a 400
  * {@link ErrorWithStatusCode} on the first problem. Returns the parsed
- * `{ type, name, geoTargetId, languageCode }`.
+ * `{ type, name, geoTargetId, languageCode, parentId }`. `parentId` (optional) is
+ * an upstream tag id under which the new tag is nested (1-level category tree).
  *
  * @param {object} body - request body.
- * @returns {{ type: string, name: string, geoTargetId: number, languageCode: string }}
+ * @returns {{
+ *   type: string, name: string, geoTargetId: number,
+ *   languageCode: string, parentId: string | undefined,
+ * }}
  */
 function parseCreateTagBody(body) {
   const type = hasText(body?.type) ? String(body.type).trim().toLowerCase() : '';
@@ -91,9 +137,30 @@ function parseCreateTagBody(body) {
       400,
     );
   }
+  const parentId = parseParentId(body?.parentId);
   return {
-    type, name: rawName, geoTargetId, languageCode,
+    type, name: rawName, geoTargetId, languageCode, parentId,
   };
+}
+
+/**
+ * Picks the created/updated tag's upstream id + parent id out of the transport
+ * result. `createProjectTags` resolves to a LIST (model.TreeNodeResponse[]);
+ * `updateProjectTag` to a single object. Returns `{ id, parentId }` with
+ * `parentId` falling back to the requested `parentId` (so the echo is stable even
+ * if the upstream omits it), or null.
+ *
+ * @param {any} result - transport result (array for create, object for update).
+ * @param {string | undefined} requestedParentId
+ * @returns {{ id: string | undefined, parentId: string | null }}
+ */
+function pickTagIds(result, requestedParentId) {
+  const node = Array.isArray(result) ? result[0] : result;
+  const id = node && typeof node.id === 'string' ? node.id : undefined;
+  const parentId = node && typeof node.parent_id === 'string' && node.parent_id
+    ? node.parent_id
+    : (requestedParentId ?? null);
+  return { id, parentId };
 }
 
 /** Throws a 404 `marketNotFound` for a slice with no backing project. */
@@ -114,7 +181,7 @@ function marketNotFound() {
  * @param {object} dataAccess - data-access layer (BrandSemrushProject).
  * @param {string} brandId - brand UUID.
  * @param {string} semrushWorkspaceId - the org's (parent) workspace id.
- * @param {object} body - request body ({ type, name, geoTargetId, languageCode }).
+ * @param {object} body - request body ({ type, name, geoTargetId, languageCode, parentId? }).
  * @param {object} log - logger.
  * @returns {Promise<{status: number, body: object}>}
  */
@@ -127,7 +194,7 @@ export async function handleCreateTag(
   log,
 ) {
   const {
-    type, name, geoTargetId, languageCode,
+    type, name, geoTargetId, languageCode, parentId,
   } = parseCreateTagBody(body);
   const row = await dataAccess.BrandSemrushProject.findBySlice(
     brandId,
@@ -138,14 +205,20 @@ export async function handleCreateTag(
     throw marketNotFound();
   }
   const tag = tagFor(type, name);
-  await transport.createProjectTags(semrushWorkspaceId, row.getSemrushProjectId(), [tag]);
+  const created = await transport.createProjectTags(
+    semrushWorkspaceId,
+    row.getSemrushProjectId(),
+    [tag],
+    { parentId },
+  );
+  const { id, parentId: createdParentId } = pickTagIds(created, parentId);
   log?.info?.('handleCreateTag: registered tag', {
-    brandId, geoTargetId, languageCode, tag,
+    brandId, geoTargetId, languageCode, tag, parentId,
   });
   return {
     status: 201,
     body: {
-      brandId, geoTargetId, languageCode, type, name, tag,
+      brandId, geoTargetId, languageCode, type, name, tag, id, parentId: createdParentId,
     },
   };
 }
@@ -156,7 +229,7 @@ export async function handleCreateTag(
  *
  * @param {object} transport - Serenity transport (Semrush proxy client).
  * @param {string} workspaceId - the brand's subworkspace id.
- * @param {object} body - request body ({ type, name, geoTargetId, languageCode }).
+ * @param {object} body - request body ({ type, name, geoTargetId, languageCode, parentId? }).
  * @param {object} log - logger.
  * @returns {Promise<{status: number, body: object}>}
  */
@@ -167,21 +240,197 @@ export async function handleCreateTagSubworkspace(
   log,
 ) {
   const {
-    type, name, geoTargetId, languageCode,
+    type, name, geoTargetId, languageCode, parentId,
   } = parseCreateTagBody(body);
   const project = await resolveProject(transport, workspaceId, geoTargetId, languageCode, log);
   if (!project) {
     throw marketNotFound();
   }
   const tag = tagFor(type, name);
-  await transport.createProjectTags(workspaceId, String(project.id), [tag]);
+  const created = await transport.createProjectTags(
+    workspaceId,
+    String(project.id),
+    [tag],
+    { parentId },
+  );
+  const { id, parentId: createdParentId } = pickTagIds(created, parentId);
   log?.info?.('handleCreateTagSubworkspace: registered tag', {
-    geoTargetId, languageCode, tag,
+    geoTargetId, languageCode, tag, parentId,
   });
   return {
     status: 201,
     body: {
-      geoTargetId, languageCode, type, name, tag,
+      geoTargetId, languageCode, type, name, tag, id, parentId: createdParentId,
+    },
+  };
+}
+
+/** Throws a 400 for a missing/blank tagId path param. Returns the trimmed id. */
+function requireTagId(tagId) {
+  if (!hasText(tagId)) {
+    throw new ErrorWithStatusCode('tagId is required', 400);
+  }
+  return String(tagId).trim();
+}
+
+/**
+ * Validates + normalizes the update-tag body, throwing a 400 on the first
+ * problem. Unlike create, `name` here is the FULL `<dimension>:<value>` tag
+ * string (upstream requires `name` on every PATCH, so a pure re-parent still
+ * carries the tag's current full name — the caller has it from a prior list). The
+ * dimension must be one of {@link CREATABLE_TAG_DIMENSIONS}, so a PATCH can never
+ * smuggle a tag into a closed taxonomy (`intent`/`source`/`type`). `parentId`
+ * (optional) re-parents when non-empty.
+ *
+ * @param {object} body - request body ({ name, parentId?, geoTargetId, languageCode }).
+ * @returns {{
+ *   tag: string, parentId: string | undefined,
+ *   geoTargetId: number, languageCode: string,
+ * }}
+ */
+function parseUpdateTagBody(body) {
+  const rawName = hasText(body?.name) ? String(body.name).trim() : '';
+  if (!rawName) {
+    throw new ErrorWithStatusCode('name is required', 400);
+  }
+  const colon = rawName.indexOf(':');
+  const dimension = colon > 0 ? rawName.slice(0, colon).toLowerCase() : '';
+  const value = colon > 0 ? rawName.slice(colon + 1) : '';
+  // Widen the frozen tuple to string[] for the runtime membership test (see the
+  // same idiom in parseCreateTagBody).
+  const creatable = /** @type {readonly string[]} */ (CREATABLE_TAG_DIMENSIONS);
+  if (!creatable.includes(dimension) || !value) {
+    throw new ErrorWithStatusCode(
+      `name must be a "<dimension>:<value>" tag where dimension is one of: ${CREATABLE_TAG_DIMENSIONS.join(', ')}`,
+      400,
+    );
+  }
+  if (value.length > MAX_TAG_NAME_LEN) {
+    throw new ErrorWithStatusCode(
+      `name value must not exceed ${MAX_TAG_NAME_LEN} characters`,
+      400,
+    );
+  }
+  // Exactly one ':' — a second colon would smuggle a nested dimension.
+  if (value.includes(':')) {
+    throw new ErrorWithStatusCode('name must contain exactly one ":"', 400);
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001F\u007F]/.test(value)) {
+    throw new ErrorWithStatusCode('name must not contain control characters', 400);
+  }
+  const parentId = parseParentId(body?.parentId);
+  const geoTargetId = normalizeGeoTargetId(Number(body?.geoTargetId));
+  if (geoTargetId === null) {
+    throw new ErrorWithStatusCode('geoTargetId must be a positive integer', 400);
+  }
+  const languageCode = normalizeLanguageCode(body?.languageCode);
+  if (languageCode === null) {
+    throw new ErrorWithStatusCode(
+      'languageCode must match ^[a-z]{2,3}(-[a-z]{2,4})?$',
+      400,
+    );
+  }
+  return {
+    tag: `${dimension}:${value}`, parentId, geoTargetId, languageCode,
+  };
+}
+
+/**
+ * PATCH /serenity/tags/:tagId (flat mode) — rename and/or re-parent a single tag
+ * in place. The market's project id comes from the persisted `BrandSemrushProject`
+ * mapping (same resolution as handleCreateTag). An unknown `tagId` surfaces as the
+ * upstream 404 (SerenityTransportError) via the controller's mapError.
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {object} dataAccess - data-access layer (BrandSemrushProject).
+ * @param {string} brandId - brand UUID.
+ * @param {string} semrushWorkspaceId - the org's (parent) workspace id.
+ * @param {string} tagId - upstream tag id to update.
+ * @param {object} body - request body ({ name, parentId?, geoTargetId, languageCode }).
+ * @param {object} log - logger.
+ * @returns {Promise<{status: number, body: object}>}
+ */
+export async function handleUpdateTag(
+  transport,
+  dataAccess,
+  brandId,
+  semrushWorkspaceId,
+  tagId,
+  body,
+  log,
+) {
+  const id = requireTagId(tagId);
+  const {
+    tag, parentId, geoTargetId, languageCode,
+  } = parseUpdateTagBody(body);
+  const row = await dataAccess.BrandSemrushProject.findBySlice(
+    brandId,
+    geoTargetId,
+    languageCode,
+  );
+  if (!row) {
+    throw marketNotFound();
+  }
+  const updated = await transport.updateProjectTag(
+    semrushWorkspaceId,
+    row.getSemrushProjectId(),
+    id,
+    { name: tag, parentId },
+  );
+  const { parentId: updatedParentId } = pickTagIds(updated, parentId);
+  log?.info?.('handleUpdateTag: updated tag', {
+    brandId, geoTargetId, languageCode, tagId: id, tag, parentId,
+  });
+  return {
+    status: 200,
+    body: {
+      brandId, geoTargetId, languageCode, tagId: id, tag, parentId: updatedParentId,
+    },
+  };
+}
+
+/**
+ * PATCH /serenity/tags/:tagId (subworkspace mode) — the market's project is
+ * resolved live from the brand's own subworkspace listing (same resolution as
+ * handleCreateTagSubworkspace).
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {string} workspaceId - the brand's subworkspace id.
+ * @param {string} tagId - upstream tag id to update.
+ * @param {object} body - request body ({ name, parentId?, geoTargetId, languageCode }).
+ * @param {object} log - logger.
+ * @returns {Promise<{status: number, body: object}>}
+ */
+export async function handleUpdateTagSubworkspace(
+  transport,
+  workspaceId,
+  tagId,
+  body,
+  log,
+) {
+  const id = requireTagId(tagId);
+  const {
+    tag, parentId, geoTargetId, languageCode,
+  } = parseUpdateTagBody(body);
+  const project = await resolveProject(transport, workspaceId, geoTargetId, languageCode, log);
+  if (!project) {
+    throw marketNotFound();
+  }
+  const updated = await transport.updateProjectTag(
+    workspaceId,
+    String(project.id),
+    id,
+    { name: tag, parentId },
+  );
+  const { parentId: updatedParentId } = pickTagIds(updated, parentId);
+  log?.info?.('handleUpdateTagSubworkspace: updated tag', {
+    geoTargetId, languageCode, tagId: id, tag, parentId,
+  });
+  return {
+    status: 200,
+    body: {
+      geoTargetId, languageCode, tagId: id, tag, parentId: updatedParentId,
     },
   };
 }

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -398,17 +398,35 @@ export function createSerenityTransport({ env, imsToken }) {
 
     /**
      * POST /v2/workspaces/{ws}/projects/{pid}/aio/tags — creates project-level
-     * AIO tags (the standard taxonomy: intent/source/type) independent of any
-     * prompt. Body shape: { names: string[] } (model.TreeNodeListRequest; flat —
-     * `parent_id` omitted). Tags already attached to prompts are reused by name,
-     * so pre-creating a tag that a later prompt also carries does not duplicate.
+     * AIO tags (the standard taxonomy: intent/source/type, plus `category:`
+     * values) independent of any prompt. Body shape: { names: string[],
+     * parent_id?: string } (model.TreeNodeListRequest). Tags already attached to
+     * prompts are reused by name, so pre-creating a tag that a later prompt also
+     * carries does not duplicate.
+     *
+     * NESTING (1-level category tree): pass `parentId` to create the names as
+     * CHILDREN of that upstream tag id — a single call, no separate re-parent
+     * needed (verified live 2026-07-01 against adobe-hackathon.semrush.com: the
+     * child comes back with `parent_id` set and lists under the parent). The one
+     * `parent_id` applies to every name in the batch. Omit for a flat/root tag.
+     *
+     * @param {string} semrushWorkspaceId
+     * @param {string} projectId
+     * @param {string[]} names
+     * @param {object} [opts]
+     * @param {string} [opts.parentId] - upstream tag id to nest the names under.
      */
-    async createProjectTags(semrushWorkspaceId, projectId, names) {
+    async createProjectTags(semrushWorkspaceId, projectId, names, { parentId } = {}) {
       return unwrap('POST', await projects.POST(
         '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
-          body: { names },
+          // Only send parent_id when nesting — an empty string is a no-op
+          // upstream and needlessly widens the flat-create wire. (typeof narrows
+          // `string | undefined` → `string`; hasText does not, per ADR-005.)
+          body: typeof parentId === 'string' && parentId !== ''
+            ? { names, parent_id: parentId }
+            : { names },
         },
       ));
     },
@@ -419,18 +437,74 @@ export function createSerenityTransport({ env, imsToken }) {
      * whether any prompt carries them. This is the only read that surfaces a tag
      * with no carrying prompt — e.g. a freshly-created, still-empty `category:<NAME>`
      * — so the Categories surface can round-trip it. `parent_id` + `search` are
-     * required by the upstream contract; pass empty strings to list all (flat).
+     * required by the upstream contract; pass empty strings to list all.
+     *
+     * TREE-AWARE: `parentId` filters the level returned — '' (default) lists the
+     * ROOTS (each carrying `children_count`), a non-empty id lists that tag's
+     * CHILDREN (each carrying a `path[]` breadcrumb up to its root). `draft=true`
+     * reads the DRAFT view so a just-created, still-unpublished category is
+     * visible (the live view hides it until the project is published — verified
+     * live 2026-07-01).
+     *
+     * @param {string} semrushWorkspaceId
+     * @param {string} projectId
+     * @param {object} [opts]
+     * @param {string} [opts.parentId] - level to list ('' = roots, id = children).
+     * @param {string} [opts.search]
+     * @param {number} [opts.page]
+     * @param {number} [opts.limit]
+     * @param {boolean} [opts.draft] - read the draft view (see unpublished tags).
      */
-    async listProjectTags(semrushWorkspaceId, projectId, { search = '', page = 1, limit = 100 } = {}) {
+    async listProjectTags(
+      semrushWorkspaceId,
+      projectId,
+      {
+        parentId = '', search = '', page = 1, limit = 100, draft,
+      } = {},
+    ) {
       return unwrap('GET', await projects.GET(
         '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
         {
           params: {
             path: { id: semrushWorkspaceId, project_id: projectId },
             query: {
-              parent_id: '', search, page, limit,
+              parent_id: parentId, search, page, limit, ...(draft ? { draft: true } : {}),
             },
           },
+        },
+      ));
+    },
+
+    /**
+     * PATCH /v2/workspaces/{ws}/projects/{pid}/aio/tags/{tag_id} — renames and/or
+     * re-parents a single tag in place (model.TreeNodeRequest body). Returns the
+     * updated tag (200); an unknown `tagId` returns 404 `{message:'not found'}`
+     * (both verified live 2026-07-01).
+     *
+     * `name` is required by the upstream contract; `parentId` re-parents when
+     * non-empty. NOTE: an empty-string `parent_id` is a live NO-OP (does NOT
+     * promote a child to root — 200 but parent unchanged), so it is only sent
+     * when non-empty; promote-to-root is not supported upstream.
+     *
+     * @param {string} semrushWorkspaceId
+     * @param {string} projectId
+     * @param {string} tagId - upstream tag id to update.
+     * @param {object} update
+     * @param {string} update.name - the tag's (possibly renamed) full name.
+     * @param {string} [update.parentId] - new parent tag id (non-empty re-parents).
+     */
+    async updateProjectTag(semrushWorkspaceId, projectId, tagId, { name, parentId }) {
+      return unwrap('PATCH', await projects.PATCH(
+        '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}',
+        {
+          params: {
+            path: { id: semrushWorkspaceId, project_id: projectId, tag_id: tagId },
+          },
+          // Send parent_id only when re-parenting — empty is a live no-op. (typeof
+          // narrows `string | undefined` → `string`; hasText does not, per ADR-005.)
+          body: typeof parentId === 'string' && parentId !== ''
+            ? { name, parent_id: parentId }
+            : { name },
         },
       ));
     },

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -991,6 +991,15 @@ describe('SerenityController', () => {
       expect(handlers.handleUpdateTag.firstCall.args[4]).to.equal('tag-1');
       expect(handlers.handleUpdateTagSubworkspace).to.not.have.been.called;
     });
+
+    it('updateTag returns the authorize error without throwing (auth.error short-circuit)', async () => {
+      accessControlHasAccessStub.resolves(false);
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.updateTag(fakeContext({ params: { tagId: 'tag-1' } }));
+      expect(response.status).to.equal(403);
+      expect(handlers.handleUpdateTag).to.not.have.been.called;
+      expect(handlers.handleUpdateTagSubworkspace).to.not.have.been.called;
+    });
   });
 
   describe('controller surface', () => {

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -122,6 +122,8 @@ describe('SerenityController', () => {
     handleBulkDeletePromptsSubworkspace: sinon.stub(),
     handleCreateTag: sinon.stub(),
     handleCreateTagSubworkspace: sinon.stub(),
+    handleUpdateTag: sinon.stub(),
+    handleUpdateTagSubworkspace: sinon.stub(),
   };
   let decommissionStub;
   let ensureSubworkspaceStub;
@@ -222,6 +224,8 @@ describe('SerenityController', () => {
       '../../src/support/serenity/handlers/tags.js': {
         handleCreateTag: handlers.handleCreateTag,
         handleCreateTagSubworkspace: handlers.handleCreateTagSubworkspace,
+        handleUpdateTag: handlers.handleUpdateTag,
+        handleUpdateTagSubworkspace: handlers.handleUpdateTagSubworkspace,
       },
       '../../src/support/serenity/workspace-lifecycle.js': {
         ensureSubworkspace: ensureSubworkspaceStub,
@@ -958,6 +962,35 @@ describe('SerenityController', () => {
       const body = await readBody(response);
       expect(body.message).to.match(/name is required/);
     });
+
+    it('updateTag requires the :tagId path param', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.updateTag(fakeContext({ params: {} }));
+      expect(response.status).to.equal(400);
+      expect(handlers.handleUpdateTag).to.not.have.been.called;
+    });
+
+    it('updateTag forwards tagId + body to the flat handler and returns its status', async () => {
+      handlers.handleUpdateTag.resolves({
+        status: 200,
+        body: {
+          brandId: BRAND, tagId: 'tag-1', tag: 'category:Footwear', parentId: 'root-1',
+        },
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.updateTag(fakeContext({
+        params: { tagId: 'tag-1' },
+        data: {
+          name: 'category:Footwear', parentId: 'root-1', geoTargetId: 2840, languageCode: 'en',
+        },
+      }));
+      expect(response.status).to.equal(200);
+      const body = await readBody(response);
+      expect(body).to.include({ tagId: 'tag-1', parentId: 'root-1' });
+      expect(handlers.handleUpdateTag).to.have.been.calledOnce;
+      expect(handlers.handleUpdateTag.firstCall.args[4]).to.equal('tag-1');
+      expect(handlers.handleUpdateTagSubworkspace).to.not.have.been.called;
+    });
   });
 
   describe('controller surface', () => {
@@ -1235,6 +1268,22 @@ describe('SerenityController', () => {
       expect(handlers.handleCreateTagSubworkspace.firstCall.args[1]).to.equal('subworkspace-ws-1');
       expect(handlers.handleCreateTagSubworkspace.firstCall.args[2]).to.deep.equal({});
       expect(handlers.handleCreateTag).to.not.have.been.called;
+    });
+
+    it('updateTag routes to the subworkspace handler with the brand workspace + tagId', async () => {
+      handlers.handleUpdateTagSubworkspace.resolves({
+        status: 200,
+        body: {
+          geoTargetId: 2840, languageCode: 'en', tagId: 'tag-1', tag: 'category:Footwear', parentId: null,
+        },
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.updateTag(fakeContext({ params: { tagId: 'tag-1' } }));
+      expect(response.status).to.equal(200);
+      expect(handlers.handleUpdateTagSubworkspace).to.have.been.calledOnce;
+      expect(handlers.handleUpdateTagSubworkspace.firstCall.args[1]).to.equal('subworkspace-ws-1');
+      expect(handlers.handleUpdateTagSubworkspace.firstCall.args[2]).to.equal('tag-1');
+      expect(handlers.handleUpdateTag).to.not.have.been.called;
     });
 
     it('bulkDeletePrompts routes to the subworkspace handler in subworkspace mode', async () => {

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -332,7 +332,9 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
 
       const child = await createTag('Sneakers', parentId);
       expect(child.status).to.equal(201);
-      expect(child.body.tag).to.equal('category:Sneakers');
+      // A child is created BARE (no dimension prefix) — mirrors the migration CLI's
+      // write shape (serenity-docs#24 §2); only roots keep the `category:` prefix.
+      expect(child.body.tag).to.equal('Sneakers');
       // parent_id echoes back through the JSON body faithfully — the child is nested.
       expect(child.body.parentId).to.equal(parentId);
 

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -300,6 +300,66 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
       expect(res.body.tag).to.equal('category:Footwear');
       expect(res.body.geoTargetId).to.equal(US_GEO);
       expect(res.body.languageCode).to.equal('en');
+      // The create echoes the upstream tag id (needed to nest / re-parent).
+      expect(res.body.id).to.be.a('string').that.is.not.empty;
+    });
+
+    // 1-level nested category tags (needs PE mock >= 1.6.0 — adobe/spacecat-shared#1758,
+    // which models parent_id on create, the tree-aware GET, and PATCH re-parent).
+    //
+    // MOCK-FIDELITY NOTE: the mock derives a tag id from its name
+    // (`tag-<encodeURIComponent(name)>`), so a `category:*` tag's id embeds a literal `%3A`. That
+    // id round-trips faithfully through a JSON body (so nested CREATE and the derived childrenCount
+    // below ARE exercised end-to-end against the mock), but NOT through a URL query/path (the `%3A`
+    // decodes back to `:` and no longer matches the stored id). So drilling a parent's children by
+    // id, and a successful PATCH-by-id, cannot be asserted against this mock. Those id-in-URL paths
+    // are validated against LIVE Semrush instead — opaque UUID ids, probed 2026-07-01 (see the
+    // rest-transport / tags handler JSDoc). Real callers use UUID ids, so this gap is mock-only.
+    const createTag = (name, parentId) => getHttpClient().admin.post(`${base}/tags`, {
+      type: 'category',
+      name,
+      geoTargetId: US_GEO,
+      languageCode: 'en',
+      ...(parentId ? { parentId } : {}),
+    });
+
+    it('POST /serenity/tags nests a child under a parent (parentId in, childrenCount out)', async () => {
+      await createUsMarket();
+      const parent = await createTag('Footwear');
+      expect(parent.status).to.equal(201);
+      const parentId = parent.body.id;
+      expect(parentId).to.be.a('string').that.is.not.empty;
+
+      const child = await createTag('Sneakers', parentId);
+      expect(child.status).to.equal(201);
+      expect(child.body.tag).to.equal('category:Sneakers');
+      // parent_id echoes back through the JSON body faithfully — the child is nested.
+      expect(child.body.parentId).to.equal(parentId);
+
+      // Roots view (parentId=''): the parent lists as a root (parentId null) and its
+      // childrenCount — derived server-side from the stored parentage — reflects the new child.
+      const roots = await getHttpClient().admin.get(
+        `${base}/tags?geoTargetId=${US_GEO}&languageCode=en&parentId=`,
+      );
+      expect(roots.status).to.equal(200);
+      const parentRow = roots.body.items.find((t) => t.id === parentId);
+      expect(parentRow, 'the parent should list among the roots').to.exist;
+      expect(parentRow.parentId).to.equal(null);
+      expect(parentRow.childrenCount).to.be.greaterThan(0);
+    });
+
+    it('PATCH /serenity/tags/:tagId route reaches upstream (unknown id → 502)', async () => {
+      await createUsMarket();
+      // A UUID tag id the mock has never stored → upstream 404, which the serenity proxy
+      // deliberately collapses to 502 (mapError does not echo upstream detail — same convention as
+      // every other serenity write). Proves the new PATCH route → controller → handler → transport
+      // → upstream wiring; the 200 re-parent/rename + the live 404 shape are covered by the unit
+      // tests and the live probe (the mock's name-derived id can't round-trip a PATCH-by-id URL).
+      const res = await getHttpClient().admin.patch(
+        `${base}/tags/00000000-0000-4000-8000-000000000000`,
+        { name: 'category:Ghost', geoTargetId: US_GEO, languageCode: 'en' },
+      );
+      expect(res.status).to.equal(502);
     });
 
     it('POST /serenity/activate provisions + publishes, then deactivate decommissions', async () => {

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -218,6 +218,26 @@ const FIXTURES = {
       type: 'category', name: 'Running Shoes', geoTargetId: 2840, languageCode: 'en',
     },
   },
+  updateSerenityTag: {
+    expectedStatus: 200,
+    controllerMethod: 'updateTag',
+    handlerName: 'handleUpdateTag',
+    handlerResult: {
+      status: 200,
+      body: {
+        brandId: BRAND,
+        geoTargetId: 2840,
+        languageCode: 'en',
+        tagId: 'tag-1',
+        tag: 'category:Running Shoes',
+        parentId: 'tag-parent',
+      },
+    },
+    params: { tagId: 'tag-1' },
+    data: {
+      name: 'category:Running Shoes', parentId: 'tag-parent', geoTargetId: 2840, languageCode: 'en',
+    },
+  },
   listSerenityModels: {
     expectedStatus: 200,
     controllerMethod: 'listModels',
@@ -335,6 +355,7 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
         handleDeleteMarket: sinon.stub(),
         handleListTags: sinon.stub(),
         handleCreateTag: sinon.stub(),
+        handleUpdateTag: sinon.stub(),
         handleListModels: sinon.stub(),
         handleUpdateModels: sinon.stub(),
         handleCreateMarketSubworkspace: sinon.stub(),
@@ -384,6 +405,8 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
           '../../src/support/serenity/handlers/tags.js': {
             handleCreateTag: handlerStubs.handleCreateTag,
             handleCreateTagSubworkspace: sinon.stub(),
+            handleUpdateTag: handlerStubs.handleUpdateTag,
+            handleUpdateTagSubworkspace: sinon.stub(),
           },
           '../../src/support/serenity/handlers/markets-subworkspace.js': {
             handleListMarketsSubworkspace: sinon.stub(),

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -873,6 +873,7 @@ describe('getRouteHandlers', () => {
       'DELETE /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags',
+      'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags/:tagId',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/models',
       'PUT /v2/orgs/:spaceCatId/brands/:brandId/serenity/models',
       'GET /v2/orgs/:spaceCatId/serenity/models',

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -673,6 +673,36 @@ describe('markets-subworkspace handlers', () => {
       expect(transport.listPromptsByTags).to.have.been.calledWith(WS, 'p-tag');
     });
 
+    it('parentId drills the standalone tree (draft view) instead of the prompt merge', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listPromptsByTags: sinon.stub(),
+        listProjectTags: sinon.stub().resolves({
+          page: 1,
+          total: 1,
+          items: [{
+            id: 'child-1',
+            name: 'category:Sneakers',
+            parent_id: 'root-1',
+            children_count: 0,
+            path: [{ id: 'root-1', name: 'category:Footwear' }],
+          }],
+        }),
+      });
+      const result = await handleListTagsSubworkspace(transport, WS, { geoTargetId: 2840, languageCode: 'en', parentId: 'root-1' }, log);
+      expect(result.items).to.deep.equal([{
+        id: 'child-1',
+        name: 'category:Sneakers',
+        parentId: 'root-1',
+        childrenCount: 0,
+        path: [{ id: 'root-1', name: 'category:Footwear' }],
+      }]);
+      expect(transport.listPromptsByTags).to.not.have.been.called;
+      expect(transport.listProjectTags).to.have.been.calledOnceWithExactly(WS, 'p-tag', {
+        parentId: 'root-1', page: 1, limit: 100, draft: true,
+      });
+    });
+
     it('merges standalone tags (prompt-less categories) with prompt-derived ones, deduped by name', async () => {
       const transport = makeTransport({
         listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -703,6 +703,34 @@ describe('markets-subworkspace handlers', () => {
       });
     });
 
+    it('400s a parentId query over the length ceiling (MysticatBot review, PR 2737)', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listProjectTags: sinon.stub(),
+      });
+      await expect(handleListTagsSubworkspace(
+        transport,
+        WS,
+        { geoTargetId: 2840, languageCode: 'en', parentId: 'x'.repeat(201) },
+        log,
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.listProjectTags).to.not.have.been.called;
+    });
+
+    it('400s a parentId query containing a control character (MysticatBot review, PR 2737)', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),
+        listProjectTags: sinon.stub(),
+      });
+      await expect(handleListTagsSubworkspace(
+        transport,
+        WS,
+        { geoTargetId: 2840, languageCode: 'en', parentId: `root-${String.fromCharCode(7)}` },
+        log,
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.listProjectTags).to.not.have.been.called;
+    });
+
     it('merges standalone tags (prompt-less categories) with prompt-derived ones, deduped by name', async () => {
       const transport = makeTransport({
         listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-tag' })] }),

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -959,6 +959,34 @@ describe('handlers/markets.js — handleListTags / handleListModels', () => {
     expect(transport.listProjectTags.firstCall.args[2]).to.include({ parentId: 'root-1', draft: true });
   });
 
+  it('listTags 400s a parentId query over the length ceiling (MysticatBot review, PR 2737)', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-tree', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+    const transport = { listPromptsByTags: sinon.stub(), listProjectTags: sinon.stub() };
+
+    await expect(handleListTags(transport, dataAccess, BRAND, WORKSPACE, {
+      geoTargetId: 2840, languageCode: 'en', parentId: 'x'.repeat(201),
+    }, fakeLog())).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+    expect(transport.listProjectTags).to.not.have.been.called;
+  });
+
+  it('listTags 400s a parentId query containing a control character (MysticatBot review, PR 2737)', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-tree', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+    const transport = { listPromptsByTags: sinon.stub(), listProjectTags: sinon.stub() };
+
+    await expect(handleListTags(transport, dataAccess, BRAND, WORKSPACE, {
+      geoTargetId: 2840, languageCode: 'en', parentId: `root-${String.fromCharCode(7)}`,
+    }, fakeLog())).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+    expect(transport.listProjectTags).to.not.have.been.called;
+  });
+
   it('listModels (catalog mode) calls listGlobalAiModels and returns items', async () => {
     const dataAccess = makeDataAccess([]);
     const transport = {

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -27,6 +27,7 @@ import {
   resolveLocation,
   clearLanguageCache,
   clearTagCache,
+  listProjectTagTree,
 } from '../../../../src/support/serenity/handlers/markets.js';
 import { SerenityTransportError } from '../../../../src/support/serenity/rest-transport.js';
 import { ErrorWithStatusCode } from '../../../../src/support/utils.js';
@@ -985,6 +986,32 @@ describe('handlers/markets.js — handleListTags / handleListModels', () => {
       geoTargetId: 2840, languageCode: 'en', parentId: `root-${String.fromCharCode(7)}`,
     }, fakeLog())).to.be.rejected.then((err) => expect(err.status).to.equal(400));
     expect(transport.listProjectTags).to.not.have.been.called;
+  });
+
+  it('listProjectTagTree warns and stops at the page ceiling when the last page is still full', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      id: `tag-${i}`, name: `Tag ${i}`, parent_id: null, children_count: 0,
+    }));
+    const listProjectTags = sinon.stub().resolves({ page: 1, total: 5000, items: fullPage });
+    const log = fakeLog();
+
+    const result = await listProjectTagTree(
+      { listProjectTags },
+      WORKSPACE,
+      'proj-tree',
+      '',
+      log,
+    );
+
+    // 50 pages x 100 items, stopped by the ceiling rather than running forever.
+    expect(result.items).to.have.lengthOf(5000);
+    expect(listProjectTags.callCount).to.equal(50);
+    expect(log.warn).to.have.been.calledOnceWith(
+      'listProjectTagTree: page ceiling hit; tag level may be truncated',
+      sinon.match({
+        semrushWorkspaceId: WORKSPACE, projectId: 'proj-tree', parentId: '', pages: 50, limit: 100,
+      }),
+    );
   });
 
   it('listModels (catalog mode) calls listGlobalAiModels and returns items', async () => {

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -886,6 +886,79 @@ describe('handlers/markets.js — handleListTags / handleListModels', () => {
     );
   });
 
+  // Nested-tree read: when the request carries a `parentId` query param, the
+  // handler drills the standalone /aio/tags tree via listProjectTags(draft:true)
+  // instead of the prompt-derived aggregation, surfacing childrenCount/path.
+  it('listTags (parentId=\'\') returns roots with childrenCount from the standalone tree', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-tree', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+    const transport = {
+      listPromptsByTags: sinon.stub(),
+      listProjectTags: sinon.stub().resolves({
+        page: 1,
+        total: 1,
+        items: [{
+          id: 'root-1', name: 'category:Footwear', parent_id: null, children_count: 2, path: null,
+        }],
+      }),
+    };
+
+    const result = await handleListTags(transport, dataAccess, BRAND, WORKSPACE, {
+      geoTargetId: 2840, languageCode: 'en', parentId: '',
+    }, fakeLog());
+
+    expect(result.items).to.deep.equal([{
+      id: 'root-1', name: 'category:Footwear', parentId: null, childrenCount: 2, path: null,
+    }]);
+    // Tree read, not the prompt-derived path.
+    expect(transport.listPromptsByTags).to.not.have.been.called;
+    expect(transport.listProjectTags).to.have.been.calledOnceWithExactly(
+      WORKSPACE,
+      'proj-tree',
+      {
+        parentId: '', page: 1, limit: 100, draft: true,
+      },
+    );
+  });
+
+  it('listTags (parentId=<id>) returns that parent\'s children with a path breadcrumb', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-tree', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+    const transport = {
+      listPromptsByTags: sinon.stub(),
+      listProjectTags: sinon.stub().resolves({
+        page: 1,
+        total: 1,
+        items: [{
+          id: 'child-1',
+          name: 'category:Sneakers',
+          parent_id: 'root-1',
+          children_count: 0,
+          path: [{ id: 'root-1', name: 'category:Footwear' }],
+        }],
+      }),
+    };
+
+    const result = await handleListTags(transport, dataAccess, BRAND, WORKSPACE, {
+      geoTargetId: 2840, languageCode: 'en', parentId: 'root-1',
+    }, fakeLog());
+
+    expect(result.items).to.deep.equal([{
+      id: 'child-1',
+      name: 'category:Sneakers',
+      parentId: 'root-1',
+      childrenCount: 0,
+      path: [{ id: 'root-1', name: 'category:Footwear' }],
+    }]);
+    expect(transport.listProjectTags.firstCall.args[2]).to.include({ parentId: 'root-1', draft: true });
+  });
+
   it('listModels (catalog mode) calls listGlobalAiModels and returns items', async () => {
     const dataAccess = makeDataAccess([]);
     const transport = {

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -112,6 +112,22 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
         .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['category:Footwear'], { parentId: undefined });
     });
 
+    it('falls back to an undefined id when the upstream create response has no usable node (defensive)', async () => {
+      const transport = makeTransport({ createProjectTags: sinon.stub().resolves([{}]) });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        validBody,
+        fakeLog(),
+      );
+      expect(res.status).to.equal(201);
+      expect(res.body.id).to.equal(undefined);
+      expect(res.body.parentId).to.equal(null);
+    });
+
     it('supports the topic dimension (also free-form)', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
@@ -369,6 +385,34 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(transport.createProjectTags.firstCall.args[3])
         .to.deep.equal({ parentId: '6f383e4e-d8e1-47bb-888e-1f93e8575567' });
     });
+
+    it('normalizes a whitespace-only parentId to undefined (trims to empty)', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        { ...validBody, parentId: '   ' },
+        fakeLog(),
+      );
+      expect(transport.createProjectTags.firstCall.args[3]).to.deep.equal({ parentId: undefined });
+    });
+
+    it('400s on a parentId over the length ceiling', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        { ...validBody, parentId: 'x'.repeat(201) },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
   });
 
   describe('handleUpdateTag (flat mode) — PATCH /serenity/tags/:tagId', () => {
@@ -530,6 +574,35 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       // The fix: parent_id is explicitly re-sent (never omitted for a child),
       // even though the request itself carried no parentId — omitting it here
       // is exactly what silently promotes a child to root on live Semrush.
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-1',
+        'child-1',
+        { name: 'SneakersRenamed', parentId: 'root-1' },
+      );
+    });
+
+    it('falls back to the root id when the upstream child listing omits parent_id (defensive)', async () => {
+      const listProjectTags = sinon.stub();
+      listProjectTags.withArgs(sinon.match.any, sinon.match.any, sinon.match({ parentId: '' }))
+        .resolves({ page: 1, total: 1, items: [{ id: 'root-1', name: 'category:Footwear', children_count: 1 }] });
+      listProjectTags.withArgs(sinon.match.any, sinon.match.any, sinon.match({ parentId: 'root-1' }))
+        .resolves({ page: 1, total: 1, items: [{ id: 'child-1', name: 'Sneakers' }] }); // no parent_id
+      const transport = makeTransport({
+        listProjectTags,
+        updateProjectTag: sinon.stub().resolves({ id: 'child-1', name: 'SneakersRenamed', parent_id: 'root-1' }),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'child-1',
+        { name: 'SneakersRenamed', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
       expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
         WORKSPACE,
         'proj-1',

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -615,6 +615,127 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
     });
   });
 
+  describe('handleUpdateTag — tagId validation (MysticatBot review, PR 2737)', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    it('400s a tagId over the length ceiling', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'x'.repeat(201),
+        { name: 'category:Footwear', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.listProjectTags).to.not.have.been.called;
+    });
+
+    it('400s a tagId containing whitespace', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'tag one',
+        { name: 'category:Footwear', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.listProjectTags).to.not.have.been.called;
+    });
+
+    it('400s a tagId containing a control character', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        `tag-${String.fromCharCode(7)}`,
+        { name: 'category:Footwear', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.listProjectTags).to.not.have.been.called;
+    });
+  });
+
+  describe('resolveTagTarget — root fan-out bounds (MysticatBot review, PR 2737)', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    it('skips a childless root (childrenCount 0) without fetching its children', async () => {
+      const listProjectTags = sinon.stub();
+      listProjectTags.withArgs(sinon.match.any, sinon.match.any, sinon.match({ parentId: '' }))
+        .resolves({
+          page: 1,
+          total: 1,
+          items: [{ id: 'root-empty', name: 'category:Empty', children_count: 0 }],
+        });
+      const transport = makeTransport({ listProjectTags });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      // tagId resolves to 'unknown' (not found among roots or their children) —
+      // same legacy dimension-prefix path as a root, so this succeeds (200); the
+      // assertion under test is the call count, not the outcome.
+      const res = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'no-such-tag',
+        { name: 'category:Whatever', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
+      // Only the roots-level call — the childless root is never drilled.
+      expect(listProjectTags).to.have.been.calledOnce;
+    });
+
+    it('caps the number of roots searched for an unresolvable tagId', async () => {
+      const ROOT_COUNT = 150;
+      const roots = Array.from({ length: ROOT_COUNT }, (_, i) => ({
+        id: `root-${i}`, name: `category:R${i}`, children_count: 1,
+      }));
+      const listProjectTags = sinon.stub().callsFake((ws, pid, opts) => {
+        if (opts.parentId === '') {
+          // Real pagination: 100 items/page (matches listProjectTagTree's LIMIT),
+          // so this correctly spans 2 pages for 150 roots.
+          const start = (opts.page - 1) * opts.limit;
+          return Promise.resolve({
+            page: opts.page, total: ROOT_COUNT, items: roots.slice(start, start + opts.limit),
+          });
+        }
+        // Any root's children: empty (tagId is never found).
+        return Promise.resolve({ page: 1, total: 0, items: [] });
+      });
+      const transport = makeTransport({ listProjectTags });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'no-such-tag',
+        { name: 'category:Whatever', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
+      // 2 roots-level pages (150 roots / 100 per page) + at most 100 per-root
+      // drills (the cap), not all 150 — bounds the total at 102, not 152.
+      expect(listProjectTags.callCount).to.be.at.most(102);
+      expect(listProjectTags.callCount).to.be.greaterThan(2);
+    });
+  });
+
   describe('handleUpdateTagSubworkspace', () => {
     const updateBody = {
       name: 'category:Footwear', parentId: 'tag-parent', geoTargetId: 2840, languageCode: 'en',

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -28,12 +28,43 @@ function fakeLog() {
   };
 }
 
+// Default: an empty tree, so resolveTagTarget() resolves any tagId to
+// 'unknown' unless a test overrides listProjectTags to place it as a root or
+// a child. This preserves the legacy full-"<dimension>:<value>"-name
+// behavior for every test that isn't specifically about child-target
+// resolution.
 function makeTransport(overrides = {}) {
   return {
     createProjectTags: sinon.stub().resolves([{ id: 'tag-1', name: 'category:Footwear' }]),
     updateProjectTag: sinon.stub().resolves({ id: 'tag-1', name: 'category:Footwear', parent_id: 'tag-parent' }),
+    listProjectTags: sinon.stub().resolves({ page: 1, total: 0, items: [] }),
     ...overrides,
   };
+}
+
+// Stubs listProjectTags so resolveTagTarget() resolves `childId` as a CHILD
+// of `rootId` (mirrors the live shape: children carry `parent_id`).
+function makeChildTreeTransport(rootId, childId, overrides = {}) {
+  const listProjectTags = sinon.stub();
+  listProjectTags.withArgs(sinon.match.any, sinon.match.any, sinon.match({ parentId: '' }))
+    .resolves({ page: 1, total: 1, items: [{ id: rootId, name: 'category:Footwear', children_count: 1 }] });
+  listProjectTags.withArgs(sinon.match.any, sinon.match.any, sinon.match({ parentId: rootId }))
+    .resolves({
+      page: 1,
+      total: 1,
+      items: [{
+        id: childId, name: 'Sneakers', parent_id: rootId, path: [{ id: rootId, name: 'category:Footwear' }],
+      }],
+    });
+  return makeTransport({ listProjectTags, ...overrides });
+}
+
+// Stubs listProjectTags so resolveTagTarget() resolves `rootId` as a ROOT.
+function makeRootTreeTransport(rootId, overrides = {}) {
+  const listProjectTags = sinon.stub();
+  listProjectTags.withArgs(sinon.match.any, sinon.match.any, sinon.match({ parentId: '' }))
+    .resolves({ page: 1, total: 1, items: [{ id: rootId, name: 'category:Footwear', children_count: 0 }] });
+  return makeTransport({ listProjectTags, ...overrides });
 }
 
 function makeDataAccess(findBySliceResult) {
@@ -225,6 +256,30 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
       expect(resolveProjectStub).to.not.have.been.called;
     });
+
+    it('creates a BARE-named child when parentId is present (twin of the flat-mode fix)', async () => {
+      const resolveProjectStub = sinon.stub().resolves({ id: 'proj-sub-1' });
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeTransport({
+        createProjectTags: sinon.stub().resolves([{ id: 'child-1', name: 'Sneakers', parent_id: 'parent-1' }]),
+      });
+      const res = await handler.handleCreateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        {
+          type: 'category', name: 'Sneakers', geoTargetId: 2840, languageCode: 'en', parentId: 'parent-1',
+        },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(201);
+      expect(res.body).to.include({ tag: 'Sneakers', id: 'child-1', parentId: 'parent-1' });
+      expect(transport.createProjectTags)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', ['Sneakers'], { parentId: 'parent-1' });
+    });
   });
 
   describe('handleCreateTag — nested (parentId)', () => {
@@ -233,10 +288,10 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       handler = await import('../../../../src/support/serenity/handlers/tags.js');
     });
 
-    it('threads parentId to the transport and echoes the created id + parentId', async () => {
+    it('threads parentId to the transport and creates a BARE-named child, echoing the id + parentId', async () => {
       const transport = makeTransport({
         createProjectTags: sinon.stub().resolves([
-          { id: 'child-1', name: 'category:Sneakers', parent_id: 'parent-1' },
+          { id: 'child-1', name: 'Sneakers', parent_id: 'parent-1' },
         ]),
       });
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
@@ -251,9 +306,11 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
         fakeLog(),
       );
       expect(res.status).to.equal(201);
-      expect(res.body).to.include({ tag: 'category:Sneakers', id: 'child-1', parentId: 'parent-1' });
+      // A child is BARE — no `category:` prefix — unlike a root (see the plain
+      // 'registers a category:<NAME> tag' test above). serenity-docs#24 §2.
+      expect(res.body).to.include({ tag: 'Sneakers', id: 'child-1', parentId: 'parent-1' });
       expect(transport.createProjectTags)
-        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['category:Sneakers'], { parentId: 'parent-1' });
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['Sneakers'], { parentId: 'parent-1' });
     });
 
     it('normalizes an empty parentId to undefined (flat create)', async () => {
@@ -358,6 +415,16 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(transport.updateProjectTag).to.not.have.been.called;
     });
 
+    it('400s on a missing/blank name', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      for (const name of [undefined, '   ']) {
+        // eslint-disable-next-line no-await-in-loop
+        await expect(handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'tag-1', { ...updateBody, name }, fakeLog())).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      }
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
     it('400s on a name that is not a creatable <dimension>:<value>', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
@@ -387,6 +454,39 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
     });
 
+    it('400s on a name whose value is empty, too long, has a second colon, or has control characters', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const bad = [
+        { ...updateBody, name: 'category:' },
+        { ...updateBody, name: `category:${'x'.repeat(101)}` },
+        { ...updateBody, name: 'category:topic:smuggled' },
+        { ...updateBody, name: 'category:bad\u0000name' },
+      ];
+      for (const body of bad) {
+        // eslint-disable-next-line no-await-in-loop
+        await expect(
+          handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'tag-1', body, fakeLog()),
+        ).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      }
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('400s on a non-positive geoTargetId or malformed languageCode', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const bad = [
+        { ...updateBody, geoTargetId: 0 },
+        { ...updateBody, languageCode: 'EN_US!' },
+      ];
+      for (const body of bad) {
+        // eslint-disable-next-line no-await-in-loop
+        await expect(
+          handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'tag-1', body, fakeLog()),
+        ).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      }
+    });
+
     it('404s (marketNotFound) when no project backs the slice', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess(null);
@@ -402,6 +502,116 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       const transport = makeTransport({ updateProjectTag: sinon.stub().rejects(notFound) });
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
       await expect(handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'ghost', updateBody, fakeLog())).to.be.rejectedWith('not found');
+    });
+  });
+
+  describe('handleUpdateTag — child target (serenity-docs#24 §3.1 gate 5)', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    it('accepts a BARE name on a child and echoes its CURRENT parent_id even when only renaming (no parentId sent)', async () => {
+      const transport = makeChildTreeTransport('root-1', 'child-1', {
+        updateProjectTag: sinon.stub().resolves({ id: 'child-1', name: 'SneakersRenamed', parent_id: 'root-1' }),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'child-1',
+        { name: 'SneakersRenamed', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({ tag: 'SneakersRenamed', parentId: 'root-1' });
+      // The fix: parent_id is explicitly re-sent (never omitted for a child),
+      // even though the request itself carried no parentId — omitting it here
+      // is exactly what silently promotes a child to root on live Semrush.
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-1',
+        'child-1',
+        { name: 'SneakersRenamed', parentId: 'root-1' },
+      );
+    });
+
+    it('400s a child rename that carries a dimension prefix (children are bare, like create)', async () => {
+      const transport = makeChildTreeTransport('root-1', 'child-1');
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'child-1',
+        { name: 'category:Sneakers', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('uses the CALLER-supplied parentId (not the current one) when explicitly re-parenting a child', async () => {
+      const transport = makeChildTreeTransport('root-1', 'child-1', {
+        updateProjectTag: sinon.stub().resolves({ id: 'child-1', name: 'Sneakers', parent_id: 'root-2' }),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'child-1',
+        {
+          name: 'Sneakers', parentId: 'root-2', geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      );
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-1',
+        'child-1',
+        { name: 'Sneakers', parentId: 'root-2' },
+      );
+    });
+
+    it('400s a BARE name on a ROOT — unaffected by the child fix, roots still require the dimension prefix', async () => {
+      const transport = makeRootTreeTransport('root-1');
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'root-1',
+        { name: 'Footwear', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('omits parentId (unaffected, safe) when renaming a ROOT with no parentId sent', async () => {
+      const transport = makeRootTreeTransport('root-1', {
+        updateProjectTag: sinon.stub().resolves({ id: 'root-1', name: 'category:FootwearRenamed' }),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'root-1',
+        { name: 'category:FootwearRenamed', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      );
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-1',
+        'root-1',
+        { name: 'category:FootwearRenamed', parentId: undefined },
+      );
     });
   });
 
@@ -440,6 +650,33 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
           expect(err.code).to.equal('marketNotFound');
         });
       expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('accepts a BARE child rename and echoes its CURRENT parent_id (twin of the flat-mode fix)', async () => {
+      const resolveProjectStub = sinon.stub().resolves({ id: 'proj-sub-1' });
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeChildTreeTransport('root-1', 'child-1', {
+        updateProjectTag: sinon.stub().resolves({ id: 'child-1', name: 'SneakersRenamed', parent_id: 'root-1' }),
+      });
+      const res = await handler.handleUpdateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        'child-1',
+        { name: 'SneakersRenamed', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({ tag: 'SneakersRenamed', parentId: 'root-1' });
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-sub-1',
+        'child-1',
+        { name: 'SneakersRenamed', parentId: 'root-1' },
+      );
     });
   });
 });

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -31,6 +31,7 @@ function fakeLog() {
 function makeTransport(overrides = {}) {
   return {
     createProjectTags: sinon.stub().resolves([{ id: 'tag-1', name: 'category:Footwear' }]),
+    updateProjectTag: sinon.stub().resolves({ id: 'tag-1', name: 'category:Footwear', parent_id: 'tag-parent' }),
     ...overrides,
   };
 }
@@ -77,7 +78,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
         tag: 'category:Footwear',
       });
       expect(transport.createProjectTags)
-        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['category:Footwear']);
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['category:Footwear'], { parentId: undefined });
     });
 
     it('supports the topic dimension (also free-form)', async () => {
@@ -189,7 +190,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
         sinon.match.any,
       );
       expect(transport.createProjectTags)
-        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', ['category:Footwear']);
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', ['category:Footwear'], { parentId: undefined });
     });
 
     it('404s (marketNotFound) when the slice has no live project', async () => {
@@ -223,6 +224,222 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
         fakeLog(),
       )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
       expect(resolveProjectStub).to.not.have.been.called;
+    });
+  });
+
+  describe('handleCreateTag — nested (parentId)', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    it('threads parentId to the transport and echoes the created id + parentId', async () => {
+      const transport = makeTransport({
+        createProjectTags: sinon.stub().resolves([
+          { id: 'child-1', name: 'category:Sneakers', parent_id: 'parent-1' },
+        ]),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        {
+          type: 'category', name: 'Sneakers', geoTargetId: 2840, languageCode: 'en', parentId: 'parent-1',
+        },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(201);
+      expect(res.body).to.include({ tag: 'category:Sneakers', id: 'child-1', parentId: 'parent-1' });
+      expect(transport.createProjectTags)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['category:Sneakers'], { parentId: 'parent-1' });
+    });
+
+    it('normalizes an empty parentId to undefined (flat create)', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        { ...validBody, parentId: '' },
+        fakeLog(),
+      );
+      expect(transport.createProjectTags.firstCall.args[3]).to.deep.equal({ parentId: undefined });
+    });
+
+    it('400s on a non-string parentId', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        { ...validBody, parentId: 123 },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('400s on a parentId with whitespace/control chars', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        { ...validBody, parentId: 'has space' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+    });
+
+    it('accepts a UUID parentId (hyphens are valid)', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        { ...validBody, parentId: '6f383e4e-d8e1-47bb-888e-1f93e8575567' },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(201);
+      expect(transport.createProjectTags.firstCall.args[3])
+        .to.deep.equal({ parentId: '6f383e4e-d8e1-47bb-888e-1f93e8575567' });
+    });
+  });
+
+  describe('handleUpdateTag (flat mode) — PATCH /serenity/tags/:tagId', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    const updateBody = {
+      name: 'category:Footwear', parentId: 'tag-parent', geoTargetId: 2840, languageCode: 'en',
+    };
+
+    it('re-parents/renames via the transport and returns 200', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'tag-1', updateBody, fakeLog());
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({
+        brandId: BRAND, tagId: 'tag-1', tag: 'category:Footwear', parentId: 'tag-parent',
+      });
+      expect(transport.updateProjectTag)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', 'tag-1', { name: 'category:Footwear', parentId: 'tag-parent' });
+    });
+
+    it('omits parent_id when only renaming (no parentId sent)', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'tag-1',
+        { name: 'category:Renamed', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      );
+      expect(transport.updateProjectTag.firstCall.args[3]).to.deep.equal({ name: 'category:Renamed', parentId: undefined });
+    });
+
+    it('400s on a missing tagId', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, '', updateBody, fakeLog())).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('400s on a name that is not a creatable <dimension>:<value>', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'tag-1',
+        { ...updateBody, name: 'intent:Informational' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('400s on a name missing its dimension prefix', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'tag-1',
+        { ...updateBody, name: 'Footwear' },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+    });
+
+    it('404s (marketNotFound) when no project backs the slice', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess(null);
+      await expect(handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'tag-1', updateBody, fakeLog())).to.be.rejected.then((err) => {
+        expect(err.status).to.equal(404);
+        expect(err.code).to.equal('marketNotFound');
+      });
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('propagates an upstream 404 for an unknown tag id', async () => {
+      const notFound = Object.assign(new Error('not found'), { status: 404 });
+      const transport = makeTransport({ updateProjectTag: sinon.stub().rejects(notFound) });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'ghost', updateBody, fakeLog())).to.be.rejectedWith('not found');
+    });
+  });
+
+  describe('handleUpdateTagSubworkspace', () => {
+    const updateBody = {
+      name: 'category:Footwear', parentId: 'tag-parent', geoTargetId: 2840, languageCode: 'en',
+    };
+
+    it('resolves the project live and updates the tag (200)', async () => {
+      const resolveProjectStub = sinon.stub().resolves({ id: 'proj-sub-1' });
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeTransport();
+      const res = await handler.handleUpdateTagSubworkspace(transport, WORKSPACE, 'tag-1', updateBody, fakeLog());
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({ tagId: 'tag-1', tag: 'category:Footwear', parentId: 'tag-parent' });
+      expect(res.body).to.not.have.property('brandId');
+      expect(transport.updateProjectTag)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', 'tag-1', { name: 'category:Footwear', parentId: 'tag-parent' });
+    });
+
+    it('404s (marketNotFound) when the slice has no live project', async () => {
+      const resolveProjectStub = sinon.stub().resolves(null);
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeTransport();
+      await expect(handler.handleUpdateTagSubworkspace(transport, WORKSPACE, 'tag-1', updateBody, fakeLog()))
+        .to.be.rejected.then((err) => {
+          expect(err.status).to.equal(404);
+          expect(err.code).to.equal('marketNotFound');
+        });
+      expect(transport.updateProjectTag).to.not.have.been.called;
     });
   });
 });

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -783,6 +783,26 @@ describe('Semrush REST transport', () => {
       );
       expect(JSON.parse(call.body)).to.deep.equal({ names });
     });
+
+    it('includes parent_id in the body when nesting under a parent', async () => {
+      fetchStub.resolves(fetchOk([{ id: 'child-1', name: 'category:Sneakers', parent_id: 'parent-1' }]));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await transport.createProjectTags(WORKSPACE_ID, PROJECT_ID, ['category:Sneakers'], { parentId: 'parent-1' });
+
+      const call = await callOf(fetchStub);
+      expect(JSON.parse(call.body)).to.deep.equal({ names: ['category:Sneakers'], parent_id: 'parent-1' });
+    });
+
+    it('omits parent_id for an empty parentId (flat create)', async () => {
+      fetchStub.resolves(fetchOk([{ id: 'tag-1', name: 'category:Flat' }]));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await transport.createProjectTags(WORKSPACE_ID, PROJECT_ID, ['category:Flat'], { parentId: '' });
+
+      const call = await callOf(fetchStub);
+      expect(JSON.parse(call.body)).to.deep.equal({ names: ['category:Flat'] });
+    });
   });
 
   describe('listProjectTags', () => {
@@ -799,7 +819,59 @@ describe('Semrush REST transport', () => {
       );
       expect(call.url).to.contain('parent_id=');
       expect(call.url).to.contain('search=');
+      expect(call.url).to.not.contain('draft=');
       expect(result.items).to.deep.equal([{ id: 't-1', name: 'category:Running Shoes' }]);
+    });
+
+    it('drills a parent level and reads the draft view when requested', async () => {
+      fetchStub.resolves(fetchOk({ items: [], page: 1, total: 0 }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await transport.listProjectTags(WORKSPACE_ID, PROJECT_ID, { parentId: 'parent-1', draft: true });
+
+      const call = await callOf(fetchStub);
+      expect(call.url).to.contain('parent_id=parent-1');
+      expect(call.url).to.contain('draft=true');
+    });
+  });
+
+  describe('updateProjectTag', () => {
+    it('PATCHes /aio/tags/{tag_id} with { name, parent_id } and returns the updated tag', async () => {
+      fetchStub.resolves(fetchOk({ id: 'tag-1', name: 'category:Renamed', parent_id: 'parent-1' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const result = await transport.updateProjectTag(WORKSPACE_ID, PROJECT_ID, 'tag-1', {
+        name: 'category:Renamed', parentId: 'parent-1',
+      });
+
+      const call = await callOf(fetchStub);
+      expect(call.method).to.equal('PATCH');
+      expect(call.url).to.equal(
+        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/tags/tag-1`,
+      );
+      expect(JSON.parse(call.body)).to.deep.equal({ name: 'category:Renamed', parent_id: 'parent-1' });
+      expect(result).to.deep.equal({ id: 'tag-1', name: 'category:Renamed', parent_id: 'parent-1' });
+    });
+
+    it('omits parent_id when only renaming', async () => {
+      fetchStub.resolves(fetchOk({ id: 'tag-1', name: 'category:Renamed' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await transport.updateProjectTag(WORKSPACE_ID, PROJECT_ID, 'tag-1', { name: 'category:Renamed' });
+
+      const call = await callOf(fetchStub);
+      expect(JSON.parse(call.body)).to.deep.equal({ name: 'category:Renamed' });
+    });
+
+    it('surfaces an upstream 404 as a SerenityTransportError', async () => {
+      fetchStub.resolves(fetchFail(404, { message: 'not found' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await expect(transport.updateProjectTag(WORKSPACE_ID, PROJECT_ID, 'ghost', { name: 'category:X' }))
+        .to.be.rejected.then((err) => {
+          expect(err.status).to.equal(404);
+          expect(err.body).to.deep.equal({ message: 'not found' });
+        });
     });
   });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Makes spacecat-api-service actually consume the 1-level nested AIO tag support shipped in `@adobe/spacecat-shared-project-engine-client` v1.6.0: nested-category create (`parentId`), a tree-aware read, and an id-keyed rename/re-parent endpoint on the Serenity (Semrush AIO) proxy.

## 2. Reasoning
The project-engine-client already modelled tag nesting (`parent_id`, `path[]`, `children_count`) and v1.6.0 taught its Counterfact mock to honour it (parent-aware create, tree-aware list, a `PATCH /aio/tags/{tag_id}` re-parent), released in https://github.com/adobe/spacecat-shared/pull/1758 . But spacecat-api-service pinned an older client and its Serenity transport was flat — `createProjectTags` dropped any hierarchy, `listProjectTags` hard-coded `parent_id: ''` (roots only), and there was no re-parent path at all. So a consumer writing `parent_id` would silently pass against the mock while losing the tree. This closes that gap — the api-service slice of the cross-repo nested-category effort ( https://github.com/adobe/spacecat-api-service/issues/2733 , parent design https://github.com/adobe/serenity-docs/issues/21 ), building on the create-tag endpoint from https://github.com/adobe/spacecat-api-service/pull/2730 .

## 3. High-level overview of the changes
Behaviour delta on the Serenity `/serenity/tags` surface (the Categories surface), additive and backward-compatible for existing flat callers:

- **Create can nest.** `POST /serenity/tags` now accepts an optional `parentId` (an upstream tag id from a prior list). When present, the new tag is created as a 1-level child of that category in a single upstream call; the response echoes the created tag's `id` and `parentId`. Omitting `parentId` is the previous flat/root behaviour, unchanged.
- **Read can drill the tree.** `GET /serenity/tags` gains an optional `parentId` query param: absent → the previous flat, prompt-derived list; present (even empty) → the standalone AIO tag tree at that level — `parentId=''` lists the root categories (each with `childrenCount`), a tag id lists that category's children (each with a `path[]` breadcrumb). The tree read uses the draft view so a just-created, still-unpublished category is visible.
- **New rename / re-parent.** `PATCH /serenity/tags/:tagId` renames and/or re-parents a single tag in place (id-keyed, mirroring the existing prompt PATCH). Parent/target are referenced by upstream tag id throughout (the reserved model): names are not assumed unique across the tree.
- Both flat-mode and sub-workspace-mode paths get the same behaviour (parity). New route classified for FACS (`tagId` is a non-resource param; the PATCH route gates on `llmo/can_configure`), and the OpenAPI contract (paths + the `SerenityTag` schema, which gains `parentId` / `childrenCount` / `path`) is updated.
- The client dependency is bumped `1.4.0` → `1.6.0`; because the integration-test mock image tag is derived from the installed client version, this also moves the IT mock to the matching `1.6.0` image.

Operationally visible note: an unknown upstream tag id on `PATCH` surfaces to clients as **502**, not 404 — this is the existing Serenity-proxy convention (upstream non-auth errors collapse to a generic 502 so upstream detail is never echoed), not a new behaviour. Local not-found checks (org / brand / market) still return 404.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/2733
- Spec: https://github.com/adobe/serenity-docs/issues/21
- Other: builds on https://github.com/adobe/spacecat-api-service/pull/2730 ; consumes https://github.com/adobe/spacecat-shared/pull/1758

## 5. Affected / used mysticat-workspace projects
- **spacecat-shared** — consumed: this PR pins `@adobe/spacecat-shared-project-engine-client` v1.6.0 (client types + the Counterfact/GHCR mock) as the upstream contract for nested tags.
- **project-elmo-ui** — contract/consumer: the Serenity Categories UI ( https://github.com/adobe/project-elmo-ui/pull/2078 ) is the intended caller of the new `parentId` create, the tree drill-down read, and the re-parent endpoint.
- **mysticat-data-service** — related: the onboarding CLI writes the nested tree ( https://github.com/adobe/mysticat-data-service/pull/737 ); it uses tag-then-reparent because it tags prompts by name, whereas this proxy nests directly via `parent_id` on create.

## 6. Additional information outside the code
**Live Semrush validation (2026-07-01, workspace `0a496c87…` / project `697156f8` US-EN, against `adobe-hackathon.semrush.com`).** Throwaway `category:*` tags were created, inspected, and deleted (verified removed — nothing left behind), to settle the create mechanism the user asked to confirm:
- Direct `POST /aio/tags {names, parent_id}` nests in a single call — the child returns with `parent_id` set and `GET ?parent_id=<id>` lists it under the parent with a `path[]` breadcrumb. So a separate tag-then-reparent step is not needed for creating children.
- `PATCH /aio/tags/{tag_id}` renames and re-parents → 200; an unknown id → 404 `{message:"not found"}`.
- A new finding worth recording: an empty-string `parent_id` on `PATCH` is a no-op (200 but parent unchanged) — it does not promote a child back to a root. Promote-to-root is therefore treated as unsupported upstream.

**Mock-data gap to fix in spacecat-shared (follow-up).** The v1.6.0 PE mock derives a tag id from its name (`tag-<encodeURIComponent(name)>`), so a `category:*` tag's id embeds a literal `%3A`. That id round-trips faithfully through a JSON body — so nested create and the derived `childrenCount` are exercised end-to-end against the mock — but it does not survive a URL query/path (the `%3A` decodes back to `:` and no longer matches the stored id). As a result, drilling a parent's children by id and a successful PATCH-by-id cannot be asserted against the mock, and are validated against live Semrush (opaque UUID ids) instead. Recommendation: switch the mock to opaque, URL-safe tag ids (a hash/UUID with no reserved characters) so the full nested read + PATCH path becomes testable against the mock. This is a mock-only gap; real Semrush uses UUIDs and the path works end-to-end (proven by the live probe above).

## 7. Test plan
(a) Local end-to-end: the Serenity integration suite was run against the v1.6.0 GHCR PE/UM mock containers (real HTTPS, not in-process stubs). It exercises the new route wiring through the full stack — nested create (`parentId` in → `childrenCount` derived on read) and the `PATCH /serenity/tags/:tagId` route reaching upstream — alongside the pre-existing market/prompt/tag lifecycle. The id-in-URL drill and a successful PATCH-by-id are covered against live Semrush instead (see section 6), because of the mock-id limitation.

(b) Per-environment (dev / stage), via the Categories UI or a direct call with an IMS bearer, for a brand's `(geoTargetId, languageCode)` market:
- `POST /serenity/tags` with `type: category` and no `parentId` → 201; capture the returned `id`.
- `POST /serenity/tags` with `parentId` = that id → 201 with `parentId` set (a nested child).
- `GET /serenity/tags?...&parentId=` → the parent lists as a root with `childrenCount ≥ 1`; `GET ...&parentId=<id>` → the child lists with a `path[]` breadcrumb.
- `PATCH /serenity/tags/:tagId` with a new `name` and/or `parentId` → 200 reflecting the rename/re-parent; an unknown tag id → 502 (proxy convention).

## 8. Deployment & merge order
Independent to merge — additive and backward-compatible; the upstream it depends on is already released.
- depends-on: https://github.com/adobe/spacecat-shared/pull/1758 — released as project-engine-client v1.6.0 (client types + mock); this PR pins it. Already merged, no ordering needed.
- related: https://github.com/adobe/project-elmo-ui/pull/2078 — the Serenity Categories UI that will call these endpoints; can integrate once this ships.
- related: https://github.com/adobe/mysticat-data-service/pull/737 — the onboarding CLI writing the nested tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
