### PR TITLE
feat(serenity): server-compute branded/non-branded prompt type on every write path

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -65,6 +65,8 @@ import { ensureSubworkspace, decommissionBrandWorkspace } from '../support/seren
 import { isSerenityActiveForOrg } from '../support/serenity/serenity-active.js';
 import { MAX_TOPICS_ON_CREATE } from '../support/serenity/brand-provisioning.js';
 import { STANDARD_PROMPT_TAGS, PROJECT_STANDARD_TAGS } from '../support/serenity/prompt-tags.js';
+import { marketForGeoTargetId } from '../support/serenity/locations.js';
+import { brandNeedles, classifyBrandedTag } from '../support/serenity/branded-classifier.js';
 import AccessControlUtil from '../support/access-control-util.js';
 import { resolveBrandUuid } from '../support/prompts-storage.js';
 import {
@@ -432,6 +434,35 @@ function SerenityController(context, log, env) {
     return brand;
   }
 
+  /**
+   * Builds the server-side `type:branded`/`type:non-branded` classifier for the
+   * manual prompt create/edit paths (serenity-docs#31). Loads the brand's display
+   * name + aliases ONCE per request, then returns a pure
+   * `(text, geoTargetId) => TYPE_TAG` closure: each prompt's market is derived
+   * from its geoTargetId and the alias needles are region-clamped to that market
+   * (memoized per market). This is the SAME classifier the AI-generation and
+   * onboarding paths use, so a prompt is classified identically no matter how it
+   * is written; the client never controls the value.
+   */
+  async function buildPromptTypeClassifier(ctx, brandUuid) {
+    const brand = await loadBrand(ctx, brandUuid);
+    const brandName = brand.getName?.() || '';
+    const brandAliases = await getBrandAliases(
+      brandUuid,
+      ctx.dataAccess.services.postgrestClient,
+    );
+    const needlesByMarket = new Map();
+    return (text, geoTargetId) => {
+      const market = marketForGeoTargetId(geoTargetId) || '';
+      let needles = needlesByMarket.get(market);
+      if (!needles) {
+        needles = brandNeedles(brandName, brandAliases, market);
+        needlesByMarket.set(market, needles);
+      }
+      return classifyBrandedTag(text, needles);
+    };
+  }
+
   const listPrompts = async (ctx) => {
     try {
       const imsToken = await resolveSemrushImsToken(ctx);
@@ -463,8 +494,15 @@ function SerenityController(context, log, env) {
         return auth.error;
       }
       const transport = buildTransport(ctx, imsToken);
+      const classifyPromptType = await buildPromptTypeClassifier(ctx, auth.brandUuid);
       const result = auth.mode === 'subworkspace'
-        ? await handleCreatePromptsSubworkspace(transport, auth.workspaceId, ctx.data || {}, log)
+        ? await handleCreatePromptsSubworkspace(
+          transport,
+          auth.workspaceId,
+          ctx.data || {},
+          log,
+          classifyPromptType,
+        )
         : await handleCreatePrompts(
           transport,
           ctx.dataAccess,
@@ -472,6 +510,7 @@ function SerenityController(context, log, env) {
           auth.workspaceId,
           ctx.data || {},
           log,
+          classifyPromptType,
         );
       return createResponse(result, 200);
     } catch (e) {
@@ -491,6 +530,7 @@ function SerenityController(context, log, env) {
         return auth.error;
       }
       const transport = buildTransport(ctx, imsToken);
+      const classifyPromptType = await buildPromptTypeClassifier(ctx, auth.brandUuid);
       const result = auth.mode === 'subworkspace'
         ? await handleUpdatePromptSubworkspace(
           transport,
@@ -498,6 +538,7 @@ function SerenityController(context, log, env) {
           semrushPromptId,
           ctx.data || {},
           log,
+          classifyPromptType,
         )
         : await handleUpdatePrompt(
           transport,
@@ -507,6 +548,7 @@ function SerenityController(context, log, env) {
           semrushPromptId,
           ctx.data || {},
           log,
+          classifyPromptType,
         );
       return createResponse(result.body, result.status);
     } catch (e) {

--- a/src/support/serenity/branded-classifier.js
+++ b/src/support/serenity/branded-classifier.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+import { TYPE_TAG } from './prompt-tags.js';
+import { collectAliasNames } from './brand-aliases.js';
+
+/**
+ * Server-side branded / non-branded classifier — the SINGLE implementation used
+ * on every path that writes a Serenity (Semrush sub-workspace) prompt: manual
+ * create / edit, CSV import (which reuses the create path), AI generation, and
+ * onboarding/provisioning seeding. A prompt is `type:branded` when its text
+ * mentions the brand name or an applicable alias as a WHOLE WORD (diacritics
+ * folded); otherwise `type:non-branded`.
+ *
+ * This replaces the earlier AI-only substring matcher (`brandedTypeTag`): the
+ * match is now word-boundary + diacritic-folding, and it is shared everywhere so
+ * the classification is identical no matter how the prompt got in. The behaviour
+ * change (substring → whole-word) is forward-only — existing prompts are not
+ * reclassified (serenity-docs#31, decisions 1/2/6).
+ */
+
+// Latin letters that carry a diacritic/ligature but have NO canonical NFD
+// decomposition, so the `\p{Diacritic}` strip alone leaves them intact. Folded
+// explicitly to their ASCII base(s) so a brand written with the accented form
+// (`Ørsted`, `Æro`) still matches the ASCII-typed spelling in prompt text
+// (`Orsted`, `Aero`). Keyed on the lower-cased form (folding runs after
+// `toLowerCase`), so only lower-case keys are needed.
+const NON_DECOMPOSING_FOLDS = Object.freeze({
+  ø: 'o', æ: 'ae', œ: 'oe', ß: 'ss', ð: 'd', þ: 'th', ł: 'l', đ: 'd', ħ: 'h',
+});
+const NON_DECOMPOSING_RE = new RegExp(`[${Object.keys(NON_DECOMPOSING_FOLDS).join('')}]`, 'g');
+
+/**
+ * Normalizes one side of the match (needle OR haystack) into a canonical,
+ * space-delimited token stream:
+ *   - fold diacritics (NFD decomposition, strip combining marks) so `café` ≈ `cafe`;
+ *   - lower-case (case-insensitive match);
+ *   - fold the non-decomposing accented/ligature letters (`ø→o`, `æ→ae`, `ß→ss`,
+ *     …) that the NFD strip leaves intact, so `Ørsted` ≈ `Orsted`;
+ *   - replace every run of non-alphanumeric characters (Unicode letters/numbers)
+ *     with a single space, so punctuation/whitespace collapses to token gaps;
+ *   - trim.
+ * Both sides go through this, so word-boundary matching reduces to a padded
+ * substring test (see {@link classifyBrandedTag}). Applying the identical
+ * transform to needle and haystack is what keeps `Ace` from matching `surface`
+ * while letting the multi-word needle `le creuset` match a contiguous run.
+ *
+ * @param {unknown} value
+ * @returns {string} the normalized, space-delimited form ('' when empty).
+ */
+export function normalizeMatch(value) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(NON_DECOMPOSING_RE, (ch) => NON_DECOMPOSING_FOLDS[ch])
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+}
+
+/**
+ * Normalizes a list of raw brand-name / alias strings into deduplicated match
+ * needles (empties dropped). The order of first appearance is preserved.
+ *
+ * @param {string[]} names
+ * @returns {string[]}
+ */
+export function needlesFromNames(names) {
+  const seen = new Set();
+  const out = [];
+  for (const name of Array.isArray(names) ? names : []) {
+    const needle = normalizeMatch(name);
+    if (needle && !seen.has(needle)) {
+      seen.add(needle);
+      out.push(needle);
+    }
+  }
+  return out;
+}
+
+/**
+ * Builds the branded-classification needles for a prompt's market: the brand
+ * display name plus the aliases applicable to `market` (region-clamped exactly
+ * as the AI/create paths clamp them, via {@link collectAliasNames}), all
+ * normalized for matching. An empty market ('' — e.g. an unknown geoTargetId)
+ * keeps region-less / 'ww' aliases and drops region-specific ones, so the brand
+ * name alone still classifies.
+ *
+ * @param {string} brandName - the brand display name.
+ * @param {Array<string|{name: string, regions?: string[]}>} aliases - brand aliases.
+ * @param {string} market - ISO-2 country code of the prompt's market ('' when unknown).
+ * @returns {string[]} normalized needles (possibly empty ⇒ everything non-branded).
+ */
+export function brandNeedles(brandName, aliases, market) {
+  return needlesFromNames([
+    ...(brandName ? [brandName] : []),
+    ...collectAliasNames(aliases, market),
+  ]);
+}
+
+/**
+ * Classifies a prompt as `type:branded` when its text contains any needle as a
+ * whole word (or contiguous whole-word run for a multi-word needle), else
+ * `type:non-branded`. Both sides are normalized via {@link normalizeMatch}; the
+ * haystack is padded with spaces so a needle wrapped in spaces matches only on
+ * token boundaries. Empty `needles` ⇒ `type:non-branded`.
+ *
+ * @param {string} promptText - the prompt text.
+ * @param {string[]} needles - normalized needles from {@link brandNeedles} /
+ *   {@link needlesFromNames}.
+ * @returns {typeof TYPE_TAG.BRANDED | typeof TYPE_TAG.NON_BRANDED}
+ */
+export function classifyBrandedTag(promptText, needles) {
+  const list = Array.isArray(needles) ? needles : [];
+  if (list.length === 0) {
+    return TYPE_TAG.NON_BRANDED;
+  }
+  const haystack = ` ${normalizeMatch(promptText)} `;
+  return list.some((n) => n && haystack.includes(` ${n} `))
+    ? TYPE_TAG.BRANDED
+    : TYPE_TAG.NON_BRANDED;
+}

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -34,7 +34,8 @@ import {
   listMarkets, resolveProject, mapPublishStatus, projectToSlice,
 } from '../subworkspace-projects.js';
 import { ensureSubworkspace } from '../workspace-lifecycle.js';
-import { TYPE_TAG, topicTag } from '../prompt-tags.js';
+import { topicTag } from '../prompt-tags.js';
+import { classifyBrandedTag, needlesFromNames } from '../branded-classifier.js';
 import { collectBrandUrlEntries, attachBrandUrlsToProject } from '../brand-urls.js';
 import { buildReservedDomains, syncCompetitorBenchmarksForProject } from '../competitor-benchmarks.js';
 import { collectAliasNames } from '../brand-aliases.js';
@@ -166,17 +167,6 @@ function validateCreateBody(body) {
 }
 
 /**
- * Classifies a generated prompt as `type:branded` when its text mentions the
- * brand — i.e. (lower-cased) prompt text contains any of the brand-name/alias
- * `needles` (already lower-cased + trimmed) as a substring — else
- * `type:non-branded`. Empty `needles` ⇒ everything is non-branded.
- */
-function brandedTypeTag(promptText, needles) {
-  const hay = String(promptText).toLowerCase();
-  return needles.some((n) => hay.includes(n)) ? TYPE_TAG.BRANDED : TYPE_TAG.NON_BRANDED;
-}
-
-/**
  * Generates topics + prompts for (domain, country) via the AI-SEO service
  * (transport.getBrandTopics) and attaches them to the project. Keeps the top
  * `topicCap` topics by search volume (0 = keep all) and tags every prompt with
@@ -197,7 +187,8 @@ function brandedTypeTag(promptText, needles) {
  * @param {number} [options.topicCap=0] - keep the top N topics by volume (0 = all).
  * @param {string[]} [options.standardTags=[]] - tags added to every generated prompt.
  * @param {string[]} [options.brandNames=[]] - brand name + aliases for branded
- *   classification (substring match, case-insensitive).
+ *   classification via the shared {@link classifyBrandedTag} (whole-word match,
+ *   diacritic-folded, case-insensitive).
  * @param {object} log - logger.
  */
 async function generateAndAttachPrompts(transport, workspaceId, projectId, {
@@ -215,18 +206,18 @@ async function generateAndAttachPrompts(transport, workspaceId, projectId, {
     .sort((a, b) => (Number(b?.volume) || 0) - (Number(a?.volume) || 0));
   const selected = topicCap > 0 ? ranked.slice(0, topicCap) : ranked;
 
-  // Brand-name + alias needles for branded classification: lower-cased + trimmed
-  // so the substring match is case-insensitive and whitespace-tolerant.
-  const brandNeedles = (Array.isArray(brandNames) ? brandNames : [])
-    .map((s) => String(s || '').trim().toLowerCase())
-    .filter((s) => s.length > 0);
+  // Brand-name + alias needles for branded classification. The shared classifier
+  // (branded-classifier.js) folds diacritics, lower-cases, and matches on whole
+  // word boundaries — the SAME implementation the manual create/edit paths use,
+  // so a prompt is classified identically no matter how it is written.
+  const needles = needlesFromNames(Array.isArray(brandNames) ? brandNames : []);
 
   const promptsByText = {};
   selected.forEach((t) => {
     const topic = topicTag(t.topic);
     (Array.isArray(t.prompts) ? t.prompts : []).forEach((p) => {
       if (hasText(p)) {
-        promptsByText[p] = [topic, ...standardTags, brandedTypeTag(p, brandNeedles)];
+        promptsByText[p] = [topic, ...standardTags, classifyBrandedTag(p, needles)];
       }
     });
   });
@@ -280,7 +271,8 @@ async function generateAndAttachPrompts(transport, workspaceId, projectId, {
  *   The market-applicable names are added to the project's `brand_names`
  *   (alongside the primary name) so the project carries them, and — together with
  *   the brand name(s) — used to classify each generated prompt as `type:branded`
- *   (text contains a name/alias, case-insensitive) or `type:non-branded`.
+ *   (text mentions a name/alias as a whole word, diacritic-folded) or
+ *   `type:non-branded`.
  * @param {string[]} [options.projectTags=[]] - project-level tag taxonomy to
  *   register on the project (via createProjectTags) independent of any prompt.
  * @param {object} [options.brandUrlSources=null] - the brand's URL sources

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -311,7 +311,7 @@ export async function handleUpdatePromptSubworkspace(
       semrushPromptId: newSemrushPromptId,
       geoTargetId,
       languageCode,
-      text: nextText,
+      text: typed.text,
       tags: typed.tags,
       ...(typed.tagIds !== undefined ? { tagIds: typed.tagIds } : {}),
     },

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -22,6 +22,7 @@ import {
   buildPromptDto,
   normalizePromptInput,
   createOnePrompt,
+  makeTypeInjector,
   parseUpdatePromptBody,
   mapLimit,
   publishAffected,
@@ -116,7 +117,13 @@ export async function handleListPromptsSubworkspace(transport, workspaceId, quer
  * project from ONE live listing (buildSliceProjectMap) instead of the DB
  * mapping, then reuses the shared per-slice create + publish-once fan-out.
  */
-export async function handleCreatePromptsSubworkspace(transport, workspaceId, body, log) {
+export async function handleCreatePromptsSubworkspace(
+  transport,
+  workspaceId,
+  body,
+  log,
+  classifyPromptType,
+) {
   const inputs = Array.isArray(body?.prompts) ? body.prompts : [];
   if (inputs.length === 0) {
     throw new ErrorWithStatusCode('Body must include a non-empty prompts array', 400);
@@ -129,6 +136,7 @@ export async function handleCreatePromptsSubworkspace(transport, workspaceId, bo
   }
 
   const projectsBySlice = await buildSliceProjectMap(transport, workspaceId, log);
+  const injectComputedType = makeTypeInjector(transport, workspaceId, classifyPromptType, log);
 
   const results = await mapLimit(inputs, BULK_CREATE_CONCURRENCY, async (raw) => {
     const input = normalizePromptInput(raw);
@@ -151,15 +159,17 @@ export async function handleCreatePromptsSubworkspace(transport, workspaceId, bo
     }
     const projectId = String(project.id);
     try {
-      const semrushPromptId = await createOnePrompt(transport, workspaceId, projectId, input);
+      // Unified layer: strip any caller-supplied type + inject the computed one.
+      const typed = await injectComputedType(projectId, input);
+      const semrushPromptId = await createOnePrompt(transport, workspaceId, projectId, typed);
       return {
         created: {
           semrushPromptId,
-          geoTargetId: input.geoTargetId,
+          geoTargetId: typed.geoTargetId,
           languageCode: input.languageCode,
-          text: input.text,
-          tags: input.tags,
-          ...(input.tagIds !== undefined ? { tagIds: input.tagIds } : {}),
+          text: typed.text,
+          tags: typed.tags,
+          ...(typed.tagIds !== undefined ? { tagIds: typed.tagIds } : {}),
         },
         affectedProjectId: projectId,
       };
@@ -216,6 +226,7 @@ export async function handleUpdatePromptSubworkspace(
   semrushPromptId,
   body,
   log,
+  classifyPromptType,
 ) {
   const parsedBody = parseUpdatePromptBody(body);
   if (!parsedBody.ok) {
@@ -246,6 +257,13 @@ export async function handleUpdatePromptSubworkspace(
   }
   const projectId = String(project.id);
 
+  // Recompute the type tag from the NEW text BEFORE the delete (see the flat-mode
+  // twin): the unified layer must not run between delete and create.
+  const injectComputedType = makeTypeInjector(transport, workspaceId, classifyPromptType, log);
+  const typed = await injectComputedType(projectId, {
+    text: nextText, geoTargetId, tags: nextTags, tagIds: nextTagIds,
+  });
+
   try {
     await transport.deletePromptsByIds(workspaceId, projectId, [semrushPromptId]);
   } catch (e) {
@@ -268,9 +286,7 @@ export async function handleUpdatePromptSubworkspace(
 
   let newSemrushPromptId;
   try {
-    newSemrushPromptId = await createOnePrompt(transport, workspaceId, projectId, {
-      text: nextText, tags: nextTags, tagIds: nextTagIds,
-    });
+    newSemrushPromptId = await createOnePrompt(transport, workspaceId, projectId, typed);
   } catch (e) {
     // The DELETE above already succeeded, so the old prompt is gone upstream —
     // a failure here (e.g. an unresolvable tagId 500ing the atomic id-based
@@ -296,8 +312,8 @@ export async function handleUpdatePromptSubworkspace(
       geoTargetId,
       languageCode,
       text: nextText,
-      tags: nextTags,
-      ...(nextTagIds !== undefined ? { tagIds: nextTagIds } : {}),
+      tags: typed.tags,
+      ...(typed.tagIds !== undefined ? { tagIds: typed.tagIds } : {}),
     },
   };
 }

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -324,7 +324,7 @@ export function makeTypeInjector(transport, semrushWorkspaceId, classifyPromptTy
         .filter((t) => !String(t).startsWith(`${TAG_DIMENSION.TYPE}:`));
       return { ...input, tags: [...stripped, typeTag] };
     }
-    const key = `${projectId} ${typeTag}`;
+    const key = `${projectId} ${typeTag}`;
     let pending = cache.get(key);
     if (!pending) {
       pending = resolveTypeTagInjection(transport, semrushWorkspaceId, projectId, typeTag, log);

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -19,6 +19,8 @@ import { redactUpstreamMessage } from '../rest-transport.js';
 import { ERROR_CODES, isUpstreamGone } from '../errors.js';
 import { normalizeGeoTargetId, normalizeLanguageCode, isValidTagIdFormat } from '../validation.js';
 import { invalidateTagCacheForProject } from './markets.js';
+import { resolveTypeTagInjection } from './tags.js';
+import { TAG_DIMENSION } from '../prompt-tags.js';
 
 // TWIN FILE: the slice→project orchestration here is paralleled by the
 // subworkspace-mode handlers in prompts-subworkspace.js. The duplication is
@@ -284,6 +286,57 @@ export async function createOnePrompt(transport, semrushWorkspaceId, projectId, 
 }
 
 /**
+ * Builds the per-request `type:*` injector — the UNIFIED classification layer
+ * (serenity-docs#31). Given a pure `classifyPromptType(text, geoTargetId)`
+ * closure (built by the controller from the brand name + region-clamped
+ * aliases), it returns `injectComputedType(projectId, input)` which:
+ *   - STRIPS any caller-supplied `type:*` tag (the client may never set it), and
+ *   - APPENDS the server-computed one — as a tag NAME on the name-based path, or
+ *     as a pre-resolved upstream tag ID on the id-based path (the atomic
+ *     `createPromptsByIds` 500s on an unresolved id, so it must be resolved
+ *     BEFORE the write).
+ * The returned input carries the rewritten `tags`/`tagIds`, so the caller's
+ * response echo reflects the computed type without a refetch (decision 5).
+ *
+ * Id-based resolution ({@link resolveTypeTagInjection}, one tag-tree read per
+ * distinct `type:` value per project) is memoized for the request, so a bulk
+ * create fans out at most two tag-tree reads per project regardless of item
+ * count. A non-function `classifyPromptType` (defensive) is a pass-through.
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {string} semrushWorkspaceId
+ * @param {((text: string, geoTargetId: number) => string) | undefined} classifyPromptType
+ * @param {object} [log]
+ * @returns {(projectId: string, input: { text: string, geoTargetId: number,
+ *   tags: string[], tagIds: string[] | undefined }) =>
+ *   Promise<{ text: string, geoTargetId: number, tags: string[], tagIds: string[] | undefined }>}
+ */
+export function makeTypeInjector(transport, semrushWorkspaceId, classifyPromptType, log) {
+  /** @type {Map<string, Promise<{ computedId: string | undefined, typeTagIds: string[] }>>} */
+  const cache = new Map();
+  return async function injectComputedType(projectId, input) {
+    if (typeof classifyPromptType !== 'function') {
+      return input;
+    }
+    const typeTag = classifyPromptType(input.text, input.geoTargetId);
+    if (input.tagIds === undefined) {
+      const stripped = (Array.isArray(input.tags) ? input.tags : [])
+        .filter((t) => !String(t).startsWith(`${TAG_DIMENSION.TYPE}:`));
+      return { ...input, tags: [...stripped, typeTag] };
+    }
+    const key = `${projectId} ${typeTag}`;
+    let pending = cache.get(key);
+    if (!pending) {
+      pending = resolveTypeTagInjection(transport, semrushWorkspaceId, projectId, typeTag, log);
+      cache.set(key, pending);
+    }
+    const { computedId, typeTagIds } = await pending;
+    const stripped = input.tagIds.filter((id) => !typeTagIds.includes(id));
+    return { ...input, tagIds: computedId ? [...stripped, computedId] : stripped };
+  };
+}
+
+/**
  * Validates + normalizes a PATCH prompt body's `text`/`tags`/`tagIds`, shared
  * by {@link handleUpdatePrompt} and its subworkspace twin. `tags` (names) and
  * `tagIds` (upstream ids) are mutually exclusive, mirroring
@@ -371,6 +424,7 @@ export async function handleCreatePrompts(
   semrushWorkspaceId,
   body,
   log,
+  classifyPromptType,
 ) {
   const inputs = Array.isArray(body?.prompts) ? body.prompts : [];
   if (inputs.length === 0) {
@@ -388,6 +442,13 @@ export async function handleCreatePrompts(
   for (const p of projects || []) {
     projectsBySlice.set(`${p.getGeoTargetId()}:${p.getLanguageCode()}`, p);
   }
+
+  const injectComputedType = makeTypeInjector(
+    transport,
+    semrushWorkspaceId,
+    classifyPromptType,
+    log,
+  );
 
   const results = await mapLimit(inputs, BULK_CREATE_CONCURRENCY, async (raw) => {
     const input = normalizePromptInput(raw);
@@ -410,20 +471,22 @@ export async function handleCreatePrompts(
     }
     const projectId = project.getSemrushProjectId();
     try {
+      // Unified layer: strip any caller-supplied type + inject the computed one.
+      const typed = await injectComputedType(projectId, input);
       const semrushPromptId = await createOnePrompt(
         transport,
         semrushWorkspaceId,
         projectId,
-        input,
+        typed,
       );
       return {
         created: {
           semrushPromptId,
-          geoTargetId: input.geoTargetId,
+          geoTargetId: typed.geoTargetId,
           languageCode: input.languageCode,
-          text: input.text,
-          tags: input.tags,
-          ...(input.tagIds !== undefined ? { tagIds: input.tagIds } : {}),
+          text: typed.text,
+          tags: typed.tags,
+          ...(typed.tagIds !== undefined ? { tagIds: typed.tagIds } : {}),
         },
         affectedProjectId: projectId,
       };
@@ -519,6 +582,7 @@ export async function handleUpdatePrompt(
   semrushPromptId,
   body,
   log,
+  classifyPromptType,
 ) {
   // `semrushPromptId` is validated as non-empty at the controller boundary
   // (serenity.js:259) before this handler is invoked over HTTP, so no
@@ -556,6 +620,19 @@ export async function handleUpdatePrompt(
   }
   const projectId = project.getSemrushProjectId();
 
+  // Recompute the type tag from the NEW text BEFORE the delete: the unified layer
+  // (tree read / on-demand tag create) must not run between delete and create,
+  // so a classification failure aborts cleanly with the old prompt still present.
+  const injectComputedType = makeTypeInjector(
+    transport,
+    semrushWorkspaceId,
+    classifyPromptType,
+    log,
+  );
+  const typed = await injectComputedType(projectId, {
+    text: nextText, geoTargetId, tags: nextTags, tagIds: nextTagIds,
+  });
+
   try {
     await transport.deletePromptsByIds(semrushWorkspaceId, projectId, [semrushPromptId]);
   } catch (e) {
@@ -578,9 +655,7 @@ export async function handleUpdatePrompt(
 
   let newSemrushPromptId;
   try {
-    newSemrushPromptId = await createOnePrompt(transport, semrushWorkspaceId, projectId, {
-      text: nextText, tags: nextTags, tagIds: nextTagIds,
-    });
+    newSemrushPromptId = await createOnePrompt(transport, semrushWorkspaceId, projectId, typed);
   } catch (e) {
     // The DELETE above already succeeded, so the old prompt is gone upstream —
     // a failure here (e.g. an unresolvable tagId 500ing the atomic id-based
@@ -606,8 +681,8 @@ export async function handleUpdatePrompt(
       geoTargetId,
       languageCode,
       text: nextText,
-      tags: nextTags,
-      ...(nextTagIds !== undefined ? { tagIds: nextTagIds } : {}),
+      tags: typed.tags,
+      ...(typed.tagIds !== undefined ? { tagIds: typed.tagIds } : {}),
     },
   };
 }

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -322,6 +322,11 @@ export async function resolveTypeTagInjection(
   if (existing) {
     return { computedId: existing.id, typeTagIds };
   }
+  // Create-on-demand for the wanted `type:` root. We only reach here when the
+  // list above had no matching root, so this is safe against duplicates for a
+  // single request; concurrent writers racing the same missing tag rely on the
+  // upstream tag resolver being idempotent by (project, name) — the same
+  // resolve-or-create assumption `resolveOrCreateClosedTag` makes.
   const createdList = await transport.createProjectTags(semrushWorkspaceId, projectId, [wantTag]);
   const { id } = pickTagIds(createdList, undefined);
   return { computedId: id, typeTagIds: id ? [...typeTagIds, id] : typeTagIds };

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -21,7 +21,7 @@ import {
 } from '../validation.js';
 import { resolveProject } from '../subworkspace-projects.js';
 import {
-  tagFor, CREATABLE_TAG_DIMENSIONS, CLOSED_TAG_DIMENSIONS, PROJECT_STANDARD_TAGS,
+  tagFor, TAG_DIMENSION, CREATABLE_TAG_DIMENSIONS, CLOSED_TAG_DIMENSIONS, PROJECT_STANDARD_TAGS,
 } from '../prompt-tags.js';
 import { listProjectTagTree } from './markets.js';
 
@@ -285,6 +285,46 @@ async function resolveOrCreateClosedTag(transport, semrushWorkspaceId, projectId
   const createdList = await transport.createProjectTags(semrushWorkspaceId, projectId, [tag]);
   const { id } = pickTagIds(createdList, undefined);
   return { id, created: true };
+}
+
+/**
+ * Resolves the id-based injection of a server-computed `type:*` tag into a
+ * prompt write (serenity-docs#31). Lists the project's ROOT tags ONCE and:
+ *   - collects the ids of ALL existing `type:` roots, so the caller can strip
+ *     any caller-supplied `type:*` tag id (the client must never set the value);
+ *   - ensures the WANTED `type:<value>` has an upstream id, creating it on-demand
+ *     for older projects that predate the standard taxonomy (idempotent — new
+ *     projects already carry both values from {@link PROJECT_STANDARD_TAGS}).
+ * Both `type:branded` and `type:non-branded` are roots (closed dims never nest).
+ *
+ * @param {object} transport - Serenity transport (Semrush proxy client).
+ * @param {string} semrushWorkspaceId
+ * @param {string} projectId
+ * @param {string} wantTag - the computed `type:<value>` wire name.
+ * @param {object} [log] - logger.
+ * @returns {Promise<{ computedId: string | undefined, typeTagIds: string[] }>}
+ *   `computedId` is the wanted value's id; `typeTagIds` is every `type:` root id
+ *   present after resolution (the strip set).
+ */
+export async function resolveTypeTagInjection(
+  transport,
+  semrushWorkspaceId,
+  projectId,
+  wantTag,
+  log,
+) {
+  const roots = await listProjectTagTree(transport, semrushWorkspaceId, projectId, '', log);
+  const typeRoots = roots.items.filter(
+    (t) => typeof t.name === 'string' && t.name.startsWith(`${TAG_DIMENSION.TYPE}:`),
+  );
+  const typeTagIds = typeRoots.map((t) => t.id).filter(Boolean);
+  const existing = typeRoots.find((t) => t.name === wantTag);
+  if (existing) {
+    return { computedId: existing.id, typeTagIds };
+  }
+  const createdList = await transport.createProjectTags(semrushWorkspaceId, projectId, [wantTag]);
+  const { id } = pickTagIds(createdList, undefined);
+  return { computedId: id, typeTagIds: id ? [...typeTagIds, id] : typeTagIds };
 }
 
 /**

--- a/src/support/serenity/locations.js
+++ b/src/support/serenity/locations.js
@@ -70,3 +70,37 @@ export function resolveLocation(market) {
     locationName: ENGLISH_REGION_NAMES.of(alpha2),
   };
 }
+
+// Reverse of the country `criterion_id = 2000 + ISO numeric` mapping, keyed by
+// the numeric code as a Number so leading-zero string forms ('004' vs 4) can't
+// cause a miss. Built once at module load from the same `iso-3166` table
+// `resolveLocation` reads forward, so the two directions can never drift.
+const NUMERIC_TO_ALPHA2 = Object.freeze(
+  Object.fromEntries(
+    Object.entries(iso31661Alpha2ToNumeric).map(([a2, num]) => [Number(num), a2]),
+  ),
+);
+
+/**
+ * Inverse of {@link resolveLocation}: resolves a country-level Google Ads Geo
+ * Target ID back to its ISO 3166-1 alpha-2 market code. Used to derive a prompt's
+ * market from its `geoTargetId` (the slice key carried on every prompt write) so
+ * brand aliases can be region-clamped per prompt — the manual create/edit paths
+ * receive a numeric `geoTargetId`, not the ISO-2 code the create-market path has.
+ *
+ * Only the country formula (`criterion_id = 2000 + ISO numeric`) is inverted;
+ * sub-national geo targets (cities/regions/postal codes) do NOT follow it and
+ * return null, matching {@link resolveLocation}'s forward coverage. Returns null
+ * on a non-country / unknown / malformed id; the caller degrades to name-only
+ * needles (region-less aliases still apply).
+ *
+ * @param {number} geoTargetId - a country-level Google Ads Geo Target ID.
+ * @returns {string|null} the ISO-2 market code, or null when not a known country id.
+ */
+export function marketForGeoTargetId(geoTargetId) {
+  const n = Number(geoTargetId);
+  if (!Number.isInteger(n) || n <= 2000) {
+    return null;
+  }
+  return NUMERIC_TO_ALPHA2[n - 2000] ?? null;
+}

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2393,6 +2393,25 @@ describe('SerenityController', () => {
       expect(handlers.handleCreatePromptsSubworkspace).not.to.have.been.called;
     });
 
+    it('builds a working type classifier from the brand name + aliases and passes it to the handler (serenity-docs#31)', async () => {
+      handlers.handleCreatePrompts.resolves({ created: 1, failed: [] });
+      // Brand name 'Test Brand' + a US-clamped alias 'Acme'.
+      getBrandAliasesStub.resolves([{ name: 'Acme', regions: ['us'] }]);
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.createPrompts(fakeContext({
+        data: { prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
+      }));
+      expect(response.status).to.equal(200);
+      expect(getBrandAliasesStub).to.have.been.calledOnce;
+      // The 7th positional arg to handleCreatePrompts is the classifier closure.
+      const classify = handlers.handleCreatePrompts.firstCall.args[6];
+      expect(classify).to.be.a('function');
+      // US market (geoTargetId 2840): brand name and the US alias both classify.
+      expect(classify('do you sell Test Brand shoes?', 2840)).to.equal('type:branded');
+      expect(classify('is Acme any good?', 2840)).to.equal('type:branded');
+      expect(classify('best running shoes?', 2840)).to.equal('type:non-branded');
+    });
+
     // Line 382: updatePrompt — `ctx?.params || {}` fallback. When ctx.params is
     // null the destructure yields `semrushPromptId = undefined`, which fails the
     // hasText check and throws a 400 before authorize() is reached. The `|| {}`

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -433,7 +433,11 @@ export default function serenityTests(getHttpClient, resetData, resetMocks = asy
       expect(created.status).to.equal(200);
       expect(created.body.created).to.have.lengthOf(1);
       expect(created.body.created[0].semrushPromptId).to.be.a('string').that.is.not.empty;
-      expect(created.body.created[0].tagIds).to.deep.equal([category.body.id, child.body.id]);
+      // The write path now server-computes a branded/non-branded `type:` tag and
+      // appends it to the supplied tagIds, so the created prompt carries the two
+      // supplied tags plus one computed type tag.
+      expect(created.body.created[0].tagIds).to.include.members([category.body.id, child.body.id]);
+      expect(created.body.created[0].tagIds).to.have.lengthOf(3);
       expect(created.body.failed).to.deep.equal([]);
 
       // by_tags correlation: the id-based create embeds the tag ids, so filtering the prompt list

--- a/test/support/serenity/branded-classifier.test.js
+++ b/test/support/serenity/branded-classifier.test.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import {
+  normalizeMatch,
+  needlesFromNames,
+  brandNeedles,
+  classifyBrandedTag,
+} from '../../../src/support/serenity/branded-classifier.js';
+import { TYPE_TAG } from '../../../src/support/serenity/prompt-tags.js';
+
+describe('serenity branded-classifier', () => {
+  describe('normalizeMatch', () => {
+    it('folds diacritics, lower-cases, collapses non-alphanumerics, trims', () => {
+      expect(normalizeMatch('  Café   Nörd! ')).to.equal('cafe nord');
+      expect(normalizeMatch('Le Creuset')).to.equal('le creuset');
+      expect(normalizeMatch('AT&T')).to.equal('at t');
+    });
+
+    it('returns empty string for empty / nullish input', () => {
+      expect(normalizeMatch('')).to.equal('');
+      expect(normalizeMatch('   ')).to.equal('');
+      expect(normalizeMatch(undefined)).to.equal('');
+      expect(normalizeMatch(null)).to.equal('');
+    });
+  });
+
+  describe('needlesFromNames', () => {
+    it('normalizes, drops empties, and de-duplicates (first spelling wins order)', () => {
+      expect(needlesFromNames(['Acme', 'ACME', '  acme ', '', 'Örsted']))
+        .to.deep.equal(['acme', 'orsted']);
+    });
+
+    it('tolerates a non-array input', () => {
+      expect(needlesFromNames(undefined)).to.deep.equal([]);
+      expect(needlesFromNames(null)).to.deep.equal([]);
+    });
+  });
+
+  describe('brandNeedles', () => {
+    it('combines the brand name with region-clamped aliases', () => {
+      const aliases = [
+        { name: 'Acme US', regions: ['us'] },
+        { name: 'Acme EU', regions: ['de'] },
+        { name: 'Acme WW' }, // region-less → applies everywhere
+      ];
+      expect(brandNeedles('Acme Corp', aliases, 'US'))
+        .to.deep.equal(['acme corp', 'acme us', 'acme ww']);
+      expect(brandNeedles('Acme Corp', aliases, 'DE'))
+        .to.deep.equal(['acme corp', 'acme eu', 'acme ww']);
+    });
+
+    it('keeps only region-less aliases when the market is unknown/empty', () => {
+      const aliases = [
+        { name: 'Regional', regions: ['us'] },
+        { name: 'Global' },
+      ];
+      expect(brandNeedles('Brand', aliases, '')).to.deep.equal(['brand', 'global']);
+    });
+
+    it('drops a blank brand name', () => {
+      expect(brandNeedles('', [], 'US')).to.deep.equal([]);
+    });
+  });
+
+  describe('classifyBrandedTag', () => {
+    const needles = needlesFromNames(['Ace', 'Le Creuset', 'Örsted']);
+
+    it('matches a needle as a whole word → branded', () => {
+      expect(classifyBrandedTag('is Ace a good brand?', needles)).to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('does NOT match a needle as a substring of a larger word → non-branded', () => {
+      expect(classifyBrandedTag('what is the best surface finish?', needles))
+        .to.equal(TYPE_TAG.NON_BRANDED);
+      expect(classifyBrandedTag('tell me about outer space', needles))
+        .to.equal(TYPE_TAG.NON_BRANDED);
+    });
+
+    it('matches a multi-word needle only as a contiguous whole-word run', () => {
+      expect(classifyBrandedTag('best Le Creuset dutch oven', needles))
+        .to.equal(TYPE_TAG.BRANDED);
+      expect(classifyBrandedTag('le fancy creuset pan', needles))
+        .to.equal(TYPE_TAG.NON_BRANDED);
+    });
+
+    it('folds decomposing diacritics on BOTH sides (café ≈ cafe, Örsted ≈ orsted)', () => {
+      expect(classifyBrandedTag('who founded Orsted energy?', needles))
+        .to.equal(TYPE_TAG.BRANDED);
+      const cafeNeedles = needlesFromNames(['Café']);
+      expect(classifyBrandedTag('a cafe near me', cafeNeedles)).to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('folds NON-decomposing accented/ligature letters (Ø/Æ/ß have no NFD form)', () => {
+      // Ørsted: Ø (U+00D8) has no canonical decomposition, so NFD+strip alone
+      // would leave it — the explicit fold table makes it match ASCII "Orsted".
+      const orsted = needlesFromNames(['Ørsted']);
+      expect(classifyBrandedTag('who founded Orsted energy?', orsted)).to.equal(TYPE_TAG.BRANDED);
+      // …and the reverse: an ASCII needle matches an accented prompt.
+      expect(classifyBrandedTag('tell me about Ørsted', needlesFromNames(['Orsted'])))
+        .to.equal(TYPE_TAG.BRANDED);
+      // ß → ss
+      expect(classifyBrandedTag('is Straße a street?', needlesFromNames(['Strasse'])))
+        .to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('is case- and punctuation-insensitive', () => {
+      expect(classifyBrandedTag('ACE!!! is great', needles)).to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('empty needles ⇒ everything is non-branded', () => {
+      expect(classifyBrandedTag('Ace Le Creuset Orsted', [])).to.equal(TYPE_TAG.NON_BRANDED);
+    });
+
+    it('tolerates empty / nullish prompt text', () => {
+      expect(classifyBrandedTag('', needles)).to.equal(TYPE_TAG.NON_BRANDED);
+      expect(classifyBrandedTag(undefined, needles)).to.equal(TYPE_TAG.NON_BRANDED);
+    });
+  });
+});

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -425,7 +425,7 @@ describe('markets-subworkspace handlers', () => {
         transport,
         makeBrand(),
         PARENT,
-        createBody,
+        { ...createBody, brandNames: ['Trail'] },
         log,
         null,
         null,
@@ -445,13 +445,15 @@ describe('markets-subworkspace handlers', () => {
       expect(transport.addAiModel).to.have.been.calledWith(WS, 'new-proj', 'm-1');
       expect(transport.addAiModel).to.have.been.calledWith(WS, 'new-proj', 'm-2');
       // only the top-1 topic by volume was attached, tagged topic:<name> +
-      // source:ai + a branded type: tag. Brand name is 'B' (needle 'b'):
-      // 'best running shoes' contains 'b' => branded; 'top trail shoes' => not.
+      // source:ai + a branded type: tag. Brand name is 'Trail' (needle 'trail'):
+      // the shared classifier now matches on WORD boundaries, so 'top trail
+      // shoes' contains the whole word 'trail' => branded, while 'best running
+      // shoes' does not => non-branded (serenity-docs#31).
       expect(transport.createTaggedPrompts).to.have.been.calledOnce;
       const [, , promptsByText] = transport.createTaggedPrompts.firstCall.args;
       expect(promptsByText).to.deep.equal({
-        'best running shoes': ['topic:Running Shoes', 'source:ai', 'type:branded'],
-        'top trail shoes': ['topic:Running Shoes', 'source:ai', 'type:non-branded'],
+        'best running shoes': ['topic:Running Shoes', 'source:ai', 'type:non-branded'],
+        'top trail shoes': ['topic:Running Shoes', 'source:ai', 'type:branded'],
       });
       expect(res.body).to.include({ topicCount: 1, promptCount: 2, published: true });
       // Models are STAGED (no inner publish) — only the single final publish runs,

--- a/test/support/serenity/handlers/prompts-subworkspace.test.js
+++ b/test/support/serenity/handlers/prompts-subworkspace.test.js
@@ -333,6 +333,24 @@ describe('prompts-subworkspace handlers', () => {
       expect(result.body.error).to.equal('invalidRequest');
     });
 
+    it('recomputes the type tag from the NEW text on edit (serenity-docs#31, twin of the flat-mode layer)', async () => {
+      // Guards the subworkspace UPDATE injection wiring: without the classifier
+      // arg the defensive `typeof !== function` bypass fires silently, so a
+      // regression in delete-then-create injection would go uncaught here.
+      const transport = makeTransport();
+      const classify = (text) => (/\bacme\b/i.test(text) ? 'type:branded' : 'type:non-branded');
+      const result = await handleUpdatePromptSubworkspace(transport, WS, 'old-id', {
+        text: 'now mentions Acme', tags: ['topic:X', 'type:non-branded'], geoTargetId: 2840, languageCode: 'en',
+      }, log, classify);
+      expect(result.status).to.equal(200);
+      expect(result.body.tags).to.deep.equal(['topic:X', 'type:branded']);
+      expect(transport.createTaggedPrompts).to.have.been.calledOnceWithExactly(
+        WS,
+        'p-us-en',
+        { 'now mentions Acme': ['topic:X', 'type:branded'] },
+      );
+    });
+
     it('re-throws a non-404 delete failure (never creates after a failed delete)', async () => {
       const transport = makeTransport({
         deletePromptsByIds: sinon.stub().rejects(new SerenityTransportError(500, 'boom')),

--- a/test/support/serenity/handlers/prompts-subworkspace.test.js
+++ b/test/support/serenity/handlers/prompts-subworkspace.test.js
@@ -146,6 +146,22 @@ describe('prompts-subworkspace handlers', () => {
       expect(transport.createTaggedPrompts).to.not.have.been.called;
     });
 
+    it('injects the computed type tag from the classifier (serenity-docs#31, twin of the flat-mode layer)', async () => {
+      const transport = makeTransport();
+      const classify = (text) => (/\bacme\b/i.test(text) ? 'type:branded' : 'type:non-branded');
+      const result = await handleCreatePromptsSubworkspace(transport, WS, {
+        prompts: [{
+          text: 'is Acme good?', tags: ['topic:X', 'type:non-branded'], geoTargetId: 2840, languageCode: 'en',
+        }],
+      }, log, classify);
+      expect(result.created[0].tags).to.deep.equal(['topic:X', 'type:branded']);
+      expect(transport.createTaggedPrompts).to.have.been.calledOnceWithExactly(
+        WS,
+        'p-us-en',
+        { 'is Acme good?': ['topic:X', 'type:branded'] },
+      );
+    });
+
     it('skips inputs whose slice has no project (one listing, no per-input lookup)', async () => {
       const transport = makeTransport();
       const result = await handleCreatePromptsSubworkspace(transport, WS, {

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -1738,3 +1738,111 @@ describe('handlers/prompts.js — defensive branch coverage', () => {
     expect(result.total).to.equal(10);
   });
 });
+
+describe('handlers/prompts.js — unified type classification (serenity-docs#31)', () => {
+  const project = () => makeProject({
+    semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
+  });
+  // A classifier that marks any text mentioning "acme" (whole word) branded.
+  const classify = (text) => (/\bacme\b/i.test(text) ? 'type:branded' : 'type:non-branded');
+
+  describe('name-based create', () => {
+    it('injects the computed type tag and strips a caller-supplied one', async () => {
+      const dataAccess = makeDataAccess([project()]);
+      const transport = {
+        createTaggedPrompts: sinon.stub().resolves({ ids: ['new-id'] }),
+        publishProject: sinon.stub().resolves(),
+      };
+
+      const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+        prompts: [{
+          text: 'is Acme good?',
+          geoTargetId: 2840,
+          languageCode: 'en',
+          tags: ['topic:X', 'type:non-branded'],
+        }],
+      }, fakeLog(), classify);
+
+      expect(result.created).to.have.lengthOf(1);
+      // caller's type:non-branded stripped; computed type:branded appended.
+      expect(result.created[0].tags).to.deep.equal(['topic:X', 'type:branded']);
+      expect(transport.createTaggedPrompts).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-us-en',
+        { 'is Acme good?': ['topic:X', 'type:branded'] },
+      );
+    });
+
+    it('classifies non-branded when the brand is not mentioned', async () => {
+      const dataAccess = makeDataAccess([project()]);
+      const transport = {
+        createTaggedPrompts: sinon.stub().resolves({ ids: ['new-id'] }),
+        publishProject: sinon.stub().resolves(),
+      };
+
+      const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+        prompts: [{
+          text: 'best running shoes', geoTargetId: 2840, languageCode: 'en', tags: ['topic:X'],
+        }],
+      }, fakeLog(), classify);
+
+      expect(result.created[0].tags).to.deep.equal(['topic:X', 'type:non-branded']);
+    });
+  });
+
+  describe('id-based create', () => {
+    it('resolves the computed type to a tag id and strips a caller-supplied type id', async () => {
+      const dataAccess = makeDataAccess([project()]);
+      const transport = {
+        listProjectTags: sinon.stub().resolves({
+          page: 1,
+          total: 2,
+          items: [
+            { id: 'tb', name: 'type:branded' },
+            { id: 'tnb', name: 'type:non-branded' },
+          ],
+        }),
+        createPromptsByIds: sinon.stub().resolves({
+          page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'is Acme good?' }],
+        }),
+        publishProject: sinon.stub().resolves(),
+      };
+
+      const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
+        prompts: [{
+          text: 'is Acme good?',
+          geoTargetId: 2840,
+          languageCode: 'en',
+          tagIds: ['tag-cat-1', 'tnb'],
+        }],
+      }, fakeLog(), classify);
+
+      expect(result.created[0].tagIds).to.deep.equal(['tag-cat-1', 'tb']);
+      expect(transport.createPromptsByIds).to.have.been.calledOnceWithExactly(
+        WORKSPACE,
+        'proj-us-en',
+        ['is Acme good?'],
+        ['tag-cat-1', 'tb'],
+      );
+    });
+  });
+
+  describe('update recomputes from the new text', () => {
+    it('recomputes the type tag on edit (name path)', async () => {
+      const dataAccess = makeDataAccess([]);
+      dataAccess.BrandSemrushProject.findBySlice.resolves(project());
+      const transport = {
+        deletePromptsByIds: sinon.stub().resolves(),
+        createTaggedPrompts: sinon.stub().resolves({ ids: ['re-id'] }),
+        publishProject: sinon.stub().resolves(),
+      };
+
+      const result = await handleUpdatePrompt(transport, dataAccess, BRAND, WORKSPACE, 'old-id', {
+        text: 'now mentions Acme', geoTargetId: 2840, languageCode: 'en', tags: ['topic:X'],
+      }, fakeLog(), classify);
+
+      expect(result.status).to.equal(200);
+      expect(result.body.tags).to.deep.equal(['topic:X', 'type:branded']);
+    });
+  });
+});

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -20,6 +20,7 @@ import {
   handleCreatePrompts,
   handleUpdatePrompt,
   handleBulkDeletePrompts,
+  makeTypeInjector,
 } from '../../../../src/support/serenity/handlers/prompts.js';
 import { ErrorWithStatusCode } from '../../../../src/support/utils.js';
 import { SerenityTransportError } from '../../../../src/support/serenity/rest-transport.js';
@@ -1843,6 +1844,37 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
 
       expect(result.status).to.equal(200);
       expect(result.body.tags).to.deep.equal(['topic:X', 'type:branded']);
+    });
+  });
+
+  describe('makeTypeInjector cache (serenity-docs#31)', () => {
+    it('resolves each (project, type) once across a batch, re-resolving only on a new key', async () => {
+      const transport = {
+        listProjectTags: sinon.stub().resolves({
+          page: 1,
+          total: 2,
+          items: [
+            { id: 'tb', name: 'type:branded' },
+            { id: 'tnb', name: 'type:non-branded' },
+          ],
+        }),
+        createProjectTags: sinon.stub(),
+      };
+      const classifyType = (text) => (/\bacme\b/i.test(text) ? 'type:branded' : 'type:non-branded');
+      const inject = makeTypeInjector(transport, WORKSPACE, classifyType, fakeLog());
+
+      const a = await inject('proj-1', { text: 'love Acme', geoTargetId: 2840, tagIds: ['x'] });
+      const b = await inject('proj-1', { text: 'Acme rocks', geoTargetId: 2840, tagIds: ['y'] });
+      // Same project + same computed type => resolved once (the cache hit).
+      expect(transport.listProjectTags).to.have.been.calledOnce;
+      expect(a.tagIds).to.deep.equal(['x', 'tb']);
+      expect(b.tagIds).to.deep.equal(['y', 'tb']);
+
+      // A different computed type is a new cache key => one more resolution.
+      const c = await inject('proj-1', { text: 'best running shoes', geoTargetId: 2840, tagIds: ['z'] });
+      expect(transport.listProjectTags).to.have.been.calledTwice;
+      expect(c.tagIds).to.deep.equal(['z', 'tnb']);
+      expect(transport.createProjectTags).to.not.have.been.called;
     });
   });
 });

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -1077,4 +1077,45 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       );
     });
   });
+
+  describe('resolveTypeTagInjection (serenity-docs#31)', () => {
+    let handler;
+    beforeEach(async () => {
+      handler = await import('../../../../src/support/serenity/handlers/tags.js');
+    });
+
+    it('resolves the wanted type value id + all type ids from the project roots (no create)', async () => {
+      const transport = makeTransport({
+        listProjectTags: sinon.stub().resolves({
+          page: 1,
+          total: 3,
+          items: [
+            { id: 'cat-1', name: 'category:Footwear' },
+            { id: 'tb', name: 'type:branded' },
+            { id: 'tnb', name: 'type:non-branded' },
+          ],
+        }),
+      });
+
+      const res = await handler.resolveTypeTagInjection(transport, WORKSPACE, 'proj-1', 'type:branded', fakeLog());
+
+      expect(res.computedId).to.equal('tb');
+      expect(res.typeTagIds).to.have.members(['tb', 'tnb']);
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('creates the type value on-demand when a legacy project lacks it', async () => {
+      const transport = makeTransport({
+        listProjectTags: sinon.stub().resolves({ page: 1, total: 0, items: [] }),
+        createProjectTags: sinon.stub().resolves([{ id: 'new-tb', name: 'type:branded' }]),
+      });
+
+      const res = await handler.resolveTypeTagInjection(transport, WORKSPACE, 'proj-1', 'type:branded', fakeLog());
+
+      expect(res.computedId).to.equal('new-tb');
+      expect(res.typeTagIds).to.deep.equal(['new-tb']);
+      expect(transport.createProjectTags)
+        .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['type:branded']);
+    });
+  });
 });

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -1117,5 +1117,31 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(transport.createProjectTags)
         .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1', ['type:branded']);
     });
+
+    it('propagates a transport failure while listing the project tag tree', async () => {
+      const transport = makeTransport({
+        listProjectTags: sinon.stub().rejects(new Error('listProjectTags 502')),
+      });
+
+      await expect(
+        handler.resolveTypeTagInjection(transport, WORKSPACE, 'proj-1', 'type:branded', fakeLog()),
+      ).to.be.rejectedWith(/listProjectTags 502/);
+      expect(transport.createProjectTags).to.not.have.been.called;
+    });
+
+    it('yields computedId undefined (skips injection) when the create response carries no id', async () => {
+      // pickTagIds returns { id: undefined } for an empty/malformed create
+      // response; the injector then keeps the input tagIds untouched rather than
+      // appending a bogus id.
+      const transport = makeTransport({
+        listProjectTags: sinon.stub().resolves({ page: 1, total: 0, items: [] }),
+        createProjectTags: sinon.stub().resolves([{}]),
+      });
+
+      const res = await handler.resolveTypeTagInjection(transport, WORKSPACE, 'proj-1', 'type:branded', fakeLog());
+
+      expect(res.computedId).to.equal(undefined);
+      expect(res.typeTagIds).to.deep.equal([]);
+    });
   });
 });

--- a/test/support/serenity/locations.test.js
+++ b/test/support/serenity/locations.test.js
@@ -12,7 +12,7 @@
 
 import { expect } from 'chai';
 
-import { resolveLocation } from '../../../src/support/serenity/locations.js';
+import { resolveLocation, marketForGeoTargetId } from '../../../src/support/serenity/locations.js';
 
 describe('serenity locations — resolveLocation', () => {
   it('maps an ISO alpha-2 code to geoTargetId (2000 + ISO numeric) + English name', () => {
@@ -43,5 +43,43 @@ describe('serenity locations — resolveLocation', () => {
   it('returns null for an unknown / unassigned country code', () => {
     expect(resolveLocation('ZZ')).to.equal(null);
     expect(resolveLocation('XX')).to.equal(null);
+  });
+});
+
+describe('serenity locations — marketForGeoTargetId (inverse)', () => {
+  it('maps a country geoTargetId back to its ISO alpha-2 code', () => {
+    expect(marketForGeoTargetId(2840)).to.equal('US');
+    expect(marketForGeoTargetId(2276)).to.equal('DE');
+    expect(marketForGeoTargetId(2250)).to.equal('FR');
+    expect(marketForGeoTargetId(2036)).to.equal('AU');
+  });
+
+  it('round-trips with resolveLocation for every resolvable market', () => {
+    for (const market of ['US', 'DE', 'FR', 'GB', 'JP', 'BR', 'IN']) {
+      const { geoTargetId } = resolveLocation(market);
+      expect(marketForGeoTargetId(geoTargetId)).to.equal(market);
+    }
+  });
+
+  it('handles a low ISO-numeric country whose numeric needs leading zeros (AF=004)', () => {
+    // Afghanistan: ISO numeric 004 → geoTargetId 2004. Number-keyed reverse map
+    // must not miss on the leading-zero string form.
+    const { geoTargetId } = resolveLocation('AF');
+    expect(geoTargetId).to.equal(2004);
+    expect(marketForGeoTargetId(2004)).to.equal('AF');
+  });
+
+  it('returns null for a non-country / sub-national / out-of-range id', () => {
+    expect(marketForGeoTargetId(1234)).to.equal(null); // region/metro band
+    expect(marketForGeoTargetId(2000)).to.equal(null); // 2000 itself is not a country
+    expect(marketForGeoTargetId(9999999)).to.equal(null);
+  });
+
+  it('returns null for a non-integer / missing / malformed id', () => {
+    expect(marketForGeoTargetId(undefined)).to.equal(null);
+    expect(marketForGeoTargetId(null)).to.equal(null);
+    expect(marketForGeoTargetId(NaN)).to.equal(null);
+    expect(marketForGeoTargetId(2840.5)).to.equal(null);
+    expect(marketForGeoTargetId('nope')).to.equal(null);
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Makes the branded / non-branded classification of Serenity (Semrush sub-workspace) prompts server-computed and applies it through one unified injection layer on every prompt write path. The client can no longer set the `type` dimension.

## 2. Reasoning
Prompt "type" (branded vs. non-branded) was an author-selected tag, which let the two write transports (id-based and name-based) and the several entry points (manual create, edit, CSV import, AI generation, onboarding) drift out of agreement, and let clients set a value that contradicts the prompt text. serenity-docs#31 is the design-of-record: the type should be derived from the prompt text against the brand name + its region-clamped aliases, computed once on the server and re-computed on every edit, so it is always consistent and never client-authored.

## 3. High-level overview of the changes
Before: each prompt carried whatever `type:branded` / `type:non-branded` tag the client chose; nothing recomputed it and the different write paths handled it inconsistently.

After: the server classifies every prompt on write and injects the correct `type:` tag, stripping any client-supplied one.

- New pure classifier module (`branded-classifier.js`): normalizes text with NFD diacritic-folding plus an explicit fold table for non-decomposing letters (ø/æ/œ/ß/ð/þ/ł/đ), matches brand needles on whole-word boundaries (not substring), and returns the canonical `type:branded` / `type:non-branded` tag. Empty needle set ⇒ non-branded.
- Per-market alias needles: `locations.js` gains `marketForGeoTargetId` (the inverse of the existing `resolveLocation`), so a prompt's geo target selects the region-appropriate brand aliases.
- One unified injection layer (`makeTypeInjector` in `prompts.js`, `resolveTypeTagInjection` in `tags.js`) wired through BOTH the flat and the subworkspace prompt handlers, on create AND update. It strips any incoming `type:` tag (by name on the name-based path, by resolved id on the id-based path) and appends the server-computed one. The classifier is built once per request in the controller from the brand name + aliases and memoized.
- On edit, the type is recomputed from the (possibly new) text before the delete/rewrite, and the response echoes the injected tag.

No backfill: only new writes and edits are affected; existing stored prompts are untouched. The read-only `type` filter continues to recognize the full branded / non-branded vocabulary. `intent` and `source` remain author-selected.

## 4. Required information
- Jira / issue: serenity-docs#31 — https://github.com/adobe/serenity-docs/issues/31
- Other: project-elmo-ui companion PR (read-only Type UI) — see section 8

## 5. Affected / used mysticat-workspace projects
- project-elmo-ui — consumer: the companion PR removes the Type authoring selector and renders the server-computed value read-only (checkmark / X). It relies on this PR computing and returning the `type:` tag on every write.
- mysticat-data-service — unchanged: no schema or storage change; classification is applied at the api-service layer via the existing tag dimensions.

## 7. Test plan
(a) Local: unit suites for the new classifier, the `marketForGeoTargetId` reverse mapping (incl. leading-zero numerics like AF=004 and a resolveLocation round-trip), the type-injection resolver, and both flat + subworkspace create/update handlers were exercised locally and the controller-level classifier wiring was verified through argument capture.

(b) Per environment — verify through the Serenity prompt endpoints against a Semrush sub-workspace brand:
- Create a prompt whose text contains the brand name (or a market alias) ⇒ response carries `type:branded`; create one that does not ⇒ `type:non-branded`.
- Send a prompt with a client-supplied `type:` tag/id ⇒ it is stripped and replaced by the computed value.
- Edit a branded prompt to remove the brand mention ⇒ re-read shows `type:non-branded` (recomputed on edit).
- CSV import and AI-generated prompts ⇒ each row/prompt receives a computed type with no client input.
- Run on eph/dev first, then stage, before prod; no migration or backfill step is required.

## 8. Deployment & merge order
- project-elmo-ui companion PR (read-only Type UI) — related: removes the client Type picker and shows the value read-only. Deploy this api-service PR first (or together) so the UI never authors a type the server would overwrite; the UI change is safe to ship after since the server ignores any client `type:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
