### PR TITLE
fix: move read-only lookup routes (regions, brand-presence stats) to capability-gated access

### DIFF
--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -254,7 +254,8 @@ const routeRequiredCapabilities = {
   'PUT /configurations/latest/handlers/:handlerType/replace-enabled-disabled': CAP_CONFIGURATION_WRITE,
   'PATCH /configurations/sites/audits': CAP_CONFIGURATION_WRITE,
 
-  // Regions lookup - global table, no org scope; readable by any consumer (session-token or S2S) holding organization:read
+  // Regions lookup - global table, no org scope; readable by any consumer
+  // (session-token or S2S) holding organization:read
   'GET /v2/regions': 'organization:read',
 
   // Organizations

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -65,10 +65,6 @@ export const INTERNAL_ROUTES = [
   'POST /slack/events',
   'POST /slack/channels/invite-by-user-id',
 
-  // Brand Presence stats - org-scoped, LLMO product; not yet required by S2S consumers
-  'GET /org/:spaceCatId/brands/all/brand-presence/stats',
-  'GET /org/:spaceCatId/brands/:brandId/brand-presence/stats',
-
   // Agentic traffic PG dashboard endpoints (site-scoped) - non-mutating POST queries
   // (complex payloads / export trigger); UI only, not yet required by S2S
   'POST /sites/:siteId/agentic-traffic/hits-by-urls',
@@ -320,6 +316,8 @@ const routeRequiredCapabilities = {
   'GET /org/:spaceCatId/brands/:brandId/fanout-report': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/filter-dimensions': 'brand:read',
   'GET /org/:spaceCatId/brands/:brandId/brand-presence/filter-dimensions': 'brand:read',
+  'GET /org/:spaceCatId/brands/all/brand-presence/stats': 'brand:read',
+  'GET /org/:spaceCatId/brands/:brandId/brand-presence/stats': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/weeks': 'brand:read',
   'GET /org/:spaceCatId/brands/:brandId/brand-presence/weeks': 'brand:read',
   'GET /org/:spaceCatId/brands/all/brand-presence/sentiment-overview': 'brand:read',

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -173,9 +173,6 @@ export const INTERNAL_ROUTES = [
   'POST /ephemeral-run/batch',
   'GET /ephemeral-run/batch/:batchId/status',
 
-  // Regions lookup - global table, no org scope; session-token authenticated, not for S2S consumers
-  'GET /v2/regions',
-
   // Monitoring - DRS Brand Presence PostgREST audit proxy. Called by DRS monitoring workers
   // via admin x-api-key only (DRS runs in a separate AWS account and holds no S2S consumer
   // registration). Kept internal because reusing `audit:read` would silently broaden that
@@ -256,6 +253,9 @@ const routeRequiredCapabilities = {
   /* TEMPORARY: This route is for cleanup task and will be removed once cleanup is done */
   'PUT /configurations/latest/handlers/:handlerType/replace-enabled-disabled': CAP_CONFIGURATION_WRITE,
   'PATCH /configurations/sites/audits': CAP_CONFIGURATION_WRITE,
+
+  // Regions lookup - global table, no org scope; session-token authenticated, not for S2S consumers
+  'GET /v2/regions': 'organization:read',
 
   // Organizations
   'GET /organizations': CAP_ORG_READ_ALL,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -254,7 +254,7 @@ const routeRequiredCapabilities = {
   'PUT /configurations/latest/handlers/:handlerType/replace-enabled-disabled': CAP_CONFIGURATION_WRITE,
   'PATCH /configurations/sites/audits': CAP_CONFIGURATION_WRITE,
 
-  // Regions lookup - global table, no org scope; session-token authenticated, not for S2S consumers
+  // Regions lookup - global table, no org scope; readable by any consumer (session-token or S2S) holding organization:read
   'GET /v2/regions': 'organization:read',
 
   // Organizations


### PR DESCRIPTION
# fix: move read-only lookup routes from INTERNAL_ROUTES to capability-gated access

## Problem

Several read-only lookup endpoints were listed in `INTERNAL_ROUTES`, so they were only reachable through the internal/session-token path and did not go through the standard required-capability check. As a result, callers on the **read-only admin org charter** (RO-admin), who are granted the relevant read capabilities, could not reach these harmless reads.

## Change

Move the following routes out of `INTERNAL_ROUTES` and into `routeRequiredCapabilities` (`src/routes/required-capabilities.js`), each gated behind the lowest read capability that fits:

| Route | Capability |
|---|---|
| `GET /v2/regions` | `organization:read` |
| `GET /org/:spaceCatId/brands/all/brand-presence/stats` | `brand:read` |
| `GET /org/:spaceCatId/brands/:brandId/brand-presence/stats` | `brand:read` |

The two brand-presence stats routes join their sibling brand-presence routes (`filter-dimensions`, `weeks`, `sentiment-overview`, etc.), which are already `brand:read`. `GET /v2/regions` is a global lookup table with no org scope, so `organization:read` is the appropriate least-privilege gate.

## Why this is safe / low-risk

- **Read-only** - all three are `GET`s on lookup/stats data. No writes, no new endpoints, no response-shape change.
- **Least-privilege reads** - gated behind the minimal read capability (`organization:read` / `brand:read`) rather than left internal-only.
- **Consistent with existing routes** - the brand-presence stats routes now match every other brand-presence endpoint's capability; `/v2/regions` uses the same `organization:read` pattern as other global reads.
- **No behavior change for existing internal callers** - they already satisfy these read capabilities.

## Note on access model

`routeRequiredCapabilities` is the shared map the S2S wrapper also consumes, so once a route has a capability, any consumer (session-token **or** S2S) holding that capability can call it. This is intended for these non-sensitive reads. The comments carried over from `INTERNAL_ROUTES` are updated/removed so they no longer claim "not for S2S consumers."

## Testing

- All modified lines covered (Codecov); `eslint` passes.
- Only the authorization path for these routes changes; responses are unchanged.
