### PR TITLE
feat(serenity): dynamic AI resource allocation — allocator core + transport read (LLMO-5616)

### DIFF
--- a/src/support/serenity/errors.js
+++ b/src/support/serenity/errors.js
@@ -36,6 +36,74 @@ export function isUpstreamGone(e) {
 }
 
 /**
+ * The upstream error body as a lowercased string, for message-based classification. The gateway
+ * returns either a JSON `{ message }` object or a bare text/html string (the disguised-405 case);
+ * this normalises both so a predicate can match on substrings.
+ * @param {unknown} e
+ * @returns {string}
+ */
+function bodyText(e) {
+  if (!(e instanceof SerenityTransportError)) {
+    return '';
+  }
+  const { body } = e;
+  if (typeof body === 'string') {
+    return body.toLowerCase();
+  }
+  const msg = body && typeof body === 'object' ? /** @type {{message?: unknown}} */ (body).message : undefined;
+  return (typeof msg === 'string' ? msg : `${e.message}`).toLowerCase();
+}
+
+/**
+ * Terminal parent-pool exhaustion: a `422` whose body says the subscription is out of units. The
+ * dynamic allocator maps this to `orgPoolExhausted` (409). MUST match on the message, not the bare
+ * status — the same route also emits a transient `422 "workspace not ready"` (see
+ * {@link isWorkspaceNotReady}) that is retried, not surfaced.
+ * @param {unknown} e
+ * @returns {boolean}
+ */
+export function isPoolExhausted(e) {
+  return e instanceof SerenityTransportError
+    && e.status === 422
+    && bodyText(e).includes('insufficient available units');
+}
+
+/**
+ * Transient async-lock `422 "workspace not ready"` — fired when a transfer/delete races a still
+ * settling workspace, and (Gate 0) can persist even after `getWorkspaceStatus` reports `created`.
+ * Retry with backoff; do NOT surface as pool exhaustion.
+ * @param {unknown} e
+ * @returns {boolean}
+ */
+export function isWorkspaceNotReady(e) {
+  return e instanceof SerenityTransportError
+    && e.status === 422
+    && bodyText(e).includes('workspace not ready');
+}
+
+/**
+ * The disguised metered-quota rejection: a `405` from a metered write/publish (the gateway returns
+ * a non-JSON/HTML body, or a "quota" message) when `used + need > total`. Under dynamic allocation
+ * a 405 right after a top-up signals stale-read / racing consumption (see the 405-recovery loop).
+ * @param {unknown} e
+ * @returns {boolean}
+ */
+export function isMeteredQuota(e) {
+  return e instanceof SerenityTransportError
+    && e.status === 405
+    && (bodyText(e).includes('quota') || typeof e.body === 'string' || e.body == null);
+}
+
+/**
+ * Upstream rate limiting (`429`) — retryable with backoff rather than the generic 502.
+ * @param {unknown} e
+ * @returns {boolean}
+ */
+export function isRateLimited(e) {
+  return e instanceof SerenityTransportError && e.status === 429;
+}
+
+/**
  * Frozen catalog of error-token strings handlers attach to
  * `ErrorWithStatusCode.code` so the controller's `mapError` emits them
  * verbatim in the response envelope (instead of the generic
@@ -55,4 +123,7 @@ export const ERROR_CODES = Object.freeze({
   // Subworkspace provisioning (serenity dual-mode, subworkspace path).
   AMBIGUOUS_WORKSPACE: 'ambiguousWorkspace',
   LINKED_SUBWORKSPACES: 'linkedSubworkspaces',
+  // Dynamic AI resource allocation (JIT top-up path).
+  ORG_POOL_EXHAUSTED: 'orgPoolExhausted',
+  BRAND_AI_LIMIT: 'brandAiLimit',
 });

--- a/src/support/serenity/errors.js
+++ b/src/support/serenity/errors.js
@@ -38,14 +38,12 @@ export function isUpstreamGone(e) {
 /**
  * The upstream error body as a lowercased string, for message-based classification. The gateway
  * returns either a JSON `{ message }` object or a bare text/html string (the disguised-405 case);
- * this normalises both so a predicate can match on substrings.
- * @param {unknown} e
+ * this normalises both so a predicate can match on substrings. Callers guard `instanceof
+ * SerenityTransportError` (short-circuit) before calling, so `e` is always a transport error here.
+ * @param {SerenityTransportError} e
  * @returns {string}
  */
 function bodyText(e) {
-  if (!(e instanceof SerenityTransportError)) {
-    return '';
-  }
   const { body } = e;
   if (typeof body === 'string') {
     return body.toLowerCase();

--- a/src/support/serenity/errors.js
+++ b/src/support/serenity/errors.js
@@ -48,8 +48,10 @@ function bodyText(e) {
   if (typeof body === 'string') {
     return body.toLowerCase();
   }
+  // Only trust the upstream body's `message`; never fall back to `e.message` (the transport URL),
+  // which would let a classifier match on the request URL rather than the upstream content.
   const msg = body && typeof body === 'object' ? /** @type {{message?: unknown}} */ (body).message : undefined;
-  return (typeof msg === 'string' ? msg : `${e.message}`).toLowerCase();
+  return typeof msg === 'string' ? msg.toLowerCase() : '';
 }
 
 /**
@@ -80,16 +82,19 @@ export function isWorkspaceNotReady(e) {
 }
 
 /**
- * The disguised metered-quota rejection: a `405` from a metered write/publish (the gateway returns
- * a non-JSON/HTML body, or a "quota" message) when `used + need > total`. Under dynamic allocation
- * a 405 right after a top-up signals stale-read / racing consumption (see the 405-recovery loop).
+ * The disguised metered-quota rejection: a `405` from a metered write/publish whose body signals a
+ * quota (`used + need > total`). Matches ONLY on an explicit quota signal in the body — NOT any
+ * `405`, so a legitimate Method-Not-Allowed is not absorbed. The exact disguised-405 body is pinned
+ * by the PR-4 live-gateway canary; widen the signal here only from that pinned shape.
  * @param {unknown} e
  * @returns {boolean}
  */
 export function isMeteredQuota(e) {
-  return e instanceof SerenityTransportError
-    && e.status === 405
-    && (bodyText(e).includes('quota') || typeof e.body === 'string' || e.body == null);
+  if (!(e instanceof SerenityTransportError) || e.status !== 405) {
+    return false;
+  }
+  const text = bodyText(e);
+  return text.includes('quota') || text.includes('allocation exhausted');
 }
 
 /**
@@ -124,4 +129,7 @@ export const ERROR_CODES = Object.freeze({
   // Dynamic AI resource allocation (JIT top-up path).
   ORG_POOL_EXHAUSTED: 'orgPoolExhausted',
   BRAND_AI_LIMIT: 'brandAiLimit',
+  // Transient: a transfer never cleared the async `workspace not ready` lock — retryable, NOT
+  // pool exhaustion (distinct from ORG_POOL_EXHAUSTED so the operator/client isn't misled).
+  WORKSPACE_BUSY: 'workspaceBusy',
 });

--- a/src/support/serenity/resource-manager.js
+++ b/src/support/serenity/resource-manager.js
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Dynamic (just-in-time) Semrush AI resource allocation — the pure allocator.
+ *
+ * Replaces the up-front flat carve: before a metered op, read the sub-workspace's real headroom and
+ * transfer only the delta from the parent; hand surplus back on delete. Semrush model,
+ * live-verified 2026-07-02 ("Gate 0"): a transfer is ABSOLUTE (sets `total`) + idempotent; a carve
+ * decrements the MASTER's `total`; `free = total − used`; over-carving the master → terminal
+ * `422 "insufficient available units in subscription"`; a transfer briefly flips the child off
+ * `created` and may `422 "workspace not ready"` transiently even past `status:created`.
+ *
+ * Two pure, transport-injected entry points sit between the handlers and the transport:
+ * - {@link ensureAiHeadroom} BEFORE a metered op — reads child headroom, tops up in grace-sized
+ *   blocks only when needed (hot path = read + compare, no transfer).
+ * - {@link releaseAiSurplus} AFTER a delete/removal (async/reconciler) — hands whole freed blocks
+ *   back, never below the child's floor; best-effort (never throws).
+ *
+ * `used` reconciles asynchronously after publish (post-publish reads are stale-low), so the caller
+ * fronting the PROMPT dimension should size `need` at the publish seam from `used + drafted`
+ * (drafted is set synchronously at draft time) — see the handler-fronting plan; this module exposes
+ * both figures via {@link readAiTotals}.
+ */
+
+import { ErrorWithStatusCode } from '../utils.js';
+import { pollUntilCreated } from './workspace-lifecycle.js';
+import {
+  ERROR_CODES, isPoolExhausted, isWorkspaceNotReady,
+} from './errors.js';
+
+/** @typedef {{ used: number, drafted: number, total: number }} AiDim */
+/** @typedef {{ projects: AiDim, prompts: AiDim }} AiTotals */
+/** @typedef {{ projects?: number, prompts?: number }} Dims a per-dimension unit count */
+/** @typedef {{ projects: number, prompts: number }} Blocks */
+/**
+ * @typedef {object} PollOpts
+ * @property {number} attempts
+ * @property {number} intervalMs
+ * @property {(ms: number) => Promise<void>} sleep
+ */
+
+/** Grace-sized top-up blocks: projects one-at-a-time (checked at publish), prompts in bulk. */
+export const PROJECT_BLOCK = 1;
+export const PROMPT_BLOCK = 100;
+/** @type {Blocks} */
+export const DEFAULT_BLOCKS = Object.freeze({ projects: PROJECT_BLOCK, prompts: PROMPT_BLOCK });
+
+/** The AI dimensions this allocator moves. */
+const DIMS = /** @type {const} */ (['projects', 'prompts']);
+
+/** Real-clock sleep; overridable via the injected `poll.sleep` in tests. */
+const realSleep = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+/**
+ * Budget-sized settle poll — deliberately tighter than the 30-attempt provisioning poll
+ * (`workspace-lifecycle.js`) so a transfer-settle wait cannot alone exceed the request budget.
+ * @type {PollOpts}
+ */
+export const DEFAULT_POLL = Object.freeze({ attempts: 12, intervalMs: 1000, sleep: realSleep });
+
+/** Bounded retries for the transient `422 "workspace not ready"` on a transfer. */
+export const NOT_READY_RETRIES = 3;
+
+/**
+ * Rounds a unit count up to the next whole block (never below the count; 0 → 0).
+ * @param {number} n
+ * @param {number} block
+ * @returns {number}
+ */
+export function roundUpToBlock(n, block) {
+  if (n <= 0) {
+    return 0;
+  }
+  return Math.ceil(n / block) * block;
+}
+
+// ---- need calculators (domain intent — a transport decorator can't compute these) --------------
+
+/**
+ * Prompt units for M texts across K attached models — metered at publish (`texts × models`).
+ * @param {number} texts @param {number} models @returns {number}
+ */
+export const promptUnits = (texts, models) => Math.max(0, texts) * Math.max(0, models);
+
+/**
+ * Prompt units for attaching/removing Δmodels to a project that already has `publishedTexts`
+ * published texts — every existing text re-meters by the model delta.
+ * @param {number} publishedTexts @param {number} deltaModels @returns {number}
+ */
+export const modelChangeUnits = (publishedTexts, deltaModels) => Math.max(0, publishedTexts)
+  * Math.max(0, deltaModels);
+
+/**
+ * Need for creating + publishing a market: one project plus its generated prompts' units.
+ * @param {{ generatedTexts?: number, models?: number }} [spec]
+ * @returns {Dims}
+ */
+export const marketNeed = ({ generatedTexts = 0, models = 0 } = {}) => ({
+  projects: 1,
+  prompts: promptUnits(generatedTexts, models),
+});
+
+// ---- reads --------------------------------------------------------------------------------------
+
+/**
+ * STRICT accessor over a `NewWorkspaceResources` body — pulls the nested
+ * `product_resources.ai.resources.{projects,prompts}` triples. Fails LOUD on a missing/renamed key
+ * rather than defaulting to 0 (a silent `undefined→0` would cause pool drain or spurious 405s).
+ * @param {any} resources the `getWorkspaceResources` response
+ * @returns {AiTotals}
+ */
+export function readAiTotals(resources) {
+  const ai = resources?.product_resources?.ai?.resources;
+  if (!ai || typeof ai !== 'object') {
+    throw new Error('resource-manager: product_resources.ai.resources missing from workspace resources');
+  }
+  /** @param {'projects'|'prompts'} name @returns {AiDim} */
+  const dim = (name) => {
+    const d = ai[name];
+    if (!d || typeof d.used !== 'number' || typeof d.total !== 'number') {
+      throw new Error(`resource-manager: ai.resources.${name}.{used,total} missing/non-numeric`);
+    }
+    return { used: d.used, drafted: typeof d.drafted === 'number' ? d.drafted : 0, total: d.total };
+  };
+  return { projects: dim('projects'), prompts: dim('prompts') };
+}
+
+// ---- typed errors -------------------------------------------------------------------------------
+
+/** @param {string} message @returns {ErrorWithStatusCode} */
+function orgPoolExhausted(message) {
+  const e = new ErrorWithStatusCode(message, 409);
+  e.code = ERROR_CODES.ORG_POOL_EXHAUSTED;
+  return e;
+}
+
+/** @param {string} message @returns {ErrorWithStatusCode} */
+function brandAiLimit(message) {
+  const e = new ErrorWithStatusCode(message, 409);
+  e.code = ERROR_CODES.BRAND_AI_LIMIT;
+  return e;
+}
+
+// ---- transfer + settle --------------------------------------------------------------------------
+
+/**
+ * Absolute transfer of `{ projects, prompts }` totals onto `workspaceId`, then settle-poll. Retries
+ * the transient `422 "workspace not ready"` with backoff; maps terminal pool exhaustion to
+ * `orgPoolExhausted`. Idempotent, so retry after a poll timeout is safe (the poll's 504 propagates;
+ * the controller maps it to a retryable `503`).
+ * @param {any} transport
+ * @param {string} workspaceId
+ * @param {{ projects: number, prompts: number }} totals
+ * @param {PollOpts} poll
+ * @param {any} log
+ * @returns {Promise<void>}
+ */
+async function transferAndSettle(transport, workspaceId, totals, poll, log) {
+  for (let attempt = 0; attempt <= NOT_READY_RETRIES; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await transport.transferWorkspaceResources(workspaceId, { ai: totals });
+      // eslint-disable-next-line no-await-in-loop
+      await pollUntilCreated(transport, workspaceId, poll);
+      return;
+    } catch (e) {
+      if (isPoolExhausted(e)) {
+        throw orgPoolExhausted(`Org pool cannot cover the transfer for ${workspaceId}`);
+      }
+      if (!isWorkspaceNotReady(e)) {
+        throw e; // any other error (incl. poll timeout 504) propagates for the caller to map
+      }
+      if (attempt === NOT_READY_RETRIES) {
+        break; // exhausted retries on the transient lock
+      }
+      log?.info?.(`SERENITY_ALLOC workspace-not-ready, retrying transfer (attempt ${attempt + 1})`);
+      // eslint-disable-next-line no-await-in-loop
+      await poll.sleep(poll.intervalMs * (attempt + 1));
+    }
+  }
+  throw orgPoolExhausted(`Transfer for ${workspaceId} never cleared 'workspace not ready'`);
+}
+
+// ---- entry points -------------------------------------------------------------------------------
+
+/**
+ * Ensure `childId` has headroom for `need` before a metered op. Hot path (already covered) does a
+ * single read and returns without a transfer. Otherwise tops up in whole blocks, gating on the
+ * per-brand ceiling and the org pool (read from the MASTER's own `/resources`).
+ * @param {any} transport
+ * @param {object} opts
+ * @param {string} opts.childId the sub-workspace being written to
+ * @param {string} opts.masterId the parent/master workspace (units source; the org pool)
+ * @param {Dims} opts.need per-dimension units the imminent op will consume
+ * @param {Partial<Blocks>} [opts.ceiling] per-brand max `total` per dim (default: no ceiling)
+ * @param {Blocks} [opts.blocks] grace blocks (default {@link DEFAULT_BLOCKS})
+ * @param {PollOpts} [opts.poll] settle-poll budget (default {@link DEFAULT_POLL})
+ * @param {any} [log]
+ * @returns {Promise<{ toppedUp: boolean, newTotal: { projects: number, prompts: number } }>}
+ */
+export async function ensureAiHeadroom(transport, {
+  childId, masterId, need, ceiling = {}, blocks = DEFAULT_BLOCKS, poll = DEFAULT_POLL,
+}, log) {
+  const child = readAiTotals(await transport.getWorkspaceResources(childId));
+
+  /** @type {{ projects: number, prompts: number }} */
+  const newTotal = { projects: child.projects.total, prompts: child.prompts.total };
+  let toppedUp = false;
+  for (const dim of DIMS) {
+    const required = child[dim].used + (Number(need?.[dim]) || 0);
+    if (required > child[dim].total) {
+      const target = roundUpToBlock(required, blocks[dim]);
+      const cap = ceiling[dim];
+      if (typeof cap === 'number' && target > cap) {
+        throw brandAiLimit(`Brand AI ${dim} allocation ${target} exceeds ceiling ${cap} for ${childId}`);
+      }
+      newTotal[dim] = target;
+      toppedUp = true;
+    }
+  }
+
+  if (!toppedUp) {
+    return { toppedUp: false, newTotal }; // hot path — no transfer, no poll
+  }
+
+  // Advisory pool precheck (the transfer 422 is authoritative). Read the MASTER's OWN /resources —
+  // NOT /parent/resources, which returns child-relative numbers (Gate 0).
+  const master = readAiTotals(await transport.getWorkspaceResources(masterId));
+  for (const dim of DIMS) {
+    const delta = newTotal[dim] - child[dim].total;
+    const free = master[dim].total - master[dim].used;
+    if (delta > 0 && free < delta) {
+      throw orgPoolExhausted(`Org pool ${dim} free ${free} < needed ${delta} for ${childId}`);
+    }
+  }
+
+  await transferAndSettle(transport, childId, newTotal, poll, log);
+  return { toppedUp: true, newTotal };
+}
+
+/**
+ * Release whole freed blocks back to the parent AFTER a delete/removal has been re-published (so
+ * `used` reflects the removal). Never drops the child below `floor`; best-effort — logs and returns
+ * on any failure (a reconciler converges strays). Intended for the async/reconciler path, not the
+ * synchronous delete request.
+ * @param {any} transport
+ * @param {object} opts
+ * @param {string} opts.childId
+ * @param {Partial<Blocks>} [opts.floor] minimum `total` per dim to retain (default 0)
+ * @param {Blocks} [opts.blocks]
+ * @param {PollOpts} [opts.poll]
+ * @param {any} [log]
+ * @returns {Promise<{ released: boolean, target?: { projects: number, prompts: number } }>}
+ */
+export async function releaseAiSurplus(transport, {
+  childId, floor = {}, blocks = DEFAULT_BLOCKS, poll = DEFAULT_POLL,
+}, log) {
+  try {
+    const child = readAiTotals(await transport.getWorkspaceResources(childId));
+    /** @type {{ projects: number, prompts: number }} */
+    const target = { projects: child.projects.total, prompts: child.prompts.total };
+    let lowered = false;
+    for (const dim of DIMS) {
+      const t = Math.max(Number(floor[dim]) || 0, roundUpToBlock(child[dim].used, blocks[dim]));
+      if (t < child[dim].total) {
+        target[dim] = t;
+        lowered = true;
+      }
+    }
+    if (!lowered) {
+      return { released: false };
+    }
+    await transferAndSettle(transport, childId, target, poll, log);
+    return { released: true, target };
+  } catch (e) {
+    log?.warn?.(`SERENITY_ALLOC releaseAiSurplus best-effort failure for ${childId}: ${e?.message}`);
+    return { released: false };
+  }
+}

--- a/src/support/serenity/resource-manager.js
+++ b/src/support/serenity/resource-manager.js
@@ -72,7 +72,8 @@ const realSleep = (ms) => new Promise((resolve) => {
  */
 export const DEFAULT_POLL = Object.freeze({ attempts: 12, intervalMs: 1000, sleep: realSleep });
 
-/** Bounded retries for the transient `422 "workspace not ready"` on a transfer. */
+/** Bounded RETRIES for the transient `422 "workspace not ready"` — 3 retries after the initial
+ * attempt (4 transfer attempts total). */
 export const NOT_READY_RETRIES = 3;
 
 /**
@@ -155,6 +156,17 @@ function brandAiLimit(message) {
   return e;
 }
 
+/**
+ * A transient failure — the transfer never cleared the async `workspace not ready` lock within the
+ * retry bound. `503` (retryable), NOT `orgPoolExhausted`: this is lock contention, not a full pool.
+ * @param {string} message @returns {ErrorWithStatusCode}
+ */
+function workspaceBusy(message) {
+  const e = new ErrorWithStatusCode(message, 503);
+  e.code = ERROR_CODES.WORKSPACE_BUSY;
+  return e;
+}
+
 // ---- transfer + settle --------------------------------------------------------------------------
 
 /**
@@ -192,7 +204,8 @@ async function transferAndSettle(transport, workspaceId, totals, poll, log) {
       await poll.sleep(poll.intervalMs * (attempt + 1));
     }
   }
-  throw orgPoolExhausted(`Transfer for ${workspaceId} never cleared 'workspace not ready'`);
+  // Lock contention, not a full pool — surface a retryable 503, not orgPoolExhausted.
+  throw workspaceBusy(`Transfer for ${workspaceId} never cleared 'workspace not ready'`);
 }
 
 // ---- entry points -------------------------------------------------------------------------------

--- a/src/support/serenity/resource-manager.js
+++ b/src/support/serenity/resource-manager.js
@@ -35,6 +35,7 @@
  */
 
 import { ErrorWithStatusCode } from '../utils.js';
+import { SerenityTransportError } from './rest-transport.js';
 import { pollUntilCreated } from './workspace-lifecycle.js';
 import {
   ERROR_CODES, isPoolExhausted, isWorkspaceNotReady,
@@ -58,7 +59,7 @@ export const PROMPT_BLOCK = 100;
 export const DEFAULT_BLOCKS = Object.freeze({ projects: PROJECT_BLOCK, prompts: PROMPT_BLOCK });
 
 /** The AI dimensions this allocator moves. */
-const DIMS = /** @type {const} */ (['projects', 'prompts']);
+const DIMS = Object.freeze(/** @type {const} */ (['projects', 'prompts']));
 
 /** Real-clock sleep; overridable via the injected `poll.sleep` in tests. */
 const realSleep = (ms) => new Promise((resolve) => {
@@ -300,6 +301,12 @@ export async function releaseAiSurplus(transport, {
     await transferAndSettle(transport, childId, target, poll, log);
     return { released: true, target };
   } catch (e) {
+    // Best-effort for EXPECTED failures (transport / pool / busy) — a reconciler converges strays.
+    // Let unexpected bugs (TypeError, malformed-response Error) propagate so they surface in
+    // monitoring rather than disappearing into a warn log.
+    if (!(e instanceof SerenityTransportError) && !(e instanceof ErrorWithStatusCode)) {
+      throw e;
+    }
     log?.warn?.(`SERENITY_ALLOC releaseAiSurplus best-effort failure for ${childId}: ${e?.message}`);
     return { released: false };
   }

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -686,6 +686,21 @@ export function createSerenityTransport({ env, imsToken }) {
     },
 
     /**
+     * GET /v1/workspaces/{ws}/resources — the workspace's own AI resources
+     * (`NewWorkspaceResources`: `product_resources.ai.resources.{projects,prompts,weekly_prompts}`
+     * as `{ used, drafted, total }`). Read by the dynamic-allocation allocator before a metered op
+     * (child headroom) and against the MASTER workspace for the org pool (`free = total − used`).
+     * NOTE: use this on the master id for the pool — `/parent/resources` returns the workspace's
+     * OWN allocation, not the master pool (live-verified 2026-07-02).
+     */
+    async getWorkspaceResources(workspaceId) {
+      return unwrap('GET', await users.GET(
+        '/v1/workspaces/{id}/resources',
+        { params: { path: { id: workspaceId } } },
+      ));
+    },
+
+    /**
      * GET /v1/workspaces/{parent}/family — list the parent's sub-workspaces
      * (and nested sub-workspaces). Used for ambiguous-create recovery: on a
      * timed-out create, match the exact title and adopt a `created`,

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -96,7 +96,7 @@ function subworkspaceTitle(brand) {
   return hasText(name) ? `${name} [${suffix}]` : `brand-${suffix}`;
 }
 
-async function pollUntilCreated(transport, workspaceId, { attempts, intervalMs, sleep }) {
+export async function pollUntilCreated(transport, workspaceId, { attempts, intervalMs, sleep }) {
   for (let i = 0; i < attempts; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     const status = await transport.getWorkspaceStatus(workspaceId);

--- a/test/support/serenity/errors.test.js
+++ b/test/support/serenity/errors.test.js
@@ -51,6 +51,7 @@ describe('serenity error classification', () => {
     it('isPoolExhausted: only a 422 whose message says insufficient units', () => {
       expect(isPoolExhausted(err(422, { message: 'insufficient available units in subscription' }))).to.be.true;
       expect(isPoolExhausted(err(422, { message: 'workspace not ready' }))).to.be.false; // transient, not exhaustion
+      expect(isPoolExhausted(err(422, {}))).to.be.false; // object without a message → no match
       expect(isPoolExhausted(err(500, { message: 'insufficient available units' }))).to.be.false;
       expect(isPoolExhausted(new Error('x'))).to.be.false;
     });
@@ -60,10 +61,13 @@ describe('serenity error classification', () => {
       expect(isWorkspaceNotReady(err(422, { message: 'insufficient available units' }))).to.be.false;
     });
 
-    it('isMeteredQuota: a 405 with a quota message, a text/html body, or no body', () => {
+    it('isMeteredQuota: only a 405 with an explicit quota signal — never a bare Method-Not-Allowed', () => {
       expect(isMeteredQuota(err(405, { message: 'Quota exceeded' }))).to.be.true;
-      expect(isMeteredQuota(err(405, '<html>method not allowed</html>'))).to.be.true;
-      expect(isMeteredQuota(err(405, null))).to.be.true;
+      expect(isMeteredQuota(err(405, 'quota exceeded'))).to.be.true; // string body
+      expect(isMeteredQuota(err(405, '<html>prompt allocation exhausted</html>'))).to.be.true;
+      expect(isMeteredQuota(err(405, { message: 'Method Not Allowed' }))).to.be.false; // legitimate 405
+      expect(isMeteredQuota(err(405, 'method not allowed'))).to.be.false;
+      expect(isMeteredQuota(err(405, null))).to.be.false; // no body signal → not quota
       expect(isMeteredQuota(err(404, null))).to.be.false;
     });
 

--- a/test/support/serenity/errors.test.js
+++ b/test/support/serenity/errors.test.js
@@ -15,6 +15,10 @@ import { expect } from 'chai';
 import {
   isUpstreamGone,
   ERROR_CODES,
+  isPoolExhausted,
+  isWorkspaceNotReady,
+  isMeteredQuota,
+  isRateLimited,
 } from '../../../src/support/serenity/errors.js';
 import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
 
@@ -35,7 +39,37 @@ describe('serenity error classification', () => {
       expect(ERROR_CODES.MARKET_NOT_FOUND).to.equal('marketNotFound');
       expect(ERROR_CODES.AMBIGUOUS_WORKSPACE).to.equal('ambiguousWorkspace');
       expect(ERROR_CODES.LINKED_SUBWORKSPACES).to.equal('linkedSubworkspaces');
+      expect(ERROR_CODES.ORG_POOL_EXHAUSTED).to.equal('orgPoolExhausted');
+      expect(ERROR_CODES.BRAND_AI_LIMIT).to.equal('brandAiLimit');
       expect(Object.isFrozen(ERROR_CODES)).to.be.true;
+    });
+  });
+
+  describe('dynamic-allocation classifiers (body/message, not status alone)', () => {
+    const err = (status, body) => new SerenityTransportError(status, 'upstream', body);
+
+    it('isPoolExhausted: only a 422 whose message says insufficient units', () => {
+      expect(isPoolExhausted(err(422, { message: 'insufficient available units in subscription' }))).to.be.true;
+      expect(isPoolExhausted(err(422, { message: 'workspace not ready' }))).to.be.false; // transient, not exhaustion
+      expect(isPoolExhausted(err(500, { message: 'insufficient available units' }))).to.be.false;
+      expect(isPoolExhausted(new Error('x'))).to.be.false;
+    });
+
+    it('isWorkspaceNotReady: only the transient 422 lock', () => {
+      expect(isWorkspaceNotReady(err(422, { message: 'workspace not ready' }))).to.be.true;
+      expect(isWorkspaceNotReady(err(422, { message: 'insufficient available units' }))).to.be.false;
+    });
+
+    it('isMeteredQuota: a 405 with a quota message, a text/html body, or no body', () => {
+      expect(isMeteredQuota(err(405, { message: 'Quota exceeded' }))).to.be.true;
+      expect(isMeteredQuota(err(405, '<html>method not allowed</html>'))).to.be.true;
+      expect(isMeteredQuota(err(405, null))).to.be.true;
+      expect(isMeteredQuota(err(404, null))).to.be.false;
+    });
+
+    it('isRateLimited: a 429', () => {
+      expect(isRateLimited(err(429, null))).to.be.true;
+      expect(isRateLimited(err(503, null))).to.be.false;
     });
   });
 });

--- a/test/support/serenity/resource-manager.test.js
+++ b/test/support/serenity/resource-manager.test.js
@@ -18,7 +18,7 @@ import { SerenityTransportError } from '../../../src/support/serenity/rest-trans
 import { ErrorWithStatusCode } from '../../../src/support/utils.js';
 import {
   roundUpToBlock, promptUnits, modelChangeUnits, marketNeed, readAiTotals,
-  ensureAiHeadroom, releaseAiSurplus, DEFAULT_BLOCKS,
+  ensureAiHeadroom, releaseAiSurplus, DEFAULT_BLOCKS, DEFAULT_POLL,
 } from '../../../src/support/serenity/resource-manager.js';
 
 use(chaiAsPromised);
@@ -247,5 +247,10 @@ describe('resource-manager — releaseAiSurplus', () => {
 
   it('exports the default blocks', () => {
     expect(DEFAULT_BLOCKS).to.deep.equal({ projects: 1, prompts: 100 });
+  });
+
+  it('DEFAULT_POLL.sleep resolves against the real timer', async () => {
+    await DEFAULT_POLL.sleep(0); // exercises the real-clock sleep default
+    expect(DEFAULT_POLL.attempts).to.be.a('number');
   });
 });

--- a/test/support/serenity/resource-manager.test.js
+++ b/test/support/serenity/resource-manager.test.js
@@ -182,17 +182,20 @@ describe('resource-manager — ensureAiHeadroom', () => {
     expect(transfer).to.have.callCount(2);
   });
 
-  it('throws orgPoolExhausted when "workspace not ready" never clears within the retry bound', async () => {
+  it('throws a transient workspaceBusy (503) when "workspace not ready" never clears — NOT pool exhaustion', async () => {
+    const transfer = sinon.stub().rejects(notReady());
     const t = makeTransport({
       child: resources(dim(2, 0, 2), dim(0, 0, 0)),
       master: resources(dim(0, 0, 100), dim(0, 0, 800)),
-      transfer: sinon.stub().rejects(notReady()),
+      transfer,
     });
     const e = await ensureAiHeadroom(t, {
       childId: CHILD, masterId: MASTER, need: { prompts: 10 }, poll,
     }, log).catch((x) => x);
-    expect(e.code).to.equal('orgPoolExhausted');
+    expect(e.status).to.equal(503);
+    expect(e.code).to.equal('workspaceBusy');
     expect(e.message).to.match(/never cleared/);
+    expect(transfer).to.have.callCount(4); // 1 initial + NOT_READY_RETRIES(3)
   });
 
   it('propagates a non-quota transfer error (e.g. 500) unchanged', async () => {

--- a/test/support/serenity/resource-manager.test.js
+++ b/test/support/serenity/resource-manager.test.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
+import { ErrorWithStatusCode } from '../../../src/support/utils.js';
+import {
+  roundUpToBlock, promptUnits, modelChangeUnits, marketNeed, readAiTotals,
+  ensureAiHeadroom, releaseAiSurplus, DEFAULT_BLOCKS,
+} from '../../../src/support/serenity/resource-manager.js';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+const CHILD = 'child-ws';
+const MASTER = 'master-ws';
+const log = { info: () => {}, warn: () => {}, error: () => {} };
+// Fast poll: created immediately, no real sleep.
+const poll = { attempts: 3, intervalMs: 0, sleep: () => Promise.resolve() };
+
+const dim = (used, drafted, total) => ({ used, drafted, total });
+const resources = (projects, prompts) => ({
+  product_resources: { ai: { resources: { projects, prompts } } },
+});
+/** Expected transfer payload. */
+const ai = (projects, prompts) => ({ ai: { projects, prompts } });
+const notReady = () => new SerenityTransportError(422, 'x', { message: 'workspace not ready' });
+const poolFull = () => new SerenityTransportError(422, 'x', { message: 'insufficient available units in subscription' });
+
+/** Transport stub: per-workspace resources + transfer + status(created). */
+function makeTransport({ child, master, transfer } = {}) {
+  const getWorkspaceResources = sinon.stub();
+  getWorkspaceResources.withArgs(CHILD).resolves(child);
+  getWorkspaceResources.withArgs(MASTER).resolves(master);
+  return {
+    getWorkspaceResources,
+    transferWorkspaceResources: transfer || sinon.stub().resolves(),
+    getWorkspaceStatus: sinon.stub().resolves({ status: 'created' }),
+  };
+}
+
+describe('resource-manager — pure helpers', () => {
+  it('roundUpToBlock: 0/negative → 0, else next whole block', () => {
+    expect(roundUpToBlock(0, 100)).to.equal(0);
+    expect(roundUpToBlock(-5, 100)).to.equal(0);
+    expect(roundUpToBlock(1, 100)).to.equal(100);
+    expect(roundUpToBlock(100, 100)).to.equal(100);
+    expect(roundUpToBlock(101, 100)).to.equal(200);
+    expect(roundUpToBlock(3, 1)).to.equal(3);
+  });
+
+  it('need calculators clamp negatives to 0', () => {
+    expect(promptUnits(3, 2)).to.equal(6);
+    expect(promptUnits(-3, 2)).to.equal(0);
+    expect(modelChangeUnits(10, 1)).to.equal(10);
+    expect(modelChangeUnits(10, -1)).to.equal(0);
+    expect(marketNeed({ generatedTexts: 4, models: 2 })).to.deep.equal({ projects: 1, prompts: 8 });
+    expect(marketNeed()).to.deep.equal({ projects: 1, prompts: 0 });
+  });
+
+  it('readAiTotals: strict nested accessor, drafted defaults to 0', () => {
+    expect(readAiTotals(resources(dim(1, 0, 5), dim(2, 3, 50)))).to.deep.equal({
+      projects: dim(1, 0, 5), prompts: dim(2, 3, 50),
+    });
+    // drafted missing → 0
+    expect(readAiTotals(resources({ used: 1, total: 5 }, { used: 0, total: 10 })).projects.drafted)
+      .to.equal(0);
+  });
+
+  it('readAiTotals: fails loud on missing ai block or dimension', () => {
+    expect(() => readAiTotals({})).to.throw(/product_resources.ai.resources missing/);
+    expect(() => readAiTotals(resources(undefined, dim(0, 0, 10)))).to.throw(/ai.resources.projects/);
+    expect(() => readAiTotals(resources({ used: 'x', total: 5 }, dim(0, 0, 10)))).to.throw(/projects/);
+  });
+});
+
+describe('resource-manager — ensureAiHeadroom', () => {
+  it('hot path: already covered → no transfer, no poll', async () => {
+    const t = makeTransport({ child: resources(dim(1, 0, 5), dim(50, 0, 800)) });
+    const r = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { projects: 1, prompts: 100 },
+    }, log);
+    expect(r.toppedUp).to.equal(false);
+    expect(t.transferWorkspaceResources).to.not.have.been.called;
+    expect(t.getWorkspaceResources).to.have.been.calledOnceWith(CHILD); // master never read
+  });
+
+  it('need = 0 (or absent) is a true no-op — zero transport writes', async () => {
+    const t = makeTransport({ child: resources(dim(2, 0, 2), dim(800, 0, 800)) });
+    const r = await ensureAiHeadroom(t, { childId: CHILD, masterId: MASTER, need: {} }, log);
+    expect(r.toppedUp).to.equal(false);
+    expect(t.transferWorkspaceResources).to.not.have.been.called;
+  });
+
+  it('tops up only the short dimension to the next block; leaves the covered dim at its total', async () => {
+    const t = makeTransport({
+      // projects covered; prompts short (need 20 → 70 > 60)
+      child: resources(dim(2, 0, 2), dim(50, 0, 60)),
+      master: resources(dim(0, 0, 100), dim(0, 0, 800)),
+    });
+    const r = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { projects: 0, prompts: 20 }, poll,
+    }, log);
+    expect(r).to.deep.equal({ toppedUp: true, newTotal: { projects: 2, prompts: 100 } });
+    expect(t.transferWorkspaceResources).to.have.been.calledOnceWith(CHILD, ai(2, 100));
+  });
+
+  it('tops up the projects dimension one block at a time', async () => {
+    const t = makeTransport({
+      child: resources(dim(2, 0, 2), dim(0, 0, 100)),
+      master: resources(dim(2, 0, 13), dim(0, 0, 800)),
+    });
+    const r = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { projects: 1 }, poll,
+    }, log);
+    expect(r.newTotal.projects).to.equal(3); // roundUpToBlock(3, 1)
+    expect(t.transferWorkspaceResources).to.have.been.calledWith(CHILD, ai(3, 100));
+  });
+
+  it('throws brandAiLimit (409) when the top-up would exceed the per-brand ceiling', async () => {
+    const t = makeTransport({ child: resources(dim(2, 0, 2), dim(0, 0, 100)) });
+    const p = ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { projects: 3 }, ceiling: { projects: 3 }, poll,
+    }, log);
+    await expect(p).to.be.rejectedWith(ErrorWithStatusCode);
+    const e = await p.catch((x) => x);
+    expect(e.status).to.equal(409);
+    expect(e.code).to.equal('brandAiLimit');
+    expect(t.transferWorkspaceResources).to.not.have.been.called;
+  });
+
+  it('throws orgPoolExhausted (409) when the master pool free < delta (advisory precheck)', async () => {
+    const t = makeTransport({
+      child: resources(dim(2, 0, 2), dim(750, 0, 750)), // prompts need 100 → 850 target, delta 100
+      master: resources(dim(2, 0, 13), dim(760, 0, 800)), // prompts free = 40 < 100
+    });
+    const e = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { prompts: 100 }, poll,
+    }, log).catch((x) => x);
+    expect(e.status).to.equal(409);
+    expect(e.code).to.equal('orgPoolExhausted');
+    expect(t.transferWorkspaceResources).to.not.have.been.called;
+  });
+
+  it('maps a terminal 422 "insufficient units" on the transfer to orgPoolExhausted', async () => {
+    const t = makeTransport({
+      child: resources(dim(2, 0, 2), dim(0, 0, 0)),
+      master: resources(dim(0, 0, 100), dim(0, 0, 800)),
+      transfer: sinon.stub().rejects(poolFull()),
+    });
+    const e = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { prompts: 10 }, poll,
+    }, log).catch((x) => x);
+    expect(e.code).to.equal('orgPoolExhausted');
+  });
+
+  it('retries the transient "workspace not ready" 422 then succeeds', async () => {
+    const transfer = sinon.stub();
+    transfer.onCall(0).rejects(notReady());
+    transfer.onCall(1).resolves();
+    const t = makeTransport({
+      child: resources(dim(2, 0, 2), dim(0, 0, 0)),
+      master: resources(dim(0, 0, 100), dim(0, 0, 800)),
+      transfer,
+    });
+    const r = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { prompts: 10 }, poll,
+    }, log);
+    expect(r.toppedUp).to.equal(true);
+    expect(transfer).to.have.callCount(2);
+  });
+
+  it('throws orgPoolExhausted when "workspace not ready" never clears within the retry bound', async () => {
+    const t = makeTransport({
+      child: resources(dim(2, 0, 2), dim(0, 0, 0)),
+      master: resources(dim(0, 0, 100), dim(0, 0, 800)),
+      transfer: sinon.stub().rejects(notReady()),
+    });
+    const e = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { prompts: 10 }, poll,
+    }, log).catch((x) => x);
+    expect(e.code).to.equal('orgPoolExhausted');
+    expect(e.message).to.match(/never cleared/);
+  });
+
+  it('propagates a non-quota transfer error (e.g. 500) unchanged', async () => {
+    const t = makeTransport({
+      child: resources(dim(2, 0, 2), dim(0, 0, 0)),
+      master: resources(dim(0, 0, 100), dim(0, 0, 800)),
+      transfer: sinon.stub().rejects(new SerenityTransportError(500, 'boom')),
+    });
+    const e = await ensureAiHeadroom(t, {
+      childId: CHILD, masterId: MASTER, need: { prompts: 10 }, poll,
+    }, log).catch((x) => x);
+    expect(e).to.be.instanceOf(SerenityTransportError);
+    expect(e.status).to.equal(500);
+  });
+});
+
+describe('resource-manager — releaseAiSurplus', () => {
+  it('no-op when nothing frees a whole block', async () => {
+    const t = makeTransport({ child: resources(dim(2, 0, 2), dim(90, 0, 100)) });
+    const r = await releaseAiSurplus(t, { childId: CHILD, poll }, log);
+    expect(r).to.deep.equal({ released: false });
+    expect(t.transferWorkspaceResources).to.not.have.been.called;
+  });
+
+  it('lowers totals to rounded used, never below the floor', async () => {
+    const t = makeTransport({ child: resources(dim(1, 0, 5), dim(50, 0, 400)) });
+    const r = await releaseAiSurplus(t, {
+      childId: CHILD, floor: { projects: 1, prompts: 0 }, poll,
+    }, log);
+    // projects → max(1, roundUp(1))=1 < 5; prompts → max(0, roundUp(50)=100)=100 < 400
+    expect(r.released).to.equal(true);
+    expect(t.transferWorkspaceResources).to.have.been.calledOnceWith(CHILD, ai(1, 100));
+  });
+
+  it('respects a floor above rounded used', async () => {
+    const t = makeTransport({ child: resources(dim(0, 0, 5), dim(0, 0, 500)) });
+    const r = await releaseAiSurplus(t, {
+      childId: CHILD, floor: { projects: 2, prompts: 200 }, poll,
+    }, log);
+    expect(t.transferWorkspaceResources).to.have.been.calledOnceWith(CHILD, ai(2, 200));
+    expect(r.target).to.deep.equal({ projects: 2, prompts: 200 });
+  });
+
+  it('is best-effort — swallows a read/transfer failure and returns released:false', async () => {
+    const warn = sinon.spy();
+    const t = makeTransport({ child: resources(dim(0, 0, 5), dim(0, 0, 500)) });
+    t.getWorkspaceResources.withArgs(CHILD).rejects(new Error('read boom'));
+    const r = await releaseAiSurplus(t, { childId: CHILD, poll }, { ...log, warn });
+    expect(r).to.deep.equal({ released: false });
+    expect(warn).to.have.been.called;
+  });
+
+  it('exports the default blocks', () => {
+    expect(DEFAULT_BLOCKS).to.deep.equal({ projects: 1, prompts: 100 });
+  });
+});

--- a/test/support/serenity/resource-manager.test.js
+++ b/test/support/serenity/resource-manager.test.js
@@ -239,13 +239,19 @@ describe('resource-manager — releaseAiSurplus', () => {
     expect(r.target).to.deep.equal({ projects: 2, prompts: 200 });
   });
 
-  it('is best-effort — swallows a read/transfer failure and returns released:false', async () => {
+  it('is best-effort — swallows an EXPECTED transport failure and returns released:false', async () => {
     const warn = sinon.spy();
     const t = makeTransport({ child: resources(dim(0, 0, 5), dim(0, 0, 500)) });
-    t.getWorkspaceResources.withArgs(CHILD).rejects(new Error('read boom'));
+    t.getWorkspaceResources.withArgs(CHILD).rejects(new SerenityTransportError(503, 'transport boom'));
     const r = await releaseAiSurplus(t, { childId: CHILD, poll }, { ...log, warn });
     expect(r).to.deep.equal({ released: false });
     expect(warn).to.have.been.called;
+  });
+
+  it('propagates an UNEXPECTED error (e.g. a bug) rather than hiding it', async () => {
+    const t = makeTransport({ child: resources(dim(0, 0, 5), dim(0, 0, 500)) });
+    t.getWorkspaceResources.withArgs(CHILD).rejects(new TypeError('undefined is not a function'));
+    await expect(releaseAiSurplus(t, { childId: CHILD, poll }, log)).to.be.rejectedWith(TypeError);
   });
 
   it('exports the default blocks', () => {

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -970,6 +970,24 @@ describe('Semrush REST transport', () => {
     });
   });
 
+  describe('getWorkspaceResources', () => {
+    it('GETs /v1/workspaces/{ws}/resources', async () => {
+      fetchStub.resolves(fetchOk({
+        product_resources: { ai: { resources: { projects: { used: 0, drafted: 0, total: 13 } } } },
+      }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const result = await transport.getWorkspaceResources(WORKSPACE_ID);
+
+      const call = await callOf(fetchStub);
+      expect(call.method).to.equal('GET');
+      expect(call.url).to.equal(
+        `https://adobe-hackathon.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}/resources`,
+      );
+      expect(result.product_resources.ai.resources.projects.total).to.equal(13);
+    });
+  });
+
   describe('listWorkspaceFamily', () => {
     it('GETs /v1/workspaces/{parent}/family', async () => {
       fetchStub.resolves(fetchOk({ items: [{ id: 'subworkspace-ws-1', title: 'Adobe Express' }] }));


### PR DESCRIPTION
**Spec / design:** [serenity-docs#22 — Dynamic Resource Allocation](https://github.com/adobe/serenity-docs/pull/22) (Gate-0 live-verified). Companion to the mock foundation [adobe/spacecat-shared#1767](https://github.com/adobe/spacecat-shared/pull/1767). This is **PR 2 (allocator core, unit-only)** of the api-service plan; PR 3 (fronting the sub-workspace handlers + flag-gated carve) follows and gates its IT on the shared mock release.

## What

The pure, transport-injected **dynamic just-in-time AI allocator** plus the resource read and error classification — no handler wiring, flag, or carve change yet.

- **`rest-transport.js`** — `getWorkspaceResources(workspaceId)`. Read the **master's own** `/resources` for the org pool (`/parent/resources` returns child-relative numbers — Gate 0).
- **`errors.js`** — `ORG_POOL_EXHAUSTED` / `BRAND_AI_LIMIT` codes; body/message classifiers that separate the terminal `422 "insufficient available units"` (`isPoolExhausted`) from the transient `422 "workspace not ready"` (`isWorkspaceNotReady`), plus `isMeteredQuota` (405) and `isRateLimited` (429).
- **`resource-manager.js`** — `ensureAiHeadroom` (hot-path read, block-sized top-up gated on ceiling + master pool) / `releaseAiSurplus` (best-effort, floor-clamped); `roundUpToBlock`, `PROJECT_BLOCK=1` / `PROMPT_BLOCK=100`, `need` calculators, a **strict fail-loud** `readAiTotals` over the nested `product_resources.ai.resources.*`, a **budget-sized** settle poll + **bounded** "workspace not ready" retry, typed `409`s via `ErrorWithStatusCode.code`.
- **`workspace-lifecycle.js`** — export `pollUntilCreated` for reuse.

## Design notes (from the 4-expert plan review)

- **No `mapError` change** — `orgPoolExhausted`/`brandAiLimit` flow via `.code`; the existing `422` handling is untouched so flag-OFF stays byte-for-byte (the current carve `422`s today).
- Reads keep `drafted` so PR 3 can front the prompt dimension at the **publish seam** using `used + drafted` (staleness-immune vs async-reconciled `used`).
- Poll is budget-sized (not the 30-attempt provisioning ceiling); release is best-effort + floor-clamped for the async/reconciler path.

## Test plan

- `npm run lint` ✓ · `npm run type-check` ✓ · `npm test` ✓ — **13590 passing**, coverage **99.94% lines / 99.28% branches** (gate 90%). +26 unit tests (`resource-manager`, `errors`, transport read) covering hot path, `need=0` no-op, block boundaries, ceiling→`brandAiLimit`, pool→`orgPoolExhausted`, transfer 422/not-ready retry+exhaustion, non-quota propagation, strict-accessor throw, best-effort release. Pure unit (stubbed transport) — no IT/live access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
