### PR TITLE
fix: crashing x-error header in onboard-site generic error

### DIFF
--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1090,15 +1090,16 @@ function LlmoController(ctx) {
     const { spaceCatId } = context.params;
     const { data } = context;
 
-    // Customers never see the internal reason - only a generic failure. Kept
-    // ASCII-only (no em dash / curly quotes): this string is copied verbatim into
-    // the `x-error` response header by badRequest()/internalServerError(), and a
-    // character outside the header-safe range (see cleanupHeaderValue) crashes the
-    // response with a 500 "Invalid character in header content" instead of the
-    // intended 400/500 body.
-    const GENERIC_ONBOARD_ERROR = "We couldn't onboard this domain right now. Please use our "
-      + 'domain onboarding guide instead: https://experienceleague.adobe.com/en/docs/'
-      + 'llm-optimizer/using/essentials/quick-start#step-1-onboard-your-domain';
+    // Customers never see the internal reason - only a generic failure. The
+    // project-elmo-ui client renders its own localized copy (with a link to the
+    // onboarding guide) instead of this raw text - this string only reaches a
+    // caller that skips the UI (e.g. a direct API/curl consumer), so it stays a
+    // short, plain fallback. Kept ASCII-only (no em dash / curly quotes): it's
+    // copied verbatim into the `x-error` response header by
+    // badRequest()/internalServerError(), and a character outside the
+    // header-safe range (see cleanupHeaderValue) crashes the response with a 500
+    // "Invalid character in header content" instead of the intended 400/500 body.
+    const GENERIC_ONBOARD_ERROR = "We couldn't onboard this domain right now. Please contact support.";
 
     try {
       // --- Resolve org (404 if missing) ---

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1090,8 +1090,15 @@ function LlmoController(ctx) {
     const { spaceCatId } = context.params;
     const { data } = context;
 
-    // Customers never see the internal reason — only a generic failure.
-    const GENERIC_ONBOARD_ERROR = "We couldn't onboard this domain — please contact support.";
+    // Customers never see the internal reason - only a generic failure. Kept
+    // ASCII-only (no em dash / curly quotes): this string is copied verbatim into
+    // the `x-error` response header by badRequest()/internalServerError(), and a
+    // character outside the header-safe range (see cleanupHeaderValue) crashes the
+    // response with a 500 "Invalid character in header content" instead of the
+    // intended 400/500 body.
+    const GENERIC_ONBOARD_ERROR = "We couldn't onboard this domain right now. Please use our "
+      + 'domain onboarding guide instead: https://experienceleague.adobe.com/en/docs/'
+      + 'llm-optimizer/using/essentials/quick-start#step-1-onboard-your-domain';
 
     try {
       // --- Resolve org (404 if missing) ---
@@ -1169,7 +1176,7 @@ function LlmoController(ctx) {
       const validation = await validateSiteNotOnboarded(baseURL, imsOrgId, dataFolder, context);
       if (!validation.isValid) {
         log.warn(`Site-only onboarding rejected for org ${spaceCatId}, domain ${domain}: ${validation.error}`);
-        return badRequest(GENERIC_ONBOARD_ERROR);
+        return badRequest(cleanupHeaderValue(GENERIC_ONBOARD_ERROR));
       }
 
       // --- Orchestrate (siteOnly: true; no `say` → zero customer Slack) ---
@@ -1205,7 +1212,7 @@ function LlmoController(ctx) {
         `:x: Site-only onboarding failed for org ${spaceCatId}: ${error.message}`,
         context,
       );
-      return internalServerError(GENERIC_ONBOARD_ERROR);
+      return internalServerError(cleanupHeaderValue(GENERIC_ONBOARD_ERROR));
     }
   };
 

--- a/test/controllers/llmo/onboard-site-only.test.js
+++ b/test/controllers/llmo/onboard-site-only.test.js
@@ -29,7 +29,13 @@ use(sinonChai);
  * orchestration tests in llmo-onboarding.test.js.
  */
 describe('LlmoController — onboardSiteOnly (LLMO-5606)', () => {
-  const GENERIC_ERROR = "We couldn't onboard this domain — please contact support.";
+  const GENERIC_ERROR = "We couldn't onboard this domain right now. Please use our "
+    + 'domain onboarding guide instead: https://experienceleague.adobe.com/en/docs/'
+    + 'llm-optimizer/using/essentials/quick-start#step-1-onboard-your-domain';
+  // Header-safe range enforced by cleanupHeaderValue() / Node's http header validation
+  // (this is the exact class of char — em dash, curly quotes — that previously crashed
+  // the response with a 500 "Invalid character in header content [\"x-error\"]").
+  const HEADER_SAFE = /^[\t\x20-\x7E\x80-\xFF]*$/;
 
   let LlmoController;
   let controller;
@@ -328,6 +334,10 @@ describe('LlmoController — onboardSiteOnly (LLMO-5606)', () => {
       const body = await res.json();
       expect(body.message).to.equal(GENERIC_ERROR);
       expect(body.message).to.not.contain('already onboarded');
+      // Regression guard (LLMO-6147): a message with a char outside this range
+      // crashes the real x-error header with a 500 at the HTTP layer — a failure
+      // this mocked http-utils test can't otherwise catch.
+      expect(HEADER_SAFE.test(body.message)).to.be.true;
       expect(performLlmoOnboardingStub).to.not.have.been.called;
     });
   });
@@ -342,6 +352,7 @@ describe('LlmoController — onboardSiteOnly (LLMO-5606)', () => {
       const body = await res.json();
       expect(body.message).to.equal(GENERIC_ERROR);
       expect(body.message).to.not.contain('SharePoint');
+      expect(HEADER_SAFE.test(body.message)).to.be.true;
 
       // Ops gets the internal reason; the customer does not.
       expect(postLlmoAlertStub).to.have.been.calledOnce;

--- a/test/controllers/llmo/onboard-site-only.test.js
+++ b/test/controllers/llmo/onboard-site-only.test.js
@@ -29,9 +29,7 @@ use(sinonChai);
  * orchestration tests in llmo-onboarding.test.js.
  */
 describe('LlmoController — onboardSiteOnly (LLMO-5606)', () => {
-  const GENERIC_ERROR = "We couldn't onboard this domain right now. Please use our "
-    + 'domain onboarding guide instead: https://experienceleague.adobe.com/en/docs/'
-    + 'llm-optimizer/using/essentials/quick-start#step-1-onboard-your-domain';
+  const GENERIC_ERROR = "We couldn't onboard this domain right now. Please contact support.";
   // Header-safe range enforced by cleanupHeaderValue() / Node's http header validation
   // (this is the exact class of char — em dash, curly quotes — that previously crashed
   // the response with a 500 "Invalid character in header content [\"x-error\"]").


### PR DESCRIPTION
## Changes Made

Fixes a 500 crash on the site-only onboarding endpoint's generic failure path.

- `GENERIC_ONBOARD_ERROR` in `onboardSiteOnly()` contained an em dash (U+2014), outside the HTTP header-safe character range. `badRequest()`/`internalServerError()` copy the message verbatim into the `x-error` response header, so any generic-failure response (e.g. re-onboarding an already-onboarded domain) crashed with a raw `500 Invalid character in header content ["x-error"]` instead of the intended `400`.
- Rewrote the message to be ASCII-only. It stays short, plain, and generic (does not reveal the internal reason — already-onboarded, org conflict, etc. — per the existing "customers never see the internal reason" policy).
- Wrapped both call sites with `cleanupHeaderValue()`, the sanitizer already used throughout this file for the same class of issue, as defense in depth against a future copy edit reintroducing an unsafe character.
- Updated the one unit test that hardcoded the old message text, and added a header-safety regression assertion (the existing test mocks out real header serialization, so it couldn't have caught this bug otherwise).

**Note on message wording:** an earlier revision of this PR also added a "please use our onboarding guide" sentence + link to this backend string. That moved to the UI instead (see the companion `project-elmo-ui` PR below) — a hardcoded English string in an API response can't be localized, so the actual user-facing copy (with a real clickable link) now lives in `project-elmo-ui`'s localized messages. This backend message is only seen by a caller that skips the UI (e.g. a direct API/curl consumer), so it stays a short, plain fallback.

### Related Issues

Relates to LLMO-6147

## Testing the PR changes

1. `POST /v2/orgs/:spaceCatId/llmo/onboard-site` with a domain that's already onboarded (or otherwise rejected by `validateSiteNotOnboarded`).
2. Confirm a clean `400` with the new plain-text message, not a `500`.
3. Run `npx mocha --timeout 15000 test/controllers/llmo/onboard-site-only.test.js` - 20/20 passing.
4. Run `npx mocha --timeout 15000 'test/controllers/llmo/*.test.js'` - 2081/2081 passing (no regressions).

## Screenshots/Videos

No screenshots available (backend-only change).

## Additional Notes

Companion frontend fix (separate repo/PR) in `project-elmo-ui`: https://github.com/adobe/project-elmo-ui/pull/2385 — the same self-serve onboarding flow also dropped any subpath (e.g. `guides.adobe.com/knowledge-ai` → `guides.adobe.com`) before sending it to this endpoint, and now owns the localized "please use our onboarding guide" copy + link that used to live in this backend's error string.
