### PR TITLE
chore(deps): bump @adobe/spacecat-shared-project-engine-client to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@adobe/spacecat-shared-http-utils": "1.33.1",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.8.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.9.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -7037,9 +7037,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.8.0.tgz",
-      "integrity": "sha512-AsFjtAubCVMBgiDnrO69GJYbZd0ivr+v3NRO2OoIWlupmEjpyyk0OU7/CqbUCEThfEF6I6nnZsOtGxAQHE/2jA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.9.0.tgz",
+      "integrity": "sha512-tiNeDXtCtn3+5aWqBwIyqsW3kuj68FHNZ1fZOiawVWd45ySnoJDSJTMIrezPrPccnkgdzPnxiuQwIaVxgJa0UA==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-http-utils": "1.33.1",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.8.0",
+    "@adobe/spacecat-shared-project-engine-client": "1.9.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Bumps `@adobe/spacecat-shared-project-engine-client` from 1.8.0 to 1.9.0 so api-service consumes the re-vendored Semrush Project Engine client.

## 2. Reasoning
spacecat-shared PR 1772 re-vendored the refreshed Project Engine swagger and reconciled the correction overlay: `GET /v1/url/resolve` and its response schema are now vendored natively (retiring the client-side overlay that added them), the now-redundant CR9/CR10 corrections were dropped, and the resolve response type was renamed `model.UrlResolveResponse` -> `model.ResolveURLResponse`. This bump keeps api-service — the live consumer of `url/resolve` (merged in PR 2748) — on the current client, and keeps the serenity IT's mock image in lockstep (the harness pins the mock image tag to the installed client version).

## 3. High-level overview of the changes
Dependency-only change: the pinned version and its lockfile entry move 1.8.0 -> 1.9.0. No api-service source changes.

- The serenity transport's `resolveUrl` calls `client.GET('/v1/url/resolve', ...)` — it keys off the path string, not the schema type name, so the internal `UrlResolveResponse` -> `ResolveURLResponse` rename is transparent and openapi-fetch still infers the same (still-`required`) `{ domain, primary_url, is_valid }` response shape.
- No other endpoint api-service uses changed shape in the re-vendor (the new/removed/reshaped surface in 1.9.0 is Site-Intelligence and catalog endpoints api-service does not consume).

## 4. Required information
- Spec: https://github.com/adobe/serenity-docs/issues/25
- Other: the client change this bump consumes — https://github.com/adobe/spacecat-shared/pull/1772

## 5. Affected / used mysticat-workspace projects
- `spacecat-shared` (`spacecat-shared-project-engine-client`) — consumed: this PR pins the 1.9.0 release produced by PR 1772 and depends on its published npm package + the matching 1.9.0 mock GHCR image.

## 6. Additional information outside the code
- Confirmed the `1.9.0` npm package is published and the `1.9.0` project-engine-client mock GHCR image exists (`ghcr.io/adobe/spacecat-shared-project-engine-client-mock:1.9.0`), which the serenity IT job pulls (tag pinned to the installed client version).
- Ran the api-service opt-in type-check (`tsc`) against the 1.9.0 types — no drift from the client's response-type rename.

## 7. Test plan
- (a) Local: type-check passes against 1.9.0, and the serenity transport + brand-urls unit tests pass against the new client. The serenity Postgres IT (which boots the pinned 1.9.0 mock image) is not run locally here — it runs in CI.
- (b) Per-env: no runtime/behaviour change to verify manually. After merge, confirm CI's serenity IT resolves and passes against the 1.9.0 mock image, and that the brand-URL write path (`url/resolve`) continues to canonicalize as before on dev.

## 8. Deployment & merge order
- Depends on https://github.com/adobe/spacecat-shared/pull/1772 (merged; `project-engine-client@1.9.0` published to npm + GHCR). This PR only needs that release to exist, which it does.

Ordered sequence: PR 1772 (done) -> this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
