### PR TITLE
feat(preflight): log terminal run outcomes from both poll handlers

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -62,6 +62,44 @@ export function countIssuesForAudit(audit) {
 }
 
 /**
+ * Process identifiers tagged onto the preflight outcome logs so a single log
+ * line tells you which surface emitted it.
+ *  - PREFLIGHT_PROCESS_AUDW → audit-worker path: POST/GET /preflight/jobs (SQS)
+ *  - PREFLIGHT_PROCESS_MYST → Mystique path: /sites/:siteId/preflights
+ */
+export const PREFLIGHT_PROCESS_AUDW = 'audw';
+export const PREFLIGHT_PROCESS_MYST = 'myst';
+
+/**
+ * Emits the server-side observability log for a terminal AsyncJob when preflight is
+ * polled. Shared by both poll handlers — getPreflightJobStatusAndResult (audit-worker
+ * path) and getPreflightById (Mystique path) — so the two appear the same.
+ * @param {Object} log - The logger instance
+ * @param {string} processName - PREFLIGHT_PROCESS_AUDW | PREFLIGHT_PROCESS_MYST
+ * @param {string} jobId - The AsyncJob id
+ * @param {Object} job - The AsyncJob entity
+ */
+export function logPreflightOutcome(log, processName, jobId, job) {
+  const status = job.getStatus();
+  const result = job.getResult();
+  if (status === AsyncJob.Status.COMPLETED && isNonEmptyArray(result)) {
+    const summary = result.map((r) => ({
+      pageUrl: r?.pageUrl,
+      step: r?.step,
+      audits: (Array.isArray(r?.audits) ? r.audits : []).map((a) => ({
+        name: a?.name,
+        type: a?.type,
+        opportunities: Array.isArray(a?.opportunities) ? a.opportunities.length : 0,
+        issues: countIssuesForAudit(a),
+      })),
+    }));
+    log.info(`[Preflight] Run complete. jobId=${jobId} status=${status} results=${JSON.stringify(summary)} process=${processName}`);
+  } else if (status === AsyncJob.Status.FAILED) {
+    log.error(`[Preflight] Run failed. jobId=${jobId} status=${status} error=${JSON.stringify(job.getError())} process=${processName}`);
+  }
+}
+
+/**
  * Creates a preflight controller instance
  * @param {Object} ctx - The context object containing dataAccess and sqs
  * @param {Object} ctx.dataAccess - The data access layer for database operations
@@ -312,20 +350,8 @@ function PreflightController(ctx, log, env) {
       const result = job.getResult();
       const status = job.getStatus();
 
-      // Log a compact summary of the audit-worker results once the job is completed.
-      if (status === AsyncJob.Status.COMPLETED && isNonEmptyArray(result)) {
-        const summary = result.map((r) => ({
-          pageUrl: r?.pageUrl,
-          step: r?.step,
-          audits: (Array.isArray(r?.audits) ? r.audits : []).map((a) => ({
-            name: a?.name,
-            type: a?.type,
-            opportunities: Array.isArray(a?.opportunities) ? a.opportunities.length : 0,
-            issues: countIssuesForAudit(a),
-          })),
-        }));
-        log.info(`[Preflight] Run complete. jobId=${jobId} status=${status} results=${JSON.stringify(summary)}`);
-      }
+      // Emit the terminal-state observability log (shared with the Mystique path).
+      logPreflightOutcome(log, PREFLIGHT_PROCESS_AUDW, jobId, job);
 
       return ok({
         jobId: job.getId(),
@@ -768,6 +794,11 @@ function PreflightController(ctx, log, env) {
         const msg = e?.message ?? String(e);
         log.warn(`Failed to fetch AsyncJob for preflight ${preflightId}: ${msg}`);
         return preflightError('PREFLIGHT_LIFECYCLE_UNAVAILABLE', 'Failed to load preflight lifecycle data', 503);
+      }
+
+      // Log terminal state if asyncJob exists
+      if (asyncJob) {
+        logPreflightOutcome(log, PREFLIGHT_PROCESS_MYST, asyncJob.getId(), asyncJob);
       }
 
       return ok(PreflightDto.toDetailJSON(preflight, asyncJob));

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -76,10 +76,10 @@ export const PREFLIGHT_PROCESS_MYST = 'myst';
  * path) and getPreflightById (Mystique path) — so the two appear the same.
  * @param {Object} log - The logger instance
  * @param {string} processName - PREFLIGHT_PROCESS_AUDW | PREFLIGHT_PROCESS_MYST
- * @param {string} jobId - The AsyncJob id
- * @param {Object} job - The AsyncJob entity
+ * @param {Object} job - The AsyncJob entity (its getId() is the logged jobId)
  */
-export function logPreflightOutcome(log, processName, jobId, job) {
+export function logPreflightOutcome(log, processName, job) {
+  const jobId = job.getId();
   const status = job.getStatus();
   const result = job.getResult();
   if (status === AsyncJob.Status.COMPLETED && isNonEmptyArray(result)) {
@@ -93,9 +93,10 @@ export function logPreflightOutcome(log, processName, jobId, job) {
         issues: countIssuesForAudit(a),
       })),
     }));
-    log.info(`[Preflight] Run complete. jobId=${jobId} status=${status} results=${JSON.stringify(summary)} process=${processName}`);
+    log.info(`[Preflight] Run complete. jobId=${jobId} process=${processName} status=${status} results=${JSON.stringify(summary)}`);
   } else if (status === AsyncJob.Status.FAILED) {
-    log.error(`[Preflight] Run failed. jobId=${jobId} status=${status} error=${JSON.stringify(job.getError())} process=${processName}`);
+    const err = job.getError();
+    log.warn(`[Preflight] Run failed. jobId=${jobId} process=${processName} status=${status} errorCode=${err?.code ?? 'none'} errorMessage=${err?.message ?? 'none'}`);
   }
 }
 
@@ -348,7 +349,7 @@ function PreflightController(ctx, log, env) {
       log.debug(`getPreflightJobStatusAndResult returning job: ${JSON.stringify(job)}`);
 
       // Emit the terminal-state observability log (shared with the Mystique path).
-      logPreflightOutcome(log, PREFLIGHT_PROCESS_AUDW, jobId, job);
+      logPreflightOutcome(log, PREFLIGHT_PROCESS_AUDW, job);
 
       return ok({
         jobId: job.getId(),
@@ -793,9 +794,8 @@ function PreflightController(ctx, log, env) {
         return preflightError('PREFLIGHT_LIFECYCLE_UNAVAILABLE', 'Failed to load preflight lifecycle data', 503);
       }
 
-      // Log terminal state if asyncJob exists
       if (asyncJob) {
-        logPreflightOutcome(log, PREFLIGHT_PROCESS_MYST, asyncJob.getId(), asyncJob);
+        logPreflightOutcome(log, PREFLIGHT_PROCESS_MYST, asyncJob);
       }
 
       return ok(PreflightDto.toDetailJSON(preflight, asyncJob));

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -347,15 +347,12 @@ function PreflightController(ctx, log, env) {
 
       log.debug(`getPreflightJobStatusAndResult returning job: ${JSON.stringify(job)}`);
 
-      const result = job.getResult();
-      const status = job.getStatus();
-
       // Emit the terminal-state observability log (shared with the Mystique path).
       logPreflightOutcome(log, PREFLIGHT_PROCESS_AUDW, jobId, job);
 
       return ok({
         jobId: job.getId(),
-        status,
+        status: job.getStatus(),
         createdAt: job.getCreatedAt(),
         updatedAt: job.getUpdatedAt(),
         startedAt: job.getStartedAt(),
@@ -363,7 +360,7 @@ function PreflightController(ctx, log, env) {
         recordExpiresAt: job.getRecordExpiresAt(),
         resultLocation: job.getResultLocation(),
         resultType: job.getResultType(),
-        result,
+        result: job.getResult(),
         error: job.getError(),
         metadata: job.getMetadata(),
       });

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -98,7 +98,7 @@ export function logPreflightOutcome(log, processName, job) {
     const err = job.getError();
     log.warn(`[Preflight] Run failed. jobId=${jobId} process=${processName} status=${status} errorCode=${err?.code ?? 'none'} errorMessage=${err?.message ?? 'none'}`);
   } else {
-    log.info(`[Preflight] Run in process.  status=${status}`);
+    log.info(`[Preflight] Run in progress.  status=${status}`);
   }
 }
 

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -97,6 +97,8 @@ export function logPreflightOutcome(log, processName, job) {
   } else if (status === AsyncJob.Status.FAILED) {
     const err = job.getError();
     log.warn(`[Preflight] Run failed. jobId=${jobId} process=${processName} status=${status} errorCode=${err?.code ?? 'none'} errorMessage=${err?.message ?? 'none'}`);
+  } else {
+    log.info(`[Preflight] Run in process.  status=${status}`);
   }
 }
 

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -97,8 +97,6 @@ export function logPreflightOutcome(log, processName, job) {
   } else if (status === AsyncJob.Status.FAILED) {
     const err = job.getError();
     log.warn(`[Preflight] Run failed. jobId=${jobId} process=${processName} status=${status} errorCode=${err?.code ?? 'none'} errorMessage=${err?.message ?? 'none'}`);
-  } else {
-    log.info(`[Preflight] Run in progress.  status=${status}`);
   }
 }
 

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -21,7 +21,11 @@ import { Site as SiteModel } from '@adobe/spacecat-shared-data-access';
 import esmock from 'esmock';
 
 import * as utils from '../../src/support/utils.js';
-import PreflightController, { countIssuesForAudit } from '../../src/controllers/preflight.js';
+import PreflightController, {
+  countIssuesForAudit,
+  PREFLIGHT_PROCESS_AUDW,
+  PREFLIGHT_PROCESS_MYST,
+} from '../../src/controllers/preflight.js';
 
 // Make fetch available globally
 global.fetch = fetch;
@@ -2276,10 +2280,12 @@ describe('Preflight Controller', () => {
 
       const infoCall = loggerStub.info.getCalls()
         .find((c) => typeof c.args[0] === 'string'
-          && c.args[0].includes(`[Preflight] Run complete. jobId=${jobId}`)
+          && c.args[0].includes('[Preflight] Run complete.')
+          && c.args[0].includes(`process=${PREFLIGHT_PROCESS_AUDW}`)
+          && c.args[0].includes(`jobId=${jobId}`)
           && c.args[0].includes('status=COMPLETED'));
       expect(infoCall, 'expected a [Preflight] jobId info log').to.not.be.undefined;
-      const logged = JSON.parse(infoCall.args[0].split('results=')[1]);
+      const logged = JSON.parse(infoCall.args[0].split('results=')[1].split(' process=')[0]);
       expect(logged).to.deep.equal([
         {
           pageUrl: 'https://main--example-site.aem.page/test.html',
@@ -2326,10 +2332,12 @@ describe('Preflight Controller', () => {
 
       const infoCall = loggerStub.info.getCalls()
         .find((c) => typeof c.args[0] === 'string'
-          && c.args[0].includes(`[Preflight] Run complete. jobId=${jobId}`)
+          && c.args[0].includes('[Preflight] Run complete.')
+          && c.args[0].includes(`process=${PREFLIGHT_PROCESS_AUDW}`)
+          && c.args[0].includes(`jobId=${jobId}`)
           && c.args[0].includes('status=COMPLETED'));
       expect(infoCall, 'expected a [Preflight] jobId info log').to.not.be.undefined;
-      const logged = JSON.parse(infoCall.args[0].split('results=')[1]);
+      const logged = JSON.parse(infoCall.args[0].split('results=')[1].split(' process=')[0]);
       expect(logged).to.deep.equal([
         { pageUrl: 'https://main--example-site.aem.page/a.html', step: 'identify', audits: [] },
         {
@@ -2362,8 +2370,73 @@ describe('Preflight Controller', () => {
       expect(response.status).to.equal(200);
 
       const infoCall = loggerStub.info.getCalls()
-        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes(`[Preflight] Run complete. jobId=${jobId}`));
+        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run complete.'));
       expect(infoCall, 'expected no [Preflight] jobId info log while IN_PROGRESS').to.be.undefined;
+    });
+
+    it('logs an error with the stringified error payload when the job is FAILED', async () => {
+      loggerStub.error.resetHistory();
+      const failedError = { code: 'MYSTICAT_ERROR', message: 'Upstream analyze service failed' };
+      const failedJob = {
+        ...mockJob,
+        getStatus: () => 'FAILED',
+        getError: () => failedError,
+      };
+      mockDataAccess.AsyncJob.findById.resolves(failedJob);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const errorCall = loggerStub.error.getCalls()
+        .find((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes('[Preflight] Run failed.')
+          && c.args[0].includes(`process=${PREFLIGHT_PROCESS_AUDW}`)
+          && c.args[0].includes(`jobId=${jobId}`)
+          && c.args[0].includes('status=FAILED'));
+      expect(errorCall, 'expected a [Preflight] Run failed error log').to.not.be.undefined;
+      expect(errorCall.args[0]).to.include(`error=${JSON.stringify(failedError)}`);
+    });
+
+    it('logs error=null when the job is FAILED without a structured error', async () => {
+      loggerStub.error.resetHistory();
+      const failedJob = {
+        ...mockJob,
+        getStatus: () => 'FAILED',
+        getError: () => null,
+      };
+      mockDataAccess.AsyncJob.findById.resolves(failedJob);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const errorCall = loggerStub.error.getCalls()
+        .find((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes('[Preflight] Run failed.')
+          && c.args[0].includes(`process=${PREFLIGHT_PROCESS_AUDW}`)
+          && c.args[0].includes(`jobId=${jobId}`)
+          && c.args[0].includes('status=FAILED'));
+      expect(errorCall, 'expected a [Preflight] Run failed error log').to.not.be.undefined;
+      expect(errorCall.args[0]).to.include('error=null');
+    });
+
+    it('does not log a failure for a COMPLETED job', async () => {
+      loggerStub.error.resetHistory();
+      const completedJob = {
+        ...mockJob,
+        getStatus: () => 'COMPLETED',
+        getResult: () => [],
+      };
+      mockDataAccess.AsyncJob.findById.resolves(completedJob);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const errorCall = loggerStub.error.getCalls()
+        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run failed.'));
+      expect(errorCall, 'expected no [Preflight] Run failed error log for a COMPLETED job').to.be.undefined;
     });
 
     it('returns 400 Bad Request for invalid job ID', async () => {
@@ -2715,6 +2788,75 @@ describe('Preflight Controller', () => {
       expect(response.status).to.equal(500);
       const result = await response.json();
       expect(result.errorCode).to.equal('PREFLIGHT_INTERNAL_ERROR');
+    });
+
+    it('logs a run-complete summary tagged with the myst process', async () => {
+      loggerStub.info.resetHistory();
+      const completedJob = {
+        ...mockJob,
+        getStatus: () => 'COMPLETED',
+        getResult: () => [
+          {
+            pageUrl: 'https://main--example-site.aem.page/test.html',
+            step: 'suggest',
+            audits: [{ name: 'metatags', type: 'seo', opportunities: [{ issue: 'Title too short' }] }],
+          },
+        ],
+      };
+      mockPreflight.getAsyncJob = sandbox.stub().resolves(completedJob);
+
+      const response = await preflightController.getPreflightById({
+        params: { siteId: 'test-site-123', preflightId },
+      });
+      expect(response.status).to.equal(200);
+
+      const infoCall = loggerStub.info.getCalls()
+        .find((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes('[Preflight] Run complete.')
+          && c.args[0].includes(`process=${PREFLIGHT_PROCESS_MYST}`)
+          && c.args[0].includes(`jobId=${jobId}`)
+          && c.args[0].includes('status=COMPLETED'));
+      expect(infoCall, 'expected a myst-process [Preflight] Run complete info log').to.not.be.undefined;
+    });
+
+    it('logs a run-failed error tagged with the myst process', async () => {
+      loggerStub.error.resetHistory();
+      const failedError = { code: 'MYSTICAT_ERROR', message: 'Upstream analyze service failed' };
+      const failedJob = {
+        ...mockJob,
+        getStatus: () => 'FAILED',
+        getError: () => failedError,
+      };
+      mockPreflight.getAsyncJob = sandbox.stub().resolves(failedJob);
+
+      const response = await preflightController.getPreflightById({
+        params: { siteId: 'test-site-123', preflightId },
+      });
+      expect(response.status).to.equal(200);
+
+      const errorCall = loggerStub.error.getCalls()
+        .find((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes('[Preflight] Run failed.')
+          && c.args[0].includes(`process=${PREFLIGHT_PROCESS_MYST}`)
+          && c.args[0].includes(`jobId=${jobId}`)
+          && c.args[0].includes('status=FAILED'));
+      expect(errorCall, 'expected a myst-process [Preflight] Run failed error log').to.not.be.undefined;
+      expect(errorCall.args[0]).to.include(`error=${JSON.stringify(failedError)}`);
+    });
+
+    it('does not emit an outcome log when no AsyncJob is linked yet (null job)', async () => {
+      loggerStub.info.resetHistory();
+      loggerStub.error.resetHistory();
+      mockPreflight.getAsyncJob = sandbox.stub().resolves(null);
+
+      const response = await preflightController.getPreflightById({
+        params: { siteId: 'test-site-123', preflightId },
+      });
+      expect(response.status).to.equal(200);
+
+      const outcomeLog = [...loggerStub.info.getCalls(), ...loggerStub.error.getCalls()]
+        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run'));
+      expect(outcomeLog, 'expected no outcome log when AsyncJob is null').to.be.undefined;
     });
   });
 });

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -2285,7 +2285,7 @@ describe('Preflight Controller', () => {
           && c.args[0].includes(`jobId=${jobId}`)
           && c.args[0].includes('status=COMPLETED'));
       expect(infoCall, 'expected a [Preflight] jobId info log').to.not.be.undefined;
-      const logged = JSON.parse(infoCall.args[0].split('results=')[1].split(' process=')[0]);
+      const logged = JSON.parse(infoCall.args[0].split('results=')[1]);
       expect(logged).to.deep.equal([
         {
           pageUrl: 'https://main--example-site.aem.page/test.html',
@@ -2337,7 +2337,7 @@ describe('Preflight Controller', () => {
           && c.args[0].includes(`jobId=${jobId}`)
           && c.args[0].includes('status=COMPLETED'));
       expect(infoCall, 'expected a [Preflight] jobId info log').to.not.be.undefined;
-      const logged = JSON.parse(infoCall.args[0].split('results=')[1].split(' process=')[0]);
+      const logged = JSON.parse(infoCall.args[0].split('results=')[1]);
       expect(logged).to.deep.equal([
         { pageUrl: 'https://main--example-site.aem.page/a.html', step: 'identify', audits: [] },
         {
@@ -2374,9 +2374,9 @@ describe('Preflight Controller', () => {
       expect(infoCall, 'expected no [Preflight] jobId info log while IN_PROGRESS').to.be.undefined;
     });
 
-    it('logs an error with the stringified error payload when the job is FAILED', async () => {
-      loggerStub.error.resetHistory();
-      const failedError = { code: 'MYSTICAT_ERROR', message: 'Upstream analyze service failed' };
+    it('warns with code + message (not the full error object) when the job is FAILED', async () => {
+      loggerStub.warn.resetHistory();
+      const failedError = { code: 'MYSTICAT_ERROR', message: 'Upstream analyze service failed', details: { secret: 'tok' } };
       const failedJob = {
         ...mockJob,
         getStatus: () => 'FAILED',
@@ -2388,18 +2388,22 @@ describe('Preflight Controller', () => {
       const response = await preflightController.getPreflightJobStatusAndResult(context);
       expect(response.status).to.equal(200);
 
-      const errorCall = loggerStub.error.getCalls()
+      const warnCall = loggerStub.warn.getCalls()
         .find((c) => typeof c.args[0] === 'string'
           && c.args[0].includes('[Preflight] Run failed.')
           && c.args[0].includes(`process=${PREFLIGHT_PROCESS_AUDW}`)
           && c.args[0].includes(`jobId=${jobId}`)
           && c.args[0].includes('status=FAILED'));
-      expect(errorCall, 'expected a [Preflight] Run failed error log').to.not.be.undefined;
-      expect(errorCall.args[0]).to.include(`error=${JSON.stringify(failedError)}`);
+      expect(warnCall, 'expected a [Preflight] Run failed warn log').to.not.be.undefined;
+      expect(warnCall.args[0]).to.include('errorCode=MYSTICAT_ERROR');
+      expect(warnCall.args[0]).to.include('errorMessage=Upstream analyze service failed');
+      // details must NOT be logged (never log secrets / freeform worker content)
+      expect(warnCall.args[0]).to.not.include('details');
+      expect(warnCall.args[0]).to.not.include('tok');
     });
 
-    it('logs error=null when the job is FAILED without a structured error', async () => {
-      loggerStub.error.resetHistory();
+    it('warns with errorCode=none when the job is FAILED without a structured error', async () => {
+      loggerStub.warn.resetHistory();
       const failedJob = {
         ...mockJob,
         getStatus: () => 'FAILED',
@@ -2411,18 +2415,55 @@ describe('Preflight Controller', () => {
       const response = await preflightController.getPreflightJobStatusAndResult(context);
       expect(response.status).to.equal(200);
 
-      const errorCall = loggerStub.error.getCalls()
+      const warnCall = loggerStub.warn.getCalls()
         .find((c) => typeof c.args[0] === 'string'
           && c.args[0].includes('[Preflight] Run failed.')
           && c.args[0].includes(`process=${PREFLIGHT_PROCESS_AUDW}`)
           && c.args[0].includes(`jobId=${jobId}`)
           && c.args[0].includes('status=FAILED'));
-      expect(errorCall, 'expected a [Preflight] Run failed error log').to.not.be.undefined;
-      expect(errorCall.args[0]).to.include('error=null');
+      expect(warnCall, 'expected a [Preflight] Run failed warn log').to.not.be.undefined;
+      expect(warnCall.args[0]).to.include('errorCode=none');
+      expect(warnCall.args[0]).to.include('errorMessage=none');
+    });
+
+    it('logs FAILED at warn level, not error', async () => {
+      loggerStub.warn.resetHistory();
+      loggerStub.error.resetHistory();
+      const failedJob = {
+        ...mockJob,
+        getStatus: () => 'FAILED',
+        getError: () => ({ code: 'MYSTICAT_ERROR', message: 'boom' }),
+      };
+      mockDataAccess.AsyncJob.findById.resolves(failedJob);
+
+      await preflightController.getPreflightJobStatusAndResult({ params: { jobId } });
+
+      const errorRunFailed = loggerStub.error.getCalls()
+        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run failed.'));
+      expect(errorRunFailed, 'FAILED must not be logged at error level').to.be.undefined;
+    });
+
+    it('re-logs the terminal outcome on every poll (stateless — one warn per poll)', async () => {
+      loggerStub.warn.resetHistory();
+      const failedJob = {
+        ...mockJob,
+        getStatus: () => 'FAILED',
+        getError: () => ({ code: 'MYSTICAT_ERROR', message: 'boom' }),
+      };
+      mockDataAccess.AsyncJob.findById.resolves(failedJob);
+
+      const context = { params: { jobId } };
+      await preflightController.getPreflightJobStatusAndResult(context);
+      await preflightController.getPreflightJobStatusAndResult(context);
+      await preflightController.getPreflightJobStatusAndResult(context);
+
+      const runFailedWarns = loggerStub.warn.getCalls()
+        .filter((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run failed.'));
+      expect(runFailedWarns).to.have.lengthOf(3);
     });
 
     it('does not log a failure for a COMPLETED job', async () => {
-      loggerStub.error.resetHistory();
+      loggerStub.warn.resetHistory();
       const completedJob = {
         ...mockJob,
         getStatus: () => 'COMPLETED',
@@ -2434,9 +2475,9 @@ describe('Preflight Controller', () => {
       const response = await preflightController.getPreflightJobStatusAndResult(context);
       expect(response.status).to.equal(200);
 
-      const errorCall = loggerStub.error.getCalls()
+      const warnCall = loggerStub.warn.getCalls()
         .find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run failed.'));
-      expect(errorCall, 'expected no [Preflight] Run failed error log for a COMPLETED job').to.be.undefined;
+      expect(warnCall, 'expected no [Preflight] Run failed warn log for a COMPLETED job').to.be.undefined;
     });
 
     it('returns 400 Bad Request for invalid job ID', async () => {
@@ -2819,9 +2860,10 @@ describe('Preflight Controller', () => {
       expect(infoCall, 'expected a myst-process [Preflight] Run complete info log').to.not.be.undefined;
     });
 
-    it('logs a run-failed error tagged with the myst process', async () => {
+    it('warns (not errors) with code + message tagged with the myst process when FAILED', async () => {
+      loggerStub.warn.resetHistory();
       loggerStub.error.resetHistory();
-      const failedError = { code: 'MYSTICAT_ERROR', message: 'Upstream analyze service failed' };
+      const failedError = { code: 'MYSTICAT_ERROR', message: 'Upstream analyze service failed', details: { secret: 'tok' } };
       const failedJob = {
         ...mockJob,
         getStatus: () => 'FAILED',
@@ -2834,18 +2876,24 @@ describe('Preflight Controller', () => {
       });
       expect(response.status).to.equal(200);
 
-      const errorCall = loggerStub.error.getCalls()
+      const warnCall = loggerStub.warn.getCalls()
         .find((c) => typeof c.args[0] === 'string'
           && c.args[0].includes('[Preflight] Run failed.')
           && c.args[0].includes(`process=${PREFLIGHT_PROCESS_MYST}`)
           && c.args[0].includes(`jobId=${jobId}`)
           && c.args[0].includes('status=FAILED'));
-      expect(errorCall, 'expected a myst-process [Preflight] Run failed error log').to.not.be.undefined;
-      expect(errorCall.args[0]).to.include(`error=${JSON.stringify(failedError)}`);
+      expect(warnCall, 'expected a myst-process [Preflight] Run failed warn log').to.not.be.undefined;
+      expect(warnCall.args[0]).to.include('errorCode=MYSTICAT_ERROR');
+      expect(warnCall.args[0]).to.include('errorMessage=Upstream analyze service failed');
+      expect(warnCall.args[0]).to.not.include('tok');
+      const errorRunFailed = loggerStub.error.getCalls()
+        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run failed.'));
+      expect(errorRunFailed, 'FAILED must not be logged at error level').to.be.undefined;
     });
 
     it('does not emit an outcome log when no AsyncJob is linked yet (null job)', async () => {
       loggerStub.info.resetHistory();
+      loggerStub.warn.resetHistory();
       loggerStub.error.resetHistory();
       mockPreflight.getAsyncJob = sandbox.stub().resolves(null);
 
@@ -2854,8 +2902,11 @@ describe('Preflight Controller', () => {
       });
       expect(response.status).to.equal(200);
 
-      const outcomeLog = [...loggerStub.info.getCalls(), ...loggerStub.error.getCalls()]
-        .find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run'));
+      const outcomeLog = [
+        ...loggerStub.info.getCalls(),
+        ...loggerStub.warn.getCalls(),
+        ...loggerStub.error.getCalls(),
+      ].find((c) => typeof c.args[0] === 'string' && c.args[0].includes('[Preflight] Run'));
       expect(outcomeLog, 'expected no outcome log when AsyncJob is null').to.be.undefined;
     });
   });


### PR DESCRIPTION
Emit a server-side observability log when a preflight AsyncJob reaches a terminal state on poll. Previously getPreflightById (Mystique path) logged nothing and getPreflightJobStatusAndResult (audit-worker path) logged only the COMPLETED summary, so failed runs were invisible in spacecat-api logs.

Extract the shared logPreflightOutcome helper so both handlers stay in lockstep as the Mysticat migration proceeds in stages, and tag each line with process=audw|myst (emitted last) to identify which surface emitted it. jobId is the AsyncJob id — the same key the worker/Mystique log as async_job_id — so failures are joinable across processes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
https://jira.corp.adobe.com/browse/SITES-47550

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
