### PR TITLE
fix(aso-overlay): rewrap native Response before aws-adapter (fix dev 500)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ import {
 } from '@adobe/spacecat-shared-slack-client';
 import { hasText, isValidUUID, logWrapper } from '@adobe/spacecat-shared-utils';
 import { traceIdResponseWrapper } from './support/trace-id-response-wrapper.js';
+import { ensureFetchResponseWrapper } from './support/ensure-fetch-response-wrapper.js';
 
 import dataAccess from './support/data-access.js';
 import sqs from './support/sqs.js';
@@ -498,4 +499,11 @@ export const main = wrappedMain
   .with(elevatedSlackClientWrapper, { slackTarget: WORKSPACE_EXTERNAL })
   .with(vaultSecrets)
   .with(compressResponse)
-  .with(helixStatus);
+  .with(helixStatus)
+  // OUTERMOST wrapper (runs LAST on the response path, just before helix-universal's
+  // AWS Lambda adapter serializes the response). Guarantees the response reaching
+  // `aws-adapter.js:254` — `splitHeaders(response.headers.raw(), ...)` — is an
+  // `@adobe/fetch` Response whose Headers has `.raw()`, not a native Web-Fetch-API
+  // Response whose Headers doesn't. See the wrapper's module-level docstring for
+  // the full backstory (SITES-48140 EMF-instrumentation bundling interaction).
+  .with(ensureFetchResponseWrapper);

--- a/src/support/ensure-fetch-response-wrapper.js
+++ b/src/support/ensure-fetch-response-wrapper.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Response as AdobeFetchResponse } from '@adobe/fetch';
+
+/**
+ * Defensive outermost wrapper that guarantees the response reaching
+ * `@adobe/helix-universal`'s AWS Lambda adapter is an `@adobe/fetch`-compatible
+ * Response.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The AWS adapter serializes the outbound response by calling
+ * `response.headers.raw()` (helix-universal `aws-adapter.js:254`). That method
+ * exists on `@adobe/fetch`'s `Headers` (a `node-fetch` v2 compatible shim) but
+ * NOT on the standard Web-Fetch-API `Headers` (the `undici` implementation
+ * bundled by esbuild alongside `@adobe/fetch`). If any code path in the
+ * wrapper chain returns a native Response instance, the adapter throws
+ * `TypeError: response.headers.raw is not a function` and every request on
+ * that path 500s.
+ *
+ * The regression was hit after SITES-48140 added `metrics-emf` imports to
+ * `RedirectsController` and `AsoOverlayKeyHandler`. Both `createResponse`
+ * (via `@adobe/spacecat-shared-http-utils`) and `authWrapper` correctly
+ * construct `@adobe/fetch` Responses at the SOURCE level — verified by a
+ * standalone local test — but the esbuild bundle produced by `helix-deploy`
+ * exposes two Response classes (the `@adobe/fetch` one AND the undici one)
+ * and something in the extended import graph now returns the undici Response
+ * from a code path that previously returned the `@adobe/fetch` one. Rather
+ * than chase the exact module resolution behavior (which is opaque and
+ * fragile), we normalize at the outermost seam.
+ *
+ * WHAT IT DOES
+ * ------------
+ * If the response reaching us already has `headers.raw` (already an
+ * `@adobe/fetch` Response), pass it through unchanged. Otherwise, rebuild
+ * it as an `@adobe/fetch` Response with the same status, headers, and body.
+ * All response bodies in this service are small text/JSON overlays — buffering
+ * to `arrayBuffer()` before rewrap is safe and non-streaming.
+ *
+ * MUST BE THE OUTERMOST WRAPPER
+ * -----------------------------
+ * Install this LAST in the `.with(...)` chain (which means it runs FIRST on
+ * the response path — helix-shared-wrap execution order is
+ * outermost-runs-first) so it sees whatever every downstream wrapper produced
+ * and hands the AWS adapter a guaranteed-compatible Response.
+ */
+export function ensureFetchResponseWrapper(fn) {
+  return async (request, context) => {
+    const response = await fn(request, context);
+    if (!response || typeof response !== 'object') {
+      return response;
+    }
+    // Fast path: already an @adobe/fetch Response (has Headers with .raw()).
+    // Guard on `.headers` because some non-HTTP handlers may return raw
+    // objects that helix-universal passes through untouched.
+    if (response.headers && typeof response.headers.raw === 'function') {
+      return response;
+    }
+    // Slow path: rebuild as @adobe/fetch Response. Buffer the body (all
+    // responses in this service are small) so the wrap is synchronous from
+    // the caller's perspective.
+    const bodyBuffer = await response.arrayBuffer();
+    const headersObj = {};
+    if (response.headers && typeof response.headers.forEach === 'function') {
+      response.headers.forEach((value, name) => {
+        headersObj[name] = value;
+      });
+    }
+    return new AdobeFetchResponse(Buffer.from(bodyBuffer), {
+      status: response.status,
+      headers: headersObj,
+    });
+  };
+}

--- a/test/support/ensure-fetch-response-wrapper.test.js
+++ b/test/support/ensure-fetch-response-wrapper.test.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from 'chai';
+import { Response as AdobeFetchResponse } from '@adobe/fetch';
+
+import { ensureFetchResponseWrapper } from '../../src/support/ensure-fetch-response-wrapper.js';
+
+describe('ensureFetchResponseWrapper', () => {
+  it('passes through an @adobe/fetch Response unchanged (fast path)', async () => {
+    const original = new AdobeFetchResponse('hello', {
+      status: 200,
+      headers: { 'content-type': 'text/plain', 'x-custom': 'yes' },
+    });
+    const wrapped = ensureFetchResponseWrapper(async () => original);
+    const result = await wrapped({}, {});
+    // Identity check — the fast path must not rebuild the response, so the
+    // returned object is the exact same reference the inner handler returned.
+    expect(result).to.equal(original);
+  });
+
+  it('rewraps a native Response into an @adobe/fetch Response (slow path)', async () => {
+    // Simulate the failure mode: some upstream returned the global Response
+    // (undici / Web-Fetch-API), whose Headers has no .raw() method. This is
+    // the exact scenario that produces the aws-adapter 500 in production.
+    const native = new Response('overlay body', {
+      status: 200,
+      headers: { 'content-type': 'text/plain', etag: '"abc123"' },
+    });
+    expect(typeof native.headers.raw).to.equal('undefined');
+
+    const wrapped = ensureFetchResponseWrapper(async () => native);
+    const result = await wrapped({}, {});
+
+    // After the wrapper, headers.raw() must exist — that's the aws-adapter
+    // contract we're preserving.
+    expect(typeof result.headers.raw).to.equal('function');
+    expect(result.status).to.equal(200);
+    expect(result.headers.get('content-type')).to.equal('text/plain');
+    expect(result.headers.get('etag')).to.equal('"abc123"');
+    expect(await result.text()).to.equal('overlay body');
+  });
+
+  it('rewraps a native Response on a non-200 status (e.g. 404)', async () => {
+    const native = new Response('{"message":"not found"}', {
+      status: 404,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    });
+    const wrapped = ensureFetchResponseWrapper(async () => native);
+    const result = await wrapped({}, {});
+    expect(result.status).to.equal(404);
+    expect(typeof result.headers.raw).to.equal('function');
+    expect(result.headers.get('cache-control')).to.equal('no-store');
+  });
+
+  it('rewraps a native Response with an empty body (304 shape)', async () => {
+    // 304 responses in RFC 7232 have no body; must still emit ETag +
+    // Cache-Control headers, and the rewrap must not corrupt that. The
+    // native Response constructor forbids a body on 304 so we build the
+    // simulate-native-Response with `null`, matching what our controller
+    // does via `createResponse('', 304, ...)` → `new Response('', 304)`
+    // in the source path (which @adobe/fetch permits).
+    const native = new Response(null, {
+      status: 304,
+      headers: { etag: '"d41d8cd"', 'cache-control': 'max-age=10' },
+    });
+    const wrapped = ensureFetchResponseWrapper(async () => native);
+    const result = await wrapped({}, {});
+    expect(result.status).to.equal(304);
+    expect(typeof result.headers.raw).to.equal('function');
+    expect(result.headers.get('etag')).to.equal('"d41d8cd"');
+    expect(await result.text()).to.equal('');
+  });
+
+  it('returns non-object results unchanged (e.g. helix-status raw payloads)', async () => {
+    // Some non-HTTP handlers can return primitives that helix-universal
+    // passes through without touching aws-adapter's Response path. We must
+    // not try to call .arrayBuffer() on those.
+    const wrapped = ensureFetchResponseWrapper(async () => undefined);
+    expect(await wrapped({}, {})).to.equal(undefined);
+
+    const wrapped2 = ensureFetchResponseWrapper(async () => null);
+    expect(await wrapped2({}, {})).to.equal(null);
+
+    const wrapped3 = ensureFetchResponseWrapper(async () => 'a string');
+    expect(await wrapped3({}, {})).to.equal('a string');
+  });
+
+  it('preserves single-value headers on rewrap (aso-overlay Surrogate-Key shape)', async () => {
+    // Regression guard: the aso-overlay response headers (Cache-Control,
+    // ETag, Content-Type, Surrogate-Key) are all single-value. This test
+    // documents the shape that matters for the actual failing endpoint —
+    // multi-value Set-Cookie is out of scope (api-service is a token-auth
+    // API, not a cookie-issuing service). If Set-Cookie support is ever
+    // needed, the wrapper's forEach loop would need to switch to
+    // getSetCookie() for that one header per WHATWG fetch spec.
+    const native = new Response('overlay body', {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        etag: '"abc123"',
+        'cache-control': 'max-age=10',
+        'surrogate-key': 'aso-overlay-cm-p154709-e1629980',
+      },
+    });
+    const wrapped = ensureFetchResponseWrapper(async () => native);
+    const result = await wrapped({}, {});
+    expect(typeof result.headers.raw).to.equal('function');
+    expect(result.headers.get('content-type')).to.equal('text/plain; charset=utf-8');
+    expect(result.headers.get('etag')).to.equal('"abc123"');
+    expect(result.headers.get('cache-control')).to.equal('max-age=10');
+    expect(result.headers.get('surrogate-key')).to.equal('aso-overlay-cm-p154709-e1629980');
+  });
+
+  it('propagates errors from the inner handler', async () => {
+    // Errors from downstream must not be swallowed by the wrapper — we only
+    // transform successful Response instances.
+    const wrapped = ensureFetchResponseWrapper(async () => {
+      throw new Error('downstream boom');
+    });
+    let caught;
+    try {
+      await wrapped({}, {});
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught?.message).to.equal('downstream boom');
+  });
+});


### PR DESCRIPTION
## The symptom

Every `GET /config/dev/*/redirects.txt` on dev is returning **HTTP 500** with:

\`\`\`
x-error: response.headers.raw is not a function
\`\`\`

Reproduced with a valid \`ASO_OVERLAY_API_KEY\` on multiple tenants (\`cm-p117653-e365853\`, \`cm-p128729-e2179647\`). Consistent on both the 200 and 304 conditional-GET code paths. Endpoint was working at 2026-07-16T00:03Z (Maksym's end-to-end verification); broke after v1.655.0 deployed (SITES-48140 EMF instrumentation, #2822).

## Root cause

The error is thrown at [\`@adobe/helix-universal/aws-adapter.js:254\`](https://github.com/adobe/helix-universal/blob/main/src/aws-adapter.js#L254):

\`\`\`js
...splitHeaders(response.headers.raw(), con.log),
\`\`\`

That helper expects \`@adobe/fetch\`-style Headers (which has \`.raw()\`), but the Response reaching the adapter has native Web-Fetch-API Headers (from \`undici\`) whose Headers has no \`.raw()\`.

**Bundle inspection** (\`dist/spacecat-services/api-service@1.657.0.zip\`, extracted \`index.js\`) shows esbuild inlines **two Response classes** side by side:

- \`Response2\` (line 2552) — \`@adobe/fetch\` shim, has \`.raw()\` on Headers ✅
- \`Response6\` (line 57669, plus 3 duplicated copies) — \`undici\` (native fetch spec), no \`.raw()\` ❌

At source level, \`createResponse\` (from \`@adobe/spacecat-shared-http-utils\`) correctly imports \`Response\` from \`@adobe/fetch\` and returns \`Response2\` — verified by a standalone local test. But after #2822 added \`metrics-emf.js\` imports to both \`RedirectsController\` and \`AsoOverlayKeyHandler\`, the extended module graph now resolves to \`Response6\` at bundle time along the overlay code path.

Rather than chase the exact esbuild resolution behavior (opaque, fragile, and could regress again on any future import graph change), we **normalize at the outermost seam** — the wrapper that runs LAST on the response path before the AWS Lambda adapter sees the response.

## The fix

New \`ensureFetchResponseWrapper\` installed as the OUTERMOST wrapper:

- **Fast path** (every response that's already an \`@adobe/fetch\` Response): the wrapper does nothing. Two property checks (\`response.headers && typeof response.headers.raw === 'function'\`) and a return of the original response object. **Zero-cost passthrough.**
- **Slow path** (the specific failure mode: response reaching us is a native Response): the wrapper rebuilds it as an \`@adobe/fetch\` Response with the same status, headers, and body. All existing behavior preserved.

This is defense-in-depth: it fixes the specific interaction from #2822 AND protects against any future PR that could introduce the same shift via a different code path.

## Zero-regression argument (this is the important part)

The wrapper is intentionally the smallest change that fixes the symptom:

1. **Every current endpoint uses \`createResponse\` from \`@adobe/spacecat-shared-http-utils\`**, which constructs \`@adobe/fetch\` Response. On the deployed Lambda, most of those already return \`Response2\` correctly today — those hit the wrapper's fast path (two property checks + return the exact same object reference). **Byte-identical outputs to what those endpoints produce today.**
2. **The two files that use bare \`new Response(...)\` today** (\`src/controllers/proxy.js\` and \`src/support/multipart-form-data.js\` error paths) hit the slow path — but they'd hit the exact same aws-adapter failure the overlay endpoint hits today, so if they were working before this PR they must be low-traffic paths that don't exercise the aws-adapter Response serialization (e.g. only used in local dev). If either is on a hot path in prod, this PR **fixes** them; it can't regress them.
3. **The slow path preserves status, headers, and body content bit-for-bit** — it buffers the body via \`response.arrayBuffer()\` and reconstructs with the same \`status\` and \`headers\`. The only theoretical difference is streaming behavior: our service does not stream any response bodies (all are small text/JSON payloads capped by the maximum-response-size guard in aws-adapter itself).
4. **Non-object results** (\`undefined\`, \`null\`, primitives — e.g. what helix-status can return for raw payloads) are passed through untouched via an early-return guard.
5. **7 unit tests** cover all these cases explicitly — fast path identity, slow path rewrap on 200/404/304, empty body, non-object returns, error propagation, single-value header preservation (the shape the overlay endpoint actually uses).
6. **Full existing test suite still green** (4908 passing across \`test/support/\` + \`test/controllers/redirects.test.js\` locally).

**Known limitation, out of scope for this PR:** multi-value headers like \`Set-Cookie\` on the slow path would collapse to their last value. api-service is a token-authenticated API and does not set cookies; if that ever changes, the wrapper's \`forEach\` loop will need to switch to \`getSetCookie()\` for that one header per WHATWG fetch spec. Documented inline.

## Why we didn't catch this in dev

Two independent gaps:

1. **Unit tests import from source** where module resolution goes to \`node_modules/@adobe/fetch\` directly — \`createResponse\` returns \`Response2\`, \`.raw()\` works, tests pass.
2. **CI's \`bundle-build\` step** invokes the bundled Lambda but only against \`/health\` (JSON, different code path from our text/plain overlay).

Follow-up ticket to add a bundle-level integration test that exercises \`/config/dev/*/redirects.txt\` on the bundled artifact. Tracked as a separate item so this PR stays scoped to the fix.

## Test plan

- [x] 7 new unit tests on the wrapper (fast path, slow path 200/304/404, empty body, non-object results, error propagation, header preservation)
- [x] Existing suites green (\`test/support/\` + \`test/controllers/redirects.test.js\` — 4908 passing locally)
- [x] Lint + type-check clean
- [ ] **Deploy to dev via CI** — user asked for this to run through the standard deploy loop so we can live-verify
- [ ] Post-deploy: curl \`/config/dev/cm-p117653-e365853/redirects.txt\` with valid key → confirm 200/304/404 shape (no more 500)
- [ ] Unblocks Alina's TTL bump (task 37) and the fleet-wide 18-env verification (task 11)

Supersedes revert PR #2838 — closing that in favor of this forward-fix.

Jira: [SITES-48140](https://jira.corp.adobe.com/browse/SITES-48140)

🤖 Generated with [Claude Code](https://claude.com/claude-code)