### PR TITLE
fix: Prompt Research prompts count from real per-topic total

### DIFF
--- a/src/support/ai-visibility/handlers/topics.js
+++ b/src/support/ai-visibility/handlers/topics.js
@@ -443,6 +443,33 @@ function topicsResearchComparator(sort) {
   return (a, b) => cmpNum(a.relevanceScore, b.relevanceScore) * dirMult || cmpStr(a.topic, b.topic);
 }
 
+/**
+ * Real prompt count for a single topic, sourced from the SAME gRPC total the expanded
+ * prompt list uses (`promptsByTopicIDsTotal` via `promptsByTopicIdsPage`), so the topic
+ * card's "Prompts count" and the prompt list's "of N" stay consistent by construction.
+ * The `topicsByFTS` row's own `promptsCount` is an FTS-scoped placeholder that understates
+ * the real total, which is the bug this backfills. Falls back to the passed value if the
+ * id is unparseable or the call fails.
+ */
+async function realPromptsCountForTopic(clients, country, llmEnum, topicId, fallback) {
+  let idBig;
+  try { idBig = BigInt(topicId); } catch { return fallback; }
+  try {
+    const res = await clients.promptClient.promptsByTopicIDsTotal({ country, llm: llmEnum, topicIds: [idBig] });
+    return num(res.total);
+  } catch { return fallback; }
+}
+
+// Returns a copy of the topic rows with `promptsCount` replaced by the real per-topic total,
+// resolved in parallel. `llmEnum` mirrors the prompt-list path: the specific engine for a
+// single-llm request, `LLM_ENUM.ALL` otherwise.
+async function withRealPromptsCount(clients, country, llmEnum, rows) {
+  const counts = await Promise.all(
+    rows.map((r) => realPromptsCountForTopic(clients, country, llmEnum, r.topicId, r.promptsCount)),
+  );
+  return rows.map((r, i) => ({ ...r, promptsCount: counts[i] }));
+}
+
 export async function handleTopicsResearch(sp, clients) {
   const country = resolveCountryForFts(sp);
   const { limit, offset } = parseLimitOffset(sp);
@@ -467,13 +494,14 @@ export async function handleTopicsResearch(sp, clients) {
       throw pair[1].reason;
     }
     const raw = pair[1].value;
-    const data = (raw.topics || []).map((t) => ({
+    const rows = (raw.topics || []).map((t) => ({
       topic: t.name,
       topicId: String(t.id),
       topicVolume: num(t.volume),
       promptsCount: num(t.promptsCount),
       relevanceScore: num(t.relevanceScore),
     }));
+    const data = await withRealPromptsCount(clients, country, llm, rows);
     return {
       status: 200,
       body: {
@@ -508,7 +536,7 @@ export async function handleTopicsResearch(sp, clients) {
     }
   }
   const merged = Array.from(seen.values()).sort(topicsResearchComparator(sort));
-  const data = merged.slice(0, limit);
+  const data = await withRealPromptsCount(clients, country, LLM_ENUM.ALL, merged.slice(0, limit));
   return {
     status: 200,
     body: {

--- a/src/support/ai-visibility/handlers/topics.js
+++ b/src/support/ai-visibility/handlers/topics.js
@@ -460,12 +460,37 @@ async function realPromptsCountForTopic(clients, country, llmEnum, topicId, fall
   } catch { return fallback; }
 }
 
-// Returns a copy of the topic rows with `promptsCount` replaced by the real per-topic total,
-// resolved in parallel. `llmEnum` mirrors the prompt-list path: the specific engine for a
-// single-llm request, `LLM_ENUM.ALL` otherwise.
+// Cap on concurrent per-topic prompt-count RPCs. A results page has no hard upper bound
+// (parseLimitOffset defaults to 100 with no max), so an uncapped Promise.all could burst
+// hundreds of parallel gRPC calls and saturate the upstream service under load.
+const PROMPTS_COUNT_FANOUT_CONCURRENCY = 10;
+
+// Bounded-concurrency map: runs `fn` over `items` with at most `concurrency` promises in
+// flight at once, preserving input order.
+async function mapWithConcurrency(items, concurrency, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  // Recursive worker (not a while-loop) to pull the next index — mirrors the file's
+  // existing recursion pattern and keeps `await` out of a loop body.
+  const runner = async () => {
+    if (next >= items.length) { return; }
+    const i = next;
+    next += 1;
+    results[i] = await fn(items[i], i);
+    await runner();
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, runner));
+  return results;
+}
+
+// Returns a copy of the topic rows with `promptsCount` replaced by the real per-topic total.
+// `llmEnum` mirrors the prompt-list path: the specific engine for a single-llm request,
+// `LLM_ENUM.ALL` otherwise. Fan-out is concurrency-capped (see above).
 async function withRealPromptsCount(clients, country, llmEnum, rows) {
-  const counts = await Promise.all(
-    rows.map((r) => realPromptsCountForTopic(clients, country, llmEnum, r.topicId, r.promptsCount)),
+  const counts = await mapWithConcurrency(
+    rows,
+    PROMPTS_COUNT_FANOUT_CONCURRENCY,
+    (r) => realPromptsCountForTopic(clients, country, llmEnum, r.topicId, r.promptsCount),
   );
   return rows.map((r, i) => ({ ...r, promptsCount: counts[i] }));
 }

--- a/test/support/ai-visibility/handlers/topics.test.js
+++ b/test/support/ai-visibility/handlers/topics.test.js
@@ -366,6 +366,7 @@ describe('AI Visibility – topics handlers', () => {
       expect(res.body.data[0].promptsCount).to.equal(100);
       const arg = clients.promptClient.promptsByTopicIDsTotal.lastCall.args[0];
       expect(arg.topicIds).to.deep.equal([1n]);
+      expect(arg.llm).to.equal(LLM_ENUM.CHAT_GPT);
     });
 
     it('falls back to the row promptsCount when the total call fails', async () => {
@@ -396,7 +397,26 @@ describe('AI Visibility – topics handlers', () => {
       const sp = new URLSearchParams('searchQuery=test');
       const res = await handleTopicsResearch(sp, clients);
       expect(res.body.data[0].promptsCount).to.equal(42);
-      expect(clients.promptClient.promptsByTopicIDsTotal.lastCall.args[0].topicIds).to.deep.equal([7n]);
+      const arg = clients.promptClient.promptsByTopicIDsTotal.lastCall.args[0];
+      expect(arg.topicIds).to.deep.equal([7n]);
+      expect(arg.llm).to.equal(LLM_ENUM.ALL);
+    });
+
+    it('does not call promptsByTopicIDsTotal for a non-numeric topic id (BigInt fallback)', async () => {
+      clients.topicClient.topicsByFTS.callsFake(({ range }) => {
+        if (range?.limit === 1000) { return Promise.resolve({ topics: [] }); }
+        return Promise.resolve({
+          topics: [{
+            id: 'abc', name: 'T1', volume: 100, promptsCount: 9,
+          }],
+        });
+      });
+      clients.promptClient.promptsByTopicIDsTotal.resolves({ total: 100 });
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt');
+      const res = await handleTopicsResearch(sp, clients);
+      // BigInt('abc') throws before any RPC → fall back to the row placeholder (9).
+      expect(res.body.data[0].promptsCount).to.equal(9);
+      expect(clients.promptClient.promptsByTopicIDsTotal.called).to.equal(false);
     });
 
     it('single LLM throws when topicsByFTS list rejects', async () => {

--- a/test/support/ai-visibility/handlers/topics.test.js
+++ b/test/support/ai-visibility/handlers/topics.test.js
@@ -350,6 +350,55 @@ describe('AI Visibility – topics handlers', () => {
       expect(res.body.data[0].topicId).to.equal('1');
     });
 
+    it('single LLM backfills promptsCount from promptsByTopicIDsTotal', async () => {
+      clients.topicClient.topicsByFTS.callsFake(({ range }) => {
+        if (range?.limit === 1000) { return Promise.resolve({ topics: [] }); }
+        return Promise.resolve({
+          topics: [{
+            id: '1', name: 'T1', volume: 100, promptsCount: 5,
+          }],
+        });
+      });
+      clients.promptClient.promptsByTopicIDsTotal.resolves({ total: 100 });
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt');
+      const res = await handleTopicsResearch(sp, clients);
+      // Real total (100), not the FTS-row placeholder (5).
+      expect(res.body.data[0].promptsCount).to.equal(100);
+      const arg = clients.promptClient.promptsByTopicIDsTotal.lastCall.args[0];
+      expect(arg.topicIds).to.deep.equal([1n]);
+    });
+
+    it('falls back to the row promptsCount when the total call fails', async () => {
+      clients.topicClient.topicsByFTS.callsFake(({ range }) => {
+        if (range?.limit === 1000) { return Promise.resolve({ topics: [] }); }
+        return Promise.resolve({
+          topics: [{
+            id: '1', name: 'T1', volume: 100, promptsCount: 5,
+          }],
+        });
+      });
+      clients.promptClient.promptsByTopicIDsTotal.rejects(new Error('totals down'));
+      const sp = new URLSearchParams('searchQuery=test&engine=chatgpt');
+      const res = await handleTopicsResearch(sp, clients);
+      expect(res.body.data[0].promptsCount).to.equal(5);
+    });
+
+    it('all LLMs backfills promptsCount via LLM_ENUM.ALL', async () => {
+      clients.topicClient.topicsByFTS.callsFake(({ range }) => {
+        if (range?.limit === 1000) { return Promise.resolve({ topics: [] }); }
+        return Promise.resolve({
+          topics: [{
+            id: '7', name: 'T', volume: 100, promptsCount: 5, relevanceScore: 10,
+          }],
+        });
+      });
+      clients.promptClient.promptsByTopicIDsTotal.resolves({ total: 42 });
+      const sp = new URLSearchParams('searchQuery=test');
+      const res = await handleTopicsResearch(sp, clients);
+      expect(res.body.data[0].promptsCount).to.equal(42);
+      expect(clients.promptClient.promptsByTopicIDsTotal.lastCall.args[0].topicIds).to.deep.equal([7n]);
+    });
+
     it('single LLM throws when topicsByFTS list rejects', async () => {
       clients.topicClient.topicsByFTS.callsFake(({ range }) => {
         if (range?.limit === 1000) { return Promise.resolve({ topics: [] }); }


### PR DESCRIPTION
## Summary

`handleTopicsResearch` (the POC `/llmo/ai-visibility/topics/research` endpoint behind Prompt Research → Related Topics) set each topic's `promptsCount` from the `topicsByFTS` row field — an FTS-scoped placeholder that understated the real total (a topic card showed e.g. 5 while its prompt list held 100). This backfills `promptsCount` per topic from `promptsByTopicIDsTotal` — the same gRPC total the expanded prompt list already uses — so the card count and the list total agree by construction. Applied to both the single-engine and all-engines (`LLM_ENUM.ALL`) paths, with a fallback to the previous value if the topic id is unparseable or the call fails.

Surfaced during TCS AI Day demo prep (llm-optimizer-customer-success Slack thread).

## API spec

No specification change — the response shape is unchanged (`promptsCount` already exists); only the value's source is corrected. No new endpoint or schema.

## Test plan

- Unit: `npx mocha test/support/ai-visibility/handlers/topics.test.js` — added 3 cases (single-LLM backfill from `promptsByTopicIDsTotal`, all-engines via `LLM_ENUM.ALL`, fallback to the row value on error). 123 passing.
- Manual: on Prompt Research → Related Topics, a topic's `promptsCount` now equals the `total` returned by `/topics/research/prompts?topicId=…` for that topic (previously 5 vs 100).

## Related Issues

No linked ticket — surfaced via the llm-optimizer-customer-success Slack thread (TCS AI Day). Problem: Prompt Research topic cards showed a placeholder prompts count that didn't match the expanded prompt list.