### PR TITLE
feat: Serenity url-inspector/domain-urls endpoint | LLMO-6160

### DIFF
--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -5,7 +5,7 @@
   of the License at http://www.apache.org/licenses/LICENSE-2.0
 -->
 
-# LLMO Semrush Elements API — Filter Dimensions, Weeks, Prompts, Cited Domains & Owned URLs
+# LLMO Semrush Elements API — Filter Dimensions, Weeks, Prompts, Cited Domains, Owned URLs & Domain URLs
 
 SpaceCat wrapper endpoints over the Semrush Elements APIs for the Brand Presence / URL Inspector dashboards.
 
@@ -20,7 +20,8 @@ SpaceCat wrapper endpoints over the Semrush Elements APIs for the Brand Presence
 3. [List Prompts](#3-list-prompts)
 4. [List Cited Domains](#4-list-cited-domains)
 5. [List Owned URLs](#5-list-owned-urls)
-6. [Supported Models](#6-supported-models)
+6. [List Domain URLs](#6-list-domain-urls)
+7. [Supported Models](#7-supported-models)
 
 ---
 
@@ -404,7 +405,71 @@ Only `domain_type='Owned'` rows are kept (client-side — the element has no ser
 
 ---
 
-## 6. Supported Models
+## 6. List Domain URLs
+
+**`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls`**
+
+Phase 2 of the URL Inspector **"Cited Third Party URLs"** expandable tree: expand a cited domain (from [Cited Domains](#4-list-cited-domains)) → the URLs within it. **Drop-in compatible with the legacy `url-inspector/domain-urls` contract.** Same Semrush element as [Owned URLs](#5-list-owned-urls) (`STATS_PER_URL` 9af5ed83) **minus** the trend element and the Postgres traffic hybrid, filtered to a single domain (required `hostname`) instead of `domain_type='Owned'`.
+
+### Parameters
+
+| Name | In | Required | Description |
+|---|---|---|---|
+| `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
+| `brandId` | path | ✅ | SpaceCat brand UUID. Selects the brand's Semrush **sub-workspace** (flat-mode falls back to the org parent). LLMO ReBAC `brand` resource (FACS `llmo/can_view`); requires `brand:read`. `404` if not in the org |
+| `hostname` / `domain` | query | ✅ | The (registered) domain to drill into, as returned by Cited Domains. `400` if missing. Matched host-or-subdomain (see below) |
+| `model` / `platform` | query | ❌ | AI model filter (`model` wins). Default `search-gpt` |
+| `startDate` / `start_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing, malformed, or after `endDate` |
+| `endDate` / `end_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing or malformed |
+| `categoryId` / `category` | query | ❌ | Category label → tag `category:<label>` (server-side, stats element) |
+| `region` | query | ❌ | Region code (e.g. `US`). Resolved to the market's Semrush **project**. `all`/absent → all the brand's markets (queried per-project) |
+| `page` | query | ❌ | 0-based page index (default `0`) |
+| `pageSize` | query | ❌ | Rows per page (default `50`, clamped to `[1, 1000]`) |
+
+### Underlying Element
+
+| Element | UUID | Shape | Role |
+|---|---|---|---|
+| `STATS_PER_URL` | `9af5ed83-049b-493a-85d7-99c7d4deddba` | `table` | Per-URL citations (`source`, `citations`, `prompts_with_citation`, `domain_type`, `project_id`) |
+
+Scoped by top-level `project_id` + date + `CBF_model`. The endpoint fans out **per project** (per market) — each call stays under the Semrush **50,000-row cap** — then merges. There is **no trend element and no traffic RPC** (that is Owned URLs only).
+
+### What it returns
+
+The element has **no server-side domain filter** (verified live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq` + `contains`, all return the full project table), so `hostname` is applied **client-side** — the same pattern Owned URLs uses for `domain_type='Owned'`. Cited Domains reports the **registered domain** (e.g. `openai.com`), but `source` hosts are often subdomains (`help.openai.com`), so a row matches when its host **equals `hostname` or is a subdomain of it** (`host === hostname || host.endsWith('.'+hostname)`, `www.`-stripped, lowercased). Exact-host matching would miss most URLs — e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`. URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full post-filter count. Field mapping:
+
+- **`url`** ← `source`; **`citations`** ← `citations`; **`promptsCited`** ← `prompts_with_citation`
+- **`contentType`** ← `domain_type`
+- **`regions`** ← the region code(s) of the project(s) the URL appears in, joined (string)
+- **`urlId`** → `''`, **`categories`** → `''` (see gaps)
+
+### Response example
+
+```json
+{
+  "urls": [
+    {
+      "urlId": "",
+      "url": "https://help.openai.com/en/articles/pricing",
+      "contentType": "Other",
+      "citations": 44,
+      "promptsCited": 40,
+      "categories": "",
+      "regions": "US"
+    }
+  ],
+  "totalCount": 37
+}
+```
+
+> **⚠️ Gaps (POC):**
+> 1. **No Semrush source for `urlId`, `categories`** — stubbed `''`. `urlId` has no `source_urls.id` equivalent (so a future url-prompts drilldown must key off the URL string); the stats element carries no per-URL category. *Deferred follow-up* (cf. LLMO-6086 / LLMO-6071).
+> 2. **`regions` is a string**, not an array — this endpoint follows the legacy `domain-urls` contract (and the UI `DomainUrlRow` type), unlike Owned URLs which returns `regions` as an array.
+> 3. **Region resolution is org-wide** (same best-effort caveat as Cited Domains gap 3).
+
+---
+
+## 7. Supported Models
 
 The `model` (or `platform`) query parameter is accepted by these endpoints. Only the following Semrush values are valid; any unrecognised value silently falls back to the default (`search-gpt`).
 

--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -422,6 +422,7 @@ Phase 2 of the URL Inspector **"Cited Third Party URLs"** expandable tree: expan
 | `startDate` / `start_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing, malformed, or after `endDate` |
 | `endDate` / `end_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing or malformed |
 | `categoryId` / `category` | query | ❌ | Category label → tag `category:<label>` (server-side, stats element) |
+| `channel` / `selectedChannel` | query | ❌ | Content-type filter (e.g. `Other`, `Social`) applied client-side on `contentType`, case-insensitive. Mirrors the legacy `p_channel` |
 | `region` | query | ❌ | Region code (e.g. `US`). Resolved to the market's Semrush **project**. `all`/absent → all the brand's markets (queried per-project) |
 | `page` | query | ❌ | 0-based page index (default `0`) |
 | `pageSize` | query | ❌ | Rows per page (default `50`, clamped to `[1, 1000]`) |
@@ -436,11 +437,11 @@ Scoped by top-level `project_id` + date + `CBF_model`. The endpoint fans out **p
 
 ### What it returns
 
-The element has **no server-side domain filter** (verified live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq` + `contains`, all return the full project table), so `hostname` is applied **client-side** — the same pattern Owned URLs uses for `domain_type='Owned'`. Cited Domains reports the **registered domain** (e.g. `openai.com`), but `source` hosts are often subdomains (`help.openai.com`), so a row matches when its host **equals `hostname` or is a subdomain of it** (`host === hostname || host.endsWith('.'+hostname)`, `www.`-stripped, lowercased). Exact-host matching would miss most URLs — e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`. URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full post-filter count. Field mapping:
+The element has **no server-side domain filter** (verified live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq` + `contains`, all return the full project table), so `hostname` is applied **client-side** — the same pattern Owned URLs uses for `domain_type='Owned'`. Cited Domains reports the **registered domain** (e.g. `openai.com`), but `source` hosts are often subdomains (`help.openai.com`), so a row matches when its host **equals `hostname` or is a subdomain of it** (`host === hostname || host.endsWith('.'+hostname)`, `www.`-stripped, lowercased). Exact-host matching would miss most URLs — e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`. An optional `channel` (content-type) filter is then applied client-side on `contentType`. URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full post-filter count. Field mapping:
 
 - **`url`** ← `source`; **`citations`** ← `citations`; **`promptsCited`** ← `prompts_with_citation`
 - **`contentType`** ← `domain_type`
-- **`regions`** ← the region code(s) of the project(s) the URL appears in, joined (string)
+- **`regions`** ← the region code(s) of the project(s) the URL appears in, comma-joined (string, no space — matches the legacy `string_agg`)
 - **`urlId`** → `''`, **`categories`** → `''` (see gaps)
 
 ### Response example
@@ -462,10 +463,31 @@ The element has **no server-side domain filter** (verified live: `CBF_domain`/`c
 }
 ```
 
-> **⚠️ Gaps (POC):**
-> 1. **No Semrush source for `urlId`, `categories`** — stubbed `''`. `urlId` has no `source_urls.id` equivalent (so a future url-prompts drilldown must key off the URL string); the stats element carries no per-URL category. *Deferred follow-up* (cf. LLMO-6086 / LLMO-6071).
-> 2. **`regions` is a string**, not an array — this endpoint follows the legacy `domain-urls` contract (and the UI `DomainUrlRow` type), unlike Owned URLs which returns `regions` as an array.
-> 3. **Region resolution is org-wide** (same best-effort caveat as Cited Domains gap 3).
+### Gaps & differences vs the legacy `rpc_url_inspector_domain_urls`
+
+The JSON shape is identical (same 7 fields + `totalCount`), so the UI is a drop-in swap. But because the backing data changes from Adobe's Postgres pipeline to Semrush, some fields lose their source and some behavior differs. Full diff:
+
+**Fields with no Semrush source (stubbed — hard gaps, cannot be fixed backend-side):**
+
+| Field | Legacy source | New | Impact |
+|---|---|---|---|
+| `urlId` | real `source_urls.id` (uuid) | `''` | The Phase-3 `url-prompts` drilldown keyed off `url_id`; on Semrush it must key off the URL **string**. Same gap as Owned URLs (LLMO-6086). |
+| `categories` | `string_agg(category_name)` | `''` | The stats element (`9af5ed83`) has no per-URL category column; the `category` param is a server-side *filter*, not a returned field. Maybe revisited under the tag→dimension work (LLMO-6130). |
+
+**Metric / vocabulary differences (inherent to re-platforming — not bugs):**
+
+| Field | Legacy | New | Note |
+|---|---|---|---|
+| `citations` | `COUNT(*)` of citation rows | Semrush `citations` | Different metric definitions; absolute counts won't match across backends. |
+| `promptsCited` | `COUNT(DISTINCT prompt\|region\|topics)` | Semrush `prompts_with_citation` | Different definitions. |
+| `contentType` | PG `content_type` | Semrush `domain_type` (`Owned`/`Other`/`Social`/`Earned`/`Benchmark Competitors`) | Different (richer) vocabulary. |
+
+**Behavioral differences:**
+
+1. **Default model.** Legacy `p_platform = NULL` meant *all models*; the Serenity endpoints default to `search-gpt`. Semrush elements return **empty without `CBF_model`**, so "all models" is not expressible — this is a platform constraint, not a choice. When the UI's platform selector is "all", counts here reflect `search-gpt` only.
+2. **Hostname matching.** Legacy matched `hostname` **exactly**; this endpoint matches **host-or-subdomain** (see above) — a required adaptation to Semrush's registered-domain granularity, so the two backends can group a domain's URLs differently.
+3. **Scoping model.** Legacy was **site-scoped** (`siteId` required + validated); this endpoint is **brand-scoped** via the Semrush sub-workspace and does not take `siteId`.
+4. **`regions` is a string** (comma-joined), not an array — matches the legacy contract + UI `DomainUrlRow` type, unlike Owned URLs which returns an array. Region resolution is org-wide (same best-effort caveat as Cited Domains gap 3).
 
 ---
 

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -679,6 +679,15 @@ export default function ElementsController(context, log, env) {
       if (startDate > endDate) {
         return badRequest('startDate must not be after endDate');
       }
+      // Bound the span (mirrors listOwnedUrls): a multi-year range fanned across every
+      // project is needlessly expensive upstream and inflates the in-memory aggregation,
+      // gated only by FACS auth.
+      const MAX_RANGE_DAYS = 366;
+      const spanDays = (Date.parse(`${endDate}T00:00:00Z`)
+        - Date.parse(`${startDate}T00:00:00Z`)) / 86400000;
+      if (spanDays > MAX_RANGE_DAYS) {
+        return badRequest(`Date range must not exceed ${MAX_RANGE_DAYS} days`);
+      }
 
       // hostname (aka domain) is the domain to drill into — required (the UI only
       // calls this after a domain row is expanded).

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -648,11 +648,93 @@ export default function ElementsController(context, log, env) {
   };
   /* c8 ignore stop */
 
+  /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence
+   *     /url-inspector/domain-urls
+   * Phase 2 of the Cited Third-Party tree: expand a cited domain → its URLs.
+   * Same Semrush element as owned-urls (Stats-per-URL 9af5ed83) minus the trend
+   * element and the Postgres traffic hybrid, filtered to a single domain
+   * (required `hostname`) client-side instead of `domain_type='Owned'`.
+   */
+  /* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
+  const listDomainUrls = async (ctx) => {
+    try {
+      const auth = await authorizeOrg(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { brandId } = ctx?.params ?? {};
+      const { workspaceId, brand } = auth;
+      const query = extractQuery(ctx);
+
+      // Date range is required + validated (mirrors cited-domains/owned-urls).
+      const startDate = query.startDate || query.start_date;
+      const endDate = query.endDate || query.end_date;
+      if (!hasText(startDate) || !hasText(endDate)) {
+        return badRequest('startDate and endDate are required (YYYY-MM-DD)');
+      }
+      if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+        return badRequest('startDate and endDate must be valid YYYY-MM-DD dates');
+      }
+      if (startDate > endDate) {
+        return badRequest('startDate must not be after endDate');
+      }
+
+      // hostname (aka domain) is the domain to drill into — required (the UI only
+      // calls this after a domain row is expanded).
+      const hostname = query.hostname || query.domain;
+      if (!hasText(hostname)) {
+        return badRequest('hostname is required for domain URL drilldown');
+      }
+
+      const service = await buildService(ctx);
+
+      const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+      const brandSemrushProjects = await fetchBrandSemrushProjects(BrandSemrushProject, [brand]);
+
+      // Scope per project (region): a specific region → that one project; otherwise
+      // all the brand's markets. Per-project keeps each element call under the
+      // Semrush 50k-row cap and lets the transform tag each URL with its region.
+      let projects;
+      const { region } = query;
+      if (hasText(region) && region.toLowerCase() !== 'all') {
+        const projectId = await service.resolveRegionProjectId(workspaceId, {
+          brandId, region, brandSemrushProjects,
+        });
+        if (!hasText(projectId)) {
+          return notFound(`No Semrush market found for region: ${region}`);
+        }
+        projects = [{ region, projectId }];
+      } else {
+        projects = await service.getOwnedUrlProjects(workspaceId, { brandSemrushProjects });
+      }
+
+      // The transform host-filters, sorts by citations desc, and slices client-side
+      // (Semrush has no server-side pagination); totalCount is the full post-filter count.
+      const result = await service.getDomainUrls(workspaceId, {
+        projects,
+        hostname,
+        model: query.model || query.platform,
+        startDate,
+        endDate,
+        category: query.categoryId || query.category,
+        page: query.page,
+        pageSize: query.pageSize,
+      });
+
+      return cachedOk(result);
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+  /* c8 ignore stop */
+
   return {
     listUrlInspectorFilterDimensions,
     listWeeks,
     listPrompts,
     listCitedDomains,
     listOwnedUrls,
+    listDomainUrls,
   };
 }

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -714,6 +714,7 @@ export default function ElementsController(context, log, env) {
       const result = await service.getDomainUrls(workspaceId, {
         projects,
         hostname,
+        channel: query.channel || query.selectedChannel,
         model: query.model || query.platform,
         startDate,
         endDate,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -802,6 +802,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/stats': 'llmo/can_view',
       // Preflight (site-scoped reads)
       'GET /sites/:siteId/preflights': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -249,6 +249,7 @@ export default function getRouteHandlers(
     // eslint-disable-next-line max-len
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': elementsController.listCitedDomains,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': elementsController.listOwnedUrls,
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls': elementsController.listDomainUrls,
     // Brand-independent Semrush language catalog (add-brand wizard language picker).
     'GET /v2/orgs/:spaceCatId/serenity/languages': serenityController.listOrgLanguages,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': serenityController.activate,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -299,6 +299,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls': 'brand:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate': 'organization:write',
   'GET /v2/orgs/:spaceCatId/sites/:siteId/brand': 'organization:read',

--- a/src/support/elements/definitions/domain-urls.js
+++ b/src/support/elements/definitions/domain-urls.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+
+/* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
+
+/**
+ * Builds the payload for the Stats-per-URL element (9af5ed83, `table`) scoped to a
+ * single (project, date, model). Identical shape to the owned-urls stats payload
+ * (date in BOTH simple + advanced, `CBF_model` in an `or` block, `category:<label>`
+ * tag, region via top-level `project_id`). `startDate`/`endDate` are required
+ * (validated in the controller).
+ *
+ * The domain filter is NOT expressed here: the element ignores a server-side domain
+ * filter (verified live — `CBF_domain`/`cbf_domain`/`CBF_source`, eq + contains, all
+ * returned the full project table unchanged), so `hostname` is applied client-side in
+ * the transform. This mirrors how owned-urls filters `domain_type='Owned'` client-side.
+ *
+ * @param {object} params
+ * @param {string} [params.model] - AI model (Semrush engine or UI platform code).
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` wins.
+ * @param {string} params.startDate - ISO date (YYYY-MM-DD).
+ * @param {string} params.endDate - ISO date (YYYY-MM-DD).
+ * @param {string} [params.category] - Category label → tag `category:<label>`.
+ * @param {string} [params.projectId] - Semrush project id (region scope, top-level).
+ */
+export function buildDomainUrlsPayload({
+  model, platform, startDate, endDate, category, projectId,
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+    { op: 'gte', val: startDate, col: 'CBF_date__start' },
+    { op: 'lte', val: endDate, col: 'CBF_date__end' },
+  ];
+  if (category) {
+    advancedFilters.push({ op: 'eq', val: `category:${category}`, col: 'CBF_tags' });
+  }
+  return {
+    ...(projectId && { project_id: projectId }),
+    comparison_data_formatting: 'union',
+    filters: {
+      simple: { CBF_date__start: startDate, CBF_date__end: endDate },
+      advanced: { op: 'and', filters: advancedFilters },
+    },
+  };
+}
+
+/**
+ * Extracts the registrable-domain-agnostic host of a URL: lowercased, `www.`-stripped.
+ * Returns null for unparseable values (defensive — Semrush `source` is always a URL).
+ */
+function hostOf(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `host` is `hostname` itself or a subdomain of it.
+ *
+ * The incoming `hostname` comes from the cited-domains element (98b91d00), which
+ * reports the REGISTERED domain (eTLD+1, e.g. `openai.com`, `cambridge.org`). But the
+ * Stats-per-URL element's `source` hosts are often subdomains (`help.openai.com`,
+ * `dictionary.cambridge.org`). So an exact-host match would drop most (or, for
+ * `cambridge.org`, ALL) of a domain's URLs. Matching `host === hostname ||
+ * host.endsWith('.'+hostname)` captures the apex + every subdomain without a
+ * public-suffix list, and the leading-dot guard prevents `notopenai.com` from
+ * matching `openai.com`. Verified live (2026-07-10): `cambridge.org` → 46 URLs, all
+ * under `dictionary.cambridge.org`; exact match would have returned 0.
+ */
+function hostMatches(host, hostname) {
+  return host === hostname || host.endsWith(`.${hostname}`);
+}
+
+/**
+ * Parses the pagination params (0-based `page`, `pageSize`) mirroring the legacy
+ * parsePaginationParams (defaultPageSize 50, clamped to [1, 1000]).
+ */
+function parsePagination({ page, pageSize } = {}) {
+  return {
+    page: Math.max(0, Number.parseInt(page, 10) || 0),
+    pageSize: Math.min(Math.max(1, Number.parseInt(pageSize, 10) || 50), 1000),
+  };
+}
+
+/**
+ * Merges per-project Stats-per-URL responses into the legacy URL Inspector
+ * `domain-urls` contract (Phase 2 drilldown):
+ *   { urls: [{ urlId, url, contentType, citations, promptsCited, categories,
+ *              regions }], totalCount }
+ *
+ * Field mapping (verified against live element rows):
+ *   url          ← stats.source
+ *   citations    ← stats.citations                (summed across a URL's projects)
+ *   promptsCited ← stats.prompts_with_citation    (summed)
+ *   contentType  ← stats.domain_type
+ *   regions      ← the region code(s) of each project the URL appears in, joined
+ * Gaps with NO Semrush source (stubbed, see LLMO-6160 notes / cf LLMO-6086):
+ *   urlId ('' — Semrush has no source_urls.id), categories ('' — no per-URL tag source).
+ * `regions`/`categories` are STRINGS here (the legacy contract + the UI `DomainUrlRow`
+ * type), NOT arrays like owned-urls.
+ *
+ * Only rows whose `source` host matches `hostname` (host-or-subdomain, see
+ * {@link hostMatches}) are kept. Semrush has no server-side pagination, so after
+ * filtering we sort by citations desc and slice client-side; `totalCount` is the
+ * post-filter, pre-slice URL count.
+ *
+ * @param {Array<{region?: string, stats: object}>} projectResults
+ * @param {object} params - { hostname (required), page, pageSize }.
+ * @returns {{ urls: Array<object>, totalCount: number }}
+ */
+export function transformDomainUrlsResponse(projectResults = [], params = {}) {
+  const { page, pageSize } = parsePagination(params);
+  const hostname = String(params.hostname ?? '').replace(/^www\./, '').toLowerCase();
+  const byUrl = new Map();
+
+  for (const { region, stats } of projectResults) {
+    for (const row of (stats?.blocks?.data ?? [])) {
+      if (!row || row.source == null) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      const host = hostOf(row.source);
+      if (!host || !hostMatches(host, hostname)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      let entry = byUrl.get(row.source);
+      if (!entry) {
+        entry = {
+          url: row.source,
+          contentType: row.domain_type || '',
+          citations: 0,
+          promptsCited: 0,
+          regions: new Set(),
+        };
+        byUrl.set(row.source, entry);
+      }
+      // `Number(x) || 0` (not `?? 0`) so a non-numeric value coerces to 0, not NaN.
+      entry.citations += Number(row.citations) || 0;
+      entry.promptsCited += Number(row.prompts_with_citation) || 0;
+      if (region) {
+        entry.regions.add(region);
+      }
+    }
+  }
+
+  const urls = [...byUrl.values()].map((e) => ({
+    urlId: '', // no Semrush source_urls.id (gap — see LLMO-6160 / cf LLMO-6086)
+    url: e.url,
+    contentType: e.contentType,
+    citations: e.citations,
+    promptsCited: e.promptsCited,
+    categories: '', // no per-URL category source on the element (Semrush gap)
+    regions: [...e.regions].sort().join(', '),
+  }));
+
+  urls.sort((a, b) => b.citations - a.citations);
+
+  const totalCount = urls.length;
+  const offset = page * pageSize;
+  return { urls: urls.slice(offset, offset + pageSize), totalCount };
+}
+/* c8 ignore stop */

--- a/src/support/elements/definitions/domain-urls.js
+++ b/src/support/elements/definitions/domain-urls.js
@@ -114,17 +114,20 @@ function parsePagination({ page, pageSize } = {}) {
  * type), NOT arrays like owned-urls.
  *
  * Only rows whose `source` host matches `hostname` (host-or-subdomain, see
- * {@link hostMatches}) are kept. Semrush has no server-side pagination, so after
- * filtering we sort by citations desc and slice client-side; `totalCount` is the
- * post-filter, pre-slice URL count.
+ * {@link hostMatches}) are kept. An optional `channel` (content-type) filter is then
+ * applied client-side on `contentType` (case-insensitive) — the element has no
+ * server-side content-type filter, so this mirrors cited-domains + the legacy RPC's
+ * `p_channel`. Semrush has no server-side pagination, so after filtering we sort by
+ * citations desc and slice client-side; `totalCount` is the post-filter, pre-slice count.
  *
  * @param {Array<{region?: string, stats: object}>} projectResults
- * @param {object} params - { hostname (required), page, pageSize }.
+ * @param {object} params - { hostname (required), channel, page, pageSize }.
  * @returns {{ urls: Array<object>, totalCount: number }}
  */
 export function transformDomainUrlsResponse(projectResults = [], params = {}) {
   const { page, pageSize } = parsePagination(params);
   const hostname = String(params.hostname ?? '').replace(/^www\./, '').toLowerCase();
+  const channel = typeof params.channel === 'string' ? params.channel.trim() : '';
   const byUrl = new Map();
 
   for (const { region, stats } of projectResults) {
@@ -158,15 +161,24 @@ export function transformDomainUrlsResponse(projectResults = [], params = {}) {
     }
   }
 
-  const urls = [...byUrl.values()].map((e) => ({
+  let urls = [...byUrl.values()].map((e) => ({
     urlId: '', // no Semrush source_urls.id (gap — see LLMO-6160 / cf LLMO-6086)
     url: e.url,
     contentType: e.contentType,
     citations: e.citations,
     promptsCited: e.promptsCited,
     categories: '', // no per-URL category source on the element (Semrush gap)
-    regions: [...e.regions].sort().join(', '),
+    // Legacy `regions` was a comma-joined string_agg with NO space — match it for
+    // exact drop-in parity. Sorted for determinism (string_agg order is arbitrary).
+    regions: [...e.regions].sort().join(','),
   }));
+
+  // `channel` = content-type filter, applied client-side (element ignores it
+  // server-side), mirroring cited-domains + the legacy RPC's `p_channel`.
+  if (channel) {
+    const wanted = channel.toLowerCase();
+    urls = urls.filter((u) => u.contentType.toLowerCase() === wanted);
+  }
 
   urls.sort((a, b) => b.citations - a.citations);
 

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -27,3 +27,4 @@ export {
   buildOwnedUrlsTrendPayload,
   transformOwnedUrlsResponse,
 } from './owned-urls.js';
+export { buildDomainUrlsPayload, transformDomainUrlsResponse } from './domain-urls.js';

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -259,6 +259,7 @@ export function createElementsService(transport) {
      * @param {Array<{region?: string, projectId?: string}>} [params.projects] -
      *   Projects to query. Empty → one unscoped (workspace-wide) fetch.
      * @param {string} params.hostname - Registered domain to drill into (required).
+     * @param {string} [params.channel] - Content-type filter, applied client-side.
      * @param {string} [params.model] / [params.platform] - AI model filter.
      * @param {string} params.startDate / params.endDate - Required YYYY-MM-DD.
      * @param {string} [params.category] - Category tag filter.
@@ -267,7 +268,8 @@ export function createElementsService(transport) {
      */
     /* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
     async getDomainUrls(workspaceId, {
-      projects = [], hostname, model, platform, startDate, endDate, category, page, pageSize,
+      projects = [], hostname, channel, model, platform, startDate, endDate, category,
+      page, pageSize,
     }) {
       const scopes = projects.length > 0 ? projects : [{}];
       // Bound the per-project fan-out (mirrors owned-urls) so a brand with many
@@ -287,7 +289,9 @@ export function createElementsService(transport) {
           return { region, stats };
         },
       );
-      return transformDomainUrlsResponse(projectResults, { hostname, page, pageSize });
+      return transformDomainUrlsResponse(projectResults, {
+        hostname, channel, page, pageSize,
+      });
     },
     /* c8 ignore stop */
   };

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -31,6 +31,8 @@ import {
   buildOwnedUrlsStatsPayload,
   buildOwnedUrlsTrendPayload,
   transformOwnedUrlsResponse,
+  buildDomainUrlsPayload,
+  transformDomainUrlsResponse,
 } from './definitions/index.js';
 
 /**
@@ -237,6 +239,55 @@ export function createElementsService(transport) {
         },
       );
       return transformOwnedUrlsResponse(projectResults);
+    },
+    /* c8 ignore stop */
+
+    /**
+     * Fetches the URL Inspector Domain URLs table (Phase 2 drilldown: the URLs
+     * within one cited domain), backed by the same Stats-per-URL element (9af5ed83)
+     * as owned-urls — but with NO trend element and NO Postgres traffic hybrid, and
+     * filtered to a single domain instead of `domain_type='Owned'`.
+     *
+     * Fans out per project (region) — each project stays under the 50k-row cap and
+     * carries its region — then merges + host-filters to the legacy shape. The
+     * `hostname` filter is applied client-side in the transform (the element ignores
+     * a server-side domain filter — verified live). Returns the paginated slice +
+     * post-filter totalCount.
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} params
+     * @param {Array<{region?: string, projectId?: string}>} [params.projects] -
+     *   Projects to query. Empty → one unscoped (workspace-wide) fetch.
+     * @param {string} params.hostname - Registered domain to drill into (required).
+     * @param {string} [params.model] / [params.platform] - AI model filter.
+     * @param {string} params.startDate / params.endDate - Required YYYY-MM-DD.
+     * @param {string} [params.category] - Category tag filter.
+     * @param {string|number} [params.page] / [params.pageSize] - Client-side slice.
+     * @returns {Promise<{ urls: object[], totalCount: number }>} Legacy contract.
+     */
+    /* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
+    async getDomainUrls(workspaceId, {
+      projects = [], hostname, model, platform, startDate, endDate, category, page, pageSize,
+    }) {
+      const scopes = projects.length > 0 ? projects : [{}];
+      // Bound the per-project fan-out (mirrors owned-urls) so a brand with many
+      // markets can't spawn unbounded parallel Semrush requests (429 / pool risk).
+      const DOMAIN_URLS_PROJECT_CONCURRENCY = 8;
+      const projectResults = await mapWithConcurrency(
+        scopes,
+        DOMAIN_URLS_PROJECT_CONCURRENCY,
+        async ({ region, projectId }) => {
+          const stats = await transport.fetchElement(
+            workspaceId,
+            ELEMENT_IDS.STATS_PER_URL,
+            buildDomainUrlsPayload({
+              model, platform, startDate, endDate, category, projectId,
+            }),
+          );
+          return { region, stats };
+        },
+      );
+      return transformDomainUrlsResponse(projectResults, { hostname, page, pageSize });
     },
     /* c8 ignore stop */
   };

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -901,6 +901,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/activate',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/deactivate',
       'GET /v2/orgs/:spaceCatId/sites/:siteId/brand',


### PR DESCRIPTION
## Summary
Phase 2 of the URL Inspector "Cited Third Party URLs" tree: expand a cited domain → the URLs within it. Re-platforms the legacy `rpc_url_inspector_domain_urls` onto Semrush's Elements API (`STATS_PER_URL` `9af5ed83`), so the shipped `project-elmo-ui` `fetchUrlInspectorDomainUrls` becomes a drop-in data-source swap. Sibling of cited-domains (LLMO-6020, Phase 1) and owned-urls (LLMO-6086) — same element as owned-urls, minus the trend element and the Postgres traffic hybrid, filtered to one domain instead of `domain_type='Owned'`.

## Changes
- **New endpoint** `GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls` returning the legacy contract `{ urls: [{ urlId, url, contentType, citations, promptsCited, categories, regions }], totalCount }`.
- `definitions/domain-urls.js` — `buildDomainUrlsPayload` (date in simple+advanced, `CBF_model` via `resolveElementModel`, `category:<label>` tag, top-level `project_id`) + `transformDomainUrlsResponse` (client-side host filter, sort, paginate).
- `elements-service.js` `getDomainUrls` — per-project fan-out over `STATS_PER_URL` (bounded concurrency), merge, transform.
- `controllers/elements.js` `listDomainUrls` — `authorizeOrg`, required+validated dates, required `hostname`, region→project, `cachedOk`.
- Route registration + capability in both `facs-capabilities.js` (`llmo/can_view`) and `required-capabilities.js` (`brand:read`) + routes test registry.
- Docs section in `docs/llmo-semrush-apis/filter-dimensions-apis.md`.

## Design notes
- **Domain filter is client-side** — the element ignores a server-side domain filter (probed live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq`+`contains`, all return the full project table). Mirrors owned-urls' client-side `domain_type` filter.
- **Host-or-subdomain match** — cited-domains reports the registered domain (`openai.com`) but `source` hosts are subdomains (`help.openai.com`), so a row matches on `host === hostname || host.endsWith('.'+hostname)`. Exact-host matching would miss most URLs (e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`).
- **Gaps (Semrush):** `urlId` and `categories` stubbed `''` (no per-URL source), consistent with the sibling endpoints. `regions` is a string here (legacy contract + UI type), not an array like owned-urls.
- POC endpoint: unit tests intentionally deferred (c8-fenced); OpenAPI skipped (consistent with sibling elements endpoints).

## Test plan
- [x] `npm run lint` clean on all touched files
- [x] Route/capability/FACS suites pass (`test/routes/index.test.js`, `test/routes/facs-capabilities.test.js`) — 32 passing; no new `:param` so classification unchanged
- [x] Existing element suites pass (`test/controllers/elements.test.js`, `test/support/elements/**`) — 163 passing
- [x] End-to-end against **prod Semrush data** (org Adobe Corp, brand Adobe, US market): `hostname=openai.com` → `totalCount 404` (matches an independent direct-Semrush probe exactly); `hostname=cambridge.org` → `46` (all `dictionary.cambridge.org`, proving the subdomain rule); missing `hostname` → `400`; pagination verified

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-6160