### PR TITLE
feat(serenity): id-based prompt writes, closed-dimension tag resolve, promote-to-root

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -10880,6 +10880,24 @@ SerenityPrompt:
         Tag names are assumed unique per Semrush project; if duplicates exist,
         only the last entry is retained.
       example: { "category:Firefly": "uuid-1", "intent:research": "uuid-2" }
+    tags:
+      type: array
+      items: { type: string }
+      description: |
+        Echo of the tag NAMES this prompt was created/updated with via the
+        legacy name-based write path (`SerenityPromptInput.tags` /
+        `SerenityUpdatePromptRequest.tags`). Only present on a create/update
+        response (`SerenityCreatePromptsResponse.created`, the
+        `updateSerenityPrompt` 200); absent on `GET /serenity/prompts` list
+        items, which carry `tagMap` instead.
+    tagIds:
+      type: array
+      items: { type: string }
+      description: |
+        Echo of the upstream tag ids this prompt was created/updated with via
+        the id-based write path (serenity-docs#24). Only present when the
+        request used `tagIds` rather than `tags` — mutually exclusive with a
+        non-empty `tags` on the same response.
 
 SerenityPromptListResponse:
   type: object

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -10894,7 +10894,12 @@ SerenityPromptListResponse:
 
 SerenityPromptInput:
   type: object
-  description: One row in a bulk-create prompts request.
+  description: |
+    One row in a bulk-create prompts request. `tags` (names, via the legacy
+    name-based upstream write path) and `tagIds` (upstream tag ids from a
+    prior tags list/create, via the id-based write path — serenity-docs#24)
+    are mutually exclusive: supply at most one. `tagIds`, when present, must
+    be non-empty.
   required: [text, geoTargetId, languageCode]
   properties:
     text: { type: string }
@@ -10902,6 +10907,12 @@ SerenityPromptInput:
       type: array
       items: { type: string }
       default: []
+      description: Tag NAMES. Mutually exclusive with tagIds.
+    tagIds:
+      type: array
+      items: { type: string }
+      minItems: 1
+      description: Upstream tag ids. Mutually exclusive with tags.
     geoTargetId:
       type: integer
       minimum: 1
@@ -10951,11 +10962,13 @@ SerenityUpdatePromptRequest:
   description: |
     Replace the prompt's text and tags. Carries the owning slice in
     `geoTargetId` + `languageCode` so the server can resolve the upstream
-    project without scanning. All four fields are required — the upstream
-    provider's API has no in-place update or GET-by-id, so the server runs
-    DELETE-old + POST-new and treats the body as the full next state.
-    Pass `tags: []` to clear tags.
-  required: [geoTargetId, languageCode, text, tags]
+    project without scanning. `geoTargetId`, `languageCode`, and `text` are
+    always required — the upstream provider's API has no in-place update or
+    GET-by-id, so the server runs DELETE-old + POST-new and treats the body
+    as the full next state. Exactly one of `tags` (pass `[]` to clear) or
+    `tagIds` (non-empty, id-based write path — serenity-docs#24) must also be
+    present; they are mutually exclusive.
+  required: [geoTargetId, languageCode, text]
   properties:
     geoTargetId:
       type: integer
@@ -10967,6 +10980,12 @@ SerenityUpdatePromptRequest:
     tags:
       type: array
       items: { type: string }
+      description: Tag NAMES. Mutually exclusive with tagIds.
+    tagIds:
+      type: array
+      items: { type: string }
+      minItems: 1
+      description: Upstream tag ids. Mutually exclusive with tags.
 
 SerenityBulkDeletePromptsRequest:
   type: object

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -101,8 +101,10 @@ v2-serenity-prompts:
     summary: Bulk-create Serenity prompts
     description: |
       Creates up to 500 prompts in one call. Each input must carry
-      (geoTargetId, languageCode, text, tags?). Inputs are grouped by slice;
-      each affected upstream project is published once at the end.
+      (geoTargetId, languageCode, text) plus at most one of `tags` (names,
+      the legacy write path) or `tagIds` (upstream tag ids, the id-based
+      write path — serenity-docs#24). Inputs are grouped by slice; each
+      affected upstream project is published once at the end.
     operationId: createSerenityPrompts
     security:
       - ims_key: []
@@ -152,18 +154,21 @@ v2-serenity-prompt-by-id:
     tags: [serenity]
     summary: Update a Serenity prompt
     description: |
-      Body carries `{geoTargetId, languageCode, text, tags}`. All four fields
-      are required — the upstream provider has no in-place update (and no
+      Body carries `{geoTargetId, languageCode, text}` plus exactly one of
+      `tags` (names) or `tagIds` (upstream ids, the id-based write path —
+      serenity-docs#24). `geoTargetId`/`languageCode`/`text` are always
+      required — the upstream provider has no in-place update (and no
       GET-by-id), so the implementation is DELETE-old + POST-new + publish
       and the payload is treated as the full next state. Clients always
-      have `text`/`tags` available locally (from the list call that
-      rendered the edit form), which keeps this endpoint a single straight
-      line and avoids the per-request pagination "preserve-on-omit"
-      semantics would force.
+      have the current text/tags(-ids) available locally (from the list
+      call that rendered the edit form), which keeps this endpoint a
+      single straight line and avoids the per-request pagination
+      "preserve-on-omit" semantics would force.
 
-      An explicit empty `tags: []` clears tags. The response carries the
-      new `semrushPromptId` (the value changes on every upstream
-      re-create).
+      An explicit empty `tags: []` clears tags (not applicable to
+      `tagIds`, which must be non-empty when present). The response
+      carries the new `semrushPromptId` (the value changes on every
+      upstream re-create).
     operationId: updateSerenityPrompt
     security:
       - ims_key: []
@@ -463,17 +468,24 @@ v2-serenity-tags:
       '500': { $ref: './responses.yaml#/500' }
   post:
     tags: [serenity]
-    summary: Create a tag on one market
+    summary: Create (or, for a closed dimension, resolve) a tag on one market
     description: |
       Registers a `<type>:<name>` prompt tag on the market addressed by the
-      `(geoTargetId, languageCode)` slice. `type` must be one of the OPEN tag
-      dimensions — `category` or `topic` — that accept customer-authored values;
-      the closed taxonomies (`source` / `intent` / `type`) have a fixed value
-      enum and are not freely creatable. The "Categories" view, for example, is
-      the `category:` slice of these tags across a brand's markets.
+      `(geoTargetId, languageCode)` slice. `type` is one of the OPEN tag
+      dimensions (`category`, `topic`, customer-authored values — a duplicate
+      name at the same tree level is a hard upstream error, resolve-before-
+      create is the CALLER's job) or one of the CLOSED dimensions (`source`,
+      `intent`, `type` — a small fixed value enum; `name` must be one of that
+      enum's values). A closed-dimension create is resolve-OR-create
+      (idempotent): if the project already has that exact tag, its existing id
+      is returned (200, `created: false`) instead of attempting another create;
+      `parentId` is not allowed for a closed dimension (always a root). The
+      "Categories" view, for example, is the `category:` slice of the open-
+      dimension tags across a brand's markets.
 
-      Pass `parentId` (an upstream tag id from a prior list) to create the tag as
-      a 1-level nested child of that category; omit it for a root/flat tag.
+      Pass `parentId` (an upstream tag id from a prior list) to create an OPEN-
+      dimension tag as a 1-level nested child of that category; omit it for a
+      root/flat tag.
     operationId: createSerenityTag
     security:
       - ims_key: []
@@ -488,13 +500,16 @@ v2-serenity-tags:
             properties:
               type:
                 type: string
-                enum: [category, topic]
-                description: The open tag dimension to create a value under.
+                enum: [category, topic, source, intent, type]
+                description: The tag dimension. category/topic are open (customer-authored); source/intent/type are closed (fixed enum).
               name:
                 type: string
                 minLength: 1
                 maxLength: 100
-                description: Free-form tag value. Must not contain ':'.
+                description: |
+                  For an open dimension: a free-form value (must not contain
+                  ':'). For a closed dimension: must exactly match one of that
+                  dimension's fixed enum values.
               geoTargetId:
                 type: integer
                 minimum: 1
@@ -507,10 +522,29 @@ v2-serenity-tags:
                 type: string
                 description: |
                   Optional upstream tag id (from a prior tags list) to nest the
-                  new tag under as a 1-level child. Omit for a root/flat tag.
+                  new OPEN-dimension tag under as a 1-level child. Omit for a
+                  root/flat tag. Not allowed for a closed dimension.
     responses:
+      '200':
+        description: Closed-dimension tag resolved (already existed or was just created — see `created`).
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                brandId: { type: string, format: uuid }
+                geoTargetId: { type: integer }
+                languageCode: { type: string }
+                type: { type: string, enum: [source, intent, type] }
+                name: { type: string }
+                tag: { type: string, description: The full `<type>:<name>` string. }
+                id: { type: string, description: The tag's upstream id. }
+                parentId: { type: 'null', description: Always null — closed-dimension tags are always roots. }
+                created:
+                  type: boolean
+                  description: 'true if this call created the tag; false if it already existed.'
       '201':
-        description: Tag registered on the market's project.
+        description: OPEN-dimension tag registered on the market's project.
         content:
           application/json:
             schema:
@@ -573,16 +607,18 @@ v2-serenity-tag-by-id:
     description: |
       Updates a single AIO tag in place on the market addressed by the
       `(geoTargetId, languageCode)` slice — renames it and/or re-parents it under
-      another category (1-level nesting). `name` is required on every call; its
-      shape depends on the CURRENT tag: a root takes the full
-      `<dimension>:<value>` string, a child takes a BARE value (no dimension
-      prefix — mirrors tag creation). `parentId` re-parents when present; when
-      omitted on a child rename, the proxy resolves and re-sends the child's
-      CURRENT `parentId` itself (never omits it for a child — omission silently
-      promotes a child to root upstream), so the parent is safely left
-      unchanged either way. Note that promoting a child back to a root is not
-      supported upstream. An unknown `tagId` is NOT a 404 — it surfaces as 502,
-      like every serenity proxy write against an upstream error.
+      another category (1-level nesting), or promotes a child back to a root.
+      `name` is required on every call; its shape depends on the CURRENT tag: a
+      root takes the full `<dimension>:<value>` string, a child takes a BARE
+      value (no dimension prefix — mirrors tag creation). `parentId` has three
+      meanings: a re-parent target id RE-PARENTS the tag; explicit JSON `null`
+      PROMOTES a child to root; omitting the field entirely leaves the parent
+      unchanged (for a child, the proxy resolves and re-sends its CURRENT
+      `parentId` itself rather than omitting it from the upstream call — an
+      omitted `parent_id` silently promotes a child to root upstream, so
+      omission and explicit `null` are NOT interchangeable). An unknown
+      `tagId` is NOT a 404 — it surfaces as 502, like every serenity proxy
+      write against an upstream error.
     operationId: updateSerenityTag
     security:
       - ims_key: []
@@ -605,12 +641,14 @@ v2-serenity-tag-by-id:
                   (currently nested under a parent), a BARE value with no
                   dimension prefix, mirroring how children are created.
               parentId:
-                type: string
+                type: [string, 'null']
                 description: |
-                  Optional upstream tag id to re-parent this tag under. Omit to
-                  leave the parent unchanged (safe for both a root and a child
-                  — the proxy resolves and preserves a child's current parent
-                  server-side rather than omitting it from the upstream call).
+                  An upstream tag id RE-PARENTS this tag under it. Explicit
+                  JSON `null` PROMOTES a child to root. Omit the field
+                  entirely to leave the parent unchanged (safe for both a root
+                  and a child — the proxy resolves and preserves a child's
+                  current parent server-side rather than omitting it from the
+                  upstream call). `null` and omission are NOT interchangeable.
               geoTargetId:
                 type: integer
                 minimum: 1

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -519,11 +519,14 @@ v2-serenity-tags:
                 pattern: '^[a-z]{2,3}(-[a-z]{2,4})?$'
                 description: BCP-47 primary subtag of the market slice.
               parentId:
-                type: string
+                type: [string, 'null']
                 description: |
                   Optional upstream tag id (from a prior tags list) to nest the
-                  new OPEN-dimension tag under as a 1-level child. Omit for a
-                  root/flat tag. Not allowed for a closed dimension.
+                  new OPEN-dimension tag under as a 1-level child. Omit, or
+                  pass explicit JSON `null`, for a root/flat tag — unlike the
+                  PATCH endpoint's `parentId`, create has no "leave unchanged"
+                  state to distinguish `null` from, so both are treated
+                  identically. Not allowed for a closed dimension.
     responses:
       '200':
         description: Closed-dimension tag resolved (already existed or was just created — see `created`).

--- a/docs/serenity.md
+++ b/docs/serenity.md
@@ -137,15 +137,15 @@ All endpoints require `Authorization: Bearer <ims_user_token>` and `organization
 | Method | Path | Purpose | OperationId |
 |---|---|---|---|
 | GET | `/serenity/prompts?geoTargetId=&languageCode=&page=&limit=&search=&tagIds=` | List prompts for one slice. geoTargetId and languageCode required. tagIds is repeatable (OR semantics, max 50). | `listSerenityPrompts` |
-| POST | `/serenity/prompts` | Bulk create prompts grouped by (geoTargetId, languageCode) | `createSerenityPrompts` |
-| PATCH | `/serenity/prompts/:semrushPromptId` | Update a prompt; body carries slice + new fields | `updateSerenityPrompt` |
+| POST | `/serenity/prompts` | Bulk create prompts grouped by (geoTargetId, languageCode); each input carries at most one of `tags` (names) or `tagIds` (upstream ids, id-based write path) | `createSerenityPrompts` |
+| PATCH | `/serenity/prompts/:semrushPromptId` | Update a prompt; body carries slice + text + exactly one of `tags`/`tagIds` | `updateSerenityPrompt` |
 | POST | `/serenity/prompts/bulk-delete` | Delete prompts; body is `{ prompts: [{semrushPromptId, geoTargetId, languageCode}] }` | `bulkDeleteSerenityPrompts` |
 | GET | `/serenity/markets` | List markets configured for the brand (incl. live `status`) | `listSerenityMarkets` |
 | POST | `/serenity/markets` | Onboard a new (brand, geoTargetId, languageCode) slice | `createSerenityMarket` |
 | DELETE | `/serenity/markets/:geoTargetId/:languageCode` | Remove a slice (idempotent; upstream-first, DB-second) | `deleteSerenityMarket` |
 | GET | `/serenity/tags?geoTargetId=&languageCode=` | Unique tag names for one slice. Add `parentId` (present, even empty) to switch to the nested-tree read instead: `parentId=''` returns root categories with `childrenCount`, `parentId=<tagId>` returns that root's children with a `path` breadcrumb. | `listSerenityTags` |
-| POST | `/serenity/tags` | Register an open-dimension (`category`/`topic`) tag on one slice; body is `{ type, name, geoTargetId, languageCode, parentId? }`. `parentId` nests the tag as a 1-level child (bare name, no dimension prefix) under an existing root. | `createSerenityTag` |
-| PATCH | `/serenity/tags/:tagId` | Rename and/or re-parent a tag by its upstream id. `name` is the full `<dimension>:<value>` string for a root, or a bare value for a child; `parentId` re-parents when present, otherwise the proxy preserves a child's current parent server-side. | `updateSerenityTag` |
+| POST | `/serenity/tags` | Create/resolve a tag on one slice; body is `{ type, name, geoTargetId, languageCode, parentId? }`. `type` is `category`/`topic` (open — customer-authored, `parentId` nests a 1-level bare-named child) or `source`/`intent`/`type` (closed — `name` must match the fixed enum; resolve-before-create, idempotent, `parentId` not allowed; response is `200 { ..., created }` not `201`). | `createSerenityTag` |
+| PATCH | `/serenity/tags/:tagId` | Rename and/or re-parent a tag by its upstream id. `name` is the full `<dimension>:<value>` string for a root, or a bare value for a child. `parentId`: an id RE-PARENTS, explicit `null` PROMOTES a child to root, omitted preserves the current parent (the proxy re-sends a child's current parent itself — omission is only safe for a root). | `updateSerenityTag` |
 | GET | `/serenity/models?geoTargetId=&languageCode=` | AI models for one slice (catalog mode when no params) | `listSerenityModels` |
 | PUT | `/serenity/models` | Replace the AI-model set for one slice (publishes after change) | `updateSerenityModels` |
 | POST | `/serenity/activate` | Activate the brand into sub-workspace mode (ensure sub-workspace + publish supplied markets) | `activateSerenityBrand` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,10 @@
         "@adobe/spacecat-shared-data-access": "3.80.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
-        "@adobe/spacecat-shared-http-utils": "^1.33.0",
+        "@adobe/spacecat-shared-http-utils": "1.33.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.6.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.7.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -825,7 +825,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -7038,9 +7037,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.6.0.tgz",
-      "integrity": "sha512-FU8vrvGxen7PtYHzW+aI7ErHG7RMOHDODrJ5zs/qgAr8TFV4BSa1kAWar3fuZcxU6XfPipAfyTjKVRjnrDQhKQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.7.0.tgz",
+      "integrity": "sha512-6tRVPen5YWSr8lLOErS/1SlNR6iVGmsIlFqjnwpFTJth9Cp+dWXGBfSl8r4rQ4bkGp8M4zz9/MGOpP0oc5JwcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"
@@ -11389,6 +11388,7 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -13299,6 +13299,7 @@
       "integrity": "sha512-wfAWZ6oIrsDOFyYm9bDQNva/WCmvIrVqP3dSCePN5YYWCGWWXkikn5YC0wPSxF92M8kQFPfdVpMaTTV1mRk4Lw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.21",
         "@smithy/core": "^3.24.6",
@@ -13315,6 +13316,7 @@
       "integrity": "sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -13378,6 +13380,7 @@
       "integrity": "sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
         "@aws-sdk/types": "^3.973.13",
@@ -13395,6 +13398,7 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -14050,8 +14054,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -14075,7 +14078,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -15053,7 +15055,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -15339,7 +15340,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -15546,7 +15546,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -15711,7 +15710,6 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -17729,7 +17727,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -17977,7 +17974,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -18024,7 +18020,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18473,7 +18468,6 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -19223,7 +19217,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -21453,7 +21446,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -25791,7 +25783,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -26848,6 +26839,7 @@
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -26858,7 +26850,6 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -29423,7 +29414,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -29897,7 +29887,8 @@
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -29951,7 +29942,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -31155,7 +31145,6 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31166,7 +31155,6 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -31915,7 +31903,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -33280,7 +33267,6 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -34174,7 +34160,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -34302,7 +34287,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -35109,7 +35093,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -35402,7 +35385,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -35412,7 +35394,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.33.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.7.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.7.1",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -7037,9 +7037,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.7.0.tgz",
-      "integrity": "sha512-6tRVPen5YWSr8lLOErS/1SlNR6iVGmsIlFqjnwpFTJth9Cp+dWXGBfSl8r4rQ4bkGp8M4zz9/MGOpP0oc5JwcA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.7.1.tgz",
+      "integrity": "sha512-RuqU1PqFLSfCwS1Rg29uU7vmr/SFMzf3Sz/O/GxJrzARCoVFfNu4+W0fg3wMJCaUUHiwnsgF8h+512EfzlRuNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.33.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.7.0",
+    "@adobe/spacecat-shared-project-engine-client": "1.7.1",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.33.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.6.0",
+    "@adobe/spacecat-shared-project-engine-client": "1.7.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -684,12 +684,25 @@ export async function listTagsForProject(transport, semrushWorkspaceId, projectI
  * @param {string} projectId - AIO project id.
  * @param {string} parentId - '' for roots, an upstream tag id for its children.
  * @param {any} [log] - logger, used to surface a ceiling-hit truncation warning.
+ * @param {(item: { id: string, name: string }) => boolean} [stopWhen] - optional
+ *   early-exit predicate. When a fetched page contains a matching item, that
+ *   page's items are still collected in full but no further pages are
+ *   requested. Callers that only need to test membership (e.g. resolve-or-
+ *   create) pass this to avoid paginating the whole tree; omit it to collect
+ *   every item, as every pre-existing caller does.
  * @returns {Promise<{ items: Array<{
  *   id: string, name: string, parentId: string | null,
  *   childrenCount: number, path: Array<{ id: string, name: string }> | null,
  * }> }>}
  */
-export async function listProjectTagTree(transport, semrushWorkspaceId, projectId, parentId, log) {
+export async function listProjectTagTree(
+  transport,
+  semrushWorkspaceId,
+  projectId,
+  parentId,
+  log,
+  stopWhen,
+) {
   const items = [];
   const LIMIT = 100;
   const PAGE_LIMIT = 50;
@@ -700,10 +713,11 @@ export async function listProjectTagTree(transport, semrushWorkspaceId, projectI
       parentId, page, limit: LIMIT, draft: true,
     });
     const batch = Array.isArray(resp?.items) ? resp.items : [];
+    let matched = false;
     for (const t of batch) {
       // AIOTag.id is required upstream; guard defensively and skip a malformed row.
       if (t && typeof t.id === 'string' && t.id) {
-        items.push({
+        const item = {
           id: t.id,
           name: typeof t.name === 'string' ? t.name : '',
           parentId: typeof t.parent_id === 'string' && t.parent_id ? t.parent_id : null,
@@ -714,8 +728,15 @@ export async function listProjectTagTree(transport, semrushWorkspaceId, projectI
               name: typeof p?.name === 'string' ? p.name : '',
             }))
             : null,
-        });
+        };
+        items.push(item);
+        if (stopWhen && stopWhen(item)) {
+          matched = true;
+        }
       }
+    }
+    if (matched) {
+      break;
     }
     if (batch.length < LIMIT) {
       break;

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -21,6 +21,8 @@ import { invalidateTagCacheForProject } from './markets.js';
 import {
   buildPromptDto,
   normalizePromptInput,
+  createOnePrompt,
+  parseUpdatePromptBody,
   mapLimit,
   publishAffected,
   DEFAULT_PAGE_LIMIT,
@@ -149,13 +151,7 @@ export async function handleCreatePromptsSubworkspace(transport, workspaceId, bo
     }
     const projectId = String(project.id);
     try {
-      const resp = await transport.createTaggedPrompts(
-        workspaceId,
-        projectId,
-        { [input.text]: input.tags },
-      );
-      const semrushPromptId = Array.isArray(resp?.ids) && resp.ids.length > 0
-        ? String(resp.ids[0]) : '';
+      const semrushPromptId = await createOnePrompt(transport, workspaceId, projectId, input);
       return {
         created: {
           semrushPromptId,
@@ -163,6 +159,7 @@ export async function handleCreatePromptsSubworkspace(transport, workspaceId, bo
           languageCode: input.languageCode,
           text: input.text,
           tags: input.tags,
+          ...(input.tagIds !== undefined ? { tagIds: input.tagIds } : {}),
         },
         affectedProjectId: projectId,
       };
@@ -220,12 +217,11 @@ export async function handleUpdatePromptSubworkspace(
   body,
   log,
 ) {
-  if (!body || body.text === undefined || body.tags === undefined) {
-    return {
-      status: 400,
-      body: { error: 'missingFields', message: 'PATCH body must include both text and tags' },
-    };
+  const parsedBody = parseUpdatePromptBody(body);
+  if (!parsedBody.ok) {
+    return { status: parsedBody.status, body: parsedBody.body };
   }
+  const { text: nextText, tags: nextTags, tagIds: nextTagIds } = parsedBody;
   const geoTargetId = normalizeGeoTargetId(Number(body.geoTargetId));
   const languageCode = normalizeLanguageCode(body.languageCode);
   if (geoTargetId === null || languageCode === null) {
@@ -250,11 +246,6 @@ export async function handleUpdatePromptSubworkspace(
   }
   const projectId = String(project.id);
 
-  const nextText = String(body.text);
-  const nextTags = Array.isArray(body.tags)
-    ? body.tags.map((t) => String(t || '').trim()).filter(Boolean)
-    : [];
-
   try {
     await transport.deletePromptsByIds(workspaceId, projectId, [semrushPromptId]);
   } catch (e) {
@@ -275,13 +266,9 @@ export async function handleUpdatePromptSubworkspace(
     throw e;
   }
 
-  const resp = await transport.createTaggedPrompts(
-    workspaceId,
-    projectId,
-    { [nextText]: nextTags },
-  );
-  const newSemrushPromptId = Array.isArray(resp?.ids) && resp.ids.length > 0
-    ? String(resp.ids[0]) : '';
+  const newSemrushPromptId = await createOnePrompt(transport, workspaceId, projectId, {
+    text: nextText, tags: nextTags, tagIds: nextTagIds,
+  });
 
   invalidateTagCacheForProject(workspaceId, projectId);
 
@@ -295,6 +282,7 @@ export async function handleUpdatePromptSubworkspace(
       languageCode,
       text: nextText,
       tags: nextTags,
+      ...(nextTagIds !== undefined ? { tagIds: nextTagIds } : {}),
     },
   };
 }

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -266,9 +266,24 @@ export async function handleUpdatePromptSubworkspace(
     throw e;
   }
 
-  const newSemrushPromptId = await createOnePrompt(transport, workspaceId, projectId, {
-    text: nextText, tags: nextTags, tagIds: nextTagIds,
-  });
+  let newSemrushPromptId;
+  try {
+    newSemrushPromptId = await createOnePrompt(transport, workspaceId, projectId, {
+      text: nextText, tags: nextTags, tagIds: nextTagIds,
+    });
+  } catch (e) {
+    // The DELETE above already succeeded, so the old prompt is gone upstream —
+    // a failure here (e.g. an unresolvable tagId 500ing the atomic id-based
+    // create) is a genuine data-loss event, not a retryable no-op. Log it
+    // distinctly from the pre-delete failure above so on-call can tell "nothing
+    // happened" apart from "the prompt is gone and must be recreated manually".
+    log?.error?.('handleUpdatePromptSubworkspace: createOnePrompt failed AFTER a successful delete; the prompt is now lost upstream and must be recreated manually', {
+      projectId,
+      semrushPromptId,
+      error: e.message,
+    });
+    throw e;
+  }
 
   invalidateTagCacheForProject(workspaceId, projectId);
 

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -184,6 +184,16 @@ export async function publishAffected(transport, semrushWorkspaceId, projectIds,
   return errors;
 }
 
+/**
+ * Normalizes one bulk-create/update prompt input. `tags` (names, the legacy
+ * write path via `aio/prompts/tagged`) and `tagIds` (upstream tag ids, the
+ * id-based write path via `aio/prompts`) are MUTUALLY EXCLUSIVE — at most one
+ * may be present, and `tagIds` when present must be non-empty. `tagIds` stays
+ * `undefined` when absent so the handler can branch on
+ * `input.tagIds !== undefined` to pick the write path; `tags` always
+ * defaults to `[]` (unused, not `undefined`) to keep the name-based path's
+ * existing contract unchanged.
+ */
 export function normalizePromptInput(input) {
   const text = String(input?.text || '').trim();
   const languageCode = normalizeLanguageCode(input?.languageCode);
@@ -191,11 +201,106 @@ export function normalizePromptInput(input) {
   const tags = Array.isArray(input?.tags)
     ? input.tags.map((t) => String(t || '').trim()).filter(Boolean)
     : [];
+  const tagIds = Array.isArray(input?.tagIds)
+    ? input.tagIds.map((t) => String(t || '').trim()).filter(Boolean)
+    : undefined;
   if (!text || languageCode === null || geoTargetId === null) {
     return null;
   }
+  if (tagIds !== undefined && (tags.length > 0 || tagIds.length === 0)) {
+    return null;
+  }
   return {
-    text, languageCode, geoTargetId, tags,
+    text, languageCode, geoTargetId, tags, tagIds,
+  };
+}
+
+/**
+ * Creates ONE prompt via whichever upstream write path `input` requests --
+ * id-based (`POST aio/prompts`, when `input.tagIds` is set -- serenity-docs#24)
+ * or the legacy name-based path (`POST aio/prompts/tagged`, when `input.tags`
+ * is used). Both {@link handleCreatePrompts}'s per-item fan-out and
+ * {@link handleUpdatePrompt}'s post-delete recreate call this, so the two
+ * upstream shapes are never duplicated across create and update.
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {string} semrushWorkspaceId
+ * @param {string} projectId
+ * @param {{ text: string, tags: string[], tagIds: string[] | undefined }} input
+ * @returns {Promise<string>} the new upstream prompt id, or '' if the
+ *   response carried none.
+ */
+export async function createOnePrompt(transport, semrushWorkspaceId, projectId, input) {
+  if (input.tagIds !== undefined) {
+    const resp = await transport.createPromptsByIds(
+      semrushWorkspaceId,
+      projectId,
+      [input.text],
+      input.tagIds,
+    );
+    return Array.isArray(resp?.items) && resp.items.length > 0 ? String(resp.items[0].id) : '';
+  }
+  const resp = await transport.createTaggedPrompts(
+    semrushWorkspaceId,
+    projectId,
+    { [input.text]: input.tags },
+  );
+  return Array.isArray(resp?.ids) && resp.ids.length > 0 ? String(resp.ids[0]) : '';
+}
+
+/**
+ * Validates + normalizes a PATCH prompt body's `text`/`tags`/`tagIds`, shared
+ * by {@link handleUpdatePrompt} and its subworkspace twin. `tags` (names) and
+ * `tagIds` (upstream ids) are mutually exclusive, mirroring
+ * {@link normalizePromptInput}; exactly one must be present. Returns either
+ * `{ ok: true, text, tags, tagIds }` or `{ ok: false, status, body }` (the
+ * caller returns the latter directly as the handler's 400 response).
+ *
+ * @param {object} body - the PATCH request body.
+ * @returns {{ ok: true, text: string, tags: string[], tagIds: string[] | undefined }
+ *   | { ok: false, status: number, body: object }}
+ */
+export function parseUpdatePromptBody(body) {
+  const hasTagsField = body?.tags !== undefined;
+  const hasTagIdsField = body?.tagIds !== undefined;
+  if (!body || body.text === undefined || (!hasTagsField && !hasTagIdsField)) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: 'missingFields',
+        message: 'PATCH body must include text and either tags or tagIds',
+      },
+    };
+  }
+  if (hasTagsField && hasTagIdsField) {
+    return {
+      ok: false,
+      status: 400,
+      body: { error: 'invalidRequest', message: 'tags and tagIds are mutually exclusive' },
+    };
+  }
+  const text = String(body.text);
+  if (hasTagIdsField) {
+    const tagIds = Array.isArray(body.tagIds)
+      ? body.tagIds.map((t) => String(t || '').trim()).filter(Boolean)
+      : [];
+    if (tagIds.length === 0) {
+      return {
+        ok: false,
+        status: 400,
+        body: { error: 'invalidRequest', message: 'tagIds must be a non-empty array' },
+      };
+    }
+    return {
+      ok: true, text, tags: [], tagIds,
+    };
+  }
+  const tags = Array.isArray(body.tags)
+    ? body.tags.map((t) => String(t || '').trim()).filter(Boolean)
+    : [];
+  return {
+    ok: true, text, tags, tagIds: undefined,
   };
 }
 
@@ -272,13 +377,12 @@ export async function handleCreatePrompts(
     }
     const projectId = project.getSemrushProjectId();
     try {
-      const resp = await transport.createTaggedPrompts(
+      const semrushPromptId = await createOnePrompt(
+        transport,
         semrushWorkspaceId,
         projectId,
-        { [input.text]: input.tags },
+        input,
       );
-      const semrushPromptId = Array.isArray(resp?.ids) && resp.ids.length > 0
-        ? String(resp.ids[0]) : '';
       return {
         created: {
           semrushPromptId,
@@ -286,6 +390,7 @@ export async function handleCreatePrompts(
           languageCode: input.languageCode,
           text: input.text,
           tags: input.tags,
+          ...(input.tagIds !== undefined ? { tagIds: input.tagIds } : {}),
         },
         affectedProjectId: projectId,
       };
@@ -347,17 +452,20 @@ export async function handleCreatePrompts(
 /**
  * PATCH /serenity/prompts/:semrushPromptId — replace.
  *
- * Body carries `{geoTargetId, languageCode, text, tags}`. All four are
- * required: the upstream provider has no in-place update (no GET-by-id
- * either), so the implementation is DELETE-then-CREATE and we treat the
- * payload as the full next state. Clients always have the existing
- * `text`/`tags` available locally (they were returned by the preceding
- * list call that rendered the edit form), so requiring both keeps the
- * server side a single straight line and removes the per-request
- * pagination that "preserve-on-omit" semantics would force.
+ * Body carries `{geoTargetId, languageCode, text, tags}` (name-based) or
+ * `{geoTargetId, languageCode, text, tagIds}` (id-based, mutually exclusive
+ * with `tags` -- see {@link parseUpdatePromptBody}). All are required: the
+ * upstream provider has no in-place update (no GET-by-id either), so the
+ * implementation is DELETE-then-CREATE and we treat the payload as the full
+ * next state. Clients always have the existing text/tags(-ids) available
+ * locally (they were returned by the preceding list call that rendered the
+ * edit form), so requiring both keeps the server side a single straight line
+ * and removes the per-request pagination that "preserve-on-omit" semantics
+ * would force.
  *
  * Contract:
- *   - body missing text or tags → 400 (missingFields).
+ *   - body missing text, or missing both tags and tagIds, or both present
+ *     → 400 (missingFields / invalidRequest).
  *   - slice missing on the brand → 404 (marketNotFound).
  *   - upstream DELETE returns 404 → 404 (promptNotFound).
  *   - upstream DELETE returns any other error → throw (handler-level
@@ -382,12 +490,11 @@ export async function handleUpdatePrompt(
   // `semrushPromptId` is validated as non-empty at the controller boundary
   // (serenity.js:259) before this handler is invoked over HTTP, so no
   // re-check here.
-  if (!body || body.text === undefined || body.tags === undefined) {
-    return {
-      status: 400,
-      body: { error: 'missingFields', message: 'PATCH body must include both text and tags' },
-    };
+  const parsedBody = parseUpdatePromptBody(body);
+  if (!parsedBody.ok) {
+    return { status: parsedBody.status, body: parsedBody.body };
   }
+  const { text: nextText, tags: nextTags, tagIds: nextTagIds } = parsedBody;
   const geoTargetId = normalizeGeoTargetId(Number(body.geoTargetId));
   const languageCode = normalizeLanguageCode(body.languageCode);
   if (geoTargetId === null || languageCode === null) {
@@ -416,11 +523,6 @@ export async function handleUpdatePrompt(
   }
   const projectId = project.getSemrushProjectId();
 
-  const nextText = String(body.text);
-  const nextTags = Array.isArray(body.tags)
-    ? body.tags.map((t) => String(t || '').trim()).filter(Boolean)
-    : [];
-
   try {
     await transport.deletePromptsByIds(semrushWorkspaceId, projectId, [semrushPromptId]);
   } catch (e) {
@@ -441,13 +543,9 @@ export async function handleUpdatePrompt(
     throw e;
   }
 
-  const resp = await transport.createTaggedPrompts(
-    semrushWorkspaceId,
-    projectId,
-    { [nextText]: nextTags },
-  );
-  const newSemrushPromptId = Array.isArray(resp?.ids) && resp.ids.length > 0
-    ? String(resp.ids[0]) : '';
+  const newSemrushPromptId = await createOnePrompt(transport, semrushWorkspaceId, projectId, {
+    text: nextText, tags: nextTags, tagIds: nextTagIds,
+  });
 
   invalidateTagCacheForProject(semrushWorkspaceId, projectId);
 
@@ -461,6 +559,7 @@ export async function handleUpdatePrompt(
       languageCode,
       text: nextText,
       tags: nextTags,
+      ...(nextTagIds !== undefined ? { tagIds: nextTagIds } : {}),
     },
   };
 }

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -17,7 +17,7 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 import { ErrorWithStatusCode } from '../../utils.js';
 import { redactUpstreamMessage } from '../rest-transport.js';
 import { ERROR_CODES, isUpstreamGone } from '../errors.js';
-import { normalizeGeoTargetId, normalizeLanguageCode } from '../validation.js';
+import { normalizeGeoTargetId, normalizeLanguageCode, isValidTagIdFormat } from '../validation.js';
 import { invalidateTagCacheForProject } from './markets.js';
 
 // TWIN FILE: the slice→project orchestration here is paralleled by the
@@ -185,33 +185,66 @@ export async function publishAffected(transport, semrushWorkspaceId, projectIds,
 }
 
 /**
+ * Trims a raw `tagIds` array to strings, drops anything empty or malformed
+ * (see {@link isValidTagIdFormat} -- the same length/control-char bound
+ * `parentId` is held to), and caps the result at {@link MAX_TAG_IDS} -- the
+ * same cap the tagIds *query* filter already enforces above, so a bulk write
+ * can't fan out further than a bulk read is allowed to. Shared by
+ * {@link normalizePromptInput} (create) and {@link parseUpdatePromptBody}
+ * (update) so the two write paths can't silently diverge on what counts as
+ * a valid tag id.
+ *
+ * @param {unknown} raw
+ * @returns {string[]}
+ */
+function sanitizeTagIds(raw) {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((t) => String(t || '').trim())
+    .filter((t) => isValidTagIdFormat(t))
+    .slice(0, MAX_TAG_IDS);
+}
+
+/**
  * Normalizes one bulk-create/update prompt input. `tags` (names, the legacy
  * write path via `aio/prompts/tagged`) and `tagIds` (upstream tag ids, the
  * id-based write path via `aio/prompts`) are MUTUALLY EXCLUSIVE — at most one
- * may be present, and `tagIds` when present must be non-empty. `tagIds` stays
- * `undefined` when absent so the handler can branch on
- * `input.tagIds !== undefined` to pick the write path; `tags` always
- * defaults to `[]` (unused, not `undefined`) to keep the name-based path's
- * existing contract unchanged.
+ * of the two BODY KEYS may be present (presence-based, matching
+ * {@link parseUpdatePromptBody}'s PATCH contract so the same input shape is
+ * accepted/rejected identically on create and update), and `tagIds` when
+ * present must resolve to a non-empty array. `tagIds` stays `undefined` when
+ * absent so the handler can branch on `input.tagIds !== undefined` to pick
+ * the write path; `tags` always defaults to `[]` (unused, not `undefined`)
+ * to keep the name-based path's existing contract unchanged.
  */
 export function normalizePromptInput(input) {
   const text = String(input?.text || '').trim();
   const languageCode = normalizeLanguageCode(input?.languageCode);
   const geoTargetId = normalizeGeoTargetId(Number(input?.geoTargetId));
-  const tags = Array.isArray(input?.tags)
-    ? input.tags.map((t) => String(t || '').trim()).filter(Boolean)
-    : [];
-  const tagIds = Array.isArray(input?.tagIds)
-    ? input.tagIds.map((t) => String(t || '').trim()).filter(Boolean)
-    : undefined;
   if (!text || languageCode === null || geoTargetId === null) {
     return null;
   }
-  if (tagIds !== undefined && (tags.length > 0 || tagIds.length === 0)) {
+  const hasTagsField = input?.tags !== undefined;
+  const hasTagIdsField = input?.tagIds !== undefined;
+  if (hasTagsField && hasTagIdsField) {
     return null;
   }
+  if (hasTagIdsField) {
+    const tagIds = sanitizeTagIds(input.tagIds);
+    if (tagIds.length === 0) {
+      return null;
+    }
+    return {
+      text, languageCode, geoTargetId, tags: [], tagIds,
+    };
+  }
+  const tags = Array.isArray(input?.tags)
+    ? input.tags.map((t) => String(t || '').trim()).filter(Boolean)
+    : [];
   return {
-    text, languageCode, geoTargetId, tags, tagIds,
+    text, languageCode, geoTargetId, tags, tagIds: undefined,
   };
 }
 
@@ -282,9 +315,7 @@ export function parseUpdatePromptBody(body) {
   }
   const text = String(body.text);
   if (hasTagIdsField) {
-    const tagIds = Array.isArray(body.tagIds)
-      ? body.tagIds.map((t) => String(t || '').trim()).filter(Boolean)
-      : [];
+    const tagIds = sanitizeTagIds(body.tagIds);
     if (tagIds.length === 0) {
       return {
         ok: false,
@@ -543,9 +574,24 @@ export async function handleUpdatePrompt(
     throw e;
   }
 
-  const newSemrushPromptId = await createOnePrompt(transport, semrushWorkspaceId, projectId, {
-    text: nextText, tags: nextTags, tagIds: nextTagIds,
-  });
+  let newSemrushPromptId;
+  try {
+    newSemrushPromptId = await createOnePrompt(transport, semrushWorkspaceId, projectId, {
+      text: nextText, tags: nextTags, tagIds: nextTagIds,
+    });
+  } catch (e) {
+    // The DELETE above already succeeded, so the old prompt is gone upstream —
+    // a failure here (e.g. an unresolvable tagId 500ing the atomic id-based
+    // create) is a genuine data-loss event, not a retryable no-op. Log it
+    // distinctly from the pre-delete failure above so on-call can tell "nothing
+    // happened" apart from "the prompt is gone and must be recreated manually".
+    log?.error?.('handleUpdatePrompt: createOnePrompt failed AFTER a successful delete; the prompt is now lost upstream and must be recreated manually', {
+      projectId,
+      semrushPromptId,
+      error: e.message,
+    });
+    throw e;
+  }
 
   invalidateTagCacheForProject(semrushWorkspaceId, projectId);
 

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -271,7 +271,9 @@ export async function createOnePrompt(transport, semrushWorkspaceId, projectId, 
       [input.text],
       input.tagIds,
     );
-    return Array.isArray(resp?.items) && resp.items.length > 0 ? String(resp.items[0].id) : '';
+    return Array.isArray(resp?.items) && resp.items.length > 0
+      ? String(resp.items[0].id ?? '')
+      : '';
   }
   const resp = await transport.createTaggedPrompts(
     semrushWorkspaceId,

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -16,7 +16,9 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 
 import { ErrorWithStatusCode } from '../../utils.js';
 import { ERROR_CODES } from '../errors.js';
-import { normalizeGeoTargetId, normalizeLanguageCode } from '../validation.js';
+import {
+  normalizeGeoTargetId, normalizeLanguageCode, MAX_TAG_ID_LEN, isValidTagIdFormat,
+} from '../validation.js';
 import { resolveProject } from '../subworkspace-projects.js';
 import {
   tagFor, CREATABLE_TAG_DIMENSIONS, CLOSED_TAG_DIMENSIONS, PROJECT_STANDARD_TAGS,
@@ -42,16 +44,19 @@ import { listProjectTagTree } from './markets.js';
  */
 
 const MAX_TAG_NAME_LEN = 100;
-// Upstream tag ids are opaque (UUIDs in practice); this only bounds an absurd
-// value, not a strict format — the id must round-trip from a prior list.
-const MAX_TAG_ID_LEN = 200;
 // Bounds resolveTagTarget's per-root fan-out for an unresolvable tagId — well
 // above any real project's root-category count, just a ceiling on amplification.
 const MAX_ROOTS_TO_SEARCH = 100;
 
 /**
- * Whitespace/control-char + length validation shared by every parentId parser
+ * Length + whitespace/control-char validation shared by every parentId parser
  * below, given an already-trimmed, already-known-to-be-a-string, non-empty id.
+ * Delegates to isValidTagIdFormat (validation.js) for the character check --
+ * the same bound prompts.js's tagIds array entries are held to -- but keeps
+ * the length and character checks as separate throws so the 400 message
+ * pinpoints which one failed. The length check runs first, so by the time
+ * isValidTagIdFormat is consulted `id.length` is already known to be in
+ * bounds and a `false` result can only mean a whitespace/control character.
  */
 function validateParentIdFormat(id) {
   if (id.length > MAX_TAG_ID_LEN) {
@@ -60,11 +65,7 @@ function validateParentIdFormat(id) {
       400,
     );
   }
-  // Whitespace / control chars can never be a valid upstream id and would corrupt
-  // the request (query value on create, path segment on PATCH). Reject them; leave
-  // the id otherwise opaque (do not assume a strict UUID shape).
-  // eslint-disable-next-line no-control-regex
-  if (/[\s\u0000-\u001F\u007F]/.test(id)) {
+  if (!isValidTagIdFormat(id)) {
     throw new ErrorWithStatusCode(
       'parentId must not contain whitespace or control characters',
       400,
@@ -430,8 +431,7 @@ function requireTagId(tagId) {
   if (id.length > MAX_TAG_ID_LEN) {
     throw new ErrorWithStatusCode(`tagId must not exceed ${MAX_TAG_ID_LEN} characters`, 400);
   }
-  // eslint-disable-next-line no-control-regex
-  if (/[\s\u0000-\u001F\u007F]/.test(id)) {
+  if (!isValidTagIdFormat(id)) {
     throw new ErrorWithStatusCode('tagId must not contain whitespace or control characters', 400);
   }
   return id;

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -18,7 +18,9 @@ import { ErrorWithStatusCode } from '../../utils.js';
 import { ERROR_CODES } from '../errors.js';
 import { normalizeGeoTargetId, normalizeLanguageCode } from '../validation.js';
 import { resolveProject } from '../subworkspace-projects.js';
-import { tagFor, CREATABLE_TAG_DIMENSIONS } from '../prompt-tags.js';
+import {
+  tagFor, CREATABLE_TAG_DIMENSIONS, CLOSED_TAG_DIMENSIONS, PROJECT_STANDARD_TAGS,
+} from '../prompt-tags.js';
 import { listProjectTagTree } from './markets.js';
 
 /**
@@ -48,6 +50,29 @@ const MAX_TAG_ID_LEN = 200;
 const MAX_ROOTS_TO_SEARCH = 100;
 
 /**
+ * Whitespace/control-char + length validation shared by every parentId parser
+ * below, given an already-trimmed, already-known-to-be-a-string, non-empty id.
+ */
+function validateParentIdFormat(id) {
+  if (id.length > MAX_TAG_ID_LEN) {
+    throw new ErrorWithStatusCode(
+      `parentId must not exceed ${MAX_TAG_ID_LEN} characters`,
+      400,
+    );
+  }
+  // Whitespace / control chars can never be a valid upstream id and would corrupt
+  // the request (query value on create, path segment on PATCH). Reject them; leave
+  // the id otherwise opaque (do not assume a strict UUID shape).
+  // eslint-disable-next-line no-control-regex
+  if (/[\s\u0000-\u001F\u007F]/.test(id)) {
+    throw new ErrorWithStatusCode(
+      'parentId must not contain whitespace or control characters',
+      400,
+    );
+  }
+}
+
+/**
  * Validates an optional upstream parent tag id (an `id` from a prior tags list).
  * Returns the trimmed id, or `undefined` when absent/empty — an empty parent is a
  * no-op upstream (a flat/root create), so it is normalized away rather than sent.
@@ -67,44 +92,75 @@ function parseParentId(raw) {
   if (!id) {
     return undefined;
   }
-  if (id.length > MAX_TAG_ID_LEN) {
-    throw new ErrorWithStatusCode(
-      `parentId must not exceed ${MAX_TAG_ID_LEN} characters`,
-      400,
-    );
+  validateParentIdFormat(id);
+  return id;
+}
+
+/**
+ * Validates the UPDATE body's `parentId`, preserving the distinction between
+ * omitted (`undefined` -- leave the current parent alone) and an explicit JSON
+ * `null` (promote a child to root -- serenity-docs#24 section 3.1 gate 1,
+ * verified live 2026-07-02: an explicit `parent_id: null` in the upstream
+ * PATCH body promotes a child; omitting the field entirely does not, and an
+ * empty string is also a live no-op). {@link parseParentId} (used by create)
+ * deliberately collapses omitted/null/empty to "no parent" because create has
+ * no current parent to preserve -- that collapse would be wrong here.
+ *
+ * @param {object} body - the raw request body.
+ * @returns {string | null | undefined}
+ */
+function parseUpdateParentId(body) {
+  if (!body || !Object.prototype.hasOwnProperty.call(body, 'parentId')) {
+    return undefined;
   }
-  // Whitespace / control chars can never be a valid upstream id and would corrupt
-  // the request (query value on create, path segment on PATCH). Reject them; leave
-  // the id otherwise opaque (do not assume a strict UUID shape).
-  // eslint-disable-next-line no-control-regex
-  if (/[\s\u0000-\u001F\u007F]/.test(id)) {
-    throw new ErrorWithStatusCode(
-      'parentId must not contain whitespace or control characters',
-      400,
-    );
+  const raw = body.parentId;
+  if (raw === null) {
+    return null;
   }
+  if (typeof raw !== 'string') {
+    throw new ErrorWithStatusCode('parentId must be a string or null', 400);
+  }
+  const id = raw.trim();
+  if (!id) {
+    // An explicit empty string carries no live-verified meaning of its own
+    // (gate 1: it's a no-op, distinct from `null`) -- treat it as omission.
+    return undefined;
+  }
+  validateParentIdFormat(id);
   return id;
 }
 
 /**
  * Validates + normalizes the create-tag body, throwing a 400
  * {@link ErrorWithStatusCode} on the first problem. Returns the parsed
- * `{ type, name, geoTargetId, languageCode, parentId }`. `parentId` (optional) is
- * an upstream tag id under which the new tag is nested (1-level category tree).
+ * `{ type, name, geoTargetId, languageCode, parentId, isClosed }`. `parentId`
+ * (optional) is an upstream tag id under which the new tag is nested (1-level
+ * category tree) -- only legal for an OPEN dimension. `isClosed` is true when
+ * `type` is one of {@link CLOSED_TAG_DIMENSIONS} (`source`/`intent`/`type`):
+ * the `name` must then be one of that dimension's fixed enum values (checked
+ * against {@link PROJECT_STANDARD_TAGS}) and no `parentId` may be present --
+ * closed-dimension tags are always roots. The handler resolves-or-creates a
+ * closed-dimension tag (idempotent) rather than blind-creating it (see
+ * {@link handleCreateTag}) since it is a small, project-wide-shared set of
+ * values every caller may need the id of, unlike an OPEN dimension's
+ * customer-authored, resolve-before-create-by-the-caller names (gate 7).
  *
  * @param {object} body - request body.
  * @returns {{
  *   type: string, name: string, geoTargetId: number,
- *   languageCode: string, parentId: string | undefined,
+ *   languageCode: string, parentId: string | undefined, isClosed: boolean,
  * }}
  */
 function parseCreateTagBody(body) {
   const type = hasText(body?.type) ? String(body.type).trim().toLowerCase() : '';
-  // CREATABLE_TAG_DIMENSIONS is a frozen literal tuple; widen to string[] so
-  // `.includes(type)` accepts an arbitrary runtime string for the membership test.
-  if (!(/** @type {readonly string[]} */ (CREATABLE_TAG_DIMENSIONS)).includes(type)) {
+  // Both tuples are frozen literal tuples; widen to string[] so `.includes(type)`
+  // accepts an arbitrary runtime string for the membership test.
+  const openDimensions = /** @type {readonly string[]} */ (CREATABLE_TAG_DIMENSIONS);
+  const closedDimensions = /** @type {readonly string[]} */ (CLOSED_TAG_DIMENSIONS);
+  const isClosed = closedDimensions.includes(type);
+  if (!isClosed && !openDimensions.includes(type)) {
     throw new ErrorWithStatusCode(
-      `type must be one of: ${CREATABLE_TAG_DIMENSIONS.join(', ')}`,
+      `type must be one of: ${[...CREATABLE_TAG_DIMENSIONS, ...CLOSED_TAG_DIMENSIONS].join(', ')}`,
       400,
     );
   }
@@ -132,6 +188,13 @@ function parseCreateTagBody(body) {
   if (/[\u0000-\u001F\u007F]/.test(rawName)) {
     throw new ErrorWithStatusCode('name must not contain control characters', 400);
   }
+  if (isClosed
+    && !(/** @type {readonly string[]} */ (PROJECT_STANDARD_TAGS)).includes(`${type}:${rawName}`)) {
+    throw new ErrorWithStatusCode(
+      `name is not a valid ${type} value`,
+      400,
+    );
+  }
   const geoTargetId = normalizeGeoTargetId(Number(body?.geoTargetId));
   if (geoTargetId === null) {
     throw new ErrorWithStatusCode('geoTargetId must be a positive integer', 400);
@@ -144,8 +207,14 @@ function parseCreateTagBody(body) {
     );
   }
   const parentId = parseParentId(body?.parentId);
+  if (isClosed && parentId !== undefined) {
+    throw new ErrorWithStatusCode(
+      `parentId is not allowed for a closed dimension (${CLOSED_TAG_DIMENSIONS.join(', ')})`,
+      400,
+    );
+  }
   return {
-    type, name: rawName, geoTargetId, languageCode, parentId,
+    type, name: rawName, geoTargetId, languageCode, parentId, isClosed,
   };
 }
 
@@ -157,7 +226,7 @@ function parseCreateTagBody(body) {
  * if the upstream omits it), or null.
  *
  * @param {any} result - transport result (array for create, object for update).
- * @param {string | undefined} requestedParentId
+ * @param {string | null | undefined} requestedParentId
  * @returns {{ id: string | undefined, parentId: string | null }}
  */
 function pickTagIds(result, requestedParentId) {
@@ -177,6 +246,34 @@ function marketNotFound() {
   );
   err.code = ERROR_CODES.MARKET_NOT_FOUND;
   return err;
+}
+
+/**
+ * Resolves a closed-dimension tag's upstream id, creating it only if the
+ * project doesn't already have it. Unlike an OPEN-dimension create (gate 7:
+ * a duplicate name is a hard 500, resolve-before-create is the CALLER's job),
+ * a closed-dimension tag is a small, fixed, project-wide-shared value that
+ * many independent callers legitimately need the id of -- so the proxy itself
+ * does the resolve-before-create, making POST /serenity/tags idempotent for
+ * these specific values. Searches the ROOTS level only (closed dims are never
+ * nested).
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {string} semrushWorkspaceId
+ * @param {string} projectId
+ * @param {string} tag - the full `<dimension>:<value>` wire name.
+ * @param {object} [log] - logger.
+ * @returns {Promise<{ id: string | undefined, created: boolean }>}
+ */
+async function resolveOrCreateClosedTag(transport, semrushWorkspaceId, projectId, tag, log) {
+  const roots = await listProjectTagTree(transport, semrushWorkspaceId, projectId, '', log);
+  const existing = roots.items.find((t) => t.name === tag);
+  if (existing) {
+    return { id: existing.id, created: false };
+  }
+  const createdList = await transport.createProjectTags(semrushWorkspaceId, projectId, [tag]);
+  const { id } = pickTagIds(createdList, undefined);
+  return { id, created: true };
 }
 
 /**
@@ -200,7 +297,7 @@ export async function handleCreateTag(
   log,
 ) {
   const {
-    type, name, geoTargetId, languageCode, parentId,
+    type, name, geoTargetId, languageCode, parentId, isClosed,
   } = parseCreateTagBody(body);
   const row = await dataAccess.BrandSemrushProject.findBySlice(
     brandId,
@@ -210,23 +307,45 @@ export async function handleCreateTag(
   if (!row) {
     throw marketNotFound();
   }
+  const projectId = row.getSemrushProjectId();
+  const tag = tagFor(type, name);
+
+  if (isClosed) {
+    const { id, created } = await resolveOrCreateClosedTag(
+      transport,
+      semrushWorkspaceId,
+      projectId,
+      tag,
+      log,
+    );
+    log?.info?.('handleCreateTag: resolved closed-dimension tag', {
+      brandId, geoTargetId, languageCode, tag, created,
+    });
+    return {
+      status: 200,
+      body: {
+        brandId, geoTargetId, languageCode, type, name, tag, id, parentId: null, created,
+      },
+    };
+  }
+
   // A nested child is created BARE (no dimension prefix) — only a root gets the
   // `<dimension>:<value>` name. See issue 21 §1 / serenity-docs#24 §2.
-  const tag = parentId ? name : tagFor(type, name);
+  const openTag = parentId ? name : tag;
   const created = await transport.createProjectTags(
     semrushWorkspaceId,
-    row.getSemrushProjectId(),
-    [tag],
+    projectId,
+    [openTag],
     { parentId },
   );
   const { id, parentId: createdParentId } = pickTagIds(created, parentId);
   log?.info?.('handleCreateTag: registered tag', {
-    brandId, geoTargetId, languageCode, tag, parentId,
+    brandId, geoTargetId, languageCode, tag: openTag, parentId,
   });
   return {
     status: 201,
     body: {
-      brandId, geoTargetId, languageCode, type, name, tag, id, parentId: createdParentId,
+      brandId, geoTargetId, languageCode, type, name, tag: openTag, id, parentId: createdParentId,
     },
   };
 }
@@ -248,29 +367,51 @@ export async function handleCreateTagSubworkspace(
   log,
 ) {
   const {
-    type, name, geoTargetId, languageCode, parentId,
+    type, name, geoTargetId, languageCode, parentId, isClosed,
   } = parseCreateTagBody(body);
   const project = await resolveProject(transport, workspaceId, geoTargetId, languageCode, log);
   if (!project) {
     throw marketNotFound();
   }
+  const projectId = String(project.id);
+  const tag = tagFor(type, name);
+
+  if (isClosed) {
+    const { id, created } = await resolveOrCreateClosedTag(
+      transport,
+      workspaceId,
+      projectId,
+      tag,
+      log,
+    );
+    log?.info?.('handleCreateTagSubworkspace: resolved closed-dimension tag', {
+      geoTargetId, languageCode, tag, created,
+    });
+    return {
+      status: 200,
+      body: {
+        geoTargetId, languageCode, type, name, tag, id, parentId: null, created,
+      },
+    };
+  }
+
   // A nested child is created BARE (no dimension prefix) — only a root gets the
   // `<dimension>:<value>` name. See issue 21 §1 / serenity-docs#24 §2.
-  const tag = parentId ? name : tagFor(type, name);
+  const openTag = parentId ? name : tag;
   const created = await transport.createProjectTags(
     workspaceId,
-    String(project.id),
-    [tag],
+    projectId,
+    [openTag],
     { parentId },
   );
   const { id, parentId: createdParentId } = pickTagIds(created, parentId);
   log?.info?.('handleCreateTagSubworkspace: registered tag', {
-    geoTargetId, languageCode, tag, parentId,
+    geoTargetId, languageCode, tag: openTag, parentId,
   });
   return {
     status: 201,
     body: {
-      geoTargetId, languageCode, type, name, tag, id, parentId: createdParentId,
+      geoTargetId, languageCode, type, name, tag: openTag, id, parentId: createdParentId,
     },
   };
 }
@@ -307,7 +448,7 @@ function requireTagId(tagId) {
  * @param {object} body - request body ({ name, parentId?, geoTargetId, languageCode }).
  * @returns {{
  *   dimension: string, value: string, hasDimensionPrefix: boolean,
- *   parentId: string | undefined, geoTargetId: number, languageCode: string,
+ *   parentId: string | null | undefined, geoTargetId: number, languageCode: string,
  * }}
  */
 function parseUpdateTagBody(body) {
@@ -337,7 +478,7 @@ function parseUpdateTagBody(body) {
   if (/[\u0000-\u001F\u007F]/.test(value)) {
     throw new ErrorWithStatusCode('name must not contain control characters', 400);
   }
-  const parentId = parseParentId(body?.parentId);
+  const parentId = parseUpdateParentId(body);
   const geoTargetId = normalizeGeoTargetId(Number(body?.geoTargetId));
   if (geoTargetId === null) {
     throw new ErrorWithStatusCode('geoTargetId must be a positive integer', 400);
@@ -415,18 +556,19 @@ async function resolveTagTarget(transport, semrushWorkspaceId, projectId, tagId,
  * {@link CREATABLE_TAG_DIMENSIONS}, unchanged); a child takes a bare name
  * (no dimension prefix -- mirrors {@link handleCreateTag}'s create-side rule)
  * and ALWAYS gets an explicit `parentId` in the outgoing PATCH: the caller's
- * requested `parentId` when re-parenting, otherwise the child's own CURRENT
- * parent so a rename-only PATCH never omits it (gate 5). An unresolvable
- * (`unknown`) target falls back to the pre-existing full-name requirement and
- * an omitted `parentId` -- the upstream 404 on the `tag_id` path segment is
- * what actually catches a genuinely unknown id, not this validation.
+ * requested `parentId` when re-parenting, explicit `null` when PROMOTING to
+ * root (gate 1), otherwise the child's own CURRENT parent so a rename-only
+ * PATCH never omits it (gate 5). An unresolvable (`unknown`) target falls
+ * back to the pre-existing full-name requirement and an omitted `parentId` --
+ * the upstream 404 on the `tag_id` path segment is what actually catches a
+ * genuinely unknown id, not this validation.
  *
  * @param {{
  *   hasDimensionPrefix: boolean, dimension: string, value: string,
- *   parentId: string | undefined,
+ *   parentId: string | null | undefined,
  * }} parsed
  * @param {{ kind: 'root' | 'child' | 'unknown', parentId: string | null }} target
- * @returns {{ tag: string, parentIdToSend: string | undefined }}
+ * @returns {{ tag: string, parentIdToSend: string | null | undefined }}
  */
 function buildUpdatePayload(parsed, target) {
   const {
@@ -438,7 +580,9 @@ function buildUpdatePayload(parsed, target) {
     }
     // target.parentId is never null here: resolveTagTarget's child branch always
     // resolves it (falling back to the child's own root id), so no `?? undefined`
-    // is needed the way the root/unknown branch below needs one.
+    // is needed the way the root/unknown branch below needs one. `parentId` is
+    // either a re-parent target string, explicit `null` (promote-to-root, gate
+    // 1), or `undefined` (omitted -- fall back to the current parent, gate 5).
     return {
       tag: value,
       parentIdToSend: parentId !== undefined ? parentId : /** @type {string} */ (target.parentId),
@@ -453,7 +597,10 @@ function buildUpdatePayload(parsed, target) {
       400,
     );
   }
-  return { tag: `${dimension}:${value}`, parentIdToSend: parentId };
+  // A root has no parent to remove, so an explicit `null` (promote-to-root) is
+  // a no-op here -- not live-verified against a root specifically, so it is
+  // defensively collapsed to omission rather than forwarded.
+  return { tag: `${dimension}:${value}`, parentIdToSend: parentId ?? undefined };
 }
 
 /**

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -267,7 +267,17 @@ function marketNotFound() {
  * @returns {Promise<{ id: string | undefined, created: boolean }>}
  */
 async function resolveOrCreateClosedTag(transport, semrushWorkspaceId, projectId, tag, log) {
-  const roots = await listProjectTagTree(transport, semrushWorkspaceId, projectId, '', log);
+  // Closed tags are seeded at project creation and will almost always be on
+  // page 1; stop paginating as soon as a match is found instead of always
+  // walking the full root tag list.
+  const roots = await listProjectTagTree(
+    transport,
+    semrushWorkspaceId,
+    projectId,
+    '',
+    log,
+    (t) => t.name === tag,
+  );
   const existing = roots.items.find((t) => t.name === tag);
   if (existing) {
     return { id: existing.id, created: false };

--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -83,6 +83,22 @@ export const CREATABLE_TAG_DIMENSIONS = Object.freeze([
   TAG_DIMENSION.TOPIC,
 ]);
 
+/**
+ * The closed dimensions — `source` / `intent` / `type` — whose values are a
+ * fixed enum ({@link PROJECT_STANDARD_TAGS}), never customer-authored. A
+ * caller may still "create" one of these (POST /serenity/tags) to learn its
+ * upstream id, but ONLY a value already in the enum, and the create is
+ * resolve-before-create/idempotent (unlike {@link CREATABLE_TAG_DIMENSIONS}'s
+ * open dimensions, where a duplicate name is a hard upstream 500 by design —
+ * see serenity-docs#24 §3.1 gate 7). Closed-dimension tags are always roots;
+ * `parentId` is rejected for them.
+ */
+export const CLOSED_TAG_DIMENSIONS = Object.freeze([
+  TAG_DIMENSION.SOURCE,
+  TAG_DIMENSION.INTENT,
+  TAG_DIMENSION.TYPE,
+]);
+
 // Tags applied to EVERY AI-generated prompt on top of its `topic:<NAME>` tag:
 // `source:ai` (AI-authored) plus the default `intent:Informational` (the most
 // common intent for brand-topic prompts; re-classification can refine it

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -335,6 +335,61 @@ export function createSerenityTransport({ env, imsToken }) {
     },
 
     /**
+     * POST /v2/.../aio/prompts — bulk-creates prompts by ID-BASED tag
+     * references (as opposed to {@link createTaggedPrompts}'s name-keyed
+     * shape). Body: { items: [text, ...], tag_ids: [id, ...] } — ONE shared
+     * `tag_ids` array applies to every text in `items` (unlike the name-based
+     * endpoint, there is no per-prompt tag list on this call).
+     *
+     * Response is a paginated LIST WRAPPER — `{ page, total, items: [{id,
+     * name}, ...], existing_count }` — NOT the vendored public swagger's
+     * single `model.StringIDName` (a known spec/live drift, verified live
+     * 2026-07-02). ATOMIC on an unresolvable tag id: live 500s and creates
+     * NOTHING, so every id in `tagIds` must already be a known-good upstream
+     * tag id (resolved/created by the caller first, never guessed).
+     * Text-dedupe mirrors `createTaggedPrompts`: a text already present is
+     * folded into `existing_count`, not re-created.
+     *
+     * @param {string} semrushWorkspaceId
+     * @param {string} projectId
+     * @param {string[]} items - prompt texts.
+     * @param {string[]} tagIds - upstream tag ids attached to EVERY item.
+     */
+    async createPromptsByIds(semrushWorkspaceId, projectId, items, tagIds) {
+      return unwrap('POST', await projects.POST(
+        '/v2/workspaces/{id}/projects/{project_id}/aio/prompts',
+        {
+          params: { path: { id: semrushWorkspaceId, project_id: projectId } },
+          body: { items, tag_ids: tagIds },
+        },
+      ));
+    },
+
+    /**
+     * PUT /v2/.../aio/prompts/tags — batch-updates a prompt's tag
+     * REFERENCES (not its text). Body: { items: [{ id, references, replace
+     * }, ...] } (id = existing prompt id, references = tag ids). Per item:
+     * `replace: false` MERGES `references` onto the prompt's existing tag
+     * set; `replace: true` REPLACES the set with exactly `references`. An
+     * unknown prompt `id` is skipped SILENTLY — live 204s with no "not
+     * found" signal, so this call alone cannot confirm a prompt exists.
+     * Response: 204 No Content (`unwrap` resolves to `null`).
+     *
+     * @param {string} semrushWorkspaceId
+     * @param {string} projectId
+     * @param {Array<{ id: string, references: string[], replace: boolean }>} items
+     */
+    async updatePromptTags(semrushWorkspaceId, projectId, items) {
+      return unwrap('PUT', await projects.PUT(
+        '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags',
+        {
+          params: { path: { id: semrushWorkspaceId, project_id: projectId } },
+          body: { items },
+        },
+      ));
+    },
+
+    /**
      * DELETE /v2/.../aio/prompts — deletes prompts by their Semrush ids in
      * this project. Body shape: { ids: [...] }.
      */
@@ -481,30 +536,38 @@ export function createSerenityTransport({ env, imsToken }) {
      * updated tag (200); an unknown `tagId` returns 404 `{message:'not found'}`
      * (both verified live 2026-07-01).
      *
-     * `name` is required by the upstream contract; `parentId` re-parents when
-     * non-empty. NOTE: an empty-string `parent_id` is a live NO-OP (does NOT
-     * promote a child to root — 200 but parent unchanged), so it is only sent
-     * when non-empty; promote-to-root is not supported upstream.
+     * `name` is required by the upstream contract. `parentId` has three
+     * meanings, all live-verified 2026-07-02 (serenity-docs#24 §3.1 gate 1):
+     * a non-empty string RE-PARENTS; explicit `null` PROMOTES a child to root
+     * (sent upstream as literal JSON `null`); `undefined` (or an empty string)
+     * OMITS `parent_id` from the body entirely, a no-op that preserves the
+     * current parent. Explicit `null` and omission are NOT interchangeable —
+     * only the former promotes.
      *
      * @param {string} semrushWorkspaceId
      * @param {string} projectId
      * @param {string} tagId - upstream tag id to update.
      * @param {object} update
      * @param {string} update.name - the tag's (possibly renamed) full name.
-     * @param {string} [update.parentId] - new parent tag id (non-empty re-parents).
+     * @param {string | null} [update.parentId] - re-parent target, `null` to
+     *   promote to root, or omit to leave the current parent unchanged.
      */
     async updateProjectTag(semrushWorkspaceId, projectId, tagId, { name, parentId }) {
+      const body = { name };
+      if (parentId === null) {
+        body.parent_id = null;
+      } else if (typeof parentId === 'string' && parentId !== '') {
+        body.parent_id = parentId;
+      }
+      // parentId undefined or '' → parent_id omitted from body (no-op, preserves
+      // the current parent).
       return unwrap('PATCH', await projects.PATCH(
         '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}',
         {
           params: {
             path: { id: semrushWorkspaceId, project_id: projectId, tag_id: tagId },
           },
-          // Send parent_id only when re-parenting — empty is a live no-op. (typeof
-          // narrows `string | undefined` → `string`; hasText does not, per ADR-005.)
-          body: typeof parentId === 'string' && parentId !== ''
-            ? { name, parent_id: parentId }
-            : { name },
+          body,
         },
       ));
     },

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -366,30 +366,6 @@ export function createSerenityTransport({ env, imsToken }) {
     },
 
     /**
-     * PUT /v2/.../aio/prompts/tags — batch-updates a prompt's tag
-     * REFERENCES (not its text). Body: { items: [{ id, references, replace
-     * }, ...] } (id = existing prompt id, references = tag ids). Per item:
-     * `replace: false` MERGES `references` onto the prompt's existing tag
-     * set; `replace: true` REPLACES the set with exactly `references`. An
-     * unknown prompt `id` is skipped SILENTLY — live 204s with no "not
-     * found" signal, so this call alone cannot confirm a prompt exists.
-     * Response: 204 No Content (`unwrap` resolves to `null`).
-     *
-     * @param {string} semrushWorkspaceId
-     * @param {string} projectId
-     * @param {Array<{ id: string, references: string[], replace: boolean }>} items
-     */
-    async updatePromptTags(semrushWorkspaceId, projectId, items) {
-      return unwrap('PUT', await projects.PUT(
-        '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags',
-        {
-          params: { path: { id: semrushWorkspaceId, project_id: projectId } },
-          body: { items },
-        },
-      ));
-    },
-
-    /**
      * DELETE /v2/.../aio/prompts — deletes prompts by their Semrush ids in
      * this project. Body shape: { ids: [...] }.
      */

--- a/src/support/serenity/validation.js
+++ b/src/support/serenity/validation.js
@@ -46,3 +46,36 @@ export function normalizeLanguageCode(value) {
 export function normalizeGeoTargetId(value) {
   return Number.isInteger(value) && value > 0 ? value : null;
 }
+
+// Upstream tag ids are opaque (UUIDs in practice); this only bounds an absurd
+// value, not a strict format — the id must round-trip from a prior list.
+export const MAX_TAG_ID_LEN = 200;
+
+// C0 control range end + DEL, checked by numeric char code (not a regex
+// escape range) so the bound in this source file stays unambiguous.
+const MAX_C0_CONTROL_CODE = 31;
+const DEL_CONTROL_CODE = 127;
+const WHITESPACE_REGEX = /\s/;
+
+/**
+ * True if `id` is a well-formed opaque upstream tag id: non-empty, bounded
+ * length, and free of whitespace/control characters that would corrupt a
+ * query value or path segment. Shared by every call site that accepts a
+ * caller-supplied upstream tag id (tags.js's parentId/tagId, prompts.js's
+ * tagIds array entries) so the bound can't silently diverge between them.
+ *
+ * @param {string} id - an already-trimmed, already-known-to-be-a-string id.
+ */
+export function isValidTagIdFormat(id) {
+  if (id.length === 0 || id.length > MAX_TAG_ID_LEN) {
+    return false;
+  }
+  for (let i = 0; i < id.length; i += 1) {
+    const ch = id[i];
+    const code = id.charCodeAt(i);
+    if (code <= MAX_C0_CONTROL_CODE || code === DEL_CONTROL_CODE || WHITESPACE_REGEX.test(ch)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -236,9 +236,9 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
       expect(res.body.error).to.equal('invalidRequest');
     });
 
-    it('POST /serenity/tags 400s when type is not a creatable dimension', async () => {
+    it('POST /serenity/tags 400s when type is not a recognized open or closed dimension', async () => {
       const res = await getHttpClient().admin.post(`${base}/tags`, {
-        type: 'intent', name: 'Whatever', geoTargetId: 2840, languageCode: 'en',
+        type: 'bogus', name: 'Whatever', geoTargetId: 2840, languageCode: 'en',
       });
       expect(res.status).to.equal(400);
       expect(res.body.message).to.match(/type must be one of/i);

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -307,14 +307,11 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
     // 1-level nested category tags (needs PE mock >= 1.6.0 — adobe/spacecat-shared#1758,
     // which models parent_id on create, the tree-aware GET, and PATCH re-parent).
     //
-    // MOCK-FIDELITY NOTE: the mock derives a tag id from its name
-    // (`tag-<encodeURIComponent(name)>`), so a `category:*` tag's id embeds a literal `%3A`. That
-    // id round-trips faithfully through a JSON body (so nested CREATE and the derived childrenCount
-    // below ARE exercised end-to-end against the mock), but NOT through a URL query/path (the `%3A`
-    // decodes back to `:` and no longer matches the stored id). So drilling a parent's children by
-    // id, and a successful PATCH-by-id, cannot be asserted against this mock. Those id-in-URL paths
-    // are validated against LIVE Semrush instead — opaque UUID ids, probed 2026-07-01 (see the
-    // rest-transport / tags handler JSDoc). Real callers use UUID ids, so this gap is mock-only.
+    // The mock derives a tag id as an opaque `tag-<sha256(name) prefix>` (spacecat-shared#1760 /
+    // adobe/spacecat-shared#1764) — URL-safe, so it round-trips through both a JSON body AND a URL
+    // query/path segment. Drilling a parent's children by id and a full PATCH-by-id round trip are
+    // therefore exercised end-to-end against the mock below (previously only testable against live
+    // Semrush, per the WP0 probe — see rest-transport / tags handler JSDoc).
     const createTag = (name, parentId) => getHttpClient().admin.post(`${base}/tags`, {
       type: 'category',
       name,
@@ -348,20 +345,113 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
       expect(parentRow, 'the parent should list among the roots').to.exist;
       expect(parentRow.parentId).to.equal(null);
       expect(parentRow.childrenCount).to.be.greaterThan(0);
+
+      // Drill the parent's CHILDREN by id (parentId=<parent's upstream id>) — round-trips through
+      // the URL query value now that tag ids are URL-safe (spacecat-shared#1760).
+      const children = await getHttpClient().admin.get(
+        `${base}/tags?geoTargetId=${US_GEO}&languageCode=en&parentId=${parentId}`,
+      );
+      expect(children.status).to.equal(200);
+      expect(children.body.items.map((t) => t.id)).to.include(child.body.id);
+      expect(children.body.items.find((t) => t.id === child.body.id).parentId).to.equal(parentId);
+    });
+
+    it('PATCH /serenity/tags/:tagId renames a child by id (URL-safe id round-trips through the path)', async () => {
+      await createUsMarket();
+      const parent = await createTag('Footwear');
+      const child = await createTag('Sneakers', parent.body.id);
+      const childId = child.body.id;
+
+      // Rename-only: parentId omitted — the proxy must re-send the child's current parent itself
+      // (gate 5) so the child stays nested, not promoted to root.
+      const renamed = await getHttpClient().admin.patch(`${base}/tags/${childId}`, {
+        name: 'Boots', geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(renamed.status).to.equal(200);
+      expect(renamed.body.tag).to.equal('Boots');
+      expect(renamed.body.parentId).to.equal(parent.body.id);
+
+      // Promote to root: explicit parentId: null (gate 1).
+      const promoted = await getHttpClient().admin.patch(`${base}/tags/${childId}`, {
+        name: 'Boots', parentId: null, geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(promoted.status).to.equal(200);
+      expect(promoted.body.parentId).to.equal(null);
     });
 
     it('PATCH /serenity/tags/:tagId route reaches upstream (unknown id → 502)', async () => {
       await createUsMarket();
       // A UUID tag id the mock has never stored → upstream 404, which the serenity proxy
       // deliberately collapses to 502 (mapError does not echo upstream detail — same convention as
-      // every other serenity write). Proves the new PATCH route → controller → handler → transport
-      // → upstream wiring; the 200 re-parent/rename + the live 404 shape are covered by the unit
-      // tests and the live probe (the mock's name-derived id can't round-trip a PATCH-by-id URL).
+      // every other serenity write). Proves the PATCH route → controller → handler → transport →
+      // upstream wiring for a genuinely unknown id (the known-id round trip is covered above).
       const res = await getHttpClient().admin.patch(
         `${base}/tags/00000000-0000-4000-8000-000000000000`,
         { name: 'category:Ghost', geoTargetId: US_GEO, languageCode: 'en' },
       );
       expect(res.status).to.equal(502);
+    });
+
+    it('POST /serenity/tags resolves a closed-dimension tag idempotently (source/intent/type)', async () => {
+      await createUsMarket();
+      const first = await getHttpClient().admin.post(`${base}/tags`, {
+        type: 'source', name: 'ai', geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(first.status).to.equal(200);
+      expect(first.body).to.include({ tag: 'source:ai', created: true });
+      expect(first.body.id).to.be.a('string').that.is.not.empty;
+
+      // Same closed-dimension value again — resolved, not re-created (no upstream collision).
+      const second = await getHttpClient().admin.post(`${base}/tags`, {
+        type: 'source', name: 'ai', geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(second.status).to.equal(200);
+      expect(second.body).to.include({ tag: 'source:ai', id: first.body.id, created: false });
+    });
+
+    it('POST /serenity/tags 400s a closed-dimension value outside the fixed enum', async () => {
+      await createUsMarket();
+      const res = await getHttpClient().admin.post(`${base}/tags`, {
+        type: 'intent', name: 'not-a-real-intent', geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(res.status).to.equal(400);
+    });
+
+    it('POST /serenity/prompts creates a prompt by id-based tagIds (serenity-docs#24)', async () => {
+      await createUsMarket();
+      const category = await createTag('Photography');
+      const child = await createTag('Cameras', category.body.id);
+
+      const created = await getHttpClient().admin.post(`${base}/prompts`, {
+        prompts: [{
+          text: 'What is the best mirrorless camera?',
+          tagIds: [category.body.id, child.body.id],
+          geoTargetId: US_GEO,
+          languageCode: 'en',
+        }],
+      });
+      expect(created.status).to.equal(200);
+      expect(created.body.created).to.have.lengthOf(1);
+      expect(created.body.created[0].semrushPromptId).to.be.a('string').that.is.not.empty;
+      expect(created.body.created[0].tagIds).to.deep.equal([category.body.id, child.body.id]);
+      expect(created.body.failed).to.deep.equal([]);
+
+      // by_tags correlation: the id-based create embeds the tag ids, so filtering the prompt list
+      // by the child's id surfaces the new prompt.
+      const list = await getHttpClient().admin.get(
+        `${base}/prompts?geoTargetId=${US_GEO}&languageCode=en&tagIds=${child.body.id}`,
+      );
+      expect(list.status).to.equal(200);
+      const promptIds = list.body.items.map((p) => p.semrushPromptId);
+      expect(promptIds).to.include(created.body.created[0].semrushPromptId);
+    });
+
+    it('PATCH /serenity/prompts/:id 400s when both tags and tagIds are supplied', async () => {
+      await createUsMarket();
+      const res = await getHttpClient().admin.patch(`${base}/prompts/00000000-0000-4000-8000-000000000000`, {
+        text: 'x', tags: ['a'], tagIds: ['b'], geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(res.status).to.equal(400);
     });
 
     it('POST /serenity/activate provisions + publishes, then deactivate decommissions', async () => {

--- a/test/support/serenity/handlers/prompts-subworkspace.test.js
+++ b/test/support/serenity/handlers/prompts-subworkspace.test.js
@@ -128,6 +128,24 @@ describe('prompts-subworkspace handlers', () => {
       expect(transport.publishProject).to.have.been.calledOnceWith(WS, 'p-us-en');
     });
 
+    it('creates a prompt by id-based tagIds via aio/prompts, not the name-based endpoint (twin of the flat-mode fix)', async () => {
+      const transport = makeTransport({
+        createPromptsByIds: sinon.stub().resolves({
+          page: 1, total: 1, items: [{ id: 'new-prompt-by-id', name: 'p' }], existing_count: 0,
+        }),
+      });
+      const result = await handleCreatePromptsSubworkspace(transport, WS, {
+        prompts: [{
+          text: 'p', tagIds: ['tag-cat-1', 'tag-child-1'], geoTargetId: 2840, languageCode: 'en',
+        }],
+      }, log);
+      expect(result.created).to.have.length(1);
+      expect(result.created[0]).to.include({ semrushPromptId: 'new-prompt-by-id' });
+      expect(result.created[0].tagIds).to.deep.equal(['tag-cat-1', 'tag-child-1']);
+      expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WS, 'p-us-en', ['p'], ['tag-cat-1', 'tag-child-1']);
+      expect(transport.createTaggedPrompts).to.not.have.been.called;
+    });
+
     it('skips inputs whose slice has no project (one listing, no per-input lookup)', async () => {
       const transport = makeTransport();
       const result = await handleCreatePromptsSubworkspace(transport, WS, {
@@ -252,6 +270,37 @@ describe('prompts-subworkspace handlers', () => {
         log,
       );
       expect(result.status).to.equal(400);
+    });
+
+    it('400s when both tags and tagIds are present (mutually exclusive)', async () => {
+      const result = await handleUpdatePromptSubworkspace(
+        makeTransport(),
+        WS,
+        'old-id',
+        {
+          text: 'new', tags: ['t'], tagIds: ['tag-1'], geoTargetId: 2840, languageCode: 'en',
+        },
+        log,
+      );
+      expect(result.status).to.equal(400);
+      expect(result.body.error).to.equal('invalidRequest');
+    });
+
+    it('replaces text+tagIds via the id-based endpoint (twin of the flat-mode fix)', async () => {
+      const transport = makeTransport({
+        createPromptsByIds: sinon.stub().resolves({
+          page: 1, total: 1, items: [{ id: 'new-prompt-by-id', name: 'new' }], existing_count: 0,
+        }),
+      });
+      const result = await handleUpdatePromptSubworkspace(transport, WS, 'old-id', {
+        text: 'new', tagIds: ['tag-cat-1'], geoTargetId: 2840, languageCode: 'en',
+      }, log);
+      expect(result.status).to.equal(200);
+      expect(result.body.semrushPromptId).to.equal('new-prompt-by-id');
+      expect(result.body.tagIds).to.deep.equal(['tag-cat-1']);
+      expect(transport.deletePromptsByIds).to.have.been.calledWith(WS, 'p-us-en', ['old-id']);
+      expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WS, 'p-us-en', ['new'], ['tag-cat-1']);
+      expect(transport.createTaggedPrompts).to.not.have.been.called;
     });
 
     it('400s when the slice key is invalid', async () => {

--- a/test/support/serenity/handlers/prompts-subworkspace.test.js
+++ b/test/support/serenity/handlers/prompts-subworkspace.test.js
@@ -326,6 +326,22 @@ describe('prompts-subworkspace handlers', () => {
       }, log)).to.be.rejected;
       expect(transport.createTaggedPrompts).to.not.have.been.called;
     });
+
+    it('logs and re-throws when createOnePrompt fails AFTER a successful delete (data-loss window)', async () => {
+      const createErr = Object.assign(new Error('unknown tag id: bogus'), { status: 500 });
+      const transport = makeTransport({
+        createPromptsByIds: sinon.stub().rejects(createErr),
+      });
+      const errorLog = sinon.stub();
+      await expect(handleUpdatePromptSubworkspace(transport, WS, 'old-id', {
+        text: 'new', tagIds: ['bogus'], geoTargetId: 2840, languageCode: 'en',
+      }, { ...log, error: errorLog })).to.be.rejectedWith(/unknown tag id: bogus/);
+      expect(transport.deletePromptsByIds).to.have.been.calledOnce;
+      expect(errorLog).to.have.been.calledOnceWith(
+        sinon.match(/createOnePrompt failed AFTER a successful delete/),
+      );
+      expect(transport.publishProject).to.not.have.been.called;
+    });
   });
 
   describe('handleBulkDeletePromptsSubworkspace', () => {

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -600,6 +600,74 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
     expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['hello'], ['keep']);
   });
 
+  it('drops malformed tagIds entries (too long / whitespace / control char) like validateParentIdFormat does for parentId', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = {
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'hello' }],
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+    const tooLong = 'x'.repeat(201);
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello',
+        geoTargetId: 2840,
+        languageCode: 'en',
+        tagIds: ['keep', 'has space', `control${String.fromCharCode(1)}char`, tooLong],
+      }],
+    }, fakeLog());
+
+    expect(result.created[0].tagIds).to.deep.equal(['keep']);
+    expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['hello'], ['keep']);
+  });
+
+  it('caps a bulk-create tagIds array at MAX_TAG_IDS (50), mirroring the list-read query cap', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = {
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'hello' }],
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+    const tooMany = Array.from({ length: 55 }, (_, i) => `tag-${i}`);
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello', geoTargetId: 2840, languageCode: 'en', tagIds: tooMany,
+      }],
+    }, fakeLog());
+
+    expect(result.created[0].tagIds).to.have.lengthOf(50);
+    expect(result.created[0].tagIds).to.deep.equal(tooMany.slice(0, 50));
+  });
+
+  it('skips a create row when tagIds sanitizes to empty (every entry malformed)', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = { createPromptsByIds: sinon.stub(), createTaggedPrompts: sinon.stub() };
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello', geoTargetId: 2840, languageCode: 'en', tagIds: ['has space', ''],
+      }],
+    }, fakeLog());
+
+    expect(result.skipped).to.have.lengthOf(1);
+    expect(transport.createPromptsByIds).to.not.have.been.called;
+  });
+
   it('skips inputs whose (geoTargetId, languageCode) slice has no row on the brand', async () => {
     const usEn = makeProject({
       semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
@@ -869,6 +937,61 @@ describe('handlers/prompts.js — handleUpdatePrompt', () => {
     expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['next'], ['keep']);
   });
 
+  it('drops malformed tagIds entries on PATCH like validateParentIdFormat does for parentId', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+
+    const transport = {
+      deletePromptsByIds: sinon.stub().resolves(),
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'next' }],
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+    const tooLong = 'x'.repeat(201);
+
+    const result = await handleUpdatePrompt(
+      transport,
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840,
+        languageCode: 'en',
+        text: 'next',
+        tagIds: ['keep', 'has space', tooLong],
+      },
+      fakeLog(),
+    );
+
+    expect(result.body.tagIds).to.deep.equal(['keep']);
+    expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['next'], ['keep']);
+  });
+
+  it('400s when tagIds sanitizes to empty (every entry malformed)', async () => {
+    const dataAccess = makeDataAccess([]);
+
+    const result = await handleUpdatePrompt(
+      {},
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840, languageCode: 'en', text: 'next', tagIds: ['has space', ''],
+      },
+      fakeLog(),
+    );
+
+    expect(result.status).to.equal(400);
+    expect(result.body.error).to.equal('invalidRequest');
+  });
+
   it('400s when geoTargetId or languageCode missing from body', async () => {
     const transport = {};
     const dataAccess = makeDataAccess([]);
@@ -1074,6 +1197,37 @@ describe('handlers/prompts.js — handleUpdatePrompt', () => {
       fakeLog(),
     )).to.be.rejectedWith(/upstream 503/);
     expect(transport.createTaggedPrompts).to.have.callCount(0);
+  });
+
+  it('logs and re-throws when createOnePrompt fails AFTER a successful delete (data-loss window)', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+
+    const createErr = Object.assign(new Error('unknown tag id: bogus'), { status: 500 });
+    const transport = {
+      deletePromptsByIds: sinon.stub().resolves(),
+      createPromptsByIds: sinon.stub().rejects(createErr),
+    };
+    const log = fakeLog();
+
+    await expect(handleUpdatePrompt(
+      transport,
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840, languageCode: 'en', text: 'x', tagIds: ['bogus'],
+      },
+      log,
+    )).to.be.rejectedWith(/unknown tag id: bogus/);
+    expect(transport.deletePromptsByIds).to.have.been.calledOnce;
+    expect(log.error).to.have.been.calledOnceWith(
+      sinon.match(/createOnePrompt failed AFTER a successful delete/),
+    );
   });
 });
 

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -576,6 +576,30 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
     expect(transport.createTaggedPrompts).to.not.have.been.called;
   });
 
+  it('skips an input that supplies BOTH an empty tags array AND tagIds (presence-based exclusivity, not content-based)', async () => {
+    // Regression lock for the content-based-vs-presence-based fix: under the
+    // old check (tags.length > 0), an explicitly-present-but-empty `tags: []`
+    // did not conflict and this input succeeded via the id-based path. Now
+    // both create and update reject on the KEYS being present, matching
+    // parseUpdatePromptBody's contract (see the mirrored 400 test on the
+    // update side above).
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = { createPromptsByIds: sinon.stub(), createTaggedPrompts: sinon.stub() };
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello', geoTargetId: 2840, languageCode: 'en', tags: [], tagIds: ['tag-1'],
+      }],
+    }, fakeLog());
+
+    expect(result.skipped).to.have.lengthOf(1);
+    expect(transport.createPromptsByIds).to.not.have.been.called;
+    expect(transport.createTaggedPrompts).to.not.have.been.called;
+  });
+
   it('drops falsy tagIds entries and returns empty semrushPromptId when createPromptsByIds has no items', async () => {
     const project = makeProject({
       semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -624,6 +624,28 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
     expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['hello'], ['keep']);
   });
 
+  it('returns empty semrushPromptId (not the string "undefined") when createPromptsByIds returns an item with no id', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = {
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 1, items: [{ name: 'hello' }],
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello', geoTargetId: 2840, languageCode: 'en', tagIds: ['tag-cat-1'],
+      }],
+    }, fakeLog());
+
+    expect(result.created[0].semrushPromptId).to.equal('');
+  });
+
   it('drops malformed tagIds entries (too long / whitespace / control char) like validateParentIdFormat does for parentId', async () => {
     const project = makeProject({
       semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
@@ -1234,6 +1256,7 @@ describe('handlers/prompts.js — handleUpdatePrompt', () => {
     const transport = {
       deletePromptsByIds: sinon.stub().resolves(),
       createPromptsByIds: sinon.stub().rejects(createErr),
+      publishProject: sinon.stub().resolves(),
     };
     const log = fakeLog();
 
@@ -1252,6 +1275,7 @@ describe('handlers/prompts.js — handleUpdatePrompt', () => {
     expect(log.error).to.have.been.calledOnceWith(
       sinon.match(/createOnePrompt failed AFTER a successful delete/),
     );
+    expect(transport.publishProject).to.not.have.been.called;
   });
 });
 

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -526,6 +526,80 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
     expect(transport.publishProject).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en');
   });
 
+  it('creates a prompt by id-based tagIds (serenity-docs#24) via aio/prompts, not the name-based endpoint', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = {
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'hello' }], existing_count: 0,
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello', geoTargetId: 2840, languageCode: 'en', tagIds: ['tag-cat-1', 'tag-child-1'],
+      }],
+    }, fakeLog());
+
+    expect(result.created).to.have.lengthOf(1);
+    expect(result.created[0]).to.deep.equal({
+      semrushPromptId: 'new-sem-id',
+      geoTargetId: 2840,
+      languageCode: 'en',
+      text: 'hello',
+      tags: [],
+      tagIds: ['tag-cat-1', 'tag-child-1'],
+    });
+    expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['hello'], ['tag-cat-1', 'tag-child-1']);
+    expect(transport.createTaggedPrompts).to.not.have.been.called;
+  });
+
+  it('skips an input that supplies both tags and tagIds (mutually exclusive)', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = { createPromptsByIds: sinon.stub(), createTaggedPrompts: sinon.stub() };
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello', geoTargetId: 2840, languageCode: 'en', tags: ['a'], tagIds: ['tag-1'],
+      }],
+    }, fakeLog());
+
+    expect(result.skipped).to.have.lengthOf(1);
+    expect(transport.createPromptsByIds).to.not.have.been.called;
+    expect(transport.createTaggedPrompts).to.not.have.been.called;
+  });
+
+  it('drops falsy tagIds entries and returns empty semrushPromptId when createPromptsByIds has no items', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([project]);
+    const transport = {
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 0, items: [], existing_count: 1,
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+
+    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+      prompts: [{
+        text: 'hello', geoTargetId: 2840, languageCode: 'en', tagIds: ['keep', '', null],
+      }],
+    }, fakeLog());
+
+    expect(result.created[0].semrushPromptId).to.equal('');
+    expect(result.created[0].tagIds).to.deep.equal(['keep']);
+    expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['hello'], ['keep']);
+  });
+
   it('skips inputs whose (geoTargetId, languageCode) slice has no row on the brand', async () => {
     const usEn = makeProject({
       semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
@@ -659,6 +733,140 @@ describe('handlers/prompts.js — handleUpdatePrompt', () => {
 
     expect(result.status).to.equal(400);
     expect(result.body.error).to.equal('missingFields');
+  });
+
+  it('400s when both tags and tagIds are present (mutually exclusive)', async () => {
+    const transport = {};
+    const dataAccess = makeDataAccess([]);
+
+    const result = await handleUpdatePrompt(
+      transport,
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840, languageCode: 'en', text: 'next', tags: ['a'], tagIds: ['tag-1'],
+      },
+      fakeLog(),
+    );
+
+    expect(result.status).to.equal(400);
+    expect(result.body.error).to.equal('invalidRequest');
+  });
+
+  it('400s when tagIds is present but not an array', async () => {
+    const transport = {};
+    const dataAccess = makeDataAccess([]);
+
+    const result = await handleUpdatePrompt(
+      transport,
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840, languageCode: 'en', text: 'next', tagIds: 'not-an-array',
+      },
+      fakeLog(),
+    );
+
+    expect(result.status).to.equal(400);
+    expect(result.body.error).to.equal('invalidRequest');
+  });
+
+  it('400s when tagIds is present but empty', async () => {
+    const transport = {};
+    const dataAccess = makeDataAccess([]);
+
+    const result = await handleUpdatePrompt(
+      transport,
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840, languageCode: 'en', text: 'next', tagIds: [],
+      },
+      fakeLog(),
+    );
+
+    expect(result.status).to.equal(400);
+    expect(result.body.error).to.equal('invalidRequest');
+  });
+
+  it('replaces text+tagIds via the id-based endpoint (delete-then-create-by-id)', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+
+    const transport = {
+      deletePromptsByIds: sinon.stub().resolves(),
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'next' }], existing_count: 0,
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+
+    const result = await handleUpdatePrompt(
+      transport,
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840, languageCode: 'en', text: 'next', tagIds: ['tag-cat-1'],
+      },
+      fakeLog(),
+    );
+
+    expect(result.status).to.equal(200);
+    expect(result.body).to.deep.equal({
+      semrushPromptId: 'new-sem-id',
+      geoTargetId: 2840,
+      languageCode: 'en',
+      text: 'next',
+      tags: [],
+      tagIds: ['tag-cat-1'],
+    });
+    expect(transport.deletePromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['sem-1']);
+    expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['next'], ['tag-cat-1']);
+    expect(transport.createTaggedPrompts).to.not.have.been.called;
+  });
+
+  it('drops falsy tagIds entries on PATCH before sending to the id-based endpoint', async () => {
+    const project = makeProject({
+      semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+    });
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(project);
+
+    const transport = {
+      deletePromptsByIds: sinon.stub().resolves(),
+      createPromptsByIds: sinon.stub().resolves({
+        page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'next' }], existing_count: 0,
+      }),
+      createTaggedPrompts: sinon.stub(),
+      publishProject: sinon.stub().resolves(),
+    };
+
+    const result = await handleUpdatePrompt(
+      transport,
+      dataAccess,
+      BRAND,
+      WORKSPACE,
+      'sem-1',
+      {
+        geoTargetId: 2840, languageCode: 'en', text: 'next', tagIds: ['keep', '', undefined],
+      },
+      fakeLog(),
+    );
+
+    expect(result.body.tagIds).to.deep.equal(['keep']);
+    expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['next'], ['keep']);
   });
 
   it('400s when geoTargetId or languageCode missing from body', async () => {

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -156,10 +156,10 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(transport.createProjectTags).to.not.have.been.called;
     });
 
-    it('400s when type is not in the creatable allow-list (closed taxonomy)', async () => {
+    it('400s when type is not a recognized open or closed dimension', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
-      for (const type of ['intent', 'source', 'type', 'bogus', '', undefined]) {
+      for (const type of ['bogus', '', undefined]) {
         // eslint-disable-next-line no-await-in-loop
         await expect(handler.handleCreateTag(
           transport,
@@ -208,6 +208,93 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
           handler.handleCreateTag(transport, dataAccess, BRAND, WORKSPACE, body, fakeLog()),
         ).to.be.rejected.then((err) => expect(err.status).to.equal(400));
       }
+    });
+  });
+
+  describe('handleCreateTag — closed dimensions (source/intent/type)', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    it('creates a closed-dimension tag when it does not yet exist (200, created:true)', async () => {
+      const transport = makeTransport({
+        createProjectTags: sinon.stub().resolves([{ id: 'tag-source-ai', name: 'source:ai' }]),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        {
+          type: 'source', name: 'ai', geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({
+        tag: 'source:ai', id: 'tag-source-ai', parentId: null, created: true,
+      });
+      expect(transport.createProjectTags)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['source:ai']);
+    });
+
+    it('resolves an EXISTING closed-dimension tag without creating a duplicate (200, created:false)', async () => {
+      const listProjectTags = sinon.stub();
+      listProjectTags.withArgs(sinon.match.any, sinon.match.any, sinon.match({ parentId: '' }))
+        .resolves({
+          page: 1, total: 1, items: [{ id: 'tag-intent-info', name: 'intent:Informational', children_count: 0 }],
+        });
+      const transport = makeTransport({ listProjectTags });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        {
+          type: 'intent', name: 'Informational', geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({
+        tag: 'intent:Informational', id: 'tag-intent-info', parentId: null, created: false,
+      });
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('400s a closed-dimension value not in the fixed enum', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        {
+          type: 'type', name: 'bogus-value', geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('400s a closed-dimension create that carries a parentId', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleCreateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        {
+          type: 'source', name: 'ai', geoTargetId: 2840, languageCode: 'en', parentId: 'root-1',
+        },
+        fakeLog(),
+      )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.createProjectTags).to.not.have.been.called;
     });
   });
 
@@ -267,7 +354,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       await expect(handler.handleCreateTagSubworkspace(
         transport,
         WORKSPACE,
-        { ...validBody, type: 'intent' },
+        { ...validBody, type: 'bogus' },
         fakeLog(),
       )).to.be.rejected.then((err) => expect(err.status).to.equal(400));
       expect(resolveProjectStub).to.not.have.been.called;
@@ -295,6 +382,32 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(res.body).to.include({ tag: 'Sneakers', id: 'child-1', parentId: 'parent-1' });
       expect(transport.createProjectTags)
         .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', ['Sneakers'], { parentId: 'parent-1' });
+    });
+
+    it('resolves a closed-dimension tag (twin of the flat-mode fix)', async () => {
+      const resolveProjectStub = sinon.stub().resolves({ id: 'proj-sub-1' });
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeTransport({
+        createProjectTags: sinon.stub().resolves([{ id: 'tag-type-branded', name: 'type:branded' }]),
+      });
+      const res = await handler.handleCreateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        {
+          type: 'type', name: 'branded', geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      );
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({
+        tag: 'type:branded', id: 'tag-type-branded', parentId: null, created: true,
+      });
+      expect(transport.createProjectTags)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', ['type:branded']);
     });
   });
 
@@ -531,6 +644,20 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       }
     });
 
+    it('400s a non-string, non-null parentId', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await expect(handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'tag-1', { ...updateBody, parentId: 123 }, fakeLog())).to.be.rejected.then((err) => expect(err.status).to.equal(400));
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('treats a whitespace-only parentId the same as omission (not promote-to-root)', async () => {
+      const transport = makeTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await handler.handleUpdateTag(transport, dataAccess, BRAND, WORKSPACE, 'tag-1', { ...updateBody, parentId: '   ' }, fakeLog());
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', 'tag-1', { name: 'category:Footwear', parentId: undefined });
+    });
+
     it('404s (marketNotFound) when no project backs the slice', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess(null);
@@ -684,6 +811,55 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
         'proj-1',
         'root-1',
         { name: 'category:FootwearRenamed', parentId: undefined },
+      );
+    });
+
+    it('forwards an explicit null parentId as promote-to-root (gate 1)', async () => {
+      const transport = makeChildTreeTransport('root-1', 'child-1', {
+        updateProjectTag: sinon.stub().resolves({ id: 'child-1', name: 'Sneakers', parent_id: null }),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'child-1',
+        {
+          name: 'Sneakers', parentId: null, geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      );
+      expect(res.body).to.include({ tag: 'Sneakers', parentId: null });
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-1',
+        'child-1',
+        { name: 'Sneakers', parentId: null },
+      );
+    });
+
+    it('treats an explicit null parentId on a ROOT as a no-op (defensive, not live-verified)', async () => {
+      const transport = makeRootTreeTransport('root-1', {
+        updateProjectTag: sinon.stub().resolves({ id: 'root-1', name: 'category:Footwear' }),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        'root-1',
+        {
+          name: 'category:Footwear', parentId: null, geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      );
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-1',
+        'root-1',
+        { name: 'category:Footwear', parentId: undefined },
       );
     });
   });

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -1048,5 +1048,33 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
         { name: 'SneakersRenamed', parentId: 'root-1' },
       );
     });
+
+    it('forwards an explicit null parentId as promote-to-root (twin of the flat-mode gate 1 fix)', async () => {
+      const resolveProjectStub = sinon.stub().resolves({ id: 'proj-sub-1' });
+      const handler = await esmock('../../../../src/support/serenity/handlers/tags.js', {
+        '../../../../src/support/serenity/subworkspace-projects.js': {
+          resolveProject: resolveProjectStub,
+        },
+      });
+      const transport = makeChildTreeTransport('root-1', 'child-1', {
+        updateProjectTag: sinon.stub().resolves({ id: 'child-1', name: 'Sneakers', parent_id: null }),
+      });
+      const res = await handler.handleUpdateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        'child-1',
+        {
+          name: 'Sneakers', parentId: null, geoTargetId: 2840, languageCode: 'en',
+        },
+        fakeLog(),
+      );
+      expect(res.body).to.include({ tag: 'Sneakers', parentId: null });
+      expect(transport.updateProjectTag).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-sub-1',
+        'child-1',
+        { name: 'Sneakers', parentId: null },
+      );
+    });
   });
 });

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -445,6 +445,48 @@ describe('Semrush REST transport', () => {
     });
   });
 
+  describe('createPromptsByIds', () => {
+    it('POSTs to /v2/.../aio/prompts with { items, tag_ids } and returns the list wrapper', async () => {
+      fetchStub.resolves(fetchOk({
+        page: 1, total: 1, items: [{ id: 'new-prompt', name: 'What is Acrobat?' }], existing_count: 0,
+      }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const result = await transport.createPromptsByIds(WORKSPACE_ID, PROJECT_ID, ['What is Acrobat?'], ['tag-cat-1', 'tag-child-1']);
+
+      const call = await callOf(fetchStub);
+      expect(call.method).to.equal('POST');
+      expect(call.url).to.match(/\/aio\/prompts$/);
+      expect(JSON.parse(call.body)).to.deep.equal({
+        items: ['What is Acrobat?'], tag_ids: ['tag-cat-1', 'tag-child-1'],
+      });
+      expect(result.items).to.deep.equal([{ id: 'new-prompt', name: 'What is Acrobat?' }]);
+    });
+
+    it('surfaces an upstream 500 (unresolvable tag id) as a SerenityTransportError', async () => {
+      fetchStub.resolves(fetchFail(500, { message: 'unknown tag id: bogus' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await expect(transport.createPromptsByIds(WORKSPACE_ID, PROJECT_ID, ['x'], ['bogus']))
+        .to.be.rejected.then((err) => expect(err.status).to.equal(500));
+    });
+  });
+
+  describe('updatePromptTags', () => {
+    it('PUTs to /v2/.../aio/prompts/tags with { items }', async () => {
+      fetchStub.resolves(fetchOk(null));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const items = [{ id: 'prompt-1', references: ['tag-1'], replace: false }];
+      await transport.updatePromptTags(WORKSPACE_ID, PROJECT_ID, items);
+
+      const call = await callOf(fetchStub);
+      expect(call.method).to.equal('PUT');
+      expect(call.url).to.match(/\/aio\/prompts\/tags$/);
+      expect(JSON.parse(call.body)).to.deep.equal({ items });
+    });
+  });
+
   describe('deletePromptsByIds', () => {
     it('DELETEs /v2/.../aio/prompts with body { ids }', async () => {
       fetchStub.resolves(fetchOk(null));
@@ -861,6 +903,18 @@ describe('Semrush REST transport', () => {
 
       const call = await callOf(fetchStub);
       expect(JSON.parse(call.body)).to.deep.equal({ name: 'category:Renamed' });
+    });
+
+    it('sends a literal null parent_id to promote a child to root (gate 1)', async () => {
+      fetchStub.resolves(fetchOk({ id: 'tag-1', name: 'Sneakers', parent_id: null }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await transport.updateProjectTag(WORKSPACE_ID, PROJECT_ID, 'tag-1', {
+        name: 'Sneakers', parentId: null,
+      });
+
+      const call = await callOf(fetchStub);
+      expect(JSON.parse(call.body)).to.deep.equal({ name: 'Sneakers', parent_id: null });
     });
 
     it('surfaces an upstream 404 as a SerenityTransportError', async () => {

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -472,21 +472,6 @@ describe('Semrush REST transport', () => {
     });
   });
 
-  describe('updatePromptTags', () => {
-    it('PUTs to /v2/.../aio/prompts/tags with { items }', async () => {
-      fetchStub.resolves(fetchOk(null));
-      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
-
-      const items = [{ id: 'prompt-1', references: ['tag-1'], replace: false }];
-      await transport.updatePromptTags(WORKSPACE_ID, PROJECT_ID, items);
-
-      const call = await callOf(fetchStub);
-      expect(call.method).to.equal('PUT');
-      expect(call.url).to.match(/\/aio\/prompts\/tags$/);
-      expect(JSON.parse(call.body)).to.deep.equal({ items });
-    });
-  });
-
   describe('deletePromptsByIds', () => {
     it('DELETEs /v2/.../aio/prompts with body { ids }', async () => {
       fetchStub.resolves(fetchOk(null));

--- a/test/support/serenity/validation.test.js
+++ b/test/support/serenity/validation.test.js
@@ -16,6 +16,8 @@ import {
   LANGUAGE_TAG_REGEX,
   normalizeLanguageCode,
   normalizeGeoTargetId,
+  isValidTagIdFormat,
+  MAX_TAG_ID_LEN,
 } from '../../../src/support/serenity/validation.js';
 
 /**
@@ -121,5 +123,32 @@ describe('serenity/validation — normalizeGeoTargetId', () => {
     expect(normalizeGeoTargetId({})).to.equal(null);
     expect(normalizeGeoTargetId([])).to.equal(null);
     expect(normalizeGeoTargetId(true)).to.equal(null);
+  });
+});
+
+describe('serenity/validation — isValidTagIdFormat', () => {
+  it('accepts an opaque tag id', () => {
+    expect(isValidTagIdFormat('tag-abc123')).to.equal(true);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isValidTagIdFormat('')).to.equal(false);
+  });
+
+  it('accepts an id exactly at MAX_TAG_ID_LEN and rejects one character over', () => {
+    expect(isValidTagIdFormat('x'.repeat(MAX_TAG_ID_LEN))).to.equal(true);
+    expect(isValidTagIdFormat('x'.repeat(MAX_TAG_ID_LEN + 1))).to.equal(false);
+  });
+
+  it('rejects an id containing whitespace', () => {
+    expect(isValidTagIdFormat('tag abc')).to.equal(false);
+    expect(isValidTagIdFormat('tag\tabc')).to.equal(false);
+    expect(isValidTagIdFormat('tag\nabc')).to.equal(false);
+  });
+
+  it('rejects an id containing a C0 control character or DEL', () => {
+    expect(isValidTagIdFormat(`tag${String.fromCharCode(1)}abc`)).to.equal(false);
+    expect(isValidTagIdFormat(`tag${String.fromCharCode(31)}abc`)).to.equal(false);
+    expect(isValidTagIdFormat(`tag${String.fromCharCode(127)}abc`)).to.equal(false);
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds the id-based prompt-write path, closed-dimension tag resolution, and promote-to-root support to the Serenity nested-category-tags surface, building on the bare-name-children fix already merged in PR #2737.

## 2. Reasoning
The nested-category alignment work (serenity-docs#24, extending issue #21) needs a way to tag prompts by upstream tag **id** rather than by name: a topic name is only unambiguous within its own category, so the name-based prompt-tagging endpoint (`aio/prompts/tagged`) can't reference a nested child at all — it's what forced the migration CLI into a flat-tag-then-reparent workaround. This PR adds the id-based upstream write path api-service needs to let a UI or migration tool tag a prompt with a specific child id directly. Landing alongside it: a way to resolve the ids of the fixed-vocabulary `source`/`intent`/`type` tags (needed to build a full `tagIds` set for a prompt), and closing gate 1 from the same live-verification session (serenity-docs#24 §3.1) — an explicit promote-to-root request was accepted by the parser but silently dropped before reaching the transport layer.

## 3. High-level overview of the changes
- **Id-based prompt writes**: `SerenityPromptInput`/`SerenityUpdatePromptRequest` gain an optional `tagIds` field (upstream tag ids), mutually exclusive with the existing `tags` (names) field. New transport methods `createPromptsByIds` (`POST aio/prompts`) and `updatePromptTags` (`PUT aio/prompts/tags`) call the corresponding upstream endpoints. Both prompt-write twin handler pairs (flat + subworkspace, create + update) route through whichever field the caller supplied.
- **Closed-dimension tag resolution**: `POST /serenity/tags` now also accepts `type: source|intent|type` (previously only `category`/`topic`). A closed-dimension create is resolve-before-create — if the project already has that exact tag, its id comes back unchanged (`200`, `created: false`) instead of attempting another create, since it's a small fixed set many independent callers need the id of. Open-dimension behavior (a duplicate name is a hard upstream error the caller must avoid) is unchanged.
- **Promote-to-root** (`PATCH /serenity/tags/:tagId`): an explicit JSON `null` `parentId` now reaches the upstream call as a literal `null`, distinct from an omitted `parentId` (which preserves the tag's current parent). Previously both were collapsed to the same "omit `parent_id`" behavior, so a client request to remove a child's parent silently did nothing.
- Un-skips two integration assertions the original PR (#2737) could only validate against live Semrush at the time: drilling a parent's children by id, and a full rename-by-id round trip against the mock — both are now exercisable because the mock's tag ids became URL-safe in a since-merged spacecat-shared fix.

## 4. Required information
- Spec: https://github.com/adobe/serenity-docs/pull/24
- Other: https://github.com/adobe/spacecat-api-service/pull/2737 · https://github.com/adobe/spacecat-shared/pull/1764

## 5. Affected / used mysticat-workspace projects
- **spacecat-shared** — consumed: the `@adobe/spacecat-shared-project-engine-client` mock (bumped to 1.7.0) supplies the id-based prompt-write routes this PR's IT suite exercises.
- **project-elmo-ui** — contract: the nested-category UI work (issue 2245) is expected to call these new endpoints once it reaches the prompt-authoring slice.

## 7. Test plan
(a) Ran the full serenity-scoped unit suite, the OpenAPI contract suite, and the route-capability coverage test locally; also ran `tsc --noEmit` and the OpenAPI spec linter. Could not run the integration suite locally (it needs the docker-compose Postgres + Semrush mock infrastructure) — the two new/updated IT test blocks (id-based prompt create + read-back, closed-dimension resolve/reject, the un-skipped id-round-trip tag tests) are new territory for this repo's local tooling and will be verified via CI's `ci/it-postgres` job.
(b) On dev/stage: exercise `POST /serenity/tags` with `type: source` twice for the same brand/market to confirm the second call returns the same id with `created: false`; exercise `PATCH /serenity/tags/:tagId` with `parentId: null` on a real nested child and confirm it lists as a root afterward.

## 8. Deployment & merge order
- Related: https://github.com/adobe/spacecat-api-service/pull/2737 — already merged; this PR is a follow-up on top of it, per the original sequencing (serenity-docs#24's implementation plan).
- Related: https://github.com/adobe/spacecat-shared/pull/1764 — already merged (published as `@adobe/spacecat-shared-project-engine-client@1.7.0`, which this PR's `package.json` now pins).
- No hard merge-order dependency: this PR's own code doesn't require anything further from spacecat-shared to merge first (1.7.0 is already released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
