### PR TITLE
feat: serenity apis to reflect tags changes in the elements api

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11551,12 +11551,12 @@ SerenityFilterDimensionItem:
   description: |
     A single id/label option for a Serenity Elements filter dropdown. `id` is
     the original, unmodified tag value returned by Semrush (including its
-    `prefix:` and any `Parent__Child` encoding, e.g. `topic:Furniture__Sofas`).
-    `parent_id`/`parent_label` are present only when the source tag encoded a
-    "Parent__Child" hierarchy; `parent_id` is the same `prefix:` reconstructed
-    over just the parent segment (e.g. for
-    `category:Living Room Furniture Retail__Living Room Furniture and Sofas`,
-    `parent_id` is `category:Living Room Furniture Retail`).
+    `prefix__` and any further `parent__child` encoding, e.g.
+    `topic__Furniture__Sofas`). `parent_id`/`parent_label` are present only
+    when the source tag encoded a "parent__child" hierarchy; `parent_id` is
+    the same `prefix__` reconstructed over just the parent segment (e.g. for
+    `category__Living Room Furniture Retail__Living Room Furniture and Sofas`,
+    `parent_id` is `category__Living Room Furniture Retail`).
   required: [id, label]
   properties:
     id: { type: string }
@@ -11573,10 +11573,12 @@ SerenityUrlInspectorFilterDimensions:
     `brands`, `regions`, `topics`, `categories`, `page_intents`, `origins`, and
     `tags` are always present (empty array when Semrush has no data). Any
     additional Semrush tag prefix not already covered by the fixed dimensions
-    (e.g. a future `type:branded` tag) surfaces as an extra dynamic array
+    (e.g. a future `type__branded` tag) surfaces as an extra dynamic array
     property keyed by that prefix — this is why the schema allows
     `additionalProperties`. Prefixes that would collide with one of the fixed
-    keys above are routed into `tags` instead of clobbering that key.
+    keys above are routed into `tags` instead of clobbering that key. Bare
+    prefix declarations with no value (e.g. a lone `category` row) are ignored
+    entirely and never appear in any dimension.
   required: [brands, regions, topics, categories, page_intents, origins, tags]
   properties:
     brands:
@@ -11609,25 +11611,25 @@ SerenityUrlInspectorFilterDimensions:
           languageCode: { type: [string, 'null'] }
     topics:
       type: array
-      description: Distinct `topic:`-prefixed tags.
+      description: Distinct `topic__`-prefixed tags.
       items: { $ref: '#/SerenityFilterDimensionItem' }
     categories:
       type: array
-      description: Distinct `category:`-prefixed tags.
+      description: Distinct `category__`-prefixed tags.
       items: { $ref: '#/SerenityFilterDimensionItem' }
     page_intents:
       type: array
-      description: Distinct `intent:`-prefixed tags. `id` is the original `intent:`-prefixed tag value.
+      description: Distinct `intent__`-prefixed tags. `id` is the original `intent__`-prefixed tag value.
       items: { $ref: '#/SerenityFilterDimensionItem' }
     origins:
       type: array
-      description: Distinct `source:`-prefixed tags. `id` is the original `source:`-prefixed tag value.
+      description: Distinct `source__`-prefixed tags. `id` is the original `source__`-prefixed tag value.
       items: { $ref: '#/SerenityFilterDimensionItem' }
     tags:
       type: array
       description: |
-        Prefix-less tags, plus any prefixed tag whose prefix collides with one
-        of this schema's other properties.
+        Any prefixed tag whose prefix collides with one of this schema's other
+        properties. Bare prefix declarations with no value are ignored.
       items: { $ref: '#/SerenityFilterDimensionItem' }
   additionalProperties:
     type: array

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1055,11 +1055,12 @@ v2-serenity-url-inspector-filter-dimensions:
       those dropdowns can show.
 
       `topics`/`categories`/`page_intents`/`origins` are derived from the same
-      underlying Topics element response, split apart by their `topic:`/
-      `category:`/`intent:`/`source:` tag prefix. Any other tag prefix Semrush
-      introduces later (e.g. `type:branded`) surfaces automatically as an extra
-      array property keyed by that prefix, and prefix-less tags collect into
-      `tags` — see `SerenityUrlInspectorFilterDimensions`.
+      underlying Topics element response, split apart by their `topic__`/
+      `category__`/`intent__`/`source__` tag prefix. Any other tag prefix Semrush
+      introduces later (e.g. `type__branded`) surfaces automatically as an extra
+      array property keyed by that prefix. Bare prefix declarations with no
+      value (e.g. a lone `category` row) are ignored — see
+      `SerenityUrlInspectorFilterDimensions`.
     operationId: listSerenityUrlInspectorFilterDimensions
     security:
       - ims_key: []

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -425,7 +425,7 @@ export default function ElementsController(context, log, env) {
    * {@link authorizeBrandSubWorkspace}.
    *
    * Query params (all optional): `model`/`platform` (AI model, default search-gpt),
-   * `tag` (CSV of FULL tag values, AND-ed — e.g. `type:branded`, `category:Brand`),
+   * `tag` (CSV of FULL tag values, AND-ed — e.g. `type__branded`, `category__Brand`),
    * `projectId` (CSV of Semrush project UUIDs; omitted → all of the brand's projects
    * in its sub-workspace).
    */

--- a/src/support/elements/definitions/cited-domains.js
+++ b/src/support/elements/definitions/cited-domains.js
@@ -47,7 +47,7 @@ function defaultDateRange() {
  * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
  * @param {string} [params.startDate] - ISO date (YYYY-MM-DD). Defaults to 28 days ago.
  * @param {string} [params.endDate] - ISO date (YYYY-MM-DD). Defaults to today.
- * @param {string} [params.category] - Category label, pushed as the tag `category:<label>`.
+ * @param {string} [params.category] - Category label, pushed as the tag `category__<label>`.
  * @param {string} [params.projectId] - Semrush project id for region scoping (top-level).
  */
 export function buildCitedDomainsPayload({
@@ -63,11 +63,11 @@ export function buildCitedDomainsPayload({
     { op: 'gte', val: start, col: 'CBF_date__start' },
     { op: 'lte', val: end, col: 'CBF_date__end' },
   ];
-  // Category is a namespaced Semrush tag (`category:<label>`). Verified honored by this
+  // Category is a namespaced Semrush tag (`category__<label>`). Verified honored by this
   // element (unlike region/brand/content-type filters, which it ignores). The label is
-  // sent straight through, e.g. category=Firefly → tag `category:Firefly`.
+  // sent straight through, e.g. category=Firefly → tag `category__Firefly`.
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category:${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
   }
 
   return {

--- a/src/support/elements/definitions/domain-urls.js
+++ b/src/support/elements/definitions/domain-urls.js
@@ -17,7 +17,7 @@ import { resolveElementModel } from '../constants.js';
 /**
  * Builds the payload for the Stats-per-URL element (9af5ed83, `table`) scoped to a
  * single (project, date, model). Identical shape to the owned-urls stats payload
- * (date in BOTH simple + advanced, `CBF_model` in an `or` block, `category:<label>`
+ * (date in BOTH simple + advanced, `CBF_model` in an `or` block, `category__<label>`
  * tag, region via top-level `project_id`). `startDate`/`endDate` are required
  * (validated in the controller).
  *
@@ -31,7 +31,7 @@ import { resolveElementModel } from '../constants.js';
  * @param {string} [params.platform] - Legacy alias for `model`; `model` wins.
  * @param {string} params.startDate - ISO date (YYYY-MM-DD).
  * @param {string} params.endDate - ISO date (YYYY-MM-DD).
- * @param {string} [params.category] - Category label → tag `category:<label>`.
+ * @param {string} [params.category] - Category label → tag `category__<label>`.
  * @param {string} [params.projectId] - Semrush project id (region scope, top-level).
  */
 export function buildDomainUrlsPayload({
@@ -44,7 +44,7 @@ export function buildDomainUrlsPayload({
     { op: 'lte', val: endDate, col: 'CBF_date__end' },
   ];
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category:${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
   }
   return {
     ...(projectId && { project_id: projectId }),

--- a/src/support/elements/definitions/owned-urls.js
+++ b/src/support/elements/definitions/owned-urls.js
@@ -20,7 +20,7 @@ import { dateToIsoWeek } from '../week-utils.js';
  * `table`). One row per cited URL in the (project, date, model) scope.
  *
  * Same filter shape as cited-domains (date in BOTH simple + advanced, CBF_model
- * in an `or` block, category as a `category:<label>` tag, region via top-level
+ * in an `or` block, category as a `category__<label>` tag, region via top-level
  * `project_id`). `startDate`/`endDate` are required (validated in the controller).
  * The element does NOT honor a server-side content-type filter, so the
  * `domain_type='Owned'` selection is applied client-side in the transform.
@@ -30,7 +30,7 @@ import { dateToIsoWeek } from '../week-utils.js';
  * @param {string} [params.platform] - Legacy alias for `model`; `model` wins.
  * @param {string} params.startDate - ISO date (YYYY-MM-DD).
  * @param {string} params.endDate - ISO date (YYYY-MM-DD).
- * @param {string} [params.category] - Category label → tag `category:<label>`.
+ * @param {string} [params.category] - Category label → tag `category__<label>`.
  * @param {string} [params.projectId] - Semrush project id (region scope, top-level).
  */
 export function buildOwnedUrlsStatsPayload({
@@ -43,7 +43,7 @@ export function buildOwnedUrlsStatsPayload({
     { op: 'lte', val: endDate, col: 'CBF_date__end' },
   ];
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category:${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
   }
   return {
     ...(projectId && { project_id: projectId }),
@@ -75,7 +75,7 @@ export function buildOwnedUrlsTrendPayload({
     { op: 'lte', val: endDate, col: 'CBF_date__end' },
   ];
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category:${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
   }
   return {
     ...(projectId && { project_id: projectId }),

--- a/src/support/elements/definitions/prompts.js
+++ b/src/support/elements/definitions/prompts.js
@@ -22,7 +22,7 @@ import { resolveElementModel } from '../constants.js';
  * - **intent coverage** — group the returned rows on `primary_intent`; no filter
  *   needed (the intent is on every row).
  * - **branded / unbranded** — the branded signal is NOT a row column; it is a
- *   `tags` value (`type:branded` / `type:non-branded`). So branded% is a
+ *   `tags` value (`type__branded` / `type__non-branded`). So branded% is a
  *   `tag`-filtered count over the total. Verified against prod (Lovesac, one
  *   project): branded 510 + non-branded 687 = total 1197 → 43%.
  *
@@ -33,9 +33,9 @@ import { resolveElementModel } from '../constants.js';
  *   the shape Semrush's own UI sends for this element.
  * - **tags** — each value becomes its own `tags contains <value>` clause; multiple
  *   tags are AND-ed (a prompt must carry all). Callers pass the FULL prefixed tag
- *   value — the element's tag taxonomy varies by workspace (`type:`, `category:`,
- *   `intent:`, `source:`, `topic:`), so no prefix is assumed here. e.g. pass
- *   `type:branded` for the branded count, `category:Brand` for a category filter.
+ *   value — the element's tag taxonomy varies by workspace (`type__`, `category__`,
+ *   `intent__`, `source__`, `topic__`), so no prefix is assumed here. e.g. pass
+ *   `type__branded` for the branded count, `category__Brand` for a category filter.
  * - **projectIds** — a `CBF_project` `or` group; omitted → all projects in the
  *   (sub-)workspace. The UI already surfaces these as `semrush_project_id` via the
  *   URL Inspector filter-dimensions `regions`.
@@ -45,7 +45,7 @@ import { resolveElementModel } from '../constants.js';
  *   platform code). Translated + validated via {@link resolveElementModel}.
  * @param {string} [params.platform] - Alias for `model`; `model` wins when both set.
  * @param {string[]} [params.tags] - Full tag values to filter on (AND-ed), e.g.
- *   `type:branded`, `category:Brand`. Empty/omitted → no tag filter.
+ *   `type__branded`, `category__Brand`. Empty/omitted → no tag filter.
  * @param {string[]} [params.projectIds] - Semrush project UUIDs to scope to.
  *   Empty/omitted → all projects in the (sub-)workspace.
  */

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -36,32 +36,36 @@ export function buildTopicsPayload({ model, platform, projectId } = {}) {
   };
 }
 
+const SEP = '__';
+
 /**
  * @typedef {object} FilterDimensionItem
  * @property {string} id - Dimension identifier: the original, unmodified tag
- *   value as returned by the Elements API (e.g. `topic:Furniture__Sofas`).
+ *   value as returned by the Elements API (e.g. `topic__Furniture__Sofas`).
  * @property {string} label - Human-readable label.
  */
 
 /**
  * @typedef {object} PrefixedTag
  * @property {string} original - The raw tag value exactly as returned by the
- *   Elements API (e.g. `topic:Furniture__Sofas`), used as the dimension `id`.
- * @property {string} stripped - `original` with the matched prefix removed
- *   (e.g. `Furniture__Sofas`), used to derive `label`/`parent_label`.
+ *   Elements API (e.g. `topic__Furniture__Sofas`), used as the dimension `id`.
+ * @property {string} stripped - `original` with the matched `prefix__` marker
+ *   removed (e.g. `Furniture__Sofas`), used to derive `label`/`parent_label`.
  */
 
 /**
  * @param {object} raw - Raw response from the Elements API.
- * @param {string} prefix - Tag prefix to filter on (e.g. `topic:`).
+ * @param {string} prefix - Tag prefix to filter on (e.g. `topic`), matched
+ *   against values starting with `${prefix}__`.
  * @returns {PrefixedTag[]}
  */
 function extractByPrefix(raw, prefix) {
+  const marker = `${prefix}${SEP}`;
   return (raw?.blocks?.value ?? [])
-    .filter((item) => String(item.value ?? '').startsWith(prefix))
+    .filter((item) => String(item.value ?? '').startsWith(marker))
     .map((item) => {
       const original = String(item.value);
-      return { original, stripped: original.substring(prefix.length) };
+      return { original, stripped: original.substring(marker.length) };
     });
 }
 
@@ -71,86 +75,91 @@ function extractByPrefix(raw, prefix) {
  * is preserved intact in the child label. `parent_id` is reconstructed as
  * `${prefix}${parent_label}` — the same original-tag shape as the item's own
  * `id` — so a caller can filter by parent the same way as by id (e.g. for
- * `category:Living Room Furniture Retail__Living Room Furniture and Sofas`,
- * `parent_id` is `category:Living Room Furniture Retail`).
- * @param {string} value - Raw stripped tag value (prefix already removed).
- * @param {string} [prefix] - The prefix (including trailing `:`) stripped from
+ * `category__Living Room Furniture Retail__Living Room Furniture and Sofas`,
+ * `parent_id` is `category__Living Room Furniture Retail`).
+ * @param {string} value - Raw stripped tag value (prefix marker already removed).
+ * @param {string} [prefix] - The prefix (including trailing `__`) stripped from
  *   `value` before it was passed in; '' when the original tag had no prefix.
  * @returns {{label: string, parent_id?: string, parent_label?: string}}
  */
 function splitParent(value, prefix = '') {
-  const sep = '__';
-  const idx = value.indexOf(sep);
+  const idx = value.indexOf(SEP);
   if (idx === -1) {
     return { label: value };
   }
   const parentLabel = value.slice(0, idx);
   return {
-    label: value.slice(idx + sep.length),
+    label: value.slice(idx + SEP.length),
     parent_id: `${prefix}${parentLabel}`,
     parent_label: parentLabel,
   };
 }
 
 /**
- * Extracts only "topic:"-prefixed entries → `{ id: original tag, label }`,
+ * Extracts only "topic__"-prefixed entries → `{ id: original tag, label }`,
  * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
  * hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformTopicsForFilterDimensions(raw) {
-  return extractByPrefix(raw, 'topic:')
-    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'topic:') }));
+  return extractByPrefix(raw, 'topic')
+    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'topic__') }));
 }
 
 /**
- * Extracts only "category:"-prefixed entries → `{ id: original tag, label }`,
+ * Extracts only "category__"-prefixed entries → `{ id: original tag, label }`,
  * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
  * hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformCategoriesToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'category:')
-    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'category:') }));
+  return extractByPrefix(raw, 'category')
+    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'category__') }));
 }
 
 /**
- * Extracts only "intent:"-prefixed entries → `{ id: original tag, label }`.
+ * Extracts only "intent__"-prefixed entries → `{ id: original tag, label }`,
+ * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
+ * hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformIntentsToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'intent:')
-    .map(({ original, stripped }) => ({ id: original, label: stripped }));
+  return extractByPrefix(raw, 'intent')
+    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'intent__') }));
 }
 
 /**
- * Extracts only "source:"-prefixed entries → `{ id: original tag, label }`.
+ * Extracts only "source__"-prefixed entries → `{ id: original tag, label }`,
+ * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
+ * hierarchy.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformOriginsToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'source:')
-    .map(({ original, stripped }) => ({ id: original, label: stripped }));
+  return extractByPrefix(raw, 'source')
+    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'source__') }));
 }
 
-const KNOWN_TAG_PREFIXES = ['topic:', 'category:', 'intent:', 'source:'];
+const KNOWN_TAG_PREFIXES = ['topic__', 'category__', 'intent__', 'source__'];
 
 /**
- * Extracts every tag NOT already covered by the known `topic:`/`category:`/
- * `intent:`/`source:` prefixes, so newly-introduced Semrush tag types (e.g.
- * `type:branded`) surface in the response without a code change per prefix.
+ * Extracts every tag NOT already covered by the known `topic__`/`category__`/
+ * `intent__`/`source__` prefixes, so newly-introduced Semrush tag types (e.g.
+ * `type__branded`) surface in the response without a code change per prefix.
  *
- * - `prefix:value` tags are grouped by their prefix into a dynamic key
- *   (e.g. `{ type: [{ id: 'type:branded', label: 'branded' }, ...] }`), unless
+ * - `prefix__value` tags are grouped by their prefix into a dynamic key
+ *   (e.g. `{ type: [{ id: 'type__branded', label: 'branded' }, ...] }`), unless
  *   `prefix` collides with an entry in `reservedResultKeys`, in which case the
  *   tag is routed to the generic `tags` array instead.
- * - Plain tags with no `prefix:` at all are also collected into `tags`.
+ * - Bare values with no `__` at all are prefix declarations (e.g. a lone
+ *   `category` row announcing the dimension itself, with no value) and are
+ *   ignored entirely — they are not tag data.
  *
  * `id` is always the original, unmodified tag value as returned by the
- * Elements API. Both forms apply the same `Parent__Child` splitting as the
+ * Elements API. Grouped tags apply the same `Parent__Child` splitting as the
  * known dimensions to derive `label`/`parent_label`.
  *
  * Tag prefixes are arbitrary strings from Semrush, so a prefix can legitimately
@@ -163,7 +172,7 @@ const KNOWN_TAG_PREFIXES = ['topic:', 'category:', 'intent:', 'source:'];
  * @param {object} raw - Raw response from the Elements API.
  * @param {string[]} [reservedResultKeys] - Keys already populated on the
  *   caller's result object (see `elements-service.js`) that a raw tag's
- *   `prefix:` must not collide with. Passed in by the caller — rather than
+ *   `prefix` must not collide with. Passed in by the caller — rather than
  *   hardcoded here — so this stays in sync automatically as the caller's
  *   result shape changes.
  * @returns {{[prefix: string]: FilterDimensionItem[], tags: FilterDimensionItem[]}}
@@ -177,19 +186,19 @@ export function transformOtherTagsForFilterDimensions(raw, reservedResultKeys = 
   const tags = [];
 
   values.forEach((value) => {
-    const sepIdx = value.indexOf(':');
+    const sepIdx = value.indexOf(SEP);
     if (sepIdx === -1) {
-      tags.push({ id: value, ...splitParent(value) });
+      // Bare prefix declaration (e.g. "category") — not tag data, ignore.
       return;
     }
     const prefix = value.slice(0, sepIdx);
-    const rest = value.slice(sepIdx + 1);
+    const rest = value.slice(sepIdx + SEP.length);
     if (reservedResultKeys.includes(prefix)) {
-      tags.push({ id: value, ...splitParent(rest, `${prefix}:`) });
+      tags.push({ id: value, ...splitParent(rest, `${prefix}${SEP}`) });
       return;
     }
     groups[prefix] = groups[prefix] ?? [];
-    groups[prefix].push({ id: value, ...splitParent(rest, `${prefix}:`) });
+    groups[prefix].push({ id: value, ...splitParent(rest, `${prefix}${SEP}`) });
   });
 
   return { ...groups, tags };

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -36,6 +36,12 @@ export function buildTopicsPayload({ model, platform, projectId } = {}) {
   };
 }
 
+// Semrush's Elements API tag encoding: `prefix__value`, with `__` also used for
+// `parent__child` nesting within the value. This replaced an earlier `prefix:value`
+// encoding (colon-delimited, `Parent__Child` nesting only within the value). The
+// cutover is a one-time, atomic migration on Semrush's side — all workspaces/customers
+// were migrated to `__` together, so there is no dual-format transition period and no
+// need to parse both encodings here.
 const SEP = '__';
 
 /**

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -615,14 +615,14 @@ describe('ElementsController', () => {
 
     it('calls getPrompts with the brand SUB-workspace ID and parsed filters', async () => {
       const ctx = fakeContext({
-        url: promptsUrl('?model=perplexity&tag=type:branded,category:Brand&projectId=proj-a,proj-b'),
+        url: promptsUrl('?model=perplexity&tag=type__branded,category__Brand&projectId=proj-a,proj-b'),
       });
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       await ctrl.listPrompts(ctx);
       expect(serviceStub.getPrompts).to.have.been.calledWith(SUB_WORKSPACE_ID, {
         model: 'perplexity',
         platform: undefined,
-        tags: ['type:branded', 'category:Brand'],
+        tags: ['type__branded', 'category__Brand'],
         projectIds: ['proj-a', 'proj-b'],
       });
     });
@@ -654,11 +654,11 @@ describe('ElementsController', () => {
     });
 
     it('trims blank CSV entries', async () => {
-      const ctx = fakeContext({ url: promptsUrl('?tag=type:branded,%20,category:Brand') });
+      const ctx = fakeContext({ url: promptsUrl('?tag=type__branded,%20,category__Brand') });
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       await ctrl.listPrompts(ctx);
       const [, params] = serviceStub.getPrompts.firstCall.args;
-      expect(params.tags).to.deep.equal(['type:branded', 'category:Brand']);
+      expect(params.tags).to.deep.equal(['type__branded', 'category__Brand']);
     });
 
     // ── sub-workspace validation ──

--- a/test/support/elements/definitions/prompts.test.js
+++ b/test/support/elements/definitions/prompts.test.js
@@ -59,17 +59,17 @@ describe('prompts definitions', () => {
     });
 
     it('adds a raw `tags contains <value>` clause for a single tag (no prefixing)', () => {
-      const payload = buildPromptsPayload({ tags: ['type:branded'] });
+      const payload = buildPromptsPayload({ tags: ['type__branded'] });
       const tagClause = advancedFilters(payload).find((f) => f.col === 'tags');
-      expect(tagClause).to.deep.equal({ op: 'contains', val: 'type:branded', col: 'tags' });
+      expect(tagClause).to.deep.equal({ op: 'contains', val: 'type__branded', col: 'tags' });
     });
 
     it('ANDs multiple tags as separate clauses (must match all)', () => {
-      const payload = buildPromptsPayload({ tags: ['type:branded', 'category:Brand'] });
+      const payload = buildPromptsPayload({ tags: ['type__branded', 'category__Brand'] });
       const tagClauses = advancedFilters(payload).filter((f) => f.col === 'tags');
       expect(tagClauses).to.deep.equal([
-        { op: 'contains', val: 'type:branded', col: 'tags' },
-        { op: 'contains', val: 'category:Brand', col: 'tags' },
+        { op: 'contains', val: 'type__branded', col: 'tags' },
+        { op: 'contains', val: 'category__Brand', col: 'tags' },
       ]);
     });
 
@@ -90,7 +90,7 @@ describe('prompts definitions', () => {
 
     it('combines model, tags and projects into one AND group', () => {
       const payload = buildPromptsPayload({
-        model: 'search-gpt', tags: ['type:branded'], projectIds: ['proj-a'],
+        model: 'search-gpt', tags: ['type__branded'], projectIds: ['proj-a'],
       });
       const af = advancedFilters(payload);
       expect(af).to.have.length(3);

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -31,16 +31,20 @@ const RESERVED_RESULT_KEYS = [
 const RAW_MIXED = {
   blocks: {
     value: [
-      { value: 'topic:SEO' },
-      { value: 'topic:AI' },
-      { value: 'category:Firefly' },
-      { value: 'category:Experience Cloud' },
-      { value: 'category:Modular & Configurable Sofas__Compact Shippable Furniture' },
-      { value: 'topic:Furniture__Compact Shippable Furniture' },
-      { value: 'intent:Informational' },
-      { value: 'intent:Transactional' },
-      { value: 'source:organic' },
-      { value: 'source:paid' },
+      { value: 'topic' },
+      { value: 'topic__SEO' },
+      { value: 'topic__AI' },
+      { value: 'category' },
+      { value: 'category__Firefly' },
+      { value: 'category__Experience Cloud' },
+      { value: 'category__Modular & Configurable Sofas__Compact Shippable Furniture' },
+      { value: 'topic__Furniture__Compact Shippable Furniture' },
+      { value: 'intent' },
+      { value: 'intent__Informational' },
+      { value: 'intent__Transactional' },
+      { value: 'source' },
+      { value: 'source__organic' },
+      { value: 'source__paid' },
     ],
   },
 };
@@ -108,59 +112,64 @@ describe('topics definitions', () => {
       expect(transformTopicsForFilterDimensions(null)).to.deep.equal([]);
     });
 
-    it('returns only topic:-prefixed entries', () => {
+    it('ignores the bare "topic" prefix declaration and returns only topic__-prefixed entries', () => {
       const result = transformTopicsForFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: 'topic:SEO', label: 'SEO' },
-        { id: 'topic:AI', label: 'AI' },
+        { id: 'topic__SEO', label: 'SEO' },
+        { id: 'topic__AI', label: 'AI' },
         {
-          id: 'topic:Furniture__Compact Shippable Furniture',
+          id: 'topic__Furniture__Compact Shippable Furniture',
           label: 'Compact Shippable Furniture',
-          parent_id: 'topic:Furniture',
+          parent_id: 'topic__Furniture',
           parent_label: 'Furniture',
         },
       ]);
     });
 
     it('adds parent_id/parent_label when the value contains a double underscore', () => {
-      const raw = { blocks: { value: [{ value: 'topic:Furniture__Sofas' }] } };
+      const raw = { blocks: { value: [{ value: 'topic__Furniture__Sofas' }] } };
       const [item] = transformTopicsForFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: 'topic:Furniture__Sofas',
+        id: 'topic__Furniture__Sofas',
         label: 'Sofas',
-        parent_id: 'topic:Furniture',
+        parent_id: 'topic__Furniture',
         parent_label: 'Furniture',
       });
     });
 
-    it('splits only on the first double underscore', () => {
-      const raw = { blocks: { value: [{ value: 'topic:A__B__C' }] } };
+    it('splits only on the first double underscore after the prefix', () => {
+      const raw = { blocks: { value: [{ value: 'topic__A__B__C' }] } };
       const [item] = transformTopicsForFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: 'topic:A__B__C',
+        id: 'topic__A__B__C',
         label: 'B__C',
-        parent_id: 'topic:A',
+        parent_id: 'topic__A',
         parent_label: 'A',
       });
     });
 
     it('sets id to the original tag value (including prefix) for each entry', () => {
-      const raw = { blocks: { value: [{ value: 'topic:SEO' }] } };
+      const raw = { blocks: { value: [{ value: 'topic__SEO' }] } };
       const [item] = transformTopicsForFilterDimensions(raw);
-      expect(item.id).to.equal('topic:SEO');
+      expect(item.id).to.equal('topic__SEO');
     });
 
-    it('strips the topic: prefix from the label', () => {
-      const raw = { blocks: { value: [{ value: 'topic:Machine Learning' }] } };
+    it('strips the topic__ prefix from the label', () => {
+      const raw = { blocks: { value: [{ value: 'topic__Machine Learning' }] } };
       const [item] = transformTopicsForFilterDimensions(raw);
       expect(item.label).to.equal('Machine Learning');
     });
 
     it('excludes non-topic entries', () => {
-      const raw = { blocks: { value: [{ value: 'category:Firefly' }, { value: 'topic:SEO' }] } };
+      const raw = { blocks: { value: [{ value: 'category__Firefly' }, { value: 'topic__SEO' }] } };
       const result = transformTopicsForFilterDimensions(raw);
       expect(result).to.have.length(1);
       expect(result[0].label).to.equal('SEO');
+    });
+
+    it('ignores a bare "topic" declaration with no value', () => {
+      const raw = { blocks: { value: [{ value: 'topic' }] } };
+      expect(transformTopicsForFilterDimensions(raw)).to.deep.equal([]);
     });
   });
 
@@ -169,74 +178,79 @@ describe('topics definitions', () => {
       expect(transformCategoriesToFilterDimensions(null)).to.deep.equal([]);
     });
 
-    it('returns only category:-prefixed entries', () => {
+    it('ignores the bare "category" prefix declaration and returns only category__-prefixed entries', () => {
       const result = transformCategoriesToFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: 'category:Firefly', label: 'Firefly' },
-        { id: 'category:Experience Cloud', label: 'Experience Cloud' },
+        { id: 'category__Firefly', label: 'Firefly' },
+        { id: 'category__Experience Cloud', label: 'Experience Cloud' },
         {
-          id: 'category:Modular & Configurable Sofas__Compact Shippable Furniture',
+          id: 'category__Modular & Configurable Sofas__Compact Shippable Furniture',
           label: 'Compact Shippable Furniture',
-          parent_id: 'category:Modular & Configurable Sofas',
+          parent_id: 'category__Modular & Configurable Sofas',
           parent_label: 'Modular & Configurable Sofas',
         },
       ]);
     });
 
     it('adds parent_id/parent_label when the value contains a double underscore', () => {
-      const raw = { blocks: { value: [{ value: 'category:Sofas__Modular Sofas' }] } };
+      const raw = { blocks: { value: [{ value: 'category__Sofas__Modular Sofas' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: 'category:Sofas__Modular Sofas',
+        id: 'category__Sofas__Modular Sofas',
         label: 'Modular Sofas',
-        parent_id: 'category:Sofas',
+        parent_id: 'category__Sofas',
         parent_label: 'Sofas',
       });
     });
 
-    it('splits only on the first double underscore', () => {
-      const raw = { blocks: { value: [{ value: 'category:A__B__C' }] } };
+    it('splits only on the first double underscore after the prefix', () => {
+      const raw = { blocks: { value: [{ value: 'category__A__B__C' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: 'category:A__B__C',
+        id: 'category__A__B__C',
         label: 'B__C',
-        parent_id: 'category:A',
+        parent_id: 'category__A',
         parent_label: 'A',
       });
     });
 
     it('sets id to the original tag value (including prefix) for each entry', () => {
-      const raw = { blocks: { value: [{ value: 'category:Creative' }] } };
+      const raw = { blocks: { value: [{ value: 'category__Creative' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);
-      expect(item.id).to.equal('category:Creative');
+      expect(item.id).to.equal('category__Creative');
     });
 
     it('sets parent_id to the prefix plus the parent label', () => {
       const raw = {
         blocks: {
-          value: [{ value: 'category:Living Room Furniture Retail__Living Room Furniture and Sofas' }],
+          value: [{ value: 'category__Living Room Furniture Retail__Living Room Furniture and Sofas' }],
         },
       };
       const [item] = transformCategoriesToFilterDimensions(raw);
       expect(item).to.deep.equal({
-        id: 'category:Living Room Furniture Retail__Living Room Furniture and Sofas',
+        id: 'category__Living Room Furniture Retail__Living Room Furniture and Sofas',
         label: 'Living Room Furniture and Sofas',
-        parent_id: 'category:Living Room Furniture Retail',
+        parent_id: 'category__Living Room Furniture Retail',
         parent_label: 'Living Room Furniture Retail',
       });
     });
 
-    it('strips the category: prefix from the label', () => {
-      const raw = { blocks: { value: [{ value: 'category:Creative Cloud' }] } };
+    it('strips the category__ prefix from the label', () => {
+      const raw = { blocks: { value: [{ value: 'category__Creative Cloud' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);
       expect(item.label).to.equal('Creative Cloud');
     });
 
     it('excludes non-category entries', () => {
-      const raw = { blocks: { value: [{ value: 'topic:SEO' }, { value: 'category:AI' }] } };
+      const raw = { blocks: { value: [{ value: 'topic__SEO' }, { value: 'category__AI' }] } };
       const result = transformCategoriesToFilterDimensions(raw);
       expect(result).to.have.length(1);
       expect(result[0].label).to.equal('AI');
+    });
+
+    it('ignores a bare "category" declaration with no value', () => {
+      const raw = { blocks: { value: [{ value: 'category' }] } };
+      expect(transformCategoriesToFilterDimensions(raw)).to.deep.equal([]);
     });
   });
 
@@ -245,26 +259,37 @@ describe('topics definitions', () => {
       expect(transformIntentsToFilterDimensions(null)).to.deep.equal([]);
     });
 
-    it('returns only intent:-prefixed entries', () => {
+    it('ignores the bare "intent" prefix declaration and returns only intent__-prefixed entries', () => {
       const result = transformIntentsToFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: 'intent:Informational', label: 'Informational' },
-        { id: 'intent:Transactional', label: 'Transactional' },
+        { id: 'intent__Informational', label: 'Informational' },
+        { id: 'intent__Transactional', label: 'Transactional' },
       ]);
     });
 
     it('sets id to the original tag value (including prefix) and preserves original casing in label', () => {
-      const raw = { blocks: { value: [{ value: 'intent:informational' }] } };
+      const raw = { blocks: { value: [{ value: 'intent__informational' }] } };
       const [item] = transformIntentsToFilterDimensions(raw);
-      expect(item.id).to.equal('intent:informational');
+      expect(item.id).to.equal('intent__informational');
       expect(item.label).to.equal('informational');
     });
 
     it('excludes non-intent entries', () => {
-      const raw = { blocks: { value: [{ value: 'category:AI' }, { value: 'intent:Buy' }] } };
+      const raw = { blocks: { value: [{ value: 'category__AI' }, { value: 'intent__Buy' }] } };
       const result = transformIntentsToFilterDimensions(raw);
       expect(result).to.have.length(1);
       expect(result[0].label).to.equal('Buy');
+    });
+
+    it('adds parent_id/parent_label when the value contains a double underscore', () => {
+      const raw = { blocks: { value: [{ value: 'intent__Commercial__Buy' }] } };
+      const [item] = transformIntentsToFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: 'intent__Commercial__Buy',
+        label: 'Buy',
+        parent_id: 'intent__Commercial',
+        parent_label: 'Commercial',
+      });
     });
   });
 
@@ -273,26 +298,26 @@ describe('topics definitions', () => {
       expect(transformOriginsToFilterDimensions(null)).to.deep.equal([]);
     });
 
-    it('returns only source:-prefixed entries', () => {
+    it('ignores the bare "source" prefix declaration and returns only source__-prefixed entries', () => {
       const result = transformOriginsToFilterDimensions(RAW_MIXED);
       expect(result).to.deep.equal([
-        { id: 'source:organic', label: 'organic' },
-        { id: 'source:paid', label: 'paid' },
+        { id: 'source__organic', label: 'organic' },
+        { id: 'source__paid', label: 'paid' },
       ]);
     });
 
     it('sets id to the original tag value (including prefix) and label to the stripped value', () => {
-      const raw = { blocks: { value: [{ value: 'source:direct' }] } };
+      const raw = { blocks: { value: [{ value: 'source__direct' }] } };
       const [item] = transformOriginsToFilterDimensions(raw);
-      expect(item.id).to.equal('source:direct');
+      expect(item.id).to.equal('source__direct');
       expect(item.label).to.equal('direct');
     });
 
     it('excludes non-source entries', () => {
-      const raw = { blocks: { value: [{ value: 'topic:SEO' }, { value: 'source:organic' }] } };
+      const raw = { blocks: { value: [{ value: 'topic__SEO' }, { value: 'source__organic' }] } };
       const result = transformOriginsToFilterDimensions(raw);
       expect(result).to.have.length(1);
-      expect(result[0].id).to.equal('source:organic');
+      expect(result[0].id).to.equal('source__organic');
     });
   });
 
@@ -307,41 +332,41 @@ describe('topics definitions', () => {
       expect(result).to.not.have.property('category');
       expect(result).to.not.have.property('intent');
       expect(result).to.not.have.property('source');
+      expect(result.tags).to.deep.equal([]);
     });
 
-    it('groups unknown prefix:value tags by their prefix', () => {
+    it('groups unknown prefix__value tags by their prefix', () => {
       const raw = {
         blocks: {
           value: [
-            { value: 'type:branded' },
-            { value: 'type:unbranded' },
-            { value: 'abc:value' },
+            { value: 'type' },
+            { value: 'type__branded' },
+            { value: 'type__unbranded' },
+            { value: 'abc__value' },
           ],
         },
       };
       const result = transformOtherTagsForFilterDimensions(raw);
       expect(result.type).to.deep.equal([
-        { id: 'type:branded', label: 'branded' },
-        { id: 'type:unbranded', label: 'unbranded' },
+        { id: 'type__branded', label: 'branded' },
+        { id: 'type__unbranded', label: 'unbranded' },
       ]);
-      expect(result.abc).to.deep.equal([{ id: 'abc:value', label: 'value' }]);
+      expect(result.abc).to.deep.equal([{ id: 'abc__value', label: 'value' }]);
       expect(result.tags).to.deep.equal([]);
     });
 
-    it('collects plain, prefix-less tags into the generic tags array', () => {
+    it('ignores bare prefix declarations (values with no double underscore)', () => {
       const raw = { blocks: { value: [{ value: 'abc' }, { value: 'another-plain-tag' }] } };
       const result = transformOtherTagsForFilterDimensions(raw);
-      expect(result.tags).to.deep.equal([
-        { id: 'abc', label: 'abc' },
-        { id: 'another-plain-tag', label: 'another-plain-tag' },
-      ]);
+      expect(result.tags).to.deep.equal([]);
+      expect(Object.keys(result)).to.deep.equal(['tags']);
     });
 
-    it('applies Parent__Child splitting to grouped and plain tags alike', () => {
+    it('applies Parent__Child splitting to grouped tags and to unreserved plain-prefix tags', () => {
       const raw = {
         blocks: {
           value: [
-            { value: 'type:Branded__Sub' },
+            { value: 'type__Branded__Sub' },
             { value: 'Parent__Child' },
           ],
         },
@@ -349,34 +374,33 @@ describe('topics definitions', () => {
       const result = transformOtherTagsForFilterDimensions(raw);
       expect(result.type).to.deep.equal([
         {
-          id: 'type:Branded__Sub', label: 'Sub', parent_id: 'type:Branded', parent_label: 'Branded',
+          id: 'type__Branded__Sub', label: 'Sub', parent_id: 'type__Branded', parent_label: 'Branded',
         },
       ]);
-      expect(result.tags).to.deep.equal([
-        {
-          id: 'Parent__Child', label: 'Child', parent_id: 'Parent', parent_label: 'Parent',
-        },
+      expect(result.Parent).to.deep.equal([
+        { id: 'Parent__Child', label: 'Child' },
       ]);
+      expect(result.tags).to.deep.equal([]);
     });
 
     it('ignores empty string values', () => {
       const raw = { blocks: { value: [{ value: '' }, { value: 'abc' }] } };
       const result = transformOtherTagsForFilterDimensions(raw);
-      expect(result.tags).to.deep.equal([{ id: 'abc', label: 'abc' }]);
+      expect(result.tags).to.deep.equal([]);
     });
 
     it('routes tags whose prefix collides with a reserved result key into tags instead of a dynamic group', () => {
       const raw = {
         blocks: {
           value: [
-            { value: 'brands:foo' },
-            { value: 'regions:APAC' },
-            { value: 'topics:x' },
-            { value: 'categories:x' },
-            { value: 'page_intents:x' },
-            { value: 'origins:x' },
-            { value: 'tags:x' },
-            { value: 'type:branded' },
+            { value: 'brands__foo' },
+            { value: 'regions__APAC' },
+            { value: 'topics__x' },
+            { value: 'categories__x' },
+            { value: 'page_intents__x' },
+            { value: 'origins__x' },
+            { value: 'tags__x' },
+            { value: 'type__branded' },
           ],
         },
       };
@@ -387,24 +411,24 @@ describe('topics definitions', () => {
       expect(result).to.not.have.property('categories');
       expect(result).to.not.have.property('page_intents');
       expect(result).to.not.have.property('origins');
-      expect(result.type).to.deep.equal([{ id: 'type:branded', label: 'branded' }]);
+      expect(result.type).to.deep.equal([{ id: 'type__branded', label: 'branded' }]);
       expect(result.tags).to.deep.equal([
-        { id: 'brands:foo', label: 'foo' },
-        { id: 'regions:APAC', label: 'APAC' },
-        { id: 'topics:x', label: 'x' },
-        { id: 'categories:x', label: 'x' },
-        { id: 'page_intents:x', label: 'x' },
-        { id: 'origins:x', label: 'x' },
-        { id: 'tags:x', label: 'x' },
+        { id: 'brands__foo', label: 'foo' },
+        { id: 'regions__APAC', label: 'APAC' },
+        { id: 'topics__x', label: 'x' },
+        { id: 'categories__x', label: 'x' },
+        { id: 'page_intents__x', label: 'x' },
+        { id: 'origins__x', label: 'x' },
+        { id: 'tags__x', label: 'x' },
       ]);
     });
 
     it('reconstructs parent_id with the reserved-key prefix when a colliding tag has a Parent__Child value', () => {
-      const raw = { blocks: { value: [{ value: 'topics:Parent__Child' }] } };
+      const raw = { blocks: { value: [{ value: 'topics__Parent__Child' }] } };
       const result = transformOtherTagsForFilterDimensions(raw, RESERVED_RESULT_KEYS);
       expect(result.tags).to.deep.equal([
         {
-          id: 'topics:Parent__Child', label: 'Child', parent_id: 'topics:Parent', parent_label: 'Parent',
+          id: 'topics__Parent__Child', label: 'Child', parent_id: 'topics__Parent', parent_label: 'Parent',
         },
       ]);
     });
@@ -413,29 +437,39 @@ describe('topics definitions', () => {
       const raw = {
         blocks: {
           value: [
-            { value: 'constructor:evil' },
-            { value: 'toString:evil' },
-            { value: '__proto__:evil' },
-            { value: 'hasOwnProperty:evil' },
+            { value: 'constructor__evil' },
+            { value: 'toString__evil' },
+            { value: 'hasOwnProperty__evil' },
           ],
         },
       };
       const result = transformOtherTagsForFilterDimensions(raw);
-      const protoKey = ['_', '_', 'proto', '_', '_'].join('');
-      expect(result.constructor).to.deep.equal([{ id: 'constructor:evil', label: 'evil' }]);
-      expect(result.toString).to.deep.equal([{ id: 'toString:evil', label: 'evil' }]);
-      expect(result[protoKey]).to.deep.equal([{ id: `${protoKey}:evil`, label: 'evil' }]);
-      expect(result.hasOwnProperty).to.deep.equal([{ id: 'hasOwnProperty:evil', label: 'evil' }]);
+      expect(result.constructor).to.deep.equal([{ id: 'constructor__evil', label: 'evil' }]);
+      expect(result.toString).to.deep.equal([{ id: 'toString__evil', label: 'evil' }]);
+      expect(result.hasOwnProperty).to.deep.equal([{ id: 'hasOwnProperty__evil', label: 'evil' }]);
+      expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+    });
+
+    it('does not throw and does not pollute the prototype for a value starting with the separator itself', () => {
+      // A value starting with "__" (e.g. a literal "__proto__..." tag) yields an
+      // empty-string prefix under first-occurrence splitting — still safe because
+      // `groups` is created with Object.create(null).
+      const raw = { blocks: { value: [{ value: '__proto__evil' }] } };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result['']).to.deep.equal([
+        {
+          id: '__proto__evil', label: 'evil', parent_id: '__proto', parent_label: 'proto',
+        },
+      ]);
       expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
     });
 
     it('routes Object.prototype-named prefixes into tags when they are reserved by the caller', () => {
-      const raw = { blocks: { value: [{ value: 'constructor:evil' }, { value: '__proto__:evil' }] } };
+      const raw = { blocks: { value: [{ value: 'constructor__evil' }] } };
       const result = transformOtherTagsForFilterDimensions(raw, RESERVED_RESULT_KEYS);
       expect(Object.prototype.hasOwnProperty.call(result, 'constructor')).to.equal(false);
       expect(result.tags).to.deep.equal([
-        { id: 'constructor:evil', label: 'evil' },
-        { id: '__proto__:evil', label: 'evil' },
+        { id: 'constructor__evil', label: 'evil' },
       ]);
     });
   });

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -214,6 +214,32 @@ describe('topics definitions', () => {
       });
     });
 
+    it('handles a parent label identical to the child label (real production data)', () => {
+      // Live Semrush taxonomy sometimes repeats the leaf name as its own parent,
+      // e.g. "category__Product__Product" — label/parent_label must not be swapped.
+      const raw = { blocks: { value: [{ value: 'category__Product__Product' }] } };
+      const [item] = transformCategoriesToFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: 'category__Product__Product',
+        label: 'Product',
+        parent_id: 'category__Product',
+        parent_label: 'Product',
+      });
+    });
+
+    it('preserves non-ASCII characters and parentheses in the label untouched (real production data)', () => {
+      const raw = {
+        blocks: { value: [{ value: 'category__Brand__Marca Lovesac (ES)' }] },
+      };
+      const [item] = transformCategoriesToFilterDimensions(raw);
+      expect(item).to.deep.equal({
+        id: 'category__Brand__Marca Lovesac (ES)',
+        label: 'Marca Lovesac (ES)',
+        parent_id: 'category__Brand',
+        parent_label: 'Brand',
+      });
+    });
+
     it('sets id to the original tag value (including prefix) for each entry', () => {
       const raw = { blocks: { value: [{ value: 'category__Creative' }] } };
       const [item] = transformCategoriesToFilterDimensions(raw);

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -41,11 +41,11 @@ const RAW_MARKETS = {
 const RAW_TOPICS = {
   blocks: {
     value: [
-      { value: 'topic:SEO' },
-      { value: 'category:Firefly' },
-      { value: 'intent:Informational' },
-      { value: 'source:organic' },
-      { value: 'type:branded' },
+      { value: 'topic__SEO' },
+      { value: 'category__Firefly' },
+      { value: 'intent__Informational' },
+      { value: 'source__organic' },
+      { value: 'type__branded' },
       { value: 'plain-tag' },
     ],
   },
@@ -93,14 +93,14 @@ describe('createElementsService', () => {
       ]);
     });
 
-    it('groups unknown prefix:value tags under their own prefix key', async () => {
+    it('groups unknown prefix__value tags under their own prefix key', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.type).to.deep.equal([{ id: 'type:branded', label: 'branded' }]);
+      expect(result.type).to.deep.equal([{ id: 'type__branded', label: 'branded' }]);
     });
 
-    it('collects plain, prefix-less tags into the generic tags key', async () => {
+    it('ignores plain, separator-less tags (bare prefix declarations)', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.tags).to.deep.equal([{ id: 'plain-tag', label: 'plain-tag' }]);
+      expect(result.tags).to.deep.equal([]);
     });
 
     it('brands contains filter dimensions for each brand', async () => {
@@ -115,24 +115,24 @@ describe('createElementsService', () => {
       expect(result.regions[0].label).to.equal('US-en');
     });
 
-    it('topics contains only topic:-prefixed entries', async () => {
+    it('topics contains only topic__-prefixed entries', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.topics).to.deep.equal([{ id: 'topic:SEO', label: 'SEO' }]);
+      expect(result.topics).to.deep.equal([{ id: 'topic__SEO', label: 'SEO' }]);
     });
 
-    it('categories contains only category:-prefixed entries', async () => {
+    it('categories contains only category__-prefixed entries', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.categories).to.deep.equal([{ id: 'category:Firefly', label: 'Firefly' }]);
+      expect(result.categories).to.deep.equal([{ id: 'category__Firefly', label: 'Firefly' }]);
     });
 
-    it('page_intents contains only intent:-prefixed entries with the original tag as id', async () => {
+    it('page_intents contains only intent__-prefixed entries with the original tag as id', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.page_intents).to.deep.equal([{ id: 'intent:Informational', label: 'Informational' }]);
+      expect(result.page_intents).to.deep.equal([{ id: 'intent__Informational', label: 'Informational' }]);
     });
 
-    it('origins contains only source:-prefixed entries', async () => {
+    it('origins contains only source__-prefixed entries', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      expect(result.origins).to.deep.equal([{ id: 'source:organic', label: 'organic' }]);
+      expect(result.origins).to.deep.equal([{ id: 'source__organic', label: 'organic' }]);
     });
 
     it('resolves spacecat_brand_id on brands when spacecatBrands are provided', async () => {
@@ -160,24 +160,22 @@ describe('createElementsService', () => {
       transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.TOPICS, sinon.match.any).resolves({
         blocks: {
           value: [
-            { value: 'constructor:evil' },
-            { value: '__proto__:evil' },
-            { value: 'toString:harmless' },
+            { value: 'constructor__evil' },
+            { value: 'toString__harmless' },
           ],
         },
       });
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
-      // constructor/__proto__ are explicitly reserved (see getUrlInspectorFilterDimensions),
-      // so they're routed into the generic `tags` array rather than becoming their own key.
+      // constructor is explicitly reserved (see getUrlInspectorFilterDimensions),
+      // so it's routed into the generic `tags` array rather than becoming its own key.
       expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
       expect(Object.prototype.hasOwnProperty.call(result, 'constructor')).to.equal(false);
       expect(result.tags).to.deep.equal([
-        { id: 'constructor:evil', label: 'evil' },
-        { id: '__proto__:evil', label: 'evil' },
+        { id: 'constructor__evil', label: 'evil' },
       ]);
       // toString isn't in the reserved list, so it becomes its own dynamic group —
       // this is safe (a plain data property shadowing the inherited one), just unusual.
-      expect(result.toString).to.deep.equal([{ id: 'toString:harmless', label: 'harmless' }]);
+      expect(result.toString).to.deep.equal([{ id: 'toString__harmless', label: 'harmless' }]);
     });
   });
 
@@ -203,7 +201,7 @@ describe('createElementsService', () => {
     });
 
     it('fetches the PROMPTS element and returns { count, prompts }', async () => {
-      const result = await service.getPrompts('ws-1', { tags: ['type:branded'], projectIds: ['proj-a'] });
+      const result = await service.getPrompts('ws-1', { tags: ['type__branded'], projectIds: ['proj-a'] });
       expect(transport.fetchElement).to.have.been.calledWith('ws-1', ELEMENT_IDS.PROMPTS, sinon.match.object);
       expect(result.count).to.equal(1);
       expect(result.prompts[0]).to.deep.include({ prompt_topic: 'AI Instagram Influencers', volume: 2119 });


### PR DESCRIPTION
# Semrush Elements Tag Format Migration (`:` → `__`)

## Problem

Semrush's Elements API changed its tag encoding:

- **Old**: `prefix:value`, with `Parent__Child` nesting inside the value (e.g. `category:Living Room__Sofas`)
- **New**: `prefix__value`, with nesting also delimited by `__` (e.g. `category__Living Room__Sofas`)
- **New behavior**: bare `prefix`-only rows (e.g. a lone `category` entry with no value) are now emitted as pure declarations and must be ignored, not treated as tag data.

## Scope

Confirmed as a **global** change — not limited to a single endpoint. Every place that builds or parses these tags was updated.

## Changes

### Core parsing logic
- **`src/support/elements/definitions/topics.js`**
  - `extractByPrefix` / `splitParent` now split on `__` instead of `:`.
  - Bare prefix-only values (no `__` at all) are ignored entirely — no longer routed into the generic `tags` array.
  - `id` remains the untouched original raw value.

### Outgoing filter builders
- **`owned-urls.js`, `domain-urls.js`, `cited-domains.js`** — now send `category__<label>` instead of `category:<label>` as the `CBF_tags` filter value.
- **`prompts.js`, `elements.js`** — doc/comment updates only (tags pass through as opaque strings; no logic change).

### Documentation
- **`docs/openapi/serenity-api.yaml`**, **`schemas.yaml`*o the `__` format and the "bare declarations ignored"rule. `docs:lint` still passes.

### Tests
- Rewrote `topics.test.js`; adjusted the `__proto__`-prefally unreachable under `__`-splitting); updated`elements-service.test.js`, `prompts.test.js`, `elements.test.js` fixtures.

## Verification
- Ran the real ~90-value production dataset through the actual functions — all correctly parsed, nothing dropped/duplicated/mis-split.
- Full suite: **14,870 passing, 0 failing**. Lint clean.

## Affected APIs

| Endpoint | Impact |
|---|---|
| `url-inspector/filter-dimensions` | Direct parse of changed format |
| `url-inspector/cited-domains` | Outgoing `category__<la
| `url-inspector/owned-urls` | Outgoing `category__<label>` filter |
| `url-inspector/domain-urls` | Outgoing `category__<labe
| `prompts` | Opaque tag pass-through |
| `weeks` | Not affected |