### PR TITLE
feat(prompts): source-aware upsertPrompts + reject unregistered sources

### DIFF
--- a/src/support/prompt-sources.js
+++ b/src/support/prompt-sources.js
@@ -84,11 +84,12 @@ export function isPermittedSource(source) {
  */
 export function assertPermittedSource(source) {
   if (!isPermittedSource(source)) {
+    // Echo the rejected value JSON-escaped and length-capped so a crafted source
+    // (newlines, control chars) cannot forge log lines, and keep internal repo/
+    // file names out of this client-facing 400 message.
+    const shown = JSON.stringify(String(source).slice(0, 64));
     const err = new Error(
-      `Unregistered prompt source '${source}'. Register it in `
-      + 'llmo-data-retrieval-service prompt_source.py (TRACKED_PROMPT_SOURCES) '
-      + 'and mirror it in spacecat-api-service prompt-sources.js before writing '
-      + 'prompts with it.',
+      `Unregistered prompt source ${shown}. It must be a registered prompt source.`,
     );
     err.status = 400;
     throw err;

--- a/src/support/prompt-sources.js
+++ b/src/support/prompt-sources.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Canonical allowlist for the `prompts.source` write chokepoint (SITES-47870).
+ *
+ * `source` records which pipeline/initiative produced a prompt; the LLMO usage
+ * report groups by it (one column per source), and — since the source is now
+ * part of the prompt uniqueness key `(brand_id, lower(text), sorted_regions,
+ * source)` — the same text produced by two pipelines coexists as separate rows.
+ *
+ * The DRS-side canonical registry lives in
+ * `llmo-data-retrieval-service` `src/common/models/prompt_source.py`
+ * (`TRACKED_PROMPT_SOURCES`). This module MUST mirror `TRACKED_PROMPT_SOURCES`;
+ * it additionally permits the legacy/UI source values already present in the
+ * column so the chokepoint does not reject writers that predate the registry.
+ */
+
+/**
+ * Pipeline sources — mirror of DRS `TRACKED_PROMPT_SOURCES` keys. A new
+ * prompt-generation pipeline registers its source here AND in the DRS module.
+ * @type {string[]}
+ */
+export const TRACKED_PROMPT_SOURCES = [
+  'gsc',
+  'base_url',
+  'citation_attempt',
+  'strategy-chat',
+  'semrush',
+  'synthetic_personas',
+];
+
+/**
+ * Legacy / UI-originated source values already written to `prompts.source`
+ * before the registry existed (see the column comment in mysticat-data-service):
+ * the schema default `config`, CSV `sheet`, and pre-registry writers including
+ * hyphen/underscore drift variants. Permitted so the chokepoint does not break
+ * existing writers or UI prompt creation. A deferred canonicalization pass
+ * (SITES-47870 §10) will collapse the drift variants and shrink this list.
+ * @type {string[]}
+ */
+export const PERMITTED_LEGACY_SOURCES = [
+  'config',
+  'sheet',
+  'brand-concierge',
+  'page-content',
+  'synthetic-personas',
+  'citation-attempt',
+  'agentic_traffic',
+];
+
+/** Full allowlist accepted at the write boundary. */
+export const PERMITTED_PROMPT_SOURCES = new Set([
+  ...TRACKED_PROMPT_SOURCES,
+  ...PERMITTED_LEGACY_SOURCES,
+]);
+
+/**
+ * @param {string} source
+ * @returns {boolean} true if `source` may be persisted to `prompts.source`.
+ */
+export function isPermittedSource(source) {
+  return PERMITTED_PROMPT_SOURCES.has(source);
+}
+
+/**
+ * Write-boundary chokepoint (SITES-47870 / D2). Throws a 400-typed error unless
+ * `source` is a permitted value. Covers UI-originated writes (e.g. `semrush` /
+ * `synthetic_personas` recommendation-accept) that never touch the DRS writer,
+ * so a client cannot introduce an untracked source the usage report can't
+ * attribute to a column.
+ *
+ * @param {string} source - resolved prompt source (after the `|| 'config'` default)
+ * @throws {Error} with `.status = 400` when the source is not permitted
+ */
+export function assertPermittedSource(source) {
+  if (!isPermittedSource(source)) {
+    const err = new Error(
+      `Unregistered prompt source '${source}'. Register it in `
+      + 'llmo-data-retrieval-service prompt_source.py (TRACKED_PROMPT_SOURCES) '
+      + 'and mirror it in spacecat-api-service prompt-sources.js before writing '
+      + 'prompts with it.',
+    );
+    err.status = 400;
+    throw err;
+  }
+}

--- a/src/support/prompt-sources.js
+++ b/src/support/prompt-sources.js
@@ -28,6 +28,8 @@
 /**
  * Pipeline sources — mirror of DRS `TRACKED_PROMPT_SOURCES` keys. A new
  * prompt-generation pipeline registers its source here AND in the DRS module.
+ * @see llmo-data-retrieval-service/src/common/models/prompt_source.py
+ *   (`TRACKED_PROMPT_SOURCES`) — the canonical registry; keep this list in sync.
  * @type {string[]}
  */
 export const TRACKED_PROMPT_SOURCES = [

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -16,6 +16,7 @@ import { hasText, isValidUUID } from '@adobe/spacecat-shared-utils';
 
 import { classifyIntents } from './intent-classifier.js';
 import { throwOnPgConstraintViolation } from './errors.js';
+import { assertPermittedSource } from './prompt-sources.js';
 import { INTENT_VALUES, normalizeIntent } from './intent.js';
 
 // Re-exported for backward compatibility — `normalizeIntent`/`INTENT_VALUES` now
@@ -728,8 +729,8 @@ export async function upsertPrompts({
   const [{ data: existing }, lookups] = await Promise.all([
     withMissingIntentFallback(postgrestClient, (includeIntent) => {
       const cols = includeIntent
-        ? 'id,prompt_id,text,regions,status,intent'
-        : 'id,prompt_id,text,regions,status';
+        ? 'id,prompt_id,text,regions,status,source,intent'
+        : 'id,prompt_id,text,regions,status,source';
       let q = postgrestClient
         .from('prompts')
         .select(cols)
@@ -748,14 +749,23 @@ export async function upsertPrompts({
   // eslint-disable-next-line no-await-in-loop,max-len
   await ensureLookupEntries(organizationId, prompts, categoryMap, topicMap, postgrestClient, updatedBy);
 
+  // `source` is part of prompt identity (SITES-47870): the store's unique key is
+  // (brand_id, lower(text), sorted_regions(regions), source), so the same text
+  // and regions produced by two pipelines coexists as separate per-source rows.
+  // Match/dedup here must therefore key on source too, or an incoming prompt
+  // would be matched to an existing same-text row of a DIFFERENT source and
+  // update it (moving counts between columns) instead of inserting its own row.
   const getKey = (p) => {
     const norm = (p.regions || []).map((r) => String(r).toLowerCase()).sort();
-    return `${String(p.prompt || p.text || '').trim().toLowerCase()}:${norm.join(',')}`;
+    const src = p.source || 'config';
+    return `${String(p.prompt || p.text || '').trim().toLowerCase()}:${norm.join(',')}:${src}`;
   };
 
   const existingById = new Map((existing || []).map((p) => [p.prompt_id, p]));
   const existingByKey = new Map(
-    (existing || []).map((p) => [getKey({ prompt: p.text, regions: p.regions }), p]),
+    (existing || []).map(
+      (p) => [getKey({ prompt: p.text, regions: p.regions, source: p.source }), p],
+    ),
   );
 
   const toInsert = [];
@@ -765,12 +775,17 @@ export async function upsertPrompts({
   for (const p of prompts) {
     const text = p.prompt || p.text;
     const regions = p.regions || [];
+    const source = p.source || 'config';
+    // Write-boundary chokepoint (SITES-47870 / D2): reject an unregistered
+    // source before it is persisted — the only place UI-originated writes
+    // (e.g. semrush / synthetic_personas accept) can be covered.
+    assertPermittedSource(source);
     const promptId = hasText(p.id)
       ? p.id
       : (p.prompt_id || crypto.randomUUID().toString());
 
     // eslint-disable-next-line max-len
-    const match = existingById.get(promptId) || existingByKey.get(getKey({ prompt: text, regions }));
+    const match = existingById.get(promptId) || existingByKey.get(getKey({ prompt: text, regions, source }));
 
     const categoryUuid = hasText(p.category)
       ? categoryMap.get(p.category.toLowerCase().trim()) || null
@@ -790,7 +805,7 @@ export async function upsertPrompts({
       topic_id: topicUuid,
       status: p.status || 'active',
       origin: p.origin || 'human',
-      source: p.source || 'config',
+      source,
       intent: normalizeIntent(p.intent),
       updated_by: updatedBy,
     };
@@ -819,9 +834,11 @@ export async function upsertPrompts({
     }
   }
 
-  // Guard against uq_prompt_text_region_per_brand: deduplicate toInsert by
-  // (lower(text), sorted_regions) before the bulk INSERT. For a new brand
-  // existingByKey is empty, so cross-topic text collisions all land here.
+  // Guard against uq_prompt_text_region_source_per_brand: deduplicate toInsert
+  // by (lower(text), sorted_regions, source) before the bulk INSERT. For a new
+  // brand existingByKey is empty, so cross-topic text collisions all land here.
+  // `source` is part of the key (SITES-47870), so the same text under two
+  // different sources is NOT a collision — each keeps its own row.
   // Deterministic tie-break: sort by (topic_id, prompt_id) asc, keep first.
   // Each drop is logged (warn) with a text hash — auditable without echoing
   // customer data. Dropped entries are removed from processed so counts stay
@@ -830,7 +847,7 @@ export async function upsertPrompts({
     const dedupKey = (row) => {
       const t = String(row.text || '').trim().toLowerCase();
       const r = [...(row.regions || [])].map((x) => String(x).toLowerCase()).sort().join(',');
-      return `${t}:${r}`;
+      return `${t}:${r}:${row.source}`;
     };
     const sortedForDedup = [...toInsert].sort((a, b) => {
       const tCmp = String(a.topic_id ?? '').localeCompare(String(b.topic_id ?? ''));
@@ -902,7 +919,7 @@ export async function upsertPrompts({
     );
     if (error) {
       throwOnPgConstraintViolation(error, {
-        23505: { status: 409, message: 'A prompt with the same text and region already exists for this brand.' },
+        23505: { status: 409, message: 'A prompt with the same text, region and source already exists for this brand.' },
       });
       throw new Error(`Failed to insert prompts: ${error.message}`);
     }

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -722,6 +722,15 @@ export async function upsertPrompts({
     throw new Error('PostgREST client is required for prompts');
   }
 
+  // Write-boundary chokepoint (SITES-47870 / D2): validate every source up front,
+  // before any DB work or side effects. ensureLookupEntries (below) creates
+  // category/topic rows for the whole batch, so validating per-prompt inside the
+  // main loop would leave orphan lookup rows when a later prompt's source is
+  // rejected. Fail the whole batch first, cleanly.
+  for (const p of prompts) {
+    assertPermittedSource(p.source || 'config');
+  }
+
   const incomingIds = prompts
     .map((p) => p.id || p.prompt_id)
     .filter(hasText);
@@ -776,10 +785,6 @@ export async function upsertPrompts({
     const text = p.prompt || p.text;
     const regions = p.regions || [];
     const source = p.source || 'config';
-    // Write-boundary chokepoint (SITES-47870 / D2): reject an unregistered
-    // source before it is persisted — the only place UI-originated writes
-    // (e.g. semrush / synthetic_personas accept) can be covered.
-    assertPermittedSource(source);
     const promptId = hasText(p.id)
       ? p.id
       : (p.prompt_id || crypto.randomUUID().toString());
@@ -810,6 +815,13 @@ export async function upsertPrompts({
       updated_by: updatedBy,
     };
 
+    // `source` is immutable on an UPDATE (SITES-47870). getKey folds source into
+    // the match key, so a key-match always shares source; but existingById
+    // matches by prompt_id ALONE, so an id-match can carry a different incoming
+    // source. Overwriting it would silently move an existing row between report
+    // columns (the exact corruption the source-aware key prevents) and could
+    // raise an unmapped 23505 on the UPDATE. Preserve the stored source; source
+    // is only set at insert time. (Existing rows are NOT NULL source.)
     if (match && match.status !== 'active') {
       if (match.status === 'deleted') {
         const reactivated = {
@@ -817,6 +829,7 @@ export async function upsertPrompts({
           id: match.id,
           status: 'active',
           intent: row.intent ?? match.intent,
+          source: match.source ?? source,
         };
         toUpdate.push(reactivated);
         processed.push({ ...reactivated, prompt_id: promptId });
@@ -826,8 +839,9 @@ export async function upsertPrompts({
     }
 
     if (match) {
-      toUpdate.push({ ...row, id: match.id });
-      processed.push({ ...row, prompt_id: promptId });
+      const updated = { ...row, id: match.id, source: match.source ?? source };
+      toUpdate.push(updated);
+      processed.push({ ...updated, prompt_id: promptId });
     } else {
       toInsert.push(row);
       processed.push({ ...row, prompt_id: promptId });

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -692,8 +692,24 @@ export async function getPromptById({
 }
 
 /**
+ * Canonical prompt-identity key: `lower(text):sorted(regions):source`, matching
+ * the store's partial unique index (brand_id, lower(text), sorted_regions, source)
+ * (SITES-47870). Both the incoming-match map and the pre-insert dedup use this so
+ * their normalization can't drift apart. `source` defaults to 'config' to mirror
+ * the column default for prompts that omit it.
+ *
+ * @param {{ text?: string, regions?: string[], source?: string }} p
+ * @returns {string}
+ */
+function buildPromptKey({ text, regions, source }) {
+  const t = String(text || '').trim().toLowerCase();
+  const r = (regions || []).map((x) => String(x).toLowerCase()).sort().join(',');
+  return `${t}:${r}:${source || 'config'}`;
+}
+
+/**
  * Upserts prompts into the prompts table.
- * Match by id (prompt_id) or by (text, regions). Regions normalized (lowercase, sorted).
+ * Match by id (prompt_id) or by (text, regions, source). Regions normalized (lowercase, sorted).
  *
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat organization UUID
@@ -764,11 +780,11 @@ export async function upsertPrompts({
   // Match/dedup here must therefore key on source too, or an incoming prompt
   // would be matched to an existing same-text row of a DIFFERENT source and
   // update it (moving counts between columns) instead of inserting its own row.
-  const getKey = (p) => {
-    const norm = (p.regions || []).map((r) => String(r).toLowerCase()).sort();
-    const src = p.source || 'config';
-    return `${String(p.prompt || p.text || '').trim().toLowerCase()}:${norm.join(',')}:${src}`;
-  };
+  const getKey = (p) => buildPromptKey({
+    text: p.prompt || p.text,
+    regions: p.regions,
+    source: p.source,
+  });
 
   const existingById = new Map((existing || []).map((p) => [p.prompt_id, p]));
   const existingByKey = new Map(
@@ -821,7 +837,11 @@ export async function upsertPrompts({
     // source. Overwriting it would silently move an existing row between report
     // columns (the exact corruption the source-aware key prevents) and could
     // raise an unmapped 23505 on the UPDATE. Preserve the stored source; source
-    // is only set at insert time. (Existing rows are NOT NULL source.)
+    // is only set at insert time. The `match.source ?? source` below is a
+    // defensive fallback only: the companion migration (#793) makes prompts.source
+    // NOT NULL, so match.source is always present for a real DB row — the `??`
+    // just keeps an in-memory/test row without a source from becoming `undefined`;
+    // it is NOT a backfill path.
     if (match && match.status !== 'active') {
       if (match.status === 'deleted') {
         const reactivated = {
@@ -858,11 +878,7 @@ export async function upsertPrompts({
   // customer data. Dropped entries are removed from processed so counts stay
   // honest. Guard is > 1: a single-row batch cannot collide with itself.
   if (toInsert.length > 1) {
-    const dedupKey = (row) => {
-      const t = String(row.text || '').trim().toLowerCase();
-      const r = [...(row.regions || [])].map((x) => String(x).toLowerCase()).sort().join(',');
-      return `${t}:${r}:${row.source}`;
-    };
+    const dedupKey = (row) => buildPromptKey(row);
     const sortedForDedup = [...toInsert].sort((a, b) => {
       const tCmp = String(a.topic_id ?? '').localeCompare(String(b.topic_id ?? ''));
       return tCmp !== 0 ? tCmp : String(a.prompt_id).localeCompare(String(b.prompt_id));

--- a/test/support/prompt-sources.test.js
+++ b/test/support/prompt-sources.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import {
   TRACKED_PROMPT_SOURCES,
+  PERMITTED_LEGACY_SOURCES,
   PERMITTED_PROMPT_SOURCES,
   isPermittedSource,
   assertPermittedSource,
@@ -26,9 +27,11 @@ describe('prompt-sources (SITES-47870 write chokepoint)', () => {
     }
   });
 
-  it("permits the schema default 'config' and legacy/UI sources", () => {
-    for (const source of ['config', 'sheet', 'brand-concierge', 'page-content']) {
+  it('permits every legacy/UI source (config, sheet, drift variants)', () => {
+    expect(PERMITTED_LEGACY_SOURCES).to.include('config');
+    for (const source of PERMITTED_LEGACY_SOURCES) {
       expect(isPermittedSource(source), source).to.equal(true);
+      expect(() => assertPermittedSource(source)).to.not.throw();
     }
   });
 

--- a/test/support/prompt-sources.test.js
+++ b/test/support/prompt-sources.test.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  TRACKED_PROMPT_SOURCES,
+  PERMITTED_PROMPT_SOURCES,
+  isPermittedSource,
+  assertPermittedSource,
+} from '../../src/support/prompt-sources.js';
+
+describe('prompt-sources (SITES-47870 write chokepoint)', () => {
+  it('permits every tracked pipeline source', () => {
+    for (const source of TRACKED_PROMPT_SOURCES) {
+      expect(isPermittedSource(source), source).to.equal(true);
+      expect(() => assertPermittedSource(source)).to.not.throw();
+    }
+  });
+
+  it("permits the schema default 'config' and legacy/UI sources", () => {
+    for (const source of ['config', 'sheet', 'brand-concierge', 'page-content']) {
+      expect(isPermittedSource(source), source).to.equal(true);
+    }
+  });
+
+  it('mirrors the DRS tracked pipeline sources', () => {
+    // Guards against drift with llmo-data-retrieval-service prompt_source.py.
+    expect(TRACKED_PROMPT_SOURCES).to.have.members([
+      'gsc',
+      'base_url',
+      'citation_attempt',
+      'strategy-chat',
+      'semrush',
+      'synthetic_personas',
+    ]);
+    for (const source of TRACKED_PROMPT_SOURCES) {
+      expect(PERMITTED_PROMPT_SOURCES.has(source)).to.equal(true);
+    }
+  });
+
+  it('rejects an unregistered source with a 400-typed error', () => {
+    expect(isPermittedSource('totally-bogus')).to.equal(false);
+    let thrown;
+    try {
+      assertPermittedSource('totally-bogus');
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).to.be.an('error');
+    expect(thrown.status).to.equal(400);
+    expect(thrown.message).to.match(/Unregistered prompt source/);
+  });
+});

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -1062,6 +1062,79 @@ describe('prompts-storage', () => {
       expect(err.status).to.equal(400);
     });
 
+    it('preserves the stored source on an id-match update (SITES-47870 immutability)', async () => {
+      const existing = [{
+        id: 'u1', prompt_id: 'p1', text: 'Kept', regions: ['us'], status: 'active', source: 'gsc',
+      }];
+      const insertStub = sinon.stub().returns({
+        select: () => thenable({ data: [], error: null }),
+      });
+      const updateStub = sinon.stub().returns({ eq: () => thenable({ error: null }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: existing, error: null }),
+                    in: () => thenable({ data: existing, error: null }),
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+      // Incoming matches by prompt_id but carries a DIFFERENT source; the stored
+      // 'gsc' must NOT be overwritten to 'semrush'.
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{
+          id: 'p1', prompt: 'Kept', regions: ['us'], source: 'semrush',
+        }],
+        postgrestClient: client,
+      });
+      expect(result.updated).to.equal(1);
+      expect(insertStub.called).to.equal(false);
+      expect(updateStub.firstCall.args[0].source).to.equal('gsc');
+      expect(result.prompts[0].source).to.equal('gsc');
+    });
+
+    it('keeps two new same-text/different-source prompts as separate inserts (dedup by source)', async () => {
+      const insertStub = sinon.stub().returns({
+        select: () => thenable({ data: [{ prompt_id: 'a' }, { prompt_id: 'b' }], error: null }),
+      });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [
+          { prompt: 'Shared', regions: ['us'], source: 'gsc' },
+          { prompt: 'Shared', regions: ['us'], source: 'base_url' },
+        ],
+        postgrestClient: client,
+      });
+      expect(result.created).to.equal(2);
+      const insertedSources = insertStub.firstCall.args[0].map((r) => r.source).sort();
+      expect(insertedSources).to.deep.equal(['base_url', 'gsc']);
+    });
+
     it('persists normalized intent on insert (lowercases, remaps; invalid -> null)', async () => {
       const insertStub = sinon.stub().returns({
         select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }),

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -971,6 +971,97 @@ describe('prompts-storage', () => {
       expect(result.prompts).to.have.lengthOf(1);
     });
 
+    it('treats same text+regions with a DIFFERENT source as a new row (SITES-47870)', async () => {
+      const existing = [{
+        id: 'u1', prompt_id: 'p-gsc', text: 'Shared prompt', regions: ['us'], status: 'active', source: 'gsc',
+      }];
+      const insertStub = sinon.stub().returns({
+        select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }),
+      });
+      const updateStub = sinon.stub().returns({ eq: () => thenable({ error: null }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({ eq: () => thenable({ data: existing, error: null }) }),
+              }),
+              insert: insertStub,
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ prompt: 'Shared prompt', regions: ['us'], source: 'base_url' }],
+        postgrestClient: client,
+      });
+      expect(result.created).to.equal(1);
+      expect(result.updated).to.equal(0);
+      expect(updateStub.called).to.equal(false);
+      expect(insertStub.firstCall.args[0][0].source).to.equal('base_url');
+    });
+
+    it('matches same text+regions+source to the existing row (updates, not inserts)', async () => {
+      const existing = [{
+        id: 'u1', prompt_id: 'p-gsc', text: 'Shared prompt', regions: ['us'], status: 'active', source: 'gsc',
+      }];
+      const insertStub = sinon.stub().returns({
+        select: () => thenable({ data: [], error: null }),
+      });
+      const updateStub = sinon.stub().returns({ eq: () => thenable({ error: null }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({ eq: () => thenable({ data: existing, error: null }) }),
+              }),
+              insert: insertStub,
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ prompt: 'Shared prompt', regions: ['us'], source: 'gsc' }],
+        postgrestClient: client,
+      });
+      expect(result.updated).to.equal(1);
+      expect(result.created).to.equal(0);
+      expect(insertStub.called).to.equal(false);
+    });
+
+    it('rejects an unregistered source with a 400 (SITES-47870 chokepoint)', async () => {
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+              insert: () => ({ select: () => thenable({ data: [], error: null }) }),
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const err = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ prompt: 'x', regions: [], source: 'totally-bogus' }],
+        postgrestClient: client,
+      }).catch((e) => e);
+      expect(err).to.be.an('error');
+      expect(err.message).to.match(/Unregistered prompt source/);
+      expect(err.status).to.equal(400);
+    });
+
     it('persists normalized intent on insert (lowercases, remaps; invalid -> null)', async () => {
       const insertStub = sinon.stub().returns({
         select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }),

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -1399,7 +1399,7 @@ describe('prompts-storage', () => {
 
     it('reactivates a deleted prompt matched by prompt_id', async () => {
       const deletedRow = {
-        id: 'row-uuid', prompt_id: 'del-1', text: 'Deleted text', regions: [], status: 'deleted',
+        id: 'row-uuid', prompt_id: 'del-1', text: 'Deleted text', regions: [], status: 'deleted', source: 'gsc',
       };
       const existingData = { data: [deletedRow], error: null };
       const updateStub = sinon.stub().returns({ eq: () => thenable({ error: null }) });
@@ -1432,11 +1432,53 @@ describe('prompts-storage', () => {
       expect(result.created).to.equal(0);
       expect(result.skipped).to.equal(0);
       expect(updateStub.callCount).to.equal(1);
+      // Reactivation preserves the stored source (SITES-47870 immutability).
+      expect(updateStub.firstCall.args[0].source).to.equal('gsc');
+    });
+
+    it('reactivating a deleted row by prompt_id keeps the stored source, not the incoming one', async () => {
+      // Deleted row is gsc-sourced; the incoming reactivation carries a DIFFERENT
+      // source. The id-match must NOT move the row to 'semrush'.
+      const deletedRow = {
+        id: 'row-uuid', prompt_id: 'del-1b', text: 'Reactivate me', regions: ['us'], status: 'deleted', source: 'gsc',
+      };
+      const existingData = { data: [deletedRow], error: null };
+      const updateStub = sinon.stub().returns({ eq: () => thenable({ error: null }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable(existingData),
+                    in: () => thenable(existingData),
+                  }),
+                }),
+              }),
+              insert: () => ({ select: () => thenable({ data: [], error: null }) }),
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{
+          id: 'del-1b', prompt: 'Reactivate me', regions: ['us'], source: 'semrush',
+        }],
+        postgrestClient: client,
+      });
+      expect(result.updated).to.equal(1);
+      expect(updateStub.firstCall.args[0].source).to.equal('gsc');
+      expect(result.prompts[0].source).to.equal('gsc');
     });
 
     it('reactivates a deleted prompt matched by text+regions without inserting', async () => {
       const deletedRow = {
-        id: 'row-uuid', prompt_id: 'del-2', text: 'Same text', regions: ['us'], status: 'deleted',
+        id: 'row-uuid', prompt_id: 'del-2', text: 'Same text', regions: ['us'], status: 'deleted', source: 'gsc',
       };
       const existingData = { data: [deletedRow], error: null };
       const insertSpy = sinon.stub().returns({
@@ -1459,11 +1501,12 @@ describe('prompts-storage', () => {
           return makeChain({});
         },
       };
-      // Incoming prompt has no id but matches the deleted row by text+regions
+      // Incoming prompt has no id but matches the deleted row by text+regions.
+      // source is part of the match key, so it must carry the same source to match.
       const result = await upsertPrompts({
         organizationId: ORG_ID,
         brandUuid: BRAND_UUID,
-        prompts: [{ prompt: 'Same text', regions: ['us'] }],
+        prompts: [{ prompt: 'Same text', regions: ['us'], source: 'gsc' }],
         postgrestClient: client,
       });
       expect(result.updated).to.equal(1);
@@ -1471,6 +1514,7 @@ describe('prompts-storage', () => {
       expect(result.skipped).to.equal(0);
       expect(insertSpy.callCount).to.equal(0);
       expect(updateStub.callCount).to.equal(1);
+      expect(updateStub.firstCall.args[0].source).to.equal('gsc');
     });
 
     it('does not reactivate a pending prompt — keeps it skipped', async () => {


### PR DESCRIPTION
## What

SITES-47870 (D0 **Option A** + D2 chokepoint). Companion to `mysticat-data-service` #793, which adds `source` to the prompts unique key `(brand_id, lower(text), sorted_regions(regions), source)`.

## Problem

`upsertPrompts` matched incoming prompts by `(lower(text), sorted_regions)` only. The same text produced by two pipelines was matched to whichever row already existed and **UPDATED** it — silently moving a prompt between sources (last-writer-wins). The LLMO usage report groups by `source`, so per-source columns were never stable.

## Change

- **Source-aware matching:** `getKey`, `existingByKey`, and the pre-insert `dedupKey` now include `source`, and the existing-rows SELECT fetches `source`. Same text+regions under a **different** source → new row (insert); same text+regions+**source** → matches and updates. Mirrors the new DB uniqueness key.
- **Write chokepoint** (`src/support/prompt-sources.js`): an allowlist that **mirrors the DRS `TRACKED_PROMPT_SOURCES` registry** plus the legacy/UI source values already present in `prompts.source` (`config`, `sheet`, `brand-concierge`, `page-content`, and hyphen-drift variants) so existing writers/UI are **not** broken. `assertPermittedSource()` throws a **400** for anything else — the only place UI-originated writes (`semrush` / `synthetic_personas` accept) can be guarded.
- 409 conflict message updated to mention source.

## Testing

- `test/support/prompts-storage.test.js`: different-source → insert; same-source → update; unregistered source → 400.
- `test/support/prompt-sources.test.js`: allowlist membership, DRS-registry parity, 400-typed rejection.
- Full `prompts-storage` suite (166 tests) green; eslint + docs:lint clean (pre-commit).

## Rollout / ordering ⚠️

- **Deploy AFTER `mysticat-data-service` #793 is released.** Until the source-aware unique index is live, the DB still enforces the stricter source-less index, so two same-text different-source prompts would 409 at insert.
- **Follow-up:** bump the IT `data-service` image (`v5.57.0` → the release containing #793) to add per-source IT coverage. Unit tests cover the JS behavior now.

## Related

- `mysticat-data-service` #793 — `source` in the prompts unique key.
- `llmo-data-retrieval-service` #2692 — canonical `prompt_source.py` registry + DRS write-boundary validation.
- `OneAdobe/llmo-usage-report-node` — per-source columns mirror this registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)