### PR TITLE
fix(SITES-44243): accept account-type suffix in IMS ID regex for executedByUser enrichment

### DIFF
--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -50,7 +50,9 @@ const VALIDATION_ERROR_NAME = 'ValidationError';
 // The auth source (after `@`) is a named source (AdobeID/AdobeOrg/Email/AdobeServices)
 // or a hex org id that may carry a single-letter account-type suffix, e.g.
 // `...495fcd.e` for reference/trial orgs — plain emails and system markers stay rejected.
-const IMS_ID_RE = /^[A-Za-z0-9]+@(AdobeID|AdobeOrg|Email|AdobeServices|[0-9a-fA-F]{16,}(?:\.[a-z])?)$/;
+// The hex run is bounded (16-40) to keep this security guard tight: it is the sole
+// gate preventing arbitrary stored values from reaching getImsAdminProfile.
+const IMS_ID_RE = /^[A-Za-z0-9]+@(AdobeID|AdobeOrg|Email|AdobeServices|[0-9a-fA-F]{16,40}(?:\.[a-z])?)$/;
 const IMS_ENRICH_BATCH_SIZE = 5;
 
 /**

--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -47,7 +47,10 @@ const VALIDATION_ERROR_NAME = 'ValidationError';
 // Only pass IMS-format IDs to the admin profile API. Rejects legacy or malformed
 // values that could have been stored before the server-side derivation fix, closing
 // the residual PII exfiltration path for pre-fix data.
-const IMS_ID_RE = /^[A-Za-z0-9]+@(AdobeID|AdobeOrg|Email|AdobeServices|[0-9a-fA-F]{24})$/;
+// The auth source (after `@`) is a named source (AdobeID/AdobeOrg/Email/AdobeServices)
+// or a hex org id that may carry a single-letter account-type suffix, e.g.
+// `...495fcd.e` for reference/trial orgs — plain emails and system markers stay rejected.
+const IMS_ID_RE = /^[A-Za-z0-9]+@(AdobeID|AdobeOrg|Email|AdobeServices|[0-9a-fA-F]{16,}(?:\.[a-z])?)$/;
 const IMS_ENRICH_BATCH_SIZE = 5;
 
 /**

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -388,6 +388,44 @@ describe('Fixes Controller', () => {
       expect(mockImsClient.getImsAdminProfile).to.not.have.been.called;
     });
 
+    [
+      { label: 'two-letter account-type suffix', id: 'AE751E8367B35D520A495CD3@41a2251964070a8d495fcd.ee' },
+      { label: 'digit account-type suffix', id: 'AE751E8367B35D520A495CD3@41a2251964070a8d495fcd.1' },
+      { label: 'trailing dot without suffix', id: 'AE751E8367B35D520A495CD3@41a2251964070a8d495fcd.' },
+      { label: 'hex run exceeding the upper bound', id: `AE751E8367B35D520A495CD3@${'a'.repeat(41)}` },
+    ].forEach(({ label, id }) => {
+      it(`skips IMS lookup when executedBy has a ${label}`, async () => {
+        const mockImsClient = {
+          getImsAdminProfile: sandbox.stub().resolves({
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john.doe@example.com',
+          }),
+        };
+        fixesController = new FixesController(
+          { dataAccess, log, imsClient: mockImsClient },
+          accessControlUtil,
+        );
+
+        const fixEntity = await fixEntityCollection.create({
+          type: Suggestion.TYPES.CONTENT_UPDATE,
+          opportunityId,
+          executedBy: id,
+          changeDetails: { arbitrary: 'value 1' },
+        });
+        fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+          .withArgs(opportunityId)
+          .resolves([{ fixEntity, suggestions: [] }]);
+
+        const response = await fixesController.getAllForOpportunity(requestContext);
+
+        expect(response).includes({ status: 200 });
+        const result = await response.json();
+        expect(result[0]).to.not.have.property('executedByUser');
+        expect(mockImsClient.getImsAdminProfile).to.not.have.been.called;
+      });
+    });
+
     it('skips IMS lookup when no fix has executedBy', async () => {
       const mockImsClient = {
         getImsAdminProfile: sandbox.stub().resolves({

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -320,6 +320,43 @@ describe('Fixes Controller', () => {
       expect(mockImsClient.getImsAdminProfile).to.have.been.calledOnceWith(hexOrgUserId);
     });
 
+    it('hydrates executedByUser when executedBy has an account-type suffix (reference/trial org)', async () => {
+      const suffixedUserId = 'AE751E8367B35D520A495CD3@41a2251964070a8d495fcd.e';
+      const mockImsClient = {
+        getImsAdminProfile: sandbox.stub().resolves({
+          first_name: 'Sandesh',
+          last_name: 'Sinha',
+          email: 'sandsinh@adobe.com',
+        }),
+      };
+      fixesController = new FixesController(
+        { dataAccess, log, imsClient: mockImsClient },
+        accessControlUtil,
+      );
+
+      const fixEntity = await fixEntityCollection.create({
+        type: Suggestion.TYPES.CONTENT_UPDATE,
+        opportunityId,
+        executedBy: suffixedUserId,
+        changeDetails: { arbitrary: 'value 1' },
+      });
+      fixEntityCollection.getAllFixesWithSuggestionsByOpportunityId
+        .withArgs(opportunityId)
+        .resolves([{ fixEntity, suggestions: [] }]);
+
+      const response = await fixesController.getAllForOpportunity(requestContext);
+
+      expect(response).includes({ status: 200 });
+      const result = await response.json();
+      expect(result[0]).to.have.property('executedByUser');
+      expect(result[0].executedByUser).to.deep.equal({
+        firstName: 'Sandesh',
+        lastName: 'Sinha',
+        email: 'sandsinh@adobe.com',
+      });
+      expect(mockImsClient.getImsAdminProfile).to.have.been.calledOnceWith(suffixedUserId);
+    });
+
     it('skips IMS lookup when executedBy is a plain email address', async () => {
       const mockImsClient = {
         getImsAdminProfile: sandbox.stub().resolves({


### PR DESCRIPTION
## Problem

`executedByUser` enrichment in `getAllForOpportunity` / `getByID` is gated by `IMS_ID_RE` in `src/controllers/fixes.js`. `#enrichFixesWithUserNames` only calls the IMS admin-profile API for `executedBy` values that match this regex.

Reference/trial orgs (e.g. **AEM Reference Demo Shared**) mint IMS user ids whose auth source carries a single-letter **account-type suffix**, e.g.:

```
AE751E8367B35D520A495CD3@41a2251964070a8d495fcd.e
                         └────── auth source ──────┘
```

The previous `[0-9a-fA-F]{24}` branch rejected these (the `.e` is not hex — the auth source is 22 hex + `.e`), so the IMS lookup was skipped and `executedByUser` was **never resolved** for those orgs. Clean 24-hex auth sources (e.g. **AEM Sites Engineering**, `...@9bcd5ee55f43b6f30a494212`) resolved fine — which is exactly the discrepancy observed between the two orgs.

`getImsAdminProfile` itself handles these ids correctly (it just splits on `@` into `guid` + `auth_src`); the regex was the only blocker.

## Fix

Widen the hex auth-source branch to allow an optional single-letter account-type suffix:

```diff
-const IMS_ID_RE = /^[A-Za-z0-9]+@(AdobeID|AdobeOrg|Email|AdobeServices|[0-9a-fA-F]{24})$/;
+const IMS_ID_RE = /^[A-Za-z0-9]+@(AdobeID|AdobeOrg|Email|AdobeServices|[0-9a-fA-F]{16,}(?:\.[a-z])?)$/;
```

The guard's intent is preserved — plain emails (`rpapani@adobe.com`) and system markers (`local-dev-admin`, `anonymous`, `github-webhook`) remain rejected because they have no `@` or a non-hex auth source. Verified against both org id formats plus all reject cases.

## Testing

- Added a controller test: `hydrates executedByUser when executedBy has an account-type suffix (reference/trial org)`.
- Full `test/controllers/fixes.test.js` suite passes (131 passing).
- `eslint` clean on changed files.

## Related Issues

SITES-44243

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)