### PR TITLE
fix(serenity): write brand URLs verbatim https, skip the brand's own primary domain

### DIFF
--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -63,6 +63,24 @@ function toEntry(url, type) {
   return { url: value, type };
 }
 
+// Normalizes a benchmark/brand domain for identity comparison: lowercase host,
+// no scheme, no leading `www.`, no path. Null when unparseable. Used to match an
+// existing own-brand benchmark across runs (idempotent ensure), to skip the
+// primary domain in the brand-URL set, and by the competitor-benchmark sync to
+// match/dedupe competitors by domain.
+export function normalizeBenchmarkDomain(value) {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw) {
+    return null;
+  }
+  try {
+    const u = new URL(raw.includes('://') ? raw : `https://${raw}`);
+    return u.hostname.toLowerCase().replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Builds the `{ url, type }[]` to push to a single market's project from a
  * brand's URL sources (the V2 shape: `urls`, `socialAccounts`, `earnedContent`
@@ -71,24 +89,45 @@ function toEntry(url, type) {
  *   - `socialAccounts` → type `social`, filtered to the market's region;
  *   - `earnedContent` → type `earned`, filtered to the market's region.
  *
- * Only HTTPS URLs survive. The result is de-duplicated by URL (first-seen wins,
- * so a brand site listed both as a URL and a social account keeps its `website`
- * type) — brand URLs are unique per project upstream, so duplicates would be
- * skipped anyway; de-duping here keeps the `type` we send deterministic.
+ * The brand's own primary domain is dropped from the `website` set when
+ * `primaryDomain` is given (skip-primary-domain): the project's own-brand
+ * benchmark already carries that domain (Semrush stores it scheme-less), and a
+ * `brand_urls` row must keep its `https://` scheme, so the two can never
+ * collapse — emitting it as a website URL just double-lists the domain in the UI
+ * (serenity-docs#25). The match is by normalized host, so both `https://x.com`
+ * and `https://www.x.com` are skipped when the benchmark domain is `x.com`.
+ * Every OTHER website URL (a secondary site) is kept verbatim.
+ *
+ * Only HTTPS URLs survive (`brand_urls` rejects non-https with a 400, so a stored
+ * value is written verbatim — no scheme/`www.` normalization; Semrush stores it
+ * as-is). The result is de-duplicated by URL (first-seen wins, so a brand site
+ * listed both as a URL and a social account keeps its `website` type) — brand
+ * URLs are unique per project upstream, so duplicates would be skipped anyway;
+ * de-duping here keeps the `type` we send deterministic. Note the upstream does
+ * NOT collapse `www.`-vs-apex, so two distinct https URLs that differ only by
+ * `www.` are two separate rows (as the user entered them).
  *
  * @param {object} sources - { urls?, socialAccounts?, earnedContent? }.
  * @param {string} market - ISO-2 country code of the target project.
+ * @param {string} [primaryDomain] - the project's own-brand domain; a `website`
+ *   URL whose host matches it is skipped (see above). Omit to keep all.
  * @returns {{url: string, type: string}[]}
  */
-export function collectBrandUrlEntries(sources, market) {
+export function collectBrandUrlEntries(sources, market, primaryDomain) {
   const urls = Array.isArray(sources?.urls) ? sources.urls : [];
   const social = Array.isArray(sources?.socialAccounts) ? sources.socialAccounts : [];
   const earned = Array.isArray(sources?.earnedContent) ? sources.earnedContent : [];
+  const primary = normalizeBenchmarkDomain(primaryDomain);
 
   const candidates = [
     // Brand URLs carry no region — always every market. Accept both the string
-    // and the { value } object shape the create payload may use.
-    ...urls.map((u) => toEntry(typeof u === 'string' ? u : u?.value, BRAND_URL_TYPE.WEBSITE)),
+    // and the { value } object shape the create payload may use. Skip the brand's
+    // own primary domain (the benchmark already holds it — see fn docstring).
+    ...urls
+      .map((u) => toEntry(typeof u === 'string' ? u : u?.value, BRAND_URL_TYPE.WEBSITE))
+      .filter((e) => e === null
+        || primary === null
+        || normalizeBenchmarkDomain(e.url) !== primary),
     ...social
       .filter((s) => regionApplies(s?.regions, market))
       .map((s) => toEntry(s?.url, BRAND_URL_TYPE.SOCIAL)),
@@ -105,100 +144,6 @@ export function collectBrandUrlEntries(sources, market) {
     seen.add(e.url);
     return true;
   });
-}
-
-/**
- * Normalizes the WEBSITE-type brand-URL entries to Semrush's canonical stored
- * form by resolving each raw URL through Project Engine's `url/resolve` endpoint,
- * so the value we write matches the benchmark Semrush already holds instead of
- * creating a duplicate `www.`-vs-apex entry (serenity-docs#25). The resolve
- * `primary_url` (scheme-less, subdomain + path preserved, e.g. `lovesac.com`) is
- * used as the stored value.
- *
- * Only `type: 'website'` entries are resolved: `social`/`earned` URLs are
- * identity handles (e.g. `https://instagram.com/brand`), not brand domains, so
- * apex-normalizing them would be wrong — they pass through unchanged.
- *
- * `url/resolve` returns `is_valid: false` with empty strings (still HTTP 200) for
- * unresolvable input; that (and the defensive `is_valid: true` but empty
- * `primary_url` case) is NOT an error, so on it we keep the raw (already
- * https-filtered) entry rather than writing the empty value. A transport ERROR
- * (non-2xx) is left to propagate — the caller's best-effort (CREATE) / hard-fail
- * (EDIT) wrapper then treats it exactly like any other upstream failure.
- *
- * A resolve can collapse two raw URLs (e.g. `https://www.x.com` and
- * `https://x.com`) onto one canonical value, so the result is re-de-duplicated by
- * url (first-seen wins) — {@link collectBrandUrlEntries} de-duped by the RAW url.
- * De-dup keys on `url` alone (like `collectBrandUrlEntries`): a Semrush brand URL
- * is unique by its url, and a canonicalized website (scheme-less apex) can't
- * collide with a social/earned handle (a full `https://` profile url).
- *
- * The optional `cache` (raw url → canonical string | null) is resolved-once memo
- * shared across calls: brand website `urls` are region-less, so the per-market
- * edit re-sync passes ONE cache to avoid re-resolving the same url for every
- * market. Only a cache MISS calls the transport (and warns on an unusable result),
- * so a bad url warns once, not once per market.
- *
- * @param {object} transport - Semrush transport (exposes `resolveUrl`).
- * @param {Array<{url: string, type: string}>} entries - collected brand-URL entries.
- * @param {object} [log] - optional logger ({ warn? }).
- * @param {Map<string, (string|null)>} [cache] - raw-url → canonical memo (see above).
- * @returns {Promise<{url: string, type: string}[]>} entries with website URLs
- *   canonicalized (a no-op passthrough for social/earned), re-de-duped by url.
- */
-export async function resolveWebsiteEntries(transport, entries, log, cache = new Map()) {
-  const resolved = [];
-  for (const entry of entries) {
-    if (entry.type !== BRAND_URL_TYPE.WEBSITE) {
-      resolved.push(entry);
-      // eslint-disable-next-line no-continue
-      continue;
-    }
-    let canonical;
-    if (cache.has(entry.url)) {
-      canonical = cache.get(entry.url);
-    } else {
-      // eslint-disable-next-line no-await-in-loop
-      const r = await transport.resolveUrl(entry.url);
-      // is_valid:false, OR (defensively) is_valid:true with an empty primary_url —
-      // both mean "no usable canonical value": keep the raw https value, never the
-      // empty one. Left un-normalized on purpose; the next edit re-attempts it.
-      canonical = (r?.is_valid === true && hasText(r?.primary_url)) ? r.primary_url : null;
-      cache.set(entry.url, canonical);
-      if (canonical === null) {
-        log?.warn?.('brand-urls: url/resolve returned no usable primary_url — keeping raw url', {
-          url: entry.url,
-        });
-      }
-    }
-    resolved.push(canonical === null ? entry : { ...entry, url: canonical });
-  }
-
-  const seen = new Set();
-  return resolved.filter((e) => {
-    if (seen.has(e.url)) {
-      return false;
-    }
-    seen.add(e.url);
-    return true;
-  });
-}
-
-// Normalizes a benchmark/brand domain for identity comparison: lowercase host,
-// no scheme, no leading `www.`, no path. Null when unparseable. Used to match an
-// existing own-brand benchmark across runs (idempotent ensure) and shared by the
-// competitor-benchmark sync to match/dedupe competitors by domain.
-export function normalizeBenchmarkDomain(value) {
-  const raw = typeof value === 'string' ? value.trim() : '';
-  if (!raw) {
-    return null;
-  }
-  try {
-    const u = new URL(raw.includes('://') ? raw : `https://${raw}`);
-    return u.hostname.toLowerCase().replace(/^www\./, '');
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -312,15 +257,15 @@ export async function attachBrandUrlsToProject(
     });
     return { created: 0, skipped: true };
   }
-  // Canonicalize website URLs to Semrush's stored form before writing them, so a
-  // create doesn't seed a `www.`-vs-apex duplicate of the benchmark (#25). Done
-  // only once a benchmark exists to write to (no wasted resolve on a skip).
-  const resolvedEntries = await resolveWebsiteEntries(transport, entries, log);
-  await transport.createBrandUrls(workspaceId, projectId, benchmarkId, resolvedEntries);
+  // Entries are written verbatim (already https-filtered, and the brand's own
+  // primary domain was dropped upstream by collectBrandUrlEntries so it doesn't
+  // duplicate the benchmark — #25). The upstream stores the value as-is and
+  // silently skips URLs already present, so a re-attach is idempotent.
+  await transport.createBrandUrls(workspaceId, projectId, benchmarkId, entries);
   log?.info?.('brand-urls: attached to project benchmark', {
-    workspaceId, projectId, benchmarkId, count: resolvedEntries.length,
+    workspaceId, projectId, benchmarkId, count: entries.length,
   });
-  return { created: resolvedEntries.length };
+  return { created: entries.length };
 }
 
 // Best-effort republish after an edit-time change so the live view reflects it.
@@ -385,11 +330,6 @@ export async function syncBrandUrlsAcrossMarkets(
   let deleted = 0;
   let markets = 0;
 
-  // Website `urls` are region-less (identical across every market), so resolve
-  // each distinct one a single time and reuse the result across markets — one
-  // shared memo passed into every per-market resolveWebsiteEntries call.
-  const resolveCache = new Map();
-
   for (const project of projects) {
     const projectId = hasText(project?.id) ? String(project.id) : null;
     const market = marketOf(project);
@@ -400,7 +340,9 @@ export async function syncBrandUrlsAcrossMarkets(
     markets += 1;
 
     try {
-      const collected = collectBrandUrlEntries(sources, market);
+      // The project's own domain is the primary domain — its own-brand website
+      // URL is skipped so it doesn't duplicate the benchmark (skip-primary-domain).
+      const collected = collectBrandUrlEntries(sources, market, project?.domain);
       // Own-brand identity for the benchmark comes from the project itself: its
       // domain plus the brand_names (display name first, the rest are aliases).
       const ai = project?.settings?.ai || {};
@@ -428,12 +370,10 @@ export async function syncBrandUrlsAcrossMarkets(
         // eslint-disable-next-line no-continue
         continue;
       }
-      // Canonicalize website URLs to Semrush's stored form BEFORE diffing, so the
-      // desired set is compared against `listBrandUrls` (which returns the same
-      // canonical form) — otherwise every re-sync would churn `www.`-vs-apex (#25).
-      // The shared cache resolves each region-less website url once across markets.
-      // eslint-disable-next-line no-await-in-loop
-      const desired = await resolveWebsiteEntries(transport, collected, log, resolveCache);
+      // Entries are written/diffed verbatim (https-ful, primary domain already
+      // dropped by collectBrandUrlEntries). `listBrandUrls` returns the same
+      // stored form, so the diff is stable across re-syncs — no www-vs-apex churn.
+      const desired = collected;
       // eslint-disable-next-line no-await-in-loop
       const existingResp = await transport.listBrandUrls(workspaceId, projectId, benchmarkId);
       const existing = Array.isArray(existingResp?.brand_urls) ? existingResp.brand_urls : [];

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -82,6 +82,27 @@ export function normalizeBenchmarkDomain(value) {
 }
 
 /**
+ * The set of normalized hosts that are the primary domain of SOME market in the
+ * brand's sub-workspace — every one of them is skipped as a `website` brand URL
+ * (see {@link collectBrandUrlEntries}). Unparseable/empty values are dropped.
+ *
+ * @param {Array<string|null|undefined>} domains - raw project domains (plus, on
+ *   the create path, the domain of the market being created — it has no project
+ *   to read a domain from yet).
+ * @returns {Set<string>} normalized hosts (lowercase, no scheme/`www.`/path).
+ */
+export function primaryDomainSet(domains) {
+  const set = new Set();
+  (Array.isArray(domains) ? domains : []).forEach((d) => {
+    const host = normalizeBenchmarkDomain(d);
+    if (host !== null) {
+      set.add(host);
+    }
+  });
+  return set;
+}
+
+/**
  * Builds the `{ url, type }[]` to push to a single market's project from a
  * brand's URL sources (the V2 shape: `urls`, `socialAccounts`, `earnedContent`
  * — the same shape the create payload and a persisted brand both carry):
@@ -89,14 +110,17 @@ export function normalizeBenchmarkDomain(value) {
  *   - `socialAccounts` → type `social`, filtered to the market's region;
  *   - `earnedContent` → type `earned`, filtered to the market's region.
  *
- * The brand's own primary domain is dropped from the `website` set when
- * `primaryDomain` is given (skip-primary-domain): the project's own-brand
- * benchmark already carries that domain (Semrush stores it scheme-less), and a
- * `brand_urls` row must keep its `https://` scheme, so the two can never
- * collapse — emitting it as a website URL just double-lists the domain in the UI
- * (serenity-docs#25). The match is by normalized host, so both `https://x.com`
- * and `https://www.x.com` are skipped when the benchmark domain is `x.com`.
- * Every OTHER website URL (a secondary site) is kept verbatim.
+ * Every market's primary domain is dropped from the `website` set
+ * (skip-primary-domain): a project's own-brand benchmark already carries its own
+ * domain (Semrush stores it scheme-less), and a `brand_urls` row must keep its
+ * `https://` scheme, so the two can never collapse — emitting it as a website URL
+ * just double-lists the domain in the UI (serenity-docs#25). The OTHER markets'
+ * primaries are skipped too: for a market-mirror brand, `chevrolet.ca` is CA-en's
+ * primary and must not surface as a US-en brand URL. Because the skip set is the
+ * same for every market, all markets end up with the same website entries. The
+ * match is by normalized host, so both `https://x.com` and `https://www.x.com`
+ * are skipped when a market's domain is `x.com`. Every OTHER website URL (a
+ * secondary site) is kept verbatim.
  *
  * Only HTTPS URLs survive (`brand_urls` rejects non-https with a 400, so a stored
  * value is written verbatim — no scheme/`www.` normalization; Semrush stores it
@@ -109,24 +133,25 @@ export function normalizeBenchmarkDomain(value) {
  *
  * @param {object} sources - { urls?, socialAccounts?, earnedContent? }.
  * @param {string} market - ISO-2 country code of the target project.
- * @param {string} [primaryDomain] - the project's own-brand domain; a `website`
- *   URL whose host matches it is skipped (see above). Omit to keep all.
+ * @param {Set<string>} [primaryDomains] - normalized hosts that are some market's
+ *   primary domain ({@link primaryDomainSet}); a `website` URL whose host is in
+ *   the set is skipped. Omit to keep all.
  * @returns {{url: string, type: string}[]}
  */
-export function collectBrandUrlEntries(sources, market, primaryDomain) {
+export function collectBrandUrlEntries(sources, market, primaryDomains) {
   const urls = Array.isArray(sources?.urls) ? sources.urls : [];
   const social = Array.isArray(sources?.socialAccounts) ? sources.socialAccounts : [];
   const earned = Array.isArray(sources?.earnedContent) ? sources.earnedContent : [];
-  const primary = normalizeBenchmarkDomain(primaryDomain);
+  const primaries = primaryDomains instanceof Set ? primaryDomains : new Set();
 
   const candidates = [
     // Brand URLs carry no region — always every market. Accept both the string
-    // and the { value } object shape the create payload may use. Skip the brand's
-    // own primary domain (the benchmark already holds it — see fn docstring).
+    // and the { value } object shape the create payload may use. Skip every
+    // market's primary domain (the benchmarks hold them — see fn docstring).
     ...urls
       .map((u) => toEntry(typeof u === 'string' ? u : u?.value, BRAND_URL_TYPE.WEBSITE))
       .filter(Boolean)
-      .filter((e) => primary === null || normalizeBenchmarkDomain(e.url) !== primary),
+      .filter((e) => !primaries.has(normalizeBenchmarkDomain(e.url))),
     ...social
       .filter((s) => regionApplies(s?.regions, market))
       .map((s) => toEntry(s?.url, BRAND_URL_TYPE.SOCIAL))
@@ -327,6 +352,12 @@ export async function syncBrandUrlsAcrossMarkets(
   // syncs), else list here. The listing is stable across a brand-row write.
   const projects = await resolveProjects(transport, workspaceId, prefetchedProjects);
 
+  // Every market's primary domain, skipped as a website URL on EVERY market (not
+  // just its own): a market-mirror brand's `chevrolet.ca` is CA-en's primary and
+  // must not surface as a US-en brand URL. Built once — the set is the same for
+  // every market, so the website entries are identical across the fan-out.
+  const primaryDomains = primaryDomainSet(projects.map((p) => p?.domain));
+
   let created = 0;
   let deleted = 0;
   let markets = 0;
@@ -341,12 +372,10 @@ export async function syncBrandUrlsAcrossMarkets(
     markets += 1;
 
     try {
-      // The project's own domain is the primary domain — its own-brand website
-      // URL is skipped so it doesn't duplicate the benchmark (skip-primary-domain).
-      // Entries are written/diffed verbatim (https-ful, with the project's own
+      // Entries are written/diffed verbatim (https-ful, with every market's
       // primary domain dropped). `listBrandUrls` returns the same stored form, so
       // the diff is stable across re-syncs — no www-vs-apex churn.
-      const desired = collectBrandUrlEntries(sources, market, project?.domain);
+      const desired = collectBrandUrlEntries(sources, market, primaryDomains);
       // Own-brand identity for the benchmark comes from the project itself: its
       // domain plus the brand_names (display name first, the rest are aliases).
       const ai = project?.settings?.ai || {};

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -403,8 +403,20 @@ export async function syncBrandUrlsAcrossMarkets(
         // eslint-disable-next-line no-continue
         continue;
       }
+      // Diff against the DRAFT view, not the published one. Creates and deletes act
+      // on the draft (a publish then promotes it), so the draft is the state this
+      // sync is converging. The published view lags it whenever the project has
+      // unpublished changes — which is exactly what a swallowed quota 405 on the
+      // republish below leaves behind. Reading published there would report an
+      // EMPTY existing set, so a URL the user removed would never be deleted (and
+      // every URL would be re-submitted on each sync).
       // eslint-disable-next-line no-await-in-loop
-      const existingResp = await transport.listBrandUrls(workspaceId, projectId, benchmarkId);
+      const existingResp = await transport.listBrandUrls(
+        workspaceId,
+        projectId,
+        benchmarkId,
+        { draft: true },
+      );
       const existing = Array.isArray(existingResp?.brand_urls) ? existingResp.brand_urls : [];
 
       const existingByUrl = new Map();

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -125,20 +125,21 @@ export function collectBrandUrlEntries(sources, market, primaryDomain) {
     // own primary domain (the benchmark already holds it — see fn docstring).
     ...urls
       .map((u) => toEntry(typeof u === 'string' ? u : u?.value, BRAND_URL_TYPE.WEBSITE))
-      .filter((e) => e === null
-        || primary === null
-        || normalizeBenchmarkDomain(e.url) !== primary),
+      .filter(Boolean)
+      .filter((e) => primary === null || normalizeBenchmarkDomain(e.url) !== primary),
     ...social
       .filter((s) => regionApplies(s?.regions, market))
-      .map((s) => toEntry(s?.url, BRAND_URL_TYPE.SOCIAL)),
+      .map((s) => toEntry(s?.url, BRAND_URL_TYPE.SOCIAL))
+      .filter(Boolean),
     ...earned
       .filter((e) => regionApplies(e?.regions, market))
-      .map((e) => toEntry(e?.url, BRAND_URL_TYPE.EARNED)),
+      .map((e) => toEntry(e?.url, BRAND_URL_TYPE.EARNED))
+      .filter(Boolean),
   ];
 
   const seen = new Set();
   return candidates.filter((e) => {
-    if (e === null || seen.has(e.url)) {
+    if (seen.has(e.url)) {
       return false;
     }
     seen.add(e.url);
@@ -342,7 +343,10 @@ export async function syncBrandUrlsAcrossMarkets(
     try {
       // The project's own domain is the primary domain — its own-brand website
       // URL is skipped so it doesn't duplicate the benchmark (skip-primary-domain).
-      const collected = collectBrandUrlEntries(sources, market, project?.domain);
+      // Entries are written/diffed verbatim (https-ful, with the project's own
+      // primary domain dropped). `listBrandUrls` returns the same stored form, so
+      // the diff is stable across re-syncs — no www-vs-apex churn.
+      const desired = collectBrandUrlEntries(sources, market, project?.domain);
       // Own-brand identity for the benchmark comes from the project itself: its
       // domain plus the brand_names (display name first, the rest are aliases).
       const ai = project?.settings?.ai || {};
@@ -370,10 +374,6 @@ export async function syncBrandUrlsAcrossMarkets(
         // eslint-disable-next-line no-continue
         continue;
       }
-      // Entries are written/diffed verbatim (https-ful, primary domain already
-      // dropped by collectBrandUrlEntries). `listBrandUrls` returns the same
-      // stored form, so the diff is stable across re-syncs — no www-vs-apex churn.
-      const desired = collected;
       // eslint-disable-next-line no-await-in-loop
       const existingResp = await transport.listBrandUrls(workspaceId, projectId, benchmarkId);
       const existing = Array.isArray(existingResp?.brand_urls) ? existingResp.brand_urls : [];

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -92,14 +92,11 @@ export function normalizeBenchmarkDomain(value) {
  * @returns {Set<string>} normalized hosts (lowercase, no scheme/`www.`/path).
  */
 export function primaryDomainSet(domains) {
-  const set = new Set();
-  (Array.isArray(domains) ? domains : []).forEach((d) => {
-    const host = normalizeBenchmarkDomain(d);
-    if (host !== null) {
-      set.add(host);
-    }
-  });
-  return set;
+  return new Set(
+    (Array.isArray(domains) ? domains : [])
+      .map(normalizeBenchmarkDomain)
+      .filter((host) => host !== null),
+  );
 }
 
 /**
@@ -403,13 +400,14 @@ export async function syncBrandUrlsAcrossMarkets(
         // eslint-disable-next-line no-continue
         continue;
       }
-      // Diff against the DRAFT view, not the published one. Creates and deletes act
-      // on the draft (a publish then promotes it), so the draft is the state this
-      // sync is converging. The published view lags it whenever the project has
-      // unpublished changes — which is exactly what a swallowed quota 405 on the
-      // republish below leaves behind. Reading published there would report an
-      // EMPTY existing set, so a URL the user removed would never be deleted (and
-      // every URL would be re-submitted on each sync).
+      // Invariant: a read must target the same view the writes act on. Creates and
+      // deletes act on the DRAFT (a publish then promotes it), so the draft — not
+      // the published view — is the state this sync converges on. Published lags
+      // the draft whenever the project has unpublished changes, which is exactly
+      // what a swallowed quota 405 on the republish below leaves behind. Reading
+      // published there would report an EMPTY existing set, so a URL the user
+      // removed would never be deleted (and every URL would be re-submitted on
+      // each sync).
       // eslint-disable-next-line no-await-in-loop
       const existingResp = await transport.listBrandUrls(
         workspaceId,

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -424,7 +424,9 @@ export async function handleCreateMarketSubworkspace(
   // region-filtered to the market. Done before publish so the URLs are part of
   // the same published version. Best-effort: URL enrichment must never abort the
   // brand create — a benchmark/URL hiccup is logged and skipped, not propagated.
-  const brandUrlEntries = collectBrandUrlEntries(brandUrlSources, body.market);
+  // Pass the brand's own domain so its own-brand website URL is skipped — the
+  // market's own-brand benchmark already carries it (skip-primary-domain, #25).
+  const brandUrlEntries = collectBrandUrlEntries(brandUrlSources, body.market, body.brandDomain);
   try {
     await attachBrandUrlsToProject(
       transport,

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -36,7 +36,8 @@ import {
 import { ensureSubworkspace } from '../workspace-lifecycle.js';
 import { topicTag } from '../prompt-tags.js';
 import { classifyBrandedTag, needlesFromNames } from '../branded-classifier.js';
-import { collectBrandUrlEntries, attachBrandUrlsToProject } from '../brand-urls.js';
+import { collectBrandUrlEntries, attachBrandUrlsToProject, primaryDomainSet } from '../brand-urls.js';
+import { resolveProjects } from '../resolve-projects.js';
 import { buildReservedDomains, syncCompetitorBenchmarksForProject } from '../competitor-benchmarks.js';
 import { collectAliasNames } from '../brand-aliases.js';
 import { upsertMappingRow, tombstoneMappingRow } from '../mapping-rows.js';
@@ -423,11 +424,24 @@ export async function handleCreateMarketSubworkspace(
   // own-brand benchmark (created on demand when Semrush hasn't provisioned one),
   // region-filtered to the market. Done before publish so the URLs are part of
   // the same published version. Best-effort: URL enrichment must never abort the
-  // brand create — a benchmark/URL hiccup is logged and skipped, not propagated.
-  // Pass the brand's own domain so its own-brand website URL is skipped — the
-  // market's own-brand benchmark already carries it (skip-primary-domain, #25).
-  const brandUrlEntries = collectBrandUrlEntries(brandUrlSources, body.market, body.brandDomain);
+  // brand create — a benchmark/URL hiccup is logged and skipped, not propagated,
+  // so the whole block (INCLUDING the project listing the skip set needs) sits
+  // inside the try.
   try {
+    // Skip EVERY market's primary domain, not just this one's: a market-mirror
+    // brand's other-market primary must not surface as a website URL here either
+    // (skip-primary-domain, #25 — see collectBrandUrlEntries). This market's own
+    // domain comes from the payload; its project may not be in the listing yet.
+    const siblings = await resolveProjects(transport, workspaceId);
+    const primaryDomains = primaryDomainSet([
+      body.brandDomain,
+      ...siblings.map((p) => p?.domain),
+    ]);
+    const brandUrlEntries = collectBrandUrlEntries(
+      brandUrlSources,
+      body.market,
+      primaryDomains,
+    );
     await attachBrandUrlsToProject(
       transport,
       workspaceId,

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -895,13 +895,29 @@ export function createSerenityTransport({ env, imsToken }) {
      * GET /v2/.../aio/benchmarks/{bid}/brand_urls — list a benchmark's brand
      * URLs. Returns `{ brand_urls: [{ id, url, type, ... }] }`. Used by the
      * brand-edit re-sync to diff the live set before adding/removing.
+     *
+     * The default is the PUBLISHED view: a brand URL that has been written but not
+     * yet published is INVISIBLE to it (live-verified 2026-07-13 — create → the row
+     * is absent from the default list and present under `?draft=true`; a project
+     * publish then promotes it into the default view, the row itself unchanged).
+     * `draft: true` selects the pending view — writes and deletes act on the DRAFT,
+     * so a diff that means to converge the draft must read the draft (see
+     * `syncBrandUrlsAcrossMarkets`); reading the published view compares against a
+     * stale snapshot whenever the project has unpublished changes.
+     *
+     * @param {string} workspaceId
+     * @param {string} projectId
+     * @param {string} benchmarkId
+     * @param {object} [opts]
+     * @param {boolean} [opts.draft=false] - read the draft (pending) view.
      */
-    async listBrandUrls(workspaceId, projectId, benchmarkId) {
+    async listBrandUrls(workspaceId, projectId, benchmarkId, { draft = false } = {}) {
       return unwrap('GET', await projects.GET(
         '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls',
         {
           params: {
             path: { id: workspaceId, project_id: projectId, benchmark_id: benchmarkId },
+            ...(draft ? { query: { draft: true } } : {}),
           },
         },
       ));

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -641,23 +641,6 @@ export function createSerenityTransport({ env, imsToken }) {
     },
 
     /**
-     * GET /v1/url/resolve — canonicalize a raw URL to the form Semrush stores as
-     * a brand URL. Returns `{ domain, primary_url, is_valid }`: `primary_url`
-     * strips the scheme and a leading `www.` (subdomain + path preserved),
-     * `domain` is the registrable apex. Unresolvable/garbage input comes back
-     * `{ domain: '', primary_url: '', is_valid: false }` at HTTP 200 (NOT an
-     * error), so callers MUST check `is_valid` and never write the empty value.
-     * Used to normalize brand URLs before writing them so the value matches the
-     * canonical benchmark Semrush already holds (avoids www-vs-apex duplicates).
-     */
-    async resolveUrl(primaryUrl) {
-      return unwrap('GET', await projects.GET(
-        '/v1/url/resolve',
-        { params: { query: { primary_url: primaryUrl } } },
-      ));
-    },
-
-    /**
      * GET /v1/languages — returns Semrush's language catalog. Used to resolve
      * the language_id UUID from an ISO 639-1 code (e.g. 'en' → UUID). The
      * caller is expected to cache the result (catalog is stable).

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -21,7 +21,6 @@ import {
   collectBrandUrlEntries,
   normalizeBenchmarkDomain,
   ensureOwnBrandBenchmark,
-  resolveWebsiteEntries,
   attachBrandUrlsToProject,
   syncBrandUrlsAcrossMarkets,
 } from '../../../src/support/serenity/brand-urls.js';
@@ -37,12 +36,6 @@ const BID = 'bench-1';
 describe('brand-urls helpers', () => {
   const sandbox = sinon.createSandbox();
   const benchOk = () => ({ aio_benchmarks: [{ id: BID, main_brand: true }] });
-  // Identity url/resolve stub: echoes the input as a valid canonical value, so the
-  // pre-existing plumbing tests keep asserting the RAW url they were written for.
-  // The actual www→apex normalization is covered by the dedicated tests below.
-  const identityResolve = () => sandbox.stub().callsFake(
-    (url) => Promise.resolve({ domain: url, primary_url: url, is_valid: true }),
-  );
   afterEach(() => sandbox.restore());
 
   describe('regionApplies', () => {
@@ -122,6 +115,34 @@ describe('brand-urls helpers', () => {
       expect(collectBrandUrlEntries(null, 'us')).to.deep.equal([]);
       expect(collectBrandUrlEntries({ urls: ['  https://acme.com  '] }, 'us')).to.deep.equal([
         { url: 'https://acme.com', type: BRAND_URL_TYPE.WEBSITE },
+      ]);
+    });
+
+    it('skips the brand primary domain website (apex + www) when primaryDomain given', () => {
+      // The benchmark already carries the primary domain (scheme-less), and a
+      // brand_urls row must be https:// — so adding it would double-list it in
+      // the UI. Both the apex and www forms of the primary are dropped (#25).
+      const sources = {
+        urls: ['https://acme.com', 'https://www.acme.com', 'https://blog.acme.com'],
+        socialAccounts: [{ url: 'https://x.com/acme', regions: [] }],
+      };
+      expect(collectBrandUrlEntries(sources, 'us', 'acme.com')).to.deep.equal([
+        { url: 'https://blog.acme.com', type: BRAND_URL_TYPE.WEBSITE },
+        { url: 'https://x.com/acme', type: BRAND_URL_TYPE.SOCIAL },
+      ]);
+    });
+
+    it('accepts the primaryDomain in any form (scheme/www/path) via host match', () => {
+      const sources = { urls: ['https://acme.com'] };
+      expect(collectBrandUrlEntries(sources, 'us', 'https://www.acme.com/x')).to.deep.equal([]);
+    });
+
+    it('keeps all website urls when primaryDomain is absent/unparseable', () => {
+      const sources = { urls: ['https://acme.com', 'https://www.acme.com'] };
+      // No primaryDomain → nothing skipped (both kept; www vs apex are two rows).
+      expect(collectBrandUrlEntries(sources, 'us')).to.deep.equal([
+        { url: 'https://acme.com', type: BRAND_URL_TYPE.WEBSITE },
+        { url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE },
       ]);
     });
   });
@@ -244,112 +265,6 @@ describe('brand-urls helpers', () => {
     });
   });
 
-  describe('resolveWebsiteEntries', () => {
-    it('canonicalizes website entries to the resolve primary_url', async () => {
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
-      };
-      const out = await resolveWebsiteEntries(
-        transport,
-        [{ url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE }],
-        undefined,
-      );
-      expect(out).to.deep.equal([{ url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE }]);
-      expect(transport.resolveUrl).to.have.been.calledOnceWith('https://www.acme.com');
-    });
-
-    it('passes social/earned entries through unchanged (never resolved)', async () => {
-      const transport = { resolveUrl: sandbox.stub() };
-      const entries = [
-        { url: 'https://instagram.com/acme', type: BRAND_URL_TYPE.SOCIAL },
-        { url: 'https://press.example/acme', type: BRAND_URL_TYPE.EARNED },
-      ];
-      const out = await resolveWebsiteEntries(transport, entries, undefined);
-      expect(out).to.deep.equal(entries);
-      expect(transport.resolveUrl).to.not.have.been.called;
-    });
-
-    it('keeps the raw url (and warns) when resolve returns is_valid:false', async () => {
-      const warn = sandbox.stub();
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: '', primary_url: '', is_valid: false }),
-      };
-      const out = await resolveWebsiteEntries(
-        transport,
-        [{ url: 'https://not-a-real-host', type: BRAND_URL_TYPE.WEBSITE }],
-        { warn },
-      );
-      // Never write the empty value — fall back to the raw (already https-filtered) url.
-      expect(out).to.deep.equal([{ url: 'https://not-a-real-host', type: BRAND_URL_TYPE.WEBSITE }]);
-      expect(warn).to.have.been.calledWithMatch(
-        'brand-urls: url/resolve returned no usable primary_url — keeping raw url',
-        sinon.match({ url: 'https://not-a-real-host' }),
-      );
-    });
-
-    it('keeps the raw url when resolve resolves null/undefined (optional-chaining defense)', async () => {
-      const transport = { resolveUrl: sandbox.stub().resolves(null) };
-      const out = await resolveWebsiteEntries(
-        transport,
-        [{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }],
-        undefined,
-      );
-      expect(out).to.deep.equal([{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }]);
-    });
-
-    it('resolves each distinct website url once via the shared cache', async () => {
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
-      };
-      const cache = new Map();
-      const entry = [{ url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE }];
-      // Two calls sharing one cache (mirrors the per-market edit loop) → one HTTP call.
-      await resolveWebsiteEntries(transport, entry, undefined, cache);
-      const out = await resolveWebsiteEntries(transport, entry, undefined, cache);
-      expect(out).to.deep.equal([{ url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE }]);
-      expect(transport.resolveUrl).to.have.been.calledOnce;
-    });
-
-    it('keeps the raw url when is_valid:true but primary_url is empty (defensive)', async () => {
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'x.com', primary_url: '', is_valid: true }),
-      };
-      const out = await resolveWebsiteEntries(
-        transport,
-        [{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }],
-        undefined,
-      );
-      expect(out).to.deep.equal([{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }]);
-    });
-
-    it('re-de-dups when two raw website urls resolve to the same canonical value', async () => {
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
-      };
-      const out = await resolveWebsiteEntries(
-        transport,
-        [
-          { url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE },
-          { url: 'https://acme.com', type: BRAND_URL_TYPE.WEBSITE },
-        ],
-        undefined,
-      );
-      expect(out).to.deep.equal([{ url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE }]);
-      expect(transport.resolveUrl).to.have.been.calledTwice;
-    });
-
-    it('propagates a transport error (leaving best-effort/hard-fail to the caller)', async () => {
-      const transport = {
-        resolveUrl: sandbox.stub().rejects(new SerenityTransportError(502, 'boom')),
-      };
-      await expect(resolveWebsiteEntries(
-        transport,
-        [{ url: 'https://x.com', type: BRAND_URL_TYPE.WEBSITE }],
-        undefined,
-      )).to.be.rejectedWith('boom');
-    });
-  });
-
   describe('attachBrandUrlsToProject', () => {
     const BRAND = { name: 'Acme', domain: 'https://acme.com' };
 
@@ -361,37 +276,22 @@ describe('brand-urls helpers', () => {
       expect(transport.createBrandUrls).to.not.have.been.called;
     });
 
-    it('ensures the benchmark and creates the URLs', async () => {
+    it('ensures the benchmark and creates the URLs verbatim (https-ful, no resolve)', async () => {
       const transport = {
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         createBenchmarks: sandbox.stub(),
         createBrandUrls: sandbox.stub().resolves({ ids: ['a'], existing_count: 0 }),
       };
-      const entries = [{ url: 'https://acme.com', type: 'website' }];
+      // Entries are written exactly as given (the caller already dropped the
+      // primary domain and https-filtered them) — no url/resolve normalization.
+      const entries = [{ url: 'https://www.acme.com', type: 'website' }];
       const result = await attachBrandUrlsToProject(transport, WS, PID, entries, BRAND, undefined);
       expect(result).to.deep.equal({ created: 1 });
       expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, PID, BID, entries);
     });
 
-    it('canonicalizes website URLs (via url/resolve) before creating them', async () => {
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
-        listBenchmarks: sandbox.stub().resolves(benchOk()),
-        createBrandUrls: sandbox.stub().resolves({ ids: ['a'], existing_count: 0 }),
-      };
-      const entries = [{ url: 'https://www.acme.com', type: 'website' }];
-      const result = await attachBrandUrlsToProject(transport, WS, PID, entries, BRAND, undefined);
-      expect(result).to.deep.equal({ created: 1 });
-      // The raw https://www.acme.com is stored as its canonical scheme-less form.
-      expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, PID, BID, [
-        { url: 'acme.com', type: 'website' },
-      ]);
-    });
-
     it('creates the benchmark first when the project has none, then attaches', async () => {
       const transport = {
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves({ aio_benchmarks: [] }),
         createBenchmarks: sandbox.stub().resolves({ ids: ['new-1'], existing_count: 0 }),
         createBrandUrls: sandbox.stub().resolves({ ids: ['a'], existing_count: 0 }),
@@ -440,7 +340,6 @@ describe('brand-urls helpers', () => {
 
     it('propagates a create-URL failure', async () => {
       const transport = {
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         createBrandUrls: sandbox.stub().rejects(new SerenityTransportError(400, 'bad url')),
       };
@@ -462,7 +361,6 @@ describe('brand-urls helpers', () => {
       };
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({
           brand_urls: [
@@ -485,82 +383,36 @@ describe('brand-urls helpers', () => {
       expect(result).to.deep.equal({ markets: 1, created: 1, deleted: 1 });
     });
 
-    it('diffs on the resolved canonical form — no churn when Semrush already stores it', async () => {
-      // Desired https://www.acme.com resolves to acme.com, which Semrush already
-      // stores → the re-sync is idempotent (no create/delete/publish).
+    it('skips the project primary-domain website (benchmark already holds it)', async () => {
+      // The project's own domain is the primary — its own-brand website URL is
+      // dropped so it does not double-list the benchmark (#25). Socials stay.
       const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
-        listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
-        listBenchmarks: sandbox.stub().resolves(benchOk()),
-        listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'keep', url: 'acme.com' }] }),
-        createBrandUrls: sandbox.stub().resolves({}),
-        deleteBrandUrls: sandbox.stub().resolves({}),
-        publishProject: sandbox.stub().resolves({}),
-      };
-      const result = await syncBrandUrlsAcrossMarkets(
-        transport,
-        { urls: ['https://www.acme.com'] },
-        WS,
-        undefined,
-      );
-      expect(transport.createBrandUrls).to.not.have.been.called;
-      expect(transport.deleteBrandUrls).to.not.have.been.called;
-      expect(transport.publishProject).to.not.have.been.called;
-      expect(result).to.deep.equal({ markets: 1, created: 0, deleted: 0 });
-    });
-
-    it('migrates a legacy raw-URL entry to its canonical form (delete raw, create scheme-less)', async () => {
-      // Semrush still holds the pre-#25 raw https value; the resolved desired set
-      // is scheme-less, so the one-time re-sync replaces it (self-correcting).
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
-        listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
-        listBenchmarks: sandbox.stub().resolves(benchOk()),
-        listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'legacy', url: 'https://www.acme.com' }] }),
-        createBrandUrls: sandbox.stub().resolves({}),
-        deleteBrandUrls: sandbox.stub().resolves({}),
-        publishProject: sandbox.stub().resolves({}),
-      };
-      const result = await syncBrandUrlsAcrossMarkets(
-        transport,
-        { urls: ['https://www.acme.com'] },
-        WS,
-        undefined,
-      );
-      expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, [
-        { url: 'acme.com', type: BRAND_URL_TYPE.WEBSITE },
-      ]);
-      expect(transport.deleteBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, ['legacy']);
-      expect(result).to.deep.equal({ markets: 1, created: 1, deleted: 1 });
-    });
-
-    it('resolves a region-less website url once across markets (shared cache)', async () => {
-      const transport = {
-        resolveUrl: sandbox.stub().resolves({ domain: 'acme.com', primary_url: 'acme.com', is_valid: true }),
         listProjects: sandbox.stub().resolves({
-          items: [projectWith('p-us', 'us'), projectWith('p-de', 'de')],
+          items: [{ id: 'p-us', domain: 'acme.com', settings: { ai: { country: { code: 'us' } } } }],
         }),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
-        listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'keep', url: 'acme.com' }] }),
+        listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
         deleteBrandUrls: sandbox.stub().resolves({}),
         publishProject: sandbox.stub().resolves({}),
       };
       const result = await syncBrandUrlsAcrossMarkets(
         transport,
-        { urls: ['https://www.acme.com'] },
+        { urls: ['https://acme.com', 'https://blog.acme.com'], socialAccounts: [{ url: 'https://x.com/acme', regions: [] }] },
         WS,
         undefined,
       );
-      expect(result.markets).to.equal(2);
-      // One region-less website url shared by both markets → resolved once (cache hit).
-      expect(transport.resolveUrl).to.have.been.calledOnce;
+      // Primary acme.com dropped; the secondary site + social remain.
+      expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, [
+        { url: 'https://blog.acme.com', type: BRAND_URL_TYPE.WEBSITE },
+        { url: 'https://x.com/acme', type: BRAND_URL_TYPE.SOCIAL },
+      ]);
+      expect(result).to.deep.equal({ markets: 1, created: 2, deleted: 0 });
     });
 
     it('reuses a pre-fetched project listing instead of calling listProjects', async () => {
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [] }), // would be empty if called
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -587,7 +439,6 @@ describe('brand-urls helpers', () => {
       const boom = new SerenityTransportError(502, 'Semrush POST https://gw.internal/x failed: 502');
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().rejects(boom),
@@ -609,7 +460,6 @@ describe('brand-urls helpers', () => {
       const sources = { urls: ['https://acme.com'] };
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [{ id: 'keep', url: 'https://acme.com' }] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -668,7 +518,6 @@ describe('brand-urls helpers', () => {
       const warn = sandbox.stub();
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -685,7 +534,6 @@ describe('brand-urls helpers', () => {
       const sources = { urls: ['https://acme.com'] };
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -792,7 +640,6 @@ describe('brand-urls helpers', () => {
       // undefined logger, leaving the truthy log?.info path uncovered.
       const info = sandbox.stub();
       const transport = {
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         createBrandUrls: sandbox.stub().resolves({}),
       };
@@ -835,7 +682,6 @@ describe('brand-urls helpers', () => {
             settings: { ai: { country: { code: 'us' } } },
           }],
         }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -866,7 +712,6 @@ describe('brand-urls helpers', () => {
             },
           }],
         }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -895,7 +740,6 @@ describe('brand-urls helpers', () => {
             },
           }],
         }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
@@ -918,7 +762,6 @@ describe('brand-urls helpers', () => {
             settings: { ai: { country: { code: 'us' } } },
           }],
         }),
-        resolveUrl: identityResolve(),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({}),
         createBrandUrls: sandbox.stub().resolves({}),

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -410,6 +410,43 @@ describe('brand-urls helpers', () => {
       expect(result).to.deep.equal({ markets: 1, created: 1, deleted: 1 });
     });
 
+    it('diffs against the DRAFT view, so a removal still lands on an unpublished project', async () => {
+      // A brand URL is written into the project's DRAFT; only a publish promotes it
+      // into the published view. `republishBestEffort` swallows a quota 405, which
+      // leaves the project unpublished — so the published view reports an EMPTY set
+      // while the draft holds the rows. Diffing the published view there would make
+      // `toDelete` empty and a user's removal would silently never reach Semrush.
+      const sources = { urls: ['https://acme.com'] };
+      const listBrandUrls = sandbox.stub();
+      // Published view: stale/empty (the pending rows are invisible to it).
+      listBrandUrls.withArgs(WS, 'p-us', BID).resolves({ brand_urls: [] });
+      // Draft view: the true pending state the sync must converge.
+      listBrandUrls.withArgs(WS, 'p-us', BID, { draft: true }).resolves({
+        brand_urls: [
+          { id: 'keep', url: 'https://acme.com' },
+          { id: 'stale', url: 'https://old.com' }, // removed by the user
+        ],
+      });
+      const transport = {
+        listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        listBenchmarks: sandbox.stub().resolves(benchOk()),
+        listBrandUrls,
+        createBrandUrls: sandbox.stub().resolves({}),
+        deleteBrandUrls: sandbox.stub().resolves({}),
+        // The republish quota-405 that strands the project as a draft in the first place.
+        publishProject: sandbox.stub().rejects(new SerenityTransportError(405, 'quota')),
+      };
+
+      const result = await syncBrandUrlsAcrossMarkets(transport, sources, WS, undefined);
+
+      // Read the draft, not the published view.
+      expect(listBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, { draft: true });
+      // The removal lands, and the already-present URL is NOT re-submitted.
+      expect(transport.deleteBrandUrls).to.have.been.calledOnceWith(WS, 'p-us', BID, ['stale']);
+      expect(transport.createBrandUrls).to.not.have.been.called;
+      expect(result).to.deep.equal({ markets: 1, created: 0, deleted: 1 });
+    });
+
     it('skips the project primary-domain website (benchmark already holds it)', async () => {
       // The project's own domain is the primary — its own-brand website URL is
       // dropped so it does not double-list the benchmark (#25). Socials stay.

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -19,6 +19,7 @@ import {
   BRAND_URL_TYPE,
   regionApplies,
   collectBrandUrlEntries,
+  primaryDomainSet,
   normalizeBenchmarkDomain,
   ensureOwnBrandBenchmark,
   attachBrandUrlsToProject,
@@ -118,7 +119,7 @@ describe('brand-urls helpers', () => {
       ]);
     });
 
-    it('skips the brand primary domain website (apex + www) when primaryDomain given', () => {
+    it('skips a market primary domain website (apex + www)', () => {
       // The benchmark already carries the primary domain (scheme-less), and a
       // brand_urls row must be https:// — so adding it would double-list it in
       // the UI. Both the apex and www forms of the primary are dropped (#25).
@@ -126,24 +127,50 @@ describe('brand-urls helpers', () => {
         urls: ['https://acme.com', 'https://www.acme.com', 'https://blog.acme.com'],
         socialAccounts: [{ url: 'https://x.com/acme', regions: [] }],
       };
-      expect(collectBrandUrlEntries(sources, 'us', 'acme.com')).to.deep.equal([
+      const primaries = primaryDomainSet(['acme.com']);
+      expect(collectBrandUrlEntries(sources, 'us', primaries)).to.deep.equal([
         { url: 'https://blog.acme.com', type: BRAND_URL_TYPE.WEBSITE },
         { url: 'https://x.com/acme', type: BRAND_URL_TYPE.SOCIAL },
       ]);
     });
 
-    it('accepts the primaryDomain in any form (scheme/www/path) via host match', () => {
-      const sources = { urls: ['https://acme.com'] };
-      expect(collectBrandUrlEntries(sources, 'us', 'https://www.acme.com/x')).to.deep.equal([]);
+    it('skips ANOTHER market primary domain too (market-mirror brand)', () => {
+      // acme.ca is CA's primary; on the US market it must not surface as a website
+      // brand URL either — the skip set is every market's primary, not just this
+      // market's. Matches the migration CLI (mysticat-data-service).
+      const sources = { urls: ['https://acme.com', 'https://acme.ca', 'https://shop.acme.com'] };
+      const primaries = primaryDomainSet(['acme.com', 'acme.ca']);
+      expect(collectBrandUrlEntries(sources, 'us', primaries)).to.deep.equal([
+        { url: 'https://shop.acme.com', type: BRAND_URL_TYPE.WEBSITE },
+      ]);
     });
 
-    it('keeps all website urls when primaryDomain is absent/unparseable', () => {
+    it('keeps all website urls when no primary domains are given', () => {
       const sources = { urls: ['https://acme.com', 'https://www.acme.com'] };
-      // No primaryDomain → nothing skipped (both kept; www vs apex are two rows).
+      // Empty skip set → nothing skipped (both kept; www vs apex are two rows).
       expect(collectBrandUrlEntries(sources, 'us')).to.deep.equal([
         { url: 'https://acme.com', type: BRAND_URL_TYPE.WEBSITE },
         { url: 'https://www.acme.com', type: BRAND_URL_TYPE.WEBSITE },
       ]);
+    });
+  });
+
+  describe('primaryDomainSet', () => {
+    it('normalizes each domain to a host and drops the unusable ones', () => {
+      // Accepts any form (scheme / www / path) — the project `domain` field is
+      // scheme-less, but the create payload's brandDomain may carry a scheme.
+      const set = primaryDomainSet([
+        'acme.com',
+        'https://www.acme.ca/en',
+        null,
+        '',
+        'not a domain !!!',
+      ]);
+      expect([...set].sort()).to.deep.equal(['acme.ca', 'acme.com']);
+    });
+
+    it('returns an empty set for a non-array', () => {
+      expect(primaryDomainSet(null).size).to.equal(0);
     });
   });
 

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -304,6 +304,35 @@ describe('markets-subworkspace handlers', () => {
       expect(transport.createBrandUrls).to.have.been.calledBefore(transport.publishProject);
     });
 
+    it('skips the brand\'s own primary domain (apex and www) when pushing brand URLs', async () => {
+      const transport = makeTransport();
+      // createBody.brandDomain is 'example.com' — the project's own-brand benchmark
+      // already carries it, so neither the apex nor the www form may be written as a
+      // `website` brand URL (serenity-docs#25). A secondary site still goes through.
+      const brandUrlSources = {
+        urls: [
+          'https://example.com',
+          'https://www.example.com',
+          'https://shop.example.com',
+        ],
+        socialAccounts: [],
+        earnedContent: [],
+      };
+      await handleCreateMarketSubworkspace(
+        transport,
+        makeBrand(),
+        PARENT,
+        createBody,
+        log,
+        null,
+        null,
+        { brandUrlSources },
+      );
+      expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, 'new-proj', 'bench-1', [
+        { url: 'https://shop.example.com', type: 'website' },
+      ]);
+    });
+
     it('tracks region-filtered competitors as benchmarks before publishing', async () => {
       const transport = makeTransport();
       const competitors = [

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -64,12 +64,6 @@ function makeTransport(overrides = {}) {
     deleteAiModelsByIds: sinon.stub().resolves(null),
     createProjectTags: sinon.stub().resolves(null),
     listBenchmarks: sinon.stub().resolves({ aio_benchmarks: [{ id: 'bench-1', main_brand: true }] }),
-    // Identity url/resolve: echoes its input as a valid canonical value, so the
-    // handler's brand-URL attach behaves as before for these tests (the www→apex
-    // normalization itself is unit-tested in brand-urls.test.js).
-    resolveUrl: sinon.stub().callsFake(
-      (url) => Promise.resolve({ domain: url, primary_url: url, is_valid: true }),
-    ),
     createBrandUrls: sinon.stub().resolves({ ids: [], existing_count: 0 }),
     createBenchmarks: sinon.stub().resolves({ ids: ['bm-new'], existing_count: 0 }),
     deleteBenchmarks: sinon.stub().resolves(null),

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -37,12 +37,13 @@ const PARENT = 'parent-ws';
 const log = { info: () => {}, error: () => {}, warn: () => {} };
 
 function proj({
-  id = 'p1', geo = 2840, lang = 'en', status = 'live',
+  id = 'p1', geo = 2840, lang = 'en', status = 'live', domain = undefined,
 } = {}) {
   return {
     id,
     publish_status: status,
     updated_at: '2026-06-02T00:00:00Z',
+    ...(domain === undefined ? {} : { domain }),
     settings: { ai: { location: { id: geo }, language: { name: lang } } },
   };
 }
@@ -315,6 +316,38 @@ describe('markets-subworkspace handlers', () => {
           'https://www.example.com',
           'https://shop.example.com',
         ],
+        socialAccounts: [],
+        earnedContent: [],
+      };
+      await handleCreateMarketSubworkspace(
+        transport,
+        makeBrand(),
+        PARENT,
+        createBody,
+        log,
+        null,
+        null,
+        { brandUrlSources },
+      );
+      expect(transport.createBrandUrls).to.have.been.calledOnceWith(WS, 'new-proj', 'bench-1', [
+        { url: 'https://shop.example.com', type: 'website' },
+      ]);
+    });
+
+    it('skips ANOTHER market\'s primary domain when pushing brand URLs (market-mirror brand)', async () => {
+      // A sibling CA project already exists on acme.ca. Creating the US market
+      // (brandDomain example.com) must skip BOTH primaries: example.com because it
+      // is this market's own, acme.ca because it is CA's — neither may be written
+      // as a website brand URL here. Only the genuine secondary site survives.
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({
+          items: [proj({
+            id: 'ca-proj', geo: 2124, lang: 'en', domain: 'acme.ca',
+          })],
+        }),
+      });
+      const brandUrlSources = {
+        urls: ['https://example.com', 'https://acme.ca', 'https://shop.example.com'],
         socialAccounts: [],
         earnedContent: [],
       };

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -501,7 +501,7 @@ describe('Semrush REST transport', () => {
       expect(call.body).to.equal(undefined);
     });
 
-    it('listBrandUrls GETs /v2/.../benchmarks/{bid}/brand_urls', async () => {
+    it('listBrandUrls GETs /v2/.../benchmarks/{bid}/brand_urls (published view by default)', async () => {
       fetchStub.resolves(fetchOk({ brand_urls: [] }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
@@ -509,7 +509,19 @@ describe('Semrush REST transport', () => {
 
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
+      // No `draft` query → the default (published) view.
       expect(call.url).to.match(/\/aio\/benchmarks\/bench-9\/brand_urls$/);
+    });
+
+    it('listBrandUrls sends ?draft=true when the draft view is requested', async () => {
+      fetchStub.resolves(fetchOk({ brand_urls: [] }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await transport.listBrandUrls(WORKSPACE_ID, PROJECT_ID, BENCHMARK_ID, { draft: true });
+
+      const call = await callOf(fetchStub);
+      expect(call.method).to.equal('GET');
+      expect(call.url).to.match(/\/aio\/benchmarks\/bench-9\/brand_urls\?draft=true$/);
     });
 
     it('createBrandUrls POSTs the entries array as the body', async () => {

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -795,24 +795,6 @@ describe('Semrush REST transport', () => {
     });
   });
 
-  describe('resolveUrl', () => {
-    it('GETs /v1/url/resolve with the primary_url query param and returns the body', async () => {
-      fetchStub.resolves(fetchOk({ domain: 'lovesac.com', primary_url: 'lovesac.com', is_valid: true }));
-      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
-
-      const result = await transport.resolveUrl('https://www.lovesac.com');
-
-      const call = await callOf(fetchStub);
-      expect(call.method).to.equal('GET');
-      const url = new URL(call.url);
-      expect(url.pathname).to.equal('/enterprise/projects/api/v1/url/resolve');
-      // The raw URL is passed verbatim as the query value (decoded here to stay
-      // robust to the client's query-encoding).
-      expect(url.searchParams.get('primary_url')).to.equal('https://www.lovesac.com');
-      expect(result).to.deep.equal({ domain: 'lovesac.com', primary_url: 'lovesac.com', is_valid: true });
-    });
-  });
-
   describe('createProjectTags', () => {
     it('POSTs { names } to /v2/workspaces/{ws}/projects/{pid}/aio/tags', async () => {
       fetchStub.resolves(fetchOk({ id: 'tag-1', name: 'source:ai' }));


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Brand URLs are written to Semrush verbatim with their `https://` scheme, and Project Engine's `url/resolve` is dropped from the write path entirely. The brand's own primary domain is skipped when building the brand-URL set, so it is not written as a redundant `website` entry alongside the benchmark that already carries it.

## 2. Reasoning
Semrush's brand-URLs API requires a literal `https://` scheme and stores the submitted value verbatim. It rejects a scheme-less value with `400 … Field validation for 'URL' failed on the 'url' tag`, and an `http://` value with `400 … failed on the 'startswith' tag`.

The write path on `main` resolves website brand URLs through `GET /v1/url/resolve` to Project Engine's canonical form — which is **scheme-less** — and writes that. Semrush therefore rejects every brand-URL write we make. In production, for serenity-active orgs:

- **Brand edit** (`PATCH /brands` → `syncBrandUrlsAcrossMarkets`) hard-fails *after* the brand row has already been committed: the caller gets a 500 and the database drifts out of sync with Semrush.
- **Market create** (`handleCreateMarketSubworkspace`) swallows the failure by design and the market goes live with **no brand URLs propagated at all**, emitting `SERENITY_MARKET_URL_ATTACH_DIVERGENCE`.

This reached production in v1.624.0 (2026-07-06) and is still live. The cause is a merge accident rather than a design decision: the pull request that introduced the `url/resolve` approach was squash-merged while only its first three commits existed. The two commits that reverted the approach — after it was discovered that a scheme-less value cannot be a `brand_urls` value at all — were authored after that merge landed and remained on the feature branch, so they never reached `main`. This change re-applies that correction to current `main`.

The duplicate the resolve was originally meant to prevent is real, but `url/resolve` was the wrong instrument for it: the brand's primary domain appears both as the benchmark's own scheme-less `primary_url` and as an explicit `website` brand-URL row. Since a `brand_urls` value must carry `https://` and a benchmark's domain never does, the two can never be made equal by normalization — the duplicate has to be avoided by not writing the row in the first place.

## 3. High-level overview of the changes
**Before:** every `website`-type brand URL was sent through `transport.resolveUrl` and the returned scheme-less canonical value was written to Semrush, which rejected it. The brand's primary domain was written as a `website` row, duplicating the benchmark's own `primary_url`.

**After:**

- Brand URLs are written **verbatim**, keeping the `https://` scheme the API demands. `social` and `earned` entries — which are identity handles such as `https://instagram.com/brand`, not brand domains — were never a sensible target for apex-normalization and are likewise written unchanged.
- `resolveWebsiteEntries` and the `resolveUrl` transport method are removed. `url/resolve` is no longer called from any write path; it is not a valid sink for `brand_urls`.
- `collectBrandUrlEntries` takes the project's own primary domain and skips a `website` entry whose host matches it, compared host-wise so that both the apex and the `www.` form are recognised. Market create passes the domain from the create payload; the edit re-sync passes the project's own domain. The benchmark continues to carry the primary domain; socials and secondary sites are unaffected.

Operationally: brand edits that touch URLs stop returning 500 and stop leaving the database diverged from Semrush, and newly created markets get their brand URLs attached instead of silently going live without them.

## 4. Required information
- Other: adobe/serenity-docs issue 25 — Brand URLs: skip the brand's own primary domain (drop url/resolve — invalid sink) https://github.com/adobe/serenity-docs/issues/25

## 5. Affected / used mysticat-workspace projects
- **spacecat-shared** (contract) — the vendored `spacecat-shared-project-engine-client` supplies the typed Project Engine client and its mock. Its `brand_urls` mock currently accepts any URL, which is why the scheme-less write path passed CI while failing against the live API. https://github.com/adobe/spacecat-shared/pull/1778 makes the mock enforce the live `https://` 400 and closes that fidelity gap.
- **mysticat-data-service** (contract, no change needed) — the Serenity migration CLI writes brand URLs to the same Semrush endpoint and already coerces to `https://` and skips the primary domain, so it stays consistent with this change.
- **project-elmo-ui** (consumed, no change needed) — already normalizes user-entered brand URLs to `https://` before calling this service, so the values arriving here carry a scheme.

## 6. Additional information outside the code
The live contract was re-probed against the production Semrush tenant on 2026-07-13, using a throwaway benchmark in an internal test sub-workspace. The benchmark and every row written during the probe were deleted afterwards; the workspace was left as found.

Against `POST /v2/workspaces/{ws}/projects/{pid}/aio/benchmarks/{bid}/brand_urls`:

| submitted | result |
|---|---|
| `example.net`, `www.example.org`, `example.net/products` | 400 — `Field validation for 'URL' failed on the 'url' tag` |
| `http://example.com` | 400 — `… failed on the 'startswith' tag` |
| `https://example.org` | 200 |
| `https://www.example.net` and `https://example.net` | 200 — persisted as two distinct rows, verbatim, with no `www`/apex de-duplication |

Two further observations that shaped this change:

- Semrush announced a deploy "unifying the format for brand URLs" on 2026-07-13. That unification is **display-only**: live rows are still *stored* verbatim with their scheme, while the Semrush UI renders them scheme-less. The write contract is unchanged, so writing scheme-less values remains incorrect.
- A `website` row whose host equals the benchmark's own primary domain is still accepted and still persists through a publish. The duplicate therefore does not resolve itself upstream, and the skip is genuinely required rather than merely defensive.

## 7. Test plan
Verified against the live production Semrush tenant as described in section 6: the scheme-less values this service currently writes are rejected, and the `https://` values it writes after this change are accepted and stored as submitted.

**dev:** with a serenity-active org, `PATCH /brands` on a brand whose `urls` are touched should return 2xx rather than 500, and the brand's `website`/`social`/`earned` URLs should appear on the market's own-brand benchmark with their `https://` scheme intact. The brand's own primary domain should be absent from the brand-URL list — it is carried by the benchmark's `primary_url` instead.

**prod:** after release, confirm that `SERENITY_MARKET_URL_ATTACH_DIVERGENCE` stops appearing in the api-service logs on Serenity market creates, and that a brand edit touching URLs no longer produces the post-commit re-sync failure.

## 8. Deployment & merge order
- https://github.com/adobe/spacecat-shared/pull/1778 — related. Makes the vendored project-engine-client mock enforce the live `https://` 400, so a regression of this class fails CI instead of shipping. Independent of this fix at runtime: it changes only the mock, so it neither blocks nor is blocked by this PR.

This PR is safe to merge and deploy on its own, and should not wait on the shared PR. Merging the shared PR first (or after) has no effect on the correctness of this change; landing it at some point is what prevents the regression from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
