### PR TITLE
refactor(serenity): skip the brand's own primary domain in brand URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.33.1",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.7.1",
+        "@adobe/spacecat-shared-project-engine-client": "^1.8.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -7037,9 +7037,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.7.1.tgz",
-      "integrity": "sha512-RuqU1PqFLSfCwS1Rg29uU7vmr/SFMzf3Sz/O/GxJrzARCoVFfNu4+W0fg3wMJCaUUHiwnsgF8h+512EfzlRuNw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.8.0.tgz",
+      "integrity": "sha512-AsFjtAubCVMBgiDnrO69GJYbZd0ivr+v3NRO2OoIWlupmEjpyyk0OU7/CqbUCEThfEF6I6nnZsOtGxAQHE/2jA==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.33.1",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "^1.8.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.8.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.33.1",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "^1.8.0",
+    "@adobe/spacecat-shared-project-engine-client": "1.8.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.33.1",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.7.1",
+    "@adobe/spacecat-shared-project-engine-client": "^1.8.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -120,7 +120,8 @@ export function collectBrandUrlEntries(sources, market) {
  * apex-normalizing them would be wrong — they pass through unchanged.
  *
  * `url/resolve` returns `is_valid: false` with empty strings (still HTTP 200) for
- * unresolvable input; that is NOT an error, so on it we keep the raw (already
+ * unresolvable input; that (and the defensive `is_valid: true` but empty
+ * `primary_url` case) is NOT an error, so on it we keep the raw (already
  * https-filtered) entry rather than writing the empty value. A transport ERROR
  * (non-2xx) is left to propagate — the caller's best-effort (CREATE) / hard-fail
  * (EDIT) wrapper then treats it exactly like any other upstream failure.
@@ -128,14 +129,24 @@ export function collectBrandUrlEntries(sources, market) {
  * A resolve can collapse two raw URLs (e.g. `https://www.x.com` and
  * `https://x.com`) onto one canonical value, so the result is re-de-duplicated by
  * url (first-seen wins) — {@link collectBrandUrlEntries} de-duped by the RAW url.
+ * De-dup keys on `url` alone (like `collectBrandUrlEntries`): a Semrush brand URL
+ * is unique by its url, and a canonicalized website (scheme-less apex) can't
+ * collide with a social/earned handle (a full `https://` profile url).
+ *
+ * The optional `cache` (raw url → canonical string | null) is resolved-once memo
+ * shared across calls: brand website `urls` are region-less, so the per-market
+ * edit re-sync passes ONE cache to avoid re-resolving the same url for every
+ * market. Only a cache MISS calls the transport (and warns on an unusable result),
+ * so a bad url warns once, not once per market.
  *
  * @param {object} transport - Semrush transport (exposes `resolveUrl`).
  * @param {Array<{url: string, type: string}>} entries - collected brand-URL entries.
  * @param {object} [log] - optional logger ({ warn? }).
+ * @param {Map<string, (string|null)>} [cache] - raw-url → canonical memo (see above).
  * @returns {Promise<{url: string, type: string}[]>} entries with website URLs
  *   canonicalized (a no-op passthrough for social/earned), re-de-duped by url.
  */
-export async function resolveWebsiteEntries(transport, entries, log) {
+export async function resolveWebsiteEntries(transport, entries, log, cache = new Map()) {
   const resolved = [];
   for (const entry of entries) {
     if (entry.type !== BRAND_URL_TYPE.WEBSITE) {
@@ -143,18 +154,24 @@ export async function resolveWebsiteEntries(transport, entries, log) {
       // eslint-disable-next-line no-continue
       continue;
     }
-    // eslint-disable-next-line no-await-in-loop
-    const r = await transport.resolveUrl(entry.url);
-    if (r?.is_valid === true && hasText(r?.primary_url)) {
-      resolved.push({ ...entry, url: r.primary_url });
+    let canonical;
+    if (cache.has(entry.url)) {
+      canonical = cache.get(entry.url);
     } else {
-      // is_valid:false / empty (HTTP 200) — keep the raw https value, never the
+      // eslint-disable-next-line no-await-in-loop
+      const r = await transport.resolveUrl(entry.url);
+      // is_valid:false, OR (defensively) is_valid:true with an empty primary_url —
+      // both mean "no usable canonical value": keep the raw https value, never the
       // empty one. Left un-normalized on purpose; the next edit re-attempts it.
-      log?.warn?.('brand-urls: url/resolve returned is_valid:false — keeping raw url', {
-        url: entry.url,
-      });
-      resolved.push(entry);
+      canonical = (r?.is_valid === true && hasText(r?.primary_url)) ? r.primary_url : null;
+      cache.set(entry.url, canonical);
+      if (canonical === null) {
+        log?.warn?.('brand-urls: url/resolve returned no usable primary_url — keeping raw url', {
+          url: entry.url,
+        });
+      }
     }
+    resolved.push(canonical === null ? entry : { ...entry, url: canonical });
   }
 
   const seen = new Set();
@@ -368,6 +385,11 @@ export async function syncBrandUrlsAcrossMarkets(
   let deleted = 0;
   let markets = 0;
 
+  // Website `urls` are region-less (identical across every market), so resolve
+  // each distinct one a single time and reuse the result across markets — one
+  // shared memo passed into every per-market resolveWebsiteEntries call.
+  const resolveCache = new Map();
+
   for (const project of projects) {
     const projectId = hasText(project?.id) ? String(project.id) : null;
     const market = marketOf(project);
@@ -409,8 +431,9 @@ export async function syncBrandUrlsAcrossMarkets(
       // Canonicalize website URLs to Semrush's stored form BEFORE diffing, so the
       // desired set is compared against `listBrandUrls` (which returns the same
       // canonical form) — otherwise every re-sync would churn `www.`-vs-apex (#25).
+      // The shared cache resolves each region-less website url once across markets.
       // eslint-disable-next-line no-await-in-loop
-      const desired = await resolveWebsiteEntries(transport, collected, log);
+      const desired = await resolveWebsiteEntries(transport, collected, log, resolveCache);
       // eslint-disable-next-line no-await-in-loop
       const existingResp = await transport.listBrandUrls(workspaceId, projectId, benchmarkId);
       const existing = Array.isArray(existingResp?.brand_urls) ? existingResp.brand_urls : [];

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -107,6 +107,66 @@ export function collectBrandUrlEntries(sources, market) {
   });
 }
 
+/**
+ * Normalizes the WEBSITE-type brand-URL entries to Semrush's canonical stored
+ * form by resolving each raw URL through Project Engine's `url/resolve` endpoint,
+ * so the value we write matches the benchmark Semrush already holds instead of
+ * creating a duplicate `www.`-vs-apex entry (serenity-docs#25). The resolve
+ * `primary_url` (scheme-less, subdomain + path preserved, e.g. `lovesac.com`) is
+ * used as the stored value.
+ *
+ * Only `type: 'website'` entries are resolved: `social`/`earned` URLs are
+ * identity handles (e.g. `https://instagram.com/brand`), not brand domains, so
+ * apex-normalizing them would be wrong — they pass through unchanged.
+ *
+ * `url/resolve` returns `is_valid: false` with empty strings (still HTTP 200) for
+ * unresolvable input; that is NOT an error, so on it we keep the raw (already
+ * https-filtered) entry rather than writing the empty value. A transport ERROR
+ * (non-2xx) is left to propagate — the caller's best-effort (CREATE) / hard-fail
+ * (EDIT) wrapper then treats it exactly like any other upstream failure.
+ *
+ * A resolve can collapse two raw URLs (e.g. `https://www.x.com` and
+ * `https://x.com`) onto one canonical value, so the result is re-de-duplicated by
+ * url (first-seen wins) — {@link collectBrandUrlEntries} de-duped by the RAW url.
+ *
+ * @param {object} transport - Semrush transport (exposes `resolveUrl`).
+ * @param {Array<{url: string, type: string}>} entries - collected brand-URL entries.
+ * @param {object} [log] - optional logger ({ warn? }).
+ * @returns {Promise<{url: string, type: string}[]>} entries with website URLs
+ *   canonicalized (a no-op passthrough for social/earned), re-de-duped by url.
+ */
+export async function resolveWebsiteEntries(transport, entries, log) {
+  const resolved = [];
+  for (const entry of entries) {
+    if (entry.type !== BRAND_URL_TYPE.WEBSITE) {
+      resolved.push(entry);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const r = await transport.resolveUrl(entry.url);
+    if (r?.is_valid === true && hasText(r?.primary_url)) {
+      resolved.push({ ...entry, url: r.primary_url });
+    } else {
+      // is_valid:false / empty (HTTP 200) — keep the raw https value, never the
+      // empty one. Left un-normalized on purpose; the next edit re-attempts it.
+      log?.warn?.('brand-urls: url/resolve returned is_valid:false — keeping raw url', {
+        url: entry.url,
+      });
+      resolved.push(entry);
+    }
+  }
+
+  const seen = new Set();
+  return resolved.filter((e) => {
+    if (seen.has(e.url)) {
+      return false;
+    }
+    seen.add(e.url);
+    return true;
+  });
+}
+
 // Normalizes a benchmark/brand domain for identity comparison: lowercase host,
 // no scheme, no leading `www.`, no path. Null when unparseable. Used to match an
 // existing own-brand benchmark across runs (idempotent ensure) and shared by the
@@ -235,11 +295,15 @@ export async function attachBrandUrlsToProject(
     });
     return { created: 0, skipped: true };
   }
-  await transport.createBrandUrls(workspaceId, projectId, benchmarkId, entries);
+  // Canonicalize website URLs to Semrush's stored form before writing them, so a
+  // create doesn't seed a `www.`-vs-apex duplicate of the benchmark (#25). Done
+  // only once a benchmark exists to write to (no wasted resolve on a skip).
+  const resolvedEntries = await resolveWebsiteEntries(transport, entries, log);
+  await transport.createBrandUrls(workspaceId, projectId, benchmarkId, resolvedEntries);
   log?.info?.('brand-urls: attached to project benchmark', {
-    workspaceId, projectId, benchmarkId, count: entries.length,
+    workspaceId, projectId, benchmarkId, count: resolvedEntries.length,
   });
-  return { created: entries.length };
+  return { created: resolvedEntries.length };
 }
 
 // Best-effort republish after an edit-time change so the live view reflects it.
@@ -314,7 +378,7 @@ export async function syncBrandUrlsAcrossMarkets(
     markets += 1;
 
     try {
-      const desired = collectBrandUrlEntries(sources, market);
+      const collected = collectBrandUrlEntries(sources, market);
       // Own-brand identity for the benchmark comes from the project itself: its
       // domain plus the brand_names (display name first, the rest are aliases).
       const ai = project?.settings?.ai || {};
@@ -342,6 +406,11 @@ export async function syncBrandUrlsAcrossMarkets(
         // eslint-disable-next-line no-continue
         continue;
       }
+      // Canonicalize website URLs to Semrush's stored form BEFORE diffing, so the
+      // desired set is compared against `listBrandUrls` (which returns the same
+      // canonical form) — otherwise every re-sync would churn `www.`-vs-apex (#25).
+      // eslint-disable-next-line no-await-in-loop
+      const desired = await resolveWebsiteEntries(transport, collected, log);
       // eslint-disable-next-line no-await-in-loop
       const existingResp = await transport.listBrandUrls(workspaceId, projectId, benchmarkId);
       const existing = Array.isArray(existingResp?.brand_urls) ? existingResp.brand_urls : [];

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -641,6 +641,23 @@ export function createSerenityTransport({ env, imsToken }) {
     },
 
     /**
+     * GET /v1/url/resolve — canonicalize a raw URL to the form Semrush stores as
+     * a brand URL. Returns `{ domain, primary_url, is_valid }`: `primary_url`
+     * strips the scheme and a leading `www.` (subdomain + path preserved),
+     * `domain` is the registrable apex. Unresolvable/garbage input comes back
+     * `{ domain: '', primary_url: '', is_valid: false }` at HTTP 200 (NOT an
+     * error), so callers MUST check `is_valid` and never write the empty value.
+     * Used to normalize brand URLs before writing them so the value matches the
+     * canonical benchmark Semrush already holds (avoids www-vs-apex duplicates).
+     */
+    async resolveUrl(primaryUrl) {
+      return unwrap('GET', await projects.GET(
+        '/v1/url/resolve',
+        { params: { query: { primary_url: primaryUrl } } },
+      ));
+    },
+
+    /**
      * GET /v1/languages — returns Semrush's language catalog. Used to resolve
      * the language_id UUID from an ISO 639-1 code (e.g. 'en' → UUID). The
      * caller is expected to cache the result (catalog is stable).

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -21,6 +21,7 @@ import {
   collectBrandUrlEntries,
   normalizeBenchmarkDomain,
   ensureOwnBrandBenchmark,
+  resolveWebsiteEntries,
   attachBrandUrlsToProject,
   syncBrandUrlsAcrossMarkets,
 } from '../../../src/support/serenity/brand-urls.js';
@@ -36,6 +37,12 @@ const BID = 'bench-1';
 describe('brand-urls helpers', () => {
   const sandbox = sinon.createSandbox();
   const benchOk = () => ({ aio_benchmarks: [{ id: BID, main_brand: true }] });
+  // Identity url/resolve stub: echoes the input as a valid canonical value, so the
+  // pre-existing plumbing tests keep asserting the RAW url they were written for.
+  // The actual www→apex normalization is covered by the dedicated tests below.
+  const identityResolve = () => sandbox.stub().callsFake(
+    (url) => Promise.resolve({ domain: url, primary_url: url, is_valid: true }),
+  );
   afterEach(() => sandbox.restore());
 
   describe('regionApplies', () => {
@@ -237,6 +244,89 @@ describe('brand-urls helpers', () => {
     });
   });
 
+  describe('resolveWebsiteEntries', () => {
+    it('canonicalizes website entries to the resolve primary_url', async () => {
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
+      };
+      const out = await resolveWebsiteEntries(
+        transport,
+        [{ url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE }],
+        undefined,
+      );
+      expect(out).to.deep.equal([{ url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE }]);
+      expect(transport.resolveUrl).to.have.been.calledOnceWith('https://www.acme.com');
+    });
+
+    it('passes social/earned entries through unchanged (never resolved)', async () => {
+      const transport = { resolveUrl: sandbox.stub() };
+      const entries = [
+        { url: 'https://instagram.com/acme', type: BRAND_URL_TYPE.SOCIAL },
+        { url: 'https://press.example/acme', type: BRAND_URL_TYPE.EARNED },
+      ];
+      const out = await resolveWebsiteEntries(transport, entries, undefined);
+      expect(out).to.deep.equal(entries);
+      expect(transport.resolveUrl).to.not.have.been.called;
+    });
+
+    it('keeps the raw url (and warns) when resolve returns is_valid:false', async () => {
+      const warn = sandbox.stub();
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: '', primary_url: '', is_valid: false }),
+      };
+      const out = await resolveWebsiteEntries(
+        transport,
+        [{ url: 'https://not-a-real-host', type: BRAND_URL_TYPE.WEBSITE }],
+        { warn },
+      );
+      // Never write the empty value — fall back to the raw (already https-filtered) url.
+      expect(out).to.deep.equal([{ url: 'https://not-a-real-host', type: BRAND_URL_TYPE.WEBSITE }]);
+      expect(warn).to.have.been.calledWithMatch(
+        'brand-urls: url/resolve returned is_valid:false — keeping raw url',
+        sinon.match({ url: 'https://not-a-real-host' }),
+      );
+    });
+
+    it('keeps the raw url when is_valid:true but primary_url is empty (defensive)', async () => {
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'x.com', primary_url: '', is_valid: true }),
+      };
+      const out = await resolveWebsiteEntries(
+        transport,
+        [{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }],
+        undefined,
+      );
+      expect(out).to.deep.equal([{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }]);
+    });
+
+    it('re-de-dups when two raw website urls resolve to the same canonical value', async () => {
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
+      };
+      const out = await resolveWebsiteEntries(
+        transport,
+        [
+          { url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE },
+          { url: 'https://acme.com', type: BRAND_URL_TYPE.WEBSITE },
+        ],
+        undefined,
+      );
+      expect(out).to.deep.equal([{ url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE }]);
+      expect(transport.resolveUrl).to.have.been.calledTwice;
+    });
+
+    it('propagates a transport error (leaving best-effort/hard-fail to the caller)', async () => {
+      const transport = {
+        resolveUrl: sandbox.stub().rejects(new SerenityTransportError(502, 'boom')),
+      };
+      await expect(resolveWebsiteEntries(
+        transport,
+        [{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }],
+        undefined,
+      )).to.be.rejectedWith('boom');
+    });
+  });
+
   describe('attachBrandUrlsToProject', () => {
     const BRAND = { name: 'Acme', domain: 'https://acme.com' };
 
@@ -250,6 +340,7 @@ describe('brand-urls helpers', () => {
 
     it('ensures the benchmark and creates the URLs', async () => {
       const transport = {
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         createBenchmarks: sandbox.stub(),
         createBrandUrls: sandbox.stub().resolves({ ids: ['a'], existing_count: 0 }),
@@ -260,8 +351,24 @@ describe('brand-urls helpers', () => {
       expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, PID, BID, entries);
     });
 
+    it('canonicalizes website URLs (via url/resolve) before creating them', async () => {
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
+        listBenchmarks: sandbox.stub().resolves(benchOk()),
+        createBrandUrls: sandbox.stub().resolves({ ids: ['a'], existing_count: 0 }),
+      };
+      const entries = [{ url: 'https://www.acme.com', type: 'website' }];
+      const result = await attachBrandUrlsToProject(transport, WS, PID, entries, BRAND, undefined);
+      expect(result).to.deep.equal({ created: 1 });
+      // The raw https://www.acme.com is stored as its canonical scheme-less form.
+      expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, PID, BID, [
+        { url: 'acme.com', type: 'website' },
+      ]);
+    });
+
     it('creates the benchmark first when the project has none, then attaches', async () => {
       const transport = {
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves({ aio_benchmarks: [] }),
         createBenchmarks: sandbox.stub().resolves({ ids: ['new-1'], existing_count: 0 }),
         createBrandUrls: sandbox.stub().resolves({ ids: ['a'], existing_count: 0 }),
@@ -310,6 +417,7 @@ describe('brand-urls helpers', () => {
 
     it('propagates a create-URL failure', async () => {
       const transport = {
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         createBrandUrls: sandbox.stub().rejects(new SerenityTransportError(400, 'bad url')),
       };
@@ -331,6 +439,7 @@ describe('brand-urls helpers', () => {
       };
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({
           brand_urls: [
@@ -353,9 +462,59 @@ describe('brand-urls helpers', () => {
       expect(result).to.deep.equal({ markets: 1, created: 1, deleted: 1 });
     });
 
+    it('diffs on the resolved canonical form — no churn when Semrush already stores it', async () => {
+      // Desired https://www.acme.com resolves to acme.com, which Semrush already
+      // stores → the re-sync is idempotent (no create/delete/publish).
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
+        listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        listBenchmarks: sandbox.stub().resolves(benchOk()),
+        listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'keep', url: 'acme.com' }] }),
+        createBrandUrls: sandbox.stub().resolves({}),
+        deleteBrandUrls: sandbox.stub().resolves({}),
+        publishProject: sandbox.stub().resolves({}),
+      };
+      const result = await syncBrandUrlsAcrossMarkets(
+        transport,
+        { urls: ['https://www.acme.com'] },
+        WS,
+        undefined,
+      );
+      expect(transport.createBrandUrls).to.not.have.been.called;
+      expect(transport.deleteBrandUrls).to.not.have.been.called;
+      expect(transport.publishProject).to.not.have.been.called;
+      expect(result).to.deep.equal({ markets: 1, created: 0, deleted: 0 });
+    });
+
+    it('migrates a legacy raw-URL entry to its canonical form (delete raw, create scheme-less)', async () => {
+      // Semrush still holds the pre-#25 raw https value; the resolved desired set
+      // is scheme-less, so the one-time re-sync replaces it (self-correcting).
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
+        listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        listBenchmarks: sandbox.stub().resolves(benchOk()),
+        listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'legacy', url: 'https://www.acme.com' }] }),
+        createBrandUrls: sandbox.stub().resolves({}),
+        deleteBrandUrls: sandbox.stub().resolves({}),
+        publishProject: sandbox.stub().resolves({}),
+      };
+      const result = await syncBrandUrlsAcrossMarkets(
+        transport,
+        { urls: ['https://www.acme.com'] },
+        WS,
+        undefined,
+      );
+      expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, [
+        { url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE },
+      ]);
+      expect(transport.deleteBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, ['legacy']);
+      expect(result).to.deep.equal({ markets: 1, created: 1, deleted: 1 });
+    });
+
     it('reuses a pre-fetched project listing instead of calling listProjects', async () => {
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [] }), // would be empty if called
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -382,6 +541,7 @@ describe('brand-urls helpers', () => {
       const boom = new SerenityTransportError(502, 'Semrush POST https://gw.internal/x failed: 502');
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().rejects(boom),
@@ -403,6 +563,7 @@ describe('brand-urls helpers', () => {
       const sources = { urls: ['https://acme.com'] };
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'keep', url: 'https://acme.com' }] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -461,6 +622,7 @@ describe('brand-urls helpers', () => {
       const warn = sandbox.stub();
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -477,6 +639,7 @@ describe('brand-urls helpers', () => {
       const sources = { urls: ['https://acme.com'] };
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -583,6 +746,7 @@ describe('brand-urls helpers', () => {
       // undefined logger, leaving the truthy log?.info path uncovered.
       const info = sandbox.stub();
       const transport = {
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         createBrandUrls: sandbox.stub().resolves({}),
       };
@@ -625,6 +789,7 @@ describe('brand-urls helpers', () => {
             settings: { ai: { country: { code: 'us' } } },
           }],
         }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -655,6 +820,7 @@ describe('brand-urls helpers', () => {
             },
           }],
         }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -683,6 +849,7 @@ describe('brand-urls helpers', () => {
             },
           }],
         }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -705,6 +872,7 @@ describe('brand-urls helpers', () => {
             settings: { ai: { country: { code: 'us' } } },
           }],
         }),
+        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({}),
         createBrandUrls: sandbox.stub().resolves({}),

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -282,9 +282,32 @@ describe('brand-urls helpers', () => {
       // Never write the empty value — fall back to the raw (already https-filtered) url.
       expect(out).to.deep.equal([{ url: 'https://not-a-real-host', type: BRAND_URL_TYPE.WEBSITE }]);
       expect(warn).to.have.been.calledWithMatch(
-        'brand-urls: url/resolve returned is_valid:false — keeping raw url',
+        'brand-urls: url/resolve returned no usable primary_url — keeping raw url',
         sinon.match({ url: 'https://not-a-real-host' }),
       );
+    });
+
+    it('keeps the raw url when resolve resolves null/undefined (optional-chaining defense)', async () => {
+      const transport = { resolveUrl: sandbox.stub().resolves(null) };
+      const out = await resolveWebsiteEntries(
+        transport,
+        [{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }],
+        undefined,
+      );
+      expect(out).to.deep.equal([{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }]);
+    });
+
+    it('resolves each distinct website url once via the shared cache', async () => {
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
+      };
+      const cache = new Map();
+      const entry = [{ url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE }];
+      // Two calls sharing one cache (mirrors the per-market edit loop) → one HTTP call.
+      await resolveWebsiteEntries(transport, entry, undefined, cache);
+      const out = await resolveWebsiteEntries(transport, entry, undefined, cache);
+      expect(out).to.deep.equal([{ url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE }]);
+      expect(transport.resolveUrl).to.have.been.calledOnce;
     });
 
     it('keeps the raw url when is_valid:true but primary_url is empty (defensive)', async () => {
@@ -509,6 +532,29 @@ describe('brand-urls helpers', () => {
       ]);
       expect(transport.deleteBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, ['legacy']);
       expect(result).to.deep.equal({ markets: 1, created: 1, deleted: 1 });
+    });
+
+    it('resolves a region-less website url once across markets (shared cache)', async () => {
+      const transport = {
+        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
+        listProjects: sandbox.stub().resolves({
+          items: [projectWith('p-us', 'us'), projectWith('p-de', 'de')],
+        }),
+        listBenchmarks: sandbox.stub().resolves(benchOk()),
+        listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'keep', url: 'acme.com' }] }),
+        createBrandUrls: sandbox.stub().resolves({}),
+        deleteBrandUrls: sandbox.stub().resolves({}),
+        publishProject: sandbox.stub().resolves({}),
+      };
+      const result = await syncBrandUrlsAcrossMarkets(
+        transport,
+        { urls: ['https://www.acme.com'] },
+        WS,
+        undefined,
+      );
+      expect(result.markets).to.equal(2);
+      // One region-less website url shared by both markets → resolved once (cache hit).
+      expect(transport.resolveUrl).to.have.been.calledOnce;
     });
 
     it('reuses a pre-fetched project listing instead of calling listProjects', async () => {

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -64,6 +64,12 @@ function makeTransport(overrides = {}) {
     deleteAiModelsByIds: sinon.stub().resolves(null),
     createProjectTags: sinon.stub().resolves(null),
     listBenchmarks: sinon.stub().resolves({ aio_benchmarks: [{ id: 'bench-1', main_brand: true }] }),
+    // Identity url/resolve: echoes its input as a valid canonical value, so the
+    // handler's brand-URL attach behaves as before for these tests (the www→apex
+    // normalization itself is unit-tested in brand-urls.test.js).
+    resolveUrl: sinon.stub().callsFake(
+      (url) => Promise.resolve({ domain: url, primary_url: url, is_valid: true }),
+    ),
     createBrandUrls: sinon.stub().resolves({ ids: [], existing_count: 0 }),
     createBenchmarks: sinon.stub().resolves({ ids: ['bm-new'], existing_count: 0 }),
     deleteBenchmarks: sinon.stub().resolves(null),

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -795,6 +795,24 @@ describe('Semrush REST transport', () => {
     });
   });
 
+  describe('resolveUrl', () => {
+    it('GETs /v1/url/resolve with the primary_url query param and returns the body', async () => {
+      fetchStub.resolves(fetchOk({ domain: 'lovesac.com', primary_url: 'lovesac.com', is_valid: true }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const result = await transport.resolveUrl('https://www.lovesac.com');
+
+      const call = await callOf(fetchStub);
+      expect(call.method).to.equal('GET');
+      const url = new URL(call.url);
+      expect(url.pathname).to.equal('/enterprise/projects/api/v1/url/resolve');
+      // The raw URL is passed verbatim as the query value (decoded here to stay
+      // robust to the client's query-encoding).
+      expect(url.searchParams.get('primary_url')).to.equal('https://www.lovesac.com');
+      expect(result).to.deep.equal({ domain: 'lovesac.com', primary_url: 'lovesac.com', is_valid: true });
+    });
+  });
+
   describe('createProjectTags', () => {
     it('POSTs { names } to /v2/workspaces/{ws}/projects/{pid}/aio/tags', async () => {
       fetchStub.resolves(fetchOk({ id: 'tag-1', name: 'source:ai' }));


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Fixes the duplicate brand-domain entry a Serenity brand shows in Semrush by not adding the brand's own primary domain as a brand URL (it already lives on the project's own-brand benchmark). Replaces the earlier "resolve brand URLs to their scheme-less form before writing" approach, which a prod re-capture showed was invalid.

## 2. Reasoning
A brand shows its primary domain twice in Semrush (e.g. `lovesac.com`): once as the own-brand benchmark's own `primary_url` (which Semrush stores scheme-less), and once as an explicit `website` brand-URL row (`https://lovesac.com`) the write path added. A prod re-capture (2026-07-06) of the live contract established two facts that invalidate the original url/resolve approach this PR opened with:
- `create_brand_urls` REQUIRES a literal `https://` value — it 400s on the scheme-less resolve `primary_url` (`'url'` tag) and on `http://` (`'startswith'` tag). So the resolved scheme-less form cannot be written as a brand URL at all.
- `create_benchmarks` already normalizes the benchmark `domain` server-side, so `url/resolve` was redundant for the one field where a scheme-less value is valid.

Because a `brand_urls` row must keep its `https://` scheme and the benchmark domain is scheme-less, the two can never collapse — the only way to remove the visible duplicate is to not emit the primary domain as a brand URL in the first place.

## 3. High-level overview of the changes
Before: every brand-URL entry was pushed to the own-brand benchmark, and (in the reverted revision) each was first run through `url/resolve`.

After: the brand's own primary domain is dropped from the `website` set; every other brand URL (secondary sites, socials, earned) is written verbatim as an `https://` value.
- `collectBrandUrlEntries` takes the project's own-brand domain and skips any `website` URL whose host matches it. The match is host-wise via the existing `normalizeBenchmarkDomain`, so both the apex and `www.` forms of the primary are dropped.
- The market-create path passes the brand's domain; the brand-edit re-sync passes each project's own domain.
- Removes the `resolveUrl` transport method and the `resolveBrandUrlEntries` step — brand URLs are now written exactly as collected (the upstream stores them as-is and does not collapse `www.`-vs-apex, so no normalization is applied).

Net user-visible effect: a Serenity brand no longer double-lists its primary domain in Semrush; socials and any secondary sites are unchanged.

## 4. Required information
- Jira / issue: serenity-docs#25 — https://github.com/adobe/serenity-docs/issues/25
- Other: prod re-capture of the live brand-URL write contract (2026-07-06, throwaway benchmark in a test workspace)

## 5. Affected / used mysticat-workspace projects
- spacecat-shared (contract) — the vendored Project Engine mock is tightened to enforce the live `https://` requirement so this repo's IT can't go green over a prod-400: https://github.com/adobe/spacecat-shared/pull/1778
- mysticat-data-service (related) — the serenity_migration CLI makes the same skip-primary-domain change on its write path: https://github.com/adobe/mysticat-data-service/pull/737

## 6. Additional information outside the code
The live contract behind this change was re-captured against prod `adobe-hackathon.semrush.com` on 2026-07-06: a read-only `url/resolve` edge matrix, plus a write-probe of `create_brand_urls` / `create_benchmarks` on a throwaway benchmark created and deleted in an authorized test workspace. That probe is what established the `https://`-only requirement and the server-side benchmark-domain normalization. The paid customer's live data was inspected read-only (no writes) and confirmed to carry the duplicate this PR prevents.

## 7. Test plan
- (a) Local: unit tests for `collectBrandUrlEntries` (primary-domain skip in apex + www forms; all-kept when no primary given) and both write paths (create attaches the non-primary set; edit diffs verbatim with no churn). The serenity IT exercises the create/edit write paths against the mock.
- (b) Per-env: after merge, verify on dev by creating (or editing) a Serenity brand whose website equals its benchmark domain and confirming the AIO benchmark shows the primary domain only once (no second `https://<domain>` brand-URL row), while socials/secondary sites still attach.

## 8. Deployment & merge order
- serenity-docs#25 redesign is a coordinated set. The spacecat-shared mock fix (https://github.com/adobe/spacecat-shared/pull/1778) hardens the contract this PR relies on; merging it first (and cutting a release) lets this PR's IT run against the tightened mock. The migration-side change (https://github.com/adobe/mysticat-data-service/pull/737) is independent but part of the same redesign. Suggested order: #1778 (+ release) → this PR / #737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
