### PR TITLE
test: cover deferred Elements POC data-shapers (URL Inspector / Brand Presence)

### DIFF
--- a/src/support/elements/constants.js
+++ b/src/support/elements/constants.js
@@ -56,9 +56,7 @@ export const PLATFORM_TO_ELEMENT_MODEL = Object.freeze({
  * @param {string} [value] - Raw value from the `model` or `platform` query param.
  * @returns {string} A member of {@link ELEMENT_MODELS}.
  */
-/* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
 export function resolveElementModel(value) {
   const mapped = PLATFORM_TO_ELEMENT_MODEL[value] ?? value;
   return ELEMENT_MODELS.includes(mapped) ? mapped : DEFAULT_ELEMENT_MODEL;
 }
-/* c8 ignore stop */

--- a/src/support/elements/definitions/cited-domains.js
+++ b/src/support/elements/definitions/cited-domains.js
@@ -17,7 +17,6 @@ import { resolveElementModel } from '../constants.js';
 // not import controller code (support/elements must never depend on controllers).
 const DEFAULT_WINDOW_DAYS = 28;
 
-/* c8 ignore start -- LLMO-6020 POC endpoint; unit tests intentionally deferred */
 function defaultDateRange() {
   const end = new Date();
   const start = new Date();
@@ -157,4 +156,3 @@ export function transformCitedDomainsResponse(raw, params = {}) {
   const offset = page * pageSize;
   return { domains: domains.slice(offset, offset + pageSize), totalCount };
 }
-/* c8 ignore stop */

--- a/src/support/elements/definitions/domain-urls.js
+++ b/src/support/elements/definitions/domain-urls.js
@@ -12,8 +12,6 @@
 
 import { resolveElementModel } from '../constants.js';
 
-/* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
-
 /**
  * Builds the payload for the Stats-per-URL element (9af5ed83, `table`) scoped to a
  * single (project, date, model). Identical shape to the owned-urls stats payload
@@ -186,4 +184,3 @@ export function transformDomainUrlsResponse(projectResults = [], params = {}) {
   const offset = page * pageSize;
   return { urls: urls.slice(offset, offset + pageSize), totalCount };
 }
-/* c8 ignore stop */

--- a/src/support/elements/definitions/owned-urls.js
+++ b/src/support/elements/definitions/owned-urls.js
@@ -13,8 +13,6 @@
 import { resolveElementModel } from '../constants.js';
 import { dateToIsoWeek } from '../week-utils.js';
 
-/* c8 ignore start -- LLMO-6086 POC endpoint; unit tests intentionally deferred */
-
 /**
  * Builds the payload for the Stats-per-URL element (9af5ed83, "Stats per URL",
  * `table`). One row per cited URL in the (project, date, model) scope.
@@ -178,4 +176,3 @@ export function transformOwnedUrlsResponse(projectResults = []) {
   urls.sort((a, b) => b.citations - a.citations);
   return urls;
 }
-/* c8 ignore stop */

--- a/src/support/elements/definitions/weeks.js
+++ b/src/support/elements/definitions/weeks.js
@@ -29,7 +29,6 @@ import { generateIsoWeekRange, getWeekDateRange } from '../week-utils.js';
  *   `CBF_ws_brand` filter, mirroring the Markets element). Resolved from `siteId` by the
  *   controller. Omitted → workspace-wide weeks.
  */
-/* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
 export function buildWeeksPayload({ model, platform, brand } = {}) {
   const resolvedModel = resolveElementModel(model || platform);
   const filters = [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }];
@@ -70,4 +69,3 @@ export function transformWeeksResponse(raw) {
     return { week, startDate, endDate };
   });
 }
-/* c8 ignore stop */

--- a/src/support/elements/owned-urls-traffic.js
+++ b/src/support/elements/owned-urls-traffic.js
@@ -21,8 +21,6 @@
  * there is no JS/SQL normalization drift.
  */
 
-/* c8 ignore start -- LLMO-6086 POC endpoint; unit tests intentionally deferred */
-
 // The referral source tables the RPC knows about. An unrecognized value makes the
 // RPC RAISE (→ caught below → silent empty), so we drop unknown values and let the
 // RPC apply its documented default ('optel') instead.
@@ -125,4 +123,3 @@ export function mergeOwnedUrlsTraffic(urls, trafficMap) {
     return t ? { ...u, ...t } : u;
   });
 }
-/* c8 ignore stop */

--- a/src/support/elements/week-utils.js
+++ b/src/support/elements/week-utils.js
@@ -25,7 +25,6 @@
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-/* c8 ignore start -- LLMO-6011 POC endpoint; unit tests intentionally deferred */
 function parseIsoWeek(weekStr) {
   const match = /^(\d{4})-W(\d{2})$/.exec(weekStr);
   if (!match) {
@@ -113,4 +112,3 @@ export function generateIsoWeekRange(minDate, maxDate) {
 
   return result.sort((a, b) => b.localeCompare(a));
 }
-/* c8 ignore stop */

--- a/test/support/elements/constants.test.js
+++ b/test/support/elements/constants.test.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Tests for resolveElementModel — the UI-platform-code → Semrush-model translation
+ * shared by every Elements definition (LLMO-6011 POC, previously c8-ignored).
+ */
+
+import { expect } from 'chai';
+import {
+  resolveElementModel,
+  DEFAULT_ELEMENT_MODEL,
+  ELEMENT_MODELS,
+} from '../../../src/support/elements/constants.js';
+
+describe('resolveElementModel', () => {
+  it('translates UI platform codes to Semrush model names', () => {
+    expect(resolveElementModel('openai')).to.equal('gpt-5');
+    expect(resolveElementModel('chatgpt')).to.equal('search-gpt');
+    expect(resolveElementModel('gemini')).to.equal('gemini-2.5-flash');
+    expect(resolveElementModel('copilot')).to.equal('microsoft-copilot');
+  });
+
+  it('passes through a value that is already a valid Semrush model', () => {
+    expect(resolveElementModel('perplexity')).to.equal('perplexity');
+    expect(resolveElementModel('grok-3')).to.equal('grok-3');
+    // every known model resolves to itself
+    for (const model of ELEMENT_MODELS) {
+      expect(resolveElementModel(model)).to.equal(model);
+    }
+  });
+
+  it('falls back to the default model for unknown or missing values', () => {
+    expect(resolveElementModel('not-a-model')).to.equal(DEFAULT_ELEMENT_MODEL);
+    expect(resolveElementModel(undefined)).to.equal(DEFAULT_ELEMENT_MODEL);
+    expect(resolveElementModel('')).to.equal(DEFAULT_ELEMENT_MODEL);
+  });
+});

--- a/test/support/elements/definitions/cited-domains.test.js
+++ b/test/support/elements/definitions/cited-domains.test.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Contract tests for the Cited Domains element definition (LLMO-6020 POC).
+ *
+ * transformCitedDomainsResponse is load-bearing data massaging: it maps raw Semrush
+ * Elements rows to the URL Inspector `cited-domains` contract, coerces numbers
+ * NaN-safely, applies the content-type filter that drives the UI's owned-vs-third-
+ * party split, sorts by citations, and paginates client-side. It shipped under a
+ * `c8 ignore` ("unit tests intentionally deferred"); this closes that hole and
+ * follows the owned-urls-traffic pattern. See TEST-COVERAGE-FINDINGS.md §5 Tier 1.
+ */
+
+import { expect } from 'chai';
+import {
+  buildCitedDomainsPayload,
+  transformCitedDomainsResponse,
+} from '../../../../src/support/elements/definitions/cited-domains.js';
+
+// A raw Elements "table" response row (blocks.data), snake_case as Semrush returns it.
+const rawRow = (overrides = {}) => ({
+  domain: 'example.com',
+  mentions_end: 42,
+  urls_count: 7,
+  prompts_with_citations: 3,
+  domain_type: 'Other',
+  ...overrides,
+});
+
+const rawResponse = (rows) => ({ blocks: { data: rows } });
+
+describe('cited-domains definition', () => {
+  describe('buildCitedDomainsPayload', () => {
+    it('translates a UI platform code to the Semrush model inside the advanced or-block', () => {
+      const payload = buildCitedDomainsPayload({ platform: 'openai', startDate: '2026-03-01', endDate: '2026-03-31' });
+      const modelFilter = payload.filters.advanced.filters.find((f) => f.op === 'or');
+      expect(modelFilter.filters[0]).to.deep.equal({ op: 'eq', val: 'gpt-5', col: 'CBF_model' });
+    });
+
+    it('prefers model over platform and falls back to the default model for unknown values', () => {
+      const payload = buildCitedDomainsPayload({ model: 'not-a-real-model', platform: 'openai' });
+      const modelFilter = payload.filters.advanced.filters.find((f) => f.op === 'or');
+      // model takes precedence, unknown → DEFAULT_ELEMENT_MODEL ('search-gpt')
+      expect(modelFilter.filters[0].val).to.equal('search-gpt');
+    });
+
+    it('duplicates the date range across the simple and advanced blocks', () => {
+      const payload = buildCitedDomainsPayload({ startDate: '2026-03-01', endDate: '2026-03-31' });
+      expect(payload.filters.simple).to.deep.equal({ CBF_date__start: '2026-03-01', CBF_date__end: '2026-03-31' });
+      const adv = payload.filters.advanced.filters;
+      expect(adv).to.deep.include({ op: 'gte', val: '2026-03-01', col: 'CBF_date__start' });
+      expect(adv).to.deep.include({ op: 'lte', val: '2026-03-31', col: 'CBF_date__end' });
+    });
+
+    it('defaults to a rolling 28-day window when dates are omitted', () => {
+      const payload = buildCitedDomainsPayload({});
+      const { CBF_date__start: start, CBF_date__end: end } = payload.filters.simple;
+      const days = (new Date(end) - new Date(start)) / (1000 * 60 * 60 * 24);
+      expect(days).to.equal(28);
+    });
+
+    it('adds a namespaced category tag filter only when a category is provided', () => {
+      const withCat = buildCitedDomainsPayload({ category: 'Firefly' });
+      expect(withCat.filters.advanced.filters).to.deep.include({ op: 'eq', val: 'category:Firefly', col: 'CBF_tags' });
+
+      const withoutCat = buildCitedDomainsPayload({});
+      expect(withoutCat.filters.advanced.filters.some((f) => f.col === 'CBF_tags')).to.equal(false);
+    });
+
+    it('includes project_id for region scoping only when provided', () => {
+      expect(buildCitedDomainsPayload({ projectId: 'proj-1' }).project_id).to.equal('proj-1');
+      expect(buildCitedDomainsPayload({})).to.not.have.property('project_id');
+    });
+  });
+
+  describe('transformCitedDomainsResponse', () => {
+    it('maps raw rows to the URL Inspector cited-domains contract', () => {
+      const result = transformCitedDomainsResponse(rawResponse([rawRow()]));
+      expect(result.totalCount).to.equal(1);
+      expect(result.domains[0]).to.deep.equal({
+        domain: 'example.com',
+        totalCitations: 42,
+        totalUrls: 7,
+        promptsCited: 3,
+        contentType: 'Other',
+        categories: '',
+        regions: '',
+      });
+    });
+
+    it('coerces non-numeric metrics to 0 and defaults a missing content type to ""', () => {
+      const result = transformCitedDomainsResponse(rawResponse([
+        rawRow({
+          mentions_end: 'nope', urls_count: undefined, prompts_with_citations: null, domain_type: undefined,
+        }),
+      ]));
+      expect(result.domains[0]).to.include({
+        totalCitations: 0, totalUrls: 0, promptsCited: 0, contentType: '',
+      });
+    });
+
+    it('keeps an empty-string domain but skips null/absent domains', () => {
+      const result = transformCitedDomainsResponse(rawResponse([
+        rawRow({ domain: 'keep.com' }),
+        rawRow({ domain: '' }), // '' passes the `!= null` filter and maps to domain ''
+        rawRow({ domain: null }), // skipped
+        { mentions_end: 5 }, // absent domain → skipped
+      ]));
+      expect(result.totalCount).to.equal(2);
+      expect(result.domains.map((d) => d.domain)).to.have.members(['keep.com', '']);
+    });
+
+    it('sorts domains by totalCitations descending', () => {
+      const result = transformCitedDomainsResponse(rawResponse([
+        rawRow({ domain: 'a.com', mentions_end: 10 }),
+        rawRow({ domain: 'b.com', mentions_end: 90 }),
+        rawRow({ domain: 'c.com', mentions_end: 50 }),
+      ]));
+      expect(result.domains.map((d) => d.domain)).to.deep.equal(['b.com', 'c.com', 'a.com']);
+    });
+
+    it('filters by content type case-insensitively (the owned vs third-party split)', () => {
+      const result = transformCitedDomainsResponse(
+        rawResponse([
+          rawRow({ domain: 'owned.com', domain_type: 'Owned' }),
+          rawRow({ domain: 'other.com', domain_type: 'Other' }),
+        ]),
+        { channel: 'owned' },
+      );
+      expect(result.totalCount).to.equal(1);
+      expect(result.domains[0].domain).to.equal('owned.com');
+    });
+
+    it('paginates client-side with totalCount reflecting the post-filter, pre-slice count', () => {
+      const rows = Array.from({ length: 5 }, (_, i) => rawRow({ domain: `d${i}.com`, mentions_end: 100 - i }));
+      const result = transformCitedDomainsResponse(rawResponse(rows), { page: 1, pageSize: 2 });
+      expect(result.totalCount).to.equal(5);
+      // page 1 (0-based), size 2 → the 3rd and 4th by citation-desc
+      expect(result.domains.map((d) => d.domain)).to.deep.equal(['d2.com', 'd3.com']);
+    });
+
+    it('returns an empty result for a missing/empty blocks payload', () => {
+      const empty = { domains: [], totalCount: 0 };
+      expect(transformCitedDomainsResponse(undefined)).to.deep.equal(empty);
+      expect(transformCitedDomainsResponse({})).to.deep.equal(empty);
+    });
+  });
+});

--- a/test/support/elements/definitions/domain-urls.test.js
+++ b/test/support/elements/definitions/domain-urls.test.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Contract tests for the domain-urls element definition (LLMO-6160 POC, previously
+ * c8-ignored). transformDomainUrlsResponse is the Phase-2 domain drilldown: it keeps
+ * only URLs whose host matches the domain (apex OR subdomain — the load-bearing
+ * `hostMatches` rule), sums across projects, applies the content-type filter, and
+ * paginates client-side.
+ */
+
+import { expect } from 'chai';
+import {
+  buildDomainUrlsPayload,
+  transformDomainUrlsResponse,
+} from '../../../../src/support/elements/definitions/domain-urls.js';
+
+const project = ({ region, data = [] }) => ({ region, stats: { blocks: { data } } });
+const statsRow = (o = {}) => ({
+  source: 'https://openai.com/a', domain_type: 'Other', citations: 10, prompts_with_citation: 2, ...o,
+});
+
+describe('domain-urls definition', () => {
+  describe('buildDomainUrlsPayload', () => {
+    it('encodes model, dates, category tag and projectId', () => {
+      const payload = buildDomainUrlsPayload({
+        platform: 'chatgpt', startDate: '2026-03-01', endDate: '2026-03-31', category: 'Firefly', projectId: 'proj-9',
+      });
+      expect(payload.project_id).to.equal('proj-9');
+      expect(payload.filters.advanced.filters.find((f) => f.op === 'or').filters[0])
+        .to.deep.equal({ op: 'eq', val: 'search-gpt', col: 'CBF_model' });
+      expect(payload.filters.advanced.filters).to.deep.include({ op: 'eq', val: 'category:Firefly', col: 'CBF_tags' });
+    });
+  });
+
+  describe('transformDomainUrlsResponse', () => {
+    it('maps matching rows to the domain-urls contract (regions as a sorted comma string)', () => {
+      const result = transformDomainUrlsResponse(
+        [project({ region: 'US', data: [statsRow()] })],
+        { hostname: 'openai.com' },
+      );
+      expect(result.totalCount).to.equal(1);
+      expect(result.urls[0]).to.deep.equal({
+        urlId: '',
+        url: 'https://openai.com/a',
+        contentType: 'Other',
+        citations: 10,
+        promptsCited: 2,
+        categories: '',
+        regions: 'US',
+      });
+    });
+
+    it('matches the apex and subdomains but not lookalike domains (hostMatches)', () => {
+      const result = transformDomainUrlsResponse(
+        [project({
+          region: 'US',
+          data: [
+            statsRow({ source: 'https://openai.com/apex' }),
+            statsRow({ source: 'https://help.openai.com/sub' }),
+            statsRow({ source: 'https://notopenai.com/nope', citations: 999 }),
+          ],
+        })],
+        { hostname: 'openai.com' },
+      );
+      expect(result.urls.map((u) => u.url)).to.have.members([
+        'https://openai.com/apex', 'https://help.openai.com/sub',
+      ]);
+      expect(result.totalCount).to.equal(2);
+    });
+
+    it('normalizes www and case on both the hostname param and the row host', () => {
+      const result = transformDomainUrlsResponse(
+        [project({ region: 'US', data: [statsRow({ source: 'https://WWW.OpenAI.com/x' })] })],
+        { hostname: 'www.OPENAI.com' },
+      );
+      expect(result.totalCount).to.equal(1);
+    });
+
+    it('sums citations/prompts and joins regions (sorted, comma, no space) across projects', () => {
+      const result = transformDomainUrlsResponse(
+        [
+          project({ region: 'US', data: [statsRow({ citations: 10, prompts_with_citation: 2 })] }),
+          project({ region: 'EU', data: [statsRow({ citations: 5, prompts_with_citation: 1 })] }),
+        ],
+        { hostname: 'openai.com' },
+      );
+      expect(result.urls[0]).to.include({ citations: 15, promptsCited: 3, regions: 'EU,US' });
+    });
+
+    it('applies the content-type (channel) filter case-insensitively', () => {
+      const result = transformDomainUrlsResponse(
+        [project({
+          region: 'US',
+          data: [
+            statsRow({ source: 'https://openai.com/owned', domain_type: 'Owned' }),
+            statsRow({ source: 'https://openai.com/other', domain_type: 'Other' }),
+          ],
+        })],
+        { hostname: 'openai.com', channel: 'owned' },
+      );
+      expect(result.urls.map((u) => u.url)).to.deep.equal(['https://openai.com/owned']);
+      expect(result.totalCount).to.equal(1);
+    });
+
+    it('paginates client-side with totalCount as the post-filter, pre-slice count', () => {
+      const data = Array.from({ length: 5 }, (_, i) => statsRow({ source: `https://openai.com/${i}`, citations: 100 - i }));
+      const result = transformDomainUrlsResponse(
+        [project({ region: 'US', data })],
+        { hostname: 'openai.com', page: 1, pageSize: 2 },
+      );
+      expect(result.totalCount).to.equal(5);
+      expect(result.urls.map((u) => u.url)).to.deep.equal(['https://openai.com/2', 'https://openai.com/3']);
+    });
+
+    it('skips null-source and unparseable-host rows and coerces non-numeric metrics to 0', () => {
+      const result = transformDomainUrlsResponse(
+        [project({
+          region: 'US',
+          data: [
+            statsRow({ source: null }),
+            statsRow({ source: 'not a url' }),
+            statsRow({ source: 'https://openai.com/x', citations: 'nope', prompts_with_citation: null }),
+          ],
+        })],
+        { hostname: 'openai.com' },
+      );
+      expect(result.totalCount).to.equal(1);
+      expect(result.urls[0]).to.include({ url: 'https://openai.com/x', citations: 0, promptsCited: 0 });
+    });
+
+    it('tolerates a project missing stats blocks and defaults a missing contentType to ""', () => {
+      const result = transformDomainUrlsResponse(
+        [
+          { region: 'US', stats: {} }, // no blocks → row loop falls back to []
+          project({ region: 'US', data: [statsRow({ source: 'https://openai.com/x', domain_type: undefined })] }),
+        ],
+        { hostname: 'openai.com' },
+      );
+      expect(result.totalCount).to.equal(1);
+      expect(result.urls[0]).to.include({ url: 'https://openai.com/x', contentType: '' });
+    });
+
+    it('returns an empty result for empty input', () => {
+      expect(transformDomainUrlsResponse([], { hostname: 'openai.com' })).to.deep.equal({ urls: [], totalCount: 0 });
+      expect(transformDomainUrlsResponse()).to.deep.equal({ urls: [], totalCount: 0 });
+    });
+  });
+});

--- a/test/support/elements/definitions/owned-urls.test.js
+++ b/test/support/elements/definitions/owned-urls.test.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Contract tests for the owned-urls element definition (LLMO-6086 POC, previously
+ * c8-ignored). transformOwnedUrlsResponse merges per-project Stats-per-URL + trend
+ * responses into the URL Inspector `owned-urls` row shape: owned-only filtering,
+ * cross-project citation summing, region collection, and weekly-citation rollup.
+ */
+
+import { expect } from 'chai';
+import {
+  buildOwnedUrlsStatsPayload,
+  buildOwnedUrlsTrendPayload,
+  transformOwnedUrlsResponse,
+} from '../../../../src/support/elements/definitions/owned-urls.js';
+
+const project = ({ region, data = [], lines = [] }) => ({
+  region,
+  stats: { blocks: { data } },
+  trend: { blocks: { lines } },
+});
+const statsRow = (o = {}) => ({
+  source: 'https://a.com/p', domain_type: 'Owned', citations: 10, prompts_with_citation: 2, ...o,
+});
+
+describe('owned-urls definition', () => {
+  describe('build payloads', () => {
+    for (const [name, build] of [
+      ['buildOwnedUrlsStatsPayload', buildOwnedUrlsStatsPayload],
+      ['buildOwnedUrlsTrendPayload', buildOwnedUrlsTrendPayload],
+    ]) {
+      it(`${name}: encodes model, dates, category tag and projectId`, () => {
+        const payload = build({
+          platform: 'openai', startDate: '2026-03-01', endDate: '2026-03-31', category: 'Firefly', projectId: 'proj-1',
+        });
+        expect(payload.project_id).to.equal('proj-1');
+        expect(payload.filters.simple).to.deep.equal({ CBF_date__start: '2026-03-01', CBF_date__end: '2026-03-31' });
+        const adv = payload.filters.advanced.filters;
+        expect(adv.find((f) => f.op === 'or').filters[0]).to.deep.equal({ op: 'eq', val: 'gpt-5', col: 'CBF_model' });
+        expect(adv).to.deep.include({ op: 'eq', val: 'category:Firefly', col: 'CBF_tags' });
+      });
+
+      it(`${name}: omits projectId and category tag when not provided`, () => {
+        const payload = build({ startDate: '2026-03-01', endDate: '2026-03-31' });
+        expect(payload).to.not.have.property('project_id');
+        expect(payload.filters.advanced.filters.some((f) => f.col === 'CBF_tags')).to.equal(false);
+      });
+    }
+  });
+
+  describe('transformOwnedUrlsResponse', () => {
+    it('maps an owned URL to the full URL Inspector row shape', () => {
+      const result = transformOwnedUrlsResponse([
+        project({
+          region: 'US',
+          data: [statsRow()],
+          lines: [{ legend: 'https://a.com/p', x: '2026-03-15', y__mentions: 4 }],
+        }),
+      ]);
+      expect(result).to.deep.equal([{
+        urlId: '',
+        url: 'https://a.com/p',
+        citations: 10,
+        promptsCited: 2,
+        products: [],
+        regions: ['US'],
+        weeklyCitations: [{ week: '2026-W11', value: 4 }],
+        weeklyPromptsCited: [],
+        agenticHits: 0,
+        agenticHitsTrend: [],
+        referralHits: 0,
+        referralHitsTrend: [],
+      }]);
+    });
+
+    it('sums citations/prompts and merges regions for the same URL across projects', () => {
+      const result = transformOwnedUrlsResponse([
+        project({ region: 'US', data: [statsRow({ citations: 10, prompts_with_citation: 2 })] }),
+        project({ region: 'EU', data: [statsRow({ citations: 5, prompts_with_citation: 1, domain_type: 'owned' })] }),
+      ]);
+      expect(result[0]).to.include({ citations: 15, promptsCited: 3 });
+      expect(result[0].regions).to.have.members(['US', 'EU']);
+    });
+
+    it('keeps only domain_type "owned" (case-insensitive) rows', () => {
+      const result = transformOwnedUrlsResponse([
+        project({
+          region: 'US',
+          data: [
+            statsRow({ source: 'https://a.com/owned', domain_type: 'Owned' }),
+            statsRow({ source: 'https://a.com/other', domain_type: 'Other', citations: 999 }),
+            statsRow({ source: 'https://a.com/none', domain_type: undefined, citations: 999 }),
+          ],
+        }),
+      ]);
+      expect(result.map((u) => u.url)).to.deep.equal(['https://a.com/owned']);
+    });
+
+    it('skips null-source rows and coerces non-numeric metrics to 0', () => {
+      const result = transformOwnedUrlsResponse([
+        project({
+          region: 'US',
+          data: [
+            statsRow({ source: null }),
+            {
+              source: 'https://a.com/x', domain_type: 'Owned', citations: 'nope', prompts_with_citation: undefined,
+            },
+          ],
+        }),
+      ]);
+      expect(result).to.have.length(1);
+      expect(result[0]).to.include({ url: 'https://a.com/x', citations: 0, promptsCited: 0 });
+    });
+
+    it('rolls trend lines into weekly citations (summed per week, sorted ascending) for kept URLs only', () => {
+      const result = transformOwnedUrlsResponse([
+        project({
+          region: 'US',
+          data: [statsRow({ source: 'https://a.com/p' })],
+          lines: [
+            { legend: 'https://a.com/p', x: '2026-03-15', y__mentions: 4 }, // W11
+            { legend: 'https://a.com/p', x: '2026-03-10', y__mentions: 1 }, // W11 → summed
+            { legend: 'https://a.com/p', x: '2026-03-02', y__mentions: 6 }, // W10
+            { legend: 'https://not-kept.com/p', x: '2026-03-15', y__mentions: 99 }, // url not kept
+            { legend: null, x: '2026-03-15', y__mentions: 1 }, // null legend
+            { legend: 'https://a.com/p', x: 12345, y__mentions: 1 }, // non-string x
+          ],
+        }),
+      ]);
+      expect(result[0].weeklyCitations).to.deep.equal([
+        { week: '2026-W10', value: 6 },
+        { week: '2026-W11', value: 5 },
+      ]);
+    });
+
+    it('sorts URLs by citations descending', () => {
+      const result = transformOwnedUrlsResponse([
+        project({
+          region: 'US',
+          data: [
+            statsRow({ source: 'https://a.com/low', citations: 10 }),
+            statsRow({ source: 'https://a.com/high', citations: 90 }),
+            statsRow({ source: 'https://a.com/mid', citations: 50 }),
+          ],
+        }),
+      ]);
+      expect(result.map((u) => u.url)).to.deep.equal([
+        'https://a.com/high', 'https://a.com/mid', 'https://a.com/low',
+      ]);
+    });
+
+    it('coerces non-numeric trend values to 0', () => {
+      const result = transformOwnedUrlsResponse([
+        project({
+          region: 'US',
+          data: [statsRow({ source: 'https://a.com/p' })],
+          lines: [{ legend: 'https://a.com/p', x: '2026-03-15', y__mentions: 'nope' }],
+        }),
+      ]);
+      expect(result[0].weeklyCitations).to.deep.equal([{ week: '2026-W11', value: 0 }]);
+    });
+
+    it('tolerates projects missing stats/trend blocks and null rows in the data array', () => {
+      const result = transformOwnedUrlsResponse([
+        { region: 'US', stats: {}, trend: {} }, // no blocks → both loops fall back to []
+        project({ region: 'US', data: [null, statsRow({ source: 'https://a.com/keep' })] }),
+      ]);
+      expect(result.map((u) => u.url)).to.deep.equal(['https://a.com/keep']);
+    });
+
+    it('returns an empty regions array when a project has no region', () => {
+      const result = transformOwnedUrlsResponse([project({ data: [statsRow()] })]);
+      expect(result[0].regions).to.deep.equal([]);
+    });
+
+    it('returns [] for empty input', () => {
+      expect(transformOwnedUrlsResponse()).to.deep.equal([]);
+      expect(transformOwnedUrlsResponse([project({ region: 'US' })])).to.deep.equal([]);
+    });
+  });
+});

--- a/test/support/elements/definitions/weeks.test.js
+++ b/test/support/elements/definitions/weeks.test.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Contract tests for the Weeks filter-dimensions element definition (LLMO-6011 POC,
+ * previously c8-ignored). transformWeeksResponse rolls raw daily rows into the ISO
+ * weeks the URL Inspector week picker consumes.
+ */
+
+import { expect } from 'chai';
+import {
+  buildWeeksPayload,
+  transformWeeksResponse,
+} from '../../../../src/support/elements/definitions/weeks.js';
+
+const rawResponse = (rows) => ({ blocks: { data: rows } });
+
+describe('weeks definition', () => {
+  describe('buildWeeksPayload', () => {
+    it('translates the platform code into a CBF_model filter', () => {
+      const payload = buildWeeksPayload({ platform: 'openai' });
+      expect(payload.filters.advanced.filters).to.deep.include({ op: 'eq', val: 'gpt-5', col: 'CBF_model' });
+    });
+
+    it('prefers model over platform', () => {
+      const payload = buildWeeksPayload({ model: 'perplexity', platform: 'openai' });
+      expect(payload.filters.advanced.filters[0]).to.deep.equal({ op: 'eq', val: 'perplexity', col: 'CBF_model' });
+    });
+
+    it('adds a CBF_ws_brand filter only when a brand is provided', () => {
+      const withBrand = buildWeeksPayload({ brand: 'Adobe' });
+      expect(withBrand.filters.advanced.filters).to.deep.include({ op: 'eq', val: 'Adobe', col: 'CBF_ws_brand' });
+
+      const withoutBrand = buildWeeksPayload({});
+      expect(withoutBrand.filters.advanced.filters.some((f) => f.col === 'CBF_ws_brand')).to.equal(false);
+    });
+  });
+
+  describe('transformWeeksResponse', () => {
+    it('rolls daily rows into ISO weeks, newest-first', () => {
+      const result = transformWeeksResponse(rawResponse([
+        { date: '2026-03-01' },
+        { date: '2026-03-15' },
+      ]));
+      expect(result).to.deep.equal([
+        { week: '2026-W11', startDate: '2026-03-09', endDate: '2026-03-15' },
+        { week: '2026-W10', startDate: '2026-03-02', endDate: '2026-03-08' },
+        { week: '2026-W09', startDate: '2026-02-23', endDate: '2026-03-01' },
+      ]);
+    });
+
+    it('slices timestamps to the date and ignores non-string date rows', () => {
+      const result = transformWeeksResponse(rawResponse([
+        { date: '2026-03-09T12:34:56Z' },
+        { date: null },
+        { notADate: true },
+      ]));
+      expect(result).to.deep.equal([
+        { week: '2026-W11', startDate: '2026-03-09', endDate: '2026-03-15' },
+      ]);
+    });
+
+    it('returns [] for missing or empty data', () => {
+      expect(transformWeeksResponse(undefined)).to.deep.equal([]);
+      expect(transformWeeksResponse(rawResponse([]))).to.deep.equal([]);
+      expect(transformWeeksResponse(rawResponse([{ notADate: true }]))).to.deep.equal([]);
+    });
+  });
+});

--- a/test/support/elements/owned-urls-traffic.test.js
+++ b/test/support/elements/owned-urls-traffic.test.js
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Contract/shape tests for the owned-urls traffic hybrid helper (LLMO-6086).
+ *
+ * These are the "Tier 1" contract tests from TEST-COVERAGE-FINDINGS.md: feed a
+ * realistic PostgREST RPC payload (snake_case rows) through the real helper and
+ * assert the exact reshaped shape the URL Inspector owned-urls view consumes.
+ * The downstream is stubbed (no network); the assertions pin the contract, not
+ * the implementation.
+ */
+
+import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  fetchOwnedUrlsTraffic,
+  mergeOwnedUrlsTraffic,
+} from '../../../src/support/elements/owned-urls-traffic.js';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+const RPC_NAME = 'rpc_url_inspector_owned_urls_traffic';
+
+// A realistic RPC row as PostgREST returns it: snake_case, string-ish numbers,
+// snake_case trend points. Mirrors what mysticat's rpc returns.
+const rpcRow = (overrides = {}) => ({
+  url: 'https://example.com/pricing',
+  agentic_hits: 42,
+  agentic_hits_trend: [
+    { week_start: '2026-06-01', value: 10 },
+    { week_start: '2026-06-08', value: 32 },
+  ],
+  referral_hits: 7,
+  referral_hits_trend: [{ week_start: '2026-06-01', value: 7 }],
+  ...overrides,
+});
+
+describe('owned-urls-traffic', () => {
+  describe('fetchOwnedUrlsTraffic — guard clauses (best-effort → empty Map)', () => {
+    const baseOpts = {
+      siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['https://example.com/a'],
+    };
+
+    it('returns an empty Map when the client is missing', async () => {
+      const result = await fetchOwnedUrlsTraffic(undefined, baseOpts);
+      expect(result).to.be.instanceOf(Map);
+      expect(result.size).to.equal(0);
+    });
+
+    it('returns an empty Map when the client has no rpc function', async () => {
+      const result = await fetchOwnedUrlsTraffic({ rpc: 'not-a-fn' }, baseOpts);
+      expect(result.size).to.equal(0);
+    });
+
+    it('returns an empty Map when siteId is missing', async () => {
+      const rpc = sinon.stub();
+      const result = await fetchOwnedUrlsTraffic({ rpc }, { ...baseOpts, siteId: undefined });
+      expect(result.size).to.equal(0);
+      expect(rpc).to.not.have.been.called;
+    });
+
+    it('returns an empty Map when urls is not an array', async () => {
+      const rpc = sinon.stub();
+      const result = await fetchOwnedUrlsTraffic({ rpc }, { ...baseOpts, urls: 'nope' });
+      expect(result.size).to.equal(0);
+      expect(rpc).to.not.have.been.called;
+    });
+
+    it('returns an empty Map when urls is empty', async () => {
+      const rpc = sinon.stub();
+      const result = await fetchOwnedUrlsTraffic({ rpc }, { ...baseOpts, urls: [] });
+      expect(result.size).to.equal(0);
+      expect(rpc).to.not.have.been.called;
+    });
+  });
+
+  describe('fetchOwnedUrlsTraffic — RPC parameter contract', () => {
+    let rpc;
+    const opts = {
+      siteId: 'site-1',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    };
+
+    beforeEach(() => {
+      rpc = sinon.stub().resolves({ data: [], error: null });
+    });
+
+    it('passes the required params and omits optional ones when not provided', async () => {
+      await fetchOwnedUrlsTraffic({ rpc }, opts);
+      expect(rpc).to.have.been.calledOnce;
+      const [name, params] = rpc.firstCall.args;
+      expect(name).to.equal(RPC_NAME);
+      expect(params).to.deep.equal({
+        p_site_id: 'site-1',
+        p_start_date: '2026-06-01',
+        p_end_date: '2026-06-30',
+        p_urls: ['https://example.com/a', 'https://example.com/b'],
+      });
+      expect(params).to.not.have.any.keys('p_region', 'p_agent_types', 'p_referral_source');
+    });
+
+    it('scopes by region only when a region is provided', async () => {
+      await fetchOwnedUrlsTraffic({ rpc }, { ...opts, region: 'us' });
+      expect(rpc.firstCall.args[1]).to.include({ p_region: 'us' });
+    });
+
+    it('passes agent types when provided', async () => {
+      await fetchOwnedUrlsTraffic({ rpc }, { ...opts, agentTypes: ['GPTBot', 'ClaudeBot'] });
+      expect(rpc.firstCall.args[1].p_agent_types).to.deep.equal(['GPTBot', 'ClaudeBot']);
+    });
+
+    it('passes a valid referral source through', async () => {
+      await fetchOwnedUrlsTraffic({ rpc }, { ...opts, referralSource: 'cja' });
+      expect(rpc.firstCall.args[1]).to.include({ p_referral_source: 'cja' });
+    });
+
+    it('drops an unrecognized referral source so the RPC applies its default', async () => {
+      await fetchOwnedUrlsTraffic({ rpc }, { ...opts, referralSource: 'bogus-source' });
+      expect(rpc.firstCall.args[1]).to.not.have.property('p_referral_source');
+    });
+  });
+
+  describe('fetchOwnedUrlsTraffic — response reshaping contract', () => {
+    it('maps snake_case RPC rows to the camelCase shape the UI consumes', async () => {
+      const rpc = sinon.stub().resolves({ data: [rpcRow()], error: null });
+      const result = await fetchOwnedUrlsTraffic({ rpc }, {
+        siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['https://example.com/pricing'],
+      });
+
+      expect(result.size).to.equal(1);
+      expect(result.get('https://example.com/pricing')).to.deep.equal({
+        agenticHits: 42,
+        agenticHitsTrend: [
+          { weekStart: '2026-06-01', value: 10 },
+          { weekStart: '2026-06-08', value: 32 },
+        ],
+        referralHits: 7,
+        referralHitsTrend: [{ weekStart: '2026-06-01', value: 7 }],
+      });
+    });
+
+    it('keys the Map by the row url and keeps multiple rows', async () => {
+      const rpc = sinon.stub().resolves({
+        data: [
+          rpcRow({ url: 'https://example.com/a' }),
+          rpcRow({ url: 'https://example.com/b', agentic_hits: 1 }),
+        ],
+        error: null,
+      });
+      const result = await fetchOwnedUrlsTraffic({ rpc }, {
+        siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['x'],
+      });
+      expect([...result.keys()]).to.deep.equal(['https://example.com/a', 'https://example.com/b']);
+      expect(result.get('https://example.com/b').agenticHits).to.equal(1);
+    });
+
+    it('coerces non-numeric / missing hit counts to 0', async () => {
+      const rpc = sinon.stub().resolves({
+        data: [rpcRow({ agentic_hits: null, referral_hits: 'not-a-number' })],
+        error: null,
+      });
+      const result = await fetchOwnedUrlsTraffic({ rpc }, {
+        siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['x'],
+      });
+      const entry = result.get('https://example.com/pricing');
+      expect(entry.agenticHits).to.equal(0);
+      expect(entry.referralHits).to.equal(0);
+    });
+
+    it('defaults a missing / non-array trend to [] and coerces trend point values', async () => {
+      const rpc = sinon.stub().resolves({
+        data: [rpcRow({
+          agentic_hits_trend: null,
+          referral_hits_trend: [{ week_start: undefined, value: 'x' }],
+        })],
+        error: null,
+      });
+      const result = await fetchOwnedUrlsTraffic({ rpc }, {
+        siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['x'],
+      });
+      const entry = result.get('https://example.com/pricing');
+      expect(entry.agenticHitsTrend).to.deep.equal([]);
+      expect(entry.referralHitsTrend).to.deep.equal([{ weekStart: null, value: 0 }]);
+    });
+
+    it('returns an empty Map when the RPC returns null data (no throw)', async () => {
+      const rpc = sinon.stub().resolves({ data: null, error: null });
+      const result = await fetchOwnedUrlsTraffic({ rpc }, {
+        siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['x'],
+      });
+      expect(result.size).to.equal(0);
+    });
+  });
+
+  describe('fetchOwnedUrlsTraffic — error handling (best-effort)', () => {
+    it('logs and returns an empty Map on an RPC error', async () => {
+      const rpc = sinon.stub().resolves({ data: null, error: { message: 'boom' } });
+      const log = { error: sinon.stub() };
+      const result = await fetchOwnedUrlsTraffic({ rpc }, {
+        siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['x'], log,
+      });
+      expect(result.size).to.equal(0);
+      expect(log.error).to.have.been.calledOnce;
+      expect(log.error.firstCall.args[0]).to.include('boom');
+    });
+
+    it('does not throw on an RPC error when no logger is supplied', async () => {
+      const rpc = sinon.stub().resolves({ data: null, error: { message: 'boom' } });
+      const result = await fetchOwnedUrlsTraffic({ rpc }, {
+        siteId: 'site-1', startDate: '2026-06-01', endDate: '2026-06-30', urls: ['x'],
+      });
+      expect(result.size).to.equal(0);
+    });
+  });
+
+  describe('mergeOwnedUrlsTraffic', () => {
+    const urls = [
+      { url: 'https://example.com/a', agenticHits: 0, referralHits: 0 },
+      { url: 'https://example.com/b', agenticHits: 0, referralHits: 0 },
+    ];
+
+    it('returns the urls unchanged when trafficMap is not a Map', () => {
+      expect(mergeOwnedUrlsTraffic(urls, null)).to.equal(urls);
+      expect(mergeOwnedUrlsTraffic(urls, {})).to.equal(urls);
+    });
+
+    it('returns the urls unchanged when trafficMap is empty', () => {
+      expect(mergeOwnedUrlsTraffic(urls, new Map())).to.equal(urls);
+    });
+
+    it('overlays traffic onto matching rows and leaves unmatched rows at their defaults', () => {
+      const trafficMap = new Map([
+        ['https://example.com/a', {
+          agenticHits: 5, agenticHitsTrend: [], referralHits: 2, referralHitsTrend: [],
+        }],
+      ]);
+      const merged = mergeOwnedUrlsTraffic(urls, trafficMap);
+      expect(merged[0]).to.include({ url: 'https://example.com/a', agenticHits: 5, referralHits: 2 });
+      // unmatched row keeps its 0/[] defaults
+      expect(merged[1]).to.deep.equal({ url: 'https://example.com/b', agenticHits: 0, referralHits: 0 });
+    });
+
+    it('does not mutate the input rows', () => {
+      const trafficMap = new Map([['https://example.com/a', { agenticHits: 5 }]]);
+      const snapshot = JSON.parse(JSON.stringify(urls));
+      mergeOwnedUrlsTraffic(urls, trafficMap);
+      expect(urls).to.deep.equal(snapshot);
+    });
+  });
+});

--- a/test/support/elements/week-utils.test.js
+++ b/test/support/elements/week-utils.test.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Tests for the ISO-week date helpers (LLMO-6011 POC, previously c8-ignored).
+ * These power the URL Inspector / Brand Presence week pickers, and the year-edge
+ * math (a week that starts in the previous calendar year) is exactly the kind of
+ * off-by-one that silently corrupts a week filter — so it is pinned explicitly.
+ */
+
+import { expect } from 'chai';
+import {
+  getWeekDateRange,
+  dateToIsoWeek,
+  generateIsoWeekRange,
+} from '../../../src/support/elements/week-utils.js';
+
+describe('week-utils', () => {
+  describe('getWeekDateRange', () => {
+    it('returns Monday→Sunday for a valid ISO week', () => {
+      const range = getWeekDateRange('2026-W11');
+      expect(range).to.deep.equal({ startDate: '2026-03-09', endDate: '2026-03-15' });
+      // Monday start, Sunday end, exactly 6 days apart
+      const days = (new Date(range.endDate) - new Date(range.startDate)) / (1000 * 60 * 60 * 24);
+      expect(days).to.equal(6);
+      expect(new Date(`${range.startDate}T00:00:00Z`).getUTCDay()).to.equal(1); // Monday
+    });
+
+    it('handles the year-edge week that starts in the previous calendar year', () => {
+      // ISO 2026-W01 begins Mon 2025-12-29 (Jan 4 2026 is a Sunday → mondayOffset -6).
+      expect(getWeekDateRange('2026-W01')).to.deep.equal({
+        startDate: '2025-12-29',
+        endDate: '2026-01-04',
+      });
+    });
+
+    it('handles a year whose Jan 4 is not a Sunday (else branch of the Monday offset)', () => {
+      // Jan 4 2025 is a Saturday → mondayOffset = 1 - 6; ISO 2025-W01 begins 2024-12-30.
+      expect(getWeekDateRange('2025-W01')).to.deep.equal({
+        startDate: '2024-12-30',
+        endDate: '2025-01-05',
+      });
+    });
+
+    it('returns null for malformed or out-of-range weeks', () => {
+      expect(getWeekDateRange('garbage')).to.equal(null);
+      expect(getWeekDateRange('2026-W00')).to.equal(null);
+      expect(getWeekDateRange('2026-W54')).to.equal(null);
+      expect(getWeekDateRange('')).to.equal(null);
+    });
+  });
+
+  describe('dateToIsoWeek', () => {
+    it('maps a date to its ISO week', () => {
+      expect(dateToIsoWeek('2026-03-15')).to.equal('2026-W11');
+    });
+
+    it('assigns a late-December date to the following year\'s W01 when appropriate', () => {
+      // Mon 2025-12-29 is the start of ISO 2026-W01.
+      expect(dateToIsoWeek('2025-12-29')).to.equal('2026-W01');
+    });
+
+    it('round-trips with getWeekDateRange (a week\'s Monday maps back to that week)', () => {
+      const { startDate } = getWeekDateRange('2026-W11');
+      expect(dateToIsoWeek(startDate)).to.equal('2026-W11');
+    });
+  });
+
+  describe('generateIsoWeekRange', () => {
+    it('returns every ISO week in the span, newest-first', () => {
+      expect(generateIsoWeekRange('2026-03-01', '2026-03-15')).to.deep.equal([
+        '2026-W11', '2026-W10', '2026-W09',
+      ]);
+    });
+
+    it('returns a single week when min and max fall in the same week', () => {
+      expect(generateIsoWeekRange('2026-03-09', '2026-03-15')).to.deep.equal(['2026-W11']);
+    });
+
+    it('returns [] when either bound is missing', () => {
+      expect(generateIsoWeekRange(null, '2026-03-15')).to.deep.equal([]);
+      expect(generateIsoWeekRange('2026-03-01', null)).to.deep.equal([]);
+    });
+
+    it('returns [] when a bound cannot be parsed into a week', () => {
+      expect(generateIsoWeekRange('garbage', '2026-03-15')).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Part of the **LLMO UI data test-coverage initiative** — hardening the `spacecat-api-service` endpoints that massage/aggregate data for the Elmo (LLMO) UI, so we don't silently regress what the product displays.

This PR closes a specific class of hole: **data-transformation code in the Semrush "Elements" support layer that shipped behind `/* c8 ignore start -- … unit tests intentionally deferred */`.** That directive hides untested code from the 90% coverage gate, so the coverage number looked healthy while the logic that shapes URL-Inspector / Brand-Presence data had **zero** verification.

## 📖 How to read this diff

The **source diffs are tiny and boring** — each just deletes the `c8 ignore` start/stop directives (no logic change). **The substance is the ~995 lines of new test files.** Please review the tests, not the one-line source deletions.

## Changes

Each source file below is de-suppressed **and** gets a sibling test. All are now **100% statements / branches / functions / lines**.

| Source (was `c8 ignore`'d) | Ticket | What the test pins |
|---|---|---|
| `support/elements/owned-urls-traffic.js` | LLMO-6086 | RPC param contract + snake_case→camelCase reshaping, best-effort error paths |
| `support/elements/constants.js` | LLMO-6011 | `resolveElementModel` UI-platform-code → Semrush-model translation |
| `support/elements/week-utils.js` | LLMO-6011 | ISO-week math incl. year-edge cases (`2026-W01`→`2025-12-29`, non-Sunday Jan-4) |
| `support/elements/definitions/cited-domains.js` | LLMO-6020 | NaN-safe coercion, owned-vs-third-party content-type filter, citation sort, client-side pagination |
| `support/elements/definitions/owned-urls.js` | LLMO-6086 | owned-only filter, cross-project citation summing, region collection, weekly-citation rollup |
| `support/elements/definitions/domain-urls.js` | LLMO-6160 | `hostMatches` apex-or-subdomain rule (the `cambridge.org`→`dictionary.cambridge.org` case), channel filter, pagination |
| `support/elements/definitions/weeks.js` | LLMO-6011 | daily-rows → ISO-weeks rollup, newest-first |

## Verification

- `test/support/elements/**` → **223 passing**
- **`npm test` (full suite, global 90% c8 gate) → green**
- **No production behavior change** — only test files added + `c8 ignore` directives removed.

## Scope / non-goals

- **No logic changes.** Pure test + coverage-visibility work.
- **`mysticat-data-service` untouched** — its referral/agentic/brand-presence RPCs are already well-covered there (118 referral RPC tests alone); duplicating them adds nothing. The seam that matters here is spacecat's reshaping layer.
- **Deferred to a follow-up PR:** the 21 untested `support/ai-visibility/v1/*` CSV/export handlers, and a few thin wrappers (`concurrency.js`, 3 blocks in `elements-service.js`).

## Status

Draft / experimental — opening for visibility on the approach before we fan out further. Full discovery + decisions log lives in `TEST-COVERAGE-FINDINGS.md` (workspace-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
