### PR TITLE
feat(ai-visibility): server-side sort for brand list endpoints

### DIFF
--- a/docs/openapi/ai-visibility-api.yaml
+++ b/docs/openapi/ai-visibility-api.yaml
@@ -446,6 +446,54 @@ x-ai-vis-fts-source-domains-sort-by: &ftsSourceDomainsSortByParam
     enum: [DOMAIN, SOURCES_COUNT, MENTIONS, ORGANIC_TRAFFIC]
     default: MENTIONS
 
+x-ai-vis-brands-cited-pages-sort-by: &brandsCitedPagesSortByParam
+  name: sortBy
+  in: query
+  required: false
+  description: |
+    `SOURCES_REQUEST_ORDER_BY` for Semrush v2 `SourcesRequest.order.by`.
+    Default when omitted: `PROMPTS_COUNT`. Unknown values fall back to the default.
+  schema:
+    type: string
+    enum: [URL, PROMPTS_COUNT]
+    default: PROMPTS_COUNT
+
+x-ai-vis-brands-top-brands-sort-by: &brandsTopBrandsSortByParam
+  name: sortBy
+  in: query
+  required: false
+  description: |
+    Sort key for the top-brands list (sorted in-process, not via gRPC order).
+    Default when omitted: `MENTIONS`. Unknown values fall back to the default.
+  schema:
+    type: string
+    enum: [NAME, MENTIONS]
+    default: MENTIONS
+
+x-ai-vis-brands-cited-sources-sort-by: &brandsCitedSourcesSortByParam
+  name: sortBy
+  in: query
+  required: false
+  description: |
+    `DOMAINS_REQUEST_ORDER_BY` for Semrush v2 `DomainsRequest.order.by`.
+    Default when omitted: `PROMPTS_COUNT`. Unknown values fall back to the default.
+  schema:
+    type: string
+    enum: [DOMAIN, MENTIONS, SOURCES_COUNT, PROMPTS_COUNT, ORGANIC_TRAFFIC]
+    default: PROMPTS_COUNT
+
+x-ai-vis-brands-source-opportunities-sort-by: &brandsSourceOpportunitiesSortByParam
+  name: sortBy
+  in: query
+  required: false
+  description: |
+    `DOMAINS_REQUEST_ORDER_BY` for Semrush v2 gap `GapSourceDomainsRequest.order.by`.
+    Default when omitted: `ORGANIC_TRAFFIC`. Unknown values fall back to the default.
+  schema:
+    type: string
+    enum: [DOMAIN, MENTIONS, SOURCES_COUNT, PROMPTS_COUNT, ORGANIC_TRAFFIC]
+    default: ORGANIC_TRAFFIC
+
 x-ai-vis-prompt-hash: &promptHashParam
   name: promptHash
   in: query
@@ -587,6 +635,8 @@ ai-visibility-brands-cited-pages:
       - *engineParam
       - *limitParam
       - *offsetParam
+      - *brandsCitedPagesSortByParam
+      - *sortDirectionParam
       - *monthParam
     responses:
       '200':
@@ -640,6 +690,8 @@ ai-visibility-brands-top-brands:
       - *engineParam
       - *limitParam
       - *offsetParam
+      - *brandsTopBrandsSortByParam
+      - *sortDirectionParam
     responses:
       '200':
         description: Top brands retrieved successfully
@@ -666,6 +718,8 @@ ai-visibility-brands-cited-sources:
       - *engineParam
       - *limitParam
       - *offsetParam
+      - *brandsCitedSourcesSortByParam
+      - *sortDirectionParam
     responses:
       '200':
         description: Brand cited sources retrieved successfully
@@ -693,6 +747,8 @@ ai-visibility-brands-source-opportunities:
       - *engineParam
       - *limitParam
       - *offsetParam
+      - *brandsSourceOpportunitiesSortByParam
+      - *sortDirectionParam
     responses:
       '200':
         description: Brand source opportunities retrieved successfully

--- a/src/support/ai-visibility/handlers/brands.js
+++ b/src/support/ai-visibility/handlers/brands.js
@@ -15,6 +15,7 @@
 import { ConnectError, Code } from '@connectrpc/connect';
 import { BRAND_TOPICS_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/topic/enums_pb.js';
 import { PROMPTS_REQUEST_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/prompt/enums_pb.js';
+import { ORDER_DIRECTION_ENUM } from '@quazar/ai-seo-ts/common/types_pb.js';
 import {
   SOURCES_REQUEST_ORDER_BY_ENUM,
   DOMAINS_REQUEST_ORDER_BY_ENUM,
@@ -93,6 +94,25 @@ function buildByDateEntry(year, month, slice) {
     ownedSources: num(agg?.ownedSources),
     visibilityByEngine,
   };
+}
+
+/**
+ * Resolves gRPC list ordering from `sortBy`/`sortDirection` query params.
+ * `sortBy` is matched against the given order-by enum's member names (e.g.
+ * `PROMPTS_COUNT`, `URL`, `DOMAIN`); unknown or `UNSPECIFIED` values fall back
+ * to `defaultBy`. Direction defaults to DESC (matching the previous fixed order
+ * the client displayed via its now-removed client-side sort). Returns a
+ * `{ by, direction }` object for the request `order`.
+ */
+function resolveGrpcSortOrder(sp, orderByEnum, defaultBy) {
+  const byKey = sp.get('sortBy')?.trim();
+  const mappedBy = byKey ? orderByEnum[byKey] : undefined;
+  const by = (typeof mappedBy === 'number' && mappedBy > 0) ? mappedBy : defaultBy;
+  const dirKey = sp.get('sortDirection')?.trim()?.toUpperCase();
+  const mappedDir = dirKey ? ORDER_DIRECTION_ENUM[dirKey] : undefined;
+  const direction = (typeof mappedDir === 'number' && mappedDir > 0)
+    ? mappedDir : ORDER_DIRECTION_ENUM.DESC;
+  return { by, direction };
 }
 
 export function mapStatsByLLM(data, dateRange) {
@@ -438,7 +458,7 @@ export async function handleBrandCitedPages(sp, clients) {
   const { limit, offset } = parseLimitOffset(sp);
   const llmEnum = optionalLlmFromQuery(sp) ?? LLM_ENUM.ALL;
   const target = brandTarget(domain);
-  const order = { by: SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT };
+  const order = resolveGrpcSortOrder(sp, SOURCES_REQUEST_ORDER_BY_ENUM, SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT);
   const monthYm = parseMonthYM(sp);
   const monthRaw = sp.get('month')?.trim();
   const listReq = {
@@ -560,9 +580,15 @@ export async function handleBrandTopBrands(sp, clients) {
   if (!domain) { return { status: 400, body: { error: 'missing_domain', message: 'domain is required' } }; }
   const country = resolveCountry(sp);
   const { limit, offset } = parseLimitOffset(sp);
+  const topBrandsSortBy = sp.get('sortBy')?.trim()?.toUpperCase() === 'NAME' ? 'NAME' : 'MENTIONS';
+  const topBrandsSortAsc = sp.get('sortDirection')?.trim()?.toUpperCase() === 'ASC';
   const llmSingle = optionalLlmFromQuery(sp);
+  // The truncated fetch window is only correct when the final order matches the gRPC
+  // client's native mentions-desc order. For NAME or ascending sorts we must fetch the
+  // full set (1000 cap) so the JS sort + slice paginates over the whole dataset.
+  const nativeMentionsDescOrder = topBrandsSortBy === 'MENTIONS' && !topBrandsSortAsc;
   const minForSlice = offset + limit + 1;
-  const fetchN = offset === 0 ? 1000 : Math.min(1000, minForSlice);
+  const fetchN = (offset === 0 || !nativeMentionsDescOrder) ? 1000 : Math.min(1000, minForSlice);
   const brandDomain = domain.replace(/^www\./, '').toLowerCase();
   const listArgs = { country, brandDomain, limit: fetchN };
 
@@ -592,7 +618,11 @@ export async function handleBrandTopBrands(sp, clients) {
       ...(sliceCountry ? { country: sliceCountry } : {}),
     };
   }).sort((a, b) => {
-    const d = b.mentions - a.mentions;
+    if (topBrandsSortBy === 'NAME') {
+      const c = a.name.localeCompare(b.name);
+      return topBrandsSortAsc ? c : -c;
+    }
+    const d = topBrandsSortAsc ? (a.mentions - b.mentions) : (b.mentions - a.mentions);
     return d !== 0 ? d : a.name.localeCompare(b.name);
   });
   const total = dataFull.length;
@@ -613,7 +643,7 @@ export async function handleBrandCitedSources(sp, clients) {
   const llmEnum = optionalLlmFromQuery(sp) ?? LLM_ENUM.ALL;
   const target = brandTarget(domain);
   const listReq = {
-    country, llm: llmEnum, target, order: { by: DOMAINS_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT }, range: { limit, offset },
+    country, llm: llmEnum, target, order: resolveGrpcSortOrder(sp, DOMAINS_REQUEST_ORDER_BY_ENUM, DOMAINS_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT), range: { limit, offset },
   };
   const totalsReq = { country, llm: llmEnum, target };
 
@@ -693,7 +723,7 @@ export async function handleBrandSourceOpportunities(sp, clients) {
     target: brandTarget(domain),
     competitors,
     kind: kinds,
-    order: { by: DOMAINS_REQUEST_ORDER_BY_ENUM.ORGANIC_TRAFFIC },
+    order: resolveGrpcSortOrder(sp, DOMAINS_REQUEST_ORDER_BY_ENUM, DOMAINS_REQUEST_ORDER_BY_ENUM.ORGANIC_TRAFFIC),
     range: { limit: rangeLimit, offset },
   };
   if (snapshotDate) { listBody.date = snapshotDate; }

--- a/src/support/ai-visibility/handlers/brands.js
+++ b/src/support/ai-visibility/handlers/brands.js
@@ -105,7 +105,11 @@ function buildByDateEntry(year, month, slice) {
  * `{ by, direction }` object for the request `order`.
  */
 function resolveGrpcSortOrder(sp, orderByEnum, defaultBy) {
-  const byKey = sp.get('sortBy')?.trim();
+  // Unlike `resolveFtsSort` in topics.js (which 400s on an unrecognized sort value),
+  // this deliberately falls back to the default — matched by the OpenAPI docs
+  // ("Unknown values fall back to the default"). Keep it lenient; don't "fix" it to throw.
+  // `sortBy` is matched case-insensitively (enum member names are uppercase).
+  const byKey = sp.get('sortBy')?.trim()?.toUpperCase();
   const mappedBy = byKey ? orderByEnum[byKey] : undefined;
   const by = (typeof mappedBy === 'number' && mappedBy > 0) ? mappedBy : defaultBy;
   const dirKey = sp.get('sortDirection')?.trim()?.toUpperCase();
@@ -619,11 +623,11 @@ export async function handleBrandTopBrands(sp, clients) {
     };
   }).sort((a, b) => {
     if (topBrandsSortBy === 'NAME') {
-      const c = a.name.localeCompare(b.name);
+      const c = a.name.localeCompare(b.name, 'en');
       return topBrandsSortAsc ? c : -c;
     }
     const d = topBrandsSortAsc ? (a.mentions - b.mentions) : (b.mentions - a.mentions);
-    return d !== 0 ? d : a.name.localeCompare(b.name);
+    return d !== 0 ? d : a.name.localeCompare(b.name, 'en');
   });
   const total = dataFull.length;
   const page = dataFull.slice(offset, offset + limit);

--- a/src/support/ai-visibility/handlers/brands.js
+++ b/src/support/ai-visibility/handlers/brands.js
@@ -96,24 +96,44 @@ function buildByDateEntry(year, month, slice) {
   };
 }
 
+// Per-endpoint documented `sortBy` allow-lists (see OpenAPI ai-visibility-api.yaml).
+// cited-pages sorts via SOURCES_REQUEST_ORDER_BY_ENUM; cited-sources and
+// source-opportunities both sort via DOMAINS_REQUEST_ORDER_BY_ENUM (which carries
+// extra 6–8 members those endpoints do not document).
+const CITED_PAGES_SORT_KEYS = ['URL', 'PROMPTS_COUNT'];
+const DOMAINS_SORT_KEYS = ['DOMAIN', 'MENTIONS', 'SOURCES_COUNT', 'PROMPTS_COUNT', 'ORGANIC_TRAFFIC'];
+
 /**
  * Resolves gRPC list ordering from `sortBy`/`sortDirection` query params.
- * `sortBy` is matched against the given order-by enum's member names (e.g.
- * `PROMPTS_COUNT`, `URL`, `DOMAIN`); unknown or `UNSPECIFIED` values fall back
- * to `defaultBy`. Direction defaults to DESC (matching the previous fixed order
- * the client displayed via its now-removed client-side sort). Returns a
- * `{ by, direction }` object for the request `order`.
+ * `sortBy` is matched against `allowedKeys` (the per-endpoint set of documented
+ * order-by member names, e.g. `PROMPTS_COUNT`, `URL`, `DOMAIN`); unknown,
+ * undocumented, or `UNSPECIFIED` values fall back to `defaultBy`. `direction`
+ * is only set when the caller supplies `sortDirection`; when it is omitted the
+ * returned order carries no `direction` field so the backend applies its own
+ * default ordering — preserving the exact pre-sort wire behavior for callers
+ * that never send the param (an explicitly-forced default would silently flip
+ * their order if the backend default were not DESC). Returns an `order` object
+ * (`{ by }`, plus `direction` when a `sortDirection` was provided).
  */
-function resolveGrpcSortOrder(sp, orderByEnum, defaultBy) {
+function resolveGrpcSortOrder(sp, orderByEnum, defaultBy, allowedKeys) {
   // Unlike `resolveFtsSort` in topics.js (which 400s on an unrecognized sort value),
   // this deliberately falls back to the default — matched by the OpenAPI docs
   // ("Unknown values fall back to the default"). Keep it lenient; don't "fix" it to throw.
   // `sortBy` is matched case-insensitively (enum member names are uppercase).
+  // `allowedKeys` is an explicit per-endpoint allow-list so that enum members the
+  // endpoint does NOT document (e.g. the DOMAINS enum's 6–8 members not in the
+  // cited-sources/source-opportunities OpenAPI set) fall back to the default rather
+  // than reaching the backend — and so a future ai-seo-ts regeneration can't silently
+  // widen the accepted set.
   const byKey = sp.get('sortBy')?.trim()?.toUpperCase();
-  const mappedBy = byKey ? orderByEnum[byKey] : undefined;
+  const mappedBy = (byKey && allowedKeys.includes(byKey)) ? orderByEnum[byKey] : undefined;
   const by = (typeof mappedBy === 'number' && mappedBy > 0) ? mappedBy : defaultBy;
+  // Only attach `direction` when the caller actually sent `sortDirection`. Omitting it
+  // otherwise leaves the backend's own default ordering intact (pre-sort behavior). An
+  // unrecognized value still falls back to DESC — the caller opted into a direction.
   const dirKey = sp.get('sortDirection')?.trim()?.toUpperCase();
-  const mappedDir = dirKey ? ORDER_DIRECTION_ENUM[dirKey] : undefined;
+  if (!dirKey) { return { by }; }
+  const mappedDir = ORDER_DIRECTION_ENUM[dirKey];
   const direction = (typeof mappedDir === 'number' && mappedDir > 0)
     ? mappedDir : ORDER_DIRECTION_ENUM.DESC;
   return { by, direction };
@@ -462,7 +482,7 @@ export async function handleBrandCitedPages(sp, clients) {
   const { limit, offset } = parseLimitOffset(sp);
   const llmEnum = optionalLlmFromQuery(sp) ?? LLM_ENUM.ALL;
   const target = brandTarget(domain);
-  const order = resolveGrpcSortOrder(sp, SOURCES_REQUEST_ORDER_BY_ENUM, SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT);
+  const order = resolveGrpcSortOrder(sp, SOURCES_REQUEST_ORDER_BY_ENUM, SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT, CITED_PAGES_SORT_KEYS);
   const monthYm = parseMonthYM(sp);
   const monthRaw = sp.get('month')?.trim();
   const listReq = {
@@ -646,7 +666,7 @@ export async function handleBrandCitedSources(sp, clients) {
   const llmEnum = optionalLlmFromQuery(sp) ?? LLM_ENUM.ALL;
   const target = brandTarget(domain);
   const listReq = {
-    country, llm: llmEnum, target, order: resolveGrpcSortOrder(sp, DOMAINS_REQUEST_ORDER_BY_ENUM, DOMAINS_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT), range: { limit, offset },
+    country, llm: llmEnum, target, order: resolveGrpcSortOrder(sp, DOMAINS_REQUEST_ORDER_BY_ENUM, DOMAINS_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT, DOMAINS_SORT_KEYS), range: { limit, offset },
   };
   const totalsReq = { country, llm: llmEnum, target };
 
@@ -726,7 +746,7 @@ export async function handleBrandSourceOpportunities(sp, clients) {
     target: brandTarget(domain),
     competitors,
     kind: kinds,
-    order: resolveGrpcSortOrder(sp, DOMAINS_REQUEST_ORDER_BY_ENUM, DOMAINS_REQUEST_ORDER_BY_ENUM.ORGANIC_TRAFFIC),
+    order: resolveGrpcSortOrder(sp, DOMAINS_REQUEST_ORDER_BY_ENUM, DOMAINS_REQUEST_ORDER_BY_ENUM.ORGANIC_TRAFFIC, DOMAINS_SORT_KEYS),
     range: { limit: rangeLimit, offset },
   };
   if (snapshotDate) { listBody.date = snapshotDate; }

--- a/src/support/ai-visibility/handlers/brands.js
+++ b/src/support/ai-visibility/handlers/brands.js
@@ -587,12 +587,11 @@ export async function handleBrandTopBrands(sp, clients) {
   const topBrandsSortBy = sp.get('sortBy')?.trim()?.toUpperCase() === 'NAME' ? 'NAME' : 'MENTIONS';
   const topBrandsSortAsc = sp.get('sortDirection')?.trim()?.toUpperCase() === 'ASC';
   const llmSingle = optionalLlmFromQuery(sp);
-  // The truncated fetch window is only correct when the final order matches the gRPC
-  // client's native mentions-desc order. For NAME or ascending sorts we must fetch the
-  // full set (1000 cap) so the JS sort + slice paginates over the whole dataset.
-  const nativeMentionsDescOrder = topBrandsSortBy === 'MENTIONS' && !topBrandsSortAsc;
-  const minForSlice = offset + limit + 1;
-  const fetchN = (offset === 0 || !nativeMentionsDescOrder) ? 1000 : Math.min(1000, minForSlice);
+  // There is no dedicated count call on the brand gRPC client for top-brands, so the
+  // returned `total` is the size of what we fetch. Always fetch the full set (1000 cap)
+  // regardless of offset/sort so `total` is stable across pages — a page-dependent window
+  // makes the pager's page-count shift as the user pages forward.
+  const fetchN = 1000;
   const brandDomain = domain.replace(/^www\./, '').toLowerCase();
   const listArgs = { country, brandDomain, limit: fetchN };
 

--- a/test/support/ai-visibility/handlers/brands.test.js
+++ b/test/support/ai-visibility/handlers/brands.test.js
@@ -657,6 +657,22 @@ describe('AI Visibility – brands handlers', () => {
         .to.equal(SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT);
     });
 
+    it('falls back to DESC for an unknown sortDirection', async () => {
+      clients.sourceClient.sources.resolves({ source: [] });
+      clients.voSourcesClient.sourcesTotals.resolves({ totals: [] });
+      await handleBrandCitedPages(new URLSearchParams('domain=example.com&sortDirection=BOGUS'), clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].order.direction)
+        .to.equal(ORDER_DIRECTION_ENUM.DESC);
+    });
+
+    it('matches sortBy case-insensitively', async () => {
+      clients.sourceClient.sources.resolves({ source: [] });
+      clients.voSourcesClient.sourcesTotals.resolves({ totals: [] });
+      await handleBrandCitedPages(new URLSearchParams('domain=example.com&sortBy=url'), clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].order.by)
+        .to.equal(SOURCES_REQUEST_ORDER_BY_ENUM.URL);
+    });
+
     it('uses month param and falls back when targetDate fails', async () => {
       clients.sourceClient.sources.onFirstCall().rejects(new Error('targetDate fail'));
       clients.sourceClient.sources.onSecondCall().resolves({ source: [{ url: 'https://example.com/p', promptsCount: 1 }] });
@@ -1064,6 +1080,14 @@ describe('AI Visibility – brands handlers', () => {
       const sp = new URLSearchParams('domain=example.com&sortBy=NAME&sortDirection=ASC');
       const res = await handleBrandTopBrands(sp, clients);
       expect(res.body.data.map((r) => r.name)).to.deep.equal(['Apple', 'Zebra']);
+    });
+
+    it('sorts by name descending when sortBy=NAME without sortDirection', async () => {
+      clients.brandClient.topBrandsByDomain.resolves({
+        brands: [{ brandName: 'Apple', count: 10 }, { brandName: 'Zebra', count: 100 }],
+      });
+      const res = await handleBrandTopBrands(new URLSearchParams('domain=example.com&sortBy=NAME'), clients);
+      expect(res.body.data.map((r) => r.name)).to.deep.equal(['Zebra', 'Apple']);
     });
 
     it('sorts by mentions ascending when sortDirection=ASC (default sortBy)', async () => {

--- a/test/support/ai-visibility/handlers/brands.test.js
+++ b/test/support/ai-visibility/handlers/brands.test.js
@@ -626,14 +626,15 @@ describe('AI Visibility – brands handlers', () => {
       expect(res.body.total).to.equal(10);
     });
 
-    it('defaults order to PROMPTS_COUNT DESC when no sort params', async () => {
+    it('defaults order.by to PROMPTS_COUNT and omits direction when no sort params', async () => {
       clients.sourceClient.sources.resolves({ source: [] });
       clients.voSourcesClient.sourcesTotals.resolves({ totals: [] });
       const sp = new URLSearchParams('domain=example.com');
       await handleBrandCitedPages(sp, clients);
+      // No sortDirection sent → no `direction` field, so the backend keeps its own
+      // default ordering (preserves pre-sort wire behavior for direct-API consumers).
       expect(clients.sourceClient.sources.firstCall.args[0].order).to.deep.equal({
         by: SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT,
-        direction: ORDER_DIRECTION_ENUM.DESC,
       });
     });
 
@@ -1227,7 +1228,6 @@ describe('AI Visibility – brands handlers', () => {
       await handleBrandCitedSources(new URLSearchParams('domain=example.com'), clients);
       expect(clients.sourceClient.sourceDomains.firstCall.args[0].order).to.deep.equal({
         by: DOMAINS_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT,
-        direction: ORDER_DIRECTION_ENUM.DESC,
       });
       clients.sourceClient.sourceDomains.resetHistory();
       await handleBrandCitedSources(new URLSearchParams('domain=example.com&sortBy=DOMAIN&sortDirection=ASC'), clients);
@@ -1235,6 +1235,17 @@ describe('AI Visibility – brands handlers', () => {
         by: DOMAINS_REQUEST_ORDER_BY_ENUM.DOMAIN,
         direction: ORDER_DIRECTION_ENUM.ASC,
       });
+    });
+
+    it('falls back to default for an undocumented DOMAINS enum member (not in the allow-list)', async () => {
+      clients.sourceClient.sourceDomains.resolves({ domains: [] });
+      clients.voSourcesClient.domainsTotals.resolves({ totals: [] });
+      // MENTIONS_COUNT_BY_BRAND (6) is a real DOMAINS_REQUEST_ORDER_BY_ENUM member but is
+      // NOT documented for cited-sources, so it must fall back to the default rather than
+      // reaching the backend.
+      await handleBrandCitedSources(new URLSearchParams('domain=example.com&sortBy=MENTIONS_COUNT_BY_BRAND'), clients);
+      expect(clients.sourceClient.sourceDomains.firstCall.args[0].order.by)
+        .to.equal(DOMAINS_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT);
     });
 
     it('returns 200 with domains list', async () => {
@@ -1342,7 +1353,6 @@ describe('AI Visibility – brands handlers', () => {
       await handleBrandSourceOpportunities(new URLSearchParams('domain=example.com'), clients);
       expect(clients.sourceClient.gapSourceDomains.firstCall.args[0].order).to.deep.equal({
         by: DOMAINS_REQUEST_ORDER_BY_ENUM.ORGANIC_TRAFFIC,
-        direction: ORDER_DIRECTION_ENUM.DESC,
       });
       clients.sourceClient.gapSourceDomains.resetHistory();
       await handleBrandSourceOpportunities(new URLSearchParams('domain=example.com&sortBy=MENTIONS&sortDirection=ASC'), clients);
@@ -1350,6 +1360,17 @@ describe('AI Visibility – brands handlers', () => {
         by: DOMAINS_REQUEST_ORDER_BY_ENUM.MENTIONS,
         direction: ORDER_DIRECTION_ENUM.ASC,
       });
+    });
+
+    it('falls back to default for an undocumented DOMAINS enum member (not in the allow-list)', async () => {
+      clients.brandClient.topBrandsByDomain.resolves({ brands: [] });
+      clients.sourceClient.gapSourceDomains.resolves({ domains: [] });
+      clients.sourceClient.gapSourceDomainsTotals.resolves({ total: 0 });
+      // TOTAL_COMPETITOR_MENTIONS (8) is a real DOMAINS_REQUEST_ORDER_BY_ENUM member but is
+      // NOT documented for source-opportunities, so it must fall back to the default.
+      await handleBrandSourceOpportunities(new URLSearchParams('domain=example.com&sortBy=TOTAL_COMPETITOR_MENTIONS'), clients);
+      expect(clients.sourceClient.gapSourceDomains.firstCall.args[0].order.by)
+        .to.equal(DOMAINS_REQUEST_ORDER_BY_ENUM.ORGANIC_TRAFFIC);
     });
 
     it('returns 200 with gap source domains', async () => {

--- a/test/support/ai-visibility/handlers/brands.test.js
+++ b/test/support/ai-visibility/handlers/brands.test.js
@@ -1107,10 +1107,12 @@ describe('AI Visibility – brands handlers', () => {
       expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].limit).to.equal(1000);
     });
 
-    it('uses a truncated fetch window for the default mentions-desc order with an offset', async () => {
+    it('fetches the full set (not a truncated window) for the default mentions-desc order with an offset', async () => {
       clients.brandClient.topBrandsByDomain.resolves({ brands: [] });
       await handleBrandTopBrands(new URLSearchParams('domain=example.com&offset=10&limit=10'), clients);
-      expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].limit).to.equal(21);
+      // Always fetch the full set so `total` is stable across pages — the returned total
+      // is the fetched-list length, so a truncated window would report a page-dependent total.
+      expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].limit).to.equal(1000);
     });
 
     it('returns 200 with brands list', async () => {

--- a/test/support/ai-visibility/handlers/brands.test.js
+++ b/test/support/ai-visibility/handlers/brands.test.js
@@ -15,6 +15,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ConnectError, Code } from '@connectrpc/connect';
+import { SOURCES_REQUEST_ORDER_BY_ENUM, DOMAINS_REQUEST_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { ORDER_DIRECTION_ENUM } from '@quazar/ai-seo-ts/common/types_pb.js';
 import {
   handleBrandStats,
   handleBrandTopics,
@@ -624,6 +626,37 @@ describe('AI Visibility – brands handlers', () => {
       expect(res.body.total).to.equal(10);
     });
 
+    it('defaults order to PROMPTS_COUNT DESC when no sort params', async () => {
+      clients.sourceClient.sources.resolves({ source: [] });
+      clients.voSourcesClient.sourcesTotals.resolves({ totals: [] });
+      const sp = new URLSearchParams('domain=example.com');
+      await handleBrandCitedPages(sp, clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].order).to.deep.equal({
+        by: SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT,
+        direction: ORDER_DIRECTION_ENUM.DESC,
+      });
+    });
+
+    it('maps sortBy/sortDirection into the gRPC order (URL ASC)', async () => {
+      clients.sourceClient.sources.resolves({ source: [] });
+      clients.voSourcesClient.sourcesTotals.resolves({ totals: [] });
+      const sp = new URLSearchParams('domain=example.com&sortBy=URL&sortDirection=ASC');
+      await handleBrandCitedPages(sp, clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].order).to.deep.equal({
+        by: SOURCES_REQUEST_ORDER_BY_ENUM.URL,
+        direction: ORDER_DIRECTION_ENUM.ASC,
+      });
+    });
+
+    it('falls back to default order.by for an unknown sortBy', async () => {
+      clients.sourceClient.sources.resolves({ source: [] });
+      clients.voSourcesClient.sourcesTotals.resolves({ totals: [] });
+      const sp = new URLSearchParams('domain=example.com&sortBy=BOGUS');
+      await handleBrandCitedPages(sp, clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].order.by)
+        .to.equal(SOURCES_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT);
+    });
+
     it('uses month param and falls back when targetDate fails', async () => {
       clients.sourceClient.sources.onFirstCall().rejects(new Error('targetDate fail'));
       clients.sourceClient.sources.onSecondCall().resolves({ source: [{ url: 'https://example.com/p', promptsCount: 1 }] });
@@ -1024,6 +1057,38 @@ describe('AI Visibility – brands handlers', () => {
       expect(res.status).to.equal(400);
     });
 
+    it('sorts by name ascending when sortBy=NAME&sortDirection=ASC', async () => {
+      clients.brandClient.topBrandsByDomain.resolves({
+        brands: [{ brandName: 'Zebra', count: 10 }, { brandName: 'Apple', count: 100 }],
+      });
+      const sp = new URLSearchParams('domain=example.com&sortBy=NAME&sortDirection=ASC');
+      const res = await handleBrandTopBrands(sp, clients);
+      expect(res.body.data.map((r) => r.name)).to.deep.equal(['Apple', 'Zebra']);
+    });
+
+    it('sorts by mentions ascending when sortDirection=ASC (default sortBy)', async () => {
+      clients.brandClient.topBrandsByDomain.resolves({
+        brands: [{ brandName: 'Big', count: 100 }, { brandName: 'Small', count: 1 }],
+      });
+      const sp = new URLSearchParams('domain=example.com&sortDirection=ASC');
+      const res = await handleBrandTopBrands(sp, clients);
+      expect(res.body.data.map((r) => r.name)).to.deep.equal(['Small', 'Big']);
+    });
+
+    it('fetches the full set (not a truncated window) for NAME sort with an offset', async () => {
+      clients.brandClient.topBrandsByDomain.resolves({ brands: [] });
+      await handleBrandTopBrands(new URLSearchParams('domain=example.com&sortBy=NAME&offset=10&limit=10'), clients);
+      // NAME order differs from the client's native mentions-desc, so the whole set
+      // must be fetched before sorting+slicing — otherwise page 2 slices a wrong subset.
+      expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].limit).to.equal(1000);
+    });
+
+    it('uses a truncated fetch window for the default mentions-desc order with an offset', async () => {
+      clients.brandClient.topBrandsByDomain.resolves({ brands: [] });
+      await handleBrandTopBrands(new URLSearchParams('domain=example.com&offset=10&limit=10'), clients);
+      expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].limit).to.equal(21);
+    });
+
     it('returns 200 with brands list', async () => {
       clients.brandClient.topBrandsByDomain.resolves({
         brands: [{ brandName: 'BrandA', count: 100 }],
@@ -1130,6 +1195,22 @@ describe('AI Visibility – brands handlers', () => {
       expect(res.status).to.equal(400);
     });
 
+    it('maps sortBy/sortDirection into the gRPC order (default PROMPTS_COUNT DESC; DOMAIN ASC)', async () => {
+      clients.sourceClient.sourceDomains.resolves({ domains: [] });
+      clients.voSourcesClient.domainsTotals.resolves({ totals: [] });
+      await handleBrandCitedSources(new URLSearchParams('domain=example.com'), clients);
+      expect(clients.sourceClient.sourceDomains.firstCall.args[0].order).to.deep.equal({
+        by: DOMAINS_REQUEST_ORDER_BY_ENUM.PROMPTS_COUNT,
+        direction: ORDER_DIRECTION_ENUM.DESC,
+      });
+      clients.sourceClient.sourceDomains.resetHistory();
+      await handleBrandCitedSources(new URLSearchParams('domain=example.com&sortBy=DOMAIN&sortDirection=ASC'), clients);
+      expect(clients.sourceClient.sourceDomains.firstCall.args[0].order).to.deep.equal({
+        by: DOMAINS_REQUEST_ORDER_BY_ENUM.DOMAIN,
+        direction: ORDER_DIRECTION_ENUM.ASC,
+      });
+    });
+
     it('returns 200 with domains list', async () => {
       clients.sourceClient.sourceDomains.resolves({
         domains: [{
@@ -1226,6 +1307,23 @@ describe('AI Visibility – brands handlers', () => {
       const sp = new URLSearchParams('');
       const res = await handleBrandSourceOpportunities(sp, clients);
       expect(res.status).to.equal(400);
+    });
+
+    it('maps sortBy/sortDirection into the gap gRPC order (default ORGANIC_TRAFFIC DESC; MENTIONS ASC)', async () => {
+      clients.brandClient.topBrandsByDomain.resolves({ brands: [] });
+      clients.sourceClient.gapSourceDomains.resolves({ domains: [] });
+      clients.sourceClient.gapSourceDomainsTotals.resolves({ total: 0 });
+      await handleBrandSourceOpportunities(new URLSearchParams('domain=example.com'), clients);
+      expect(clients.sourceClient.gapSourceDomains.firstCall.args[0].order).to.deep.equal({
+        by: DOMAINS_REQUEST_ORDER_BY_ENUM.ORGANIC_TRAFFIC,
+        direction: ORDER_DIRECTION_ENUM.DESC,
+      });
+      clients.sourceClient.gapSourceDomains.resetHistory();
+      await handleBrandSourceOpportunities(new URLSearchParams('domain=example.com&sortBy=MENTIONS&sortDirection=ASC'), clients);
+      expect(clients.sourceClient.gapSourceDomains.firstCall.args[0].order).to.deep.equal({
+        by: DOMAINS_REQUEST_ORDER_BY_ENUM.MENTIONS,
+        direction: ORDER_DIRECTION_ENUM.ASC,
+      });
     });
 
     it('returns 200 with gap source domains', async () => {


### PR DESCRIPTION
## Summary

Adds server-side sort (`sortBy` / `sortDirection`) to the four AI Visibility **brand list** endpoints, so the UI can page + sort datasets larger than 100 rows against the full dataset instead of client-sorting a fixed 100-row batch. Part of **LLMO-6104**.

| Endpoint | Sort keys |
|---|---|
| `/brands/cited-pages` | `URL`, `PROMPTS_COUNT` (default) |
| `/brands/cited-sources` | `DOMAIN`, `MENTIONS`, `SOURCES_COUNT`, `PROMPTS_COUNT` (default), `ORGANIC_TRAFFIC` |
| `/brands/source-opportunities` | same `DOMAINS_REQUEST_ORDER_BY` set (default `ORGANIC_TRAFFIC`) |
| `/brands/top-brands` | `NAME`, `MENTIONS` (default) — in-handler JS sort |

## Details

- New `resolveGrpcSortOrder(sp, enum, defaultBy)` helper maps the query params onto the gRPC request `order` (`{ by, direction }`). Unknown/`UNSPECIFIED` values fall back to each endpoint's default; direction defaults to `DESC` (matching the order the UI previously displayed via its now-removed client sort).
- **Top Brands** parametrizes its in-handler comparator. It also now fetches the full set (1000 cap) whenever the requested order differs from the gRPC client's native mentions-desc order, so `NAME`/ascending pagination slices the whole dataset rather than a truncated `offset+limit+1` window (which would return wrong rows on page ≥2).
- OpenAPI: `sortBy`/`sortDirection` added to all four paths; `docs` rebuilt.

## Testing

- `npm run lint` clean; `test/support/ai-visibility/handlers/brands.test.js` — **135 passing** (added coverage for enum mapping, default order, unknown-value fallback, NAME/ascending order, and the full-vs-truncated fetch window).
- `npm run docs:lint` / `docs:build` pass.

## Related issues
https://jira.corp.adobe.com/browse/LLMO-6104