### PR TITLE
feat: enhance serenity filter-dimensions for sub categories

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -174,6 +174,8 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-activate'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/deactivate:
     $ref: './serenity-api.yaml#/v2-serenity-deactivate'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/url-inspector/filter-dimensions:
+    $ref: './serenity-api.yaml#/v2-serenity-url-inspector-filter-dimensions'
   /organizations/{organizationId}/sites:
     $ref: './sites-api.yaml#/sites-for-organization'
   /organizations/{organizationId}/entitlements:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11475,14 +11475,18 @@ SerenityFilterDimensionItem:
   type: object
   description: |
     A single id/label option for a Serenity Elements filter dropdown. `id` is
-    `null` when Semrush has no stable identifier for the value (most tag-derived
-    dimensions); `parent_id`/`parent_label` are present only when the source tag
-    encoded a "Parent__Child" hierarchy (e.g. `topic:Furniture__Sofas`).
+    the original, unmodified tag value returned by Semrush (including its
+    `prefix:` and any `Parent__Child` encoding, e.g. `topic:Furniture__Sofas`).
+    `parent_id`/`parent_label` are present only when the source tag encoded a
+    "Parent__Child" hierarchy; `parent_id` is the same `prefix:` reconstructed
+    over just the parent segment (e.g. for
+    `category:Living Room Furniture Retail__Living Room Furniture and Sofas`,
+    `parent_id` is `category:Living Room Furniture Retail`).
   required: [id, label]
   properties:
-    id: { type: [string, 'null'] }
+    id: { type: string }
     label: { type: string }
-    parent_id: { type: [string, 'null'] }
+    parent_id: { type: string }
     parent_label: { type: string }
 
 SerenityUrlInspectorFilterDimensions:
@@ -11503,14 +11507,14 @@ SerenityUrlInspectorFilterDimensions:
     brands:
       type: array
       description: |
-        Available brands in the workspace. `id` is always null (Semrush has no
+        Available brands in the workspace. `id` mirrors `label` (Semrush has no
         stable brand id); `spacecat_brand_id` resolves by case-insensitive name
         match against the org's SpaceCat brands.
       items:
         type: object
         required: [id, label]
         properties:
-          id: { type: [string, 'null'] }
+          id: { type: string }
           label: { type: string }
           spacecat_brand_id: { type: [string, 'null'] }
     regions:
@@ -11538,11 +11542,11 @@ SerenityUrlInspectorFilterDimensions:
       items: { $ref: '#/SerenityFilterDimensionItem' }
     page_intents:
       type: array
-      description: Distinct `intent:`-prefixed tags. `id` is the uppercased label.
+      description: Distinct `intent:`-prefixed tags. `id` is the original `intent:`-prefixed tag value.
       items: { $ref: '#/SerenityFilterDimensionItem' }
     origins:
       type: array
-      description: Distinct `source:`-prefixed tags. `id` mirrors `label`.
+      description: Distinct `source:`-prefixed tags. `id` is the original `source:`-prefixed tag value.
       items: { $ref: '#/SerenityFilterDimensionItem' }
     tags:
       type: array

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11471,6 +11471,90 @@ SerenityErrorResponse:
     error: { type: string }
     message: { type: string }
 
+SerenityFilterDimensionItem:
+  type: object
+  description: |
+    A single id/label option for a Serenity Elements filter dropdown. `id` is
+    `null` when Semrush has no stable identifier for the value (most tag-derived
+    dimensions); `parent_id`/`parent_label` are present only when the source tag
+    encoded a "Parent__Child" hierarchy (e.g. `topic:Furniture__Sofas`).
+  required: [id, label]
+  properties:
+    id: { type: [string, 'null'] }
+    label: { type: string }
+    parent_id: { type: [string, 'null'] }
+    parent_label: { type: string }
+
+SerenityUrlInspectorFilterDimensions:
+  type: object
+  description: |
+    Filter dimensions for the Serenity (Semrush Elements-backed) URL Inspector
+    dashboard, sourced from the Semrush Brands, Markets, and Topics elements.
+
+    `brands`, `regions`, `topics`, `categories`, `page_intents`, `origins`, and
+    `tags` are always present (empty array when Semrush has no data). Any
+    additional Semrush tag prefix not already covered by the fixed dimensions
+    (e.g. a future `type:branded` tag) surfaces as an extra dynamic array
+    property keyed by that prefix — this is why the schema allows
+    `additionalProperties`. Prefixes that would collide with one of the fixed
+    keys above are routed into `tags` instead of clobbering that key.
+  required: [brands, regions, topics, categories, page_intents, origins, tags]
+  properties:
+    brands:
+      type: array
+      description: |
+        Available brands in the workspace. `id` is always null (Semrush has no
+        stable brand id); `spacecat_brand_id` resolves by case-insensitive name
+        match against the org's SpaceCat brands.
+      items:
+        type: object
+        required: [id, label]
+        properties:
+          id: { type: [string, 'null'] }
+          label: { type: string }
+          spacecat_brand_id: { type: [string, 'null'] }
+    regions:
+      type: array
+      description: Available markets (Semrush projects), one per location + language combination.
+      items:
+        type: object
+        required: [id, semrush_project_id, label]
+        properties:
+          id:
+            type: [string, 'null']
+            description: Region code parsed from the label's leading segment (e.g. `US` from `US-en`); null when the label has no `-`.
+          semrush_project_id: { type: [string, 'null'] }
+          label: { type: string }
+          spacecat_brand_id: { type: [string, 'null'] }
+          geoTargetId: { type: [integer, 'null'] }
+          languageCode: { type: [string, 'null'] }
+    topics:
+      type: array
+      description: Distinct `topic:`-prefixed tags.
+      items: { $ref: '#/SerenityFilterDimensionItem' }
+    categories:
+      type: array
+      description: Distinct `category:`-prefixed tags.
+      items: { $ref: '#/SerenityFilterDimensionItem' }
+    page_intents:
+      type: array
+      description: Distinct `intent:`-prefixed tags. `id` is the uppercased label.
+      items: { $ref: '#/SerenityFilterDimensionItem' }
+    origins:
+      type: array
+      description: Distinct `source:`-prefixed tags. `id` mirrors `label`.
+      items: { $ref: '#/SerenityFilterDimensionItem' }
+    tags:
+      type: array
+      description: |
+        Prefix-less tags, plus any prefixed tag whose prefix collides with one
+        of this schema's other properties.
+      items: { $ref: '#/SerenityFilterDimensionItem' }
+  additionalProperties:
+    type: array
+    description: Tags grouped by a Semrush tag prefix not covered by the fixed dimensions above.
+    items: { $ref: '#/SerenityFilterDimensionItem' }
+
 # ── Referral Traffic PG schemas ───────────────────────────────────────────────
 
 ReferralTrafficSource:

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1002,3 +1002,99 @@ v2-serenity-org-languages:
       '404':
         description: Organization not found.
       '500': { $ref: './responses.yaml#/500' }
+
+v2-serenity-url-inspector-filter-dimensions:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Filter dimensions for the Serenity URL Inspector dashboard
+    description: |
+      Returns the option universe for the URL Inspector Brand/Region/Topic/
+      Category/Intent/Origin filter dropdowns, sourced from the Semrush Brands,
+      Markets, and Topics elements (not from Adobe Postgres). Unlike the
+      cascading `/brand-presence/filter-dimensions` endpoint, this read is not
+      itself filtered by any of the dimensions it returns — it defines what
+      those dropdowns can show.
+
+      `topics`/`categories`/`page_intents`/`origins` are derived from the same
+      underlying Topics element response, split apart by their `topic:`/
+      `category:`/`intent:`/`source:` tag prefix. Any other tag prefix Semrush
+      introduces later (e.g. `type:branded`) surfaces automatically as an extra
+      array property keyed by that prefix, and prefix-less tags collect into
+      `tags` — see `SerenityUrlInspectorFilterDimensions`.
+    operationId: listSerenityUrlInspectorFilterDimensions
+    security:
+      - ims_key: []
+    parameters:
+      - name: model
+        in: query
+        required: false
+        description: |
+          AI model to scope brands/topics to. Accepts a Semrush Elements model
+          name directly, or a SpaceCat/UI platform code (translated
+          server-side). Defaults to `search-gpt` when omitted or unrecognized.
+        schema:
+          type: string
+          x-canonical-values:
+            - google-ai-mode
+            - grok-3
+            - google-ai-overview
+            - microsoft-copilot
+            - open-evidence
+            - gemini-2.5-flash
+            - claude-sonnet-4
+            - gpt-5
+            - deepseek
+            - search-gpt
+            - perplexity
+          x-known-aliases:
+            copilot: microsoft-copilot
+            gemini: gemini-2.5-flash
+            openai: gpt-5
+            chatgpt: search-gpt
+      - name: platform
+        in: query
+        required: false
+        description: Legacy alias for `model`; `model` takes precedence when both are given.
+        schema: { type: string }
+      - name: projectId
+        in: query
+        required: false
+        description: Semrush project UUID to scope the Topics element to a specific market.
+        schema: { type: string, format: uuid }
+    responses:
+      '200':
+        description: Filter dimensions retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityUrlInspectorFilterDimensions' }
+      '400': { $ref: './responses.yaml#/400' }
+      '403':
+        description: Caller lacks access to the organization.
+      '404':
+        description: Organization not found, brand not found for this organization, or the brand has no resolvable Semrush workspace.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '503':
+        description: PostgREST client not configured for this deployment.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -826,6 +826,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.1.tgz",
       "integrity": "sha512-wgmjwo0xJkYhFQUmv6GTPvCFjDYBoT7zP3OuAxLN+FlHgS6kDkbJOtKxwQn9SrWbhoIfM8GdCnRDpBn6BmkASw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -11554,7 +11555,6 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -13465,7 +13465,6 @@
       "integrity": "sha512-wfAWZ6oIrsDOFyYm9bDQNva/WCmvIrVqP3dSCePN5YYWCGWWXkikn5YC0wPSxF92M8kQFPfdVpMaTTV1mRk4Lw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.21",
         "@smithy/core": "^3.24.6",
@@ -13482,7 +13481,6 @@
       "integrity": "sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -13546,7 +13544,6 @@
       "integrity": "sha512-FMgyzUq3Jh+ONRYxryBRNdBd+FUX8PwRl07ccQknNdoms6KCeAEusCkl6whqpDrPQ6OH0ddeSifKyqYSs2DLIw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
         "@aws-sdk/types": "^3.973.13",
@@ -13564,7 +13561,6 @@
       "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -14220,7 +14216,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.7.0.tgz",
       "integrity": "sha512-qn6tAIZEw5i/wiESBF4nQxZkl86aY4KoO0IkUa2Lh+rya64oTOdJQFlZuMwI1Qz9VBJQrQC4QlSA2DNek5gCOA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -14244,6 +14241,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -15221,6 +15219,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
       "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -15506,6 +15505,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -15712,6 +15712,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -15876,6 +15877,7 @@
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -17893,6 +17895,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -18140,6 +18143,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -18186,6 +18190,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18634,6 +18639,7 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -19383,6 +19389,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -21612,6 +21619,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -25949,6 +25957,7 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -27005,7 +27014,6 @@
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -27016,6 +27024,7 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -29580,6 +29589,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -30053,8 +30063,7 @@
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -30108,6 +30117,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
       "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -31311,6 +31321,7 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31321,6 +31332,7 @@
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -32069,6 +32081,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -33433,6 +33446,7 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -34326,6 +34340,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -34453,6 +34468,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -35259,6 +35275,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -35551,6 +35568,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -35560,6 +35578,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
       "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/src/support/elements/definitions/brands.js
+++ b/src/support/elements/definitions/brands.js
@@ -36,12 +36,12 @@ export function buildBrandsPayload({ model, platform } = {}) {
 
 /**
  * Transforms the raw Semrush Brands element response into URL Inspector filter-dimension brands.
- * `id` is always null (Semrush has no stable brand ID); `spacecat_brand_id` is resolved by
+ * `id` mirrors `label` (Semrush has no stable brand ID); `spacecat_brand_id` is resolved by
  * case-insensitive name matching against the caller-supplied SpaceCat brands list.
  *
  * @param {object} raw - Raw response from the Elements API.
  * @param {Array<{id: string, name: string}>} [spacecatBrands=[]] - SpaceCat brands for this org.
- * @returns {Array<{id: null, label: string, spacecat_brand_id: string|null}>}
+ * @returns {Array<{id: string, label: string, spacecat_brand_id: string|null}>}
  */
 export function transformBrandsToFilterDimensions(raw, spacecatBrands = []) {
   const brandIdByName = new Map(
@@ -50,7 +50,7 @@ export function transformBrandsToFilterDimensions(raw, spacecatBrands = []) {
   return (raw?.blocks?.value ?? []).map((item) => {
     const label = item.value ?? '';
     return {
-      id: null,
+      id: label,
       label,
       spacecat_brand_id: brandIdByName.get(label.toLowerCase()) ?? null,
     };

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -18,6 +18,7 @@ export {
   transformCategoriesToFilterDimensions,
   transformIntentsToFilterDimensions,
   transformOriginsToFilterDimensions,
+  transformOtherTagsForFilterDimensions,
 } from './topics.js';
 export { buildWeeksPayload, transformWeeksResponse } from './weeks.js';
 export { buildPromptsPayload, transformPromptsResponse } from './prompts.js';

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -139,39 +139,41 @@ export function transformOriginsToFilterDimensions(raw) {
 const KNOWN_TAG_PREFIXES = ['topic:', 'category:', 'intent:', 'source:'];
 
 /**
- * Keys already populated on the filter-dimensions result before the dynamic
- * groups are merged in (see `getUrlInspectorFilterDimensions`). A raw tag whose
- * `prefix:` matches one of these verbatim (e.g. `brands:foo`, `regions:APAC`)
- * would otherwise be grouped under that same key and merged into the
- * pre-existing array, corrupting it — so such tags are routed to the generic
- * `tags` bucket instead.
- */
-const RESERVED_RESULT_KEYS = ['brands', 'regions', 'topics', 'categories', 'page_intents', 'origins', 'tags'];
-
-/**
  * Extracts every tag NOT already covered by the known `topic:`/`category:`/
  * `intent:`/`source:` prefixes, so newly-introduced Semrush tag types (e.g.
  * `type:branded`) surface in the response without a code change per prefix.
  *
  * - `prefix:value` tags are grouped by their prefix into a dynamic key
  *   (e.g. `{ type: [{ id: 'type:branded', label: 'branded' }, ...] }`), unless
- *   `prefix` collides with a {@link RESERVED_RESULT_KEYS} entry, in which case
- *   the tag is routed to the generic `tags` array instead.
+ *   `prefix` collides with an entry in `reservedResultKeys`, in which case the
+ *   tag is routed to the generic `tags` array instead.
  * - Plain tags with no `prefix:` at all are also collected into `tags`.
  *
  * `id` is always the original, unmodified tag value as returned by the
  * Elements API. Both forms apply the same `Parent__Child` splitting as the
  * known dimensions to derive `label`/`parent_label`.
  *
+ * Tag prefixes are arbitrary strings from Semrush, so a prefix can legitimately
+ * be `constructor`, `__proto__`, etc. `groups` is created with `Object.create(null)`
+ * (not `{}`) so `groups[prefix]` never resolves to an inherited `Object.prototype`
+ * member for such a prefix — with a plain `{}`, `groups[prefix] ?? []` would
+ * silently return e.g. the `Object` constructor function instead of `undefined`,
+ * and the following `.push(...)` would throw.
+ *
  * @param {object} raw - Raw response from the Elements API.
+ * @param {string[]} [reservedResultKeys] - Keys already populated on the
+ *   caller's result object (see `elements-service.js`) that a raw tag's
+ *   `prefix:` must not collide with. Passed in by the caller — rather than
+ *   hardcoded here — so this stays in sync automatically as the caller's
+ *   result shape changes.
  * @returns {{[prefix: string]: FilterDimensionItem[], tags: FilterDimensionItem[]}}
  */
-export function transformOtherTagsForFilterDimensions(raw) {
+export function transformOtherTagsForFilterDimensions(raw, reservedResultKeys = []) {
   const values = (raw?.blocks?.value ?? [])
     .map((item) => String(item.value ?? ''))
     .filter((value) => value !== '' && !KNOWN_TAG_PREFIXES.some((p) => value.startsWith(p)));
 
-  const groups = {};
+  const groups = Object.create(null);
   const tags = [];
 
   values.forEach((value) => {
@@ -182,7 +184,7 @@ export function transformOtherTagsForFilterDimensions(raw) {
     }
     const prefix = value.slice(0, sepIdx);
     const rest = value.slice(sepIdx + 1);
-    if (RESERVED_RESULT_KEYS.includes(prefix)) {
+    if (reservedResultKeys.includes(prefix)) {
       tags.push({ id: value, ...splitParent(rest, `${prefix}:`) });
       return;
     }

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -38,72 +38,102 @@ export function buildTopicsPayload({ model, platform, projectId } = {}) {
 
 /**
  * @typedef {object} FilterDimensionItem
- * @property {string|null} id - Dimension identifier (null when no stable ID exists).
+ * @property {string} id - Dimension identifier: the original, unmodified tag
+ *   value as returned by the Elements API (e.g. `topic:Furniture__Sofas`).
  * @property {string} label - Human-readable label.
  */
 
+/**
+ * @typedef {object} PrefixedTag
+ * @property {string} original - The raw tag value exactly as returned by the
+ *   Elements API (e.g. `topic:Furniture__Sofas`), used as the dimension `id`.
+ * @property {string} stripped - `original` with the matched prefix removed
+ *   (e.g. `Furniture__Sofas`), used to derive `label`/`parent_label`.
+ */
+
+/**
+ * @param {object} raw - Raw response from the Elements API.
+ * @param {string} prefix - Tag prefix to filter on (e.g. `topic:`).
+ * @returns {PrefixedTag[]}
+ */
 function extractByPrefix(raw, prefix) {
   return (raw?.blocks?.value ?? [])
     .filter((item) => String(item.value ?? '').startsWith(prefix))
-    .map((item) => String(item.value).substring(prefix.length));
+    .map((item) => {
+      const original = String(item.value);
+      return { original, stripped: original.substring(prefix.length) };
+    });
 }
 
 /**
  * Splits a "Parent__Child" value into its child label and parent label.
  * Splits on the first "__" only, so a label containing further "__" occurrences
- * is preserved intact in the child label.
- * @param {string} value - Raw stripped tag value.
- * @returns {{label: string, parent_id?: null, parent_label?: string}}
+ * is preserved intact in the child label. `parent_id` is reconstructed as
+ * `${prefix}${parent_label}` — the same original-tag shape as the item's own
+ * `id` — so a caller can filter by parent the same way as by id (e.g. for
+ * `category:Living Room Furniture Retail__Living Room Furniture and Sofas`,
+ * `parent_id` is `category:Living Room Furniture Retail`).
+ * @param {string} value - Raw stripped tag value (prefix already removed).
+ * @param {string} [prefix] - The prefix (including trailing `:`) stripped from
+ *   `value` before it was passed in; '' when the original tag had no prefix.
+ * @returns {{label: string, parent_id?: string, parent_label?: string}}
  */
-function splitParent(value) {
+function splitParent(value, prefix = '') {
   const sep = '__';
   const idx = value.indexOf(sep);
   if (idx === -1) {
     return { label: value };
   }
+  const parentLabel = value.slice(0, idx);
   return {
     label: value.slice(idx + sep.length),
-    parent_id: null,
-    parent_label: value.slice(0, idx),
+    parent_id: `${prefix}${parentLabel}`,
+    parent_label: parentLabel,
   };
 }
 
 /**
- * Extracts only "topic:"-prefixed entries → `{ id: null, label }`, plus
- * `parent_id`/`parent_label` when the tag encodes a "Parent__Child" hierarchy.
+ * Extracts only "topic:"-prefixed entries → `{ id: original tag, label }`,
+ * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
+ * hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformTopicsForFilterDimensions(raw) {
-  return extractByPrefix(raw, 'topic:').map((value) => ({ id: null, ...splitParent(value) }));
+  return extractByPrefix(raw, 'topic:')
+    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'topic:') }));
 }
 
 /**
- * Extracts only "category:"-prefixed entries → `{ id: null, label }`, plus
- * `parent_id`/`parent_label` when the tag encodes a "Parent__Child" hierarchy.
+ * Extracts only "category:"-prefixed entries → `{ id: original tag, label }`,
+ * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
+ * hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformCategoriesToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'category:').map((value) => ({ id: null, ...splitParent(value) }));
+  return extractByPrefix(raw, 'category:')
+    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'category:') }));
 }
 
 /**
- * Extracts only "intent:"-prefixed entries → `{ id: UPPERCASED, label: UPPERCASED }`.
+ * Extracts only "intent:"-prefixed entries → `{ id: original tag, label }`.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformIntentsToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'intent:').map((label) => ({ id: label.toUpperCase(), label }));
+  return extractByPrefix(raw, 'intent:')
+    .map(({ original, stripped }) => ({ id: original, label: stripped }));
 }
 
 /**
- * Extracts only "source:"-prefixed entries → `{ id: value, label: value }`.
+ * Extracts only "source:"-prefixed entries → `{ id: original tag, label }`.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformOriginsToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'source:').map((label) => ({ id: label, label }));
+  return extractByPrefix(raw, 'source:')
+    .map(({ original, stripped }) => ({ id: original, label: stripped }));
 }
 
 const KNOWN_TAG_PREFIXES = ['topic:', 'category:', 'intent:', 'source:'];
@@ -124,12 +154,14 @@ const RESERVED_RESULT_KEYS = ['brands', 'regions', 'topics', 'categories', 'page
  * `type:branded`) surface in the response without a code change per prefix.
  *
  * - `prefix:value` tags are grouped by their prefix into a dynamic key
- *   (e.g. `{ type: [{ id: null, label: 'branded' }, ...] }`), unless `prefix`
- *   collides with a {@link RESERVED_RESULT_KEYS} entry, in which case the tag
- *   is routed to the generic `tags` array instead.
+ *   (e.g. `{ type: [{ id: 'type:branded', label: 'branded' }, ...] }`), unless
+ *   `prefix` collides with a {@link RESERVED_RESULT_KEYS} entry, in which case
+ *   the tag is routed to the generic `tags` array instead.
  * - Plain tags with no `prefix:` at all are also collected into `tags`.
  *
- * Both forms apply the same `Parent__Child` splitting as the known dimensions.
+ * `id` is always the original, unmodified tag value as returned by the
+ * Elements API. Both forms apply the same `Parent__Child` splitting as the
+ * known dimensions to derive `label`/`parent_label`.
  *
  * @param {object} raw - Raw response from the Elements API.
  * @returns {{[prefix: string]: FilterDimensionItem[], tags: FilterDimensionItem[]}}
@@ -145,17 +177,17 @@ export function transformOtherTagsForFilterDimensions(raw) {
   values.forEach((value) => {
     const sepIdx = value.indexOf(':');
     if (sepIdx === -1) {
-      tags.push({ id: null, ...splitParent(value) });
+      tags.push({ id: value, ...splitParent(value) });
       return;
     }
     const prefix = value.slice(0, sepIdx);
     const rest = value.slice(sepIdx + 1);
     if (RESERVED_RESULT_KEYS.includes(prefix)) {
-      tags.push({ id: null, ...splitParent(rest) });
+      tags.push({ id: value, ...splitParent(rest, `${prefix}:`) });
       return;
     }
     groups[prefix] = groups[prefix] ?? [];
-    groups[prefix].push({ id: null, ...splitParent(rest) });
+    groups[prefix].push({ id: value, ...splitParent(rest, `${prefix}:`) });
   });
 
   return { ...groups, tags };

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -49,21 +49,43 @@ function extractByPrefix(raw, prefix) {
 }
 
 /**
- * Extracts only "topic:"-prefixed entries → `{ id: null, label }`.
+ * Splits a "Parent__Child" value into its child label and parent label.
+ * Splits on the first "__" only, so a label containing further "__" occurrences
+ * is preserved intact in the child label.
+ * @param {string} value - Raw stripped tag value.
+ * @returns {{label: string, parent_id?: null, parent_label?: string}}
+ */
+function splitParent(value) {
+  const sep = '__';
+  const idx = value.indexOf(sep);
+  if (idx === -1) {
+    return { label: value };
+  }
+  return {
+    label: value.slice(idx + sep.length),
+    parent_id: null,
+    parent_label: value.slice(0, idx),
+  };
+}
+
+/**
+ * Extracts only "topic:"-prefixed entries → `{ id: null, label }`, plus
+ * `parent_id`/`parent_label` when the tag encodes a "Parent__Child" hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformTopicsForFilterDimensions(raw) {
-  return extractByPrefix(raw, 'topic:').map((label) => ({ id: null, label }));
+  return extractByPrefix(raw, 'topic:').map((value) => ({ id: null, ...splitParent(value) }));
 }
 
 /**
- * Extracts only "category:"-prefixed entries → `{ id: null, label }`.
+ * Extracts only "category:"-prefixed entries → `{ id: null, label }`, plus
+ * `parent_id`/`parent_label` when the tag encodes a "Parent__Child" hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformCategoriesToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'category:').map((label) => ({ id: null, label }));
+  return extractByPrefix(raw, 'category:').map((value) => ({ id: null, ...splitParent(value) }));
 }
 
 /**
@@ -82,4 +104,43 @@ export function transformIntentsToFilterDimensions(raw) {
  */
 export function transformOriginsToFilterDimensions(raw) {
   return extractByPrefix(raw, 'source:').map((label) => ({ id: label, label }));
+}
+
+const KNOWN_TAG_PREFIXES = ['topic:', 'category:', 'intent:', 'source:'];
+
+/**
+ * Extracts every tag NOT already covered by the known `topic:`/`category:`/
+ * `intent:`/`source:` prefixes, so newly-introduced Semrush tag types (e.g.
+ * `type:branded`) surface in the response without a code change per prefix.
+ *
+ * - `prefix:value` tags are grouped by their prefix into a dynamic key
+ *   (e.g. `{ type: [{ id: null, label: 'branded' }, ...] }`).
+ * - Plain tags with no `prefix:` at all are collected into a generic `tags` array.
+ *
+ * Both forms apply the same `Parent__Child` splitting as the known dimensions.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @returns {{[prefix: string]: FilterDimensionItem[], tags: FilterDimensionItem[]}}
+ */
+export function transformOtherTagsForFilterDimensions(raw) {
+  const values = (raw?.blocks?.value ?? [])
+    .map((item) => String(item.value ?? ''))
+    .filter((value) => value !== '' && !KNOWN_TAG_PREFIXES.some((p) => value.startsWith(p)));
+
+  const groups = {};
+  const tags = [];
+
+  values.forEach((value) => {
+    const sepIdx = value.indexOf(':');
+    if (sepIdx === -1) {
+      tags.push({ id: null, ...splitParent(value) });
+      return;
+    }
+    const prefix = value.slice(0, sepIdx);
+    const rest = value.slice(sepIdx + 1);
+    groups[prefix] = groups[prefix] ?? [];
+    groups[prefix].push({ id: null, ...splitParent(rest) });
+  });
+
+  return { ...groups, tags };
 }

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -109,13 +109,25 @@ export function transformOriginsToFilterDimensions(raw) {
 const KNOWN_TAG_PREFIXES = ['topic:', 'category:', 'intent:', 'source:'];
 
 /**
+ * Keys already populated on the filter-dimensions result before the dynamic
+ * groups are merged in (see `getUrlInspectorFilterDimensions`). A raw tag whose
+ * `prefix:` matches one of these verbatim (e.g. `brands:foo`, `regions:APAC`)
+ * would otherwise be grouped under that same key and merged into the
+ * pre-existing array, corrupting it — so such tags are routed to the generic
+ * `tags` bucket instead.
+ */
+const RESERVED_RESULT_KEYS = ['brands', 'regions', 'topics', 'categories', 'page_intents', 'origins', 'tags'];
+
+/**
  * Extracts every tag NOT already covered by the known `topic:`/`category:`/
  * `intent:`/`source:` prefixes, so newly-introduced Semrush tag types (e.g.
  * `type:branded`) surface in the response without a code change per prefix.
  *
  * - `prefix:value` tags are grouped by their prefix into a dynamic key
- *   (e.g. `{ type: [{ id: null, label: 'branded' }, ...] }`).
- * - Plain tags with no `prefix:` at all are collected into a generic `tags` array.
+ *   (e.g. `{ type: [{ id: null, label: 'branded' }, ...] }`), unless `prefix`
+ *   collides with a {@link RESERVED_RESULT_KEYS} entry, in which case the tag
+ *   is routed to the generic `tags` array instead.
+ * - Plain tags with no `prefix:` at all are also collected into `tags`.
  *
  * Both forms apply the same `Parent__Child` splitting as the known dimensions.
  *
@@ -138,6 +150,10 @@ export function transformOtherTagsForFilterDimensions(raw) {
     }
     const prefix = value.slice(0, sepIdx);
     const rest = value.slice(sepIdx + 1);
+    if (RESERVED_RESULT_KEYS.includes(prefix)) {
+      tags.push({ id: null, ...splitParent(rest) });
+      return;
+    }
     groups[prefix] = groups[prefix] ?? [];
     groups[prefix].push({ id: null, ...splitParent(rest) });
   });

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -77,7 +77,7 @@ export function createElementsService(transport) {
       Object.entries(otherGroups).forEach(([key, items]) => {
         result[key] = result[key] ? [...result[key], ...items] : items;
       });
-      result.tags = tags;
+      result.tags = result.tags ? [...result.tags, ...tags] : tags;
       return result;
     },
 

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -22,6 +22,7 @@ import {
   transformCategoriesToFilterDimensions,
   transformIntentsToFilterDimensions,
   transformOriginsToFilterDimensions,
+  transformOtherTagsForFilterDimensions,
   buildWeeksPayload,
   transformWeeksResponse,
   buildPromptsPayload,
@@ -61,7 +62,7 @@ export function createElementsService(transport) {
         transport.fetchElement(workspaceId, ELEMENT_IDS.BRANDS, buildBrandsPayload(params)),
         transport.fetchElement(workspaceId, ELEMENT_IDS.MARKETS, buildMarketsPayload({})),
       ]);
-      return {
+      const result = {
         brands: transformBrandsToFilterDimensions(rawBrands, spacecatBrands),
         regions: transformMarketsToFilterDimensions(rawMarkets, brandSemrushProjects),
         topics: transformTopicsForFilterDimensions(rawTopics),
@@ -69,6 +70,15 @@ export function createElementsService(transport) {
         page_intents: transformIntentsToFilterDimensions(rawTopics),
         origins: transformOriginsToFilterDimensions(rawTopics),
       };
+      // Merge any tag types not covered above (e.g. `type:branded`) under their own
+      // prefix key, and plain prefix-less tags under `tags` — see
+      // transformOtherTagsForFilterDimensions.
+      const { tags, ...otherGroups } = transformOtherTagsForFilterDimensions(rawTopics);
+      Object.entries(otherGroups).forEach(([key, items]) => {
+        result[key] = result[key] ? [...result[key], ...items] : items;
+      });
+      result.tags = tags;
+      return result;
     },
 
     /**

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -72,12 +72,24 @@ export function createElementsService(transport) {
       };
       // Merge any tag types not covered above (e.g. `type:branded`) under their own
       // prefix key, and plain prefix-less tags under `tags` — see
-      // transformOtherTagsForFilterDimensions.
-      const { tags, ...otherGroups } = transformOtherTagsForFilterDimensions(rawTopics);
+      // transformOtherTagsForFilterDimensions. The reserved-key list is derived
+      // from `result`'s own keys (not hand-duplicated) so it can't drift out of
+      // sync if a key here is ever renamed or a new fixed dimension is added.
+      // `__proto__`/`constructor`/`prototype` are added on top: `result[key] = ...`
+      // below would repoint result's prototype instead of adding a property for
+      // those (rather than dropping such tags, routing them as "reserved" sends
+      // them into the generic `tags` array, same as any other collision).
+      const reservedResultKeys = [
+        ...Object.keys(result), 'tags', '__proto__', 'constructor', 'prototype',
+      ];
+      const { tags, ...otherGroups } = transformOtherTagsForFilterDimensions(
+        rawTopics,
+        reservedResultKeys,
+      );
       Object.entries(otherGroups).forEach(([key, items]) => {
-        result[key] = result[key] ? [...result[key], ...items] : items;
+        result[key] = items;
       });
-      result.tags = result.tags ? [...result.tags, ...tags] : tags;
+      result.tags = tags;
       return result;
     },
 

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -27,7 +27,7 @@ const SUB_WORKSPACE_ID = 'sub-ws-uuid-456';
 const IMS_TOKEN = 'test-ims-token';
 const ENV = { SEMRUSH_PROJECTS_BASE_URL: 'https://www.semrush.com' };
 
-const BRANDS_RESULT = [{ id: null, label: 'Adobe', spacecat_brand_id: 'brand-1' }];
+const BRANDS_RESULT = [{ id: 'Adobe', label: 'Adobe', spacecat_brand_id: 'brand-1' }];
 const MARKETS_RESULT = [{ id: 'US', label: 'US-en', semrush_project_id: 'proj-1' }];
 const URL_INSPECTOR_RESULT = {
   brands: BRANDS_RESULT,

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -301,6 +301,27 @@ const FIXTURES = {
       items: [{ id: 'lang-en', name: 'English' }],
     },
   },
+  // Unlike the rest of this file's fixtures, this operation is served by
+  // ElementsController (src/controllers/elements.js), not SerenityController —
+  // it wraps the Semrush Brands/Markets/Topics elements directly rather than
+  // going through the serenity handlers/*.js stack. `usesElementsController`
+  // routes it through a dedicated esmock load below instead of the shared one.
+  listSerenityUrlInspectorFilterDimensions: {
+    expectedStatus: 200,
+    usesElementsController: true,
+    controllerMethod: 'listUrlInspectorFilterDimensions',
+    handlerResult: {
+      brands: [{ id: 'Test Brand', label: 'Test Brand', spacecat_brand_id: BRAND }],
+      regions: [{
+        id: 'US', semrush_project_id: 'proj-1', label: 'US-en',
+      }],
+      topics: [],
+      categories: [],
+      page_intents: [],
+      origins: [],
+      tags: [],
+    },
+  },
 };
 
 function makeAjv() {
@@ -343,6 +364,55 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
     it(`${operationId} response conforms to OpenAPI schema`, async () => {
       const op = opsByOperationId.get(operationId);
       expect(op, `operation ${operationId} not found in spec`).to.exist;
+
+      if (fx.usesElementsController) {
+        const ElementsController = (await esmock(
+          '../../src/controllers/elements.js',
+          {
+            '../../src/support/brands-storage.js': {
+              getBrandIdentity: () => Promise.resolve({ id: BRAND, name: 'Test Brand' }),
+              getBrandBySite: sinon.stub(),
+            },
+            '../../src/support/serenity/workspace-resolver.js': {
+              resolveBrandWorkspace: () => Promise.resolve({
+                mode: 'subworkspace', workspaceId: WORKSPACE, parentWorkspaceId: 'parent-ws',
+              }),
+            },
+            '../../src/support/access-control-util.js': {
+              default: { fromContext: () => ({ hasAccess: () => Promise.resolve(true) }) },
+            },
+            '../../src/support/elements/elements-service.js': {
+              createElementsService: () => ({
+                getUrlInspectorFilterDimensions: sinon.stub().resolves(fx.handlerResult),
+              }),
+            },
+          },
+        )).default;
+
+        const ctx = fakeContext({
+          params: fx.params || {},
+          data: fx.data,
+          query: fx.query || {},
+        });
+        const controller = ElementsController(ctx, fakeLog(), { SEMRUSH_PROJECTS_BASE_URL: 'https://www.semrush.com' });
+        const response = await controller[fx.controllerMethod](ctx);
+
+        expect(response.status).to.equal(fx.expectedStatus);
+
+        const responseSchema = op.responseSchema(fx.expectedStatus);
+        expect(responseSchema, `no ${fx.expectedStatus} schema for ${operationId}`).to.exist;
+
+        const body = await readJsonBody(response);
+        const ajv = makeAjv();
+        const validate = ajv.compile(responseSchema);
+        const validBody = validate(body);
+        if (!validBody) {
+          const detail = validate.errors.map((e) => `${e.instancePath || '/'} ${e.message} (${JSON.stringify(e.params)})`).join('\n  ');
+          throw new Error(`AJV validation failed for ${operationId} ${fx.expectedStatus} response:\n  ${detail}\nbody: ${JSON.stringify(body, null, 2)}`);
+        }
+        expect(validBody).to.equal(true);
+        return;
+      }
 
       const handlerStubs = {
         handleListPrompts: sinon.stub(),

--- a/test/support/elements/definitions/brands.test.js
+++ b/test/support/elements/definitions/brands.test.js
@@ -74,10 +74,10 @@ describe('brands definitions', () => {
       expect(transformBrandsToFilterDimensions({})).to.deep.equal([]);
     });
 
-    it('always sets id to null', () => {
+    it('sets id to the brand label', () => {
       const raw = { blocks: { value: [{ value: 'Adobe' }] } };
       const [item] = transformBrandsToFilterDimensions(raw);
-      expect(item.id).to.be.null;
+      expect(item.id).to.equal('Adobe');
     });
 
     it('uses item.value as label', () => {

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -21,6 +21,13 @@ import {
 } from '../../../../src/support/elements/definitions/topics.js';
 import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
 
+// Mirrors the fixed keys elements-service.js's `getUrlInspectorFilterDimensions`
+// builds `result` with, plus the JS-unsafe names it also guards against.
+const RESERVED_RESULT_KEYS = [
+  'brands', 'regions', 'topics', 'categories', 'page_intents', 'origins', 'tags',
+  '__proto__', 'constructor', 'prototype',
+];
+
 const RAW_MIXED = {
   blocks: {
     value: [
@@ -373,7 +380,7 @@ describe('topics definitions', () => {
           ],
         },
       };
-      const result = transformOtherTagsForFilterDimensions(raw);
+      const result = transformOtherTagsForFilterDimensions(raw, RESERVED_RESULT_KEYS);
       expect(result).to.not.have.property('brands');
       expect(result).to.not.have.property('regions');
       expect(result).to.not.have.property('topics');
@@ -394,11 +401,41 @@ describe('topics definitions', () => {
 
     it('reconstructs parent_id with the reserved-key prefix when a colliding tag has a Parent__Child value', () => {
       const raw = { blocks: { value: [{ value: 'topics:Parent__Child' }] } };
-      const result = transformOtherTagsForFilterDimensions(raw);
+      const result = transformOtherTagsForFilterDimensions(raw, RESERVED_RESULT_KEYS);
       expect(result.tags).to.deep.equal([
         {
           id: 'topics:Parent__Child', label: 'Child', parent_id: 'topics:Parent', parent_label: 'Parent',
         },
+      ]);
+    });
+
+    it('does not throw for an Object.prototype-named prefix and does not leak the prototype value', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: 'constructor:evil' },
+            { value: 'toString:evil' },
+            { value: '__proto__:evil' },
+            { value: 'hasOwnProperty:evil' },
+          ],
+        },
+      };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      const protoKey = ['_', '_', 'proto', '_', '_'].join('');
+      expect(result.constructor).to.deep.equal([{ id: 'constructor:evil', label: 'evil' }]);
+      expect(result.toString).to.deep.equal([{ id: 'toString:evil', label: 'evil' }]);
+      expect(result[protoKey]).to.deep.equal([{ id: `${protoKey}:evil`, label: 'evil' }]);
+      expect(result.hasOwnProperty).to.deep.equal([{ id: 'hasOwnProperty:evil', label: 'evil' }]);
+      expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+    });
+
+    it('routes Object.prototype-named prefixes into tags when they are reserved by the caller', () => {
+      const raw = { blocks: { value: [{ value: 'constructor:evil' }, { value: '__proto__:evil' }] } };
+      const result = transformOtherTagsForFilterDimensions(raw, RESERVED_RESULT_KEYS);
+      expect(Object.prototype.hasOwnProperty.call(result, 'constructor')).to.equal(false);
+      expect(result.tags).to.deep.equal([
+        { id: 'constructor:evil', label: 'evil' },
+        { id: '__proto__:evil', label: 'evil' },
       ]);
     });
   });

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -17,6 +17,7 @@ import {
   transformCategoriesToFilterDimensions,
   transformIntentsToFilterDimensions,
   transformOriginsToFilterDimensions,
+  transformOtherTagsForFilterDimensions,
 } from '../../../../src/support/elements/definitions/topics.js';
 import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
 
@@ -27,6 +28,8 @@ const RAW_MIXED = {
       { value: 'topic:AI' },
       { value: 'category:Firefly' },
       { value: 'category:Experience Cloud' },
+      { value: 'category:Modular & Configurable Sofas__Compact Shippable Furniture' },
+      { value: 'topic:Furniture__Compact Shippable Furniture' },
       { value: 'intent:Informational' },
       { value: 'intent:Transactional' },
       { value: 'source:organic' },
@@ -103,7 +106,35 @@ describe('topics definitions', () => {
       expect(result).to.deep.equal([
         { id: null, label: 'SEO' },
         { id: null, label: 'AI' },
+        {
+          id: null,
+          label: 'Compact Shippable Furniture',
+          parent_id: null,
+          parent_label: 'Furniture',
+        },
       ]);
+    });
+
+    it('adds parent_id/parent_label when the value contains a double underscore', () => {
+      const raw = { blocks: { value: [{ value: 'topic:Furniture__Sofas' }] } };
+      const [item] = transformTopicsForFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: null,
+        label: 'Sofas',
+        parent_id: null,
+        parent_label: 'Furniture',
+      });
+    });
+
+    it('splits only on the first double underscore', () => {
+      const raw = { blocks: { value: [{ value: 'topic:A__B__C' }] } };
+      const [item] = transformTopicsForFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: null,
+        label: 'B__C',
+        parent_id: null,
+        parent_label: 'A',
+      });
     });
 
     it('sets id to null for each entry', () => {
@@ -136,7 +167,35 @@ describe('topics definitions', () => {
       expect(result).to.deep.equal([
         { id: null, label: 'Firefly' },
         { id: null, label: 'Experience Cloud' },
+        {
+          id: null,
+          label: 'Compact Shippable Furniture',
+          parent_id: null,
+          parent_label: 'Modular & Configurable Sofas',
+        },
       ]);
+    });
+
+    it('adds parent_id/parent_label when the value contains a double underscore', () => {
+      const raw = { blocks: { value: [{ value: 'category:Sofas__Modular Sofas' }] } };
+      const [item] = transformCategoriesToFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: null,
+        label: 'Modular Sofas',
+        parent_id: null,
+        parent_label: 'Sofas',
+      });
+    });
+
+    it('splits only on the first double underscore', () => {
+      const raw = { blocks: { value: [{ value: 'category:A__B__C' }] } };
+      const [item] = transformCategoriesToFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: null,
+        label: 'B__C',
+        parent_id: null,
+        parent_label: 'A',
+      });
     });
 
     it('sets id to null for each entry', () => {
@@ -212,6 +271,76 @@ describe('topics definitions', () => {
       const result = transformOriginsToFilterDimensions(raw);
       expect(result).to.have.length(1);
       expect(result[0].id).to.equal('organic');
+    });
+  });
+
+  describe('transformOtherTagsForFilterDimensions', () => {
+    it('returns only an empty tags array when raw is null', () => {
+      expect(transformOtherTagsForFilterDimensions(null)).to.deep.equal({ tags: [] });
+    });
+
+    it('excludes known-prefixed entries (topic/category/intent/source)', () => {
+      const result = transformOtherTagsForFilterDimensions(RAW_MIXED);
+      expect(result).to.not.have.property('topic');
+      expect(result).to.not.have.property('category');
+      expect(result).to.not.have.property('intent');
+      expect(result).to.not.have.property('source');
+    });
+
+    it('groups unknown prefix:value tags by their prefix', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: 'type:branded' },
+            { value: 'type:unbranded' },
+            { value: 'abc:value' },
+          ],
+        },
+      };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result.type).to.deep.equal([
+        { id: null, label: 'branded' },
+        { id: null, label: 'unbranded' },
+      ]);
+      expect(result.abc).to.deep.equal([{ id: null, label: 'value' }]);
+      expect(result.tags).to.deep.equal([]);
+    });
+
+    it('collects plain, prefix-less tags into the generic tags array', () => {
+      const raw = { blocks: { value: [{ value: 'abc' }, { value: 'another-plain-tag' }] } };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result.tags).to.deep.equal([
+        { id: null, label: 'abc' },
+        { id: null, label: 'another-plain-tag' },
+      ]);
+    });
+
+    it('applies Parent__Child splitting to grouped and plain tags alike', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: 'type:Branded__Sub' },
+            { value: 'Parent__Child' },
+          ],
+        },
+      };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result.type).to.deep.equal([
+        {
+          id: null, label: 'Sub', parent_id: null, parent_label: 'Branded',
+        },
+      ]);
+      expect(result.tags).to.deep.equal([
+        {
+          id: null, label: 'Child', parent_id: null, parent_label: 'Parent',
+        },
+      ]);
+    });
+
+    it('ignores empty string values', () => {
+      const raw = { blocks: { value: [{ value: '' }, { value: 'abc' }] } };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result.tags).to.deep.equal([{ id: null, label: 'abc' }]);
     });
   });
 });

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -342,5 +342,39 @@ describe('topics definitions', () => {
       const result = transformOtherTagsForFilterDimensions(raw);
       expect(result.tags).to.deep.equal([{ id: null, label: 'abc' }]);
     });
+
+    it('routes tags whose prefix collides with a reserved result key into tags instead of a dynamic group', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: 'brands:foo' },
+            { value: 'regions:APAC' },
+            { value: 'topics:x' },
+            { value: 'categories:x' },
+            { value: 'page_intents:x' },
+            { value: 'origins:x' },
+            { value: 'tags:x' },
+            { value: 'type:branded' },
+          ],
+        },
+      };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result).to.not.have.property('brands');
+      expect(result).to.not.have.property('regions');
+      expect(result).to.not.have.property('topics');
+      expect(result).to.not.have.property('categories');
+      expect(result).to.not.have.property('page_intents');
+      expect(result).to.not.have.property('origins');
+      expect(result.type).to.deep.equal([{ id: null, label: 'branded' }]);
+      expect(result.tags).to.deep.equal([
+        { id: null, label: 'foo' },
+        { id: null, label: 'APAC' },
+        { id: null, label: 'x' },
+        { id: null, label: 'x' },
+        { id: null, label: 'x' },
+        { id: null, label: 'x' },
+        { id: null, label: 'x' },
+      ]);
+    });
   });
 });

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -104,12 +104,12 @@ describe('topics definitions', () => {
     it('returns only topic:-prefixed entries', () => {
       const result = transformTopicsForFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: null, label: 'SEO' },
-        { id: null, label: 'AI' },
+        { id: 'topic:SEO', label: 'SEO' },
+        { id: 'topic:AI', label: 'AI' },
         {
-          id: null,
+          id: 'topic:Furniture__Compact Shippable Furniture',
           label: 'Compact Shippable Furniture',
-          parent_id: null,
+          parent_id: 'topic:Furniture',
           parent_label: 'Furniture',
         },
       ]);
@@ -119,9 +119,9 @@ describe('topics definitions', () => {
       const raw = { blocks: { value: [{ value: 'topic:Furniture__Sofas' }] } };
       const [item] = transformTopicsForFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: null,
+        id: 'topic:Furniture__Sofas',
         label: 'Sofas',
-        parent_id: null,
+        parent_id: 'topic:Furniture',
         parent_label: 'Furniture',
       });
     });
@@ -130,17 +130,17 @@ describe('topics definitions', () => {
       const raw = { blocks: { value: [{ value: 'topic:A__B__C' }] } };
       const [item] = transformTopicsForFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: null,
+        id: 'topic:A__B__C',
         label: 'B__C',
-        parent_id: null,
+        parent_id: 'topic:A',
         parent_label: 'A',
       });
     });
 
-    it('sets id to null for each entry', () => {
+    it('sets id to the original tag value (including prefix) for each entry', () => {
       const raw = { blocks: { value: [{ value: 'topic:SEO' }] } };
       const [item] = transformTopicsForFilterDimensions(raw);
-      expect(item.id).to.be.null;
+      expect(item.id).to.equal('topic:SEO');
     });
 
     it('strips the topic: prefix from the label', () => {
@@ -165,12 +165,12 @@ describe('topics definitions', () => {
     it('returns only category:-prefixed entries', () => {
       const result = transformCategoriesToFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: null, label: 'Firefly' },
-        { id: null, label: 'Experience Cloud' },
+        { id: 'category:Firefly', label: 'Firefly' },
+        { id: 'category:Experience Cloud', label: 'Experience Cloud' },
         {
-          id: null,
+          id: 'category:Modular & Configurable Sofas__Compact Shippable Furniture',
           label: 'Compact Shippable Furniture',
-          parent_id: null,
+          parent_id: 'category:Modular & Configurable Sofas',
           parent_label: 'Modular & Configurable Sofas',
         },
       ]);
@@ -180,9 +180,9 @@ describe('topics definitions', () => {
       const raw = { blocks: { value: [{ value: 'category:Sofas__Modular Sofas' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: null,
+        id: 'category:Sofas__Modular Sofas',
         label: 'Modular Sofas',
-        parent_id: null,
+        parent_id: 'category:Sofas',
         parent_label: 'Sofas',
       });
     });
@@ -191,17 +191,32 @@ describe('topics definitions', () => {
       const raw = { blocks: { value: [{ value: 'category:A__B__C' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: null,
+        id: 'category:A__B__C',
         label: 'B__C',
-        parent_id: null,
+        parent_id: 'category:A',
         parent_label: 'A',
       });
     });
 
-    it('sets id to null for each entry', () => {
+    it('sets id to the original tag value (including prefix) for each entry', () => {
       const raw = { blocks: { value: [{ value: 'category:Creative' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);
-      expect(item.id).to.be.null;
+      expect(item.id).to.equal('category:Creative');
+    });
+
+    it('sets parent_id to the prefix plus the parent label', () => {
+      const raw = {
+        blocks: {
+          value: [{ value: 'category:Living Room Furniture Retail__Living Room Furniture and Sofas' }],
+        },
+      };
+      const [item] = transformCategoriesToFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: 'category:Living Room Furniture Retail__Living Room Furniture and Sofas',
+        label: 'Living Room Furniture and Sofas',
+        parent_id: 'category:Living Room Furniture Retail',
+        parent_label: 'Living Room Furniture Retail',
+      });
     });
 
     it('strips the category: prefix from the label', () => {
@@ -226,15 +241,15 @@ describe('topics definitions', () => {
     it('returns only intent:-prefixed entries', () => {
       const result = transformIntentsToFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: 'INFORMATIONAL', label: 'Informational' },
-        { id: 'TRANSACTIONAL', label: 'Transactional' },
+        { id: 'intent:Informational', label: 'Informational' },
+        { id: 'intent:Transactional', label: 'Transactional' },
       ]);
     });
 
-    it('uppercases id but preserves original casing in label', () => {
+    it('sets id to the original tag value (including prefix) and preserves original casing in label', () => {
       const raw = { blocks: { value: [{ value: 'intent:informational' }] } };
       const [item] = transformIntentsToFilterDimensions(raw);
-      expect(item.id).to.equal('INFORMATIONAL');
+      expect(item.id).to.equal('intent:informational');
       expect(item.label).to.equal('informational');
     });
 
@@ -254,15 +269,15 @@ describe('topics definitions', () => {
     it('returns only source:-prefixed entries', () => {
       const result = transformOriginsToFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: 'organic', label: 'organic' },
-        { id: 'paid', label: 'paid' },
+        { id: 'source:organic', label: 'organic' },
+        { id: 'source:paid', label: 'paid' },
       ]);
     });
 
-    it('sets both id and label to the stripped label value', () => {
+    it('sets id to the original tag value (including prefix) and label to the stripped value', () => {
       const raw = { blocks: { value: [{ value: 'source:direct' }] } };
       const [item] = transformOriginsToFilterDimensions(raw);
-      expect(item.id).to.equal('direct');
+      expect(item.id).to.equal('source:direct');
       expect(item.label).to.equal('direct');
     });
 
@@ -270,7 +285,7 @@ describe('topics definitions', () => {
       const raw = { blocks: { value: [{ value: 'topic:SEO' }, { value: 'source:organic' }] } };
       const result = transformOriginsToFilterDimensions(raw);
       expect(result).to.have.length(1);
-      expect(result[0].id).to.equal('organic');
+      expect(result[0].id).to.equal('source:organic');
     });
   });
 
@@ -299,10 +314,10 @@ describe('topics definitions', () => {
       };
       const result = transformOtherTagsForFilterDimensions(raw);
       expect(result.type).to.deep.equal([
-        { id: null, label: 'branded' },
-        { id: null, label: 'unbranded' },
+        { id: 'type:branded', label: 'branded' },
+        { id: 'type:unbranded', label: 'unbranded' },
       ]);
-      expect(result.abc).to.deep.equal([{ id: null, label: 'value' }]);
+      expect(result.abc).to.deep.equal([{ id: 'abc:value', label: 'value' }]);
       expect(result.tags).to.deep.equal([]);
     });
 
@@ -310,8 +325,8 @@ describe('topics definitions', () => {
       const raw = { blocks: { value: [{ value: 'abc' }, { value: 'another-plain-tag' }] } };
       const result = transformOtherTagsForFilterDimensions(raw);
       expect(result.tags).to.deep.equal([
-        { id: null, label: 'abc' },
-        { id: null, label: 'another-plain-tag' },
+        { id: 'abc', label: 'abc' },
+        { id: 'another-plain-tag', label: 'another-plain-tag' },
       ]);
     });
 
@@ -327,12 +342,12 @@ describe('topics definitions', () => {
       const result = transformOtherTagsForFilterDimensions(raw);
       expect(result.type).to.deep.equal([
         {
-          id: null, label: 'Sub', parent_id: null, parent_label: 'Branded',
+          id: 'type:Branded__Sub', label: 'Sub', parent_id: 'type:Branded', parent_label: 'Branded',
         },
       ]);
       expect(result.tags).to.deep.equal([
         {
-          id: null, label: 'Child', parent_id: null, parent_label: 'Parent',
+          id: 'Parent__Child', label: 'Child', parent_id: 'Parent', parent_label: 'Parent',
         },
       ]);
     });
@@ -340,7 +355,7 @@ describe('topics definitions', () => {
     it('ignores empty string values', () => {
       const raw = { blocks: { value: [{ value: '' }, { value: 'abc' }] } };
       const result = transformOtherTagsForFilterDimensions(raw);
-      expect(result.tags).to.deep.equal([{ id: null, label: 'abc' }]);
+      expect(result.tags).to.deep.equal([{ id: 'abc', label: 'abc' }]);
     });
 
     it('routes tags whose prefix collides with a reserved result key into tags instead of a dynamic group', () => {
@@ -365,15 +380,25 @@ describe('topics definitions', () => {
       expect(result).to.not.have.property('categories');
       expect(result).to.not.have.property('page_intents');
       expect(result).to.not.have.property('origins');
-      expect(result.type).to.deep.equal([{ id: null, label: 'branded' }]);
+      expect(result.type).to.deep.equal([{ id: 'type:branded', label: 'branded' }]);
       expect(result.tags).to.deep.equal([
-        { id: null, label: 'foo' },
-        { id: null, label: 'APAC' },
-        { id: null, label: 'x' },
-        { id: null, label: 'x' },
-        { id: null, label: 'x' },
-        { id: null, label: 'x' },
-        { id: null, label: 'x' },
+        { id: 'brands:foo', label: 'foo' },
+        { id: 'regions:APAC', label: 'APAC' },
+        { id: 'topics:x', label: 'x' },
+        { id: 'categories:x', label: 'x' },
+        { id: 'page_intents:x', label: 'x' },
+        { id: 'origins:x', label: 'x' },
+        { id: 'tags:x', label: 'x' },
+      ]);
+    });
+
+    it('reconstructs parent_id with the reserved-key prefix when a colliding tag has a Parent__Child value', () => {
+      const raw = { blocks: { value: [{ value: 'topics:Parent__Child' }] } };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result.tags).to.deep.equal([
+        {
+          id: 'topics:Parent__Child', label: 'Child', parent_id: 'topics:Parent', parent_label: 'Parent',
+        },
       ]);
     });
   });

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -155,6 +155,30 @@ describe('createElementsService', () => {
       await expect(service.getUrlInspectorFilterDimensions('ws-1', {}))
         .to.be.rejectedWith('upstream failure');
     });
+
+    it('does not throw and does not corrupt the result prototype for Object.prototype-named tag prefixes', async () => {
+      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.TOPICS, sinon.match.any).resolves({
+        blocks: {
+          value: [
+            { value: 'constructor:evil' },
+            { value: '__proto__:evil' },
+            { value: 'toString:harmless' },
+          ],
+        },
+      });
+      const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
+      // constructor/__proto__ are explicitly reserved (see getUrlInspectorFilterDimensions),
+      // so they're routed into the generic `tags` array rather than becoming their own key.
+      expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+      expect(Object.prototype.hasOwnProperty.call(result, 'constructor')).to.equal(false);
+      expect(result.tags).to.deep.equal([
+        { id: 'constructor:evil', label: 'evil' },
+        { id: '__proto__:evil', label: 'evil' },
+      ]);
+      // toString isn't in the reserved list, so it becomes its own dynamic group —
+      // this is safe (a plain data property shadowing the inherited one), just unusual.
+      expect(result.toString).to.deep.equal([{ id: 'toString:harmless', label: 'harmless' }]);
+    });
   });
 
   describe('getPrompts', () => {

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -45,6 +45,8 @@ const RAW_TOPICS = {
       { value: 'category:Firefly' },
       { value: 'intent:Informational' },
       { value: 'source:organic' },
+      { value: 'type:branded' },
+      { value: 'plain-tag' },
     ],
   },
 };
@@ -84,9 +86,21 @@ describe('createElementsService', () => {
       expect(calledIds).to.include(ELEMENT_IDS.MARKETS);
     });
 
-    it('returns an object with brands, regions, topics, categories, page_intents, origins keys', async () => {
+    it('returns an object with brands, regions, topics, categories, page_intents, origins, type, tags keys', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result).to.have.all.keys(['brands', 'regions', 'topics', 'categories', 'page_intents', 'origins']);
+      expect(result).to.have.all.keys([
+        'brands', 'regions', 'topics', 'categories', 'page_intents', 'origins', 'type', 'tags',
+      ]);
+    });
+
+    it('groups unknown prefix:value tags under their own prefix key', async () => {
+      const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
+      expect(result.type).to.deep.equal([{ id: null, label: 'branded' }]);
+    });
+
+    it('collects plain, prefix-less tags into the generic tags key', async () => {
+      const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
+      expect(result.tags).to.deep.equal([{ id: null, label: 'plain-tag' }]);
     });
 
     it('brands contains filter dimensions for each brand', async () => {

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -95,18 +95,18 @@ describe('createElementsService', () => {
 
     it('groups unknown prefix:value tags under their own prefix key', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.type).to.deep.equal([{ id: null, label: 'branded' }]);
+      expect(result.type).to.deep.equal([{ id: 'type:branded', label: 'branded' }]);
     });
 
     it('collects plain, prefix-less tags into the generic tags key', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.tags).to.deep.equal([{ id: null, label: 'plain-tag' }]);
+      expect(result.tags).to.deep.equal([{ id: 'plain-tag', label: 'plain-tag' }]);
     });
 
     it('brands contains filter dimensions for each brand', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
       expect(result.brands).to.have.length(2);
-      expect(result.brands[0]).to.deep.include({ id: null, label: 'Adobe' });
+      expect(result.brands[0]).to.deep.include({ id: 'Adobe', label: 'Adobe' });
     });
 
     it('regions contains transformed markets', async () => {
@@ -117,22 +117,22 @@ describe('createElementsService', () => {
 
     it('topics contains only topic:-prefixed entries', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.topics).to.deep.equal([{ id: null, label: 'SEO' }]);
+      expect(result.topics).to.deep.equal([{ id: 'topic:SEO', label: 'SEO' }]);
     });
 
     it('categories contains only category:-prefixed entries', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.categories).to.deep.equal([{ id: null, label: 'Firefly' }]);
+      expect(result.categories).to.deep.equal([{ id: 'category:Firefly', label: 'Firefly' }]);
     });
 
-    it('page_intents contains only intent:-prefixed entries with uppercased id', async () => {
+    it('page_intents contains only intent:-prefixed entries with the original tag as id', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.page_intents).to.deep.equal([{ id: 'INFORMATIONAL', label: 'Informational' }]);
+      expect(result.page_intents).to.deep.equal([{ id: 'intent:Informational', label: 'Informational' }]);
     });
 
     it('origins contains only source:-prefixed entries', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.origins).to.deep.equal([{ id: 'organic', label: 'organic' }]);
+      expect(result.origins).to.deep.equal([{ id: 'source:organic', label: 'organic' }]);
     });
 
     it('resolves spacecat_brand_id on brands when spacecatBrands are provided', async () => {


### PR DESCRIPTION
# feat: enhance serenity filter-dimensions for sub categories

## Summary

Enhances the Serenity (Semrush Elements-backed) URL Inspector filter-dimensions
response (`getUrlInspectorFilterDimensions` / `src/support/elements/definitions/topics.js`,
`brands.js`) to handle tag hierarchies, surface previously-unmodeled tag types, and
give every filter-dimension item a stable, real `id` instead of `null`.

## Changes

### 1. Category/topic subcategory hierarchy (`Parent__Child` tags)

- Semrush's Elements API can return tag values encoding a two-level hierarchy, e.g.
  `category:Modular & Configurable Sofas__Compact Shippable Furniture`.
- `transformCategoriesToFilterDimensions` / `transformTopicsForFilterDimensions`
  (`src/support/elements/definitions/topics.js`) split on the first `__`: the
  suffix becomes `label`, and `parent_id` / `parent_label` are added for the prefix.
- Entries without `__` are unchanged (no parent keys added).

### 2. Generic handling of unknown tag types

- The tags element can also return types beyond `topic:` / `category:` / `intent:` /
  `source:` (e.g. `type:branded`), plus plain untyped tags (e.g. `abc`).
- New `transformOtherTagsForFilterDimensions` groups unknown `prefix:value` tags
  dynamically by their prefix (response key = prefix, e.g. `type: [...]`), and
  collects plain, prefix-less values into a generic `tags` array. Tags whose
  prefix collides with an existing response key (`brands`, `regions`, `topics`,
  `categories`, `page_intents`, `origins`, `tags`) are routed into the generic
  `tags` array instead of clobbering that key.
- Wired into `elements-service.js`'s `getUrlInspectorFilterDimensions`, which now
  merges these dynamic groups + `tags` into its response alongside the existing
  fixed keys (`brands`, `regions`, `topics`, `categories`, `page_intents`, `origins`),
  with collision-safe merging.

### 3. `id` is now the original, unmodified tag value (not `null`)

- Previously `topics`, `categories`, and the generic `tags`/dynamic-group items
  always had `id: null`; `page_intents` used an uppercased label; `origins` used
  the stripped label.
- All of these now set `id` to the **original tag value exactly as returned by
  Semrush**, including its prefix (e.g. `topic:Furniture__Sofas`,
  `intent:Informational`, `source:organic`). `label` is unchanged (the
  prefix-stripped, non-uppercased value).

### 4. `parent_id` is now derived, not `null`

- For hierarchical (`Parent__Child`) tags, `parent_id` is reconstructed as
  `${prefix}${parent_label}` — the same original-tag shape as the item's own
  `id` — instead of always being `null`.
- Example: `category:Living Room Furniture Retail__Living Room Furniture and Sofas`
  → `parent_id: 'category:Living Room Furniture Retail'`.
- Applies uniformly to the fixed dimensions (`topics`, `categories`) and to the
  dynamic/generic tag groups from `transformOtherTagsForFilterDimensions`.

### 5. Brand `id` now mirrors `label`

- `transformBrandsToFilterDimensions` (`src/support/elements/definitions/brands.js`)
  now sets `id: label` instead of `id: null`, since Semrush has no stable brand ID
  and the label is the only distinguishing value available.

## Docs

- `docs/openapi/schemas.yaml`: `SerenityFilterDimensionItem.id` and `.parent_id`
  are now `string` (no longer nullable); `SerenityUrlInspectorFilterDimensions.brands[].id`
  is now `string` (no longer nullable). Descriptions updated to explain the
  original-tag-value semantics and the `parent_id` reconstruction rule.
- Validated with `npm run docs:lint`.

## Tests

- Full coverage added/updated in `topics.test.js`, `brands.test.js`,
  `elements-service.test.js`, `controllers/elements.test.js`, and
  `openapi-contract/serenity-api.test.js` for all of the above behaviors
  (id values, parent_id reconstruction, brand id, dynamic tag grouping,
  reserved-key collision routing).
- Full suite: **14517 passing**, no failures.
- Lint: clean.

#

<img width="749" height="815" alt="image" src="https://github.com/user-attachments/assets/b07a5b3d-0e38-40ac-8cac-dbe1e5a65f43" />

