### PR TITLE
fix(serenity): match regular plurals and possessives in the branded classifier

### DIFF
--- a/src/support/serenity/branded-classifier.js
+++ b/src/support/serenity/branded-classifier.js
@@ -20,14 +20,24 @@ import { collectAliasNames } from './brand-aliases.js';
  * on every path that writes a Serenity (Semrush sub-workspace) prompt: manual
  * create / edit, CSV import (which reuses the create path), AI generation, and
  * onboarding/provisioning seeding. A prompt is `type:branded` when its text
- * mentions the brand name or an applicable alias as a WHOLE WORD (diacritics
- * folded); otherwise `type:non-branded`.
+ * mentions the brand name or an applicable alias as a WHOLE WORD — allowing the
+ * regular English plural of that word (diacritics folded); otherwise
+ * `type:non-branded`.
  *
  * This replaces the earlier AI-only substring matcher (`brandedTypeTag`): the
  * match is now word-boundary + diacritic-folding, and it is shared everywhere so
  * the classification is identical no matter how the prompt got in. The behaviour
  * change (substring → whole-word) is forward-only — existing prompts are not
  * reclassified (serenity-docs#31, decisions 1/2/6).
+ *
+ * Plurals and possessives are handled morphologically, NOT by relaxing the match
+ * to a substring test. Proper nouns only ever take the regular plural in English
+ * — `the Buicks`, `the Kennedys`, `the Bosches` — never the irregular stem
+ * changes that common nouns take (no `Buickies`, no `Bosch → *Bosches` via
+ * `-ves`/`-ies`). So the classifier admits exactly two suffixes on the needle's
+ * final token, `-s` and (after a sibilant) `-es`, and strips the possessive
+ * clitic `'s` from BOTH sides before matching. `Ace` therefore still does not
+ * match `surface` or `spaces`, but does match `Aces`.
  */
 
 // Latin letters that carry a diacritic/ligature but have NO canonical NFD
@@ -42,12 +52,32 @@ const NON_DECOMPOSING_FOLDS = Object.freeze({
 const NON_DECOMPOSING_RE = new RegExp(`[${Object.keys(NON_DECOMPOSING_FOLDS).join('')}]`, 'g');
 
 /**
+ * The English possessive clitic: an apostrophe (straight or typographic) + `s`,
+ * at a token end. Dropped from both sides so `Kellogg's` ≡ `Kellogg` — otherwise
+ * the alias `Kellogg's` normalizes to the two-token needle `kellogg s`, which
+ * matches only a literal possessive and never the bare brand name. Runs after
+ * `toLowerCase` (so only lower-case `s`) and before punctuation collapse (which
+ * would otherwise turn the apostrophe into a token gap). The bare trailing
+ * apostrophe of a plural possessive (`Buicks'`) is left to the plural rule.
+ */
+const POSSESSIVE_RE = /['’]s(?=[^\p{L}\p{N}]|$)/gu;
+
+/**
+ * Needle endings after which the regular English plural is spelled `-es` rather
+ * than `-s` (the sibilants): `Lexus → Lexuses`, `Bosch → Bosches`, `Fox → Foxes`.
+ * Restricting `-es` to these keeps the suffix set from admitting non-words like
+ * `Buickes` as a match.
+ */
+const SIBILANT_RE = /(?:[sxz]|ch|sh)$/;
+
+/**
  * Normalizes one side of the match (needle OR haystack) into a canonical,
  * space-delimited token stream:
  *   - fold diacritics (NFD decomposition, strip combining marks) so `café` ≈ `cafe`;
  *   - lower-case (case-insensitive match);
  *   - fold the non-decomposing accented/ligature letters (`ø→o`, `æ→ae`, `ß→ss`,
  *     …) that the NFD strip leaves intact, so `Ørsted` ≈ `Orsted`;
+ *   - drop the possessive clitic `'s`, so `Kellogg's` ≡ `Kellogg`;
  *   - replace every run of non-alphanumeric characters (Unicode letters/numbers)
  *     with a single space, so punctuation/whitespace collapses to token gaps;
  *   - trim.
@@ -65,6 +95,7 @@ export function normalizeMatch(value) {
     .replace(/\p{Diacritic}/gu, '')
     .toLowerCase()
     .replace(NON_DECOMPOSING_RE, (ch) => NON_DECOMPOSING_FOLDS[ch])
+    .replace(POSSESSIVE_RE, '')
     .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim();
 }
@@ -110,11 +141,32 @@ export function brandNeedles(brandName, aliases, market) {
 }
 
 /**
+ * Tests one normalized needle against an already space-padded, normalized
+ * haystack. The needle must occupy whole tokens: it matches bare, or with the
+ * regular English plural suffix on its FINAL token only (`-s` always, `-es`
+ * after a sibilant). Leading/trailing spaces anchor both ends, so this stays a
+ * word-boundary test rather than a substring test — `ace` matches `aces` but
+ * not `spaces`, and the multi-word `le creuset` matches `le creusets` but not
+ * `les creuset`.
+ *
+ * @param {string} haystack - normalized prompt text, padded with a leading and
+ *   trailing space.
+ * @param {string} needle - a normalized, non-empty needle.
+ * @returns {boolean}
+ */
+function needleMatches(haystack, needle) {
+  return haystack.includes(` ${needle} `)
+    || haystack.includes(` ${needle}s `)
+    || (SIBILANT_RE.test(needle) && haystack.includes(` ${needle}es `));
+}
+
+/**
  * Classifies a prompt as `type:branded` when its text contains any needle as a
- * whole word (or contiguous whole-word run for a multi-word needle), else
- * `type:non-branded`. Both sides are normalized via {@link normalizeMatch}; the
- * haystack is padded with spaces so a needle wrapped in spaces matches only on
- * token boundaries. Empty `needles` ⇒ `type:non-branded`.
+ * whole word — or that word's regular English plural — else `type:non-branded`.
+ * A multi-word needle must match as a contiguous whole-word run. Both sides are
+ * normalized via {@link normalizeMatch} (which also strips the possessive `'s`,
+ * so `Buick's` and `Buicks'` both classify as branded). Empty `needles` ⇒
+ * `type:non-branded`.
  *
  * @param {string} promptText - the prompt text.
  * @param {string[]} needles - normalized needles from {@link brandNeedles} /
@@ -127,7 +179,7 @@ export function classifyBrandedTag(promptText, needles) {
     return TYPE_TAG.NON_BRANDED;
   }
   const haystack = ` ${normalizeMatch(promptText)} `;
-  return list.some((n) => n && haystack.includes(` ${n} `))
+  return list.some((n) => n && needleMatches(haystack, n))
     ? TYPE_TAG.BRANDED
     : TYPE_TAG.NON_BRANDED;
 }

--- a/test/support/serenity/branded-classifier.test.js
+++ b/test/support/serenity/branded-classifier.test.js
@@ -34,6 +34,22 @@ describe('serenity branded-classifier', () => {
       expect(normalizeMatch(undefined)).to.equal('');
       expect(normalizeMatch(null)).to.equal('');
     });
+
+    it("drops the possessive clitic 's (straight and typographic)", () => {
+      expect(normalizeMatch("Kellogg's")).to.equal('kellogg');
+      expect(normalizeMatch('Kellogg’s')).to.equal('kellogg');
+      expect(normalizeMatch("Kellogg's Frosted Flakes")).to.equal('kellogg frosted flakes');
+    });
+
+    it("leaves a plural possessive's bare apostrophe to the plural rule", () => {
+      expect(normalizeMatch("Buicks' best selling vehicle")).to.equal('buicks best selling vehicle');
+    });
+
+    it("does not strip an 's that is not a possessive clitic", () => {
+      // Word-internal 's' and a leading apostrophe are untouched.
+      expect(normalizeMatch('sacs')).to.equal('sacs');
+      expect(normalizeMatch("'salem")).to.equal('salem');
+    });
   });
 
   describe('needlesFromNames', () => {
@@ -126,6 +142,83 @@ describe('serenity branded-classifier', () => {
     it('tolerates empty / nullish prompt text', () => {
       expect(classifyBrandedTag('', needles)).to.equal(TYPE_TAG.NON_BRANDED);
       expect(classifyBrandedTag(undefined, needles)).to.equal(TYPE_TAG.NON_BRANDED);
+    });
+  });
+
+  describe('classifyBrandedTag — regular plurals of the brand name', () => {
+    const branded = (text, names) => classifyBrandedTag(text, needlesFromNames(names));
+
+    it('matches the plain -s plural of a single-word needle', () => {
+      expect(branded('Are Buicks luxury cars?', ['Buick'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('Do Cadillacs hold their value?', ['Cadillac'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('Are GMCs expensive to maintain?', ['GMC'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('Are Chevys expensive to maintain?', ['Chevy'])).to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('matches the -es plural only after a sibilant stem', () => {
+      // Sibilant stems take -es: Lexus → Lexuses, Bosch → Bosches, Fox → Foxes.
+      expect(branded('are Lexuses reliable?', ['Lexus'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('do Bosches last long?', ['Bosch'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('are Foxes fast?', ['Fox'])).to.equal(TYPE_TAG.BRANDED);
+      // A non-sibilant stem must NOT admit -es — `Buickes` is not a word, and
+      // admitting it would let any needle match an arbitrary `…es` word.
+      expect(branded('are Buickes good?', ['Buick'])).to.equal(TYPE_TAG.NON_BRANDED);
+    });
+
+    it('matches the singular and plural possessive', () => {
+      expect(branded("What is Buick's best selling vehicle?", ['Buick']))
+        .to.equal(TYPE_TAG.BRANDED);
+      expect(branded("What is Buicks' best selling vehicle?", ['Buick']))
+        .to.equal(TYPE_TAG.BRANDED);
+      // The alias itself may carry the possessive (WK Kellogg Co ships `Kellogg's`).
+      expect(branded('how does kellogg ensure cereal safety?', ["Kellogg's"]))
+        .to.equal(TYPE_TAG.BRANDED);
+      expect(branded('are Kelloggs cereals healthy?', ["Kellogg's"]))
+        .to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('pluralizes only the FINAL token of a multi-word needle', () => {
+      expect(branded('best Le Creusets on sale', ['Le Creuset'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('best les creuset pans', ['Le Creuset'])).to.equal(TYPE_TAG.NON_BRANDED);
+    });
+
+    it('folds diacritics on a pluralized match', () => {
+      expect(branded('do Ørsteds wind farms pay?', ['Orsted'])).to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('does NOT become a substring match — the stem must still be whole-word', () => {
+      // The suffix rule only extends the RIGHT edge by -s/-es; the left edge is
+      // still anchored, and no other suffix is admitted.
+      expect(branded('tell me about outer space', ['Ace'])).to.equal(TYPE_TAG.NON_BRANDED);
+      expect(branded('what is the best surface finish?', ['Ace'])).to.equal(TYPE_TAG.NON_BRANDED);
+      expect(branded('how many spaces are there?', ['Ace'])).to.equal(TYPE_TAG.NON_BRANDED);
+      expect(branded('is this a Buickmobile?', ['Buick'])).to.equal(TYPE_TAG.NON_BRANDED);
+      expect(branded('Buicking around town', ['Buick'])).to.equal(TYPE_TAG.NON_BRANDED);
+      // …but the true plural of the same short needle does match.
+      expect(branded('Aces are wild', ['Ace'])).to.equal(TYPE_TAG.BRANDED);
+    });
+
+    it('makes hand-maintained plural aliases redundant (Lovesac)', () => {
+      // Lovesac ships `Sacs`, `Sactionals`, `Supersacs`, `pillowsacs` purely to
+      // work around the missing plural rule; the singular aliases now suffice.
+      const singular = needlesFromNames(['Lovesac', 'Sac', 'Sactional', 'SuperSac', 'PillowSac']);
+      for (const text of [
+        'How do Lovesac Sacs differ in durability from other bean bags?',
+        'are Sactionals worth it?',
+        'how many SuperSacs fit in a living room?',
+        'compare pillowsacs to floor cushions',
+      ]) {
+        expect(classifyBrandedTag(text, singular), text).to.equal(TYPE_TAG.BRANDED);
+      }
+    });
+
+    it('leaves genuinely non-branded prompts non-branded', () => {
+      // Real non-branded prompts from the GM / Kellogg workspaces.
+      const gmc = needlesFromNames(['GMC', 'Sierra', 'Denali', 'Yukon', 'Canyon', 'Hummer']);
+      expect(classifyBrandedTag('best midsize truck for towing', gmc))
+        .to.equal(TYPE_TAG.NON_BRANDED);
+      expect(classifyBrandedTag('which cereals have the least sugar?', needlesFromNames(["Kellogg's"])))
+        .to.equal(TYPE_TAG.NON_BRANDED);
     });
   });
 });

--- a/test/support/serenity/branded-classifier.test.js
+++ b/test/support/serenity/branded-classifier.test.js
@@ -143,6 +143,11 @@ describe('serenity branded-classifier', () => {
       expect(classifyBrandedTag('', needles)).to.equal(TYPE_TAG.NON_BRANDED);
       expect(classifyBrandedTag(undefined, needles)).to.equal(TYPE_TAG.NON_BRANDED);
     });
+
+    it('tolerates a non-array needles argument', () => {
+      expect(classifyBrandedTag('is Ace a good brand?', undefined)).to.equal(TYPE_TAG.NON_BRANDED);
+      expect(classifyBrandedTag('is Ace a good brand?', null)).to.equal(TYPE_TAG.NON_BRANDED);
+    });
   });
 
   describe('classifyBrandedTag — regular plurals of the brand name', () => {
@@ -156,13 +161,25 @@ describe('serenity branded-classifier', () => {
     });
 
     it('matches the -es plural only after a sibilant stem', () => {
-      // Sibilant stems take -es: Lexus → Lexuses, Bosch → Bosches, Fox → Foxes.
+      // One case per SIBILANT_RE alternation: s, x, z, ch, sh.
       expect(branded('are Lexuses reliable?', ['Lexus'])).to.equal(TYPE_TAG.BRANDED);
-      expect(branded('do Bosches last long?', ['Bosch'])).to.equal(TYPE_TAG.BRANDED);
       expect(branded('are Foxes fast?', ['Fox'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('are Benzes reliable?', ['Benz'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('do Bosches last long?', ['Bosch'])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('are Bushes evergreen?', ['Bush'])).to.equal(TYPE_TAG.BRANDED);
       // A non-sibilant stem must NOT admit -es — `Buickes` is not a word, and
       // admitting it would let any needle match an arbitrary `…es` word.
       expect(branded('are Buickes good?', ['Buick'])).to.equal(TYPE_TAG.NON_BRANDED);
+      // A sibilant stem with neither the bare form nor a plural present stays non-branded.
+      expect(branded('best luxury sedan', ['Lexus'])).to.equal(TYPE_TAG.NON_BRANDED);
+    });
+
+    it('composes the possessive strip with the sibilant -es plural', () => {
+      // `Ross's` normalizes to the needle `ross` (possessive stripped), whose
+      // stem is sibilant — so the plural `Rosses` matches through both new paths.
+      expect(branded('are Rosses near you?', ["Ross's"])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded("is Ross's open today?", ["Ross's"])).to.equal(TYPE_TAG.BRANDED);
+      expect(branded('is Ross open today?', ["Ross's"])).to.equal(TYPE_TAG.BRANDED);
     });
 
     it('matches the singular and plural possessive', () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
The server-side Serenity branded/non-branded prompt classifier now recognises the regular English plural and the possessive form of a brand name or alias. It remains a word-boundary matcher, not a substring match.

## 2. Reasoning
The classifier matched brand needles as whole tokens only, so any inflection of the brand name fell through to `type:non-branded`. `Buick` classified as branded; `Buicks` did not — even though "Are Buicks luxury cars?" is plainly a branded prompt.

Investigating that turned up a second, quieter defect in the same code. The alias `Kellogg's` normalizes to the two-token needle `kellogg s`, because the apostrophe collapses into a token gap. Such a needle matches a literal possessive and nothing else, so it never matched the bare word "Kellogg". That is why the WK Kellogg Co brand had only 14 of its 311 prompts tagged branded, while 22 of them name the brand.

The obvious fix — relaxing the match to a `contains` test — is not acceptable: it would classify "outer space" as a mention of the brand `Ace`. The fix had to stay morphological.

## 3. High-level overview of the changes
The insight that makes a narrow fix possible is that **proper nouns only ever take the regular English plural**. One writes "the Kennedys", never "*the Kennedies"; brand names never undergo the irregular stem changes (`-ves`, `-ies`) that common nouns do. So the matcher can admit a small, closed set of suffixes and remain principled.

Behaviour delta:

- A needle now matches when it is followed by the regular plural suffix on its **final token only**: `-s` in every case, and `-es` only after a sibilant stem (`s`, `x`, `z`, `ch`, `sh`). `Lexuses` and `Bosches` therefore match, while the non-word `Buickes` does not.
- The possessive clitic `'s` (straight and typographic) is stripped from **both** the needle and the prompt text before matching. This makes `Buick's` classify, and it simultaneously repairs the `Kellogg's` alias so it matches the bare brand name.
- A plural possessive (`Buicks'`) leaves a bare trailing apostrophe, which the plural rule already covers.
- Multi-word needles pluralize only their last token: `Le Creusets` matches, `les creuset` does not.

What deliberately did **not** change is the left edge of the match. It stays anchored, and no suffix other than the two above is admitted. `Ace` still does not match `surface`, `spaces`, or `outer space`, and `Buick` still does not match `Buickmobile` or `Buicking` — but `Aces` and `Buicks` now do.

Operationally visible effect: prompts written from now on through any Serenity write path (manual create/edit, CSV import, AI generation, onboarding seeding) get the corrected tag. Because these paths all share this single classifier, the behaviour is uniform across them.

**Reclassification is out of scope here.** Per serenity-docs issue 31 the classifier is forward-only — existing prompts are not reclassified — and this PR takes the migrated data as it stands. A backfill pass over already-migrated prompts would be entirely possible and is a sensible follow-up: it would flip roughly 43 plural-form prompts across the General Motors brands, plus about 8 bare-"Kellogg" prompts in WK Kellogg Co, from non-branded to branded. Nothing would flip the other way.

## 4. Required information
- Spec: https://github.com/adobe/serenity-docs/issues/31

## 5. Affected / used mysticat-workspace projects
- `project-elmo-ui` — consumed / contract. It renders the branded vs non-branded tag (read-only) and derives the branded-ratio prompt-health statistics from it. No UI change is required; the tag values and their shape are unchanged, only which prompts receive which tag.
- `serenity-docs` — contract. Issue 31 defines the classifier as a single server-owned layer, forward-only. This change keeps both properties.

## 6. Additional information outside the code
The rule was designed against real migrated data rather than invented examples. Using the read-only prod Postgres MCP, the classifier's matching logic was replayed over the actual prompt text and the actual `brand_aliases` rows for all 13 brands in the Lovesac, Kellogg and General Motors workspaces — 5,002 prompts in total.

- Every prompt the old rule missed was a regular plural: `Buicks`, `Cadillacs`, `Chevys`, `GMCs`. There were 43 of them, and each was read individually; each genuinely names its brand.
- The new rule flips exactly those 43 to branded and flips **zero** prompts in the wrong direction across the whole corpus.
- An independent check corroborates the rule. The Lovesac workspace showed zero misses, but only because someone had hand-added `Sacs`, `Sactionals`, `Supersacs` and `pillowsacs` as aliases to work around the missing plural rule. Dropping those four workaround aliases and applying the plural rule instead reproduces Lovesac's branded set exactly — 591 prompts before, 591 after, nothing lost and nothing gained. The rule derives what a human had been maintaining by hand.

One caveat on the evidence: this replay reads the prompt corpus and alias lists from Postgres. The `type:branded` tags themselves live upstream in the Semrush sub-workspaces and were not read back.

## 7. Test plan
Locally, beyond the unit tests, the verification that mattered was the corpus replay described in section 6 — the matching logic exercised against the real prod prompt text and alias rows for the three migrated workspaces, with every flipped prompt inspected by hand.

To verify on **dev**:

1. Pick a Serenity brand with a single-word name (or add an alias such as `Buick`).
2. Create a prompt through the normal write path whose text uses the plural, e.g. "Are Buicks luxury cars?", and confirm the stored prompt carries `type:branded`.
3. Create one using the possessive, "What is Buick's best selling vehicle?", and confirm `type:branded`.
4. Confirm the guard still holds: with an alias of `Ace`, a prompt reading "tell me about outer space" must remain `type:non-branded`.
5. For an alias carrying a possessive (`Kellogg's`), confirm a prompt naming the bare brand ("how does kellogg ensure cereal safety?") now classifies as `type:branded`.

The same five checks apply on **stage** and **prod** after deploy. No migration or backfill runs as part of this change, so existing prompt tags are expected to be untouched — that is the forward-only contract, and seeing old prompts keep their old tags is the correct outcome, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
