### PR TITLE
feat: Semrush Elements weeks endpoint for URL Inspector | LLMO-6011

### DIFF
--- a/docs/elements/semrush-elements-api-reference.md
+++ b/docs/elements/semrush-elements-api-reference.md
@@ -406,6 +406,8 @@ Follow these steps in order. Steps 1–4 are contained within `src/support/eleme
 
 Source: `src/support/elements/element-ids.js`
 
+> **Surfaced endpoints:** `BRANDS`/`MARKETS`/`TOPICS` (rows 1–3) back the [URL Inspector Filter Dimensions](../llmo-semrush-apis/filter-dimensions-apis.md#1-list-url-inspector-filter-dimensions) endpoint; `WEEKS` (row 5) backs the [Weeks](../llmo-semrush-apis/filter-dimensions-apis.md#2-list-weeks) endpoint.
+
 | Constant | UUID | Section | Row(s) |
 |---|---|---|---|
 | `BRANDS` | `b178ce4e-6471-4430-9a32-8228ce72b2e6` | Filter Dimensions | 1 |

--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -5,9 +5,9 @@
   of the License at http://www.apache.org/licenses/LICENSE-2.0
 -->
 
-# LLMO Semrush Elements API — Filter Dimensions
+# LLMO Semrush Elements API — Filter Dimensions & Weeks
 
-SpaceCat wrapper endpoint over the Semrush Elements APIs for the Brand Presence / URL Inspector dashboards.
+SpaceCat wrapper endpoints over the Semrush Elements APIs for the Brand Presence / URL Inspector dashboards.
 
 > **Upstream wiki:** https://wiki.corp.adobe.com/spaces/AEMSites/pages/3928196548/Project+Serenity+LLMO+x+Semrush+API+for+Brand+Presence+Data
 
@@ -16,7 +16,8 @@ SpaceCat wrapper endpoint over the Semrush Elements APIs for the Brand Presence 
 ## Index
 
 1. [List URL Inspector Filter Dimensions](#1-list-url-inspector-filter-dimensions)
-2. [Supported Models](#2-supported-models)
+2. [List Weeks](#2-list-weeks)
+3. [Supported Models](#3-supported-models)
 
 ---
 
@@ -99,9 +100,54 @@ A single object with six dimension arrays, each shaped for direct use as filter 
 
 ---
 
-## 2. Supported Models
+## 2. List Weeks
 
-The `model` query parameter is accepted by the Filter Dimensions endpoint. Only the following values are valid. Any unrecognised value silently falls back to the default (`search-gpt`).
+**`GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks`**
+
+Returns the weeks that have Brand Presence data, for the week/date filter dropdown. **Drop-in compatible with the legacy Brand Presence `weeks` contract**, so the URL Inspector filter consumes it unchanged.
+
+### Parameters
+
+| Name | In | Required | Description |
+|---|---|---|---|
+| `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
+| `model` / `platform` | query | ❌ | AI model filter. Accepts **either** key (`model` wins if both are sent). UI platform codes are translated to Semrush models — see [Supported Models](#3-supported-models) (default: `search-gpt`) |
+| `siteId` / `site_id` | query | ❌ | Site UUID. Reverse-mapped to the site's **primary brand** (`brands.site_id`), which scopes the weeks via a `CBF_ws_brand` filter. Returns `404` if the site has no brand. Omitted → workspace-wide weeks |
+
+### Underlying Element
+
+| Element | UUID | Shape |
+|---|---|---|
+| `WEEKS` | `afa7458b-d34f-43d9-8cc5-e8794753551c` | `table` — one row per day that has data (`{ date, models }`) |
+
+### What it returns
+
+The daily rows are rolled up into ISO weeks spanning the earliest→latest day present, ordered **newest-first**. Each entry matches the legacy contract exactly:
+
+- **`week`** — ISO week string `YYYY-Wnn`
+- **`startDate`** — Monday of that week (`YYYY-MM-DD`)
+- **`endDate`** — Sunday of that week (`YYYY-MM-DD`)
+
+### Response example
+
+```json
+{
+  "weeks": [
+    { "week": "2026-W27", "startDate": "2026-06-29", "endDate": "2026-07-05" },
+    { "week": "2026-W26", "startDate": "2026-06-22", "endDate": "2026-06-28" }
+  ]
+}
+```
+
+> **`siteId` → brand:** Semrush has no concept of a site. The endpoint resolves `siteId` to the site's primary brand via `getBrandBySite` and scopes the query with `CBF_ws_brand` (brand **name**), mirroring the Markets element. The brand ID itself is not sent upstream.
+
+> **⚠️ Open (POC):** (1) the `openai`→`gpt-5` and `chatgpt`→`search-gpt` model mappings are provisional pending product confirmation; (2) whether the `WEEKS` element honours `CBF_ws_brand` is unverified — if it does not, brand scoping will move to `CBF_project` via the brand's Semrush projects.
+
+---
+
+## 3. Supported Models
+
+The `model` (or `platform`) query parameter is accepted by these endpoints. Only the following Semrush values are valid; any unrecognised value silently falls back to the default (`search-gpt`).
 
 | # | Model value | Default |
 |---|---|---|
@@ -117,4 +163,18 @@ The `model` query parameter is accepted by the Filter Dimensions endpoint. Only 
 | 10 | `search-gpt` | ✅ |
 | 11 | `perplexity` | |
 
-> Source of truth: [`src/support/elements/constants.js`](../../src/support/elements/constants.js) — `ELEMENT_MODELS` and `DEFAULT_ELEMENT_MODEL`.
+### UI platform code → Semrush model
+
+The UI keeps sending its existing platform filter codes (project-elmo-ui `PLATFORM_CODES`); SpaceCat translates them to Semrush model values via `resolveElementModel`. Codes already identical to a Semrush model, and Semrush-only models with no UI counterpart, pass through unchanged.
+
+| UI platform code | Semrush model | Note |
+|---|---|---|
+| `openai` (ChatGPT Paid) | `gpt-5` | ⚠️ provisional — confirm with product |
+| `chatgpt` (ChatGPT Free) | `search-gpt` | ⚠️ provisional — confirm with product |
+| `copilot` | `microsoft-copilot` | rename |
+| `gemini` | `gemini-2.5-flash` | rename |
+| `google-ai-overview` | `google-ai-overview` | identical |
+| `google-ai-mode` | `google-ai-mode` | identical |
+| `perplexity` | `perplexity` | identical |
+
+> Source of truth: [`src/support/elements/constants.js`](../../src/support/elements/constants.js) — `ELEMENT_MODELS`, `DEFAULT_ELEMENT_MODEL`, `PLATFORM_TO_ELEMENT_MODEL`, and `resolveElementModel`.

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -16,7 +16,7 @@ import {
 import { hasText, isNonEmptyObject } from '@adobe/spacecat-shared-utils';
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 
-import { listBrands as listSpacecatBrands } from '../support/brands-storage.js';
+import { listBrands as listSpacecatBrands, getBrandBySite } from '../support/brands-storage.js';
 import { createElementsTransport } from '../support/elements/elements-transport.js';
 import { ElementsTransportError } from '../support/elements/errors.js';
 import { createElementsService } from '../support/elements/elements-service.js';
@@ -229,7 +229,44 @@ export default function ElementsController(context, log, env) {
     }
   };
 
+  /**
+   * GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks
+   * Returns the list of weeks that have Brand Presence data (week filter dropdown).
+   */
+  /* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
+  const listWeeks = async (ctx) => {
+    try {
+      const auth = await authorizeOrg(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { spaceCatId } = ctx?.params ?? {};
+      const query = extractQuery(ctx);
+
+      // The URL Inspector filter sends a siteId, which Semrush has no concept of.
+      // Reverse-map it to the site's primary brand (brands.site_id) and scope the
+      // weeks to that brand. Omitted siteId → workspace-wide weeks.
+      const siteId = query.siteId || query.site_id;
+      let brand;
+      if (hasText(siteId)) {
+        const postgrestClient = ctx?.dataAccess?.services?.postgrestClient;
+        const resolved = await getBrandBySite(spaceCatId, siteId, postgrestClient, log);
+        if (!resolved) {
+          return notFound(`No brand found for site: ${siteId}`);
+        }
+        brand = resolved.name;
+      }
+
+      const result = await buildService(ctx).getWeeks(auth.workspaceId, { ...query, brand });
+      return ok(result);
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+  /* c8 ignore stop */
+
   return {
     listUrlInspectorFilterDimensions,
+    listWeeks,
   };
 }

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -789,6 +789,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/serenity/models': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/serenity/languages': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/stats': 'llmo/can_view',
       // Preflight (site-scoped reads)
       'GET /sites/:siteId/preflights': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -239,6 +239,7 @@ export default function getRouteHandlers(
     'GET /v2/orgs/:spaceCatId/serenity/models': serenityController.listOrgModels,
     // Serenity: Semrush Elements APIs Wrappers wiki https://wiki.corp.adobe.com/spaces/AEMSites/pages/3928196548/Project+Serenity+LLMO+x+Semrush+API+for+Brand+Presence+Data
     'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions': elementsController.listUrlInspectorFilterDimensions,
+    'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks': elementsController.listWeeks,
     // Brand-independent Semrush language catalog (add-brand wizard language picker).
     'GET /v2/orgs/:spaceCatId/serenity/languages': serenityController.listOrgLanguages,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': serenityController.activate,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -335,6 +335,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/serenity/models': 'organization:read',
   'GET /v2/orgs/:spaceCatId/serenity/languages': 'organization:read',
   'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions': 'organization:read',
+  'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks': 'organization:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate': 'organization:write',
   'GET /v2/orgs/:spaceCatId/sites/:siteId/brand': 'organization:read',

--- a/src/support/elements/constants.js
+++ b/src/support/elements/constants.js
@@ -25,3 +25,38 @@ export const ELEMENT_MODELS = Object.freeze([
   'search-gpt',
   'perplexity',
 ]);
+
+/**
+ * Maps the UI's platform filter codes (project-elmo-ui `PLATFORM_CODES`) to the
+ * Semrush Elements model names in {@link ELEMENT_MODELS}. Vivek/UI confirmed the UI
+ * keeps sending its existing platform values, so the translation lives here on the
+ * SpaceCat side.
+ *
+ * Only entries whose names DIFFER are listed. Codes that are already identical to a
+ * Semrush model (`google-ai-overview`, `google-ai-mode`, `perplexity`) and any
+ * Semrush-only model with no UI counterpart (`grok-3`, `open-evidence`,
+ * `claude-sonnet-4`, `deepseek`) need no entry — {@link resolveElementModel} passes
+ * them through unchanged.
+ *
+ * TODO(LLMO-6011): confirm the two ChatGPT tier mappings with product — `openai`
+ * (ChatGPT Paid) → `gpt-5` and `chatgpt` (ChatGPT Free) → `search-gpt` are best-guess.
+ */
+export const PLATFORM_TO_ELEMENT_MODEL = Object.freeze({
+  copilot: 'microsoft-copilot',
+  gemini: 'gemini-2.5-flash',
+  openai: 'gpt-5',
+  chatgpt: 'search-gpt',
+});
+
+/**
+ * Resolves a requested platform/model value to a valid Semrush Elements model.
+ * Applies the UI→Semrush translation first, then respects any value that is already
+ * a valid Semrush model, and finally falls back to {@link DEFAULT_ELEMENT_MODEL}.
+ *
+ * @param {string} [value] - Raw value from the `model` or `platform` query param.
+ * @returns {string} A member of {@link ELEMENT_MODELS}.
+ */
+export function resolveElementModel(value) {
+  const mapped = PLATFORM_TO_ELEMENT_MODEL[value] ?? value;
+  return ELEMENT_MODELS.includes(mapped) ? mapped : DEFAULT_ELEMENT_MODEL;
+}

--- a/src/support/elements/constants.js
+++ b/src/support/elements/constants.js
@@ -56,7 +56,9 @@ export const PLATFORM_TO_ELEMENT_MODEL = Object.freeze({
  * @param {string} [value] - Raw value from the `model` or `platform` query param.
  * @returns {string} A member of {@link ELEMENT_MODELS}.
  */
+/* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
 export function resolveElementModel(value) {
   const mapped = PLATFORM_TO_ELEMENT_MODEL[value] ?? value;
   return ELEMENT_MODELS.includes(mapped) ? mapped : DEFAULT_ELEMENT_MODEL;
 }
+/* c8 ignore stop */

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -19,3 +19,4 @@ export {
   transformIntentsToFilterDimensions,
   transformOriginsToFilterDimensions,
 } from './topics.js';
+export { buildWeeksPayload, transformWeeksResponse } from './weeks.js';

--- a/src/support/elements/definitions/weeks.js
+++ b/src/support/elements/definitions/weeks.js
@@ -11,16 +11,9 @@
  */
 
 import { resolveElementModel } from '../constants.js';
-// Reused for exact parity with the legacy Brand Presence `weeks` endpoint. These are
-// pure, side-effect-free ISO-week helpers exported by the legacy controller; importing
-// them guarantees identical week boundaries (incl. year-edge cases like 2026-W01 →
-// 2025-12-29) without re-deriving the math here.
-// TODO(LLMO-6011, productization): extract these to a shared date util so the elements
-// layer no longer imports from the controller layer.
-import {
-  generateIsoWeekRange,
-  getWeekDateRange,
-} from '../../../controllers/llmo/llmo-brand-presence.js';
+// Pure ISO-week helpers live in the support layer (week-utils.js) so this file does not
+// import from the controller layer — see week-utils.js for the parity note.
+import { generateIsoWeekRange, getWeekDateRange } from '../week-utils.js';
 
 /**
  * Builds the payload for the Weeks filter-dimensions element (row 5).

--- a/src/support/elements/definitions/weeks.js
+++ b/src/support/elements/definitions/weeks.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+// Reused for exact parity with the legacy Brand Presence `weeks` endpoint. These are
+// pure, side-effect-free ISO-week helpers exported by the legacy controller; importing
+// them guarantees identical week boundaries (incl. year-edge cases like 2026-W01 →
+// 2025-12-29) without re-deriving the math here.
+// TODO(LLMO-6011, productization): extract these to a shared date util so the elements
+// layer no longer imports from the controller layer.
+import {
+  generateIsoWeekRange,
+  getWeekDateRange,
+} from '../../../controllers/llmo/llmo-brand-presence.js';
+
+/**
+ * Builds the payload for the Weeks filter-dimensions element (row 5).
+ * The element is a `table` — it returns one row per day that has Brand Presence
+ * data (`blocks.data[] = { date, models }`), which we roll up into ISO weeks.
+ *
+ * @param {object} [params]
+ * @param {string} [params.model] - AI model filter value (Semrush engine name or UI
+ *   platform code). Translated + validated via {@link resolveElementModel}.
+ * @param {string} [params.platform] - Legacy alias for `model`; the URL Inspector week
+ *   filter sends the value under this key. `model` takes precedence when both are present.
+ * @param {string} [params.brand] - Brand NAME to scope the weeks to (added as a
+ *   `CBF_ws_brand` filter, mirroring the Markets element). Resolved from `siteId` by the
+ *   controller. Omitted → workspace-wide weeks.
+ */
+/* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
+export function buildWeeksPayload({ model, platform, brand } = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  const filters = [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }];
+  if (brand) {
+    filters.push({ op: 'eq', val: brand, col: 'CBF_ws_brand' });
+  }
+  return {
+    comparison_data_formatting: 'union',
+    filters: {
+      advanced: { op: 'and', filters },
+    },
+  };
+}
+
+/**
+ * Transforms the raw Semrush Weeks element response into the legacy Brand Presence
+ * `weeks` contract so the URL Inspector week filter is drop-in compatible:
+ *   [{ week: 'YYYY-Wnn', startDate: 'YYYY-MM-DD', endDate: 'YYYY-MM-DD' }]
+ * ordered newest-first.
+ *
+ * The element returns a `table` of daily rows (`blocks.data[] = { date, models }`).
+ * We take the min/max day present and expand to every ISO week in that span —
+ * matching the legacy handler, which derives weeks from an execution-date range.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @returns {Array<{ week: string, startDate: string, endDate: string }>}
+ */
+export function transformWeeksResponse(raw) {
+  const dates = (raw?.blocks?.data ?? [])
+    .map((row) => (typeof row?.date === 'string' ? row.date.slice(0, 10) : null))
+    .filter(Boolean)
+    .sort();
+  if (dates.length === 0) {
+    return [];
+  }
+  return generateIsoWeekRange(dates[0], dates[dates.length - 1]).map((week) => {
+    const { startDate, endDate } = getWeekDateRange(week);
+    return { week, startDate, endDate };
+  });
+}
+/* c8 ignore stop */

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -21,6 +21,8 @@ import {
   transformCategoriesToFilterDimensions,
   transformIntentsToFilterDimensions,
   transformOriginsToFilterDimensions,
+  buildWeeksPayload,
+  transformWeeksResponse,
 } from './definitions/index.js';
 
 /**
@@ -60,5 +62,23 @@ export function createElementsService(transport) {
         origins: transformOriginsToFilterDimensions(rawTopics),
       };
     },
+
+    /**
+     * Fetches the list of weeks that have Brand Presence data (week filter dropdown).
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} params - Query parameters (model, etc.).
+     * @returns {Promise<object>} `{ weeks: [{ week, startDate, endDate }] }`.
+     */
+    /* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
+    async getWeeks(workspaceId, params) {
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.WEEKS,
+        buildWeeksPayload(params),
+      );
+      return { weeks: transformWeeksResponse(raw) };
+    },
+    /* c8 ignore stop */
   };
 }

--- a/src/support/elements/week-utils.js
+++ b/src/support/elements/week-utils.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Pure ISO-week date helpers for the Semrush elements layer.
+ *
+ * Extracted here so the support/elements layer does NOT import from the controller
+ * layer (`controllers/llmo/llmo-brand-presence.js`) — keeping the dependency direction
+ * correct (support ← controllers) and avoiding partial-export cycles. Copied verbatim
+ * from that controller to guarantee identical week boundaries, including year-edge cases
+ * (e.g. `2026-W01` → `2025-12-29`).
+ *
+ * TODO(LLMO-6011, productization): dedupe by having `llmo-brand-presence.js` import these
+ * from here instead of keeping its own copies.
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
+function parseIsoWeek(weekStr) {
+  const match = /^(\d{4})-W(\d{2})$/.exec(weekStr);
+  if (!match) {
+    return { weekNumber: 0, year: 0 };
+  }
+  return {
+    year: Number.parseInt(match[1], 10),
+    weekNumber: Number.parseInt(match[2], 10),
+  };
+}
+
+/**
+ * Returns startDate (Monday) and endDate (Sunday) for an ISO week string (YYYY-Wnn).
+ * @param {string} isoWeek - e.g. "2026-W11"
+ * @returns {{ startDate: string, endDate: string } | null} - YYYY-MM-DD or null if invalid
+ */
+export function getWeekDateRange(isoWeek) {
+  const { year, weekNumber: week } = parseIsoWeek(isoWeek);
+  if (!year || week < 1 || week > 53) {
+    return null;
+  }
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const dayOfWeek = jan4.getUTCDay();
+  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const week1MondayMs = jan4.getTime() + mondayOffset * MS_PER_DAY;
+  const targetMondayMs = week1MondayMs + (week - 1) * 7 * MS_PER_DAY;
+  const targetSundayMs = targetMondayMs + 6 * MS_PER_DAY;
+  const toYMD = (ms) => {
+    const d = new Date(ms);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
+  return {
+    startDate: toYMD(targetMondayMs),
+    endDate: toYMD(targetSundayMs),
+  };
+}
+
+/**
+ * Converts a date string (YYYY-MM-DD) to an ISO week string (YYYY-Wnn).
+ * @param {string} dateStr - e.g. "2026-03-15"
+ * @returns {string} e.g. "2026-W11"
+ */
+export function dateToIsoWeek(dateStr) {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  const dayOfWeek = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNumber = Math.ceil(((d - yearStart) / MS_PER_DAY + 1) / 7);
+  const year = d.getUTCFullYear();
+  return `${year}-W${String(weekNumber).padStart(2, '0')}`;
+}
+
+/**
+ * Generates every ISO week (YYYY-Wnn) between minDate and maxDate, inclusive,
+ * sorted newest-first.
+ * @param {string|null} minDate - Earliest date (YYYY-MM-DD)
+ * @param {string|null} maxDate - Latest date (YYYY-MM-DD)
+ * @returns {string[]} ISO week strings sorted descending
+ */
+export function generateIsoWeekRange(minDate, maxDate) {
+  if (!minDate || !maxDate) {
+    return [];
+  }
+  const minRange = getWeekDateRange(dateToIsoWeek(minDate));
+  const maxRange = getWeekDateRange(dateToIsoWeek(maxDate));
+  if (!minRange || !maxRange) {
+    return [];
+  }
+
+  const result = [];
+  let currentMs = new Date(`${minRange.startDate}T00:00:00Z`).getTime();
+  const maxMs = new Date(`${maxRange.startDate}T00:00:00Z`).getTime();
+
+  while (currentMs <= maxMs) {
+    const d = new Date(currentMs);
+    const y = d.getUTCFullYear();
+    const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    result.push(dateToIsoWeek(`${y}-${mo}-${day}`));
+    currentMs += 7 * MS_PER_DAY;
+  }
+
+  return result.sort((a, b) => b.localeCompare(a));
+}
+/* c8 ignore stop */

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -886,6 +886,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/serenity/models',
       'GET /v2/orgs/:spaceCatId/serenity/languages',
       'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions',
+      'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate',
       'GET /v2/orgs/:spaceCatId/sites/:siteId/brand',


### PR DESCRIPTION
## Summary

Adds `GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks` — an org-scoped SpaceCat wrapper over the Semrush `WEEKS` element that powers the URL Inspector week/date filter. Part of Project Serenity (migrating Brand Presence data onto Semrush Elements APIs), following the merged filter-dimensions wrapper (#2666). The response is a drop-in match for the legacy Brand Presence weeks contract, so the UI filter consumes it unchanged.

## Changes

- **New endpoint** `GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks` → `elementsController.listWeeks`, wrapping the Semrush `WEEKS` element (`afa7458b`).
- **Response transform**: the element returns a `table` of daily rows, rolled up into ISO weeks (`{ week, startDate, endDate }`, newest-first) matching the legacy contract — reuses the exported `generateIsoWeekRange` / `getWeekDateRange` helpers for exact parity.
- **model / platform param**: accepts either key (`model` wins); UI platform codes are translated to Semrush model names via a new `resolveElementModel` + `PLATFORM_TO_ELEMENT_MODEL` map in `constants.js` (shared, reusable by filter-dimensions).
- **siteId → brand**: Semrush has no site concept, so `siteId` is reverse-mapped to the site's primary brand via `getBrandBySite` and scoped with a `CBF_ws_brand` filter; `404` when the site has no brand; omitted → workspace-wide.
- **FACS / capabilities**: route registered as `llmo/can_view` (facs-capabilities.js) and `organization:read` (required-capabilities.js); `:spaceCatId` already classified.
- **Docs**: added a Weeks section + platform→model mapping table to `filter-dimensions-apis.md`, plus a note in `semrush-elements-api-reference.md`.
- **POC**: unit tests intentionally deferred per the ticket — new code is `c8 ignore`-fenced. Existing route-registry drift test updated to include the new route.

## Test plan

- [x] `npm run lint` and `npm run type-check` — clean
- [x] `npm test` route/FACS/capability + elements suites green (2863 passing); route-coverage drift test passes with the new route in both capability maps
- [x] `transformWeeksResponse` output byte-matches the legacy `{ week, startDate, endDate }` contract against real element data
- [x] `resolveElementModel` mapping verified (UI codes → Semrush models, Semrush pass-through, default fallback)
- [ ] **Live**: `GET .../serenity/all/brand-presence/weeks?siteId=<site>&platform=chatgpt` returns weeks scoped to the site's brand (confirms `WEEKS` honours `CBF_ws_brand`)

## Open / to confirm before productization

- `openai`→`gpt-5` and `chatgpt`→`search-gpt` model mappings are provisional — need product sign-off.
- Whether the `WEEKS` element honours `CBF_ws_brand` is unverified; if not, brand scoping moves to `CBF_project` via the brand's Semrush projects.
- OpenAPI spec intentionally not added, consistent with the merged elements endpoints (#2666) and POC scope.

## Related Issues

https://jira.corp.adobe.com/browse/LLMO-6011