### PR TITLE
fix(referral-traffic): omit p_category_name on by-url RPC to stop prod 500s | LLMO-6026

### DIFF
--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -530,6 +530,13 @@ export function createReferralTrafficByUrlHandler(getSiteAndValidateAccess) {
           p_sort_by: sortBy,
           p_sort_order: sortOrder,
         };
+        // HOTFIX (LLMO-6026): prod rpc_referral_traffic_by_url does not yet accept
+        // p_category_name — the data-service migration adding it (mysticat-data-service
+        // #786) has not been promoted to prod. Sending the param makes PostgREST fail
+        // overload resolution ("Could not find the function ... in the schema cache")
+        // and every by-url request 500s. Omit it here until the migration lands in prod,
+        // then revert this deletion to restore category filtering on by-url.
+        delete rpcParams.p_category_name;
         const { data, error } = await client.rpc('rpc_referral_traffic_by_url', rpcParams);
 
         if (error) {

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -659,6 +659,15 @@ describe('llmo-referral-traffic', () => {
       expect(client.rpc.getCall(0).args[1].p_url_search).to.equal('blog');
     });
 
+    it('omits p_category_name from the by-url RPC even when categoryName is provided (LLMO-6026 hotfix)', async () => {
+      // prod rpc_referral_traffic_by_url does not yet accept p_category_name; sending
+      // it breaks PostgREST overload resolution and 500s. See controller hotfix comment.
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficByUrlHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { categoryName: 'Footwear' } }));
+      expect(client.rpc.getCall(0).args[1]).to.not.have.property('p_category_name');
+    });
+
     it('clamps pageSize above the max', async () => {
       const client = makeRpcClient({ data: [] });
       const handler = createReferralTrafficByUrlHandler(stubbedValidateAccess);


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Stops the LLMO referral-traffic **by-url** endpoint from returning 500s in production by no longer sending the `p_category_name` argument to the `rpc_referral_traffic_by_url` PostgREST function.

## 2. Reasoning
The by-url referral-traffic endpoint began returning 500s in prod (onset ~17:10 UTC 2026-07-16). PR #2790 added `p_category_name` to `commonRpcParams`, which the by-url handler spreads into its `rpc_referral_traffic_by_url` call. PostgREST resolves function overloads by exact named-argument set, and the prod `rpc_referral_traffic_by_url` function does not yet accept `p_category_name` — the data-service migration that adds it (mysticat-data-service #786) has not been promoted to prod (the prod promotion deploy failed at the migration step). Every by-url request therefore failed with `Could not find the function public.rpc_referral_traffic_by_url( ... p_category_name ...) in the schema cache`, and the controller returned 500.

## 3. High-level overview of the changes
- The by-url handler previously passed `p_category_name` (via `commonRpcParams`) to `rpc_referral_traffic_by_url`. It no longer does.
- Behaviour delta: before — every by-url request 500s in prod because the argument set matches no function overload; after — the argument set matches the existing prod overload and the endpoint returns data again.
- Category filtering on by-url is temporarily not applied. It is restored by reverting this one-line deletion once the data-service migration adding `p_category_name` to the function lands in prod.
- Other referral-traffic endpoints are unaffected — their prod RPCs already accept `p_category_name`. This change touches only the by-url call path.

## 4. Required information
- Jira / issue: [LLMO-6026](https://jira.corp.adobe.com/browse/LLMO-6026)

## 5. Affected / used mysticat-workspace projects
- **mysticat-data-service** (contract): owns `rpc_referral_traffic_by_url`. The permanent fix is promoting #786 (adds `p_category_name` to the function) to prod; this PR is the temporary mitigation until that promotion succeeds. Revert this deletion once the migration is live in prod.

## 6. Additional information outside the code
- Diagnosed from Splunk `dx_aem_sites_spacecat_backend_prod` (`service=api-service`): 260 errors over 3h, all from a single RPC `rpc_referral_traffic_by_url`, onset ~17:10 UTC 2026-07-16 (zero before 17:00), matching the deploy that shipped the `p_category_name` change.
- Confirmed prod `rpc_referral_traffic_by_url` signature lacks `p_category_name` (13 params) vs the function on `mysticat-data-service` main (14 params, adds `p_category_name`).
- The data-service prod promotion (v5.69.0, run #812) failed at the migration step (dbmate exit code 2), so the DB-side fix is not live in prod — motivating this app-side mitigation.

## 7. Test plan
- (a) Exercised the by-url handler locally through its unit suite, including a new regression case asserting the by-url RPC never receives `p_category_name`.
- (b) After deploy: call the referral-traffic by-url endpoint for an affected site and confirm HTTP 200, and watch Splunk `dx_aem_sites_spacecat_backend_prod` for `service=api-service "schema cache" "rpc_referral_traffic_by_url"` — the error stream should drop to zero.

## 8. Deployment & merge order
- Related: **mysticat-data-service #786** (adds `p_category_name` to `rpc_referral_traffic_by_url`) + its prod promotion. This PR is a temporary mitigation and should be **reverted** once #786 is promoted to prod, to restore category filtering on by-url.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
