### PR TITLE
docs(openapi): document GET /organizations/:id/permission/audit-logs

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -801,6 +801,8 @@ paths:
     $ref: './state-access-mappings-api.yaml#/product-capabilities'
   /user/capabilities/{resourceId}:
     $ref: './state-access-mappings-api.yaml#/user-capabilities-by-resource'
+  /organizations/{organizationId}/permission/audit-logs:
+    $ref: './state-access-mappings-api.yaml#/permission-audit-logs'
 
 components:
   securitySchemes:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11975,6 +11975,92 @@ UserCapabilitiesResponse:
         items:
           type: string
           enum: [jwt, 'state:user', 'state:org']
+
+FacsAuditEvent:
+  type: object
+  description: |
+    One row from the `facs_access_mapping_audit_events` log — a single
+    state-mapping operation (create / patch / delete / revoke) with its
+    outcome. Shape is intentionally flat so the admin UI can render whichever
+    fields it needs. Fields describing the affected binding (`mappingId`,
+    `binding*`, `resource*`, `grantedCapabilities`, `revokeReason`) are null
+    for operations that did not touch a specific row.
+  required:
+    - id
+    - createdAt
+    - imsOrgId
+    - actorId
+    - operation
+    - outcome
+  properties:
+    id: { $ref: '#/Id' }
+    createdAt: { $ref: '#/DateTime' }
+    requestId:
+      type: [string, 'null']
+      description: Correlates the audit event with the originating request.
+    imsOrgId:
+      type: string
+      example: ABC123@AdobeOrg
+    actorId:
+      type: string
+      description: IMS ident of the caller who performed the operation.
+      example: admin@AdobeID
+    operation:
+      type: string
+      description: The attempted state-mapping operation.
+      example: create
+    outcome:
+      type: string
+      description: Whether the operation was allowed and applied, or denied.
+      example: allowed
+    denialReason:
+      type: [string, 'null']
+      description: Populated when `outcome` is a denial.
+    statusCode:
+      type: [integer, 'null']
+      description: HTTP status the operation returned.
+      example: 201
+    errorMessage:
+      type: [string, 'null']
+    mappingId:
+      type: [string, 'null']
+      description: ID of the affected `facs_access_mappings` row, when applicable.
+    bindingSubjectType:
+      oneOf:
+        - { $ref: '#/StateAccessMappingSubjectType' }
+        - type: 'null'
+    bindingSubjectId:
+      type: [string, 'null']
+      example: someone@AdobeID
+    resourceType:
+      oneOf:
+        - { $ref: '#/StateAccessMappingResourceType' }
+        - type: 'null'
+    resourceId:
+      type: [string, 'null']
+      example: '11111111-2222-4333-9444-555555555555'
+    product:
+      type: [string, 'null']
+      enum: [LLMO, ASO, ACO, null]
+      example: LLMO
+    grantedCapabilities:
+      oneOf:
+        - type: array
+          items: { $ref: '#/StateGrantedCapability' }
+        - type: 'null'
+    revokeReason:
+      type: [string, 'null']
+
+FacsAuditLogsResponse:
+  type: object
+  required: [items]
+  properties:
+    items:
+      type: array
+      items: { $ref: '#/FacsAuditEvent' }
+    cursor:
+      type: [string, 'null']
+      description: Opaque cursor for fetching the next page, or null when the result is the final page.
 # ── Referral Traffic PG schemas ───────────────────────────────────────────────
 
 

--- a/docs/openapi/state-access-mappings-api.yaml
+++ b/docs/openapi/state-access-mappings-api.yaml
@@ -330,3 +330,90 @@ user-capabilities-by-resource:
         $ref: './responses.yaml#/503'
     security:
       - ims_key: []
+
+permission-audit-logs:
+  parameters:
+    - *xProductHeader
+    - in: path
+      name: organizationId
+      required: true
+      description: SpaceCat organization UUID. Its IMS org id is resolved server-side and used as the tenant-isolation key.
+      schema: { type: string, format: uuid }
+  get:
+    tags:
+      - state-access-mappings
+    summary: List the FACS state-mapping audit log for an organization
+    description: |
+      Returns the `facs_access_mapping_audit_events` for the org, scoped to the
+      product carried by the `x-product` header. Every create / patch / delete /
+      revoke on a state-layer binding is logged with its outcome; this is the
+      operation history behind the hybrid permission model.
+
+      Authority (hybrid-model §3): this is an **org-wide** read, admitted for a
+      FACS-layer `<product>/can_manage_users` holder (or admin) only — a
+      resource-scoped state-layer manager has no org-wide audit view and is
+      denied. Tenant isolation: a non-admin caller may read only their OWN org's
+      audit (the resolved org's IMS id must equal the caller's).
+
+      Pagination is cursor-based; page size defaults to 50 and is hard-capped at
+      200. Optional filters narrow the log by operation, outcome, resource,
+      actor, mapping, and time window.
+    operationId: listFacsPermissionAuditLogs
+    parameters:
+      - in: query
+        name: operation
+        description: Filter by operation kind (e.g. `create`, `patch`, `delete`, `revoke`).
+        schema: { type: string }
+      - in: query
+        name: outcome
+        description: Filter by outcome (e.g. `allowed`, `denied`).
+        schema: { type: string }
+      - in: query
+        name: resourceType
+        schema: { type: string }
+      - in: query
+        name: resourceId
+        schema: { type: string }
+      - in: query
+        name: actorId
+        description: Filter by the IMS ident of the acting caller.
+        schema: { type: string }
+      - in: query
+        name: mappingId
+        description: Filter by the affected access-mapping row id.
+        schema: { type: string, format: uuid }
+      - in: query
+        name: since
+        description: Lower bound (inclusive) on event time, ISO 8601.
+        schema: { type: string, format: date-time }
+      - in: query
+        name: until
+        description: Upper bound (exclusive) on event time, ISO 8601.
+        schema: { type: string, format: date-time }
+      - in: query
+        name: limit
+        schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+      - in: query
+        name: cursor
+        schema: { type: string }
+    responses:
+      '200':
+        description: Page of audit events.
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/FacsAuditLogsResponse'
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '403':
+        $ref: './responses.yaml#/403'
+      '404':
+        $ref: './responses.yaml#/404'
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        $ref: './responses.yaml#/503'
+    security:
+      - ims_key: []


### PR DESCRIPTION
## What

Documents the FACS state-mapping **audit-log** endpoint — `GET /organizations/:organizationId/permission/audit-logs` — which was a live route (`src/routes/index.js` → `stateAccessMappingsController.getAuditLogs`) but had **no OpenAPI spec**, so it was missing from the published docs.

## Why now

[#2726](https://github.com/adobe/spacecat-api-service/pull/2726) graduated the state-layer management endpoints to prod (removed the `devOnly` blocker). The audit-log endpoint is now reachable in production, so an undocumented prod endpoint was being exposed. This closes that gap.

## Changes

- **`state-access-mappings-api.yaml`** — new `permission-audit-logs` path: `x-product` header, `organizationId` path param, the full optional filter set (`operation`, `outcome`, `resourceType`, `resourceId`, `actorId`, `mappingId`, `since`, `until`), cursor pagination, and the authority (org-wide → FACS-layer `can_manage_users` / admin only) + tenant-isolation notes.
- **`schemas.yaml`** — `FacsAuditEvent` (flat DTO matching `toAuditEventDto`) + `FacsAuditLogsResponse` (items + cursor).
- **`api.yaml`** — register the path.
- **`docs/index.html`** — regenerated via `npm run docs:build`.

## Verification

- `npm run docs:lint` — passes (only pre-existing ambiguous-path / example warnings, none from this change).
- `npm run docs:build` — bundles cleanly; endpoint present in `docs/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)