### PR TITLE
fix: Return cited prompts in URL Inspector details for Postgres-backed (-pg) domains | LLMO-5992

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -9011,6 +9011,14 @@ UrlInspectorStats:
 UrlInspectorOwnedUrlRow:
   type: object
   properties:
+    urlId:
+      type: string
+      description: >-
+        Real source_urls.id for this URL, used by the URL Details "Prompt
+        Analysis" drilldown to key rpc_url_inspector_url_prompts on a genuine
+        uuid (LLMO-5992). Empty string when an older RPC build has not yet
+        shipped the column.
+      example: '44444444-4444-4444-4444-444444444444'
     url:
       type: string
       format: uri

--- a/src/controllers/llmo/llmo-url-inspector.js
+++ b/src/controllers/llmo/llmo-url-inspector.js
@@ -302,6 +302,13 @@ export function createUrlInspectorOwnedUrlsHandler(getOrgAndValidateAccess) {
       const totalCount = rows.length > 0 ? Number(rows[0].total_count ?? 0) : 0;
 
       const urls = rows.map((r) => ({
+        // url_id is the real source_urls.id (LLMO-5992). The URL Details
+        // "Prompt Analysis" drilldown forwards it as p_url_id to
+        // rpc_url_inspector_url_prompts; without it the dashboard synthesised a
+        // fake id that failed the uuid parse and returned no prompts. Mirrors
+        // getUrlInspectorDomainUrls. Empty-string fallback keeps the shape
+        // stable if an older RPC build (pre-url_id) is deployed.
+        urlId: r.url_id || '',
         url: r.url,
         citations: Number(r.citations ?? 0),
         promptsCited: Number(r.prompts_cited ?? 0),

--- a/test/controllers/llmo/llmo-url-inspector.test.js
+++ b/test/controllers/llmo/llmo-url-inspector.test.js
@@ -437,6 +437,7 @@ describe('URL Inspector Handlers', () => {
     it('returns paginated owned URLs with agentic + referral fields mapped', async () => {
       const rpcData = [
         {
+          url_id: '11111111-1111-4111-8111-111111111111',
           url: 'https://example.com/page1',
           citations: 42,
           prompts_cited: 12,
@@ -505,6 +506,11 @@ describe('URL Inspector Handlers', () => {
       expect(body.totalCount).to.equal(100);
       expect(body.urls[0].url).to.equal('https://example.com/page1');
       expect(body.urls[0].citations).to.equal(42);
+      // LLMO-5992: url_id (real source_urls.id) is surfaced so the URL Details
+      // "Prompt Analysis" drilldown can key rpc_url_inspector_url_prompts on a
+      // real uuid. A row that omits url_id (older RPC build) falls back to ''.
+      expect(body.urls[0].urlId).to.equal('11111111-1111-4111-8111-111111111111');
+      expect(body.urls[2].urlId).to.equal('');
       expect(body.urls[0].weeklyCitations).to.deep.equal([{ week: '2026-W10', value: 20 }]);
       // Server-side agentic merge (LLMO-4526 M2): the dashboard reads these
       // straight off each row, so they must come through camelCased and the


### PR DESCRIPTION
## What & why

The URL Inspector PG dashboard's Owned URLs list showed a non-zero "Prompts Cited In" count per URL, but the URL Details "Prompt Analysis" section rendered "No prompts found" for Postgres-backed (`-pg`) domains. Root cause (confirmed across all 3 repos + live prod-reader): `rpc_url_inspector_owned_urls` returned no `url_id`, so the UI synthesised a fake `url-<index>-<slug>` id that failed the uuid-typed `p_url_id` of `rpc_url_inspector_url_prompts`; the API swallowed the `22P02` error into an empty prompt list.

**This repo (API):** map the newly-surfaced `url_id` through the URL Inspector owned-urls handler so the UI receives the real id for the per-URL prompt drilldown. Empty-fallback assertions added so the API degrades gracefully during the cross-repo deploy window.

## Cross-repo change

Part of a **3-PR cross-repo change** (deploy order: **mysticat-data-service DB → spacecat-api-service API → project-elmo-ui UI**). All changes are additive and backward-compatible (graceful `|| ''` / `|| synthetic` fallbacks), so no single deploy order causes a crash; the fix takes full effect once all three ship. This is the **API** PR (deploy after DB, before UI).

### Cross-repo PRs
- DB (mysticat-data-service): https://github.com/adobe/mysticat-data-service/pull/766
- API (spacecat-api-service) — **this PR**: https://github.com/adobe/spacecat-api-service/pull/2743
- UI (project-elmo-ui): https://github.com/adobe/project-elmo-ui/pull/2264

## Links

- Jira: https://jira.corp.adobe.com/browse/LLMO-5992
- Slack thread: https://adobe.enterprise.slack.com/archives/C0BEJH1SNNL/p1782985114412969

## Tests

87 controller unit tests pass (incl. new `url_id` + empty-fallback assertions); `eslint` clean; `npm run docs:lint` valid.

---
Draft PR opened by the slack-pipeline. Do not merge until all three cross-repo PRs are green and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
