### PR TITLE
chore(deps): bump spacecat-shared-utils to 1.124.1 (fail-closed site scope)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10554,7 +10554,7 @@
     },
     "node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.124.1",
-      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.124.1.tgz",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.124.1.tgz",
       "integrity": "sha512-ZtCNrwed//kpqyTKppFUoICLfXaL/iJ6heiKd8QLNWfAbi9oHVWFIv+VlpmnONdyxfMIEW+tbf9EOWOwXbS16w==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@adobe/spacecat-shared-tier-client": "1.5.1",
     "@adobe/spacecat-shared-tokowaka-client": "1.20.0",
     "@adobe/spacecat-shared-user-manager-client": "1.3.1",
-    "@adobe/spacecat-shared-utils": "1.123.0",
+    "@adobe/spacecat-shared-utils": "1.124.1",
     "@adobe/spacecat-shared-vault-secrets": "1.3.5",
     "@aws-sdk/client-cloudfront": "3.1045.0",
     "@aws-sdk/client-iam": "3.1045.0",


### PR DESCRIPTION
## What

Bumps `@adobe/spacecat-shared-utils` `1.123.0` → `1.124.1`.

## Why

Adopts the **fail-closed** behavior of `isWithinSiteScope` / `isPathPatternWithinSiteScope` from **adobe/spacecat-shared#1770**: a missing/empty `siteBaseUrl` now denies rather than allows in the edge-deploy scope guard (`isSuggestionInScope`). This is the downstream consumer of that shared-utils change.

## Status: ready for review

- `adobe/spacecat-shared#1770` has merged and `1.124.1` is published on npm.
- Branch merged with latest `main` (which picked up #2595, the subpath deploy-guards feature) and `package.json` conflict resolved — utils stays at `1.124.1`.
- `package-lock.json` regenerated against the now-published `1.124.1`.
- Full test suite passes: 13566 passing, 0 failing.

## Scope note

`origin/main` was on `1.123.0` when this PR was opened, so this is a `1.123.0` → `1.124.1` jump (not just the fail-closed patch). It pulls in the intervening `1.124.x` changes too, including the `isPathPatternWithinSiteScope` export. The behavioral change is confined to the missing-`siteBaseUrl` branch, which is unreachable in the normal deploy flow (`site.getBaseURL()` is always truthy).

## Verification

Ran the full test suite after merging main and regenerating the lockfile → **13566 passing, 0 failing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
