### PR TITLE
fix(serenity): enable bounded-backoff retry on the Semrush REST transport

### DIFF
--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -255,26 +255,53 @@ export function createSerenityTransport({ env, imsToken }) {
     return imsToken;
   };
 
-  // Typed Project Engine client over the project gateway. maxRetries:0 preserves
-  // the one-shot behaviour the hand-rolled transport had; the injected fetch
-  // re-adds the 15s timeout + Accept header the client does not impose. `root` is
-  // the validated origin; the client appends its own '/enterprise/projects/api'
+  // Typed Project Engine client over the project gateway. `root` is the
+  // validated origin; the client appends its own '/enterprise/projects/api'
   // prefix.
+  //
+  // Retries: the client's own bounded-backoff retry (createRetryingFetch in
+  // spacecat-shared-project-engine-client's internal.js) is left at its library
+  // defaults (maxRetries: 2, retryBaseDelayMs: 200 — 3 attempts total, jittered
+  // exponential backoff up to a 20s/attempt ceiling, honouring Retry-After).
+  // It was explicitly pinned to maxRetries: 0 when this transport migrated onto
+  // the typed clients, purely to preserve the hand-rolled transport's one-shot
+  // behaviour at the time — api-service had no retry logic at all, unlike the
+  // sibling shared client. That gap is closed here: idempotent methods (GET,
+  // HEAD, PUT, DELETE, OPTIONS) retry on 429 and on retryable 5xx; POST (and any
+  // other non-idempotent method) retries ONLY on 429, never on 5xx, so a create
+  // (createProject, createSubworkspace, createBenchmarks, createBrandUrls,
+  // createTaggedPrompts, transferWorkspaceResources, addAiModel,
+  // createProjectTags, publishProject, listPromptsByTags — all POST) can never
+  // be double-submitted by the retry layer on a 5xx; a 429 is safe to retry for
+  // any method because the Semrush gateway rejects it at the edge before the
+  // handler runs, so the create never happened.
+  //
+  // Per-attempt timeout: the injected `fetch` is `createTimeoutFetch`, which the
+  // retry layer calls once per attempt (it wraps `injectedFetch`, not the other
+  // way around) — so every retry gets its OWN fresh 15s AbortController/timer,
+  // not one 15s budget shared across the whole retry+backoff sequence. A timeout
+  // is surfaced to the retry layer as a thrown error (SerenityTransportError
+  // status 504), gated by the same idempotent-method rule as any other network
+  // error.
   const projects = createSerenityProjectEngineApiClient({
     baseUrl: root,
     authToken,
-    maxRetries: 0,
     fetch: createTimeoutFetch(DEFAULT_TIMEOUT_MS),
   });
 
   // Typed User Manager client over the sub-workspace lifecycle gateway. Same
-  // shape as the project client; appends its own '/enterprise/users/api' prefix.
-  // Uses `usersRoot` (SEMRUSH_USERS_BASE_URL, or `root` by fallback) so the
-  // lifecycle gateway can be a separate host from Project Engine.
+  // shape and retry/timeout rationale as the project client above; appends its
+  // own '/enterprise/users/api' prefix. Uses `usersRoot` (SEMRUSH_USERS_BASE_URL,
+  // or `root` by fallback) so the lifecycle gateway can be a separate host from
+  // Project Engine. Its own POST creates (createSubworkspace,
+  // transferWorkspaceResources) are covered by the same POST-never-retries-on-5xx
+  // rule — createSubworkspace in particular must never be silently double-fired
+  // by the retry layer (see workspace-lifecycle.js's own 504-triggered adoption
+  // recovery, which is a SEPARATE, application-level mechanism for the transport
+  // timeout case and unaffected by this change).
   const users = createSerenityUserManagerApiClient({
     baseUrl: usersRoot,
     authToken,
-    maxRetries: 0,
     fetch: createTimeoutFetch(DEFAULT_TIMEOUT_MS),
   });
 

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -255,50 +255,23 @@ export function createSerenityTransport({ env, imsToken }) {
     return imsToken;
   };
 
-  // Typed Project Engine client over the project gateway. `root` is the
-  // validated origin; the client appends its own '/enterprise/projects/api'
-  // prefix.
-  //
-  // Retries: the client's own bounded-backoff retry (createRetryingFetch in
-  // spacecat-shared-project-engine-client's internal.js) is left at its library
-  // defaults (maxRetries: 2, retryBaseDelayMs: 200 — 3 attempts total, jittered
-  // exponential backoff up to a 20s/attempt ceiling, honouring Retry-After).
-  // It was explicitly pinned to maxRetries: 0 when this transport migrated onto
-  // the typed clients, purely to preserve the hand-rolled transport's one-shot
-  // behaviour at the time — api-service had no retry logic at all, unlike the
-  // sibling shared client. That gap is closed here: idempotent methods (GET,
-  // HEAD, PUT, DELETE, OPTIONS) retry on 429 and on retryable 5xx; POST (and any
-  // other non-idempotent method) retries ONLY on 429, never on 5xx, so a create
-  // (createProject, createSubworkspace, createBenchmarks, createBrandUrls,
-  // createTaggedPrompts, transferWorkspaceResources, addAiModel,
-  // createProjectTags, publishProject, listPromptsByTags — all POST) can never
-  // be double-submitted by the retry layer on a 5xx; a 429 is safe to retry for
-  // any method because the Semrush gateway rejects it at the edge before the
-  // handler runs, so the create never happened.
-  //
-  // Per-attempt timeout: the injected `fetch` is `createTimeoutFetch`, which the
-  // retry layer calls once per attempt (it wraps `injectedFetch`, not the other
-  // way around) — so every retry gets its OWN fresh 15s AbortController/timer,
-  // not one 15s budget shared across the whole retry+backoff sequence. A timeout
-  // is surfaced to the retry layer as a thrown error (SerenityTransportError
-  // status 504), gated by the same idempotent-method rule as any other network
-  // error.
+  // Typed Project Engine client; appends '/enterprise/projects/api'. Retry,
+  // backoff, and the POST-never-retries-on-5xx idempotency gate are the shared
+  // library's contract, not this file's — see createRetryingFetch in
+  // spacecat-shared-project-engine-client's internal.js (library defaults:
+  // maxRetries 2, retryBaseDelayMs 200; per-attempt timeout via the injected
+  // `createTimeoutFetch` below, since the retry layer wraps it and calls it
+  // once per attempt).
   const projects = createSerenityProjectEngineApiClient({
     baseUrl: root,
     authToken,
     fetch: createTimeoutFetch(DEFAULT_TIMEOUT_MS),
   });
 
-  // Typed User Manager client over the sub-workspace lifecycle gateway. Same
-  // shape and retry/timeout rationale as the project client above; appends its
-  // own '/enterprise/users/api' prefix. Uses `usersRoot` (SEMRUSH_USERS_BASE_URL,
-  // or `root` by fallback) so the lifecycle gateway can be a separate host from
-  // Project Engine. Its own POST creates (createSubworkspace,
-  // transferWorkspaceResources) are covered by the same POST-never-retries-on-5xx
-  // rule — createSubworkspace in particular must never be silently double-fired
-  // by the retry layer (see workspace-lifecycle.js's own 504-triggered adoption
-  // recovery, which is a SEPARATE, application-level mechanism for the transport
-  // timeout case and unaffected by this change).
+  // Typed User Manager client over the sub-workspace lifecycle gateway (same
+  // retry/timeout contract as above); appends '/enterprise/users/api'. Uses
+  // `usersRoot` (SEMRUSH_USERS_BASE_URL, falling back to `root`) since this
+  // gateway can be a separate host from Project Engine.
   const users = createSerenityUserManagerApiClient({
     baseUrl: usersRoot,
     authToken,

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -368,6 +368,23 @@ describe('Semrush REST transport', () => {
       expect(fetchStub.callCount).to.equal(2);
     }));
 
+    it('retries a retryable DELETE (503) and returns the eventual success', withFakeTimers(async (clock) => {
+      // GET is the only idempotent method exercised for retryable 5xx above.
+      // The idempotency gate treats GET/HEAD/PUT/DELETE/OPTIONS alike, so this
+      // locks in that DELETE gets the same guarantee, using deleteProject (a
+      // real transport method) rather than a synthetic call.
+      fetchStub.onCall(0).resolves(fetchFail(503, { code: 'unavailable' }));
+      fetchStub.onCall(1).resolves(fetchOk(null));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.deleteProject(WORKSPACE_ID, PROJECT_ID);
+      await clock.tickAsync(60_000);
+      await promise;
+
+      expect(fetchStub.callCount).to.equal(2);
+      expect((await callOf(fetchStub, 1)).method).to.equal('DELETE');
+    }));
+
     it('retries a 429 even on a POST create (createSubworkspace) and returns the eventual success', withFakeTimers(async (clock) => {
       // createSubworkspace is the real brand-provisioning create-call shape
       // (brand-provisioning.js -> workspace-lifecycle.js#ensureSubworkspace ->
@@ -445,10 +462,7 @@ describe('Semrush REST transport', () => {
       expect(fetchStub.callCount).to.equal(2);
     }));
 
-    it('honours Retry-After (delta-seconds) as a floor on the backoff wait', async () => {
-      // No fake timers here: assert real elapsed time is at least the
-      // server-requested delay, proving Retry-After is actually being read
-      // and applied (not just backoff jitter, which defaults to ~100-200ms).
+    it('honours Retry-After (delta-seconds) as a floor on the backoff wait', withFakeTimers(async (clock) => {
       fetchStub.onCall(0).resolves(new Response(JSON.stringify({ code: 'rate_limited' }), {
         status: 429,
         headers: { 'content-type': 'application/json', 'retry-after': '1' },
@@ -456,14 +470,21 @@ describe('Semrush REST transport', () => {
       fetchStub.onCall(1).resolves(fetchOk({ status: 'created' }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
-      const start = Date.now();
-      const result = await transport.getWorkspaceStatus(WORKSPACE_ID);
-      const elapsed = Date.now() - start;
+      const promise = transport.getWorkspaceStatus(WORKSPACE_ID);
+
+      // Retry-After: 1 is a 1s FLOOR on the wait. Advancing to just under it
+      // must not dispatch the retry yet -- proving the header is what's gating
+      // the delay, not backoff jitter alone (which defaults to ~100-200ms and
+      // would otherwise let this pass for the wrong reason).
+      await clock.tickAsync(900);
+      expect(fetchStub.callCount).to.equal(1);
+
+      await clock.tickAsync(200);
+      const result = await promise;
 
       expect(result.status).to.equal('created');
       expect(fetchStub.callCount).to.equal(2);
-      expect(elapsed).to.be.at.least(950); // ~1s Retry-After, small slack for timer drift
-    }).timeout(5000);
+    }));
 
     it('returns the last retryable response after exhausting all retries (does not swallow into an exception)', withFakeTimers(async (clock) => {
       fetchStub.resolves(fetchFail(503, { code: 'still_unavailable' }));
@@ -477,6 +498,23 @@ describe('Semrush REST transport', () => {
       expect(fetchStub.callCount).to.equal(3);
       expect(err).to.be.instanceOf(SerenityTransportError);
       expect(err.status).to.equal(503);
+    }));
+
+    it('exhausts all retries on a POST create under sustained 429 (createProject)', withFakeTimers(async (clock) => {
+      // The other exhaustion test above only covers GET+503. POST retries via a
+      // different branch of the idempotency gate (429-only, never 5xx), so
+      // exhaustion needs its own coverage in case that branch's retry-count/
+      // last-response behavior ever drifts from the idempotent-method path.
+      fetchStub.resolves(fetchFail(429, { code: 'rate_limited' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.createProject(WORKSPACE_ID, { name: 'US - EN' }).catch((e) => e);
+      await clock.tickAsync(60_000);
+      const err = await promise;
+
+      expect(fetchStub.callCount).to.equal(3);
+      expect(err).to.be.instanceOf(SerenityTransportError);
+      expect(err.status).to.equal(429);
     }));
 
     it('rethrows the last network error after exhausting all retries on an idempotent method', withFakeTimers(async (clock) => {

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -27,6 +27,10 @@ use(sinonChai);
 const IMS = 'ims-bearer-test-token';
 const WORKSPACE_ID = '11111111-2222-3333-4444-555555555555';
 const PROJECT_ID = 'proj-xyz';
+// Sub-workspace lifecycle (serenity dual-mode, subworkspace path) parent id —
+// used both by the createSubworkspace/listWorkspaceFamily describe blocks below
+// and by the retry-behaviour suite's real create-call-shape tests.
+const PARENT_WS = 'bb0f4e1c-8bb1-402e-88f2-f68618ea7397';
 
 // Strict mode: rest-transport now requires SEMRUSH_PROJECTS_BASE_URL to be
 // supplied via env (Vault-backed in dev/stage/prod). Tests inject a
@@ -320,6 +324,236 @@ describe('Semrush REST transport', () => {
         global.setTimeout = realSetTimeout;
       }
     });
+  });
+
+  // ── Retry / backoff (LLMO reliability gap-fix) ──────────────────────────
+  //
+  // Both typed clients underlying this transport (Project Engine, User
+  // Manager) ship a bounded-backoff retry layer (createRetryingFetch in
+  // spacecat-shared-project-engine-client / -user-manager-client's
+  // internal.js). It used to be pinned off here (`maxRetries: 0`) to preserve
+  // the pre-migration hand-rolled transport's one-shot behaviour; this suite
+  // covers it now that the pin is removed and the library defaults
+  // (maxRetries: 2, retryBaseDelayMs: 200 -> 3 attempts total) apply.
+  //
+  // Every test that drives a retryable outcome fakes `setTimeout`/`clearTimeout`
+  // so the jittered exponential backoff (and the per-attempt 15s timeout) never
+  // costs real wall-clock time; `tickAsync` (not `tick`) is required throughout
+  // because the typed client's auth middleware and openapi-fetch both interleave
+  // microtasks before each attempt's timer is registered.
+  describe('retry behaviour', () => {
+    const FAKE_NOW = 1_700_000_000_000;
+
+    function withFakeTimers(fn) {
+      return async () => {
+        const clock = sinon.useFakeTimers({ now: FAKE_NOW, toFake: ['setTimeout', 'clearTimeout'] });
+        try {
+          await fn(clock);
+        } finally {
+          clock.restore();
+        }
+      };
+    }
+
+    it('retries a retryable GET (503) and returns the eventual success', withFakeTimers(async (clock) => {
+      fetchStub.onCall(0).resolves(fetchFail(503, { code: 'unavailable' }));
+      fetchStub.onCall(1).resolves(fetchOk({ status: 'created' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.getWorkspaceStatus(WORKSPACE_ID);
+      await clock.tickAsync(60_000);
+      const result = await promise;
+
+      expect(result.status).to.equal('created');
+      expect(fetchStub.callCount).to.equal(2);
+    }));
+
+    it('retries a 429 even on a POST create (createSubworkspace) and returns the eventual success', withFakeTimers(async (clock) => {
+      // createSubworkspace is the real brand-provisioning create-call shape
+      // (brand-provisioning.js -> workspace-lifecycle.js#ensureSubworkspace ->
+      // transport.createSubworkspace). A 429 means the Semrush gateway rejected
+      // the request at the edge before the handler ran, so the create never
+      // happened -- safe to retry for ANY method, including this POST.
+      fetchStub.onCall(0).resolves(fetchFail(429, { code: 'rate_limited' }));
+      fetchStub.onCall(1).resolves(fetchOk({ id: 'subworkspace-ws-1', status: 'not ready' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const resources = { ai: { projects: 3, prompts: 1500 } };
+      const promise = transport.createSubworkspace(PARENT_WS, 'Adobe Express', resources);
+      await clock.tickAsync(60_000);
+      const result = await promise;
+
+      expect(result.id).to.equal('subworkspace-ws-1');
+      expect(fetchStub.callCount).to.equal(2);
+      const retryCall = await callOf(fetchStub, 1);
+      expect(retryCall.method).to.equal('POST');
+      expect(JSON.parse(retryCall.body)).to.deep.equal({ title: 'Adobe Express', resources });
+    }));
+
+    it('does NOT retry a 500 on a POST create (createSubworkspace) -- avoids double-provisioning', withFakeTimers(async (clock) => {
+      // The critical guardrail: a create is a POST, and a 5xx is retried ONLY
+      // for idempotent methods. Retrying a POST on 500 could double-fire the
+      // sub-workspace/resource create upstream, so it must surface the 500
+      // immediately, in a single attempt.
+      fetchStub.resolves(fetchFail(500, { code: 'internal_error' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const resources = { ai: { projects: 3, prompts: 1500 } };
+      const promise = transport.createSubworkspace(PARENT_WS, 'Adobe Express', resources)
+        .catch((e) => e);
+      await clock.tickAsync(60_000);
+      const err = await promise;
+
+      expect(err).to.be.instanceOf(SerenityTransportError);
+      expect(err.status).to.equal(500);
+      expect(fetchStub.callCount).to.equal(1);
+    }));
+
+    it('does NOT retry a 500 on the createProject POST either (same idempotency rule)', withFakeTimers(async (clock) => {
+      fetchStub.resolves(fetchFail(500, { code: 'internal_error' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.createProject(WORKSPACE_ID, {
+        name: 'US - EN',
+        type: 'ai',
+        brand_name_display: 'Acme',
+        brand_names: ['Acme'],
+        domain: 'acme.com',
+        country_code: 'us',
+        location_id: 2840,
+        location_name: 'United States',
+        language_id: 'lang-uuid-en',
+      }).catch((e) => e);
+      await clock.tickAsync(60_000);
+      const err = await promise;
+
+      expect(err).to.be.instanceOf(SerenityTransportError);
+      expect(err.status).to.equal(500);
+      expect(fetchStub.callCount).to.equal(1);
+    }));
+
+    it('retries a 429 on createProject (POST) and eventually succeeds', withFakeTimers(async (clock) => {
+      fetchStub.onCall(0).resolves(fetchFail(429, { code: 'rate_limited' }));
+      fetchStub.onCall(1).resolves(fetchOk({ id: 'new-project-uuid' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.createProject(WORKSPACE_ID, { name: 'US - EN' });
+      await clock.tickAsync(60_000);
+      const result = await promise;
+
+      expect(result.id).to.equal('new-project-uuid');
+      expect(fetchStub.callCount).to.equal(2);
+    }));
+
+    it('honours Retry-After (delta-seconds) as a floor on the backoff wait', async () => {
+      // No fake timers here: assert real elapsed time is at least the
+      // server-requested delay, proving Retry-After is actually being read
+      // and applied (not just backoff jitter, which defaults to ~100-200ms).
+      fetchStub.onCall(0).resolves(new Response(JSON.stringify({ code: 'rate_limited' }), {
+        status: 429,
+        headers: { 'content-type': 'application/json', 'retry-after': '1' },
+      }));
+      fetchStub.onCall(1).resolves(fetchOk({ status: 'created' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const start = Date.now();
+      const result = await transport.getWorkspaceStatus(WORKSPACE_ID);
+      const elapsed = Date.now() - start;
+
+      expect(result.status).to.equal('created');
+      expect(fetchStub.callCount).to.equal(2);
+      expect(elapsed).to.be.at.least(950); // ~1s Retry-After, small slack for timer drift
+    }).timeout(5000);
+
+    it('returns the last retryable response after exhausting all retries (does not swallow into an exception)', withFakeTimers(async (clock) => {
+      fetchStub.resolves(fetchFail(503, { code: 'still_unavailable' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.getWorkspaceStatus(WORKSPACE_ID).catch((e) => e);
+      await clock.tickAsync(60_000);
+      const err = await promise;
+
+      // Default maxRetries: 2 -> 3 attempts total.
+      expect(fetchStub.callCount).to.equal(3);
+      expect(err).to.be.instanceOf(SerenityTransportError);
+      expect(err.status).to.equal(503);
+    }));
+
+    it('rethrows the last network error after exhausting all retries on an idempotent method', withFakeTimers(async (clock) => {
+      const netErr = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' });
+      fetchStub.rejects(netErr);
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.getWorkspaceStatus(WORKSPACE_ID).catch((e) => e);
+      await clock.tickAsync(60_000);
+      const err = await promise;
+
+      expect(fetchStub.callCount).to.equal(3);
+      expect(err.message).to.equal('ECONNRESET');
+    }));
+
+    it('gives each retry attempt its OWN fresh per-attempt timeout (not one budget for the whole retry loop)', withFakeTimers(async (clock) => {
+      // Simulate: attempt 1 times out (never resolves until aborted), attempt 2
+      // succeeds immediately. If the timeout were shared across the whole retry
+      // loop (a single 15s AbortController for every attempt, rather than a new
+      // one per attempt), the clock advance below -- 15s for attempt 1's abort,
+      // then a further tick for backoff -- would either abort the already-
+      // succeeded second attempt or never let it run at all. Getting a clean
+      // 200 after exactly 2 calls proves attempt 2 got its own untouched budget.
+      let call = 0;
+      fetchStub.callsFake((_input, init) => {
+        call += 1;
+        if (call === 1) {
+          return new Promise((resolve, reject) => {
+            init.signal.addEventListener('abort', () => {
+              const e = new Error('aborted');
+              e.name = 'AbortError';
+              reject(e);
+            });
+          });
+        }
+        return Promise.resolve(fetchOk({ status: 'created' }));
+      });
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.getWorkspaceStatus(WORKSPACE_ID);
+      await clock.tickAsync(60_000);
+      const result = await promise;
+
+      expect(result.status).to.equal('created');
+      expect(fetchStub.callCount).to.equal(2);
+    }));
+
+    it('does NOT retry a per-attempt timeout on a non-idempotent method (POST)', withFakeTimers(async (clock) => {
+      fetchStub.callsFake((_input, init) => new Promise((resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          reject(e);
+        });
+      }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.publishProject(WORKSPACE_ID, PROJECT_ID).catch((e) => e);
+      await clock.tickAsync(20_000); // past the 15s per-attempt timeout, once
+      const err = await promise;
+
+      expect(err).to.be.instanceOf(SerenityTransportError);
+      expect(err.status).to.equal(504);
+      expect(fetchStub.callCount).to.equal(1);
+    }));
+
+    it('does not retry a non-retryable 4xx (e.g. 404) regardless of method', withFakeTimers(async (clock) => {
+      fetchStub.resolves(fetchFail(404, { message: 'not found' }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      const promise = transport.getWorkspaceStatus(WORKSPACE_ID).catch((e) => e);
+      await clock.tickAsync(60_000);
+      const err = await promise;
+
+      expect(err.status).to.equal(404);
+      expect(fetchStub.callCount).to.equal(1);
+    }));
   });
 
   describe('non-2xx upstream', () => {
@@ -951,8 +1185,6 @@ describe('Semrush REST transport', () => {
   });
 
   // ── Sub-workspace lifecycle (serenity dual-mode, subworkspace path) ──────────────
-  const PARENT_WS = 'bb0f4e1c-8bb1-402e-88f2-f68618ea7397';
-
   describe('createSubworkspace', () => {
     it('POSTs { title, resources } to /v2/workspaces/{parent}/child (no X-Upload-Receipt)', async () => {
       fetchStub.resolves(fetchOk({ id: 'subworkspace-ws-1', status: 'not ready' }));
@@ -1106,41 +1338,67 @@ describe('Semrush REST transport', () => {
       expect(fetchStub.called).to.equal(false);
     });
 
-    it('throws SerenityTransportError carrying upstream status + parsed body on non-2xx', async () => {
+    it('throws SerenityTransportError carrying upstream status + parsed body on non-2xx (after exhausting GET retries)', async () => {
+      // getWorkspaceStatus is a GET (idempotent) — a persistent 503 is now
+      // retried (default maxRetries: 2 -> 3 attempts total) before the last
+      // response is surfaced. Fake timers keep the jittered backoff sleeps from
+      // costing real wall-clock time in the test run.
       fetchStub.resolves(fetchFail(503, { code: 'unavailable' }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+      const clock = sinon.useFakeTimers({ now: 1_700_000_000_000, toFake: ['setTimeout', 'clearTimeout'] });
       try {
-        await transport.getWorkspaceStatus(WORKSPACE_ID);
-        expect.fail('should have thrown');
-      } catch (err) {
+        const promise = transport.getWorkspaceStatus(WORKSPACE_ID).catch((e) => e);
+        await clock.tickAsync(60_000);
+        const err = await promise;
         expect(err).to.be.instanceOf(SerenityTransportError);
         expect(err.status).to.equal(503);
         expect(err.body).to.deep.equal({ code: 'unavailable' });
+        expect(fetchStub.callCount).to.equal(3);
+      } finally {
+        clock.restore();
       }
     });
 
-    it('falls back to raw text when the upstream body is not JSON', async () => {
+    it('falls back to raw text when the upstream body is not JSON (after exhausting GET retries)', async () => {
       fetchStub.resolves(new Response('gateway exploded', {
         status: 500,
         headers: { 'content-type': 'text/plain' },
       }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+      const clock = sinon.useFakeTimers({ now: 1_700_000_000_000, toFake: ['setTimeout', 'clearTimeout'] });
       try {
-        await transport.getWorkspaceStatus(WORKSPACE_ID);
-        expect.fail('should have thrown');
-      } catch (err) {
+        const promise = transport.getWorkspaceStatus(WORKSPACE_ID).catch((e) => e);
+        await clock.tickAsync(60_000);
+        const err = await promise;
         expect(err.body).to.equal('gateway exploded');
+        expect(fetchStub.callCount).to.equal(3);
+      } finally {
+        clock.restore();
       }
     });
 
-    it('re-throws a non-abort network error verbatim', async () => {
+    it('retries a network error on GET, then rethrows it verbatim once retries are exhausted', async () => {
       const netErr = Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
       fetchStub.rejects(netErr);
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
-      await expect(transport.getWorkspaceStatus(WORKSPACE_ID)).to.be.rejectedWith(/ENOTFOUND/);
+      const clock = sinon.useFakeTimers({ now: 1_700_000_000_000, toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        const promise = transport.getWorkspaceStatus(WORKSPACE_ID).catch((e) => e);
+        await clock.tickAsync(60_000);
+        const err = await promise;
+        expect(err.message).to.equal('ENOTFOUND');
+        expect(fetchStub.callCount).to.equal(3);
+      } finally {
+        clock.restore();
+      }
     });
 
-    it('aborts with SerenityTransportError(504) on timeout', async () => {
+    it('aborts with SerenityTransportError(504) on timeout, retried on GET (idempotent) then exhausted', async () => {
+      // getWorkspaceStatus is a GET (idempotent) — every attempt times out here,
+      // so the retry layer treats each timeout as a network-error-equivalent
+      // retryable failure, retries up to the default 3 attempts total, and
+      // surfaces the last one as the 504 once exhausted. Needs a longer tick
+      // than a single attempt's 15s ceiling: 3 attempts x 15s + 2 backoff waits.
       fetchStub.callsFake((_url, init) => new Promise((resolve, reject) => {
         init.signal.addEventListener('abort', () => {
           const e = new Error('aborted');
@@ -1152,14 +1410,15 @@ describe('Semrush REST transport', () => {
       const clock = sinon.useFakeTimers({ now: 1_700_000_000_000, toFake: ['setTimeout', 'clearTimeout'] });
       try {
         const promise = transport.getWorkspaceStatus(WORKSPACE_ID);
-        await clock.tickAsync(20_000);
+        await clock.tickAsync(90_000);
         const err = await promise.catch((e) => e);
         expect(err).to.be.instanceOf(SerenityTransportError);
         expect(err.status).to.equal(504);
+        expect(fetchStub.callCount).to.equal(3);
       } finally {
         clock.restore();
       }
-    });
+    }).timeout(15000);
   });
 
   describe('defensive branch coverage', () => {


### PR DESCRIPTION
## Spec

**The gap.** `src/support/serenity/rest-transport.js` (the Semrush "Serenity" transport) had a real reliability gap that the sibling shared client already closed. Confirmed via a whole-tree + fresh-`origin/main` search before writing any code.

The transport is built on two typed, vendored Semrush clients — `@adobe/spacecat-shared-project-engine-client` and `@adobe/spacecat-shared-user-manager-client` — both of which ship an idempotency-aware, jittered-backoff retry layer (`createRetryingFetch` in each package's `internal.js`, defaults `maxRetries: 2`, `retryBaseDelayMs: 200`). That retry logic landed in the shared packages well before the versions api-service currently pins (1.8.0 / 1.3.1 respectively), so **no dependency bump is needed here.**

The retry was explicitly disabled in api-service: when `rest-transport.js` migrated onto these typed clients, both were constructed with `maxRetries: 0`, with a comment stating this "preserves the one-shot behaviour the hand-rolled transport had." That was a deliberate deferral at migration time, not a bug — but it meant api-service's Semrush calls had zero retry coverage for transient 429/5xx/network failures, unlike the shared client. This PR closes exactly that gap: flip the pin off, nothing else.

(Note: an earlier framing of this task assumed the transport was still fully hand-rolled with *no* retry-capable dependency underneath it. That premise was stale — by the time this branch was cut from `origin/main`, the transport had already migrated to the typed clients described above, as part of unrelated, already-shipped work. This PR does not touch or extend that migration; it only flips the one config value the migration left off.)

## Implementation plan

**What changed** — `src/support/serenity/rest-transport.js`: removed `maxRetries: 0` from both `createSerenityProjectEngineApiClient` and `createSerenityUserManagerApiClient` constructions, letting the library defaults apply (2 retries, 200ms base backoff, jittered exponential growth capped at 20s/attempt, `Retry-After` honored). Added doc comments explaining the retry/idempotency/timeout behavior at the call site. No other files changed.

**Guardrail 1 — per-attempt timeout, not whole-loop.** Verified by reading the composition order rather than assuming it: the transport passes `createTimeoutFetch(DEFAULT_TIMEOUT_MS)` (its own pre-existing 15s `AbortController` wrapper) as the `fetch` option into each typed client. Internally each client does `fetch: createRetryingFetch(injectedFetch, maxRetries, retryBaseDelayMs, onRetry)` — the retry layer wraps the timeout-fetch, not the other way around. The retry loop calls the timeout-wrapped fetch once per attempt, so every retry gets a brand-new `AbortController` + `setTimeout(15_000)`. A timeout surfaces as a thrown error inside the retry loop and is gated by the same idempotent-method rule as any other network error (retried for GET/HEAD/PUT/DELETE/OPTIONS, rethrown immediately for POST). This was architecturally already correct — no code change was needed for this guardrail, only verification, which the new "per-attempt timeout" tests lock in.

**Guardrail 2 — idempotency correctness.** Checked every caller of the transport:
- `src/controllers/serenity.js` and `src/controllers/brands.js` call `createSerenityTransport(...)` and drive it through `src/support/serenity/handlers/*.js` and `src/support/serenity/workspace-lifecycle.js`.
- `src/support/serenity/brand-provisioning.js` drives `handleCreateMarketSubworkspace` (`handlers/markets-subworkspace.js`), which calls `ensureSubworkspace` (`workspace-lifecycle.js`) — the actual workspace/resource **create** path: `transport.createSubworkspace(parentWorkspaceId, title, CREATE_ALLOCATION)` (POST `/v2/workspaces/{parent}/child`) and `transport.createProject(...)` (POST).
- Cross-referenced every transport method against its HTTP verb directly in `rest-transport.js`. All create/mutate-only calls (`createProject`, `createSubworkspace`, `createBenchmarks`, `createBrandUrls`, `createTaggedPrompts`, `createPromptsByIds`, `transferWorkspaceResources`, `addAiModel`, `createProjectTags`, `publishProject`, `listPromptsByTags`) are POST. Reads are GET. Updates are PUT/PATCH; deletes are DELETE.

  The idempotency gate lives inside the shared retry layer itself (429 retried for any method; 5xx retried only for GET/HEAD/PUT/DELETE/OPTIONS), so gating is uniform across every call site automatically. Confirmed POST creates never retry on 5xx with a direct test against the real `brand-provisioning.js` call shape.

**Test coverage added** (`test/support/serenity/rest-transport.test.js`, new `describe('retry behaviour', ...)` block, plus fixes to 4 pre-existing tests whose GET/timeout assertions now interact with retry):
- 429 retried on a POST create (`createSubworkspace`, the real `brand-provisioning.js` → `workspace-lifecycle.js#ensureSubworkspace` call shape) — retries and succeeds.
- 500 on that same POST create is **NOT** retried — single attempt, immediate 500 (the core anti-double-provisioning guarantee). Same check repeated for `createProject`.
- 429 retried on `createProject` (POST) — succeeds.
- 503 retried on a GET (`getWorkspaceStatus`) — succeeds after retry.
- `Retry-After` (delta-seconds) honored as a floor on the backoff wait (real-clock assertion, to prove it's actually driving the wait).
- Exhaustion returns the last retryable HTTP response rather than throwing (GET, 3 attempts).
- Exhaustion rethrows the last network error verbatim once retries run out (GET, 3 attempts).
- Per-attempt timeout: attempt 1 times out, attempt 2 gets its own fresh budget and succeeds — proves the timeout isn't shared across the whole retry loop.
- A per-attempt timeout on POST is NOT retried (single attempt, immediate 504).
- Non-retryable 4xx (404) never retries regardless of method.
- Fixed 3 pre-existing GET-based tests (503, non-JSON-500, ENOTFOUND on `getWorkspaceStatus`) and 1 timeout test to account for retries now happening on idempotent methods — added fake timers where needed to keep them fast/deterministic, plus explicit `fetchStub.callCount` assertions.

## Verification

- `npm run lint` — clean (0 errors).
- `npx mocha test/support/serenity/rest-transport.test.js` — **93 passing, 0 failing**.
- `npm test` (full repo suite) — **14124 passing, 0 failing**; coverage 99.94% lines / 99.23% branches / 99.12% functions (gate: 90%/90%/90%).
- No dependency version bump required — the retry logic already ships in the currently-pinned `@adobe/spacecat-shared-project-engine-client@1.8.0` / `@adobe/spacecat-shared-user-manager-client@1.3.1`.

## Scope

Retry only. Did not touch typed-error work (LLMO-5978) or a timeout redesign (LLMO-5979) — both shared-client-scope tickets, out of scope here. No new config surface, no `onRetry` observability hook added (would need threading a `log` into `createSerenityTransport`, which none of the current call sites pass — left out to keep this the smallest shippable fix).