### PR TITLE
[SITES-47932] docs: add GET /sites response examples for all three response shapes

### DIFF
--- a/docs/openapi/examples.yaml
+++ b/docs/openapi/examples.yaml
@@ -1,3 +1,71 @@
+site-list:
+  description: Legacy flat-array response (no query params supplied)
+  value:
+    - id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+      organizationId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901'
+      baseURL: 'https://www.example.com'
+      name: 'Example Site'
+      deliveryType: 'aem_edge'
+      gitHubURL: 'https://github.com/example/repo'
+      isLive: true
+      isSandbox: false
+      createdAt: '2024-01-15T10:00:00.000Z'
+      updatedAt: '2024-06-01T12:30:00.000Z'
+      region: null
+      config: null
+site-paged-response:
+  description: Cursor-paginated response (limit or cursor query param supplied)
+  value:
+    sites:
+      - id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+        organizationId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901'
+        baseURL: 'https://www.example.com'
+        name: 'Example Site'
+        deliveryType: 'aem_edge'
+        gitHubURL: 'https://github.com/example/repo'
+        isLive: true
+        isSandbox: false
+        createdAt: '2024-01-15T10:00:00.000Z'
+        updatedAt: '2024-06-01T12:30:00.000Z'
+        region: null
+        config: null
+    pagination:
+      limit: 100
+      cursor: 'eyJzayI6IjIwMjQtMDYtMDFUMTI6MzA6MDBaIiwiaWQiOiJhMWIyYzNkNC1lNWY2LTc4OTAtYWJjZC1lZjEyMzQ1Njc4OTAifQ=='
+      hasMore: true
+site-search-response:
+  description: Substring-search response (baseUrlContains query param supplied)
+  value:
+    sites:
+      - id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+        organizationId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901'
+        baseURL: 'https://www.adobe.com'
+        name: 'Adobe'
+        deliveryType: 'aem_edge'
+        gitHubURL: 'https://github.com/adobe/repo'
+        isLive: true
+        isSandbox: false
+        createdAt: '2024-01-15T10:00:00.000Z'
+        updatedAt: '2024-06-01T12:30:00.000Z'
+        region: null
+        config: null
+      - id: 'c3d4e5f6-a7b8-9012-cdef-123456789012'
+        organizationId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901'
+        baseURL: 'https://business.adobe.com'
+        name: 'Adobe Business'
+        deliveryType: 'aem_edge'
+        gitHubURL: null
+        isLive: true
+        isSandbox: false
+        createdAt: '2024-03-10T08:00:00.000Z'
+        updatedAt: '2024-06-05T09:15:00.000Z'
+        region: null
+        config: null
+    pagination:
+      limit: 50
+      offset: 0
+      hasMore: false
+      baseUrlContains: 'adobe'
 BotBlockerResultBlocked:
   description: Example for a site that is bot blocked
   value:

--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -231,6 +231,13 @@ sites:
                   deprecated: true
                 - $ref: './schemas.yaml#/SitePagedResponse'
                 - $ref: './schemas.yaml#/SiteSearchResponse'
+            examples:
+              SiteList:
+                $ref: './examples.yaml#/site-list'
+              SitePagedResponse:
+                $ref: './examples.yaml#/site-paged-response'
+              SiteSearchResponse:
+                $ref: './examples.yaml#/site-search-response'
       '400':
         $ref: './responses.yaml#/400'
       '401':

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "4.9.0",
-        "@adobe/spacecat-shared-drs-client": "1.13.0",
+        "@adobe/spacecat-shared-drs-client": "^1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
@@ -4096,9 +4096,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-drs-client": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.13.0.tgz",
-      "integrity": "sha512-wliAqyKgtKmN7nDwGjSUxTLJqi7EVfj7+AhySm4KJR3L6a97yC6crN2/Pt0oyxbj4vrKCf4gXgqVjyp8cVGV0g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.14.0.tgz",
+      "integrity": "sha512-k591VQXqbhAKnCggsjZWOlURyH5jmlLjAW0FrcO6QWrY+9Ft7MwSAx9oRcr+mPhhWQG5gBupqexvzWvLCK5Q8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
     "@adobe/spacecat-shared-data-access": "4.9.0",
-    "@adobe/spacecat-shared-drs-client": "1.13.0",
+    "@adobe/spacecat-shared-drs-client": "^1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",


### PR DESCRIPTION
## Related Issues

SITES-47932

## Summary

The GET /sites endpoint supports three response shapes but none had named OpenAPI examples, so the API docs showed an empty `[]` placeholder in the right-hand dropdown regardless of which shape was used.

- Adds `site-list`, `site-paged-response`, and `site-search-response` to `examples.yaml`
- Wires them up under the `responses.200` block in `sites-api.yaml` so all three appear in the Redoc dropdown
- Rebuilds `docs/index.html`
- Bumps `@adobe/spacecat-shared-drs-client` 1.13.0 → 1.14.0 to fix pre-existing type-check failures (`listJobs` and `createBrandPresenceSchedule` were missing from the published `DrsClient` type definition)

## Test plan

- [ ] `npm run docs:lint` — passes with 0 errors
- [ ] `npm run docs:build` — builds successfully
- [ ] `npm run type-check` — passes clean
- [ ] Open `docs/index.html` locally and verify GET /sites shows three options in the Example dropdown: SiteList, SitePagedResponse, SiteSearchResponse, each with real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)