### PR TITLE
feat(prompts): add source filter to v2 prompts list endpoint

### DIFF
--- a/docs/openapi/prompts-v2-api.yaml
+++ b/docs/openapi/prompts-v2-api.yaml
@@ -78,6 +78,16 @@ v2-prompts-by-brand:
         type: string
         enum: [ai, human]
       description: Filter by origin (ai or human)
+    - name: source
+      in: query
+      required: false
+      schema:
+        type: string
+      description: >-
+        Filter by prompt source (exact match), e.g. `gsc`, `semrush`,
+        `base_url`, `config`. Free-form string — sources are open-ended and
+        added by upstream producers (e.g. DRS) without API changes, so no enum
+        is enforced.
     - name: sort
       in: query
       required: false

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -401,7 +401,7 @@ function BrandsController(ctx, log, env) {
     const { spaceCatId, brandId } = context.params || {};
     const {
       limit, page, categoryId, topicId, status,
-      search, region, origin, sort, order,
+      search, region, origin, source, sort, order,
     } = getQueryParams(context);
 
     try {
@@ -449,6 +449,7 @@ function BrandsController(ctx, log, env) {
         search,
         region,
         origin,
+        source,
         sort,
         order,
         limit,

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -453,6 +453,7 @@ function mapRowToPrompt(row) {
  * topic name, category name
  * @param {string} [params.region] - Filter by region (array containment)
  * @param {string} [params.origin] - Filter by origin (ai, human)
+ * @param {string} [params.source] - Filter by source (e.g. gsc, semrush, base_url, config)
  * @param {string} [params.sort] - Sort column (topic, prompt, category, origin,
  * status, updatedAt)
  * @param {string} [params.order] - Sort direction (asc, desc). Default desc
@@ -470,6 +471,7 @@ export async function listPrompts({
   search,
   region,
   origin,
+  source,
   sort,
   order,
   limit = 100,
@@ -579,6 +581,10 @@ export async function listPrompts({
 
     if (hasText(origin)) {
       baseQuery = baseQuery.eq('origin', origin);
+    }
+
+    if (hasText(source)) {
+      baseQuery = baseQuery.eq('source', source);
     }
 
     if (hasText(region)) {

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -4625,6 +4625,43 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(200);
     });
 
+    it('forwards source param through to the prompts query as an exact filter', async () => {
+      // Recording client so the assertion fails if source stops being forwarded
+      // from the controller through to listPrompts' `.eq('source', ...)`.
+      const eqCalls = [];
+      mockDataAccess.services.postgrestClient = {
+        from: sandbox.stub().callsFake((table) => {
+          const chain = {
+            select: sandbox.stub().returnsThis(),
+            eq: sandbox.stub().callsFake((column, value) => {
+              eqCalls.push({ column, value });
+              return chain;
+            }),
+            neq: sandbox.stub().returnsThis(),
+            order: sandbox.stub().returnsThis(),
+            or: sandbox.stub().returnsThis(),
+            contains: sandbox.stub().returnsThis(),
+            overlaps: sandbox.stub().returnsThis(),
+            range: sandbox.stub().resolves({ data: [], error: null, count: 0 }),
+            maybeSingle: sandbox.stub().callsFake(() => (table === 'brands'
+              ? Promise.resolve({ data: { id: BRAND_UUID }, error: null })
+              : Promise.resolve({ data: null, error: null }))),
+          };
+          return chain;
+        }),
+      };
+      brandsController = BrandsController(context, loggerStub, mockEnv);
+
+      const response = await brandsController.listPromptsByBrand({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        invocation: { event: { rawQueryString: 'source=gsc' } },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(200);
+      expect(eqCalls).to.deep.include({ column: 'source', value: 'gsc' });
+    });
+
     it('returns prompt items from normalized tables', async () => {
       const response = await brandsController.listPromptsByBrand({
         ...context,

--- a/test/it/shared/tests/categories-prompts.js
+++ b/test/it/shared/tests/categories-prompts.js
@@ -230,6 +230,50 @@ export default function categoriesPromptsTests(getHttpClient, resetData) {
       });
     });
 
+    describe('Prompt-list source filter narrows by exact source', () => {
+      before(() => resetData());
+
+      it('returns only prompts with the requested source, and 0 for an unknown source', async () => {
+        const http = getHttpClient();
+
+        // Two gsc-sourced prompts and one config-sourced prompt.
+        const created = await http.admin.post(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
+          [
+            { prompt: 'First GSC prompt', source: 'gsc' },
+            { prompt: 'Second GSC prompt', source: 'gsc' },
+            { prompt: 'A config prompt', source: 'config' },
+          ],
+        );
+        expect(created.status).to.equal(201);
+        expect(created.body.created).to.equal(3);
+
+        // source=gsc returns only the two gsc rows.
+        const filtered = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts?source=gsc`,
+        );
+        expect(filtered.status).to.equal(200);
+        expect(filtered.body.total).to.equal(2);
+        expect(filtered.body.items).to.have.lengthOf(2);
+        expect(filtered.body.items.every((p) => p.source === 'gsc')).to.equal(true);
+
+        // No filter returns all three — proving the filter narrowed the set.
+        const unfiltered = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts`,
+        );
+        expect(unfiltered.status).to.equal(200);
+        expect(unfiltered.body.total).to.equal(3);
+
+        // Fail-loud guard: an unknown source must return 0, proving the param is
+        // honored and not silently ignored (a two-stage-deploy inflation risk).
+        const unknown = await http.admin.get(
+          `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/prompts?source=__nonexistent__`,
+        );
+        expect(unknown.status).to.equal(200);
+        expect(unknown.body.total).to.equal(0);
+      });
+    });
+
     // ── Multibyte / non-ASCII-only names (LLMO-5515) ──
 
     describe('Category creation with an all-multibyte name (no explicit id)', () => {

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -392,6 +392,57 @@ describe('prompts-storage', () => {
       expect(overlapsCall.value).to.have.lengthOf(2);
     });
 
+    // Records every .eq() call so the assertion fails if the `.eq('source', source)`
+    // filter is deleted — a no-op `eq: () => chain` stub would pass regardless.
+    function makeEqRecordingClient(eqCalls) {
+      const recordingChain = (result) => {
+        const chain = {
+          select: () => chain,
+          eq: (column, value) => {
+            eqCalls.push({ column, value });
+            return chain;
+          },
+          neq: () => chain,
+          order: () => chain,
+          or: () => chain,
+          contains: () => chain,
+          overlaps: () => chain,
+          in: () => chain,
+          range: () => thenable(result),
+          maybeSingle: () => thenable(result),
+          single: () => thenable(result),
+          then: (resolve) => resolve(result),
+        };
+        return chain;
+      };
+      return {
+        from: (table) => (table === 'brands'
+          ? recordingChain({ data: { id: BRAND_UUID }, error: null })
+          : recordingChain({ data: [], error: null, count: 0 })),
+      };
+    }
+
+    it('applies the source filter as an exact match when source is provided', async () => {
+      const eqCalls = [];
+      await listPrompts({
+        organizationId: ORG_ID,
+        brandId: BRAND_UUID,
+        source: 'gsc',
+        postgrestClient: makeEqRecordingClient(eqCalls),
+      });
+      expect(eqCalls).to.deep.include({ column: 'source', value: 'gsc' });
+    });
+
+    it('does not apply a source filter when source is omitted', async () => {
+      const eqCalls = [];
+      await listPrompts({
+        organizationId: ORG_ID,
+        brandId: BRAND_UUID,
+        postgrestClient: makeEqRecordingClient(eqCalls),
+      });
+      expect(eqCalls.some((c) => c.column === 'source')).to.equal(false);
+    });
+
     it('uses explicit limit and page values', async () => {
       const row = {
         prompt_id: PROMPT_ID,


### PR DESCRIPTION
## What

Adds a `source` query parameter to `GET /v2/orgs/:spaceCatId/brands/:brandId/prompts`, so callers can filter prompts by their `source` (e.g. `gsc`, `semrush`, `base_url`, `config`). The `source` column already exists on the `prompts` table and is already returned per row — this adds the missing filter predicate, mirroring the existing `origin` filter exactly.

## Why

The LLMO usage-tracking report's **"GSC Prompts" column has shown 0 for every customer since 2026-06-19** — not data loss, a reporting gap. The report generator (`OneAdobe/llmo-usage-report-node`) stubbed the GSC count to `0` for brandalf-enabled orgs with an explicit TODO:

> `// TODO: return accurate count once the brandalf prompts API supports filtering by source param`

This endpoint is that missing primitive. A follow-up PR in the generator will consume `?source=gsc` (and the same applies to the Library-prompts column). Full analysis in the implementation spec.

## Changes

- `src/support/prompts-storage.js` — `listPrompts` accepts `source`, applies `.eq('source', source)` (exact match).
- `src/controllers/brands.js` — `listPromptsByBrand` forwards `source` from query params.
- `docs/openapi/prompts-v2-api.yaml` — documents `source` as a **free-form string, no enum** (sources are open-ended and added by upstream producers like DRS without API changes).
- Tests:
  - Unit tests that **actually assert the filter fires** (recording stubs, not the no-op `eq: () => chain` — a cloned test would pass even with the filter deleted), plus an omitted-source no-op case.
  - Controller forwarding test (asserts `source` reaches the query, not just `200`).
  - `test/it/` integration case proving `?source=gsc` narrows rows, including a **fail-loud `?source=__nonexistent__` → `total: 0`** check (guards against the endpoint silently ignoring the param during a two-stage deploy).

## Compatibility & safety

- Fully backward-compatible: omitting `source` is a true no-op.
- Security: `.eq('source', source)` binds the value as a PostgREST parameter (no injection), exact-match only; tenant scoping (org access check + `organization_id`/`brand_id` filters) is upstream and unconditional — `source` can only narrow an already-scoped set.
- No new index needed: `count: 'exact'` already runs on every list call; adding a predicate makes it strictly cheaper.

## Testing

- `npx mocha test/support/prompts-storage.test.js test/controllers/brands.test.js` → 553 passing.
- `npm run docs:lint` → API description valid (pre-existing warnings only).
- IT: `test/it/postgres/categories-prompts.test.js` covers the new `source` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)