### PR TITLE
feat(referral-traffic): plumb categoryName through controller | LLMO-6026

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -5120,8 +5120,8 @@ llmo-referral-traffic-filter-dimensions:
     summary: Distinct referral traffic filter values
     description: |
       Returns the distinct filter values (platforms, regions, devices, page
-      intents) and available sources for the selected site and date range.
-      Queries `rpc_referral_traffic_filter_dimensions`.
+      intents, categories) and available sources for the selected site and date
+      range. Queries `rpc_referral_traffic_filter_dimensions`.
     operationId: getReferralTrafficFilterDimensions
     parameters:
       - name: source
@@ -5168,6 +5168,7 @@ llmo-referral-traffic-kpis:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
     responses:
       '200':
         description: Aggregated KPI metrics
@@ -5207,6 +5208,7 @@ llmo-referral-traffic-trend:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
     responses:
       '200':
         description: Referral traffic KPI time series
@@ -5245,6 +5247,7 @@ llmo-referral-traffic-by-platform:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
     responses:
       '200':
         description: Traffic by platform
@@ -5280,6 +5283,7 @@ llmo-referral-traffic-by-region:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
     responses:
       '200':
         description: Traffic by region
@@ -5315,6 +5319,7 @@ llmo-referral-traffic-by-page-intent:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
     responses:
       '200':
         description: Traffic by page intent
@@ -5364,6 +5369,7 @@ llmo-referral-traffic-by-url:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
       - name: pageSize
         in: query
         description: 'Number of rows per page (default 50, max 500). Aliases: page_size, limit'
@@ -5439,6 +5445,7 @@ llmo-referral-traffic-by-url-trend:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
       - name: urlPath
         in: query
         required: true
@@ -5482,6 +5489,7 @@ llmo-referral-traffic-by-device:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
     responses:
       '200':
         description: Traffic by device
@@ -5533,6 +5541,7 @@ llmo-referral-traffic-business-impact:
       - { name: region, in: query, schema: { type: string } }
       - { name: pageIntent, in: query, description: 'Snake alias: page_intent', schema: { type: string } }
       - { name: deviceType, in: query, description: 'Aliases: device_type, device', schema: { type: string } }
+      - { name: categoryName, in: query, description: 'Snake alias: category_name', schema: { type: string } }
     responses:
       '200':
         description: Business impact metrics

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11878,12 +11878,18 @@ ReferralTrafficFilterDimensions:
       items:
         type: string
       example: ['optel', 'cdn']
+    categories:
+      type: array
+      items:
+        type: string
+      example: ['Apparel', 'Footwear']
   required:
     - platforms
     - regions
     - devices
     - pageIntents
     - availableSources
+    - categories
 
 ReferralTrafficKpis:
   type: object

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -116,6 +116,7 @@ function parseParams(context) {
     region: q.region || null,
     pageIntent: q.pageIntent || q.page_intent || null,
     deviceType: q.deviceType || q.device_type || q.device || null,
+    category: q.categoryName || q.category_name || null,
   };
 }
 
@@ -132,6 +133,7 @@ function commonRpcParams(siteId, parsed) {
     p_region: parsed.region,
     p_device: parsed.deviceType,
     p_page_intent: parsed.pageIntent,
+    p_category_name: parsed.category,
   };
 }
 
@@ -221,6 +223,7 @@ export function createReferralTrafficFilterDimensionsHandler(getSiteAndValidateA
           devices: row?.devices ?? [],
           pageIntents: row?.page_intents ?? [],
           availableSources: row?.available_sources ?? [],
+          categories: row?.categories ?? [],
         });
       },
     );

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -219,6 +219,28 @@ describe('llmo-referral-traffic', () => {
       expect(rpcArgs.p_start_date).to.be.a('string').and.match(/^\d{4}-\d{2}-\d{2}$/);
       expect(rpcArgs.p_end_date).to.be.a('string').and.match(/^\d{4}-\d{2}-\d{2}$/);
     });
+
+    it('maps categoryName to p_category_name and defaults to null when absent', async () => {
+      const client = makeRpcClient({ data: [] });
+      const ctx = makeContext({ client });
+      ctx.data = { categoryName: 'Footwear' };
+      await createReferralTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      expect(client.rpc.getCall(0).args[1].p_category_name).to.equal('Footwear');
+
+      const clientEmpty = makeRpcClient({ data: [] });
+      const ctxEmpty = makeContext({ client: clientEmpty });
+      ctxEmpty.data = {};
+      await createReferralTrafficKpisHandler(stubbedValidateAccess)(ctxEmpty);
+      expect(clientEmpty.rpc.getCall(0).args[1].p_category_name).to.equal(null);
+    });
+
+    it('accepts category_name snake_case alias', async () => {
+      const client = makeRpcClient({ data: [] });
+      const ctx = makeContext({ client });
+      ctx.data = { category_name: 'Apparel' };
+      await createReferralTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      expect(client.rpc.getCall(0).args[1].p_category_name).to.equal('Apparel');
+    });
   });
 
   // ── /filter-dimensions ────────────────────────────────────────────────────
@@ -232,6 +254,7 @@ describe('llmo-referral-traffic', () => {
           devices: ['desktop', 'mobile'],
           page_intents: ['purchase'],
           available_sources: ['optel', 'cdn'],
+          categories: ['Apparel', 'Footwear'],
         }],
       });
       const handler = createReferralTrafficFilterDimensionsHandler(stubbedValidateAccess);
@@ -243,6 +266,7 @@ describe('llmo-referral-traffic', () => {
       expect(body.devices).to.deep.equal(['desktop', 'mobile']);
       expect(body.pageIntents).to.deep.equal(['purchase']);
       expect(body.availableSources).to.deep.equal(['optel', 'cdn']);
+      expect(body.categories).to.deep.equal(['Apparel', 'Footwear']);
     });
 
     it('returns empty arrays when RPC returns no rows', async () => {
@@ -252,6 +276,7 @@ describe('llmo-referral-traffic', () => {
       const body = await res.json();
       expect(body.platforms).to.deep.equal([]);
       expect(body.availableSources).to.deep.equal([]);
+      expect(body.categories).to.deep.equal([]);
     });
 
     it('returns 500 on PostgREST error', async () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Plumbs a `categoryName` filter through the Referral Traffic controller: it is read from the query string, passed to every referral RPC, and the distinct categories are surfaced on the filter-dimensions response. This is the API slice (B) of the Referral Traffic "Category" filter.

## 2. Reasoning
Customers define **categories** (named groups of URLs) in Customer Configuration and can already slice Agentic Traffic by them. The ask (parent LLMO-5440) is to offer the same category slicing on Referral Traffic. The data-service RPCs now accept a category and expose the available categories; this change exposes both over the HTTP API so the UI can use them.

## 3. High-level overview of the changes
Before: the Referral Traffic endpoints had no category concept, and filter-dimensions returned platforms / regions / devices / page-intents only.

After:
- `parseParams` reads a new `categoryName` query parameter (accepting the `category_name` snake alias).
- `commonRpcParams` forwards it as `p_category_name` to every referral RPC — including by_url and url_trend via the shared spread — so all referral metric endpoints can be scoped to a category.
- The filter-dimensions handler returns `categories` (defaulting to an empty array when the RPC returns none), matching the platforms/regions/devices/page-intents shape.
- The OpenAPI spec documents the `categoryName` query parameter on the referral metric endpoints and the new `categories` field on the filter-dimensions schema.

No behaviour changes when `categoryName` is absent — every endpoint responds exactly as before.

## 4. Required information
- Jira / issue: [LLMO-6026](https://jira.corp.adobe.com/browse/LLMO-6026); parent [LLMO-5440](https://jira.corp.adobe.com/browse/LLMO-5440)

## 5. Affected / used mysticat-workspace projects
- **mysticat-data-service** — contract/consumed: relies on the referral RPCs accepting `p_category_name` and filter-dimensions returning `categories[]` (delivered in the data-service migration PR). Deploy that first.
- **project-elmo-ui** — downstream consumer: sends `categoryName` and reads `categories[]` to populate the Referral Traffic Category dropdown.

## 6. Additional information outside the code
Verified over real HTTP against a local stack (this service pointed at a local PostgREST + seeded Postgres):
- Curled the referral filter-dimensions, kpis, by_platform and by_url endpoints with `categoryName` set. Filter-dimensions returned `categories: ["Apparel","Footwear"]`; kpis went 190 → 150 (Footwear) → 30 (Apparel); the other endpoints scoped to the category as expected.
- Confirmed the `category_name` snake alias maps to the same parameter, and that omitting the parameter leaves responses unchanged.

## 7. Test plan
(a) Local: exercised the endpoints over HTTP as described in section 6, plus controller-level tests covering the `categoryName` → `p_category_name` mapping, the snake alias, and `categories` in the filter-dimensions response.

(b) Per environment:
- **eph / dev / stage / prod:** call a referral metric endpoint (e.g. kpis) without `categoryName` and confirm the response is unchanged, then with `categoryName=<real category>` for a site with classified URLs and confirm the metrics scope to it. Call the referral filter-dimensions endpoint and confirm a `categories` array is present (non-empty for a site that has classified categories).

## 8. Deployment & merge order
Sits in the middle of a three-repo change.
- depends-on: **mysticat-data-service** migration PR (the RPC signatures + `categories[]` this controller calls) — must deploy first.
- related: **project-elmo-ui** UI PR — https://github.com/adobe/project-elmo-ui/pull/2389 (consumes this API; degrades to "All" until this is live).

Ordered sequence: mysticat-data-service → **this (spacecat-api-service)** → project-elmo-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
