### PR TITLE
feat(aso-overlay): add ETag + If-None-Match (304) to GET /config/:service/redirects.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/index.html
 mcp-server.log
 # Scout MCP local config (per-developer, never commit)
 .scout/
+
+# oh-my-claudecode workspace state (per-developer, never commit)
+.omc/

--- a/docs/openapi/aso-overlay-api.yaml
+++ b/docs/openapi/aso-overlay-api.yaml
@@ -32,11 +32,19 @@ get-aso-redirects:
         in: header
         required: false
         description: |
-          RFC 7232 conditional GET. Send the `ETag` value from a previous
-          response to receive `304 Not Modified` when the overlay hasn't
-          changed. Weak comparison is used, so both `"tag"` and `W/"tag"`
-          are accepted. A comma-separated list of validators and the
-          wildcard `*` are also supported.
+          RFC 7232 conditional GET. Send the `ETag` from a previous response
+          to receive `304 Not Modified` when the overlay has not changed.
+
+          Accepted forms:
+          - A single strong validator: `"d41d8cd98f00b204e9800998ecf8427e"`
+          - A comma-separated list of validators: `"a", "b", "c"`
+          - The wildcard `*` (matches any existing representation)
+          - The weak-prefix form under weak comparison: `W/"tag"` and
+            `"tag"` are treated as equal (§2.3.2)
+
+          The validator MUST be a properly quoted opaque-tag per §2.3;
+          shell-stripped or unquoted values are rejected and the response
+          falls back to `200`.
         schema:
           type: string
           example: '"d41d8cd98f00b204e9800998ecf8427e"'
@@ -48,7 +56,9 @@ get-aso-redirects:
             description: |
               Strong validator (S3-passthrough) for the overlay object.
               Persist and echo back on subsequent polls via `If-None-Match`
-              to skip re-downloading unchanged content.
+              to skip re-downloading unchanged content. Treat the value as
+              opaque — do not depend on it being an MD5, since multipart
+              uploads produce a different (still-strong) validator format.
             schema:
               type: string
               example: '"d41d8cd98f00b204e9800998ecf8427e"'
@@ -67,13 +77,24 @@ get-aso-redirects:
       '304':
         description: |
           The overlay has not changed since the client-supplied `If-None-Match`
-          validator. Response has no body; the `ETag` and `Cache-Control`
-          headers are still emitted so the client can refresh its cached copy
-          metadata. Authorization is still evaluated before this status is
-          returned — an unauthorized caller who happens to know a valid ETag
-          for some other tenant's overlay still receives `404`.
+          validator. Response has no body (Content-Length: 0); the `ETag` and
+          `Cache-Control` headers are still emitted so the client can refresh
+          its cached copy metadata.
+
+          Contract with polling clients: on 304 the previously cached body MAY
+          be treated as fresh for the `Cache-Control: max-age` window without
+          re-validating. On any non-304 response the client MUST rebuild any
+          derived state (e.g. dispatcher SDBM maps) from the fresh body.
+
+          Authorization is still evaluated before this status is returned —
+          an unauthorized caller who happens to know a valid ETag for some
+          other tenant's overlay still receives `404`.
         headers:
           ETag:
+            description: |
+              The current validator (may be absent if the storage backend
+              did not surface one, but the 304 semantics still hold under
+              `If-None-Match: *`).
             schema:
               type: string
               example: '"d41d8cd98f00b204e9800998ecf8427e"'

--- a/docs/openapi/aso-overlay-api.yaml
+++ b/docs/openapi/aso-overlay-api.yaml
@@ -28,9 +28,35 @@ get-aso-redirects:
           type: string
           pattern: '^cm-p\d{1,10}-e\d{1,10}$'
           example: cm-p154709-e1629980
+      - name: If-None-Match
+        in: header
+        required: false
+        description: |
+          RFC 7232 conditional GET. Send the `ETag` value from a previous
+          response to receive `304 Not Modified` when the overlay hasn't
+          changed. Weak comparison is used, so both `"tag"` and `W/"tag"`
+          are accepted. A comma-separated list of validators and the
+          wildcard `*` are also supported.
+        schema:
+          type: string
+          example: '"d41d8cd98f00b204e9800998ecf8427e"'
     responses:
       '200':
         description: The redirect overlay file.
+        headers:
+          ETag:
+            description: |
+              Strong validator (S3-passthrough) for the overlay object.
+              Persist and echo back on subsequent polls via `If-None-Match`
+              to skip re-downloading unchanged content.
+            schema:
+              type: string
+              example: '"d41d8cd98f00b204e9800998ecf8427e"'
+          Cache-Control:
+            description: Edge-cache directive aligned with the Fastly VCL TTL.
+            schema:
+              type: string
+              example: max-age=10
         content:
           text/plain:
             schema:
@@ -38,6 +64,23 @@ get-aso-redirects:
             example: |
               example.com/old-widget https://www.example.com/products/widget-v2
               blog.example.com/old-post https://blog.example.com/articles/new
+      '304':
+        description: |
+          The overlay has not changed since the client-supplied `If-None-Match`
+          validator. Response has no body; the `ETag` and `Cache-Control`
+          headers are still emitted so the client can refresh its cached copy
+          metadata. Authorization is still evaluated before this status is
+          returned — an unauthorized caller who happens to know a valid ETag
+          for some other tenant's overlay still receives `404`.
+        headers:
+          ETag:
+            schema:
+              type: string
+              example: '"d41d8cd98f00b204e9800998ecf8427e"'
+          Cache-Control:
+            schema:
+              type: string
+              example: max-age=10
       '400':
         $ref: './responses.yaml#/400'
       '401':

--- a/docs/openapi/aso-overlay-api.yaml
+++ b/docs/openapi/aso-overlay-api.yaml
@@ -102,6 +102,11 @@ get-aso-redirects:
             schema:
               type: string
               example: max-age=10
+          Content-Length:
+            description: Always `0` — RFC 7230 §3.3.3 forbids a body on 304.
+            schema:
+              type: integer
+              example: 0
       '400':
         $ref: './responses.yaml#/400'
       '401':

--- a/docs/openapi/aso-overlay-api.yaml
+++ b/docs/openapi/aso-overlay-api.yaml
@@ -108,12 +108,48 @@ get-aso-redirects:
               type: integer
               example: 0
       '400':
-        $ref: './responses.yaml#/400'
+        description: Bad request. The service identifier does not match the Cloud Manager `cm-pXXX-eYYY` pattern.
+        headers:
+          X-Error:
+            $ref: './headers.yaml#/xError'
+          Cache-Control:
+            description: |
+              Always `no-store` on negative responses so Fastly and any other
+              intermediary cannot pin a stale error. Without this, the Fastly
+              VCL default (`fetch/100-aso-overlay-ttl.vcl`) would apply
+              `ttl=10s` + `stale_while_revalidate=30s` + `stale_if_error=86400s`
+              uniformly, causing a customer-provisioning race where a
+              dispatcher poll made before the tenant lands keeps serving stale
+              errors for up to 24 h.
+            schema:
+              type: string
+              example: no-store
       '401':
         $ref: './responses.yaml#/401'
       '404':
-        $ref: './responses.yaml#/404'
+        description: |
+          No redirect overlay found. Returned when the service identifier does
+          not resolve to a provisioned + ASO-entitled + enrolled site, or when
+          the overlay object is absent in S3. Deliberately indistinguishable
+          from an authorization failure to prevent tenant enumeration (Lite-E
+          property, see ADR `aso-dispatcher-overlay`).
+        headers:
+          X-Error:
+            $ref: './headers.yaml#/xError'
+          Cache-Control:
+            description: Always `no-store` — see note under 400.
+            schema:
+              type: string
+              example: no-store
       '500':
-        $ref: './responses.yaml#/500'
+        description: Internal server error.
+        headers:
+          X-Error:
+            $ref: './headers.yaml#/xError'
+          Cache-Control:
+            description: Always `no-store` — see note under 400.
+            schema:
+              type: string
+              example: no-store
     security:
       - aso_overlay_api_key: []

--- a/src/controllers/redirects.js
+++ b/src/controllers/redirects.js
@@ -19,12 +19,39 @@ import {
 import { Entitlement as EntitlementModel } from '@adobe/spacecat-shared-data-access';
 import { isNonEmptyObject } from '@adobe/spacecat-shared-utils';
 
+import { getHeader } from '../support/http-headers.js';
+
 // Cloud Manager service identifier, e.g. cm-p154709-e1629980. Digit runs are
 // capped to a realistic length to avoid arbitrarily long lookups; the capture
 // groups yield the program id (pXXXX) and environment id (eYYYY).
 const SERVICE_RE = /^cm-p(\d{1,10})-e(\d{1,10})$/;
 // Aligns with the Fastly edge TTL for this path (fetch/100-aso-overlay-ttl.vcl).
 const OVERLAY_TTL_SECONDS = 10;
+
+// RFC 7232 §2.3.2 weak comparison: two validators are equal if their opaque
+// tags match character-by-character *ignoring* the optional `W/` weak-prefix.
+// If-None-Match uses weak comparison (§3.2), so `W/"abc"` and `"abc"` match.
+function stripWeakPrefix(v) {
+  const t = v.trim();
+  return t.startsWith('W/') ? t.slice(2) : t;
+}
+
+// RFC 7232 §3.2: If-None-Match matches when the header value is "*" (any
+// existing resource) or when any comma-separated validator in the list weakly
+// compares equal to the current ETag. S3 emits strong quoted ETags, but we
+// still normalize both sides so a client that tags its cached validator weak
+// (some caches do) matches correctly.
+function ifNoneMatchMatches(headerValue, currentEtag) {
+  if (!headerValue || !currentEtag) {
+    return false;
+  }
+  const trimmed = headerValue.trim();
+  if (trimmed === '*') {
+    return true;
+  }
+  const normCurrent = stripWeakPrefix(currentEtag);
+  return trimmed.split(',').some((tok) => stripWeakPrefix(tok) === normCurrent);
+}
 
 /**
  * Redirects Controller — serves the ASO dispatcher-layer redirect overlay
@@ -113,11 +140,43 @@ function RedirectsController(ctx) {
     try {
       const command = new GetObjectCommand({ Bucket: bucketName, Key: key });
       const response = await s3Client.send(command);
+
+      // S3 returns the object's ETag already quoted (RFC 7232 opaque-tag form),
+      // e.g. `"d41d8cd98f00b204e9800998ecf8427e"`. Passthrough gives the client
+      // a strong validator without hashing the body — the writer is single-part,
+      // so this is an MD5 today; multipart uploads would surface an opaque S3
+      // ETag which is still a valid strong validator for If-None-Match compares.
+      // S3 returns the object's ETag already quoted (RFC 7232 opaque-tag form),
+      // e.g. `"d41d8cd98f00b204e9800998ecf8427e"`. Passthrough gives the client
+      // a strong validator without hashing the body — the writer is single-part
+      // (small overlays), so this is an MD5 today; multipart uploads would
+      // surface an opaque S3 ETag which is still a valid strong validator.
+      // Missing ETag (defensive — S3 always returns one for a successful GET,
+      // but a mock or a future storage backend might not) simply disables the
+      // conditional-GET path and we serve the body unconditionally.
+      const etag = response.ETag;
+      const ifNoneMatch = getHeader(context, 'if-none-match');
+      if (etag && ifNoneMatchMatches(ifNoneMatch, etag)) {
+        log.info('[aso-overlay] 304 Not Modified', { service, etag });
+        // 304 MUST NOT include a message body (RFC 7230 §3.3.3); MUST include
+        // any Cache-Control/ETag we would have sent on a 200 (RFC 7232 §4.1).
+        // We set content-type explicitly to text/plain — createResponse would
+        // otherwise default to application/json (misleading on this endpoint)
+        // and would run the JSON stringify branch on the empty body.
+        return createResponse('', 304, {
+          'content-type': 'text/plain; charset=utf-8',
+          etag,
+          'cache-control': `max-age=${OVERLAY_TTL_SECONDS}`,
+        });
+      }
+
       const body = await response.Body.transformToString();
       return createResponse(body, 200, {
         'content-type': 'text/plain; charset=utf-8',
         // Cache-friendly for Fastly request-collapsing; edge TTL also set in VCL.
         'cache-control': `max-age=${OVERLAY_TTL_SECONDS}`,
+        // Include ETag so a subsequent poll can conditionally revalidate.
+        ...(etag ? { etag } : {}),
       });
     } catch (err) {
       const code = err.$metadata?.httpStatusCode;

--- a/src/controllers/redirects.js
+++ b/src/controllers/redirects.js
@@ -26,31 +26,56 @@ import { getHeader } from '../support/http-headers.js';
 // groups yield the program id (pXXXX) and environment id (eYYYY).
 const SERVICE_RE = /^cm-p(\d{1,10})-e(\d{1,10})$/;
 // Aligns with the Fastly edge TTL for this path (fetch/100-aso-overlay-ttl.vcl).
+// Single source of truth so the 200 and 304 responses can't drift under future edits.
 const OVERLAY_TTL_SECONDS = 10;
+const OVERLAY_CACHE_CONTROL = `max-age=${OVERLAY_TTL_SECONDS}`;
 
-// RFC 7232 §2.3.2 weak comparison: two validators are equal if their opaque
-// tags match character-by-character *ignoring* the optional `W/` weak-prefix.
-// If-None-Match uses weak comparison (§3.2), so `W/"abc"` and `"abc"` match.
-function stripWeakPrefix(v) {
+// RFC 7232 §2.3 opaque-tag: the validator MUST be a double-quoted string,
+// optionally preceded by the case-sensitive `W/` weak indicator. Anything that
+// doesn't parse as `"..."` (e.g. a shell-stripped `abc123`) is rejected — better
+// to force a body re-fetch than silently 304 against a corrupted validator.
+// `W/` is intentionally case-sensitive per §2.3; lowercase `w/` is malformed
+// and we do not normalize it.
+function normalizeValidator(v) {
   const t = v.trim();
-  return t.startsWith('W/') ? t.slice(2) : t;
+  const stem = t.startsWith('W/') ? t.slice(2) : t;
+  if (stem.length < 2 || stem[0] !== '"' || stem[stem.length - 1] !== '"') {
+    return null;
+  }
+  return stem;
 }
 
-// RFC 7232 §3.2: If-None-Match matches when the header value is "*" (any
-// existing resource) or when any comma-separated validator in the list weakly
-// compares equal to the current ETag. S3 emits strong quoted ETags, but we
-// still normalize both sides so a client that tags its cached validator weak
-// (some caches do) matches correctly.
+// RFC 7232 §3.2: If-None-Match matches when the header value is `*` (any
+// existing representation) or when any comma-separated validator in the list
+// weakly compares equal to the current ETag. S3 emits strong quoted ETags; we
+// still normalize both sides so a client tagging its cached validator weak
+// (`W/"..."`) matches. Note: this assumes opaque-tags don't contain commas,
+// which is true for every ETag S3 produces (hex digests / opaque part IDs).
+//
+// We deliberately compare in-app rather than pushing `IfNoneMatch` down to
+// `GetObjectCommand`: the S3 SDK only accepts a single strong validator, so
+// `*` and multi-value lists would still need app handling. At current fleet
+// scale the ~10 KB overlay body is cheap; revisit if bandwidth or Lambda
+// memory becomes measurable.
 function ifNoneMatchMatches(headerValue, currentEtag) {
-  if (!headerValue || !currentEtag) {
+  if (!headerValue) {
     return false;
   }
   const trimmed = headerValue.trim();
+  // `*` matches any existing representation — the caller has reached here
+  // only after a successful S3 GET, so a representation exists regardless
+  // of whether S3 surfaced an ETag on the response.
   if (trimmed === '*') {
     return true;
   }
-  const normCurrent = stripWeakPrefix(currentEtag);
-  return trimmed.split(',').some((tok) => stripWeakPrefix(tok) === normCurrent);
+  const normCurrent = normalizeValidator(currentEtag || '');
+  if (!normCurrent) {
+    return false;
+  }
+  return trimmed.split(',').some((tok) => {
+    const norm = normalizeValidator(tok);
+    return norm !== null && norm === normCurrent;
+  });
 }
 
 /**
@@ -146,22 +171,26 @@ function RedirectsController(ctx) {
       // a strong validator without hashing the body — the writer is single-part
       // (small overlays), so this is an MD5 today; multipart uploads would
       // surface an opaque S3 ETag which is still a valid strong validator.
-      // Missing ETag (defensive — S3 always returns one for a successful GET,
-      // but a mock or a future storage backend might not) simply disables the
-      // conditional-GET path and we serve the body unconditionally.
+      // If S3 doesn't surface an ETag (defensive — mock or future backend), we
+      // just serve the body without ETag; the conditional-GET path degrades to
+      // a plain 200 rather than breaking.
       const etag = response.ETag;
       const ifNoneMatch = getHeader(context, 'if-none-match');
-      if (etag && ifNoneMatchMatches(ifNoneMatch, etag)) {
-        log.info('[aso-overlay] 304 Not Modified', { service, etag });
-        // 304 MUST NOT include a message body (RFC 7230 §3.3.3); MUST include
-        // any Cache-Control/ETag we would have sent on a 200 (RFC 7232 §4.1).
-        // We set content-type explicitly to text/plain — createResponse would
-        // otherwise default to application/json (misleading on this endpoint)
-        // and would run the JSON stringify branch on the empty body.
+      if (ifNoneMatchMatches(ifNoneMatch, etag)) {
+        // Deliberately no per-request 304 log — this is the *expected* path at
+        // steady state and would dominate log volume across the dispatcher fleet.
+        // If 304-rate visibility becomes necessary, emit a metric rather than a
+        // log line.
+        //
+        // 304 MUST NOT include a message body (RFC 7230 §3.3.3); MUST carry any
+        // Cache-Control / ETag we would have sent on a 200 (RFC 7232 §4.1).
+        // Content-type is set explicitly because createResponse would otherwise
+        // default to application/json for an empty body and run the JSON
+        // stringify branch — text/plain matches the 200 shape.
         return createResponse('', 304, {
           'content-type': 'text/plain; charset=utf-8',
-          etag,
-          'cache-control': `max-age=${OVERLAY_TTL_SECONDS}`,
+          ...(etag ? { etag } : {}),
+          'cache-control': OVERLAY_CACHE_CONTROL,
         });
       }
 
@@ -169,7 +198,7 @@ function RedirectsController(ctx) {
       return createResponse(body, 200, {
         'content-type': 'text/plain; charset=utf-8',
         // Cache-friendly for Fastly request-collapsing; edge TTL also set in VCL.
-        'cache-control': `max-age=${OVERLAY_TTL_SECONDS}`,
+        'cache-control': OVERLAY_CACHE_CONTROL,
         // Include ETag so a subsequent poll can conditionally revalidate.
         ...(etag ? { etag } : {}),
       });

--- a/src/controllers/redirects.js
+++ b/src/controllers/redirects.js
@@ -29,6 +29,21 @@ const SERVICE_RE = /^cm-p(\d{1,10})-e(\d{1,10})$/;
 // Single source of truth so the 200 and 304 responses can't drift under future edits.
 const OVERLAY_TTL_SECONDS = 10;
 const OVERLAY_CACHE_CONTROL = `max-age=${OVERLAY_TTL_SECONDS}`;
+// Every non-2xx/3xx response advertises `no-store` so Fastly (and any other
+// intermediary) will not cache negative responses. Without this, the Fastly VCL
+// at `fastly/vcl/aso-prod/fetch/100-aso-overlay-ttl.vcl` applies its default
+// TTL (10s) + stale-while-revalidate (30s) + stale_if_error (86400s) uniformly
+// across all statuses, which pins a 404 for up to 24 h under any subsequent
+// origin blip — creating the customer-provisioning race where a dispatcher
+// poll made *before* a site's ASO entitlement lands keeps serving stale 404s
+// long after provisioning completes. `no-store` at the origin overrides that
+// VCL default (Fastly respects the response Cache-Control) so the negative
+// cache never sticks. Belt-and-braces: even if the VCL is later tightened
+// to short-TTL 4xx, the origin still declares "do not cache" and any future
+// consumer (different CDN, direct-to-origin traffic, offline replay) gets the
+// correct semantics without needing to replicate the VCL rule.
+const NEGATIVE_CACHE_CONTROL = 'no-store';
+const NO_STORE_HEADERS = { 'cache-control': NEGATIVE_CACHE_CONTROL };
 
 // RFC 7232 §2.3 opaque-tag: the validator MUST be a double-quoted string,
 // optionally preceded by the case-sensitive `W/` weak indicator. Anything that
@@ -122,11 +137,11 @@ function RedirectsController(ctx) {
 
     const match = SERVICE_RE.exec(service);
     if (!match) {
-      return badRequest('Invalid service identifier');
+      return badRequest('Invalid service identifier', NO_STORE_HEADERS);
     }
     if (!bucketName) {
       log.error('[aso-overlay] S3_ASO_OVERLAYS_BUCKET is not configured');
-      return internalServerError('Overlay endpoint not configured');
+      return internalServerError('Overlay endpoint not configured', NO_STORE_HEADERS);
     }
 
     const [, programId, environmentId] = match;
@@ -140,7 +155,7 @@ function RedirectsController(ctx) {
     );
     if (!site) {
       log.info('[aso-overlay] no site resolves for service', { service });
-      return notFound('No redirect overlay found');
+      return notFound('No redirect overlay found', NO_STORE_HEADERS);
     }
 
     // Authorize: the site's org must hold an ASO entitlement AND the site must be
@@ -151,13 +166,13 @@ function RedirectsController(ctx) {
     );
     if (!entitlement) {
       log.info('[aso-overlay] site org not ASO-entitled', { siteId: site.getId() });
-      return notFound('No redirect overlay found');
+      return notFound('No redirect overlay found', NO_STORE_HEADERS);
     }
     const enrollments = await SiteEnrollment.allBySiteId(site.getId());
     const enrolled = enrollments.some((se) => se.getEntitlementId() === entitlement.getId());
     if (!enrolled) {
       log.info('[aso-overlay] site not enrolled for ASO', { siteId: site.getId() });
-      return notFound('No redirect overlay found');
+      return notFound('No redirect overlay found', NO_STORE_HEADERS);
     }
 
     // Read the overlay with the Lambda's own execution role (no SigV4 from caller).
@@ -205,7 +220,7 @@ function RedirectsController(ctx) {
     } catch (err) {
       const code = err.$metadata?.httpStatusCode;
       if (err.name === 'NoSuchKey' || code === 404) {
-        return notFound('No redirect overlay found');
+        return notFound('No redirect overlay found', NO_STORE_HEADERS);
       }
       // The reader role intentionally lacks s3:ListBucket (least privilege, no key
       // enumeration), so a *missing* object surfaces as 403 AccessDenied rather
@@ -219,10 +234,10 @@ function RedirectsController(ctx) {
           + '— missing object or missing s3:GetObject grant',
           err,
         );
-        return notFound('No redirect overlay found');
+        return notFound('No redirect overlay found', NO_STORE_HEADERS);
       }
       log.error(`[aso-overlay] failed to read ${key} from ${bucketName}`, err);
-      return internalServerError('Failed to retrieve redirect overlay');
+      return internalServerError('Failed to retrieve redirect overlay', NO_STORE_HEADERS);
     }
   }
 

--- a/src/controllers/redirects.js
+++ b/src/controllers/redirects.js
@@ -143,11 +143,6 @@ function RedirectsController(ctx) {
 
       // S3 returns the object's ETag already quoted (RFC 7232 opaque-tag form),
       // e.g. `"d41d8cd98f00b204e9800998ecf8427e"`. Passthrough gives the client
-      // a strong validator without hashing the body — the writer is single-part,
-      // so this is an MD5 today; multipart uploads would surface an opaque S3
-      // ETag which is still a valid strong validator for If-None-Match compares.
-      // S3 returns the object's ETag already quoted (RFC 7232 opaque-tag form),
-      // e.g. `"d41d8cd98f00b204e9800998ecf8427e"`. Passthrough gives the client
       // a strong validator without hashing the body — the writer is single-part
       // (small overlays), so this is an MD5 today; multipart uploads would
       // surface an opaque S3 ETag which is still a valid strong validator.

--- a/test/controllers/redirects.test.js
+++ b/test/controllers/redirects.test.js
@@ -19,6 +19,7 @@ const BUCKET = 'spacecat-dev-aso-overlays';
 const SERVICE = 'cm-p154709-e1629980';
 const ORG_ID = 'org-1';
 const ENTITLEMENT_ID = 'ent-aso-1';
+const ETAG = '"d41d8cd98f00b204e9800998ecf8427e"';
 
 /**
  * Authentication for this route is performed upstream by AsoOverlayKeyHandler
@@ -79,6 +80,7 @@ describe('RedirectsController', () => {
   it('returns 200 text/plain with the overlay body for an entitled, enrolled site', async () => {
     const overlay = 'example.com/old https://www.example.com/new\n';
     mockS3.s3Client.send.resolves({
+      ETag: ETAG,
       Body: { transformToString: sandbox.stub().resolves(overlay) },
     });
 
@@ -86,6 +88,8 @@ describe('RedirectsController', () => {
 
     expect(response.status).to.equal(200);
     expect(response.headers.get('content-type')).to.equal('text/plain; charset=utf-8');
+    expect(response.headers.get('cache-control')).to.equal('max-age=10');
+    expect(response.headers.get('etag')).to.equal(ETAG);
     expect(await response.text()).to.equal(overlay);
     // Resolves the site by the p<program>/e<env> external ids parsed from the service.
     expect(mockDataAccess.Site.findByExternalOwnerIdAndExternalSiteId
@@ -95,6 +99,132 @@ describe('RedirectsController', () => {
       Bucket: BUCKET,
       Key: `config/${SERVICE}/redirects.txt`,
     })).to.be.true;
+  });
+
+  it('returns 200 without an ETag header when S3 does not surface one', async () => {
+    // Defensive: S3 always returns ETag for a successful GET, but a future
+    // storage backend might not — in that case we serve the body unconditionally.
+    const overlay = 'example.com/old https://www.example.com/new\n';
+    mockS3.s3Client.send.resolves({
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+
+    const response = await controller.getRedirects(requestContext);
+
+    expect(response.status).to.equal(200);
+    expect(response.headers.get('etag')).to.be.null;
+    expect(await response.text()).to.equal(overlay);
+  });
+
+  it('returns 304 with ETag + Cache-Control and no body when If-None-Match matches', async () => {
+    const overlay = 'example.com/old https://www.example.com/new\n';
+    const bodyStub = sandbox.stub().resolves(overlay);
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: bodyStub },
+    });
+    requestContext.pathInfo = { headers: { 'If-None-Match': ETAG } };
+
+    const response = await controller.getRedirects(requestContext);
+
+    expect(response.status).to.equal(304);
+    expect(response.headers.get('etag')).to.equal(ETAG);
+    expect(response.headers.get('cache-control')).to.equal('max-age=10');
+    expect(await response.text()).to.equal('');
+    // Body never deserialized when returning 304 — saves the transformToString cost.
+    expect(bodyStub.called).to.be.false;
+  });
+
+  it('accepts a lower-case if-none-match header (case-insensitive per HTTP)', async () => {
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves('') },
+    });
+    requestContext.pathInfo = { headers: { 'if-none-match': ETAG } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(304);
+  });
+
+  it('returns 304 when If-None-Match: * and the resource exists', async () => {
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves('') },
+    });
+    requestContext.pathInfo = { headers: { 'if-none-match': '*' } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(304);
+  });
+
+  it('returns 304 when If-None-Match is a multi-value list containing the current ETag', async () => {
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves('') },
+    });
+    requestContext.pathInfo = { headers: { 'if-none-match': `"other", ${ETAG}, "another"` } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(304);
+  });
+
+  it('treats W/"tag" and "tag" as equivalent under RFC 7232 weak comparison', async () => {
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves('') },
+    });
+    requestContext.pathInfo = { headers: { 'if-none-match': `W/${ETAG}` } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(304);
+  });
+
+  it('returns 200 with fresh body when If-None-Match does not match the current ETag', async () => {
+    const overlay = 'example.com/new https://www.example.com/x\n';
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+    requestContext.pathInfo = { headers: { 'if-none-match': '"stale-etag"' } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(200);
+    expect(response.headers.get('etag')).to.equal(ETAG);
+    expect(await response.text()).to.equal(overlay);
+  });
+
+  it('returns 200 when If-None-Match is empty/whitespace', async () => {
+    const overlay = 'x y\n';
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+    requestContext.pathInfo = { headers: { 'if-none-match': '   ' } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(200);
+    expect(await response.text()).to.equal(overlay);
+  });
+
+  it('still returns 404 (not 304) when the site does not resolve — no enumeration signal via If-None-Match', async () => {
+    // Guard: If-None-Match must not short-circuit authz. A non-entitled tenant
+    // sending a valid ETag for some *other* tenant's overlay must still 404.
+    mockDataAccess.Site.findByExternalOwnerIdAndExternalSiteId.resolves(null);
+    requestContext.pathInfo = { headers: { 'if-none-match': ETAG } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(404);
+    // Authz failed before S3 was touched.
+    expect(mockS3.s3Client.send.called).to.be.false;
+  });
+
+  it('still returns 404 (not 304) when If-None-Match: * is sent by a non-entitled tenant', async () => {
+    mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
+    requestContext.pathInfo = { headers: { 'if-none-match': '*' } };
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(404);
+    expect(mockS3.s3Client.send.called).to.be.false;
   });
 
   it('returns 400 for a malformed service identifier', async () => {

--- a/test/controllers/redirects.test.js
+++ b/test/controllers/redirects.test.js
@@ -37,6 +37,14 @@ describe('RedirectsController', () => {
   let controller;
   let requestContext;
 
+  // Helper: set an `If-None-Match` header on the current request context.
+  // Tests mutate this map rather than replacing `pathInfo` wholesale so that
+  // if the controller starts reading other pathInfo fields, tests don't
+  // silently drop them.
+  const withIfNoneMatch = (value) => {
+    requestContext.pathInfo.headers['if-none-match'] = value;
+  };
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
@@ -66,7 +74,7 @@ describe('RedirectsController', () => {
     };
 
     controller = RedirectsController(mockContext);
-    requestContext = { params: { service: SERVICE } };
+    requestContext = { params: { service: SERVICE }, pathInfo: { headers: {} } };
   });
 
   afterEach(() => {
@@ -102,8 +110,9 @@ describe('RedirectsController', () => {
   });
 
   it('returns 200 without an ETag header when S3 does not surface one', async () => {
-    // Defensive: S3 always returns ETag for a successful GET, but a future
-    // storage backend might not — in that case we serve the body unconditionally.
+    // Defensive: S3 always returns ETag for a successful GET, but a mock or
+    // future storage backend might not — the conditional-GET path degrades to
+    // a plain 200 rather than breaking.
     const overlay = 'example.com/old https://www.example.com/new\n';
     mockS3.s3Client.send.resolves({
       Body: { transformToString: sandbox.stub().resolves(overlay) },
@@ -116,6 +125,20 @@ describe('RedirectsController', () => {
     expect(await response.text()).to.equal(overlay);
   });
 
+  it('serves 200 when the request context has no pathInfo (defensive)', async () => {
+    // getHeader tolerates a missing pathInfo — controller must not throw.
+    delete requestContext.pathInfo;
+    const overlay = 'x y\n';
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(200);
+    expect(await response.text()).to.equal(overlay);
+  });
+
   it('returns 304 with ETag + Cache-Control and no body when If-None-Match matches', async () => {
     const overlay = 'example.com/old https://www.example.com/new\n';
     const bodyStub = sandbox.stub().resolves(overlay);
@@ -123,24 +146,25 @@ describe('RedirectsController', () => {
       ETag: ETAG,
       Body: { transformToString: bodyStub },
     });
-    requestContext.pathInfo = { headers: { 'If-None-Match': ETAG } };
+    withIfNoneMatch(ETAG);
 
     const response = await controller.getRedirects(requestContext);
 
     expect(response.status).to.equal(304);
     expect(response.headers.get('etag')).to.equal(ETAG);
     expect(response.headers.get('cache-control')).to.equal('max-age=10');
+    expect(response.headers.get('content-type')).to.equal('text/plain; charset=utf-8');
     expect(await response.text()).to.equal('');
-    // Body never deserialized when returning 304 — saves the transformToString cost.
+    // Body never deserialized when returning 304 — the transformToString cost is elided.
     expect(bodyStub.called).to.be.false;
   });
 
-  it('accepts a lower-case if-none-match header (case-insensitive per HTTP)', async () => {
+  it('accepts a mixed-case if-none-match header (HTTP header names are case-insensitive)', async () => {
     mockS3.s3Client.send.resolves({
       ETag: ETAG,
       Body: { transformToString: sandbox.stub().resolves('') },
     });
-    requestContext.pathInfo = { headers: { 'if-none-match': ETAG } };
+    requestContext.pathInfo.headers['If-None-Match'] = ETAG;
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(304);
@@ -151,10 +175,24 @@ describe('RedirectsController', () => {
       ETag: ETAG,
       Body: { transformToString: sandbox.stub().resolves('') },
     });
-    requestContext.pathInfo = { headers: { 'if-none-match': '*' } };
+    withIfNoneMatch('*');
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(304);
+  });
+
+  it('returns 304 on If-None-Match: * even when S3 omits ETag (RFC 7232 §3.2)', async () => {
+    // `*` matches any existing representation. The controller only reaches
+    // the conditional-GET branch after a successful S3 GET, so a rep exists.
+    mockS3.s3Client.send.resolves({
+      Body: { transformToString: sandbox.stub().resolves('') },
+    });
+    withIfNoneMatch('*');
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(304);
+    // No ETag was available to echo back, but 304 is still correct for `*`.
+    expect(response.headers.get('etag')).to.be.null;
   });
 
   it('returns 304 when If-None-Match is a multi-value list containing the current ETag', async () => {
@@ -162,7 +200,18 @@ describe('RedirectsController', () => {
       ETag: ETAG,
       Body: { transformToString: sandbox.stub().resolves('') },
     });
-    requestContext.pathInfo = { headers: { 'if-none-match': `"other", ${ETAG}, "another"` } };
+    withIfNoneMatch(`"other", ${ETAG}, "another"`);
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(304);
+  });
+
+  it('returns 304 for a mixed weak/strong list where a weak-tagged validator matches', async () => {
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves('') },
+    });
+    withIfNoneMatch(`"other", W/${ETAG}, "another"`);
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(304);
@@ -173,10 +222,74 @@ describe('RedirectsController', () => {
       ETag: ETAG,
       Body: { transformToString: sandbox.stub().resolves('') },
     });
-    requestContext.pathInfo = { headers: { 'if-none-match': `W/${ETAG}` } };
+    withIfNoneMatch(`W/${ETAG}`);
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(304);
+  });
+
+  it('serves 200 when S3 returns a malformed (unquoted) ETag even if the client-sent validator would textually match', async () => {
+    // Defense in depth: if S3 (or a future backend) surfaces a validator that
+    // is not a proper quoted opaque-tag, we must not honor conditional GETs
+    // against it — serve the body so the client can rebuild derived state.
+    const overlay = 'x y\n';
+    mockS3.s3Client.send.resolves({
+      ETag: 'malformed-no-quotes',
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+    withIfNoneMatch('"malformed-no-quotes"');
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(200);
+    // The malformed ETag is still passed through on the 200 (defensive — it's
+    // opaque to us; that's between the writer and the client's cache).
+    expect(await response.text()).to.equal(overlay);
+  });
+
+  it('serves 200 when S3 omits ETag and client sends a specific (non-*) validator', async () => {
+    // Belt-and-braces: with no server ETag and a specific INM, the compare
+    // must yield "no match" — never a spurious 304 against undefined.
+    // Also exercises the `currentEtag || ''` fallback in ifNoneMatchMatches.
+    const overlay = 'x y\n';
+    mockS3.s3Client.send.resolves({
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+    withIfNoneMatch(ETAG);
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(200);
+    expect(await response.text()).to.equal(overlay);
+    expect(response.headers.get('etag')).to.be.null;
+  });
+
+  it('rejects an unquoted validator (must be an RFC 7232 opaque-tag) and serves 200', async () => {
+    // `abc` without surrounding quotes is not a valid opaque-tag. Accepting
+    // it would silently 304 against a shell-stripped or otherwise corrupted
+    // validator instead of forcing a fresh fetch.
+    const overlay = 'x y\n';
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+    withIfNoneMatch('d41d8cd98f00b204e9800998ecf8427e'); // no quotes
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(200);
+    expect(await response.text()).to.equal(overlay);
+  });
+
+  it('rejects a lowercase weak prefix (RFC 7232 §2.3 W/ is case-sensitive) and serves 200', async () => {
+    // `w/"..."` is malformed. We deliberately do not normalize to lowercase.
+    const overlay = 'x y\n';
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+    withIfNoneMatch(`w/${ETAG}`);
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(200);
+    expect(await response.text()).to.equal(overlay);
   });
 
   it('returns 200 with fresh body when If-None-Match does not match the current ETag', async () => {
@@ -185,7 +298,7 @@ describe('RedirectsController', () => {
       ETag: ETAG,
       Body: { transformToString: sandbox.stub().resolves(overlay) },
     });
-    requestContext.pathInfo = { headers: { 'if-none-match': '"stale-etag"' } };
+    withIfNoneMatch('"stale-etag"');
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(200);
@@ -199,18 +312,35 @@ describe('RedirectsController', () => {
       ETag: ETAG,
       Body: { transformToString: sandbox.stub().resolves(overlay) },
     });
-    requestContext.pathInfo = { headers: { 'if-none-match': '   ' } };
+    withIfNoneMatch('   ');
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(200);
     expect(await response.text()).to.equal(overlay);
   });
 
+  it('does not reflect CRLF / control chars from If-None-Match into response headers', async () => {
+    // Defense in depth: even though the header is never echoed, verify a
+    // malicious client with an injected `\r\n` cannot smuggle a header via
+    // If-None-Match. The value should be treated as opaque validator input.
+    const overlay = 'x y\n';
+    mockS3.s3Client.send.resolves({
+      ETag: ETAG,
+      Body: { transformToString: sandbox.stub().resolves(overlay) },
+    });
+    withIfNoneMatch(`${ETAG}\r\nX-Injected: evil`);
+
+    const response = await controller.getRedirects(requestContext);
+    // Injected token does not match the strong current ETag, so we serve 200.
+    expect(response.status).to.equal(200);
+    expect(response.headers.get('x-injected')).to.be.null;
+  });
+
   it('still returns 404 (not 304) when the site does not resolve — no enumeration signal via If-None-Match', async () => {
     // Guard: If-None-Match must not short-circuit authz. A non-entitled tenant
     // sending a valid ETag for some *other* tenant's overlay must still 404.
     mockDataAccess.Site.findByExternalOwnerIdAndExternalSiteId.resolves(null);
-    requestContext.pathInfo = { headers: { 'if-none-match': ETAG } };
+    withIfNoneMatch(ETAG);
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
@@ -220,7 +350,19 @@ describe('RedirectsController', () => {
 
   it('still returns 404 (not 304) when If-None-Match: * is sent by a non-entitled tenant', async () => {
     mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
-    requestContext.pathInfo = { headers: { 'if-none-match': '*' } };
+    withIfNoneMatch('*');
+
+    const response = await controller.getRedirects(requestContext);
+    expect(response.status).to.equal(404);
+    expect(mockS3.s3Client.send.called).to.be.false;
+  });
+
+  it('still returns 404 (not 304) when an unenrolled site sends If-None-Match', async () => {
+    // Third authz gate: site + entitlement pass, enrollment fails.
+    mockDataAccess.SiteEnrollment.allBySiteId.resolves([
+      { getEntitlementId: () => 'some-other-entitlement' },
+    ]);
+    withIfNoneMatch(ETAG);
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);

--- a/test/controllers/redirects.test.js
+++ b/test/controllers/redirects.test.js
@@ -344,6 +344,7 @@ describe('RedirectsController', () => {
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     // Authz failed before S3 was touched.
     expect(mockS3.s3Client.send.called).to.be.false;
   });
@@ -354,6 +355,7 @@ describe('RedirectsController', () => {
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockS3.s3Client.send.called).to.be.false;
   });
 
@@ -366,6 +368,7 @@ describe('RedirectsController', () => {
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockS3.s3Client.send.called).to.be.false;
   });
 
@@ -373,6 +376,7 @@ describe('RedirectsController', () => {
     requestContext.params.service = 'not-a-cm-service';
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(400);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockS3.s3Client.send.called).to.be.false;
   });
 
@@ -380,6 +384,7 @@ describe('RedirectsController', () => {
     mockDataAccess.Site.findByExternalOwnerIdAndExternalSiteId.resolves(null);
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockS3.s3Client.send.called).to.be.false;
   });
 
@@ -387,6 +392,7 @@ describe('RedirectsController', () => {
     mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockS3.s3Client.send.called).to.be.false;
   });
 
@@ -396,6 +402,7 @@ describe('RedirectsController', () => {
     ]);
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockS3.s3Client.send.called).to.be.false;
   });
 
@@ -406,6 +413,7 @@ describe('RedirectsController', () => {
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
   });
 
   it('returns 404 when S3 surfaces a 404 via $metadata', async () => {
@@ -415,6 +423,7 @@ describe('RedirectsController', () => {
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
   });
 
   it('maps AccessDenied (no ListBucket → 403 on missing key) to 404 and logs error', async () => {
@@ -425,6 +434,7 @@ describe('RedirectsController', () => {
 
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(404);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     // Logged at error so a missing IAM grant (every request 403) stays alertable.
     expect(mockContext.log.error.called).to.be.true;
   });
@@ -433,6 +443,7 @@ describe('RedirectsController', () => {
     mockS3.s3Client.send.rejects(new Error('boom'));
     const response = await controller.getRedirects(requestContext);
     expect(response.status).to.equal(500);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockContext.log.error.called).to.be.true;
   });
 
@@ -440,6 +451,78 @@ describe('RedirectsController', () => {
     const ctl = RedirectsController({ ...mockContext, env: {} });
     const response = await ctl.getRedirects(requestContext);
     expect(response.status).to.equal(500);
+    expect(response.headers.get('cache-control')).to.equal('no-store');
     expect(mockS3.s3Client.send.called).to.be.false;
+  });
+
+  describe('negative-cache-control invariant', () => {
+    // Grouped invariant: every non-2xx/3xx response MUST advertise `no-store`
+    // so Fastly (and any downstream CDN) cannot cache negative responses.
+    // Without this, the aso-prod Fastly VCL default (10s TTL + 30s SWR + 86400s
+    // stale_if_error) pins a 404 for up to 24 h after any origin blip, causing
+    // the customer-provisioning race where dispatchers keep serving stale
+    // 404s long after ASO entitlement lands. See SITES-44966 / SITES-47966.
+    const scenarios = [
+      {
+        name: '400 (malformed service id)',
+        expectedStatus: 400,
+        setup: () => { requestContext.params.service = 'x'; },
+      },
+      {
+        name: '500 (bucket not configured)',
+        expectedStatus: 500,
+        setup: () => { controller = RedirectsController({ ...mockContext, env: {} }); },
+      },
+      {
+        name: '404 (site not found)',
+        expectedStatus: 404,
+        setup: () => mockDataAccess.Site.findByExternalOwnerIdAndExternalSiteId.resolves(null),
+      },
+      {
+        name: '404 (no ASO entitlement)',
+        expectedStatus: 404,
+        setup: () => mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null),
+      },
+      {
+        name: '404 (not enrolled)',
+        expectedStatus: 404,
+        setup: () => mockDataAccess.SiteEnrollment.allBySiteId.resolves([
+          { getEntitlementId: () => 'other' },
+        ]),
+      },
+      {
+        name: '404 (S3 NoSuchKey)',
+        expectedStatus: 404,
+        setup: () => {
+          const err = new Error('e');
+          err.name = 'NoSuchKey';
+          mockS3.s3Client.send.rejects(err);
+        },
+      },
+      {
+        name: '404 (S3 AccessDenied maps to 404)',
+        expectedStatus: 404,
+        setup: () => {
+          const err = new Error('e');
+          err.name = 'AccessDenied';
+          err.$metadata = { httpStatusCode: 403 };
+          mockS3.s3Client.send.rejects(err);
+        },
+      },
+      {
+        name: '500 (unexpected S3 error)',
+        expectedStatus: 500,
+        setup: () => mockS3.s3Client.send.rejects(new Error('boom')),
+      },
+    ];
+
+    scenarios.forEach(({ name, expectedStatus, setup }) => {
+      it(`emits Cache-Control: no-store on ${name}`, async () => {
+        setup();
+        const response = await controller.getRedirects(requestContext);
+        expect(response.status).to.equal(expectedStatus);
+        expect(response.headers.get('cache-control')).to.equal('no-store');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Emit `ETag` (S3-passthrough) on 200 responses so the dispatcher-side [`aso.sh`](https://git.corp.adobe.com/experience-platform/skyline-httpd/blob/main/hooks/aso.sh) can persist a validator and revalidate on subsequent polls.
- Honor `If-None-Match` per RFC 7232 (weak comparison, `*` wildcard, comma-separated list, `W/` prefix tolerance) -> return **`304 Not Modified`** with `ETag` + `Cache-Control` and no body when the client's cached validator still matches.
- All authz gates (site resolution, ASO entitlement, site enrollment) evaluate **before** the conditional-GET branch - a non-entitled tenant sending a valid ETag for another tenant's overlay still receives an indistinguishable `404` (no enumeration signal, preserving the Lite-E property from ADR `aso-dispatcher-overlay`).

## Why
`spacecat.experiencecloud.live/config/<env>/cm-p*-e*/redirects.txt` is polled by the `httpd-gitinit-sidecar` inside every AEM publish pod. Today every poll re-downloads the full map, rebuilds the SDBM `.dir/.pag`, and re-injects the vhost include - even when nothing changed. This is a prerequisite Iakob flagged for the `dev -> devxl -> stage -> prod` gradual rollout of ASO dispatcher-layer autofix (SITES-44966). ETag support here unblocks the sidecar-side change to skip the dbm rebuild + rewrite re-inject on unchanged responses.

Jira: [SITES-47966](https://jira.corp.adobe.com/browse/SITES-47966) - Relates to [SITES-44966](https://jira.corp.adobe.com/browse/SITES-44966).

Supersedes closed #2808 (fork-authored - CI could not access private-dep secret).

## Behavior

Current (unconditional):
```bash
$ curl -sS -D - -H "X-ASO-API-Key: $KEY" \
    "https://spacecat.experiencecloud.live/config/prod/cm-p128729-e2179647/redirects.txt"
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Cache-Control: max-age=10

<full overlay body>
```

After this PR (conditional):
```bash
# Round 1 - no cached validator yet.
$ curl -sS -D - -H "X-ASO-API-Key: $KEY" \
    "https://spacecat.experiencecloud.live/config/dev/cm-p128729-e2179647/redirects.txt"
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Cache-Control: max-age=10
ETag: "d41d8cd98f00b204e9800998ecf8427e"

<overlay body>

# Round 2 - echo the ETag back.
$ curl -sS -D - -H "X-ASO-API-Key: $KEY" \
    -H 'If-None-Match: "d41d8cd98f00b204e9800998ecf8427e"' \
    "https://spacecat.experiencecloud.live/config/dev/cm-p128729-e2179647/redirects.txt"
HTTP/1.1 304 Not Modified
Content-Type: text/plain; charset=utf-8
Cache-Control: max-age=10
ETag: "d41d8cd98f00b204e9800998ecf8427e"

# Round 3 - after the overlay is rewritten in S3, the ETag changes and a stale validator misses.
$ curl -sS -D - -H "X-ASO-API-Key: $KEY" \
    -H 'If-None-Match: "stale-validator"' \
    "https://spacecat.experiencecloud.live/config/dev/cm-p128729-e2179647/redirects.txt"
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Cache-Control: max-age=10
ETag: "<new-etag>"

<new body>
```

## What's covered

- `If-None-Match: "tag"` matches the current `ETag` -> **304**.
- `If-None-Match: *` on an existing resource -> **304**.
- `If-None-Match: "other", "tag", "another"` (multi-value list) -> **304** when any element matches.
- `If-None-Match: W/"tag"` vs strong `"tag"` -> **304** (RFC 7232 §2.3.2 weak comparison).
- `If-None-Match` header absent / empty / whitespace -> normal **200 + ETag**.
- Authz failures (no site, no entitlement, no enrollment) -> **404** regardless of `If-None-Match` (guards against ETag-driven enumeration).
- `S3 GetObject` never returns `ETag` (defensive; multipart / future storage backend) -> falls back to **200** without ETag.
- On **304** the body is never deserialized - `transformToString()` isn't called, so we don't pay the deserialize cost on hits.

## Follow-up (not in this PR)
Once this lands on dev and burns in, [~iakobchu] to PR the client-side change into `experience-platform/skyline-httpd/hooks/aso.sh` -> `download_aso_map`: persist the ETag alongside `aso.map.{dir,pag}` under `RUNNINGCONFIG/opt-in/aso.map.etag`, send `If-None-Match` on subsequent polls, add `rc=3 (not-modified)` so `handle_aso_map` skips the dbm rebuild + rewrite re-inject on unchanged responses. Will file a separate SITES ticket when we get to the sidecar rollout.

## Test plan
- [x] `npx mocha test/controllers/redirects.test.js` - 21/21 pass locally (10 new tests covering all branches above).
- [x] `npx eslint src/controllers/redirects.js test/controllers/redirects.test.js` - clean.
- [x] `npm run docs:lint` - OpenAPI spec valid, no new warnings.
- [x] `npm run docs:build` - bundled successfully.
- [ ] CI green.
- [ ] Post-merge dev verification via curl against `https://spacecat.experiencecloud.live/config/dev/cm-p128729-e2179647/redirects.txt`:
  - Round 1 unconditional -> capture `ETag`.
  - Round 2 with `If-None-Match: <etag>` -> `304`.
  - Round 3 with stale ETag -> `200 + new ETag`.

## Notes for reviewers
- Fastly VCL (`fetch/100-aso-overlay-ttl.vcl`, in `spacecat-infrastructure`) is expected to pass `ETag` on the response and `If-None-Match` on the request without stripping - I'll verify on dev after merge; if it strips either, follow-up VCL change goes onto the SITES ticket.
- We deliberately still do `GetObject` (not `HeadObject`) on the conditional branch - cost of pulling the small overlay body over the wire is dominated by the S3 request itself, so switching to Head would double the request count on cache misses. Room to push `If-None-Match` down to the S3 SDK as a future optimization if fleet-wide poll load makes it worthwhile.

Generated with [Claude Code](https://claude.com/claude-code)