### PR TITLE
fix(slack): forward mode to non-prerender audit types (LLMO-6167)

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -334,10 +334,18 @@ function RunAuditCommand(context) {
         [baseURLInputArg] = positionalArgs;
         auditTypeInputArg = keywords.audit;
 
-        // Build audit data from remaining keywords (excluding 'audit' and 'mode')
+        // Build audit data from remaining keywords (excluding 'audit').
+        // 'mode' is also excluded here ONLY for prerender — prerender does its own
+        // suggestion selection/batching on the API side (see PRERENDER_MODES /
+        // buildEffectiveData below) and re-injects a normalized `mode` value itself.
+        // Other audit types (e.g. toc's mode:ai-only, LLMO-6167) have no API-side
+        // selection logic of their own — mode must pass through untouched so the
+        // audit-worker can act on it directly.
         const auditDataKeywords = { ...keywords };
         delete auditDataKeywords.audit;
-        delete auditDataKeywords.mode;
+        if (auditTypeInputArg === PRERENDER) {
+          delete auditDataKeywords.mode;
+        }
 
         auditDataInputArg = Object.keys(auditDataKeywords).length > 0
           ? JSON.stringify(auditDataKeywords)

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -582,6 +582,22 @@ describe('RunAuditCommand', () => {
       });
     });
 
+    it('forwards mode in audit data for non-prerender audit types (e.g. toc\'s mode:ai-only, LLMO-6167)', async () => {
+      const command = RunAuditCommand(context);
+
+      await command.handleExecution(['validsite.com', 'audit:geo-brand-presence', 'generatePrompts:true', 'mode:ai-only'], slackContext);
+
+      expect(slackContext.say.called).to.be.true;
+      expect(sqsStub.sendMessage).called;
+
+      const sendMessageCall = sqsStub.sendMessage.firstCall;
+      const parsedData = JSON.parse(sendMessageCall.args[1].data);
+      expect(parsedData).to.deep.include({
+        generatePrompts: 'true',
+        mode: 'ai-only',
+      });
+    });
+
     it('handles keyword format with spaces after colon', async () => {
       const command = RunAuditCommand(context);
 


### PR DESCRIPTION
## Summary

- `run-audit`'s keyword-parsing path unconditionally deleted `mode` from the audit `data` payload sent to the audit-worker, regardless of audit type.
- That was harmless while `mode` only meant something for `prerender` — prerender re-injects a normalized `mode` value itself via `buildEffectiveData()` for its own API-side AI-only suggestion selection.
- TOC's `mode:ai-only` (LLMO-6167) has no equivalent API-side selection logic — it relies entirely on the audit-worker receiving `mode` directly in `data`. Because `run-audit.js` never special-cased TOC, `mode:ai-only` was silently dropped before the SQS message was even built, so `run audit {site} audit:toc mode:ai-only` fell through to a normal full audit instead of the prompts-only path.
- Fix: only delete `mode` for `prerender`; let it pass through untouched for every other audit type.

## Test plan

- [x] Added a unit test confirming `mode` now survives for a non-prerender audit type alongside `generatePrompts`
- [x] All existing `run-audit.test.js` tests pass (62/62), including all prerender-mode tests (`mode:all`, `mode:ai-only`, `mode:ai-only-current`, `mode:ai-only-missing`) — unchanged behavior confirmed
- [x] Verified against real production Splunk logs: `run audit asianpaints.com audit:toc generatePrompts:true mode:ai-only` previously logged `auditData="{"generatePrompts":"true"}"` (mode missing) at the api-service layer, before this fix

Refs: LLMO-6167

🤖 Generated with [Claude Code](https://claude.com/claude-code)