### PR TITLE
feat(serenity): flag-gated carve — skip flat re-grant under dynamic allocation (LLMO-5616)

### DIFF
--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -259,6 +259,9 @@ async function adoptFromFamily(transport, parentWorkspaceId, title, log) {
  *   re-reads the brand's CURRENT semrush_workspace_id from the data layer.
  *   When supplied, the create path uses it as a last-update concurrency guard
  *   (see below) so a parallel activation cannot orphan a resourced workspace.
+ * @param {object} [options] - feature-flag toggles for the dual-mode carve.
+ * @param {boolean} [options.dynamicAllocation] - when true (LLMO/dynamic-allocation ON), skip
+ *   the flat re-grant on an existing sub-workspace; JIT top-up owns sizing. Default false.
  * @returns {Promise<string>} the subworkspace id.
  */
 export async function ensureSubworkspace(
@@ -269,7 +272,9 @@ export async function ensureSubworkspace(
   log,
   timing = {},
   reloadPointer = null,
+  options = {},
 ) {
+  const { dynamicAllocation = false } = options;
   const poll = {
     attempts: timing.attempts ?? DEFAULT_POLL_ATTEMPTS,
     intervalMs: timing.intervalMs ?? DEFAULT_POLL_INTERVAL_MS,
@@ -291,8 +296,15 @@ export async function ensureSubworkspace(
     // 2026-06-15). So settle before AND after the transfer so the caller can
     // immediately create/publish projects against it.
     await pollUntilCreated(transport, existing, poll);
-    await transport.transferWorkspaceResources(existing, resourceAllocation(marketCount));
-    await pollUntilCreated(transport, existing, poll);
+    // Dynamic allocation (flag ON): SKIP the flat re-grant. The pre-sized
+    // `resourceAllocation(marketCount)` carve is exactly the up-front over/under-allocation JIT
+    // replaces — the metered handlers top up just-in-time (ensureAiHeadroom) and release surplus,
+    // so re-flattening the total here would both undo a JIT top-up and, on an ON→OFF rollback of an
+    // already-grown child, risk setting `total` below `used`. Flag OFF unchanged (byte-for-byte).
+    if (!dynamicAllocation) {
+      await transport.transferWorkspaceResources(existing, resourceAllocation(marketCount));
+      await pollUntilCreated(transport, existing, poll);
+    }
     return existing;
   }
 

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -295,6 +295,8 @@ export async function ensureSubworkspace(
     // and a subsequent op 422s "workspace not ready" (verified live
     // 2026-06-15). So settle before AND after the transfer so the caller can
     // immediately create/publish projects against it.
+    // This pre-poll runs regardless of mode — the workspace must be `created` before we return it
+    // (dynamic allocation only skips the flat re-grant below, not the readiness settle).
     await pollUntilCreated(transport, existing, poll);
     // Dynamic allocation (flag ON): SKIP the flat re-grant. The pre-sized
     // `resourceAllocation(marketCount)` carve is exactly the up-front over/under-allocation JIT

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -110,6 +110,8 @@ describe('workspace-lifecycle', () => {
       // No flat re-grant transfer — the metered handlers top up just-in-time instead.
       expect(transport.transferWorkspaceResources).to.not.have.been.called;
       expect(transport.createSubworkspace).to.not.have.been.called;
+      // The readiness settle still runs (workspace must be `created` before return).
+      expect(transport.getWorkspaceStatus).to.have.been.calledOnceWith(SUB_WS);
     });
 
     it('dynamic-allocation OFF (default): re-grant is byte-for-byte unchanged', async () => {

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -91,6 +91,46 @@ describe('workspace-lifecycle', () => {
       expect(brand.save).to.not.have.been.called;
     });
 
+    it('dynamic-allocation ON: SKIPS the flat re-grant on an existing workspace (JIT owns sizing)', async () => {
+      const transport = makeTransport();
+      const brand = makeBrand({ workspaceId: SUB_WS });
+
+      const result = await ensureSubworkspace(
+        transport,
+        brand,
+        PARENT_WS,
+        2,
+        log,
+        NOOP_TIMING,
+        null,
+        { dynamicAllocation: true },
+      );
+
+      expect(result).to.equal(SUB_WS);
+      // No flat re-grant transfer — the metered handlers top up just-in-time instead.
+      expect(transport.transferWorkspaceResources).to.not.have.been.called;
+      expect(transport.createSubworkspace).to.not.have.been.called;
+    });
+
+    it('dynamic-allocation OFF (default): re-grant is byte-for-byte unchanged', async () => {
+      const transport = makeTransport();
+      const brand = makeBrand({ workspaceId: SUB_WS });
+
+      await ensureSubworkspace(
+        transport,
+        brand,
+        PARENT_WS,
+        2,
+        log,
+        NOOP_TIMING,
+        null,
+        { dynamicAllocation: false },
+      );
+
+      expect(transport.transferWorkspaceResources)
+        .to.have.been.calledOnceWithExactly(SUB_WS, resourceAllocation(2));
+    });
+
     it('creates, polls until created, then persists the column', async () => {
       const transport = makeTransport();
       transport.getWorkspaceStatus


### PR DESCRIPTION
**Spec / design:** [serenity-docs#22](https://github.com/adobe/serenity-docs/pull/22). Part of the dynamic just-in-time Semrush AI resource-allocation work (api-service side). Independent of the flag PR #2750 and allocator-core PR #2749 (this touches only `ensureSubworkspace`).

## What

Makes `ensureSubworkspace` **dual-mode** via an options bag. When `{ dynamicAllocation: true }` it **skips the flat `resourceAllocation(marketCount)` re-grant** on an already-bound sub-workspace — that up-front pre-sized carve is exactly the over/under-allocation JIT replaces, so the metered handlers top up just-in-time instead. Flag **OFF (default)** is **byte-for-byte unchanged**.

Why skip rather than re-grant under JIT: re-flattening `total` would undo a JIT top-up and, on an ON→OFF rollback of an already-grown child, risk setting `total` below `used` (instant 405).

**Inert for now:** no caller passes the option yet (it defaults OFF), so this is capability + tests only; the handler wiring that threads `auth.dynamicAllocation` through lands in the follow-up fronting PR.

## Test plan

`npm run type-check` ✓ · `npm run lint` ✓ · unit tests assert **ON → skips the re-grant** and **OFF → byte-for-byte** (`transferWorkspaceResources` called with `resourceAllocation(2)`), spying the transport call. 46 workspace-lifecycle tests pass. Pure unit — no IT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
