### PR TITLE
feat: Semrush Elements prompts (count) endpoint for prompt healthcheck

### DIFF
--- a/docs/elements/semrush-elements-api-reference.md
+++ b/docs/elements/semrush-elements-api-reference.md
@@ -406,10 +406,11 @@ Follow these steps in order. Steps 1–4 are contained within `src/support/eleme
 
 Source: `src/support/elements/element-ids.js`
 
-> **Surfaced endpoints:** `BRANDS`/`MARKETS`/`TOPICS` (rows 1–3) back the [URL Inspector Filter Dimensions](../llmo-semrush-apis/filter-dimensions-apis.md#1-list-url-inspector-filter-dimensions) endpoint; `WEEKS` (row 5) backs the [Weeks](../llmo-semrush-apis/filter-dimensions-apis.md#2-list-weeks) endpoint.
+> **Surfaced endpoints:** `BRANDS`/`MARKETS`/`TOPICS` (rows 1–3) back the [URL Inspector Filter Dimensions](../llmo-semrush-apis/filter-dimensions-apis.md#1-list-url-inspector-filter-dimensions) endpoint; `WEEKS` (row 5) backs the [Weeks](../llmo-semrush-apis/filter-dimensions-apis.md#2-list-weeks) endpoint; `PROMPTS` backs the [Prompts (count)](../llmo-semrush-apis/filter-dimensions-apis.md#3-list-prompts) endpoint.
 
 | Constant | UUID | Section | Row(s) |
 |---|---|---|---|
+| `PROMPTS` | `406ba6e0-0de2-475e-80d9-42fab8616032` | Prompts (count) | — |
 | `BRANDS` | `b178ce4e-6471-4430-9a32-8228ce72b2e6` | Filter Dimensions | 1 |
 | `MARKETS` | `478968a7-8851-4daf-83f7-2e8fb6185ddc` | Filter Dimensions | 2 |
 | `TOPICS` | `ba3b19c1-22d4-460a-8dc3-1ff05c360852` | Filter Dimensions | 3 |

--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -195,7 +195,14 @@ Both metrics are **per project** — issue one request per `projectId`.
 
 ### What it returns
 
-`count` (number of matching prompts) plus the `prompts` array. Semrush field names are passed through unchanged.
+`count` (number of matching prompts) plus the `prompts` array. Semrush field names are passed through unchanged; each row means:
+
+| Field | Meaning |
+|---|---|
+| `prompt` | The prompt text — the question a user asked the LLM |
+| `prompt_topic` | The topic the prompt belongs to. Assigned by a Semrush-developed model that groups together prompts which ask similar things and receive similar replies. **Not a tag** — a derived grouping, one topic per prompt |
+| `primary_intent` | The primary intent **of the `prompt_topic`** (a property of the topic, not the individual prompt). The field the intent-coverage metric groups on |
+| `volume` | Estimated number of times per month a user asked the LLM a question about this topic. A per-topic estimate, so prompts sharing a topic carry the same volume |
 
 ### Response example
 

--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -154,6 +154,13 @@ Returns the prompts matching the given filters, plus their **count**. Powers the
 
 **Brand-scoped (not org-scoped).** Semrush projects — and therefore prompts — live only in a brand's own Semrush **sub-workspace**, never in the org's shared parent workspace (verified against prod: the same project payload returns data on the sub-workspace and `0` on the parent). The endpoint resolves the brand's sub-workspace and **refuses to run against an org workspace**.
 
+**Auth (required).** Like all Semrush-wrapping endpoints, this needs **two** credentials on the request:
+
+- `Authorization: Bearer <jwt>` — a **spacecat JWT session token** (authenticates the caller to SpaceCat).
+- `x-promise-token: <token>` — exchanged server-side for the upstream Semrush IMS token. A request without it cannot reach Semrush.
+
+In project-elmo-ui the JWT is attached automatically by `authenticatedFetch`; the promise token is **not** — the v2 machinery (`getValidPromiseToken()`, `POST /auth/v2/promise`) is built but has no live consumer yet, so this endpoint would be its first. Attach it per the pattern in the elmo `docs/api/promise-token.md`: `headers: { 'x-promise-token': await getValidPromiseToken() }`.
+
 ### Parameters
 
 | Name | In | Required | Description |
@@ -169,13 +176,39 @@ Returns the prompts matching the given filters, plus their **count**. Powers the
 Both metrics are **per project** — issue one request per `projectId`.
 
 - **Intent coverage** — one call, no tag filter. Group the returned rows by
-  `primary_intent` (`informational` / `commercial` / `navigational` / `task` / …) and
-  compare each intent's share against its target band. `count` is the denominator.
+  `primary_intent` and compare each intent's share against its target band. `count` is
+  the denominator. `primary_intent` is the **Semrush 5-value taxonomy**:
+  `informational` / `task` / `commercial` / `transactional` / `navigational`. This is
+  the same set the serenity SR surface already uses (`SRBrandTopicCatalogIntent`); the
+  legacy LLMO 6-value intents map onto it via `INTENT_MAP` in mysticat-data-service
+  (`scripts/serenity_migration/tags.py`): `informational→Informational`,
+  `instructional→Task`, `comparative→Commercial`, `transactional→Transactional`,
+  `delegation→Task`, `planning→Task` (`Navigational` is Semrush-only, no LLMO source).
 - **Branded / unbranded** — the branded flag is a **tag**, not a row field. Two counts:
   - total = `?projectId=<id>` → `count`
   - branded = `?projectId=<id>&tag=type:branded` → `count`
   - branded% = branded ÷ total. (`type:branded` + `type:non-branded` partition the
     total exactly — verified in prod: 510 + 687 = 1197 → **43%**.)
+
+### Consumer integration (project-elmo-ui prompt healthcheck)
+
+The serenity healthcheck consumes this **raw** endpoint and aggregates client-side (the
+established serenity pattern — e.g. `buildTopicResearchIntentBreakdownFromRows`), rather
+than the brand-wide `/prompts/stats` + Postgres RPC used by the legacy path. Wiring it up
+means:
+
+1. **Attach `x-promise-token`** on the call (see Auth above) — the endpoint's hard
+   requirement and elmo's first live use of the v2 promise-token path.
+2. **Resolve per-project ids.** The health panel holds only `orgId` + `brandId`; fetch
+   the brand's Semrush project ids (the `regions` from [filter-dimensions](#1-list-url-inspector-filter-dimensions),
+   held as `semrush_project_id`) and issue one call per project. Omitting `projectId`
+   yields a brand-wide number instead.
+3. **Branded needs a second call** per project (`&tag=type:branded`) divided by the
+   unfiltered total.
+4. **Re-base the intent tile.** `IntentCoverageTile` / `intentCoverageMath.ts` still
+   encode the legacy 6-value LLMO taxonomy; point them at the 5-value Semrush set above
+   so the bands line up with `primary_intent` (this aligns the tile with the rest of the
+   serenity surface).
 
 ### Errors
 

--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -5,7 +5,7 @@
   of the License at http://www.apache.org/licenses/LICENSE-2.0
 -->
 
-# LLMO Semrush Elements API — Filter Dimensions & Weeks
+# LLMO Semrush Elements API — Filter Dimensions, Weeks & Prompts
 
 SpaceCat wrapper endpoints over the Semrush Elements APIs for the Brand Presence / URL Inspector dashboards.
 
@@ -17,7 +17,8 @@ SpaceCat wrapper endpoints over the Semrush Elements APIs for the Brand Presence
 
 1. [List URL Inspector Filter Dimensions](#1-list-url-inspector-filter-dimensions)
 2. [List Weeks](#2-list-weeks)
-3. [Supported Models](#3-supported-models)
+3. [List Prompts](#3-list-prompts)
+4. [Supported Models](#4-supported-models)
 
 ---
 
@@ -32,7 +33,7 @@ Returns all filter dimensions needed to initialise the URL Inspector dashboard i
 | Name | In | Required | Description |
 |---|---|---|---|
 | `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
-| `model` | query | ❌ | AI model filter. See [Supported Models](#2-supported-models) for valid values (default: `search-gpt`) |
+| `model` | query | ❌ | AI model filter. See [Supported Models](#4-supported-models) for valid values (default: `search-gpt`) |
 
 ### Underlying Elements
 
@@ -111,7 +112,7 @@ Returns the weeks that have Brand Presence data, for the week/date filter dropdo
 | Name | In | Required | Description |
 |---|---|---|---|
 | `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
-| `model` / `platform` | query | ❌ | AI model filter. Accepts **either** key (`model` wins if both are sent). UI platform codes are translated to Semrush models — see [Supported Models](#3-supported-models) (default: `search-gpt`) |
+| `model` / `platform` | query | ❌ | AI model filter. Accepts **either** key (`model` wins if both are sent). UI platform codes are translated to Semrush models — see [Supported Models](#4-supported-models) (default: `search-gpt`) |
 | `siteId` / `site_id` | query | ❌ | Site UUID. Reverse-mapped to the site's **primary brand** (`brands.site_id`), which scopes the weeks via a `CBF_ws_brand` filter. Returns `404` if the site has no brand. Omitted → workspace-wide weeks |
 
 ### Underlying Element
@@ -145,7 +146,74 @@ The daily rows are rolled up into ISO weeks spanning the earliest→latest day p
 
 ---
 
-## 3. Supported Models
+## 3. List Prompts
+
+**`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts`**
+
+Returns the prompts matching the given filters, plus their **count**. Powers the prompt healthcheck metrics: **intent %** is derived by grouping the returned rows on `primary_intent`; **branded %** by comparing a topic-filtered count against the unfiltered count.
+
+**Brand-scoped (not org-scoped).** Semrush projects — and therefore prompts — live only in a brand's own Semrush **sub-workspace**, never in the org's shared parent workspace (verified against prod: the same project payload returns data on the sub-workspace and `0` on the parent). The endpoint resolves the brand's sub-workspace and **refuses to run against an org workspace**.
+
+### Parameters
+
+| Name | In | Required | Description |
+|---|---|---|---|
+| `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
+| `brandId` | path | ✅ | Brand UUID. Must be a UUID (`400` otherwise) and resolve to a brand in the org (`404` otherwise) |
+| `model` / `platform` | query | ❌ | AI model filter. Accepts **either** key (`model` wins if both are sent). UI platform codes are translated to Semrush models — see [Supported Models](#4-supported-models) (default: `search-gpt`) |
+| `tag` | query | ❌ | Comma-separated **full** tag values (`tags contains <value>`), AND-ed (a prompt must carry all). Pass the whole prefixed value — the tag taxonomy varies by brand: `type:branded` / `type:non-branded`, `category:<name>`, `intent:<name>`, `source:<name>`, `topic:<name>`. Omitted → no tag filter |
+| `projectId` / `project_id` | query | ❌ | Comma-separated Semrush project UUIDs to scope to (OR-ed). The UI already holds these as `semrush_project_id` from the [filter-dimensions `regions`](#1-list-url-inspector-filter-dimensions). Omitted → all of the brand's projects in its sub-workspace |
+
+### Computing the prompt healthcheck metrics (per project)
+
+Both metrics are **per project** — issue one request per `projectId`.
+
+- **Intent coverage** — one call, no tag filter. Group the returned rows by
+  `primary_intent` (`informational` / `commercial` / `navigational` / `task` / …) and
+  compare each intent's share against its target band. `count` is the denominator.
+- **Branded / unbranded** — the branded flag is a **tag**, not a row field. Two counts:
+  - total = `?projectId=<id>` → `count`
+  - branded = `?projectId=<id>&tag=type:branded` → `count`
+  - branded% = branded ÷ total. (`type:branded` + `type:non-branded` partition the
+    total exactly — verified in prod: 510 + 687 = 1197 → **43%**.)
+
+### Errors
+
+| Status | error | When |
+|---|---|---|
+| `400` | `invalidRequest` | `brandId` is not a UUID |
+| `403` | `forbidden` | Caller has no access to the organisation |
+| `404` | `notFound` | Organisation or brand not found |
+| `404` | `subWorkspaceRequired` | Brand has no Semrush sub-workspace (flat mode / org workspace) — nothing to query |
+| `409` | `workspaceMisconfigured` | Brand sub-workspace pointer equals the org parent workspace (bad backfill) |
+
+### Underlying Element
+
+| Element | UUID | Shape |
+|---|---|---|
+| `PROMPTS` | `406ba6e0-0de2-475e-80d9-42fab8616032` | `table` — one row per prompt (`{ prompt, prompt_topic, primary_intent, volume }`) |
+
+### What it returns
+
+`count` (number of matching prompts) plus the `prompts` array. Semrush field names are passed through unchanged.
+
+### Response example
+
+```json
+{
+  "count": 2,
+  "prompts": [
+    { "prompt": "can i make ai influencer for free", "prompt_topic": "AI Instagram Influencers", "primary_intent": "informational", "volume": 2119 },
+    { "prompt": "What is the best AI free image generator?", "prompt_topic": "AI Image Generators", "primary_intent": "informational", "volume": 997 }
+  ]
+}
+```
+
+> **Project ids stay explicit:** within the resolved sub-workspace, the endpoint filters by Semrush project id via `CBF_project` (the UI already holds these as `semrush_project_id` from the filter-dimensions `regions`). Omitting `projectId` returns every prompt in the brand's sub-workspace.
+
+---
+
+## 4. Supported Models
 
 The `model` (or `platform`) query parameter is accepted by these endpoints. Only the following Semrush values are valid; any unrecognised value silently falls back to the default (`search-gpt`).
 

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -188,10 +188,11 @@ function requireImsBearer(ctx) {
  * @param {object} env - Environment variables.
  */
 /**
- * Validates org access and resolves the Semrush workspace ID.
- * Returns `{ workspaceId }` on success or `{ error: Response }` on failure.
+ * Resolves the organization and verifies the caller has access to it.
+ * Shared pre-flight for the org- and brand-scoped authorizers.
+ * Returns `{ organization }` on success or `{ error: Response }` on failure.
  */
-async function authorizeOrg(ctx) {
+async function authorizeOrgAccess(ctx) {
   const spaceCatId = ctx?.params?.spaceCatId;
   const Organization = ctx?.dataAccess?.Organization;
   if (!Organization || typeof Organization.findById !== 'function') {
@@ -205,7 +206,19 @@ async function authorizeOrg(ctx) {
   if (!await accessControl.hasAccess(organization)) {
     return { error: forbidden('User does not have access to this organization') };
   }
-  const workspaceId = await resolveWorkspaceId(ctx, spaceCatId);
+  return { organization };
+}
+
+/**
+ * Validates org access and resolves the Semrush workspace ID.
+ * Returns `{ workspaceId }` on success or `{ error: Response }` on failure.
+ */
+async function authorizeOrg(ctx) {
+  const access = await authorizeOrgAccess(ctx);
+  if (access.error) {
+    return access;
+  }
+  const workspaceId = await resolveWorkspaceId(ctx, ctx?.params?.spaceCatId);
   if (!hasText(workspaceId)) {
     return { error: notFound('Organization has no semrush_workspace_id') };
   }
@@ -234,17 +247,9 @@ async function authorizeBrandSubWorkspace(ctx, log) {
   if (!isValidUUID(brandId)) {
     return { error: createResponse({ error: 'invalidRequest', message: 'brandId must be a UUID' }, 400) };
   }
-  const Organization = ctx?.dataAccess?.Organization;
-  if (!Organization || typeof Organization.findById !== 'function') {
-    return { error: internalServerError('Organization data-access not available') };
-  }
-  const organization = await Organization.findById(spaceCatId);
-  if (!organization) {
-    return { error: notFound(`Organization not found: ${spaceCatId}`) };
-  }
-  const accessControl = AccessControlUtil.fromContext(ctx);
-  if (!await accessControl.hasAccess(organization)) {
-    return { error: forbidden('User does not have access to this organization') };
+  const access = await authorizeOrgAccess(ctx);
+  if (access.error) {
+    return access;
   }
   const postgrestClient = ctx?.dataAccess?.services?.postgrestClient;
   if (!postgrestClient?.from) {

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -13,14 +13,15 @@
 import {
   createResponse, forbidden, internalServerError, notFound, ok,
 } from '@adobe/spacecat-shared-http-utils';
-import { hasText, isNonEmptyObject } from '@adobe/spacecat-shared-utils';
+import { hasText, isNonEmptyObject, isValidUUID } from '@adobe/spacecat-shared-utils';
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 
 import { listBrands as listSpacecatBrands, getBrandBySite } from '../support/brands-storage.js';
+import { resolveBrandUuid } from '../support/prompts-storage.js';
 import { createElementsTransport } from '../support/elements/elements-transport.js';
 import { ElementsTransportError } from '../support/elements/errors.js';
 import { createElementsService } from '../support/elements/elements-service.js';
-import { resolveWorkspaceId } from '../support/serenity/workspace-resolver.js';
+import { resolveWorkspaceId, resolveBrandWorkspace } from '../support/serenity/workspace-resolver.js';
 import AccessControlUtil from '../support/access-control-util.js';
 import { ErrorWithStatusCode, resolveSemrushImsToken } from '../support/utils.js';
 import { X_PROMISE_TOKEN_HEADER, PROMISE_TOKEN_REQUIRED_ERROR_CODE } from '../utils/constants.js';
@@ -134,6 +135,21 @@ function extractQuery(context) {
 }
 
 /**
+ * Splits a comma-separated query value into a trimmed, non-empty string array.
+ * `extractQuery` collapses repeated params (last value wins), so multi-valued
+ * filters (topics, project ids) are passed as a single CSV value.
+ *
+ * @param {string} [value] - Raw query value (e.g. "AI,Commerce").
+ * @returns {string[]} Parsed values, or [] when absent/blank.
+ */
+function splitCsv(value) {
+  if (!hasText(value)) {
+    return [];
+  }
+  return value.split(',').map((v) => v.trim()).filter((v) => v.length > 0);
+}
+
+/**
  * Extracts and validates the IMS bearer token from the inbound Authorization header.
  * Throws 401 if missing or if the caller authenticated via a non-IMS mechanism.
  *
@@ -192,6 +208,80 @@ async function authorizeOrg(ctx) {
   const workspaceId = await resolveWorkspaceId(ctx, spaceCatId);
   if (!hasText(workspaceId)) {
     return { error: notFound('Organization has no semrush_workspace_id') };
+  }
+  return { workspaceId };
+}
+
+/**
+ * Validates access and resolves the Semrush **sub-workspace** for a brand.
+ *
+ * Semrush projects (and therefore prompts) live ONLY in a brand's own
+ * sub-workspace — never in the org's shared parent workspace (verified against
+ * prod: the same project payload returns data on the sub-workspace and 0 on the
+ * parent). So a prompts query must resolve the brand's sub-workspace and refuse
+ * to run against an org workspace. This helper enforces exactly that.
+ *
+ * @param {object} ctx - Request context.
+ * @param {object} log - Logger (for the misconfiguration alert).
+ * @returns {Promise<{workspaceId: string} | {error: Response}>} the brand's
+ *   sub-workspace id on success, or a Response on failure (400 non-UUID brandId,
+ *   403 no access, 404 org/brand not found or brand has no sub-workspace,
+ *   409 sub-workspace misconfigured as the parent).
+ */
+async function authorizeBrandSubWorkspace(ctx, log) {
+  const spaceCatId = ctx?.params?.spaceCatId;
+  const brandId = ctx?.params?.brandId;
+  if (!isValidUUID(brandId)) {
+    return { error: createResponse({ error: 'invalidRequest', message: 'brandId must be a UUID' }, 400) };
+  }
+  const Organization = ctx?.dataAccess?.Organization;
+  if (!Organization || typeof Organization.findById !== 'function') {
+    return { error: internalServerError('Organization data-access not available') };
+  }
+  const organization = await Organization.findById(spaceCatId);
+  if (!organization) {
+    return { error: notFound(`Organization not found: ${spaceCatId}`) };
+  }
+  const accessControl = AccessControlUtil.fromContext(ctx);
+  if (!await accessControl.hasAccess(organization)) {
+    return { error: forbidden('User does not have access to this organization') };
+  }
+  const postgrestClient = ctx?.dataAccess?.services?.postgrestClient;
+  if (!postgrestClient?.from) {
+    return { error: createResponse({ error: 'configurationError', message: 'PostgREST client not available' }, 503) };
+  }
+  const brandUuid = await resolveBrandUuid(spaceCatId, brandId, postgrestClient);
+  if (!brandUuid) {
+    return { error: notFound(`Brand not found for organization: ${brandId}`) };
+  }
+  const { mode, workspaceId, parentWorkspaceId } = await resolveBrandWorkspace(
+    ctx,
+    spaceCatId,
+    brandUuid,
+  );
+  // Require sub-workspace mode: a flat-mode brand (no semrush_sub_workspace_id)
+  // resolves to the org parent workspace, which holds no projects/prompts.
+  if (mode !== 'subworkspace') {
+    return {
+      error: createResponse(
+        { error: 'subWorkspaceRequired', message: 'Brand has no Semrush sub-workspace; org workspaces have no projects' },
+        404,
+      ),
+    };
+  }
+  // Safety invariant (mirrors the serenity controller): a sub-workspace must
+  // never coincide with the org parent, or a scoped query would run against the
+  // shared parent pool.
+  if (workspaceId === parentWorkspaceId) {
+    log.error('elements: brand sub-workspace equals org parent workspace - refusing', {
+      brandUuid, spaceCatId, workspaceId,
+    });
+    return {
+      error: createResponse(
+        { error: 'workspaceMisconfigured', message: 'Brand sub-workspace must not be the organization parent workspace' },
+        409,
+      ),
+    };
   }
   return { workspaceId };
 }
@@ -295,7 +385,8 @@ export default function ElementsController(context, log, env) {
         brand = resolved.name;
       }
 
-      const result = await buildService(ctx).getWeeks(auth.workspaceId, { ...query, brand });
+      const service = await buildService(ctx);
+      const result = await service.getWeeks(auth.workspaceId, { ...query, brand });
       return ok(result);
     } catch (e) {
       return mapError(e, log);
@@ -303,8 +394,44 @@ export default function ElementsController(context, log, env) {
   };
   /* c8 ignore stop */
 
+  /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts
+   * Returns the prompts matching the given filters plus their count
+   * (`{ count, prompts }`). Powers the prompt healthcheck metrics (intent %, and
+   * — via a topic-filtered count ratio — branded %).
+   *
+   * Brand-scoped: resolves the brand's Semrush **sub-workspace** (where projects
+   * and prompts live) and refuses to run against an org workspace — see
+   * {@link authorizeBrandSubWorkspace}.
+   *
+   * Query params (all optional): `model`/`platform` (AI model, default search-gpt),
+   * `tag` (CSV of FULL tag values, AND-ed — e.g. `type:branded`, `category:Brand`),
+   * `projectId` (CSV of Semrush project UUIDs; omitted → all of the brand's projects
+   * in its sub-workspace).
+   */
+  const listPrompts = async (ctx) => {
+    try {
+      const auth = await authorizeBrandSubWorkspace(ctx, log);
+      if (auth.error) {
+        return auth.error;
+      }
+      const query = extractQuery(ctx);
+      const service = await buildService(ctx);
+      const result = await service.getPrompts(auth.workspaceId, {
+        model: query.model,
+        platform: query.platform,
+        tags: splitCsv(query.tag),
+        projectIds: splitCsv(query.projectId || query.project_id),
+      });
+      return ok(result);
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+
   return {
     listUrlInspectorFilterDimensions,
     listWeeks,
+    listPrompts,
   };
 }

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -790,6 +790,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/serenity/languages': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/stats': 'llmo/can_view',
       // Preflight (site-scoped reads)
       'GET /sites/:siteId/preflights': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -240,6 +240,9 @@ export default function getRouteHandlers(
     // Serenity: Semrush Elements APIs Wrappers wiki https://wiki.corp.adobe.com/spaces/AEMSites/pages/3928196548/Project+Serenity+LLMO+x+Semrush+API+for+Brand+Presence+Data
     'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions': elementsController.listUrlInspectorFilterDimensions,
     'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks': elementsController.listWeeks,
+    // Brand-scoped: prompts/projects live in the brand's sub-workspace, not the org workspace.
+    // eslint-disable-next-line max-len
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': elementsController.listPrompts,
     // Brand-independent Semrush language catalog (add-brand wizard language picker).
     'GET /v2/orgs/:spaceCatId/serenity/languages': serenityController.listOrgLanguages,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': serenityController.activate,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -287,6 +287,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/serenity/languages': 'organization:read',
   'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions': 'organization:read',
   'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks': 'organization:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'organization:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate': 'organization:write',
   'GET /v2/orgs/:spaceCatId/sites/:siteId/brand': 'organization:read',

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -20,3 +20,4 @@ export {
   transformOriginsToFilterDimensions,
 } from './topics.js';
 export { buildWeeksPayload, transformWeeksResponse } from './weeks.js';
+export { buildPromptsPayload, transformPromptsResponse } from './prompts.js';

--- a/src/support/elements/definitions/prompts.js
+++ b/src/support/elements/definitions/prompts.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+
+/**
+ * Builds the payload for the Prompts element ({@link ELEMENT_IDS.PROMPTS}).
+ *
+ * The element is a `table` — it returns one row per prompt
+ * (`blocks.data[] = { prompt, prompt_topic, primary_intent, volume }`), which the
+ * Prompts (count) endpoint surfaces as `{ count, prompts }`. It is the building
+ * block for the prompt healthcheck (both metrics are per project):
+ * - **intent coverage** — group the returned rows on `primary_intent`; no filter
+ *   needed (the intent is on every row).
+ * - **branded / unbranded** — the branded signal is NOT a row column; it is a
+ *   `tags` value (`type:branded` / `type:non-branded`). So branded% is a
+ *   `tag`-filtered count over the total. Verified against prod (Lovesac, one
+ *   project): branded 510 + non-branded 687 = total 1197 → 43%.
+ *
+ * The advanced filter is an `and` group whose members are added only when the
+ * corresponding input is present:
+ * - **model** — always included (defaults to `search-gpt` via
+ *   {@link resolveElementModel}); a one-member `or` group on `CBF_model`, mirroring
+ *   the shape Semrush's own UI sends for this element.
+ * - **tags** — each value becomes its own `tags contains <value>` clause; multiple
+ *   tags are AND-ed (a prompt must carry all). Callers pass the FULL prefixed tag
+ *   value — the element's tag taxonomy varies by workspace (`type:`, `category:`,
+ *   `intent:`, `source:`, `topic:`), so no prefix is assumed here. e.g. pass
+ *   `type:branded` for the branded count, `category:Brand` for a category filter.
+ * - **projectIds** — a `CBF_project` `or` group; omitted → all projects in the
+ *   (sub-)workspace. The UI already surfaces these as `semrush_project_id` via the
+ *   URL Inspector filter-dimensions `regions`.
+ *
+ * @param {object} [params]
+ * @param {string} [params.model] - AI model filter (Semrush engine name or UI
+ *   platform code). Translated + validated via {@link resolveElementModel}.
+ * @param {string} [params.platform] - Alias for `model`; `model` wins when both set.
+ * @param {string[]} [params.tags] - Full tag values to filter on (AND-ed), e.g.
+ *   `type:branded`, `category:Brand`. Empty/omitted → no tag filter.
+ * @param {string[]} [params.projectIds] - Semrush project UUIDs to scope to.
+ *   Empty/omitted → all projects in the (sub-)workspace.
+ */
+export function buildPromptsPayload({
+  model, platform, tags = [], projectIds = [],
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  const filters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+  ];
+
+  for (const tag of tags) {
+    filters.push({ op: 'contains', val: tag, col: 'tags' });
+  }
+
+  if (projectIds.length > 0) {
+    filters.push({
+      op: 'or',
+      filters: projectIds.map((projectId) => ({ op: 'eq', val: projectId, col: 'CBF_project' })),
+    });
+  }
+
+  return {
+    comparison_data_formatting: 'union',
+    filters: {
+      advanced: { op: 'and', filters },
+    },
+  };
+}
+
+/**
+ * @typedef {object} PromptRow
+ * @property {string} prompt - The prompt text.
+ * @property {string} prompt_topic - The topic Semrush assigned to the prompt.
+ * @property {string} primary_intent - The prompt's primary intent (e.g. `informational`).
+ * @property {number} volume - Search volume for the prompt.
+ */
+
+/**
+ * Transforms the raw Semrush Prompts element response into `{ count, prompts }`.
+ * The element returns a `table` of prompt rows (`blocks.data[]`); we pass the raw
+ * Semrush field names through unchanged (`prompt`, `prompt_topic`,
+ * `primary_intent`, `volume`) and report `count` = number of rows.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @returns {{ count: number, prompts: PromptRow[] }}
+ */
+export function transformPromptsResponse(raw) {
+  const rows = Array.isArray(raw?.blocks?.data) ? raw.blocks.data : [];
+  const prompts = rows.map((row) => ({
+    prompt: row?.prompt,
+    prompt_topic: row?.prompt_topic,
+    primary_intent: row?.primary_intent,
+    volume: row?.volume,
+  }));
+  return { count: prompts.length, prompts };
+}

--- a/src/support/elements/definitions/prompts.js
+++ b/src/support/elements/definitions/prompts.js
@@ -78,10 +78,17 @@ export function buildPromptsPayload({
 
 /**
  * @typedef {object} PromptRow
- * @property {string} prompt - The prompt text.
- * @property {string} prompt_topic - The topic Semrush assigned to the prompt.
- * @property {string} primary_intent - The prompt's primary intent (e.g. `informational`).
- * @property {number} volume - Search volume for the prompt.
+ * @property {string} prompt - The prompt text (the question a user asked the LLM).
+ * @property {string} prompt_topic - The topic the prompt belongs to. Assigned by a
+ *   Semrush-developed model that groups together prompts which ask similar things and
+ *   receive similar replies. This is NOT a tag — it is a derived grouping, one topic
+ *   per prompt.
+ * @property {string} primary_intent - The primary intent of the `prompt_topic` (e.g.
+ *   `informational`), i.e. the intent is a property of the topic, not the individual
+ *   prompt. This is the field the healthcheck's intent-coverage metric groups on.
+ * @property {number} volume - Estimated number of times per month a user asked the LLM
+ *   a question about this topic. A per-topic estimate, so prompts sharing a topic carry
+ *   the same volume.
  */
 
 /**

--- a/src/support/elements/element-ids.js
+++ b/src/support/elements/element-ids.js
@@ -51,6 +51,13 @@ export const ELEMENT_IDS = Object.freeze({
   // Shared UUID: powers rows 21 (Citations+Source Count), 23 (AI Answers), 30 (Executions).
   CITATIONS_SOURCES: '141adc88-830c-4801-a67d-f8a86d0a21f7',
 
+  // Prompts (filtered list + count). Returns a `table` of prompts — one row per
+  // prompt with `{ prompt, prompt_topic, primary_intent, volume }` — filtered by
+  // topic tag, AI model, and Semrush project(s). Backs the Prompts (count)
+  // endpoint that feeds the prompt healthcheck metrics (intent %, and — via a
+  // filtered count ratio — branded %).
+  PROMPTS: '406ba6e0-0de2-475e-80d9-42fab8616032',
+
   // Topic Prompts
   PROMPTS_BY_TOPIC: '78864493-90a7-449a-89ab-1ba3d09a712e',
   SOURCES: '553cd819-d507-460d-a8ff-e34486bad3e1',

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -23,6 +23,8 @@ import {
   transformOriginsToFilterDimensions,
   buildWeeksPayload,
   transformWeeksResponse,
+  buildPromptsPayload,
+  transformPromptsResponse,
 } from './definitions/index.js';
 
 /**
@@ -80,5 +82,21 @@ export function createElementsService(transport) {
       return { weeks: transformWeeksResponse(raw) };
     },
     /* c8 ignore stop */
+
+    /**
+     * Fetches the prompts matching the given filters, plus their count.
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} params - Filter parameters (model/platform, topics, projectIds).
+     * @returns {Promise<{count: number, prompts: object[]}>} `{ count, prompts }`.
+     */
+    async getPrompts(workspaceId, params) {
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.PROMPTS,
+        buildPromptsPayload(params),
+      );
+      return transformPromptsResponse(raw);
+    },
   };
 }

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -105,6 +105,7 @@ function fakeContext({
   brandSemrushProjects = [],
   withBrandSemrushProject = false,
   promiseToken = undefined,
+  postgrestClient = { from: sinon.stub() },
 } = {}) {
   const BrandSemrushProject = withBrandSemrushProject
     ? { allByBrandId: sinon.stub().resolves(brandSemrushProjects) }
@@ -123,7 +124,7 @@ function fakeContext({
     },
     dataAccess: {
       Organization: { findById: sinon.stub().resolves(org) },
-      services: { postgrestClient: { from: sinon.stub() } },
+      services: { postgrestClient },
       ...(BrandSemrushProject && { BrandSemrushProject }),
     },
     _spacecatBrands: spacecatBrands,
@@ -617,6 +618,16 @@ describe('ElementsController', () => {
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       const res = await ctrl.listPrompts(ctx);
       expect(res.status).to.equal(404);
+      expect(serviceStub.getPrompts).to.not.have.been.called;
+    });
+
+    it('503s when the PostgREST client is not available', async () => {
+      const ctx = fakeContext({ url: promptsUrl(), postgrestClient: null });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(503);
+      const body = await readBody(res);
+      expect(body.error).to.equal('configurationError');
       expect(serviceStub.getPrompts).to.not.have.been.called;
     });
 

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -23,6 +23,7 @@ use(sinonChai);
 const ORG_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 const BRAND_ID = '11111111-2222-3333-4444-555555555555';
 const WORKSPACE_ID = 'ws-uuid-123';
+const SUB_WORKSPACE_ID = 'sub-ws-uuid-456';
 const IMS_TOKEN = 'test-ims-token';
 const ENV = { SEMRUSH_PROJECTS_BASE_URL: 'https://www.semrush.com' };
 
@@ -35,6 +36,15 @@ const URL_INSPECTOR_RESULT = {
   categories: [],
   page_intents: [],
   origins: [],
+};
+const PROMPTS_RESULT = {
+  count: 1,
+  prompts: [{
+    prompt: 'can i make ai influencer for free',
+    prompt_topic: 'AI Instagram Influencers',
+    primary_intent: 'informational',
+    volume: 2119,
+  }],
 };
 
 function fakeLog() {
@@ -113,7 +123,7 @@ function fakeContext({
     },
     dataAccess: {
       Organization: { findById: sinon.stub().resolves(org) },
-      services: { postgrestClient: {} },
+      services: { postgrestClient: { from: sinon.stub() } },
       ...(BrandSemrushProject && { BrandSemrushProject }),
     },
     _spacecatBrands: spacecatBrands,
@@ -143,17 +153,24 @@ describe('ElementsController', () => {
   let createElementsServiceStub;
   let createElementsTransportStub;
   let exchangePromiseTokenStub;
+  let resolveBrandUuidStub;
+  let resolveBrandWorkspaceStub;
   let MockElementsTransportError;
   let ElementsController;
 
   beforeEach(async () => {
     resolveWorkspaceIdStub = sinon.stub().resolves(WORKSPACE_ID);
+    resolveBrandUuidStub = sinon.stub().resolves(BRAND_ID);
+    resolveBrandWorkspaceStub = sinon.stub().resolves({
+      mode: 'subworkspace', workspaceId: SUB_WORKSPACE_ID, parentWorkspaceId: WORKSPACE_ID,
+    });
     accessControlHasAccessStub = sinon.stub().resolves(true);
 
     listSpacecatBrandsStub = sinon.stub().resolves([{ id: 'brand-1', name: 'Adobe' }]);
 
     serviceStub = {
       getUrlInspectorFilterDimensions: sinon.stub().resolves(URL_INSPECTOR_RESULT),
+      getPrompts: sinon.stub().resolves(PROMPTS_RESULT),
     };
     createElementsServiceStub = sinon.stub().returns(serviceStub);
     createElementsTransportStub = sinon.stub().returns({ fetchElement: sinon.stub() });
@@ -187,8 +204,12 @@ describe('ElementsController', () => {
       '../../src/support/brands-storage.js': {
         listBrands: listSpacecatBrandsStub,
       },
+      '../../src/support/prompts-storage.js': {
+        resolveBrandUuid: resolveBrandUuidStub,
+      },
       '../../src/support/serenity/workspace-resolver.js': {
         resolveWorkspaceId: resolveWorkspaceIdStub,
+        resolveBrandWorkspace: resolveBrandWorkspaceStub,
       },
       '../../src/support/access-control-util.js': MockAccessControlUtil,
       '../../src/support/utils.js': {
@@ -514,6 +535,157 @@ describe('ElementsController', () => {
       const ctx = fakeContext();
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       const res = await ctrl.listUrlInspectorFilterDimensions(ctx);
+      expect(res.status).to.equal(502);
+    });
+  });
+
+  // ─── listPrompts ──────────────────────────────────────────────────────────
+
+  describe('listPrompts', () => {
+    const promptsUrl = (qs = '') => `https://api.example.com/v2/orgs/${ORG_ID}`
+      + `/brands/${BRAND_ID}/serenity/brand-presence/prompts${qs}`;
+
+    it('returns 200 with the { count, prompts } result', async () => {
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(200);
+      const body = await readBody(res);
+      expect(body).to.deep.equal(PROMPTS_RESULT);
+    });
+
+    it('calls getPrompts with the brand SUB-workspace ID and parsed filters', async () => {
+      const ctx = fakeContext({
+        url: promptsUrl('?model=perplexity&tag=type:branded,category:Brand&projectId=proj-a,proj-b'),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      await ctrl.listPrompts(ctx);
+      expect(serviceStub.getPrompts).to.have.been.calledWith(SUB_WORKSPACE_ID, {
+        model: 'perplexity',
+        platform: undefined,
+        tags: ['type:branded', 'category:Brand'],
+        projectIds: ['proj-a', 'proj-b'],
+      });
+    });
+
+    it('resolves the brand uuid via resolveBrandUuid before querying', async () => {
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      await ctrl.listPrompts(ctx);
+      expect(resolveBrandUuidStub).to.have.been.calledWith(ORG_ID, BRAND_ID, sinon.match.object);
+      expect(resolveBrandWorkspaceStub)
+        .to.have.been.calledWith(sinon.match.object, ORG_ID, BRAND_ID);
+    });
+
+    it('defaults tags and projectIds to empty arrays when absent', async () => {
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      await ctrl.listPrompts(ctx);
+      const [, params] = serviceStub.getPrompts.firstCall.args;
+      expect(params.tags).to.deep.equal([]);
+      expect(params.projectIds).to.deep.equal([]);
+    });
+
+    it('accepts the project_id snake_case alias for projectId', async () => {
+      const ctx = fakeContext({ url: promptsUrl('?project_id=proj-x') });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      await ctrl.listPrompts(ctx);
+      const [, params] = serviceStub.getPrompts.firstCall.args;
+      expect(params.projectIds).to.deep.equal(['proj-x']);
+    });
+
+    it('trims blank CSV entries', async () => {
+      const ctx = fakeContext({ url: promptsUrl('?tag=type:branded,%20,category:Brand') });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      await ctrl.listPrompts(ctx);
+      const [, params] = serviceStub.getPrompts.firstCall.args;
+      expect(params.tags).to.deep.equal(['type:branded', 'category:Brand']);
+    });
+
+    // ── sub-workspace validation ──
+    it('400s when brandId is not a UUID', async () => {
+      const ctx = fakeContext({ url: promptsUrl(), params: { brandId: 'not-a-uuid' } });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(400);
+      expect(serviceStub.getPrompts).to.not.have.been.called;
+    });
+
+    it('404s when the brand does not resolve for the org', async () => {
+      resolveBrandUuidStub.resolves(null);
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(404);
+      expect(serviceStub.getPrompts).to.not.have.been.called;
+    });
+
+    it('404s (subWorkspaceRequired) when the brand is in flat mode (no sub-workspace)', async () => {
+      resolveBrandWorkspaceStub.resolves({
+        mode: 'flat', workspaceId: WORKSPACE_ID, parentWorkspaceId: WORKSPACE_ID,
+      });
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(404);
+      const body = await readBody(res);
+      expect(body.error).to.equal('subWorkspaceRequired');
+      expect(serviceStub.getPrompts).to.not.have.been.called;
+    });
+
+    it('409s when the brand sub-workspace equals the org parent workspace', async () => {
+      resolveBrandWorkspaceStub.resolves({
+        mode: 'subworkspace', workspaceId: WORKSPACE_ID, parentWorkspaceId: WORKSPACE_ID,
+      });
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(409);
+      const body = await readBody(res);
+      expect(body.error).to.equal('workspaceMisconfigured');
+      expect(serviceStub.getPrompts).to.not.have.been.called;
+    });
+
+    it('403s when access control denies org access', async () => {
+      accessControlHasAccessStub.resolves(false);
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(403);
+      expect(serviceStub.getPrompts).to.not.have.been.called;
+    });
+
+    it('exchanges x-promise-token and reaches getPrompts for a non-IMS caller', async () => {
+      const ctx = fakeContext({
+        authType: 'jwt',
+        bearer: 'spacecat-jwt-abc',
+        promiseToken: 'promise-token-xyz',
+        url: promptsUrl(),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(200);
+      expect(serviceStub.getPrompts).to.have.been.calledOnce;
+      expect(createElementsTransportStub).to.have.been.calledWith(
+        sinon.match({ imsToken: 'exchanged-ims-token' }),
+      );
+    });
+
+    it('401s a non-IMS caller with no x-promise-token, without calling getPrompts', async () => {
+      const ctx = fakeContext({ authType: 'jwt', url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
+      expect(res.status).to.equal(401);
+      const body = await readBody(res);
+      expect(body.error).to.equal('promiseTokenRequired');
+      expect(serviceStub.getPrompts).to.not.have.been.called;
+    });
+
+    it('propagates upstream errors through mapError', async () => {
+      serviceStub.getPrompts.rejects(new MockElementsTransportError(503, 'upstream down'));
+      const ctx = fakeContext({ url: promptsUrl() });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listPrompts(ctx);
       expect(res.status).to.equal(502);
     });
   });

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -887,6 +887,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/serenity/languages',
       'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/url-inspector/filter-dimensions',
       'GET /v2/orgs/:spaceCatId/serenity/all/brand-presence/weeks',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate',
       'GET /v2/orgs/:spaceCatId/sites/:siteId/brand',

--- a/test/support/elements/definitions/prompts.test.js
+++ b/test/support/elements/definitions/prompts.test.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  buildPromptsPayload,
+  transformPromptsResponse,
+} from '../../../../src/support/elements/definitions/prompts.js';
+
+const advancedFilters = (payload) => payload.filters.advanced.filters;
+const clauseFor = (payload, col) => advancedFilters(payload)
+  .find((f) => f.filters?.some((c) => c.col === col));
+
+describe('prompts definitions', () => {
+  describe('buildPromptsPayload', () => {
+    it('defaults the model to search-gpt when none is provided', () => {
+      const payload = buildPromptsPayload();
+      const modelClause = clauseFor(payload, 'CBF_model');
+      expect(modelClause).to.deep.equal({
+        op: 'or',
+        filters: [{ op: 'eq', val: 'search-gpt', col: 'CBF_model' }],
+      });
+    });
+
+    it('sets comparison_data_formatting to union with an AND advanced group', () => {
+      const payload = buildPromptsPayload();
+      expect(payload.comparison_data_formatting).to.equal('union');
+      expect(payload.filters.advanced.op).to.equal('and');
+    });
+
+    it('resolves a UI platform code to its Semrush model', () => {
+      const payload = buildPromptsPayload({ platform: 'copilot' });
+      expect(clauseFor(payload, 'CBF_model').filters[0].val).to.equal('microsoft-copilot');
+    });
+
+    it('prefers model over platform when both are given', () => {
+      const payload = buildPromptsPayload({ model: 'perplexity', platform: 'copilot' });
+      expect(clauseFor(payload, 'CBF_model').filters[0].val).to.equal('perplexity');
+    });
+
+    it('falls back to the default model for an unrecognised value', () => {
+      const payload = buildPromptsPayload({ model: 'not-a-model' });
+      expect(clauseFor(payload, 'CBF_model').filters[0].val).to.equal('search-gpt');
+    });
+
+    it('omits any tag clause when no tags are provided', () => {
+      const payload = buildPromptsPayload();
+      const hasTagsClause = advancedFilters(payload).some((f) => f.col === 'tags');
+      expect(hasTagsClause).to.be.false;
+    });
+
+    it('adds a raw `tags contains <value>` clause for a single tag (no prefixing)', () => {
+      const payload = buildPromptsPayload({ tags: ['type:branded'] });
+      const tagClause = advancedFilters(payload).find((f) => f.col === 'tags');
+      expect(tagClause).to.deep.equal({ op: 'contains', val: 'type:branded', col: 'tags' });
+    });
+
+    it('ANDs multiple tags as separate clauses (must match all)', () => {
+      const payload = buildPromptsPayload({ tags: ['type:branded', 'category:Brand'] });
+      const tagClauses = advancedFilters(payload).filter((f) => f.col === 'tags');
+      expect(tagClauses).to.deep.equal([
+        { op: 'contains', val: 'type:branded', col: 'tags' },
+        { op: 'contains', val: 'category:Brand', col: 'tags' },
+      ]);
+    });
+
+    it('omits the project clause when no projectIds are provided (workspace-wide)', () => {
+      const payload = buildPromptsPayload();
+      const hasProjectClause = advancedFilters(payload)
+        .some((f) => f.filters?.some((c) => c.col === 'CBF_project'));
+      expect(hasProjectClause).to.be.false;
+    });
+
+    it('ORs multiple project ids together', () => {
+      const payload = buildPromptsPayload({ projectIds: ['proj-a', 'proj-b'] });
+      expect(clauseFor(payload, 'CBF_project').filters).to.deep.equal([
+        { op: 'eq', val: 'proj-a', col: 'CBF_project' },
+        { op: 'eq', val: 'proj-b', col: 'CBF_project' },
+      ]);
+    });
+
+    it('combines model, tags and projects into one AND group', () => {
+      const payload = buildPromptsPayload({
+        model: 'search-gpt', tags: ['type:branded'], projectIds: ['proj-a'],
+      });
+      const af = advancedFilters(payload);
+      expect(af).to.have.length(3);
+      expect(af.find((f) => f.filters?.[0]?.col === 'CBF_model')).to.exist;
+      expect(af.find((f) => f.col === 'tags')).to.exist;
+      expect(af.find((f) => f.filters?.[0]?.col === 'CBF_project')).to.exist;
+    });
+  });
+
+  describe('transformPromptsResponse', () => {
+    const RAW = {
+      type: 'table',
+      blocks: {
+        data: [
+          {
+            primary_intent: 'informational',
+            prompt: 'can i make ai influencer for free',
+            prompt_topic: 'AI Instagram Influencers',
+            volume: 2119,
+          },
+          {
+            primary_intent: 'informational',
+            prompt: 'What is the best AI free image generator?',
+            prompt_topic: 'AI Image Generators',
+            volume: 997,
+          },
+        ],
+      },
+    };
+
+    it('returns count and prompts passing Semrush field names through unchanged', () => {
+      const result = transformPromptsResponse(RAW);
+      expect(result.count).to.equal(2);
+      expect(result.prompts[0]).to.deep.equal({
+        prompt: 'can i make ai influencer for free',
+        prompt_topic: 'AI Instagram Influencers',
+        primary_intent: 'informational',
+        volume: 2119,
+      });
+    });
+
+    it('returns an empty result when blocks.data is missing', () => {
+      expect(transformPromptsResponse({})).to.deep.equal({ count: 0, prompts: [] });
+    });
+
+    it('returns an empty result when raw is null', () => {
+      expect(transformPromptsResponse(null)).to.deep.equal({ count: 0, prompts: [] });
+    });
+
+    it('returns an empty result when blocks.data is not an array', () => {
+      expect(transformPromptsResponse({ blocks: { data: null } }))
+        .to.deep.equal({ count: 0, prompts: [] });
+    });
+  });
+});

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -142,4 +142,47 @@ describe('createElementsService', () => {
         .to.be.rejectedWith('upstream failure');
     });
   });
+
+  describe('getPrompts', () => {
+    const RAW_PROMPTS = {
+      type: 'table',
+      blocks: {
+        data: [
+          {
+            primary_intent: 'informational',
+            prompt: 'can i make ai influencer for free',
+            prompt_topic: 'AI Instagram Influencers',
+            volume: 2119,
+          },
+        ],
+      },
+    };
+
+    beforeEach(() => {
+      transport.fetchElement
+        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, sinon.match.any)
+        .resolves(RAW_PROMPTS);
+    });
+
+    it('fetches the PROMPTS element and returns { count, prompts }', async () => {
+      const result = await service.getPrompts('ws-1', { tags: ['type:branded'], projectIds: ['proj-a'] });
+      expect(transport.fetchElement).to.have.been.calledWith('ws-1', ELEMENT_IDS.PROMPTS, sinon.match.object);
+      expect(result.count).to.equal(1);
+      expect(result.prompts[0]).to.deep.include({ prompt_topic: 'AI Instagram Influencers', volume: 2119 });
+    });
+
+    it('passes the built filter payload to the transport', async () => {
+      await service.getPrompts('ws-1', { model: 'perplexity' });
+      const call = transport.fetchElement.getCalls().find((c) => c.args[1] === ELEMENT_IDS.PROMPTS);
+      const modelClause = call.args[2].filters.advanced.filters
+        .find((f) => f.filters?.[0]?.col === 'CBF_model');
+      expect(modelClause.filters[0].val).to.equal('perplexity');
+    });
+
+    it('propagates transport errors', async () => {
+      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, sinon.match.any)
+        .rejects(new Error('prompts upstream failure'));
+      await expect(service.getPrompts('ws-1', {})).to.be.rejectedWith('prompts upstream failure');
+    });
+  });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a brand-scoped Semrush Elements wrapper endpoint — `GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts` — that returns `{ count, prompts }` for a brand, filtered by AI model, tag(s), and Semrush project id(s). It is the data source for the prompt healthcheck's Branded/Unbranded and Intent-coverage cards.

## 2. Reasoning
The prompt healthcheck needs two per-project numbers it had no API for: the branded/unbranded ratio and intent coverage. The underlying Semrush "PROMPTS" element returns a table of prompts (with `primary_intent` and `volume`) and can be filtered to a branded subset, but nothing in SpaceCat exposed it. This endpoint wraps that element so the UI can compute both metrics without talking to Semrush directly, and without leaking Semrush workspace/project mechanics into the call path (IMS/promise-token auth is handled server-side).

## 3. High-level overview of the changes
Before: no way to retrieve a brand's prompts or their count through the API; the healthcheck's Branded% and Intent-coverage cards had no backing endpoint.

After: a new read endpoint that, given a brand, resolves the brand's Semrush **sub-workspace** and returns the matching prompts plus a `count`.

- **Brand-scoped, sub-workspace-resolved.** Semrush projects (and therefore prompts) live only in a brand's own sub-workspace, never in the org's shared parent workspace. The endpoint resolves the brand's sub-workspace and **refuses to run against an org workspace**: a flat-mode brand (no sub-workspace) returns `404 subWorkspaceRequired`; a sub-workspace pointer that equals the org parent returns `409 workspaceMisconfigured`; a non-UUID `brandId` returns `400`; a brand not in the org returns `404`.
- **Filters.** `model`/`platform` (translated to a Semrush model, default `search-gpt`), `tag` (comma-separated **full** tag values such as `type:branded` or `category:Brand`, AND-ed — the tag taxonomy varies per brand, so no prefix is assumed), and `projectId` (comma-separated Semrush project UUIDs; omitted → all of the brand's projects).
- **Response.** `{ count, prompts: [{ prompt, prompt_topic, primary_intent, volume }] }`, with the Semrush field names passed through unchanged.
- **Powers the healthcheck (per project):** Branded% = `?projectId=<id>&tag=type:branded` count ÷ unfiltered count; Intent coverage = one unfiltered call per project, grouping rows by `primary_intent`.
- **Auth** reuses the existing elements-wrapper flow: a spacecat JWT session token authenticates to SpaceCat and `x-promise-token` is exchanged for the upstream Semrush IMS token — no new auth surface.
- **Incidental fix:** the sibling `listWeeks` handler called a method off the async `buildService` Promise (`await buildService(ctx).getWeeks(...)`), which threw on every invocation; corrected here (it was an untested, coverage-ignored POC handler).

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/2768

## 5. Affected / used mysticat-workspace projects
- project-elmo-ui — consumer (contract): the prompt-management / healthcheck UI will call this endpoint to render the Branded/Unbranded and Intent-coverage cards. No elmo change in this PR; it establishes the contract the UI consumes.

## 6. Additional information outside the code
Validated end-to-end against **prod Semrush** by running the actual new code (`buildPromptsPayload` → transport POST → `transformPromptsResponse` / `getPrompts`) for THE LOVESAC COMPANY (org `e07a0aae-…`), which is on the sub-workspace model.

- Workspace resolution proof: the same project payload returns **1246 prompts** against the brand sub-workspace (`3cbb3c36-…`) and **0** against the org parent workspace (`ad76b37d-…`) — this is why the endpoint is brand-scoped and validates sub-workspace mode.
- Metric proof (per project, through the real service method):
  - US-en project: total **1197**, branded (`tag=type:branded`) **510** → **43% branded**, which matches the product UI's "43% Branded" card exactly; `type:branded` (510) + `type:non-branded` (687) partition the total (1197).
  - Intent coverage (group by `primary_intent`): US-en `{ informational: 1020, commercial: 66, navigational: 102, task: 9 }`.
- Data-model check via prod PostgREST: confirmed Lovesac's active brand carries `semrush_sub_workspace_id` and two `brand_to_semrush_projects` rows (US-en, US-es).

## 7. Test plan
(a) Local/through-API: exercised the endpoint's service path against prod Semrush for Lovesac (see section 6) — both metrics reproduce the numbers behind the UI cards.

(b) Per-environment once deployed:
- **dev / ci** (`https://spacecat.experiencecloud.live/api/ci/`): for a sub-workspace brand, `GET /v2/orgs/{orgId}/brands/{brandId}/serenity/brand-presence/prompts` returns `{ count, prompts }`; add `?tag=type:branded` and confirm `count` drops to the branded subset; confirm a flat-mode brand returns `404 subWorkspaceRequired` and a non-UUID `brandId` returns `400`. Send auth as a spacecat JWT on `Authorization` plus `x-promise-token`.
- **prod**: spot-check the Lovesac brand returns the same 43% branded ratio the UI shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
