### PR TITLE
feat: Semrush Elements owned-urls endpoint | LLMO-6086

### DIFF
--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -5,7 +5,7 @@
   of the License at http://www.apache.org/licenses/LICENSE-2.0
 -->
 
-# LLMO Semrush Elements API — Filter Dimensions, Weeks, Prompts & Cited Domains
+# LLMO Semrush Elements API — Filter Dimensions, Weeks, Prompts, Cited Domains & Owned URLs
 
 SpaceCat wrapper endpoints over the Semrush Elements APIs for the Brand Presence / URL Inspector dashboards.
 
@@ -19,7 +19,8 @@ SpaceCat wrapper endpoints over the Semrush Elements APIs for the Brand Presence
 2. [List Weeks](#2-list-weeks)
 3. [List Prompts](#3-list-prompts)
 4. [List Cited Domains](#4-list-cited-domains)
-5. [Supported Models](#5-supported-models)
+5. [List Owned URLs](#5-list-owned-urls)
+6. [Supported Models](#6-supported-models)
 
 ---
 
@@ -331,7 +332,79 @@ Rows are sorted by `totalCitations` **descending** and sliced client-side (Semru
 
 ---
 
-## 5. Supported Models
+## 5. List Owned URLs
+
+**`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls`**
+
+Returns the brand's own cited URLs with per-URL citation metrics + weekly trends, for the URL Inspector **"Your cited URLs"** table. **Drop-in compatible with the legacy `url-inspector/owned-urls` contract.** **Hybrid data source:** citations + trends come from Semrush; agentic + referral traffic come from Adobe Postgres (a separate pipeline), joined by `(site_id, url_path)`.
+
+### Parameters
+
+| Name | In | Required | Description |
+|---|---|---|---|
+| `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
+| `brandId` | path | ✅ | SpaceCat brand UUID. Selects the brand's Semrush **sub-workspace** (flat-mode falls back to the org parent). LLMO ReBAC `brand` resource (FACS `llmo/can_view`); requires `brand:read`. `404` if not in the org |
+| `model` / `platform` | query | ❌ | AI model filter (`model` wins). Default `search-gpt` |
+| `startDate` / `start_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing, malformed, or after `endDate` |
+| `endDate` / `end_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing or malformed |
+| `categoryId` / `category` | query | ❌ | Category label → tag `category:<label>` (server-side, stats element) |
+| `region` | query | ❌ | Region code (e.g. `US`). Resolved to the market's Semrush **project**. `all`/absent → all the brand's markets (queried per-project) |
+| `siteId` / `site_id` | query | ❌ | SpaceCat site UUID for the **traffic** join only. Validated to belong to `brandId` (`400` otherwise). Absent → agentic/referral degrade to `0`/`[]` |
+| `referralSource` / `referral_source` | query | ❌ | `optel` (default) \| `cdn` \| `ga4` \| `adobe_analytics` \| `cja` — selects the referral source table |
+| `page` | query | ❌ | 0-based page index (default `0`) |
+| `pageSize` | query | ❌ | Rows per page (default `50`, clamped to `[1, 1000]`) |
+
+### Underlying Elements
+
+| Element | UUID | Shape | Role |
+|---|---|---|---|
+| `STATS_PER_URL` | `9af5ed83-049b-493a-85d7-99c7d4deddba` | `table` | Per-URL citations (`source`, `citations`, `prompts_with_citation`, `domain_type`, `project_id`) |
+| `URL_TRENDS` | `afb2e5d3-3955-4e0d-aeb1-7e28cdecd9f9` | `line` | Weekly per-URL trend — **all URLs in ONE call** (`legend`=url, `x`=week, `y__mentions`, `y__positions`) |
+
+Both are scoped by top-level `project_id` + date + `CBF_model`. The endpoint fans out **per project** (per market) — each call stays under the Semrush **50,000-row cap** (a workspace-wide call hits it) and carries its region — then merges. Traffic comes from `rpc_url_inspector_owned_urls_traffic` (mysticat-data-service, LLMO-6086), which takes the page's URLs and joins `agentic_traffic_weekly` + `referral_traffic_<source>` by `(site_id, url_path)`.
+
+### What it returns
+
+Only `domain_type='Owned'` rows are kept (client-side — the element has no server-side content-type filter). URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full owned count. Traffic is joined for the current page's URLs only. Field mapping:
+
+- **`url`** ← `source`; **`citations`** ← `citations`; **`promptsCited`** ← `prompts_with_citation`
+- **`regions`** ← the region code(s) of the project(s) the URL appears in
+- **`weeklyCitations`** ← trend rows grouped by URL: `{ week: 'YYYY-Www', value: y__mentions }`
+- **`agenticHits` / `agenticHitsTrend` / `referralHits` / `referralHitsTrend`** ← Postgres traffic RPC (`0`/`[]` when no match)
+- **`urlId`** → `''`, **`products`** → `[]`, **`weeklyPromptsCited`** → `[]` (see gaps)
+
+### Response example
+
+```json
+{
+  "urls": [
+    {
+      "urlId": "",
+      "url": "https://www.example.com/pricing",
+      "citations": 44,
+      "promptsCited": 40,
+      "products": [],
+      "regions": ["US"],
+      "weeklyCitations": [{ "week": "2026-W18", "value": 12 }],
+      "weeklyPromptsCited": [],
+      "agenticHits": 0,
+      "agenticHitsTrend": [],
+      "referralHits": 0,
+      "referralHitsTrend": []
+    }
+  ],
+  "totalCount": 37
+}
+```
+
+> **⚠️ Gaps (POC):**
+> 1. **No Semrush source for `urlId`, `products`, `weeklyPromptsCited`** — stubbed `''`/`[]`/`[]`. `urlId` has no `source_urls.id` equivalent, so the future url-prompts drilldown must key off the URL string, not a uuid. The trend element exposes mentions + positions only (no per-week prompt count). *Deferred follow-up* (cf. LLMO-6071).
+> 2. **Traffic is a separate Adobe pipeline.** Semrush owned URLs frequently have no matching agentic/referral rows (different pipeline, different time coverage), so those fields legitimately return `0`/`[]`. Requires `siteId` + `DATA_SERVICE_PROVIDER=postgres`.
+> 3. **Region resolution is org-wide** (same best-effort caveat as Cited Domains gap 3).
+
+---
+
+## 6. Supported Models
 
 The `model` (or `platform`) query parameter is accepted by these endpoints. Only the following Semrush values are valid; any unrecognised value silently falls back to the default (`search-gpt`).
 

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -22,6 +22,7 @@ import { createElementsTransport } from '../support/elements/elements-transport.
 import { ElementsTransportError } from '../support/elements/errors.js';
 import { createElementsService } from '../support/elements/elements-service.js';
 import { fetchOwnedUrlsTraffic, mergeOwnedUrlsTraffic } from '../support/elements/owned-urls-traffic.js';
+import { mapWithConcurrency } from '../support/elements/concurrency.js';
 import { resolveBrandWorkspace } from '../support/serenity/workspace-resolver.js';
 import { cachedOk } from '../support/cached-response.js';
 import AccessControlUtil from '../support/access-control-util.js';
@@ -31,30 +32,8 @@ import { X_PROMISE_TOKEN_HEADER, PROMISE_TOKEN_REQUIRED_ERROR_CODE } from '../ut
 const MAX_ERR_MSG_LEN = 500;
 const BEARER_PREFIX = 'Bearer ';
 // Caps concurrent DB queries / upstream POSTs when fanning out across brands or projects.
+// mapWithConcurrency itself lives in support/elements/concurrency.js (shared with the service).
 const FANOUT_CONCURRENCY = 8;
-
-/**
- * Runs `mapper` over `items` with at most `limit` concurrent invocations,
- * preserving input order in the returned array. Bounds fan-out so a workspace
- * with many brands/projects can't spawn an unbounded number of parallel calls.
- */
-async function mapWithConcurrency(items, limit, mapper) {
-  const out = new Array(items.length);
-  let cursor = 0;
-  const workers = Array.from(
-    { length: Math.max(1, Math.min(limit, items.length)) },
-    async () => {
-      while (cursor < items.length) {
-        const idx = cursor;
-        cursor += 1;
-        // eslint-disable-next-line no-await-in-loop
-        out[idx] = await mapper(items[idx], idx);
-      }
-    },
-  );
-  await Promise.all(workers);
-  return out;
-}
 
 /**
  * Maps a BrandSemrushProject model instance to the plain object shape the
@@ -584,6 +563,14 @@ export default function ElementsController(context, log, env) {
       }
       if (startDate > endDate) {
         return badRequest('startDate must not be after endDate');
+      }
+      // Bound the span (defense-in-depth alongside the traffic RPC's p_urls cap): a
+      // multi-year range fanned across every project is needlessly expensive upstream.
+      const MAX_RANGE_DAYS = 366;
+      const spanDays = (Date.parse(`${endDate}T00:00:00Z`)
+        - Date.parse(`${startDate}T00:00:00Z`)) / 86400000;
+      if (spanDays > MAX_RANGE_DAYS) {
+        return badRequest(`Date range must not exceed ${MAX_RANGE_DAYS} days`);
       }
 
       // siteId is OPTIONAL here (unlike the legacy site-scoped RPC): citations come

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -21,7 +21,9 @@ import { resolveBrandUuid } from '../support/prompts-storage.js';
 import { createElementsTransport } from '../support/elements/elements-transport.js';
 import { ElementsTransportError } from '../support/elements/errors.js';
 import { createElementsService } from '../support/elements/elements-service.js';
+import { fetchOwnedUrlsTraffic, mergeOwnedUrlsTraffic } from '../support/elements/owned-urls-traffic.js';
 import { resolveBrandWorkspace } from '../support/serenity/workspace-resolver.js';
+import { cachedOk } from '../support/cached-response.js';
 import AccessControlUtil from '../support/access-control-util.js';
 import { ErrorWithStatusCode, resolveSemrushImsToken } from '../support/utils.js';
 import { X_PROMISE_TOKEN_HEADER, PROMISE_TOKEN_REQUIRED_ERROR_CODE } from '../utils/constants.js';
@@ -552,10 +554,118 @@ export default function ElementsController(context, log, env) {
   };
   /* c8 ignore stop */
 
+  /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence
+   *     /url-inspector/owned-urls
+   * The URL Inspector "Your cited URLs" table. Hybrid: per-URL citations +
+   * weekly trends from Semrush (Stats-per-URL 9af5ed83 + trend afb2e5d3);
+   * agentic/referral traffic from Adobe Postgres, joined by (site_id, url_path).
+   */
+  /* c8 ignore start -- LLMO-6086 POC endpoint; unit tests intentionally deferred */
+  const listOwnedUrls = async (ctx) => {
+    try {
+      const auth = await authorizeOrg(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { spaceCatId, brandId } = ctx?.params ?? {};
+      const { workspaceId, brand } = auth;
+      const query = extractQuery(ctx);
+
+      // Date range is required + validated (mirrors cited-domains) — never silently
+      // default to a rolling window nor forward a malformed date to Semrush.
+      const startDate = query.startDate || query.start_date;
+      const endDate = query.endDate || query.end_date;
+      if (!hasText(startDate) || !hasText(endDate)) {
+        return badRequest('startDate and endDate are required (YYYY-MM-DD)');
+      }
+      if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+        return badRequest('startDate and endDate must be valid YYYY-MM-DD dates');
+      }
+      if (startDate > endDate) {
+        return badRequest('startDate must not be after endDate');
+      }
+
+      // siteId is OPTIONAL here (unlike the legacy site-scoped RPC): citations come
+      // from Semrush (brand-scoped), so siteId only feeds the Postgres traffic join.
+      // When supplied it must belong to this brand (mirrors listWeeks). Absent →
+      // agentic/referral degrade to 0/[].
+      const siteId = query.siteId || query.site_id;
+      let resolvedSiteId;
+      if (hasText(siteId)) {
+        const postgrestClient = ctx?.dataAccess?.services?.postgrestClient;
+        const resolved = await getBrandBySite(spaceCatId, siteId, postgrestClient, log);
+        if (!resolved || resolved.id !== brand.id) {
+          return badRequest('siteId does not belong to the specified brand');
+        }
+        resolvedSiteId = siteId;
+      }
+
+      const service = await buildService(ctx);
+
+      const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+      const brandSemrushProjects = await fetchBrandSemrushProjects(BrandSemrushProject, [brand]);
+
+      // Scope per project (region): a specific region → that one project; otherwise
+      // all the brand's markets. Per-project keeps each element call under the
+      // Semrush 50k-row cap and lets the transform tag each URL with its region.
+      let projects;
+      let regionFilter;
+      const { region } = query;
+      if (hasText(region) && region.toLowerCase() !== 'all') {
+        const projectId = await service.resolveRegionProjectId(workspaceId, {
+          brandId, region, brandSemrushProjects,
+        });
+        if (!hasText(projectId)) {
+          return notFound(`No Semrush market found for region: ${region}`);
+        }
+        projects = [{ region, projectId }];
+        regionFilter = region;
+      } else {
+        projects = await service.getOwnedUrlProjects(workspaceId, { brandSemrushProjects });
+      }
+
+      const allUrls = await service.getOwnedUrls(workspaceId, {
+        projects,
+        model: query.model || query.platform,
+        startDate,
+        endDate,
+        category: query.categoryId || query.category,
+      });
+
+      // Client-side pagination — Semrush has no server-side pagination; totalCount is
+      // the full post-filter (owned) count.
+      const page = Math.max(0, Number.parseInt(query.page, 10) || 0);
+      const pageSize = Math.min(Math.max(1, Number.parseInt(query.pageSize, 10) || 50), 1000);
+      const totalCount = allUrls.length;
+      const offset = page * pageSize;
+      const pageUrls = allUrls.slice(offset, offset + pageSize);
+
+      // Hybrid: join agentic/referral from Postgres for JUST this page's URLs
+      // (keeps p_urls small). Best-effort — degrades to 0/[] on any failure.
+      const trafficMap = await fetchOwnedUrlsTraffic(ctx?.dataAccess?.Site?.postgrestService, {
+        siteId: resolvedSiteId,
+        startDate,
+        endDate,
+        urls: pageUrls.map((u) => u.url),
+        region: regionFilter,
+        referralSource: query.referralSource || query.referral_source,
+        log,
+      });
+      const urls = mergeOwnedUrlsTraffic(pageUrls, trafficMap);
+
+      return cachedOk({ urls, totalCount });
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+  /* c8 ignore stop */
+
   return {
     listUrlInspectorFilterDimensions,
     listWeeks,
     listPrompts,
     listCitedDomains,
+    listOwnedUrls,
   };
 }

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -792,6 +792,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/weeks': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/stats': 'llmo/can_view',
       // Preflight (site-scoped reads)
       'GET /sites/:siteId/preflights': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -246,6 +246,7 @@ export default function getRouteHandlers(
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': elementsController.listPrompts,
     // eslint-disable-next-line max-len
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': elementsController.listCitedDomains,
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': elementsController.listOwnedUrls,
     // Brand-independent Semrush language catalog (add-brand wizard language picker).
     'GET /v2/orgs/:spaceCatId/serenity/languages': serenityController.listOrgLanguages,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': serenityController.activate,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -289,6 +289,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/weeks': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'brand:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate': 'organization:write',
   'GET /v2/orgs/:spaceCatId/sites/:siteId/brand': 'organization:read',

--- a/src/support/elements/concurrency.js
+++ b/src/support/elements/concurrency.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Runs `mapper` over `items` with at most `limit` concurrent invocations,
+ * preserving input order in the returned array. Bounds fan-out so a workspace
+ * with many brands/projects can't spawn an unbounded number of parallel calls
+ * (which risks upstream rate-limiting and connection-pool exhaustion).
+ *
+ * Shared by the Elements controller (per-brand DB fan-out) and service
+ * (per-project element fan-out) — lives in the support layer so neither the
+ * service nor other support code has to import controller code.
+ *
+ * @param {Array<T>} items - Items to map over.
+ * @param {number} limit - Max concurrent invocations.
+ * @param {(item: T, index: number) => Promise<R>} mapper - Async mapper.
+ * @returns {Promise<Array<R>>} Results in input order.
+ * @template T, R
+ */
+/* c8 ignore start -- LLMO-6086 POC endpoint; unit tests intentionally deferred */
+export async function mapWithConcurrency(items, limit, mapper) {
+  const out = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    async () => {
+      while (cursor < items.length) {
+        const idx = cursor;
+        cursor += 1;
+        // eslint-disable-next-line no-await-in-loop
+        out[idx] = await mapper(items[idx], idx);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return out;
+}
+/* c8 ignore stop */

--- a/src/support/elements/definitions/brands.js
+++ b/src/support/elements/definitions/brands.js
@@ -10,18 +10,19 @@
  * governing permissions and limitations under the License.
  */
 
-import { DEFAULT_ELEMENT_MODEL, ELEMENT_MODELS } from '../constants.js';
+import { resolveElementModel } from '../constants.js';
 
 /**
  * Builds the payload for the Brands filter-dimensions element (row 1).
  * Returns the list of all available brands in the workspace — powers the brand selector dropdown.
  *
  * @param {object} [params]
- * @param {string} [params.model] - AI model filter value. Must be one of {@link ELEMENT_MODELS};
- *   falls back to {@link DEFAULT_ELEMENT_MODEL} if omitted or unrecognised.
+ * @param {string} [params.model] - AI model (Semrush engine name or SpaceCat/UI platform code).
+ *   Translated to a Semrush model + validated via {@link resolveElementModel} (default search-gpt).
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
  */
-export function buildBrandsPayload({ model } = {}) {
-  const resolvedModel = ELEMENT_MODELS.includes(model) ? model : DEFAULT_ELEMENT_MODEL;
+export function buildBrandsPayload({ model, platform } = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
   return {
     comparison_data_formatting: 'union',
     filters: {

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -22,3 +22,8 @@ export {
 export { buildWeeksPayload, transformWeeksResponse } from './weeks.js';
 export { buildPromptsPayload, transformPromptsResponse } from './prompts.js';
 export { buildCitedDomainsPayload, transformCitedDomainsResponse } from './cited-domains.js';
+export {
+  buildOwnedUrlsStatsPayload,
+  buildOwnedUrlsTrendPayload,
+  transformOwnedUrlsResponse,
+} from './owned-urls.js';

--- a/src/support/elements/definitions/owned-urls.js
+++ b/src/support/elements/definitions/owned-urls.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+import { dateToIsoWeek } from '../week-utils.js';
+
+/* c8 ignore start -- LLMO-6086 POC endpoint; unit tests intentionally deferred */
+
+/**
+ * Builds the payload for the Stats-per-URL element (9af5ed83, "Stats per URL",
+ * `table`). One row per cited URL in the (project, date, model) scope.
+ *
+ * Same filter shape as cited-domains (date in BOTH simple + advanced, CBF_model
+ * in an `or` block, category as a `category:<label>` tag, region via top-level
+ * `project_id`). `startDate`/`endDate` are required (validated in the controller).
+ * The element does NOT honor a server-side content-type filter, so the
+ * `domain_type='Owned'` selection is applied client-side in the transform.
+ *
+ * @param {object} params
+ * @param {string} [params.model] - AI model (Semrush engine or UI platform code).
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` wins.
+ * @param {string} params.startDate - ISO date (YYYY-MM-DD).
+ * @param {string} params.endDate - ISO date (YYYY-MM-DD).
+ * @param {string} [params.category] - Category label → tag `category:<label>`.
+ * @param {string} [params.projectId] - Semrush project id (region scope, top-level).
+ */
+export function buildOwnedUrlsStatsPayload({
+  model, platform, startDate, endDate, category, projectId,
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+    { op: 'gte', val: startDate, col: 'CBF_date__start' },
+    { op: 'lte', val: endDate, col: 'CBF_date__end' },
+  ];
+  if (category) {
+    advancedFilters.push({ op: 'eq', val: `category:${category}`, col: 'CBF_tags' });
+  }
+  return {
+    ...(projectId && { project_id: projectId }),
+    comparison_data_formatting: 'union',
+    filters: {
+      simple: { CBF_date__start: startDate, CBF_date__end: endDate },
+      advanced: { op: 'and', filters: advancedFilters },
+    },
+  };
+}
+
+/**
+ * Builds the payload for the URL trend element (afb2e5d3, `line`). Verified to
+ * return ALL URLs' weekly trends in ONE call when scoped by `project_id` + date
+ * + model (no per-URL filter — the wiki's "one call per URL" claim is wrong).
+ * Category is intentionally omitted (the line element's tag support is
+ * unverified; date+model+project is the confirmed-working scope).
+ */
+export function buildOwnedUrlsTrendPayload({
+  model, platform, startDate, endDate, projectId,
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  return {
+    ...(projectId && { project_id: projectId }),
+    comparison_data_formatting: 'union',
+    filters: {
+      simple: { CBF_date__start: startDate, CBF_date__end: endDate },
+      advanced: {
+        op: 'and',
+        filters: [
+          { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+          { op: 'gte', val: startDate, col: 'CBF_date__start' },
+          { op: 'lte', val: endDate, col: 'CBF_date__end' },
+        ],
+      },
+    },
+  };
+}
+
+/**
+ * Merges per-project Stats-per-URL + URL-trend responses into the legacy URL
+ * Inspector `owned-urls` row shape (traffic fields defaulted here; the controller
+ * fills agentic/referral from Postgres for the paginated slice).
+ *
+ * Field mapping (verified against live element rows):
+ *   url             ← stats.source
+ *   citations       ← stats.citations           (summed across a URL's projects)
+ *   promptsCited    ← stats.prompts_with_citation
+ *   contentType     ← stats.domain_type         (used only for the owned filter)
+ *   regions         ← the region code of each project the URL appears in
+ *   weeklyCitations ← trend rows grouped by legend(=url): { week: ISO, value: y__mentions }
+ * Gaps with NO Semrush source (stubbed, see LLMO-6086 notes / cf LLMO-6071):
+ *   urlId ('' — Semrush has no source_urls.id), products ([]), weeklyPromptsCited ([]).
+ *
+ * Only `domain_type='Owned'` rows are kept (client-side; the element ignores a
+ * server-side content-type filter). Returns the FULL owned list sorted by
+ * citations desc — the controller applies client-side pagination and then joins
+ * traffic for just the page's URLs (Semrush has no server-side pagination).
+ *
+ * @param {Array<{region?: string, stats: object, trend: object}>} projectResults
+ * @returns {Array<object>} Full owned-URL list, sorted by citations desc.
+ */
+export function transformOwnedUrlsResponse(projectResults = []) {
+  const byUrl = new Map();
+
+  const ensure = (url) => {
+    let entry = byUrl.get(url);
+    if (!entry) {
+      entry = {
+        url, citations: 0, promptsCited: 0, regions: new Set(), weekly: new Map(),
+      };
+      byUrl.set(url, entry);
+    }
+    return entry;
+  };
+
+  for (const { region, stats, trend } of projectResults) {
+    for (const row of (stats?.blocks?.data ?? [])) {
+      // Owned filter is client-side: the element ignores a server-side
+      // content-type filter (verified on cited-domains).
+      if (!row || row.source == null) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      if (String(row.domain_type ?? '').toLowerCase() !== 'owned') {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      const entry = ensure(row.source);
+      // `Number(x) || 0` (not `?? 0`) so a non-numeric value coerces to 0, not NaN.
+      entry.citations += Number(row.citations) || 0;
+      entry.promptsCited += Number(row.prompts_with_citation) || 0;
+      if (region) {
+        entry.regions.add(region);
+      }
+    }
+
+    for (const line of (trend?.blocks?.lines ?? [])) {
+      const url = line?.legend;
+      // Only accumulate trends for URLs we kept as owned above.
+      if (url == null || !byUrl.has(url) || typeof line.x !== 'string') {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      const week = dateToIsoWeek(line.x.slice(0, 10));
+      const entry = byUrl.get(url);
+      entry.weekly.set(week, (entry.weekly.get(week) || 0) + (Number(line.y__mentions) || 0));
+    }
+  }
+
+  const urls = [...byUrl.values()].map((e) => ({
+    urlId: '', // no Semrush source_urls.id (gap — see LLMO-6086)
+    url: e.url,
+    citations: e.citations,
+    promptsCited: e.promptsCited,
+    products: [], // no per-URL product source on the element (Semrush gap)
+    regions: [...e.regions],
+    weeklyCitations: [...e.weekly.entries()]
+      .map(([week, value]) => ({ week, value }))
+      .sort((a, b) => a.week.localeCompare(b.week)),
+    weeklyPromptsCited: [], // trend exposes mentions + positions only (Semrush gap)
+    agenticHits: 0,
+    agenticHitsTrend: [],
+    referralHits: 0,
+    referralHitsTrend: [],
+  }));
+
+  urls.sort((a, b) => b.citations - a.citations);
+  return urls;
+}
+/* c8 ignore stop */

--- a/src/support/elements/definitions/owned-urls.js
+++ b/src/support/elements/definitions/owned-urls.js
@@ -59,26 +59,30 @@ export function buildOwnedUrlsStatsPayload({
  * Builds the payload for the URL trend element (afb2e5d3, `line`). Verified to
  * return ALL URLs' weekly trends in ONE call when scoped by `project_id` + date
  * + model (no per-URL filter — the wiki's "one call per URL" claim is wrong).
- * Category is intentionally omitted (the line element's tag support is
- * unverified; date+model+project is the confirmed-working scope).
+ *
+ * `category` is applied here identically to {@link buildOwnedUrlsStatsPayload} so
+ * the weekly sparklines and the aggregate totals share the same filter set — if
+ * only stats were category-filtered, a category-filtered view's weekly values
+ * could exceed its totals.
  */
 export function buildOwnedUrlsTrendPayload({
-  model, platform, startDate, endDate, projectId,
+  model, platform, startDate, endDate, category, projectId,
 } = {}) {
   const resolvedModel = resolveElementModel(model || platform);
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+    { op: 'gte', val: startDate, col: 'CBF_date__start' },
+    { op: 'lte', val: endDate, col: 'CBF_date__end' },
+  ];
+  if (category) {
+    advancedFilters.push({ op: 'eq', val: `category:${category}`, col: 'CBF_tags' });
+  }
   return {
     ...(projectId && { project_id: projectId }),
     comparison_data_formatting: 'union',
     filters: {
       simple: { CBF_date__start: startDate, CBF_date__end: endDate },
-      advanced: {
-        op: 'and',
-        filters: [
-          { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
-          { op: 'gte', val: startDate, col: 'CBF_date__start' },
-          { op: 'lte', val: endDate, col: 'CBF_date__end' },
-        ],
-      },
+      advanced: { op: 'and', filters: advancedFilters },
     },
   };
 }

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -10,19 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
-import { DEFAULT_ELEMENT_MODEL, ELEMENT_MODELS } from '../constants.js';
+import { resolveElementModel } from '../constants.js';
 
 /**
  * Builds the payload for the Topics (Tags) filter-dimensions element (row 3).
  * Returns all available topic and category tags — powers the Topics/Tags filter dropdown.
  *
  * @param {object} [params]
- * @param {string} [params.model] - AI model filter value. Must be one of {@link ELEMENT_MODELS};
- *   falls back to {@link DEFAULT_ELEMENT_MODEL} if omitted or unrecognised.
+ * @param {string} [params.model] - AI model (Semrush engine name or SpaceCat/UI platform code).
+ *   Translated to a Semrush model + validated via {@link resolveElementModel} (default search-gpt).
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
  * @param {string} [params.projectId] - Semrush project UUID to scope tags to a specific market.
  */
-export function buildTopicsPayload({ model, projectId } = {}) {
-  const resolvedModel = ELEMENT_MODELS.includes(model) ? model : DEFAULT_ELEMENT_MODEL;
+export function buildTopicsPayload({ model, platform, projectId } = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
   return {
     ...(projectId && { project_id: projectId }),
     comparison_data_formatting: 'union',

--- a/src/support/elements/element-ids.js
+++ b/src/support/elements/element-ids.js
@@ -29,6 +29,20 @@ export const ELEMENT_IDS = Object.freeze({
   // Brand scoping is via the request's sub-workspace, not a filter (`CBF_ws_brand` is a no-op).
   CITED_DOMAINS: '98b91d00-9531-4120-b3b5-17cc27489fce',
 
+  // URL Inspector — Owned URLs ("Your cited URLs" table). Two elements, both
+  // scoped by a top-level `project_id` (region/market) + date + `CBF_model`;
+  // neither honors a server-side content-type filter, so `domain_type='Owned'`
+  // is applied client-side (verified). Brand scoping is via the sub-workspace.
+  //  - STATS_PER_URL (`table`): one row per cited URL —
+  //    { source(=url), citations, prompts_with_citation, domain_type, avg_position,
+  //      project_id, url_cbf }. Shared with domain-urls.
+  //  - URL_TRENDS (`line`): weekly per-URL trend — one row per (url, week):
+  //    { legend(=url), project_id, x(=ISO week), y__mentions, y__positions }.
+  //    Verified: returns ALL URLs in ONE call when scoped by project only (no
+  //    per-URL filter needed — the wiki's "one call per URL" claim is wrong).
+  STATS_PER_URL: '9af5ed83-049b-493a-85d7-99c7d4deddba',
+  URL_TRENDS: 'afb2e5d3-3955-4e0d-aeb1-7e28cdecd9f9',
+
   MENTIONS: 'e1a6811b-d0c9-4d6f-8a29-290a32db863f',
   VISIBILITY: '2724878e-e0e9-4217-ad21-d6bcb7887a09',
   CITATIONS_KPI: '588054fe-b987-40f6-9360-b5673738bdfa',

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -11,6 +11,7 @@
  */
 
 import { ELEMENT_IDS } from './element-ids.js';
+import { mapWithConcurrency } from './concurrency.js';
 import {
   buildBrandsPayload,
   transformBrandsToFilterDimensions,
@@ -207,25 +208,34 @@ export function createElementsService(transport) {
       projects = [], model, platform, startDate, endDate, category,
     }) {
       const scopes = projects.length > 0 ? projects : [{}];
-      const projectResults = await Promise.all(scopes.map(async ({ region, projectId }) => {
-        const [stats, trend] = await Promise.all([
-          transport.fetchElement(
-            workspaceId,
-            ELEMENT_IDS.STATS_PER_URL,
-            buildOwnedUrlsStatsPayload({
-              model, platform, startDate, endDate, category, projectId,
-            }),
-          ),
-          transport.fetchElement(
-            workspaceId,
-            ELEMENT_IDS.URL_TRENDS,
-            buildOwnedUrlsTrendPayload({
-              model, platform, startDate, endDate, projectId,
-            }),
-          ),
-        ]);
-        return { region, stats, trend };
-      }));
+      // Bound the per-project fan-out (2 element calls each) so a brand with many
+      // markets can't spawn unbounded parallel Semrush requests (429 / pool risk).
+      const OWNED_URLS_PROJECT_CONCURRENCY = 8;
+      const projectResults = await mapWithConcurrency(
+        scopes,
+        OWNED_URLS_PROJECT_CONCURRENCY,
+        async ({ region, projectId }) => {
+          const [stats, trend] = await Promise.all([
+            transport.fetchElement(
+              workspaceId,
+              ELEMENT_IDS.STATS_PER_URL,
+              buildOwnedUrlsStatsPayload({
+                model, platform, startDate, endDate, category, projectId,
+              }),
+            ),
+            transport.fetchElement(
+              workspaceId,
+              ELEMENT_IDS.URL_TRENDS,
+              // category applied here too (mirrors stats) so weekly sparklines and
+              // aggregate totals share the same filter set.
+              buildOwnedUrlsTrendPayload({
+                model, platform, startDate, endDate, category, projectId,
+              }),
+            ),
+          ]);
+          return { region, stats, trend };
+        },
+      );
       return transformOwnedUrlsResponse(projectResults);
     },
     /* c8 ignore stop */

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -27,6 +27,9 @@ import {
   transformPromptsResponse,
   buildCitedDomainsPayload,
   transformCitedDomainsResponse,
+  buildOwnedUrlsStatsPayload,
+  buildOwnedUrlsTrendPayload,
+  transformOwnedUrlsResponse,
 } from './definitions/index.js';
 
 /**
@@ -157,6 +160,73 @@ export function createElementsService(transport) {
       // Prefer the site's brand when it owns a project for this region; else first match.
       const preferred = matches.find((r) => r.spacecat_brand_id === brandId);
       return (preferred ?? matches[0]).semrush_project_id;
+    },
+
+    /**
+     * Resolves every (region, projectId) pair for the workspace, used to fan the
+     * owned-urls query out per-project. Per-project scoping keeps each element
+     * call under the Semrush 50k-row cap (a workspace-wide call hit it) and lets
+     * the transform tag each URL with the region it was cited in. Reuses the
+     * Markets element + transform (same as resolveRegionProjectId).
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} [opts]
+     * @param {object[]} [opts.brandSemrushProjects] - Flattened BrandSemrushProject
+     *   rows, to enrich/match the Markets response.
+     * @returns {Promise<Array<{region: string, projectId: string}>>}
+     */
+    async getOwnedUrlProjects(workspaceId, { brandSemrushProjects = [] } = {}) {
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.MARKETS,
+        buildMarketsPayload({}),
+      );
+      return transformMarketsToFilterDimensions(raw, brandSemrushProjects)
+        .filter((r) => r.semrush_project_id)
+        .map((r) => ({ region: r.id, projectId: r.semrush_project_id }));
+    },
+
+    /**
+     * Fetches the URL Inspector Owned URLs table (citations + weekly trends) from
+     * Semrush, backed by Stats-per-URL (9af5ed83) + URL trend (afb2e5d3). Fans out
+     * per project (region) — each project stays under the 50k-row cap and carries
+     * its region — fetching both elements in parallel, then merges to the legacy
+     * shape. Returns the FULL owned list sorted by citations desc; the controller
+     * paginates client-side and joins agentic/referral traffic for the page.
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} params
+     * @param {Array<{region?: string, projectId?: string}>} [params.projects] -
+     *   Projects to query. Empty → one unscoped (workspace-wide) fetch.
+     * @param {string} [params.model] / [params.platform] - AI model filter.
+     * @param {string} params.startDate / params.endDate - Required YYYY-MM-DD.
+     * @param {string} [params.category] - Category tag filter.
+     * @returns {Promise<object[]>} Full owned-URL list (no traffic, no slice).
+     */
+    async getOwnedUrls(workspaceId, {
+      projects = [], model, platform, startDate, endDate, category,
+    }) {
+      const scopes = projects.length > 0 ? projects : [{}];
+      const projectResults = await Promise.all(scopes.map(async ({ region, projectId }) => {
+        const [stats, trend] = await Promise.all([
+          transport.fetchElement(
+            workspaceId,
+            ELEMENT_IDS.STATS_PER_URL,
+            buildOwnedUrlsStatsPayload({
+              model, platform, startDate, endDate, category, projectId,
+            }),
+          ),
+          transport.fetchElement(
+            workspaceId,
+            ELEMENT_IDS.URL_TRENDS,
+            buildOwnedUrlsTrendPayload({
+              model, platform, startDate, endDate, projectId,
+            }),
+          ),
+        ]);
+        return { region, stats, trend };
+      }));
+      return transformOwnedUrlsResponse(projectResults);
     },
     /* c8 ignore stop */
   };

--- a/src/support/elements/owned-urls-traffic.js
+++ b/src/support/elements/owned-urls-traffic.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Owned-URLs traffic hybrid: agentic + referral metrics come from the Adobe
+ * Postgres pipeline (NOT Semrush), joined onto the Semrush-derived owned URLs by
+ * (site_id, url_path). This is the ONLY non-Semrush data in owned-urls.
+ *
+ * Pure support helper — no controller imports (support/elements must not depend
+ * on controllers). The RPC (rpc_url_inspector_owned_urls_traffic, LLMO-6086)
+ * receives the full Semrush URLs and normalizes them to url_path itself, so
+ * there is no JS/SQL normalization drift.
+ */
+
+/* c8 ignore start -- LLMO-6086 POC endpoint; unit tests intentionally deferred */
+
+/**
+ * Maps an RPC weekly-trend array ([{ week_start, value }]) to the legacy JS shape
+ * ([{ weekStart, value }]), mirroring the legacy owned-urls handler.
+ */
+function mapTrend(trend) {
+  if (!Array.isArray(trend)) {
+    return [];
+  }
+  return trend.map((p) => ({
+    weekStart: p?.week_start ?? null,
+    value: Number(p?.value) || 0,
+  }));
+}
+
+/**
+ * Fetches agentic/referral traffic for the given URLs via the traffic RPC and
+ * returns a Map keyed by URL. Best-effort: a missing client, missing siteId,
+ * empty URL list, or RPC error all yield an empty Map so citations still render
+ * (traffic degrades to 0/[]). Call with the page's URLs only — keeps `p_urls`
+ * small and the join cheap.
+ *
+ * @param {object} postgrestService - RPC-capable client (`dataAccess.Site.postgrestService`).
+ * @param {object} opts
+ * @param {string} [opts.siteId] - SpaceCat site UUID (traffic tables are site-scoped).
+ * @param {string} opts.startDate / opts.endDate - YYYY-MM-DD.
+ * @param {string[]} opts.urls - Full Semrush URLs for the current page.
+ * @param {string} [opts.region] - Region code; passed only when a single region filter is active.
+ * @param {string[]} [opts.agentTypes] - Optional agentic agent-type filter.
+ * @param {string} [opts.referralSource] - optel|cdn|ga4|adobe_analytics|cja
+ *   (RPC defaults to optel).
+ * @param {object} [opts.log] - Logger.
+ * @returns {Promise<Map<string, object>>} url → { agenticHits, agenticHitsTrend,
+ *   referralHits, referralHitsTrend }
+ */
+export async function fetchOwnedUrlsTraffic(postgrestService, {
+  siteId, startDate, endDate, urls, region, agentTypes, referralSource, log,
+} = {}) {
+  if (typeof postgrestService?.rpc !== 'function'
+    || !siteId
+    || !Array.isArray(urls)
+    || urls.length === 0) {
+    return new Map();
+  }
+
+  const rpcParams = {
+    p_site_id: siteId,
+    p_start_date: startDate,
+    p_end_date: endDate,
+    p_urls: urls,
+  };
+  // Only scope by region when a single region filter is active — a page can span
+  // multiple regions, and the RPC aggregates across all of them when p_region is null.
+  if (region) {
+    rpcParams.p_region = region;
+  }
+  if (agentTypes) {
+    rpcParams.p_agent_types = agentTypes;
+  }
+  if (referralSource) {
+    rpcParams.p_referral_source = referralSource;
+  }
+
+  const { data, error } = await postgrestService.rpc(
+    'rpc_url_inspector_owned_urls_traffic',
+    rpcParams,
+  );
+  if (error) {
+    // Traffic is best-effort; never fail the whole endpoint on a traffic-side error.
+    log?.error?.(`owned-urls traffic RPC error: ${error.message}`);
+    return new Map();
+  }
+
+  const map = new Map();
+  for (const row of (data ?? [])) {
+    map.set(row.url, {
+      agenticHits: Number(row.agentic_hits) || 0,
+      agenticHitsTrend: mapTrend(row.agentic_hits_trend),
+      referralHits: Number(row.referral_hits) || 0,
+      referralHitsTrend: mapTrend(row.referral_hits_trend),
+    });
+  }
+  return map;
+}
+
+/**
+ * Overlays the traffic Map onto the owned-URL rows (matched by `url`). Rows with
+ * no traffic keep their 0/[] defaults from the transform.
+ */
+export function mergeOwnedUrlsTraffic(urls, trafficMap) {
+  if (!(trafficMap instanceof Map) || trafficMap.size === 0) {
+    return urls;
+  }
+  return urls.map((u) => {
+    const t = trafficMap.get(u.url);
+    return t ? { ...u, ...t } : u;
+  });
+}
+/* c8 ignore stop */

--- a/src/support/elements/owned-urls-traffic.js
+++ b/src/support/elements/owned-urls-traffic.js
@@ -23,6 +23,11 @@
 
 /* c8 ignore start -- LLMO-6086 POC endpoint; unit tests intentionally deferred */
 
+// The referral source tables the RPC knows about. An unrecognized value makes the
+// RPC RAISE (→ caught below → silent empty), so we drop unknown values and let the
+// RPC apply its documented default ('optel') instead.
+const VALID_REFERRAL_SOURCES = new Set(['optel', 'cdn', 'ga4', 'adobe_analytics', 'cja']);
+
 /**
  * Maps an RPC weekly-trend array ([{ week_start, value }]) to the legacy JS shape
  * ([{ weekStart, value }]), mirroring the legacy owned-urls handler.
@@ -81,7 +86,7 @@ export async function fetchOwnedUrlsTraffic(postgrestService, {
   if (agentTypes) {
     rpcParams.p_agent_types = agentTypes;
   }
-  if (referralSource) {
+  if (referralSource && VALID_REFERRAL_SOURCES.has(referralSource)) {
     rpcParams.p_referral_source = referralSource;
   }
 

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -889,6 +889,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/weeks',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate',
       'GET /v2/orgs/:spaceCatId/sites/:siteId/brand',

--- a/test/support/elements/definitions/brands.test.js
+++ b/test/support/elements/definitions/brands.test.js
@@ -34,6 +34,16 @@ describe('brands definitions', () => {
       expect(payload.filters.advanced.filters[0].val).to.equal('perplexity');
     });
 
+    it('translates a SpaceCat/UI platform code to the Semrush model', () => {
+      const payload = buildBrandsPayload({ model: 'copilot' });
+      expect(payload.filters.advanced.filters[0].val).to.equal('microsoft-copilot');
+    });
+
+    it('accepts the platform alias and translates it', () => {
+      const payload = buildBrandsPayload({ platform: 'openai' });
+      expect(payload.filters.advanced.filters[0].val).to.equal('gpt-5');
+    });
+
     it('sets comparison_data_formatting to union', () => {
       const payload = buildBrandsPayload();
       expect(payload.comparison_data_formatting).to.equal('union');

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -52,6 +52,16 @@ describe('topics definitions', () => {
       expect(payload.filters.advanced.filters[0].val).to.equal('perplexity');
     });
 
+    it('translates a SpaceCat/UI platform code to the Semrush model', () => {
+      const payload = buildTopicsPayload({ model: 'gemini' });
+      expect(payload.filters.advanced.filters[0].val).to.equal('gemini-2.5-flash');
+    });
+
+    it('accepts the platform alias and translates it', () => {
+      const payload = buildTopicsPayload({ platform: 'openai' });
+      expect(payload.filters.advanced.filters[0].val).to.equal('gpt-5');
+    });
+
     it('sets comparison_data_formatting to union', () => {
       const payload = buildTopicsPayload();
       expect(payload.comparison_data_formatting).to.equal('union');


### PR DESCRIPTION
## Summary
Adds the URL Inspector "Your cited URLs" table (`owned-urls`) to the Serenity Semrush-Elements wrapper, mirroring the merged cited-domains endpoint. Hybrid: per-URL citations + weekly trends from Semrush; agentic/referral traffic from Adobe Postgres.

`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls`

## Changes
- `definitions/owned-urls.js` — stats-per-url (`9af5ed83`) + trend (`afb2e5d3`) payload builders + transform (owned filtered client-side, per-project to stay under the 50k row cap, weekly citations grouped by URL).
- `elements-service.js` — `getOwnedUrls` (per-project parallel fetch) + `getOwnedUrlProjects`.
- `owned-urls-traffic.js` — best-effort Postgres join (agentic/referral by `(site_id, url_path)`) via `rpc_url_inspector_owned_urls_traffic`; degrades to `0`/`[]`.
- `controllers/elements.js` — `listOwnedUrls`: brand auth, required+validated dates, region→project, optional brand-scoped `siteId`, client-side pagination, `cachedOk`.
- Route + `facs-capabilities` (`llmo/can_view`) + `required-capabilities` (`brand:read`) + route-registry test + docs.

## Dependency
Traffic data needs the RPC from adobe/mysticat-data-service#779 (LLMO-6086) deployed to the target env. Until then agentic/referral return `0`/`[]` (graceful); citations render from Semrush regardless.

## Test plan
- [x] `npm run lint` clean; route-registry / FACS / required-capabilities drift + existing elements tests (106) pass.
- [x] Transform + traffic-merge logic verified against live-probe-shaped data (owned filter, cross-project dedup, ISO-week grouping, graceful empty traffic).
- [x] Element shapes/payloads verified against live Semrush (stg).
- [ ] Reviewer: confirm final JSON via curl on a running local server (localhost:3002).

## API specification
OpenAPI intentionally skipped — consistent with the sibling Serenity elements endpoints (filter-dimensions / weeks / prompts / cited-domains), none of which have specs. Endpoint is implemented (no 501 stub).

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-6086

## Deferred follow-ups
- Retrofit `cachedOk` (private, 2h) onto the sibling Serenity elements endpoints (`filter-dimensions`, `weeks`, `brand-presence/prompts`, `cited-domains`), which currently use plain `ok()`. This PR keeps `cachedOk` on `owned-urls` (part of the agreed caching approach); the follow-up aligns the siblings rather than dropping the better pattern. Raised by MysticatBot review.

## Also in this PR (per Vivek)
Fixes a pre-existing model-translation bug in the **filter-dimensions** builders (`brands.js`, `topics.js`): they used `ELEMENT_MODELS.includes(model) ? model : DEFAULT`, which does **no** SpaceCat→Semrush translation, so UI platform codes (`copilot`/`openai`/`gemini`/`chatgpt`) silently fell back to `search-gpt`. Switched both to the shared `resolveElementModel()` (also accepting the `platform` alias) — matching `weeks`/`cited-domains`/`prompts`/`owned-urls`. Added translation unit tests. Not originally in this workstream; folded in at Vivek's request.