### PR TITLE
fix(aso-overlay): add Surrogate-Key header for Fastly targeted purge (SITES-48140)

### DIFF
--- a/src/controllers/redirects.js
+++ b/src/controllers/redirects.js
@@ -206,6 +206,11 @@ function RedirectsController(ctx) {
           'content-type': 'text/plain; charset=utf-8',
           ...(etag ? { etag } : {}),
           'cache-control': OVERLAY_CACHE_CONTROL,
+          // Same Surrogate-Key as the 200 so any 304 stragglers still on the
+          // old TTL can be purged by the same call. Fastly stores the header
+          // for edge state; RFC 7232 requires we carry cache-control + etag,
+          // and Surrogate-Key is an operationally-linked companion.
+          'surrogate-key': `aso-overlay-${service}`,
         });
       }
 
@@ -216,6 +221,12 @@ function RedirectsController(ctx) {
         'cache-control': OVERLAY_CACHE_CONTROL,
         // Include ETag so a subsequent poll can conditionally revalidate.
         ...(etag ? { etag } : {}),
+        // Fastly surrogate key so Mystique can targeted-purge this tenant's
+        // overlay on Deploy (see mystique#3381). Namespaced with `aso-overlay-`
+        // prefix so future overlays under different routes don't collide with
+        // this key space. Fastly VCL strips the /config/<tier>/ prefix before
+        // reaching origin, so we only need per-service uniqueness (not per-tier).
+        'surrogate-key': `aso-overlay-${service}`,
       });
     } catch (err) {
       const code = err.$metadata?.httpStatusCode;

--- a/test/controllers/redirects.test.js
+++ b/test/controllers/redirects.test.js
@@ -98,6 +98,10 @@ describe('RedirectsController', () => {
     expect(response.headers.get('content-type')).to.equal('text/plain; charset=utf-8');
     expect(response.headers.get('cache-control')).to.equal('max-age=10');
     expect(response.headers.get('etag')).to.equal(ETAG);
+    // Surrogate-Key enables Mystique to targeted-purge this tenant's overlay
+    // via Fastly's key-purge endpoint (POST /service/<sid>/purge/<key>) after
+    // a successful S3 write. See mystique#3381.
+    expect(response.headers.get('surrogate-key')).to.equal(`aso-overlay-${SERVICE}`);
     expect(await response.text()).to.equal(overlay);
     // Resolves the site by the p<program>/e<env> external ids parsed from the service.
     expect(mockDataAccess.Site.findByExternalOwnerIdAndExternalSiteId
@@ -154,6 +158,8 @@ describe('RedirectsController', () => {
     expect(response.headers.get('etag')).to.equal(ETAG);
     expect(response.headers.get('cache-control')).to.equal('max-age=10');
     expect(response.headers.get('content-type')).to.equal('text/plain; charset=utf-8');
+    // Surrogate-Key echoed on 304 so purges hit both HIT and NOT_MODIFIED entries.
+    expect(response.headers.get('surrogate-key')).to.equal(`aso-overlay-${SERVICE}`);
     expect(await response.text()).to.equal('');
     // Body never deserialized when returning 304 — the transformToString cost is elided.
     expect(bodyStub.called).to.be.false;


### PR DESCRIPTION
## Summary

Adds a `Surrogate-Key: aso-overlay-<service>` header to the 200 and 304 responses of `GET /config/:service/redirects.txt`, so that Mystique can targeted-purge Fastly's edge cache for a specific tenant's overlay via the existing `POST /service/{sid}/purge/{key}` endpoint after a successful S3 write.

Pairs with:
- experience-platform/mystique#3381 - Mystique's `fastly_purge.py` calls the key-purge endpoint
- experience-platform/mystique-deploy#568 - wires FASTLY_ASO_PURGE_TOKEN env var

## Why this is needed

Alina live-verified mystique#3381 against prod (`DlxppS2VoAizEqJ9bPasq6`, dev tenant `cm-p117653-e365853`) and found the purge is a silent no-op as currently wired: Fastly's `POST /service/{sid}/purge/<path>` endpoint is a **surrogate-key** purge (the path after `/purge/` is the key name), not a URL purge. Because our 200 responses had no `Surrogate-Key` header, the purge invalidated a key nothing was tagged with -> HTTP 200 + zero effect (`x-cache=HIT` age incrementing across polls, never resetting to 0).

Two fix options were considered:
1. **Surrogate keys** (this PR) - origin tags responses with a key, Mystique purges that key. No VCL change needed, works with the existing purge endpoint.
2. **URL purge + VCL exemption** - would require adding a FASTLYPURGE method exemption in `fastly/vcl/aso-prod/recv/40-aso-overlay-route.vcl` (that VCL auth-gates all requests, including purge). Touches prod VCL.

Alina recommended option 1; taking that path.

## Key format

`aso-overlay-<service>` where `<service>` is the CM identifier (e.g., `aso-overlay-cm-p117653-e365853`).

- Namespaced with `aso-overlay-` prefix so future overlays under other routes cannot collide with this key space
- Service-scoped only (no tier segment): Fastly VCL strips the public `/config/<tier>/...` prefix before proxying to origin, so per-service uniqueness is sufficient
- Emitted on both 200 and 304 responses so any 304 stragglers still cached at that status get purged in the same call (RFC 7232 requires we carry cache-control + etag on 304; Surrogate-Key is an operationally-linked companion)

## Coordination

Once this PR lands:
- Maksym updates mystique#3381's `fastly_purge.py` endpoint from `POST /service/{sid}/purge{url_path}` to `POST /service/{sid}/purge/aso-overlay-<tenant_id>`
- Drop `_URL_TIER_BY_BUCKET_SEGMENT` from `handler.py` since the key is now tier-agnostic (also cleans up the stage-returns-None edge case)

## Test plan

- [x] `test/controllers/redirects.test.js`: added `surrogate-key` header assertions on both the 200 happy-path test and the 304 conditional-GET test (38 passing)
- [x] ESLint + type-check clean
- [ ] Post-deploy on dev: hit the endpoint via curl, verify response includes `Surrogate-Key: aso-overlay-<service>`
- [ ] After mystique#3381 lands + deploys, trigger a Deploy in ESS UI, verify `x-cache` flips from HIT to MISS and `age` resets to 0
- [ ] Once verified end-to-end, spacecat-infrastructure Fastly VCL `beresp.ttl` can bump from 10s -> 24h for the cost win

Separately: this change is deliberately scoped narrow (17 lines) and split out from the paired observability PR (adobe/spacecat-api-service#2822) so it can be reviewed and shipped on its own timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)