### PR TITLE
feat(serenity): LLMO/dynamic-allocation feature flag + auth threading (LLMO-5616)

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -63,6 +63,7 @@ import {
 } from '../support/serenity/handlers/tags.js';
 import { ensureSubworkspace, decommissionBrandWorkspace } from '../support/serenity/workspace-lifecycle.js';
 import { isSerenityActiveForOrg } from '../support/serenity/serenity-active.js';
+import { isDynamicAllocationActiveForOrg } from '../support/serenity/dynamic-allocation-active.js';
 import { MAX_TOPICS_ON_CREATE } from '../support/serenity/brand-provisioning.js';
 import { STANDARD_PROMPT_TAGS, PROJECT_STANDARD_TAGS } from '../support/serenity/prompt-tags.js';
 import AccessControlUtil from '../support/access-control-util.js';
@@ -326,7 +327,15 @@ function SerenityController(context, log, env) {
     // 404 (the same "no serenity for this org" contract the UI already handles
     // for an org without a workspace). Checked before brand resolution so an
     // inactive org never leaks brand existence.
-    if (!await isSerenityActiveForOrg(ctx, spaceCatId, log)) {
+    // Read both org-wide flags in parallel (independent): the serenity rollout gate (hard 404 when
+    // OFF) and the dynamic-allocation switch. dynamicAllocation is NOT a gate — it's threaded onto
+    // the auth object so the metered handlers branch between JIT top-up (ON) and the flat carve
+    // (OFF). OFF is the default and stays OFF for every org until the PR-4 safeguards land.
+    const [serenityActive, dynamicAllocation] = await Promise.all([
+      isSerenityActiveForOrg(ctx, spaceCatId, log),
+      isDynamicAllocationActiveForOrg(ctx, spaceCatId, log),
+    ]);
+    if (!serenityActive) {
       return { error: notFound('Serenity is not active for this organization') };
     }
     const brandUuid = await resolveBrandUuid(spaceCatId, brandId, postgrestClient);
@@ -369,7 +378,7 @@ function SerenityController(context, log, env) {
       };
     }
     return {
-      brandUuid, mode, workspaceId, parentWorkspaceId,
+      brandUuid, mode, workspaceId, parentWorkspaceId, dynamicAllocation,
     };
   }
 

--- a/src/support/serenity/dynamic-allocation-active.js
+++ b/src/support/serenity/dynamic-allocation-active.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+import { hasText } from '@adobe/spacecat-shared-utils';
+
+import { readFeatureFlag } from '../feature-flags-storage.js';
+import { CACHE_TTL_MS, NEG_TTL_MS, MAX_ENTRIES } from './workspace-resolver.js';
+
+/**
+ * The per-org rollout switch for **dynamic (just-in-time) AI resource allocation**, stored in the
+ * `feature_flags` table (organization_id + product + flag_name). It is a SECOND, independent flag
+ * from `LLMO/serenity`: serenity must already be active for an org, and this flag additionally
+ * decides whether the sub-workspace metered ops top up JIT (ON) or keep the flat pre-calculated
+ * carve (OFF).
+ *
+ * DEFAULT OFF and, per the dynamic-allocation rollout plan, it stays OFF for every org until the
+ * PR-4 safeguards (per-org rightsizing sweep, concurrency serialization, the SLIs, and the
+ * live-gateway canary) are in place — flipping it ON before then is unsafe. A missing/`false` row,
+ * an unavailable PostgREST client, or a transient read error all resolve to `false`.
+ */
+export const DYNAMIC_ALLOCATION_FEATURE_FLAG_PRODUCT = 'LLMO';
+export const DYNAMIC_ALLOCATION_FEATURE_FLAG_NAME = 'dynamic-allocation';
+
+/**
+ * Module-scoped TTL+size-bounded cache — its own Map, separate from the serenity-flag cache, so the
+ * two flags never collide. Positive value cached for the positive TTL; `false`/absent for the
+ * shorter negative TTL so flipping an org ON takes effect within ~NEG_TTL_MS. Reuses the resolver's
+ * TTL/size constants to stay in lockstep. Exported clear is for unit tests only.
+ */
+const flagCache = new Map();
+
+/**
+ * @param {string} spaceCatId - SpaceCat organization UUID.
+ * @returns {string} composite cache key (org + product + flag).
+ */
+function flagCacheKey(spaceCatId) {
+  return `${spaceCatId}::${DYNAMIC_ALLOCATION_FEATURE_FLAG_PRODUCT}::${DYNAMIC_ALLOCATION_FEATURE_FLAG_NAME}`;
+}
+
+export function clearDynamicAllocationFlagCache() {
+  flagCache.clear();
+}
+
+function evictIfNeeded() {
+  while (flagCache.size >= MAX_ENTRIES) {
+    const oldest = flagCache.keys().next().value;
+    /* c8 ignore start -- defensive: size>=MAX_ENTRIES implies a key exists */
+    if (oldest === undefined) {
+      break;
+    }
+    /* c8 ignore stop */
+    flagCache.delete(oldest);
+  }
+}
+
+/**
+ * Is dynamic (JIT) AI resource allocation active for an organization? Reads the org-wide
+ * `LLMO/dynamic-allocation` feature flag (cached). Default OFF: a missing flag row, a `false` row,
+ * an unavailable PostgREST client, or a transient read error all resolve to `false`, so an org is
+ * never silently switched to JIT allocation.
+ *
+ * @param {object} ctx - Request context (uses `ctx.dataAccess.services.postgrestClient`).
+ * @param {string} spaceCatId - SpaceCat organization UUID.
+ * @param {object} [log] - Optional logger (surfaces a missing client / read error, never throws).
+ * @returns {Promise<boolean>} `true` only when the org-wide dynamic-allocation flag is on.
+ */
+export async function isDynamicAllocationActiveForOrg(ctx, spaceCatId, log) {
+  if (!hasText(spaceCatId)) {
+    return false;
+  }
+
+  const postgrestClient = ctx?.dataAccess?.services?.postgrestClient;
+  if (!postgrestClient?.from) {
+    log?.warn?.('[serenity] isDynamicAllocationActiveForOrg: PostgREST client unavailable — treating dynamic allocation as inactive');
+    return false;
+  }
+
+  const now = Date.now();
+  const cacheKey = flagCacheKey(spaceCatId);
+  const cached = flagCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+
+  let raw;
+  try {
+    raw = await readFeatureFlag({
+      organizationId: spaceCatId,
+      product: DYNAMIC_ALLOCATION_FEATURE_FLAG_PRODUCT,
+      flagName: DYNAMIC_ALLOCATION_FEATURE_FLAG_NAME,
+      postgrestClient,
+    });
+  } catch (e) {
+    // Fail safe (inactive) on a transient read error, and do NOT cache it so a recovered DB takes
+    // effect on the next call rather than after a TTL.
+    log?.error?.(`[serenity] isDynamicAllocationActiveForOrg: failed to read flag for org ${spaceCatId}: ${e?.message}`);
+    return false;
+  }
+
+  const value = raw === true;
+  flagCache.delete(cacheKey);
+  evictIfNeeded();
+  flagCache.set(cacheKey, { value, expiresAt: now + (value ? CACHE_TTL_MS : NEG_TTL_MS) });
+  return value;
+}

--- a/src/support/serenity/dynamic-allocation-active.js
+++ b/src/support/serenity/dynamic-allocation-active.js
@@ -30,7 +30,9 @@ import { CACHE_TTL_MS, NEG_TTL_MS, MAX_ENTRIES } from './workspace-resolver.js';
  * an unavailable PostgREST client, or a transient read error all resolve to `false`.
  */
 export const DYNAMIC_ALLOCATION_FEATURE_FLAG_PRODUCT = 'LLMO';
-export const DYNAMIC_ALLOCATION_FEATURE_FLAG_NAME = 'dynamic-allocation';
+// Lowercase snake_case per the feature-flags admin API validation (^[a-z][a-z0-9_]*$) —
+// hyphens are rejected (see feature-flags-storage.js FLAG_NAME_PATTERN).
+export const DYNAMIC_ALLOCATION_FEATURE_FLAG_NAME = 'dynamic_allocation';
 
 /**
  * Module-scoped TTL+size-bounded cache — its own Map, separate from the serenity-flag cache, so the

--- a/test/support/serenity/dynamic-allocation-active.test.js
+++ b/test/support/serenity/dynamic-allocation-active.test.js
@@ -55,16 +55,16 @@ describe('isDynamicAllocationActiveForOrg', () => {
 
   afterEach(() => sinon.restore());
 
-  it('exposes the org-wide LLMO/dynamic-allocation flag identity', () => {
+  it('exposes the org-wide LLMO/dynamic_allocation flag identity', () => {
     expect(PRODUCT).to.equal('LLMO');
-    expect(NAME).to.equal('dynamic-allocation');
+    expect(NAME).to.equal('dynamic_allocation');
   });
 
   it('returns true when the flag is true and reads it with the right key', async () => {
     readFeatureFlagStub.resolves(true);
     expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(true);
     expect(readFeatureFlagStub.firstCall.args[0]).to.include({
-      organizationId: ORG, product: 'LLMO', flagName: 'dynamic-allocation',
+      organizationId: ORG, product: 'LLMO', flagName: 'dynamic_allocation',
     });
   });
 

--- a/test/support/serenity/dynamic-allocation-active.test.js
+++ b/test/support/serenity/dynamic-allocation-active.test.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+import { CACHE_TTL_MS, NEG_TTL_MS, MAX_ENTRIES } from '../../../src/support/serenity/workspace-resolver.js';
+
+use(sinonChai);
+
+const ORG = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function fakeLog() {
+  return {
+    info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+  };
+}
+
+function fakeCtx() {
+  return { dataAccess: { services: { postgrestClient: { from: () => ({}) } } } };
+}
+
+describe('isDynamicAllocationActiveForOrg', () => {
+  let readFeatureFlagStub;
+  let isDynamicAllocationActiveForOrg;
+  let clearDynamicAllocationFlagCache;
+  let PRODUCT;
+  let NAME;
+
+  beforeEach(async () => {
+    readFeatureFlagStub = sinon.stub();
+    const mod = await esmock('../../../src/support/serenity/dynamic-allocation-active.js', {
+      '../../../src/support/feature-flags-storage.js': {
+        readFeatureFlag: readFeatureFlagStub,
+      },
+    });
+    ({
+      isDynamicAllocationActiveForOrg,
+      clearDynamicAllocationFlagCache,
+      DYNAMIC_ALLOCATION_FEATURE_FLAG_PRODUCT: PRODUCT,
+      DYNAMIC_ALLOCATION_FEATURE_FLAG_NAME: NAME,
+    } = mod);
+    clearDynamicAllocationFlagCache();
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('exposes the org-wide LLMO/dynamic-allocation flag identity', () => {
+    expect(PRODUCT).to.equal('LLMO');
+    expect(NAME).to.equal('dynamic-allocation');
+  });
+
+  it('returns true when the flag is true and reads it with the right key', async () => {
+    readFeatureFlagStub.resolves(true);
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(true);
+    expect(readFeatureFlagStub.firstCall.args[0]).to.include({
+      organizationId: ORG, product: 'LLMO', flagName: 'dynamic-allocation',
+    });
+  });
+
+  it('defaults OFF for false / null (missing row)', async () => {
+    readFeatureFlagStub.resolves(false);
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(false);
+    clearDynamicAllocationFlagCache();
+    readFeatureFlagStub.resolves(null);
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(false);
+  });
+
+  it('returns false for a missing/blank org id without touching the DB', async () => {
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), '', fakeLog())).to.equal(false);
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), undefined, fakeLog())).to.equal(false);
+    expect(readFeatureFlagStub).to.not.have.been.called;
+  });
+
+  it('returns false and warns when the PostgREST client is unavailable', async () => {
+    const log = fakeLog();
+    const ctx = { dataAccess: { services: {} } };
+    expect(await isDynamicAllocationActiveForOrg(ctx, ORG, log)).to.equal(false);
+    expect(readFeatureFlagStub).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledOnce;
+  });
+
+  it('returns false and logs (does not throw) when the flag read fails', async () => {
+    const log = fakeLog();
+    readFeatureFlagStub.rejects(new Error('boom'));
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, log)).to.equal(false);
+    expect(log.error).to.have.been.calledOnce;
+  });
+
+  it('does not require a logger', async () => {
+    readFeatureFlagStub.resolves(true);
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG)).to.equal(true);
+  });
+
+  it('caches within the TTL, and clear forces a re-read', async () => {
+    readFeatureFlagStub.resolves(true);
+    await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+    await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+    expect(readFeatureFlagStub).to.have.been.calledOnce;
+    clearDynamicAllocationFlagCache();
+    await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+    expect(readFeatureFlagStub).to.have.been.calledTwice;
+  });
+
+  it('evicts the oldest entry once the cache exceeds MAX_ENTRIES', async () => {
+    readFeatureFlagStub.resolves(true);
+    for (let i = 0; i < MAX_ENTRIES + 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await isDynamicAllocationActiveForOrg(fakeCtx(), `org-${i}`, fakeLog());
+    }
+    const afterFill = readFeatureFlagStub.callCount;
+    await isDynamicAllocationActiveForOrg(fakeCtx(), 'org-0', fakeLog()); // evicted → re-read
+    expect(readFeatureFlagStub.callCount).to.equal(afterFill + 1);
+  });
+
+  it('does NOT cache a transient read error (re-reads on the next call)', async () => {
+    readFeatureFlagStub.onFirstCall().rejects(new Error('boom'));
+    readFeatureFlagStub.onSecondCall().resolves(true);
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(false);
+    expect(await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(true);
+    expect(readFeatureFlagStub).to.have.been.calledTwice;
+  });
+
+  describe('TTL expiry (fake timers)', () => {
+    let clock;
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({ now: 1_000_000 });
+    });
+    afterEach(() => clock.restore());
+
+    it('re-reads a positive value only after the positive TTL', async () => {
+      readFeatureFlagStub.resolves(true);
+      await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+      clock.tick(CACHE_TTL_MS - 1);
+      await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+      expect(readFeatureFlagStub).to.have.been.calledOnce;
+      clock.tick(2);
+      await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+      expect(readFeatureFlagStub).to.have.been.calledTwice;
+    });
+
+    it('re-reads a negative value after the shorter negative TTL', async () => {
+      readFeatureFlagStub.resolves(false);
+      await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+      clock.tick(NEG_TTL_MS - 1);
+      await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+      expect(readFeatureFlagStub).to.have.been.calledOnce;
+      clock.tick(2);
+      await isDynamicAllocationActiveForOrg(fakeCtx(), ORG, fakeLog());
+      expect(readFeatureFlagStub).to.have.been.calledTwice;
+    });
+  });
+});


### PR DESCRIPTION
**Spec / design:** [serenity-docs#22](https://github.com/adobe/serenity-docs/pull/22). Part of the dynamic just-in-time Semrush AI resource-allocation work (api-service side); companion to allocator-core PR #2749 and mock PR [spacecat-shared#1767](https://github.com/adobe/spacecat-shared/pull/1767).

## What

The per-org **`LLMO/dynamic-allocation` feature flag** and its plumbing — **foundation only, inert**:
- `dynamic-allocation-active.js` — `isDynamicAllocationActiveForOrg` (cloned from `serenity-active.js`: own TTL/size-bounded cache, fail-safe **OFF**, reuses the resolver's cache constants).
- `authorize()` now reads it in parallel with `isSerenityActiveForOrg` and threads the value onto the auth object as `dynamicAllocation`. It is **NOT a gate** — nothing consumes it yet.

Default **OFF**, and per the rollout plan it stays OFF for every org until the PR-4 safeguards (rightsizing sweep, concurrency serialization, SLIs, live-gateway canary) land. Because no code branches on it yet, behavior is **byte-for-byte unchanged**.

## Test plan

`npm run type-check` ✓ · `npm run lint` ✓ · new module **100% covered** (12 unit tests: identity, true/false/null default-OFF, blank org, missing client, read-failure fail-safe, cache TTL/eviction, no-cache-on-error); 185 serenity controller tests still pass. Pure unit — no IT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
