### PR TITLE
chore: clotton dev alias for isolated testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l clotton --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "docs": "npm run docs:lint && npm run docs:build",
     "docs:build": "npx @redocly/cli build-docs -o ./docs/index.html --config docs/openapi/redocly-config.yaml",


### PR DESCRIPTION
## Summary
- Changes `deploy-dev` script to use `-l clotton` alias instead of `-l latest`
- Enables an isolated dev Lambda alias for end-to-end testing without affecting shared `latest`

## Test plan
- [ ] CI `branch-deploy` deploys `spacecat-services--api-service:clotton` Lambda alias
- [ ] Will be deleted after testing is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)