### PR TITLE
chore(aso-overlay): document ASO_OVERLAY_API_KEY_PREVIOUS in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,11 +83,17 @@ S3_SCRAPER_BUCKET=dummy-scraper-bucket
 # Bucket holding the per-env redirect overlays (spacecat-<env>-aso-overlays),
 # read by RedirectsController with the Lambda's own execution role. The API key
 # is the inbound X-ASO-API-Key the dispatcher sends (same value Fastly checks).
-# Both Vault-backed in prod under dx_mysticat/<env>/api-service:
-#   vault kv get -field=S3_ASO_OVERLAYS_BUCKET dx_mysticat/<env>/api-service
-#   vault kv get -field=ASO_OVERLAY_API_KEY    dx_mysticat/<env>/api-service
+# ASO_OVERLAY_API_KEY_PREVIOUS is empty in steady state and populated during
+# key rotation to accept the previous key alongside the current one — the
+# handler falls back to it when the current key doesn't match, so dispatcher
+# pods still holding the old value are not 401'd during EVO propagation.
+# All Vault-backed in prod under dx_mysticat/<env>/api-service:
+#   vault kv get -field=S3_ASO_OVERLAYS_BUCKET       dx_mysticat/<env>/api-service
+#   vault kv get -field=ASO_OVERLAY_API_KEY          dx_mysticat/<env>/api-service
+#   vault kv get -field=ASO_OVERLAY_API_KEY_PREVIOUS dx_mysticat/<env>/api-service
 S3_ASO_OVERLAYS_BUCKET=dummy-aso-overlays-bucket
 ASO_OVERLAY_API_KEY=dummy-aso-overlay-key
+ASO_OVERLAY_API_KEY_PREVIOUS=
 
 # ── Scrape client (eagerly parsed in constructor) ─────────────────────────────
 SCRAPE_JOB_CONFIGURATION={"queues":[],"scrapeWorkerQueue":"https://sqs.us-east-1.amazonaws.com/000000000000/dummy-scrape","s3Bucket":"dummy-scrape-bucket","options":{},"maxUrlsPerJob":4000,"maxUrlsPerMessage":1000,"scrapeQueueUrlPrefix":"https://sqs.us-east-1.amazonaws.com/000000000000/dummy"}


### PR DESCRIPTION
## Summary

- Adds `ASO_OVERLAY_API_KEY_PREVIOUS=` (empty) to `.env.example` for
  discoverability + local parity, so devs know the previous-key fallback
  env var exists without having to grep the auth handler.
- Extends the surrounding comment block with the rotation-time rationale
  (empty in steady state; populated in lockstep with `aso_keys_previous`
  on the Fastly edge during rotation — see spacecat-infrastructure#627
  `MIGRATION-lite-e.md`).

## Background

Non-blocking follow-up from @alinarublea's approving review on the
already-merged #2663 (dual-key overlap for API key rotation, ADR I13):

> Non-blocking nit (still open): add `ASO_OVERLAY_API_KEY_PREVIOUS=`
> (empty) to `.env.example` for discoverability/local parity.

## Test plan

- [ ] `.env.example` still parseable — no code changes, pure docs/config example.
- [ ] No functional impact — dual-key handler logic is unchanged (already
      shipped in #2663).

🤖 Generated with [Claude Code](https://claude.com/claude-code)