### PR TITLE
feat(referral-traffic): has-data probes all referral sources by priority

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -5089,8 +5089,10 @@ llmo-referral-traffic-has-data:
     description: |
       Returns whether the site has any referral traffic data and which sources
       are available. Uses a direct table existence check (no RPC). Ignores the
-      `source` query param. Response is cacheable. `availableSources` items are
-      `optel` or `cdn` only, in priority order (optel first).
+      `source` query param. Response is cacheable. `availableSources` lists all
+      sources with data in resolution-priority order
+      (`adobe_analytics` > `cja` > `ga4` > `cdn` > `optel`); callers use the
+      first entry as the active source.
     operationId: getReferralTrafficHasData
     responses:
       '200':

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -5092,7 +5092,8 @@ llmo-referral-traffic-has-data:
       `source` query param. Response is cacheable. `availableSources` lists all
       sources with data in resolution-priority order
       (`adobe_analytics` > `cja` > `ga4` > `cdn` > `optel`); callers use the
-      first entry as the active source.
+      first entry as the active source. `activeSource` exposes that highest-priority
+      source directly, or null when no source has data.
     operationId: getReferralTrafficHasData
     responses:
       '200':

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11667,11 +11667,15 @@ ReferralTrafficHasData:
       example: true
     availableSources:
       type: array
-      description: Available sources in priority order; items are `optel` or `cdn` only (optel first)
+      description: >-
+        Sources that have data for the site, in resolution-priority order
+        (`adobe_analytics` > `cja` > `ga4` > `cdn` > `optel`). Callers use the
+        first entry as the active source. The ARRAY order — not the `enum`
+        order, which is an unordered set — is the priority contract.
       items:
         type: string
-        enum: [optel, cdn]
-      example: ['optel', 'cdn']
+        enum: [adobe_analytics, cja, ga4, cdn, optel]
+      example: ['adobe_analytics', 'cdn']
   required:
     - hasData
     - availableSources

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11676,9 +11676,15 @@ ReferralTrafficHasData:
         type: string
         enum: [adobe_analytics, cja, ga4, cdn, optel]
       example: ['adobe_analytics', 'cdn']
+    activeSource:
+      type: [string, 'null']
+      enum: [adobe_analytics, cja, ga4, cdn, optel, null]
+      description: The highest-priority available source (`availableSources[0]`) or null when none.
+      example: adobe_analytics
   required:
     - hasData
     - availableSources
+    - activeSource
 
 ReferralTrafficFilterDimensions:
   type: object
@@ -12571,4 +12577,3 @@ TicketCreateRequest:
       items:
         $ref: '#/TicketAttachment'
       maxItems: 10
-

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -786,6 +786,9 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
  */
 export const REFERRAL_HAS_DATA_SOURCES = ['adobe_analytics', 'cja', 'ga4', 'cdn', 'optel'];
 export const REFERRAL_HAS_DATA_TABLES = REFERRAL_HAS_DATA_SOURCES.map((s) => SOURCE_TO_TABLE[s]);
+// ~60 weeks; UI can only query the last 52 weeks, so this hides no visible data
+// while letting Postgres prune old traffic_date-RANGE referral traffic partitions.
+const HAS_DATA_LOOKBACK_DAYS = 420;
 
 /**
  * GET /sites/:siteId/referral-traffic/has-data
@@ -795,11 +798,12 @@ export const REFERRAL_HAS_DATA_TABLES = REFERRAL_HAS_DATA_SOURCES.map((s) => SOU
  *
  * Response:
  *   { hasData: boolean,
- *     availableSources: Array<'adobe_analytics'|'cja'|'ga4'|'cdn'|'optel'> }
+ *     availableSources: Array<'adobe_analytics'|'cja'|'ga4'|'cdn'|'optel'>,
+ *     activeSource: 'adobe_analytics'|'cja'|'ga4'|'cdn'|'optel'|null }
  *
  * availableSources lists whichever sources have at least one row for the site,
  * in resolution-priority order (adobe_analytics > cja > ga4 > cdn > optel).
- * Callers use the first entry as the active source. hasData is true iff
+ * activeSource mirrors the first entry. hasData is true iff
  * availableSources is non-empty.
  *
  * All source tables are checked in parallel with limit(1) — no RPC required.
@@ -814,8 +818,16 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
       async (ctx, client, siteId) => {
         let results;
         try {
+          const lookback = new Date(Date.now() - HAS_DATA_LOOKBACK_DAYS * 86400000)
+            .toISOString()
+            .slice(0, 10);
           results = await Promise.all(
-            REFERRAL_HAS_DATA_TABLES.map((table) => client.from(table).select('traffic_date').eq('site_id', siteId).limit(1)),
+            REFERRAL_HAS_DATA_TABLES.map((table) => client
+              .from(table)
+              .select('traffic_date')
+              .eq('site_id', siteId)
+              .gte('traffic_date', lookback)
+              .limit(1)),
           );
         } catch (err) {
           ctx.log.error(`Referral traffic has-data PostgREST error: ${err.message} (siteId=${siteId})`);
@@ -832,7 +844,12 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
         const availableSources = REFERRAL_HAS_DATA_SOURCES.filter(
           (_, i) => (results[i].data || []).length > 0,
         );
-        return cachedOk({ hasData: availableSources.length > 0, availableSources });
+        const activeSource = availableSources[0] ?? null;
+        return cachedOk({
+          hasData: availableSources.length > 0,
+          availableSources,
+          activeSource,
+        });
       },
     );
   };

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -773,32 +773,36 @@ export function createReferralTrafficBusinessImpactHandler(getSiteAndValidateAcc
 }
 
 /**
- * Traffic Insights sources — the only tables that feed the Traffic Insights tab.
- * Business Impact (adobe_analytics, ga4) has its own DRS provider check and is
- * intentionally excluded here.
+ * All referral sources probed by has-data, in resolution-priority order.
  *
- * Order matters: optel is listed first because it is the preferred source.
- * The has-data response preserves this order in availableSources so callers
- * can pick the first entry as the active source (optel wins over cdn).
+ * Business Impact sources (adobe_analytics, cja, ga4) rank ABOVE the Traffic
+ * Insights sources (cdn, optel): a site connected to an analytics provider
+ * should resolve to it first. The has-data response preserves this order in
+ * availableSources so callers pick the first entry as the active source.
+ *
+ * NOTE: this list is intentionally broader than the Traffic Insights tab
+ * (optel/cdn). Consumers that only care about Traffic Insights must filter
+ * availableSources down to those two sources themselves.
  */
-const TRAFFIC_INSIGHTS_SOURCES = ['optel', 'cdn'];
-const TRAFFIC_INSIGHTS_TABLES = TRAFFIC_INSIGHTS_SOURCES.map((s) => SOURCE_TO_TABLE[s]);
+export const REFERRAL_HAS_DATA_SOURCES = ['adobe_analytics', 'cja', 'ga4', 'cdn', 'optel'];
+export const REFERRAL_HAS_DATA_TABLES = REFERRAL_HAS_DATA_SOURCES.map((s) => SOURCE_TO_TABLE[s]);
 
 /**
  * GET /sites/:siteId/referral-traffic/has-data
  *
- * Fast existence check for Traffic Insights data (optel and cdn).
- * Business Impact sources (adobe_analytics, ga4) are gated separately via DRS.
+ * Fast existence check across ALL referral sources (adobe_analytics, cja, ga4,
+ * cdn, optel).
  *
  * Response:
- *   { hasData: boolean, availableSources: Array<'optel'|'cdn'> }
+ *   { hasData: boolean,
+ *     availableSources: Array<'adobe_analytics'|'cja'|'ga4'|'cdn'|'optel'> }
  *
- * availableSources lists whichever of optel/cdn has at least one row, in
- * priority order (optel first). Callers should use the first entry as the
- * active source so they naturally prefer optel over cdn.
- * hasData is true iff availableSources is non-empty.
+ * availableSources lists whichever sources have at least one row for the site,
+ * in resolution-priority order (adobe_analytics > cja > ga4 > cdn > optel).
+ * Callers use the first entry as the active source. hasData is true iff
+ * availableSources is non-empty.
  *
- * Both tables are checked in parallel with limit(1) — no RPC required.
+ * All source tables are checked in parallel with limit(1) — no RPC required.
  * Fails closed: if any query errors, returns 500 rather than a partial result.
  */
 export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
@@ -811,7 +815,7 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
         let results;
         try {
           results = await Promise.all(
-            TRAFFIC_INSIGHTS_TABLES.map((table) => client.from(table).select('traffic_date').eq('site_id', siteId).limit(1)),
+            REFERRAL_HAS_DATA_TABLES.map((table) => client.from(table).select('traffic_date').eq('site_id', siteId).limit(1)),
           );
         } catch (err) {
           ctx.log.error(`Referral traffic has-data PostgREST error: ${err.message} (siteId=${siteId})`);
@@ -820,12 +824,12 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
 
         for (const [i, result] of results.entries()) {
           if (result.error) {
-            ctx.log.error(`Referral traffic has-data ${TRAFFIC_INSIGHTS_TABLES[i]} PostgREST error: ${result.error.message} (siteId=${siteId})`);
+            ctx.log.error(`Referral traffic has-data ${REFERRAL_HAS_DATA_TABLES[i]} PostgREST error: ${result.error.message} (siteId=${siteId})`);
             return internalServerError('Failed to check referral traffic data');
           }
         }
 
-        const availableSources = TRAFFIC_INSIGHTS_SOURCES.filter(
+        const availableSources = REFERRAL_HAS_DATA_SOURCES.filter(
           (_, i) => (results[i].data || []).length > 0,
         );
         return cachedOk({ hasData: availableSources.length > 0, availableSources });

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -83,6 +83,7 @@ function makeHasDataChainClient(resultsByTable = {}) {
   const makeChain = (result) => ({
     select: sinon.stub().returnsThis(),
     eq: sinon.stub().returnsThis(),
+    gte: sinon.stub().returnsThis(),
     limit: sinon.stub().resolves(result),
   });
   const chains = {};
@@ -1090,6 +1091,7 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(true);
       expect(body.availableSources).to.deep.equal(['optel']);
+      expect(body.activeSource).to.equal('optel');
     });
 
     it('returns hasData:true and availableSources:["cdn"] when only cdn has records', async () => {
@@ -1103,6 +1105,7 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(true);
       expect(body.availableSources).to.deep.equal(['cdn']);
+      expect(body.activeSource).to.equal('cdn');
     });
 
     it('returns availableSources:["cdn","optel"] (cdn before optel) when both Traffic Insights sources have records', async () => {
@@ -1117,6 +1120,7 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(true);
       expect(body.availableSources).to.deep.equal(['cdn', 'optel']);
+      expect(body.activeSource).to.equal('cdn');
     });
 
     it('returns hasData:true and availableSources:["adobe_analytics"] when only adobe_analytics has records', async () => {
@@ -1130,6 +1134,7 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(true);
       expect(body.availableSources).to.deep.equal(['adobe_analytics']);
+      expect(body.activeSource).to.equal('adobe_analytics');
     });
 
     it('ranks Business Impact sources above Traffic Insights (adobe_analytics before cdn)', async () => {
@@ -1142,6 +1147,7 @@ describe('llmo-referral-traffic', () => {
       );
       const body = await res.json();
       expect(body.availableSources).to.deep.equal(['adobe_analytics', 'cdn']);
+      expect(body.activeSource).to.equal('adobe_analytics');
     });
 
     it('preserves full priority order (adobe_analytics > cja > ga4 > cdn > optel) when all sources have records', async () => {
@@ -1153,6 +1159,7 @@ describe('llmo-referral-traffic', () => {
       );
       const body = await res.json();
       expect(body.availableSources).to.deep.equal(['adobe_analytics', 'cja', 'ga4', 'cdn', 'optel']);
+      expect(body.activeSource).to.equal('adobe_analytics');
     });
 
     it('orders non-adjacent combos correctly (ga4 before optel)', async () => {
@@ -1165,6 +1172,7 @@ describe('llmo-referral-traffic', () => {
       );
       const body = await res.json();
       expect(body.availableSources).to.deep.equal(['ga4', 'optel']);
+      expect(body.activeSource).to.equal('ga4');
     });
 
     it('orders non-adjacent combos correctly (cja before cdn)', async () => {
@@ -1177,6 +1185,7 @@ describe('llmo-referral-traffic', () => {
       );
       const body = await res.json();
       expect(body.availableSources).to.deep.equal(['cja', 'cdn']);
+      expect(body.activeSource).to.equal('cja');
     });
 
     it('returns availableSources:["cja"] when only cja has records', async () => {
@@ -1189,6 +1198,7 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(true);
       expect(body.availableSources).to.deep.equal(['cja']);
+      expect(body.activeSource).to.equal('cja');
     });
 
     it('returns availableSources:["ga4"] when only ga4 has records', async () => {
@@ -1201,9 +1211,10 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(true);
       expect(body.availableSources).to.deep.equal(['ga4']);
+      expect(body.activeSource).to.equal('ga4');
     });
 
-    it('returns hasData:false and availableSources:[] when both tables are empty', async () => {
+    it('returns hasData:false and availableSources:[] when all sources are empty', async () => {
       const client = makeHasDataChainClient();
       const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
         makeContext({ client }),
@@ -1212,9 +1223,10 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(false);
       expect(body.availableSources).to.deep.equal([]);
+      expect(body.activeSource).to.equal(null);
     });
 
-    it('returns hasData:false and availableSources:[] when both tables return null data', async () => {
+    it('returns hasData:false and availableSources:[] when all sources return null data', async () => {
       const nullResults = Object.fromEntries(
         HAS_DATA_TABLES.map((t) => [t, { data: null, error: null }]),
       );
@@ -1226,6 +1238,7 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.hasData).to.equal(false);
       expect(body.availableSources).to.deep.equal([]);
+      expect(body.activeSource).to.equal(null);
     });
 
     it('returns 500 and fails closed when one source errors (even if the other has data)', async () => {
@@ -1250,7 +1263,7 @@ describe('llmo-referral-traffic', () => {
       expect(ctx.log.error).to.have.been.calledWithMatch(/referral_traffic_ga4/);
     });
 
-    it('returns 500 when both sources error simultaneously', async () => {
+    it('returns 500 when all sources error simultaneously', async () => {
       const errorResults = Object.fromEntries(
         HAS_DATA_TABLES.map((t) => [t, { data: null, error: { message: `${t}-fail` } }]),
       );
@@ -1276,6 +1289,7 @@ describe('llmo-referral-traffic', () => {
       const throwingChain = {
         select: sinon.stub().returnsThis(),
         eq: sinon.stub().returnsThis(),
+        gte: sinon.stub().returnsThis(),
         limit: sinon.stub().rejects(new Error('network timeout')),
       };
       const ctx = makeContext({ client: { from: sinon.stub().returns(throwingChain) } });
@@ -1283,14 +1297,27 @@ describe('llmo-referral-traffic', () => {
       expect(res.status).to.equal(500);
     });
 
-    it('queries all five referral source tables with the site id, once each', async () => {
+    it('queries all five referral source tables with the site id and lookback bound, once each', async () => {
       const client = makeHasDataChainClient();
+      const beforeProbe = Date.now();
       await createReferralTrafficHasDataHandler(stubbedValidateAccess)(makeContext({ client }));
+      const afterProbe = Date.now();
+      const minLookback = new Date(beforeProbe - 420 * 86400000).toISOString().slice(0, 10);
+      const maxLookback = new Date(afterProbe - 420 * 86400000).toISOString().slice(0, 10);
+      const lookbacks = new Set();
       for (const table of HAS_DATA_TABLES) {
         expect(client.from).to.have.been.calledWith(table);
         expect(client.chains[table].eq).to.have.been.calledWith('site_id', SITE_ID);
+        expect(client.chains[table].gte).to.have.been.calledWith(
+          'traffic_date',
+          sinon.match(/^\d{4}-\d{2}-\d{2}$/),
+        );
+        const lookback = client.chains[table].gte.firstCall.args[1];
+        expect(lookback >= minLookback && lookback <= maxLookback).to.equal(true);
+        lookbacks.add(lookback);
         expect(client.chains[table].limit).to.have.been.calledWith(1);
       }
+      expect(lookbacks.size).to.equal(1);
       // Exactly one probe per source — no extra or duplicate table reads.
       expect(client.from.callCount).to.equal(HAS_DATA_TABLES.length);
     });

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -26,6 +26,8 @@ import {
   createReferralTrafficWeeksHandler,
   createReferralTrafficByDeviceHandler,
   createReferralTrafficHasDataHandler,
+  REFERRAL_HAS_DATA_SOURCES,
+  REFERRAL_HAS_DATA_TABLES,
 } from '../../../src/controllers/llmo/llmo-referral-traffic.js';
 
 use(sinonChai);
@@ -59,12 +61,16 @@ function makeWeeksChainClient(
 }
 
 /**
- * The two Traffic Insights tables checked by the has-data handler.
- * Must stay in sync with TRAFFIC_INSIGHTS_TABLES in llmo-referral-traffic.js.
+ * All referral tables checked by the has-data handler, in resolution-priority
+ * order. Must stay in sync with REFERRAL_HAS_DATA_TABLES in
+ * llmo-referral-traffic.js.
  */
 const HAS_DATA_TABLES = [
-  'referral_traffic_optel',
+  'referral_traffic_adobe_analytics',
+  'referral_traffic_cja',
+  'referral_traffic_ga4',
   'referral_traffic_cdn',
+  'referral_traffic_optel',
 ];
 
 /**
@@ -1056,12 +1062,23 @@ describe('llmo-referral-traffic', () => {
   });
 
   // ── /has-data ─────────────────────────────────────────────────────────────
-  // Checks only Traffic Insights sources (optel, cdn). Business Impact sources
-  // (adobe_analytics, ga4) are gated separately via the DRS provider endpoint.
+  // Checks ALL referral sources and returns availableSources in
+  // resolution-priority order (adobe_analytics > cja > ga4 > cdn > optel).
 
   const ROW = { traffic_date: '2026-01-05' };
 
   describe('has-data', () => {
+    it('keeps the test table list in sync with the controller and maps every source to a table (drift guard)', () => {
+      // The local HAS_DATA_TABLES mirrors REFERRAL_HAS_DATA_TABLES; asserting
+      // equality makes adding/removing/reordering a source in the controller
+      // fail the build here instead of silently drifting.
+      expect(HAS_DATA_TABLES).to.deep.equal(REFERRAL_HAS_DATA_TABLES);
+      // Guards REFERRAL_HAS_DATA_SOURCES ⊆ SOURCE_TO_TABLE keys: a typo'd or
+      // newly-added source with no table mapping would surface as undefined.
+      expect(REFERRAL_HAS_DATA_TABLES).to.have.lengthOf(REFERRAL_HAS_DATA_SOURCES.length);
+      expect(REFERRAL_HAS_DATA_TABLES.every((t) => typeof t === 'string' && t.length > 0)).to.equal(true);
+    });
+
     it('returns hasData:true and availableSources:["optel"] when only optel has records', async () => {
       const client = makeHasDataChainClient({
         referral_traffic_optel: { data: [ROW], error: null },
@@ -1088,7 +1105,7 @@ describe('llmo-referral-traffic', () => {
       expect(body.availableSources).to.deep.equal(['cdn']);
     });
 
-    it('returns hasData:true and availableSources:["optel","cdn"] when both have records', async () => {
+    it('returns availableSources:["cdn","optel"] (cdn before optel) when both Traffic Insights sources have records', async () => {
       const client = makeHasDataChainClient({
         referral_traffic_optel: { data: [ROW], error: null },
         referral_traffic_cdn: { data: [ROW], error: null },
@@ -1099,7 +1116,91 @@ describe('llmo-referral-traffic', () => {
       expect(res.status).to.equal(200);
       const body = await res.json();
       expect(body.hasData).to.equal(true);
-      expect(body.availableSources).to.deep.equal(['optel', 'cdn']);
+      expect(body.availableSources).to.deep.equal(['cdn', 'optel']);
+    });
+
+    it('returns hasData:true and availableSources:["adobe_analytics"] when only adobe_analytics has records', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_adobe_analytics: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+      expect(body.availableSources).to.deep.equal(['adobe_analytics']);
+    });
+
+    it('ranks Business Impact sources above Traffic Insights (adobe_analytics before cdn)', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_adobe_analytics: { data: [ROW], error: null },
+        referral_traffic_cdn: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
+      const body = await res.json();
+      expect(body.availableSources).to.deep.equal(['adobe_analytics', 'cdn']);
+    });
+
+    it('preserves full priority order (adobe_analytics > cja > ga4 > cdn > optel) when all sources have records', async () => {
+      const client = makeHasDataChainClient(
+        Object.fromEntries(HAS_DATA_TABLES.map((t) => [t, { data: [ROW], error: null }])),
+      );
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
+      const body = await res.json();
+      expect(body.availableSources).to.deep.equal(['adobe_analytics', 'cja', 'ga4', 'cdn', 'optel']);
+    });
+
+    it('orders non-adjacent combos correctly (ga4 before optel)', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_ga4: { data: [ROW], error: null },
+        referral_traffic_optel: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
+      const body = await res.json();
+      expect(body.availableSources).to.deep.equal(['ga4', 'optel']);
+    });
+
+    it('orders non-adjacent combos correctly (cja before cdn)', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_cja: { data: [ROW], error: null },
+        referral_traffic_cdn: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
+      const body = await res.json();
+      expect(body.availableSources).to.deep.equal(['cja', 'cdn']);
+    });
+
+    it('returns availableSources:["cja"] when only cja has records', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_cja: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+      expect(body.availableSources).to.deep.equal(['cja']);
+    });
+
+    it('returns availableSources:["ga4"] when only ga4 has records', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_ga4: { data: [ROW], error: null },
+      });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(
+        makeContext({ client }),
+      );
+      const body = await res.json();
+      expect(body.hasData).to.equal(true);
+      expect(body.availableSources).to.deep.equal(['ga4']);
     });
 
     it('returns hasData:false and availableSources:[] when both tables are empty', async () => {
@@ -1138,6 +1239,17 @@ describe('llmo-referral-traffic', () => {
       expect(res.status).to.equal(500);
     });
 
+    it('fails closed (500) and logs the table when a Business Impact source is the sole errorer', async () => {
+      const client = makeHasDataChainClient({
+        referral_traffic_ga4: { data: null, error: { message: 'ga4-fail' } },
+        referral_traffic_cdn: { data: [ROW], error: null },
+      });
+      const ctx = makeContext({ client });
+      const res = await createReferralTrafficHasDataHandler(stubbedValidateAccess)(ctx);
+      expect(res.status).to.equal(500);
+      expect(ctx.log.error).to.have.been.calledWithMatch(/referral_traffic_ga4/);
+    });
+
     it('returns 500 when both sources error simultaneously', async () => {
       const errorResults = Object.fromEntries(
         HAS_DATA_TABLES.map((t) => [t, { data: null, error: { message: `${t}-fail` } }]),
@@ -1171,7 +1283,7 @@ describe('llmo-referral-traffic', () => {
       expect(res.status).to.equal(500);
     });
 
-    it('queries only optel and cdn tables with the site id', async () => {
+    it('queries all five referral source tables with the site id, once each', async () => {
       const client = makeHasDataChainClient();
       await createReferralTrafficHasDataHandler(stubbedValidateAccess)(makeContext({ client }));
       for (const table of HAS_DATA_TABLES) {
@@ -1179,8 +1291,8 @@ describe('llmo-referral-traffic', () => {
         expect(client.chains[table].eq).to.have.been.calledWith('site_id', SITE_ID);
         expect(client.chains[table].limit).to.have.been.calledWith(1);
       }
-      expect(client.from).not.to.have.been.calledWith('referral_traffic_adobe_analytics');
-      expect(client.from).not.to.have.been.calledWith('referral_traffic_ga4');
+      // Exactly one probe per source — no extra or duplicate table reads.
+      expect(client.from.callCount).to.equal(HAS_DATA_TABLES.length);
     });
 
     it('returns 400 when Site.postgrestService is missing', async () => {

--- a/test/it/postgres/llmo-referral-traffic.test.js
+++ b/test/it/postgres/llmo-referral-traffic.test.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ctx } from './harness.js';
+import { resetPostgres } from './seed.js';
+import llmoReferralTrafficTests from '../shared/tests/llmo-referral-traffic.js';
+
+llmoReferralTrafficTests(() => ctx.httpClient, resetPostgres);

--- a/test/it/postgres/llmo-referral-traffic.test.js
+++ b/test/it/postgres/llmo-referral-traffic.test.js
@@ -11,7 +11,7 @@
  */
 
 import { ctx } from './harness.js';
-import { resetPostgres } from './seed.js';
+import { resetPostgres, seedReferralPresence } from './seed.js';
 import llmoReferralTrafficTests from '../shared/tests/llmo-referral-traffic.js';
 
-llmoReferralTrafficTests(() => ctx.httpClient, resetPostgres);
+llmoReferralTrafficTests(() => ctx.httpClient, resetPostgres, seedReferralPresence);

--- a/test/it/postgres/seed.js
+++ b/test/it/postgres/seed.js
@@ -127,10 +127,13 @@ const REFERRAL_SOURCE_TABLES = {
  * requested source so `GET /sites/:siteId/referral-traffic/has-data` reports
  * exactly those sources (in the backend's resolution-priority order).
  *
- * Rows go into an on-demand far-future (2099) partition: the has-data existence
- * check is date-agnostic (`WHERE site_id = ? LIMIT 1`), and a 2099 range can't
- * collide with the image's real monthly partitions. Runs as the `postgres`
- * superuser via psql to bypass PostgREST role grants + partition routing.
+ * Rows go into an on-demand far-future (2099) partition: the has-data lower
+ * bound accepts them, and a 2099 range can't collide with the image's real
+ * monthly partitions. Runs as the `postgres` superuser via psql to bypass
+ * PostgREST role grants + partition routing.
+ *
+ * Keep siteId/source inputs trusted constants only (canonical seed UUIDs and
+ * the whitelisted source-to-table map), never request-derived values.
  *
  * @param {string} siteId  Site the rows belong to (a canonical seed UUID).
  * @param {Array<'optel'|'cdn'|'adobe_analytics'|'ga4'|'cja'>} sources Sources to

--- a/test/it/postgres/seed.js
+++ b/test/it/postgres/seed.js
@@ -112,6 +112,47 @@ function clearData() {
   );
 }
 
+const REFERRAL_SOURCE_TABLES = {
+  optel: 'referral_traffic_optel',
+  cdn: 'referral_traffic_cdn',
+  adobe_analytics: 'referral_traffic_adobe_analytics',
+  ga4: 'referral_traffic_ga4',
+  cja: 'referral_traffic_cja',
+};
+
+/**
+ * Seeds referral-traffic source *presence* for the has-data IT.
+ *
+ * Clears all five `referral_traffic_*` tables, then inserts one minimal row per
+ * requested source so `GET /sites/:siteId/referral-traffic/has-data` reports
+ * exactly those sources (in the backend's resolution-priority order).
+ *
+ * Rows go into an on-demand far-future (2099) partition: the has-data existence
+ * check is date-agnostic (`WHERE site_id = ? LIMIT 1`), and a 2099 range can't
+ * collide with the image's real monthly partitions. Runs as the `postgres`
+ * superuser via psql to bypass PostgREST role grants + partition routing.
+ *
+ * @param {string} siteId  Site the rows belong to (a canonical seed UUID).
+ * @param {Array<'optel'|'cdn'|'adobe_analytics'|'ga4'|'cja'>} sources Sources to
+ *   mark present; pass [] to clear all five (test cleanup).
+ */
+export function seedReferralPresence(siteId, sources = []) {
+  const statements = [
+    ...Object.values(REFERRAL_SOURCE_TABLES).map((t) => `DELETE FROM ${t};`),
+    ...sources.flatMap((source) => {
+      const table = REFERRAL_SOURCE_TABLES[source];
+      return [
+        `CREATE TABLE IF NOT EXISTS ${table}_itseed PARTITION OF ${table} FOR VALUES FROM ('2099-01-01') TO ('2099-02-01');`,
+        `INSERT INTO ${table} (site_id, traffic_date, url_path, pageviews) VALUES ('${siteId}', '2099-01-15', '/it-seed', 1);`,
+      ];
+    }),
+  ];
+  execSync(
+    `docker exec ${POSTGRES_CONTAINER} psql -U postgres -d ${POSTGRES_DB} -v ON_ERROR_STOP=1 -c "${statements.join(' ')}"`,
+    { stdio: 'pipe', timeout: 10_000 },
+  );
+}
+
 /**
  * Seeds all tables, parallelizing inserts within each FK dependency level.
  *

--- a/test/it/shared/tests/llmo-referral-traffic.js
+++ b/test/it/shared/tests/llmo-referral-traffic.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import { SITE_1_ID } from '../seed-ids.js';
+
+/**
+ * Shared LLMO Referral Traffic endpoint tests.
+ *
+ * Covers the has-data handler widened in LLMO-5599:
+ *   GET /sites/:siteId/referral-traffic/has-data
+ *
+ * The handler now probes ALL five referral source tables
+ * (referral_traffic_{adobe_analytics,cja,ga4,cdn,optel}) via a direct
+ * PostgREST table existence check (LIMIT 1) and returns `availableSources`
+ * in resolution-priority order (adobe_analytics > cja > ga4 > cdn > optel),
+ * with hasData true iff any source has rows. Because this is a plain table
+ * read (not an RPC), it does not depend on the RPC-signature migrations the
+ * url-inspector IT is waiting on.
+ *
+ * NOTE on referral seeding:
+ *   The baseline IT seed does not populate the partitioned
+ *   referral_traffic_* tables, so the runnable cases below exercise the
+ *   empty-data and access-validation paths end-to-end through PostgREST. The
+ *   source-presence + priority-ordering exercises are skipped pending a
+ *   referral seed helper, mirroring the deferred referral-source exercises
+ *   in llmo-url-inspector.js.
+ *
+ * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
+ * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
+ */
+export default function llmoReferralTrafficTests(getHttpClient, resetData) {
+  describe('LLMO Referral Traffic — has-data handler (LLMO-5599)', () => {
+    before(() => resetData());
+
+    const hasDataPath = (siteId) => `/sites/${siteId}/referral-traffic/has-data`;
+
+    it('returns hasData:false and empty availableSources for a site with no referral rows', async () => {
+      const http = getHttpClient();
+      const res = await http.admin.get(hasDataPath(SITE_1_ID));
+      expect(res.status).to.equal(200);
+      expect(res.body).to.have.property('hasData', false);
+      expect(res.body).to.have.property('availableSources').that.deep.equals([]);
+    });
+
+    it('rejects an unknown site with a non-2xx (access validation runs before the probe)', async () => {
+      const http = getHttpClient();
+      const res = await http.admin.get(hasDataPath('99999999-9999-4999-8999-999999999999'));
+      expect(res.status).to.be.oneOf([400, 403, 404, 500]);
+    });
+
+    // ── Skipped: source presence + priority ordering (needs referral seed) ──
+    // Enable once the IT harness can seed rows into the partitioned
+    // referral_traffic_{optel,cdn,adobe_analytics,ga4,cja} tables. Mirrors the
+    // deferred referral-source exercises in llmo-url-inspector.js. With seeded
+    // rows for SITE_1_ID, assert availableSources is returned in
+    // resolution-priority order and hasData flips to true.
+    describe('source presence + priority ordering (skipped pending referral seed)', () => {
+      it.skip('returns availableSources in priority order when multiple sources have rows', async () => {
+        // Seed e.g. referral_traffic_adobe_analytics + referral_traffic_cdn rows
+        // for SITE_1_ID, then:
+        const http = getHttpClient();
+        const res = await http.admin.get(hasDataPath(SITE_1_ID));
+        expect(res.status).to.equal(200);
+        expect(res.body.hasData).to.equal(true);
+        expect(res.body.availableSources).to.deep.equal(['adobe_analytics', 'cdn']);
+      });
+    });
+  });
+}

--- a/test/it/shared/tests/llmo-referral-traffic.js
+++ b/test/it/shared/tests/llmo-referral-traffic.js
@@ -12,7 +12,7 @@
 
 import { expect } from 'chai';
 
-import { SITE_1_ID } from '../seed-ids.js';
+import { SITE_1_ID, SITE_2_ID, SITE_3_ID } from '../seed-ids.js';
 
 /**
  * Shared LLMO Referral Traffic endpoint tests.
@@ -54,8 +54,10 @@ export default function llmoReferralTrafficTests(getHttpClient, resetData, seedR
       const http = getHttpClient();
       const res = await http.admin.get(hasDataPath(SITE_1_ID));
       expect(res.status).to.equal(200);
+      expect(res.headers.get('cache-control')).to.equal('private, max-age=7200');
       expect(res.body).to.have.property('hasData', false);
       expect(res.body).to.have.property('availableSources').that.deep.equals([]);
+      expect(res.body).to.have.property('activeSource', null);
     });
 
     it('rejects an unknown site with a non-2xx (access validation runs before the probe)', async () => {
@@ -82,6 +84,17 @@ export default function llmoReferralTrafficTests(getHttpClient, resetData, seedR
         expect(res.status).to.equal(200);
         expect(res.body.hasData).to.equal(true);
         expect(res.body.availableSources).to.deep.equal(['adobe_analytics', 'cdn']);
+        expect(res.body.activeSource).to.equal('adobe_analytics');
+      });
+
+      it('returns a Business Impact-only source when that is the only source with rows', async () => {
+        seedReferralPresence(SITE_1_ID, ['ga4']);
+        const http = getHttpClient();
+        const res = await http.admin.get(hasDataPath(SITE_1_ID));
+        expect(res.status).to.equal(200);
+        expect(res.body.hasData).to.equal(true);
+        expect(res.body.availableSources).to.deep.equal(['ga4']);
+        expect(res.body.activeSource).to.equal('ga4');
       });
 
       it('preserves full priority order (adobe_analytics > cja > ga4 > cdn > optel) when all sources have rows', async () => {
@@ -91,6 +104,21 @@ export default function llmoReferralTrafficTests(getHttpClient, resetData, seedR
         expect(res.status).to.equal(200);
         expect(res.body.hasData).to.equal(true);
         expect(res.body.availableSources).to.deep.equal(['adobe_analytics', 'cja', 'ga4', 'cdn', 'optel']);
+        expect(res.body.activeSource).to.equal('adobe_analytics');
+      });
+
+      it('keeps source presence isolated by site and denies out-of-org user access', async () => {
+        seedReferralPresence(SITE_3_ID, ['cja']);
+        const http = getHttpClient();
+
+        const sameOrgOtherSite = await http.admin.get(hasDataPath(SITE_2_ID));
+        expect(sameOrgOtherSite.status).to.equal(200);
+        expect(sameOrgOtherSite.body.hasData).to.equal(false);
+        expect(sameOrgOtherSite.body.availableSources).to.deep.equal([]);
+        expect(sameOrgOtherSite.body.activeSource).to.equal(null);
+
+        const denied = await http.user.get(hasDataPath(SITE_3_ID));
+        expect(denied.status).to.equal(403);
       });
     });
   });

--- a/test/it/shared/tests/llmo-referral-traffic.js
+++ b/test/it/shared/tests/llmo-referral-traffic.js
@@ -42,6 +42,11 @@ import { SITE_1_ID } from '../seed-ids.js';
 export default function llmoReferralTrafficTests(getHttpClient, resetData, seedReferralPresence) {
   describe('LLMO Referral Traffic — has-data handler (LLMO-5599)', () => {
     before(() => resetData());
+    // Baseline clearData() doesn't touch the partitioned referral_traffic_*
+    // tables, so a crashed prior run could leave presence rows behind and turn
+    // the empty-data assertion red. Clear them up front so the suite is
+    // self-contained regardless of prior state.
+    before(() => seedReferralPresence(SITE_1_ID, []));
 
     const hasDataPath = (siteId) => `/sites/${siteId}/referral-traffic/has-data`;
 
@@ -56,16 +61,21 @@ export default function llmoReferralTrafficTests(getHttpClient, resetData, seedR
     it('rejects an unknown site with a non-2xx (access validation runs before the probe)', async () => {
       const http = getHttpClient();
       const res = await http.admin.get(hasDataPath('99999999-9999-4999-8999-999999999999'));
-      expect(res.status).to.be.oneOf([400, 403, 404, 500]);
+      // Access validation runs before the probe: a bad/unknown site is a client
+      // error (400/403/404). 500 is intentionally excluded so an internal crash
+      // can't masquerade as access validation.
+      expect(res.status).to.be.oneOf([400, 403, 404]);
     });
 
     describe('source presence + priority ordering', () => {
       // Clear the referral tables after each case so presence rows don't leak.
       afterEach(() => seedReferralPresence(SITE_1_ID, []));
 
-      it('returns availableSources in resolution-priority order (adobe_analytics before cdn), not insertion order', async () => {
-        // Seed cdn first to prove the ordering comes from the backend, not the
-        // order rows were written.
+      it('returns only sources that have rows, in backend priority order (excludes absent sources)', async () => {
+        // Seed a 2-source subset (cdn written first) with the other three
+        // absent: the response must drop the absent sources and order the
+        // present pair by backend priority (adobe_analytics before cdn),
+        // independent of the order rows were written.
         seedReferralPresence(SITE_1_ID, ['cdn', 'adobe_analytics']);
         const http = getHttpClient();
         const res = await http.admin.get(hasDataPath(SITE_1_ID));
@@ -79,6 +89,7 @@ export default function llmoReferralTrafficTests(getHttpClient, resetData, seedR
         const http = getHttpClient();
         const res = await http.admin.get(hasDataPath(SITE_1_ID));
         expect(res.status).to.equal(200);
+        expect(res.body.hasData).to.equal(true);
         expect(res.body.availableSources).to.deep.equal(['adobe_analytics', 'cja', 'ga4', 'cdn', 'optel']);
       });
     });

--- a/test/it/shared/tests/llmo-referral-traffic.js
+++ b/test/it/shared/tests/llmo-referral-traffic.js
@@ -29,17 +29,17 @@ import { SITE_1_ID } from '../seed-ids.js';
  * url-inspector IT is waiting on.
  *
  * NOTE on referral seeding:
- *   The baseline IT seed does not populate the partitioned
- *   referral_traffic_* tables, so the runnable cases below exercise the
- *   empty-data and access-validation paths end-to-end through PostgREST. The
- *   source-presence + priority-ordering exercises are skipped pending a
- *   referral seed helper, mirroring the deferred referral-source exercises
- *   in llmo-url-inspector.js.
+ *   The baseline IT seed does not populate the partitioned referral_traffic_*
+ *   tables, so `seedReferralPresence` inserts minimal per-source rows on demand
+ *   (see test/it/postgres/seed.js) to drive the source-presence + ordering
+ *   cases; the empty-data + access-validation cases run without it.
  *
  * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
  * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
+ * @param {(siteId: string, sources: string[]) => void} seedReferralPresence -
+ *   Seeds referral source presence for a site (see seed.js).
  */
-export default function llmoReferralTrafficTests(getHttpClient, resetData) {
+export default function llmoReferralTrafficTests(getHttpClient, resetData, seedReferralPresence) {
   describe('LLMO Referral Traffic — has-data handler (LLMO-5599)', () => {
     before(() => resetData());
 
@@ -59,21 +59,27 @@ export default function llmoReferralTrafficTests(getHttpClient, resetData) {
       expect(res.status).to.be.oneOf([400, 403, 404, 500]);
     });
 
-    // ── Skipped: source presence + priority ordering (needs referral seed) ──
-    // Enable once the IT harness can seed rows into the partitioned
-    // referral_traffic_{optel,cdn,adobe_analytics,ga4,cja} tables. Mirrors the
-    // deferred referral-source exercises in llmo-url-inspector.js. With seeded
-    // rows for SITE_1_ID, assert availableSources is returned in
-    // resolution-priority order and hasData flips to true.
-    describe('source presence + priority ordering (skipped pending referral seed)', () => {
-      it.skip('returns availableSources in priority order when multiple sources have rows', async () => {
-        // Seed e.g. referral_traffic_adobe_analytics + referral_traffic_cdn rows
-        // for SITE_1_ID, then:
+    describe('source presence + priority ordering', () => {
+      // Clear the referral tables after each case so presence rows don't leak.
+      afterEach(() => seedReferralPresence(SITE_1_ID, []));
+
+      it('returns availableSources in resolution-priority order (adobe_analytics before cdn), not insertion order', async () => {
+        // Seed cdn first to prove the ordering comes from the backend, not the
+        // order rows were written.
+        seedReferralPresence(SITE_1_ID, ['cdn', 'adobe_analytics']);
         const http = getHttpClient();
         const res = await http.admin.get(hasDataPath(SITE_1_ID));
         expect(res.status).to.equal(200);
         expect(res.body.hasData).to.equal(true);
         expect(res.body.availableSources).to.deep.equal(['adobe_analytics', 'cdn']);
+      });
+
+      it('preserves full priority order (adobe_analytics > cja > ga4 > cdn > optel) when all sources have rows', async () => {
+        seedReferralPresence(SITE_1_ID, ['optel', 'cdn', 'adobe_analytics', 'ga4', 'cja']);
+        const http = getHttpClient();
+        const res = await http.admin.get(hasDataPath(SITE_1_ID));
+        expect(res.status).to.equal(200);
+        expect(res.body.availableSources).to.deep.equal(['adobe_analytics', 'cja', 'ga4', 'cdn', 'optel']);
       });
     });
   });


### PR DESCRIPTION
## Changes Made

Widen the referral-traffic `has-data` endpoint to probe **all five** referral source tables and report them in resolution-priority order, so clients (URL Inspector, Referral Traffic) can resolve a connected analytics source ahead of the Traffic Insights sources.

- `has-data` now probes `referral_traffic_{adobe_analytics,cja,ga4,cdn,optel}` with parallel `LIMIT 1` existence checks (index-backed on `(site_id, traffic_date)`), returning `availableSources` in priority order **adobe_analytics > cja > ga4 > cdn > optel**. `hasData` is true iff any source has rows. Fail-closed behaviour on any query error is preserved.
- Export `REFERRAL_HAS_DATA_SOURCES` and probe/order by it.
- OpenAPI: `ReferralTrafficHasData.availableSources` enum + description updated (the **array order**, not the enum, is the priority contract); `docs/index.html` regenerated.

### Signal choice

"Connected" = **table-row presence** (the same existence check used for optel/cdn). The DRS pipeline only populates these tables when a provider is connected, so rows imply both connected *and* has data to show. The DRS `/providers` (`get_analytics_providers`) endpoint reports configuration, not data availability — resolving to a configured-but-empty source would render 0 hits, so it is intentionally not used here; it would also add a synchronous cross-service hop to a hot endpoint.

### Blast radius

`has-data` also feeds the onboarding overlay + Traffic-Insights tab gating. The paired frontend PR handles this: `ReferralTrafficPgDashboard` scopes its "no traffic data" detection to optel/cdn so analytics-only sites still open the Business Impact tab.

## Testing

- `npm test` (referral controller): 98 passing, including new has-data cases — ordering across combos (incl. non-adjacent), per-source presence, Business-Impact-source fail-closed, and a drift guard tying the test table list to the controller.
- Integration test (`test/it/postgres/llmo-referral-traffic.test.js`): runnable empty-data + access-validation paths pass end-to-end through PostgREST; the source-presence ordering IT is scaffolded and `.skip`ped pending a referral seed helper (mirrors the existing deferred referral-source exercises in `llmo-url-inspector.js`).
- `npm run docs:lint` valid.

## Related

- Frontend: adobe/project-elmo-ui#2086
- Relates to LLMO-5599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
