### PR TITLE
feat(aso-overlay): document ASO_OVERLAY_API_KEY_PREVIOUS in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,11 +83,17 @@ S3_SCRAPER_BUCKET=dummy-scraper-bucket
 # Bucket holding the per-env redirect overlays (spacecat-<env>-aso-overlays),
 # read by RedirectsController with the Lambda's own execution role. The API key
 # is the inbound X-ASO-API-Key the dispatcher sends (same value Fastly checks).
-# Both Vault-backed in prod under dx_mysticat/<env>/api-service:
-#   vault kv get -field=S3_ASO_OVERLAYS_BUCKET dx_mysticat/<env>/api-service
-#   vault kv get -field=ASO_OVERLAY_API_KEY    dx_mysticat/<env>/api-service
+# ASO_OVERLAY_API_KEY_PREVIOUS is empty in steady state and populated during
+# key rotation to accept the previous key alongside the current one — the
+# handler falls back to it when the current key doesn't match, so dispatcher
+# pods still holding the old value are not 401'd during EVO propagation.
+# All Vault-backed in prod under dx_mysticat/<env>/api-service:
+#   vault kv get -field=S3_ASO_OVERLAYS_BUCKET       dx_mysticat/<env>/api-service
+#   vault kv get -field=ASO_OVERLAY_API_KEY          dx_mysticat/<env>/api-service
+#   vault kv get -field=ASO_OVERLAY_API_KEY_PREVIOUS dx_mysticat/<env>/api-service
 S3_ASO_OVERLAYS_BUCKET=dummy-aso-overlays-bucket
 ASO_OVERLAY_API_KEY=dummy-aso-overlay-key
+ASO_OVERLAY_API_KEY_PREVIOUS=
 
 # ── Scrape client (eagerly parsed in constructor) ─────────────────────────────
 SCRAPE_JOB_CONFIGURATION={"queues":[],"scrapeWorkerQueue":"https://sqs.us-east-1.amazonaws.com/000000000000/dummy-scrape","s3Bucket":"dummy-scrape-bucket","options":{},"maxUrlsPerJob":4000,"maxUrlsPerMessage":1000,"scrapeQueueUrlPrefix":"https://sqs.us-east-1.amazonaws.com/000000000000/dummy"}


### PR DESCRIPTION
## Summary

Documents the `ASO_OVERLAY_API_KEY_PREVIOUS` env var in `.env.example`. This is a pure docs / dev-onboarding change — no runtime behavior changes.

## Context

`AsoOverlayKeyHandler` (`src/support/aso-overlay-key-handler.js:109`) already reads `ASO_OVERLAY_API_KEY_PREVIOUS` and falls back to it when the current key doesn't match — see the dual-key rotation logic at lines 107-124. But the dev-onboarding template (`.env.example`) didn't list it, so every new engineer had to reverse-engineer the rotation setup from the handler code + the deploy pipeline.

**Empty in steady state** (the `if (previousKey && ...)` guard at handler line 118 treats empty string as falsy). **Populated during a key-rotation window** so dispatcher pods still holding the old value are not 401'd during EVO secret propagation.

## Why re-open (replaces #2797)

Original PR #2797 was opened from a personal fork (`abhishekgarg18/spacecat-api-service`), which meant several org-scoped CI checks were skipped. Re-opened from an internal branch so the full pipeline runs.

## Diff

- `.env.example`: adds `ASO_OVERLAY_API_KEY_PREVIOUS=` with a comment block explaining rotation semantics + the vault lookup command aligned with the existing `ASO_OVERLAY_API_KEY` entry. Comment section is 6 lines added, 3 removed.

## Test plan

- [x] Self-review: auth handler behavior matches the comment (verified at `aso-overlay-key-handler.js:107-124`)
- [x] Only 2 code sites reference `ASO_OVERLAY_API_KEY_PREVIOUS` (JSDoc + handler read); both consistent
- [x] No Terraform / deploy-manifest drift — this var flows via Vault → helix-deploy secret resolution, same as `ASO_OVERLAY_API_KEY`
- [x] Tests already cover current-key, previous-key, and empty-previous scenarios (`test/support/aso-overlay-key-handler.test.js` dual-key rotation describe block)

## Related

- Jira: [SITES-48140](https://jira.corp.adobe.com/browse/SITES-48140) (parent — ASO overlay observability + hardening)
- ADR I13 — key rotation playbook (in `mysticat-architecture/`)
- Companion PR #2835: `resolveEnvironment` warn-once on missing env — same audit sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)