### PR TITLE
feat: add Slack commands for path-level prerender suggestions

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -59,6 +59,8 @@ import removeDelegate from './commands/remove-delegate.js';
 import checkAgenticTrafficDbStatus from './commands/check-agentic-traffic-db-status.js';
 import checkCdnLogsStatus from './commands/check-cdn-logs-status.js';
 import addOaeStageDomain from './commands/add-oae-stage-domain.js';
+import togglePathSuggestions from './commands/toggle-path-suggestions.js';
+import getPathSuggestionsStatus from './commands/get-path-suggestions-status.js';
 
 /**
  * Returns all commands.
@@ -116,4 +118,6 @@ export default (context) => [
   checkAgenticTrafficDbStatus(context),
   checkCdnLogsStatus(context),
   addOaeStageDomain(context),
+  togglePathSuggestions(context),
+  getPathSuggestionsStatus(context),
 ];

--- a/src/support/slack/commands/get-path-suggestions-status.js
+++ b/src/support/slack/commands/get-path-suggestions-status.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import BaseCommand from './base.js';
+
+import {
+  extractURLFromSlackInput,
+  postErrorMessage,
+  postSiteNotFoundMessage,
+} from '../../../utils/slack/base.js';
+
+const PHRASES = ['get path-suggestions'];
+
+/**
+ * Factory function to create the GetPathSuggestionsStatusCommand object.
+ * Checks whether path-level prerender suggestion generation is enabled for a site.
+ *
+ * @param {Object} context - The context object.
+ * @returns {Object} The GetPathSuggestionsStatusCommand object.
+ */
+function GetPathSuggestionsStatusCommand(context) {
+  const baseCommand = BaseCommand({
+    id: 'get-path-suggestions-status',
+    name: 'Get Path-Level Suggestions Status',
+    description: 'Checks whether path-level prerender suggestion generation is enabled for a site.',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {site}`,
+  });
+
+  const { dataAccess, log } = context;
+  const { Site } = dataAccess;
+
+  /**
+   * Fetches the site and reports the pathSuggestionsEnabled status
+   * from the prerender handler config.
+   *
+   * @param {string[]} args - The arguments ([siteBaseURL]).
+   * @param {Object} slackContext - The Slack context object.
+   * @param {Function} slackContext.say - The Slack say function.
+   * @returns {Promise} A promise that resolves when the operation is complete.
+   */
+  const handleExecution = async (args, slackContext) => {
+    const { say } = slackContext;
+
+    try {
+      const [siteInput] = args;
+
+      if (!siteInput) {
+        await say(':warning: Please provide a valid site base URL.');
+        return;
+      }
+
+      const baseURL = extractURLFromSlackInput(siteInput);
+
+      const site = baseURL
+        ? await Site.findByBaseURL(baseURL)
+        : await Site.findById(siteInput);
+
+      if (!site) {
+        await postSiteNotFoundMessage(say, siteInput);
+        return;
+      }
+
+      const config = site.getConfig();
+      const prerenderConfig = config.getHandlerConfig('prerender') || {};
+      const isEnabled = prerenderConfig.pathSuggestionsEnabled === true;
+
+      const statusEmoji = isEnabled ? ':large_green_circle:' : ':red_circle:';
+      const statusText = isEnabled ? 'enabled' : 'disabled';
+
+      await say(`${statusEmoji} Path-level suggestions are *${statusText}* for "${site.getBaseURL()}".`);
+    } catch (error) {
+      log.error(error);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+}
+
+export default GetPathSuggestionsStatusCommand;

--- a/src/support/slack/commands/toggle-path-suggestions.js
+++ b/src/support/slack/commands/toggle-path-suggestions.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
+import BaseCommand from './base.js';
+
+import {
+  extractURLFromSlackInput,
+  postErrorMessage,
+  postSiteNotFoundMessage,
+} from '../../../utils/slack/base.js';
+
+const PHRASES = ['path-suggestions'];
+
+/**
+ * Factory function to create the TogglePathSuggestionsCommand object.
+ * Enables or disables path-level prerender suggestion generation for a site.
+ * This sets `pathSuggestionsEnabled` in the site's prerender handler config.
+ *
+ * @param {Object} context - The context object.
+ * @returns {Object} The TogglePathSuggestionsCommand object.
+ */
+function TogglePathSuggestionsCommand(context) {
+  const baseCommand = BaseCommand({
+    id: 'toggle-path-suggestions',
+    name: 'Enable/Disable Path-Level Suggestions',
+    description: 'Enables or disables path-level prerender suggestion generation for a site.',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {enable/disable} {site}`,
+  });
+
+  const { dataAccess, log } = context;
+  const { Site } = dataAccess;
+
+  /**
+   * Validates input, fetches the site, and toggles pathSuggestionsEnabled
+   * in the prerender handler config.
+   *
+   * @param {string[]} args - The arguments ([action, siteBaseURL]).
+   * @param {Object} slackContext - The Slack context object.
+   * @param {Function} slackContext.say - The Slack say function.
+   * @returns {Promise} A promise that resolves when the operation is complete.
+   */
+  const handleExecution = async (args, slackContext) => {
+    const { say } = slackContext;
+
+    try {
+      const [actionInput, siteInput] = args;
+
+      if (!actionInput || !['enable', 'disable'].includes(actionInput.toLowerCase())) {
+        await say(':warning: Please specify `enable` or `disable`.');
+        return;
+      }
+
+      if (!siteInput) {
+        await say(':warning: Please provide a valid site base URL.');
+        return;
+      }
+
+      const action = actionInput.toLowerCase();
+      const isEnable = action === 'enable';
+      const baseURL = extractURLFromSlackInput(siteInput);
+
+      const site = baseURL
+        ? await Site.findByBaseURL(baseURL)
+        : await Site.findById(siteInput);
+
+      if (!site) {
+        await postSiteNotFoundMessage(say, siteInput);
+        return;
+      }
+
+      const config = site.getConfig();
+      const handlers = config.getHandlers() || {};
+      const prerenderConfig = handlers.prerender || {};
+
+      const updatedHandlers = {
+        ...handlers,
+        prerender: {
+          ...prerenderConfig,
+          pathSuggestionsEnabled: isEnable,
+        },
+      };
+
+      const configData = Config.toDynamoItem(config);
+      configData.handlers = updatedHandlers;
+      site.setConfig(configData);
+      await site.save();
+
+      const statusEmoji = isEnable ? ':white_check_mark:' : ':no_entry_sign:';
+      await say(`${statusEmoji} Path-level suggestions have been *${action}d* for "${site.getBaseURL()}".`);
+    } catch (error) {
+      log.error(error);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+}
+
+export default TogglePathSuggestionsCommand;

--- a/test/support/slack/commands/get-path-suggestions-status.test.js
+++ b/test/support/slack/commands/get-path-suggestions-status.test.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import GetPathSuggestionsStatusCommand from '../../../../src/support/slack/commands/get-path-suggestions-status.js';
+
+use(sinonChai);
+
+describe('GetPathSuggestionsStatusCommand', () => {
+  let context;
+  let slackContext;
+  let dataAccessStub;
+
+  beforeEach(() => {
+    dataAccessStub = {
+      Site: {
+        findByBaseURL: sinon.stub(),
+        findById: sinon.stub(),
+      },
+    };
+    context = { dataAccess: dataAccessStub, log: { error: sinon.stub() } };
+    slackContext = { say: sinon.spy() };
+  });
+
+  describe('Initialization', () => {
+    it('initializes correctly with base command properties', () => {
+      const command = GetPathSuggestionsStatusCommand(context);
+      expect(command.id).to.equal('get-path-suggestions-status');
+      expect(command.name).to.equal('Get Path-Level Suggestions Status');
+      expect(command.phrases).to.deep.equal(['get path-suggestions']);
+    });
+  });
+
+  describe('Handle Execution Method', () => {
+    it('reports enabled status when pathSuggestionsEnabled is true', async () => {
+      const mockConfig = {
+        getHandlerConfig: sinon.stub().withArgs('prerender').returns({
+          pathSuggestionsEnabled: true,
+        }),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution(['example.com'], slackContext);
+
+      expect(dataAccessStub.Site.findByBaseURL).to.have.been.calledWith('https://example.com');
+      expect(slackContext.say).to.have.been.calledWithMatch(/enabled/);
+      expect(slackContext.say).to.have.been.calledWithMatch(/large_green_circle/);
+    });
+
+    it('reports disabled status when pathSuggestionsEnabled is false', async () => {
+      const mockConfig = {
+        getHandlerConfig: sinon.stub().withArgs('prerender').returns({
+          pathSuggestionsEnabled: false,
+        }),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution(['example.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWithMatch(/disabled/);
+      expect(slackContext.say).to.have.been.calledWithMatch(/red_circle/);
+    });
+
+    it('reports disabled when prerender config is missing', async () => {
+      const mockConfig = {
+        getHandlerConfig: sinon.stub().withArgs('prerender').returns(null),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution(['example.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWithMatch(/disabled/);
+    });
+
+    it('reports disabled when pathSuggestionsEnabled is not set', async () => {
+      const mockConfig = {
+        getHandlerConfig: sinon.stub().withArgs('prerender').returns({}),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution(['example.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWithMatch(/disabled/);
+    });
+
+    it('looks up site by ID when input is not a valid URL', async () => {
+      const mockConfig = {
+        getHandlerConfig: sinon.stub().returns({}),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+      };
+      dataAccessStub.Site.findById.resolves(mockSite);
+
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution(['some-site-id'], slackContext);
+
+      expect(dataAccessStub.Site.findById).to.have.been.calledWith('some-site-id');
+      expect(dataAccessStub.Site.findByBaseURL).to.not.have.been.called;
+    });
+
+    it('warns when site input is missing', async () => {
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution([], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWith(':warning: Please provide a valid site base URL.');
+    });
+
+    it('reports site not found', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(null);
+
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution(['unknownsite.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWithMatch(/No site found/);
+    });
+
+    it('handles errors during execution', async () => {
+      dataAccessStub.Site.findByBaseURL.throws(new Error('Test Error'));
+
+      const command = GetPathSuggestionsStatusCommand(context);
+
+      await command.handleExecution(['example.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWithMatch(/Oops! Something went wrong: Test Error/);
+    });
+  });
+});

--- a/test/support/slack/commands/toggle-path-suggestions.test.js
+++ b/test/support/slack/commands/toggle-path-suggestions.test.js
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('TogglePathSuggestionsCommand', () => {
+  let context;
+  let slackContext;
+  let dataAccessStub;
+  let TogglePathSuggestionsCommand;
+  let toDynamoItemStub;
+
+  beforeEach(async () => {
+    toDynamoItemStub = sinon.stub().returns({ handlers: {} });
+
+    TogglePathSuggestionsCommand = await esmock(
+      '../../../../src/support/slack/commands/toggle-path-suggestions.js',
+      {
+        '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
+          Config: { toDynamoItem: toDynamoItemStub },
+        },
+      },
+    );
+
+    dataAccessStub = {
+      Site: {
+        findByBaseURL: sinon.stub(),
+        findById: sinon.stub(),
+      },
+    };
+    context = { dataAccess: dataAccessStub, log: { error: sinon.stub() } };
+    slackContext = { say: sinon.spy() };
+  });
+
+  describe('Initialization', () => {
+    it('initializes correctly with base command properties', () => {
+      const command = TogglePathSuggestionsCommand(context);
+      expect(command.id).to.equal('toggle-path-suggestions');
+      expect(command.name).to.equal('Enable/Disable Path-Level Suggestions');
+      expect(command.phrases).to.deep.equal(['path-suggestions']);
+    });
+  });
+
+  describe('Handle Execution Method', () => {
+    it('enables path suggestions for a site by URL', async () => {
+      const mockConfig = {
+        getHandlers: sinon.stub().returns({}),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub(),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['enable', 'example.com'], slackContext);
+
+      expect(dataAccessStub.Site.findByBaseURL).to.have.been.calledWith('https://example.com');
+      expect(mockSite.setConfig).to.have.been.calledOnce;
+      const setConfigArg = mockSite.setConfig.firstCall.args[0];
+      expect(setConfigArg.handlers.prerender.pathSuggestionsEnabled).to.equal(true);
+      expect(mockSite.save).to.have.been.calledOnce;
+      expect(slackContext.say).to.have.been.calledWithMatch(/enabled/);
+    });
+
+    it('disables path suggestions for a site by URL', async () => {
+      const mockConfig = {
+        getHandlers: sinon.stub().returns({
+          prerender: { pathSuggestionsEnabled: true, someOtherSetting: 'value' },
+        }),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub(),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['disable', 'example.com'], slackContext);
+
+      const setConfigArg = mockSite.setConfig.firstCall.args[0];
+      expect(setConfigArg.handlers.prerender.pathSuggestionsEnabled).to.equal(false);
+      expect(setConfigArg.handlers.prerender.someOtherSetting).to.equal('value');
+      expect(slackContext.say).to.have.been.calledWithMatch(/disabled/);
+    });
+
+    it('looks up site by ID when input is not a valid URL', async () => {
+      const mockConfig = {
+        getHandlers: sinon.stub().returns({}),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub(),
+      };
+      dataAccessStub.Site.findById.resolves(mockSite);
+
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['enable', 'some-site-id'], slackContext);
+
+      expect(dataAccessStub.Site.findById).to.have.been.calledWith('some-site-id');
+      expect(dataAccessStub.Site.findByBaseURL).to.not.have.been.called;
+    });
+
+    it('warns when action is missing', async () => {
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution([], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWith(':warning: Please specify `enable` or `disable`.');
+    });
+
+    it('warns when action is invalid', async () => {
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['toggle', 'example.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWith(':warning: Please specify `enable` or `disable`.');
+    });
+
+    it('warns when site input is missing', async () => {
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['enable'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWith(':warning: Please provide a valid site base URL.');
+    });
+
+    it('reports site not found', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(null);
+
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['enable', 'unknownsite.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWithMatch(/No site found/);
+    });
+
+    it('preserves existing handler configs when enabling', async () => {
+      const mockConfig = {
+        getHandlers: sinon.stub().returns({
+          'broken-backlinks': { excludedURLs: ['/test'] },
+          prerender: { someExisting: true },
+        }),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub(),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['enable', 'example.com'], slackContext);
+
+      const setConfigArg = mockSite.setConfig.firstCall.args[0];
+      expect(setConfigArg.handlers['broken-backlinks']).to.deep.equal({ excludedURLs: ['/test'] });
+      expect(setConfigArg.handlers.prerender.someExisting).to.equal(true);
+      expect(setConfigArg.handlers.prerender.pathSuggestionsEnabled).to.equal(true);
+    });
+
+    it('handles null handlers gracefully', async () => {
+      const mockConfig = {
+        getHandlers: sinon.stub().returns(null),
+      };
+      const mockSite = {
+        getBaseURL: sinon.stub().returns('https://example.com'),
+        getConfig: sinon.stub().returns(mockConfig),
+        setConfig: sinon.stub(),
+        save: sinon.stub(),
+      };
+      dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['enable', 'example.com'], slackContext);
+
+      const setConfigArg = mockSite.setConfig.firstCall.args[0];
+      expect(setConfigArg.handlers.prerender.pathSuggestionsEnabled).to.equal(true);
+    });
+
+    it('handles errors during execution', async () => {
+      dataAccessStub.Site.findByBaseURL.throws(new Error('Test Error'));
+
+      const command = TogglePathSuggestionsCommand(context);
+
+      await command.handleExecution(['enable', 'example.com'], slackContext);
+
+      expect(slackContext.say).to.have.been.calledWithMatch(/Oops! Something went wrong: Test Error/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `path-suggestions {enable/disable} {site}` Slack command to toggle path-level prerender suggestion generation for a site. This sets `pathSuggestionsEnabled` in the site's `handlers.prerender` config, which is read by the audit worker ([spacecat-audit-worker#2500](https://github.com/adobe/spacecat-audit-worker/pull/2500)).
- Adds `get path-suggestions {site}` Slack command to check whether path-level suggestions are currently enabled for a site.
- Both commands support site lookup by base URL or site ID.

## Test plan

- [x] Unit tests for `toggle-path-suggestions` command (11 tests)
- [x] Unit tests for `get-path-suggestions-status` command (9 tests)
- [ ] Manual Slack test: `path-suggestions enable <site>` then verify config via `get path-suggestions <site>`
- [ ] Manual Slack test: `path-suggestions disable <site>` then verify disabled status