### PR TITLE
feat(llmo): register recurring prompt-suggestion schedules only for paying sites; one-shot for trial

### DIFF
--- a/docs/specs/2026-07-16-prompt-suggestion-schedules-onboarding.md
+++ b/docs/specs/2026-07-16-prompt-suggestion-schedules-onboarding.md
@@ -54,6 +54,32 @@ DRS; the immediate run is best-effort.
 - **Tenant identity.** Only `siteId` crosses the boundary. No `imsOrgId`/`orgId`
   is threaded — DRS derives the isolation key from `siteId` server-side.
 
+## Tier gating
+
+Whether a pipeline is registered as a **recurring schedule** or run **once**
+depends on the site's paying tier, resolved by `isPayingLlmoSite(site, context)`:
+
+| Tier | Behavior per pipeline |
+|---|---|
+| **PAID** | Recurring `createSchedule` (immediate first run) — the durable outcome is the server-side schedule row. |
+| **FREE_TRIAL / non-paid** | One-shot `submitJob` — a single on-demand run, no recurring schedule. The three providers are on-demand-capable, so a trial site still gets its first suggestions without committing recurring Fargate load. |
+| **Indeterminate** (no entitlement, or the tier lookup throws/hangs) | Treated as trial (one-shot). |
+
+- **Fail-safe-to-trial.** `isPayingLlmoSite` returns `false` (and logs a WARN)
+  when the LLMO entitlement is absent or the lookup throws, so a site whose paying
+  status is unknown never gets a recurring, fleet-wide Fargate schedule.
+- **Latency bound on the lookup.** The `isPayingLlmoSite` call is itself wrapped in
+  `settleWithin(..., TIER_LOOKUP_TIMEOUT_MS = 5000ms)`, **defaulting to `false`
+  (trial) on timeout**. Its internal try/catch handles rejections but not a hung
+  tier service; the wrap caps that hang so a slow tier service cannot push the
+  synchronous onboarding response past the CDN first-byte timeout. This is
+  separate from, and runs before, the `settleWithin(..., 8000ms)` that bounds the
+  schedule-registration step.
+- **Error wording.** The per-pipeline catch reports the branch accurately —
+  "…prompt-suggestion (schedule)" for the paying `createSchedule` failure,
+  "…prompt-suggestion (one-shot run)" for the trial `submitJob` failure — since
+  either failure means the site needs a manual trigger.
+
 ## Dependency / deployment order
 
 `createSchedule` ships in `@adobe/spacecat-shared-drs-client@1.14.0` (spacecat-shared PR #1816), which is not yet published. Therefore:

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -76,6 +76,15 @@ const OVERRIDE_DETECT_TIMEOUT_MS = 5000;
 // outcome is the server-side schedule row, so on timeout we stop waiting.
 const SCHEDULE_REGISTRATION_TIMEOUT_MS = 8000;
 
+// Cap for the best-effort paying-tier lookup (isPayingLlmoSite). It runs on the
+// synchronous onboarding path, before the schedule-registration step, and hits the
+// tier service — a slow/hung tier service would otherwise stall onboarding past
+// the CDN first-byte timeout even though isPayingLlmoSite's own try/catch already
+// handles rejections. On timeout we fall back to `false` (trial), consistent with
+// isPayingLlmoSite's fail-safe-to-trial intent: an indeterminate tier never gets a
+// recurring, fleet-wide Fargate schedule.
+const TIER_LOOKUP_TIMEOUT_MS = 5000;
+
 /**
  * Awaits `promise`, but resolves to `fallback` if it rejects or doesn't settle
  * within `timeoutMs`. The underlying promise is left running and any late
@@ -372,10 +381,14 @@ export async function registerPromptSuggestionSchedules({
         // brands.js (activateBrand). `status` is the upstream HTTP status when the
         // DRS client attaches one, else 'unknown'.
         const status = scheduleError.status ?? 'unknown';
-        log.error(`Failed to register DRS ${name} schedule provider_id=${providerId} `
-          + `site_id=${siteId} status=${status}: ${scheduleError.message}`);
-        say(`:warning: Failed to register DRS ${name} schedule for site ${siteId} `
-          + '(will need manual trigger)');
+        // Wording tracks the branch: paying → createSchedule (recurring schedule),
+        // trial/non-paying → submitJob (one-shot run). "schedule" alone would
+        // misdescribe the trial-path failure.
+        const mode = isPaying ? 'schedule' : 'one-shot run';
+        log.error(`Failed to run/register DRS ${name} prompt-suggestion (${mode}) `
+          + `provider_id=${providerId} site_id=${siteId} status=${status}: ${scheduleError.message}`);
+        say(`:warning: Failed to run/register DRS ${name} prompt-suggestion (${mode}) `
+          + `for site ${siteId} (will need manual trigger)`);
       }
     }),
   );
@@ -1662,7 +1675,16 @@ export async function activateBrandAndGeneratePrompts({
       // Brandalf→prompt-gen chain) and out of scope here.
       // TODO(LLMO-4258 follow-up): have DRS trigger these once base prompt
       // generation completes, instead of racing the Brandalf submit.
-      const isPaying = await isPayingLlmoSite(site, context);
+      // Bound by settleWithin: isPayingLlmoSite hits the tier service and is
+      // awaited on the synchronous response path. Its own try/catch handles
+      // rejections but NOT a hang, so cap it and fall back to `false` (trial) on
+      // timeout — same fail-safe-to-trial intent as isPayingLlmoSite itself, so an
+      // indeterminate tier never gets a recurring, fleet-wide schedule.
+      const isPaying = await settleWithin(
+        isPayingLlmoSite(site, context),
+        TIER_LOOKUP_TIMEOUT_MS,
+        false,
+      );
 
       // Bound by settleWithin: the per-pipeline createSchedule/submitJob calls are
       // awaited on the synchronous response path, so a slow/hung DRS could

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -216,15 +216,57 @@ export const PROMPT_SUGGESTION_PIPELINES = [
 ];
 
 /**
- * Registers a recurring DRS schedule for one prompt-suggestion provider, with an
- * immediate first run. Shared body for {@link registerPromptSuggestionSchedules}.
+ * Reports whether a site is on the paying (PAID) LLMO tier, which decides the
+ * prompt-suggestion behavior at onboarding: PAID → a recurring schedule;
+ * anything else (FREE_TRIAL, or an entitlement that cannot be read) → a single
+ * on-demand run.
+ *
+ * Fails safe to trial: if the current LLMO entitlement is absent or the lookup
+ * throws, this returns `false` (and logs a WARN) rather than assuming PAID, so a
+ * site whose paying status is unknown never gets a recurring, fleet-wide Fargate
+ * schedule.
+ *
+ * @param {object} site - The SpaceCat site model.
+ * @param {object} context - The request context (passed to TierClient).
+ * @returns {Promise<boolean>} True only when the current LLMO tier is PAID.
+ */
+export async function isPayingLlmoSite(site, context) {
+  const { log } = context;
+  try {
+    const tierClient = await TierClient.createForSite(context, site, LLMO_PRODUCT_CODE);
+    const { entitlement } = await tierClient.checkValidEntitlement();
+    if (!entitlement) {
+      log.warn(`Could not determine LLMO tier for site ${site.getId()} `
+        + '(no entitlement found); defaulting to one-time (trial) prompt-suggestion runs');
+      return false;
+    }
+    return entitlement.getTier() === EntitlementModel.TIERS.PAID;
+  } catch (error) {
+    log.warn(`Failed to read LLMO tier for site ${site.getId()}; `
+      + `defaulting to one-time (trial) prompt-suggestion runs: ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Runs one prompt-suggestion provider for a newly onboarded site, tier-gated.
+ * Shared body for {@link registerPromptSuggestionSchedules}.
+ *
+ * - **Paying (`isPaying === true`)**: registers a recurring DRS schedule
+ *   (`createSchedule`) with an immediate first run.
+ * - **Trial / non-paying (any other value)**: submits a single on-demand run
+ *   (`submitJob`) with NO recurring schedule. These three providers are
+ *   on-demand-capable, so a one-shot job is valid and gives a trial site its
+ *   first suggestions without committing recurring Fargate load.
  *
  * Split error semantics (see the V2 caller): the immediate first run is
  * best-effort — if it produces nothing (e.g. brand/base-prompt data not present
- * yet) the next scheduled run self-heals. A `createSchedule` (schedule
+ * yet) the next scheduled run (paying) self-heals. A `createSchedule` (schedule
  * REGISTRATION) failure is NOT best-effort: the site would never get a recurring
  * schedule and nothing self-heals, so it propagates to the caller which logs it
- * at ERROR. This helper therefore does not swallow the failure itself.
+ * at ERROR. This helper therefore does not swallow the failure itself. The
+ * one-shot `submitJob` failure is handled the same way (propagated, logged by the
+ * caller) so both paths share one per-pipeline try/catch.
  *
  * NOTE: `createSchedule` derives the tenant-isolation key from `siteId`
  * server-side and REJECTS any caller-supplied imsOrgId, so we deliberately do not
@@ -232,21 +274,39 @@ export const PROMPT_SUGGESTION_PIPELINES = [
  *
  * @param {object} params
  * @param {object} params.drsClient - Configured DRS client.
- * @param {string} params.providerId - DRS provider id to schedule.
- * @param {string} params.cadence - One of DRS_CADENCE_* labels.
+ * @param {string} params.providerId - DRS provider id to schedule/run.
+ * @param {string} params.cadence - One of DRS_CADENCE_* labels (paying path only).
  * @param {string} params.siteId - SpaceCat site UUID.
+ * @param {boolean} params.isPaying - True → recurring schedule; else one-shot run.
  * @param {object} params.log - Logger.
  * @param {Function} [params.say] - Optional Slack say callback.
- * @returns {Promise<object|null>} The createSchedule result, or null when DRS is not configured.
+ * @returns {Promise<object|null>} The createSchedule/submitJob result, or null when
+ *   DRS is not configured.
  */
 export async function registerPromptSuggestionSchedule({
-  drsClient, providerId, cadence, siteId, log, say = () => {},
+  drsClient, providerId, cadence, siteId, isPaying, log, say = () => {},
 }) {
   if (!drsClient.isConfigured()) {
     log.debug(`DRS client not configured, skipping ${providerId} schedule for site ${siteId}`);
     return null;
   }
 
+  // Trial / non-paying (or indeterminate tier): run the pipeline ONCE via an
+  // on-demand submitJob, with no recurring schedule.
+  if (!isPaying) {
+    const job = await drsClient.submitJob({
+      provider_id: providerId,
+      source: 'onboarding',
+      priority: 'HIGH',
+      parameters: { siteId },
+    });
+    log.info(`Submitted one-time DRS ${providerId} run (trial site) `
+      + `job=${job?.job_id ?? 'unknown'} for site ${siteId}`);
+    say(`:zap: Submitted one-time DRS ${providerId} run (trial site) for site ${siteId}`);
+    return job;
+  }
+
+  // Paying (PAID): register the recurring schedule with an immediate first run.
   // Default enable_brand_presence off (plan Phase 0.4): these prompt-suggestion
   // pipelines must not push unexpected load into the brand-presence pipeline / SNS
   // allowlist unless a site is explicitly BP-enabled. `providerIds` is an array
@@ -267,25 +327,28 @@ export async function registerPromptSuggestionSchedule({
 }
 
 /**
- * Registers every recurring prompt-suggestion schedule (see
- * {@link PROMPT_SUGGESTION_PIPELINES}) for a newly onboarded v2 site, each with
- * an immediate first run.
+ * Runs every prompt-suggestion pipeline (see {@link PROMPT_SUGGESTION_PIPELINES})
+ * for a newly onboarded v2 site, tier-gated: paying sites get a recurring
+ * schedule (immediate first run), trial/non-paying sites get a single on-demand
+ * run per pipeline (no recurring schedule). See {@link registerPromptSuggestionSchedule}.
  *
  * Error ownership is single-layer: each pipeline is wrapped in its own try/catch
  * that owns the failure (logs at ERROR + emits an operator Slack signal) and
- * never rethrows, so one pipeline's schedule-REGISTRATION failure neither aborts
- * onboarding nor masks the other pipelines. Because no callback rejects, the
- * pipelines run under `Promise.all` (not `allSettled`).
+ * never rethrows, so one pipeline's failure (schedule REGISTRATION on the paying
+ * path, or the one-shot submit on the trial path) neither aborts onboarding nor
+ * masks the other pipelines. Because no callback rejects, the pipelines run under
+ * `Promise.all` (not `allSettled`).
  *
  * @param {object} params
  * @param {object} params.drsClient - Configured DRS client.
  * @param {string} params.siteId - SpaceCat site UUID.
+ * @param {boolean} params.isPaying - True → recurring schedules; else one-shot runs.
  * @param {object} params.log - Logger.
  * @param {Function} [params.say] - Optional Slack say callback.
  * @returns {Promise<void>}
  */
 export async function registerPromptSuggestionSchedules({
-  drsClient, siteId, log, say = () => {},
+  drsClient, siteId, isPaying, log, say = () => {},
 }) {
   // Short-circuit once for an unconfigured client instead of letting each
   // per-pipeline registerPromptSuggestionSchedule log "not configured" N times.
@@ -298,13 +361,14 @@ export async function registerPromptSuggestionSchedules({
     PROMPT_SUGGESTION_PIPELINES.map(async ({ name, providerId, cadence }) => {
       try {
         await registerPromptSuggestionSchedule({
-          drsClient, providerId, cadence, siteId, log, say,
+          drsClient, providerId, cadence, siteId, isPaying, log, say,
         });
       } catch (scheduleError) {
-        // Schedule-REGISTRATION failure (distinct from the best-effort immediate
-        // run): the site would never get a recurring schedule and nothing
-        // self-heals, so surface it loudly with full context. Onboarding still
-        // succeeds, mirroring the brand-activation side-effect handling in
+        // Pipeline REGISTRATION/SUBMIT failure (distinct from the best-effort
+        // immediate run): on the paying path the site would never get a recurring
+        // schedule and nothing self-heals; on the trial path the one-shot run
+        // never fires. Either way, surface it loudly with full context. Onboarding
+        // still succeeds, mirroring the brand-activation side-effect handling in
         // brands.js (activateBrand). `status` is the upstream HTTP status when the
         // DRS client attaches one, else 'unknown'.
         const status = scheduleError.status ?? 'unknown';
@@ -1582,28 +1646,35 @@ export async function activateBrandAndGeneratePrompts({
         say(':warning: Failed to start DRS Brandalf flow (will need manual trigger)');
       }
 
-      // Register the recurring "prompt suggestion" schedules, each with an
-      // immediate first run. These fire right after we SUBMIT the async Brandalf
-      // job above (submit, not completion), so they race Brandalf: for a genuinely
-      // new site the immediate first run typically no-ops because base-prompt/brand
-      // data does not exist yet. That is acceptable — the durable outcome is the
-      // recurring schedule row, and the next scheduled run self-heals once brand
-      // data exists. Cold-start latency is worst for synthetic_personas (quarterly):
-      // if its immediate run no-ops, the first real output can be up to a quarter
-      // out. Chaining registration off base-prompt-generation completion is
-      // cross-repo (DRS owns the Brandalf→prompt-gen chain) and out of scope here.
-      // TODO(LLMO-4258 follow-up): have DRS trigger these schedules once base prompt
+      // Run the "prompt suggestion" pipelines, tier-gated (LLMO prompt-suggestion
+      // tier gate): PAYING sites get a recurring schedule with an immediate first
+      // run; TRIAL / non-paying (or an indeterminate tier — isPayingLlmoSite fails
+      // safe to trial) get a single on-demand run per pipeline, no recurring
+      // schedule. These fire right after we SUBMIT the async Brandalf job above
+      // (submit, not completion), so they race Brandalf: for a genuinely new site
+      // the immediate first run typically no-ops because base-prompt/brand data
+      // does not exist yet. For a paying site that is acceptable — the durable
+      // outcome is the recurring schedule row, and the next scheduled run
+      // self-heals once brand data exists. Cold-start latency is worst for
+      // synthetic_personas (quarterly): if its immediate run no-ops, the first real
+      // output can be up to a quarter out. Chaining registration off
+      // base-prompt-generation completion is cross-repo (DRS owns the
+      // Brandalf→prompt-gen chain) and out of scope here.
+      // TODO(LLMO-4258 follow-up): have DRS trigger these once base prompt
       // generation completes, instead of racing the Brandalf submit.
-      //
-      // Bound by settleWithin: the three createSchedule calls are awaited on the
-      // synchronous response path, so a slow/hung DRS could otherwise stall
-      // onboarding. On timeout we stop waiting — createSchedule is idempotent, the
-      // durable outcome is the server-side schedule row, and per-pipeline ERROR
-      // logging inside registerPromptSuggestionSchedules stays deterministic.
+      const isPaying = await isPayingLlmoSite(site, context);
+
+      // Bound by settleWithin: the per-pipeline createSchedule/submitJob calls are
+      // awaited on the synchronous response path, so a slow/hung DRS could
+      // otherwise stall onboarding. On timeout we stop waiting — createSchedule is
+      // idempotent, the durable outcome is the server-side schedule row (paying)
+      // or a submitted job (trial), and per-pipeline ERROR logging inside
+      // registerPromptSuggestionSchedules stays deterministic.
       const scheduleResult = await settleWithin(
         registerPromptSuggestionSchedules({
           drsClient,
           siteId: site.getId(),
+          isPaying,
           log,
           say,
         }),

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -132,7 +132,22 @@ describe('LLMO Onboarding Functions', () => {
           getId: sandbox.stub().returns('enrollment123'),
         },
       }),
+      // Default the tier read to PAID so the full-flow V2 onboarding tests keep
+      // exercising the recurring-schedule prompt-suggestion path (tier gate).
+      checkValidEntitlement: sandbox.stub().resolves({
+        entitlement: { getTier: sandbox.stub().returns('PAID') },
+      }),
       revokeSiteEnrollment: sandbox.stub().resolves(),
+    }),
+  });
+
+  // TierClient mock resolving a specific LLMO tier via checkValidEntitlement,
+  // for the prompt-suggestion tier-gate tests.
+  const createMockTierClientForTier = (tier, sandbox = sinon) => ({
+    createForSite: sandbox.stub().returns({
+      checkValidEntitlement: sandbox.stub().resolves({
+        entitlement: { getTier: sandbox.stub().returns(tier) },
+      }),
     }),
   });
 
@@ -238,14 +253,16 @@ describe('LLMO Onboarding Functions', () => {
       '@adobe/spacecat-shared-data-access/src/models/entitlement/index.js': {
         Entitlement: {
           PRODUCT_CODES: { LLMO: 'LLMO' },
-          TIERS: { FREE_TRIAL: 'FREE_TRIAL' },
+          TIERS: { FREE_TRIAL: 'FREE_TRIAL', PAID: 'PAID' },
         },
       },
     };
 
-    if (mockTierClient) {
-      deps['@adobe/spacecat-shared-tier-client'] = { default: mockTierClient };
-    }
+    // Default the tier client to a PAID reader so the recurring-schedule
+    // prompt-suggestion path (tier gate) is exercised unless a test overrides it.
+    deps['@adobe/spacecat-shared-tier-client'] = {
+      default: mockTierClient || createMockTierClientForTier('PAID'),
+    };
 
     if (sharePointClient) {
       deps['@adobe/spacecat-helix-content-sdk'] = { createFrom: sinon.stub().resolves(sharePointClient) };
@@ -5778,10 +5795,12 @@ describe('LLMO Onboarding Functions', () => {
       sandbox.restore();
     });
 
-    const buildDrsClient = (createScheduleImpl) => ({
+    const buildDrsClient = (createScheduleImpl, submitJobImpl) => ({
       isConfigured: sandbox.stub().returns(true),
       createSchedule: createScheduleImpl
         || sandbox.stub().resolves({ scheduleId: 'sched-1', alreadyExisted: false }),
+      submitJob: submitJobImpl
+        || sandbox.stub().resolves({ job_id: 'job-1' }),
     });
 
     const buildLog = () => ({
@@ -5804,13 +5823,14 @@ describe('LLMO Onboarding Functions', () => {
     });
 
     PIPELINES.forEach(([providerId, cadence]) => {
-      it(`registerPromptSuggestionSchedule registers a ${cadence} schedule for ${providerId} with an immediate first run`, async () => {
+      it(`registerPromptSuggestionSchedule registers a ${cadence} schedule for ${providerId} with an immediate first run (paying)`, async () => {
         const drsClient = buildDrsClient();
         const result = await onboardingModule.registerPromptSuggestionSchedule({
-          drsClient, providerId, cadence, siteId: 'site-123', log: buildLog(), say: sandbox.stub(),
+          drsClient, providerId, cadence, siteId: 'site-123', isPaying: true, log: buildLog(), say: sandbox.stub(),
         });
 
         expect(drsClient.createSchedule).to.have.been.calledOnce;
+        expect(drsClient.submitJob).to.not.have.been.called;
         const arg = drsClient.createSchedule.firstCall.args[0];
         expect(arg).to.deep.include({
           siteId: 'site-123',
@@ -5825,16 +5845,37 @@ describe('LLMO Onboarding Functions', () => {
         expect(result).to.deep.equal({ scheduleId: 'sched-1', alreadyExisted: false });
       });
 
-      it(`registerPromptSuggestionSchedule skips (no createSchedule) for ${providerId} when the DRS client is not configured`, async () => {
+      it(`registerPromptSuggestionSchedule submits a one-time run (no schedule) for ${providerId} on a trial site`, async () => {
+        const drsClient = buildDrsClient();
+        const log = buildLog();
+        const result = await onboardingModule.registerPromptSuggestionSchedule({
+          drsClient, providerId, cadence, siteId: 'site-123', isPaying: false, log, say: sandbox.stub(),
+        });
+
+        // Trial → one-shot submitJob, NO recurring schedule.
+        expect(drsClient.createSchedule).to.not.have.been.called;
+        expect(drsClient.submitJob).to.have.been.calledOnce;
+        expect(drsClient.submitJob.firstCall.args[0]).to.deep.equal({
+          provider_id: providerId,
+          source: 'onboarding',
+          priority: 'HIGH',
+          parameters: { siteId: 'site-123' },
+        });
+        expect(result).to.deep.equal({ job_id: 'job-1' });
+        expect(log.info).to.have.been.calledWithMatch(/Submitted one-time DRS/);
+      });
+
+      it(`registerPromptSuggestionSchedule skips (no createSchedule/submitJob) for ${providerId} when the DRS client is not configured`, async () => {
         const drsClient = buildDrsClient();
         drsClient.isConfigured.returns(false);
         const log = buildLog();
 
         const result = await onboardingModule.registerPromptSuggestionSchedule({
-          drsClient, providerId, cadence, siteId: 'site-123', log, say: sandbox.stub(),
+          drsClient, providerId, cadence, siteId: 'site-123', isPaying: true, log, say: sandbox.stub(),
         });
 
         expect(drsClient.createSchedule).to.not.have.been.called;
+        expect(drsClient.submitJob).to.not.have.been.called;
         expect(result).to.equal(null);
         expect(log.debug).to.have.been.calledWithMatch(providerId);
       });
@@ -5844,8 +5885,17 @@ describe('LLMO Onboarding Functions', () => {
         const drsClient = buildDrsClient(sandbox.stub().rejects(err));
 
         await expect(onboardingModule.registerPromptSuggestionSchedule({
-          drsClient, providerId, cadence, siteId: 'site-123', log: buildLog(), say: sandbox.stub(),
+          drsClient, providerId, cadence, siteId: 'site-123', isPaying: true, log: buildLog(), say: sandbox.stub(),
         })).to.be.rejectedWith('DRS POST /schedules failed: 500');
+      });
+
+      it(`registerPromptSuggestionSchedule propagates a one-shot submit failure for ${providerId} (trial, not swallowed)`, async () => {
+        const err = new Error('DRS POST /jobs failed: 500');
+        const drsClient = buildDrsClient(undefined, sandbox.stub().rejects(err));
+
+        await expect(onboardingModule.registerPromptSuggestionSchedule({
+          drsClient, providerId, cadence, siteId: 'site-123', isPaying: false, log: buildLog(), say: sandbox.stub(),
+        })).to.be.rejectedWith('DRS POST /jobs failed: 500');
       });
     });
 
@@ -5860,6 +5910,7 @@ describe('LLMO Onboarding Functions', () => {
         providerId: 'prompt_generation_semrush',
         cadence: 'twice_monthly',
         siteId: 'site-123',
+        isPaying: true,
         log,
         say: sandbox.stub(),
       });
@@ -5872,28 +5923,49 @@ describe('LLMO Onboarding Functions', () => {
       expect(log.info).to.have.been.calledWithMatch(/prompt_generation_semrush/);
     });
 
-    it('registerPromptSuggestionSchedules resolves to a completion sentinel on success', async () => {
+    it('registerPromptSuggestionSchedules resolves to a completion sentinel on success (paying)', async () => {
       // The caller distinguishes "finished" from a settleWithin timeout by this
       // sentinel (timeout resolves to the null fallback instead).
+      const drsClient = buildDrsClient(
+        sandbox.stub().resolves({ scheduleId: 'sched-1', alreadyExisted: false }),
+      );
       const result = await onboardingModule.registerPromptSuggestionSchedules({
-        drsClient: buildDrsClient(
-          sandbox.stub().resolves({ scheduleId: 'sched-1', alreadyExisted: false }),
-        ),
+        drsClient,
         siteId: 'site-123',
+        isPaying: true,
         log: buildLog(),
         say: sandbox.stub(),
       });
       expect(result).to.deep.equal({ completed: true });
+      // Paying → recurring schedule per pipeline, no one-shot submits.
+      expect(drsClient.createSchedule).to.have.been.calledThrice;
+      expect(drsClient.submitJob).to.not.have.been.called;
+    });
+
+    it('registerPromptSuggestionSchedules submits one-time runs (no schedules) for a trial site', async () => {
+      const drsClient = buildDrsClient();
+      const result = await onboardingModule.registerPromptSuggestionSchedules({
+        drsClient,
+        siteId: 'site-123',
+        isPaying: false,
+        log: buildLog(),
+        say: sandbox.stub(),
+      });
+      expect(result).to.deep.equal({ completed: true });
+      // Trial → one-shot submitJob per pipeline, no recurring schedules.
+      expect(drsClient.submitJob).to.have.been.calledThrice;
+      expect(drsClient.createSchedule).to.not.have.been.called;
     });
 
     it('registerPromptSuggestionSchedules resolves to the sentinel when DRS is not configured', async () => {
       const drsClient = buildDrsClient(sandbox.stub());
       drsClient.isConfigured = sandbox.stub().returns(false);
       const result = await onboardingModule.registerPromptSuggestionSchedules({
-        drsClient, siteId: 'site-123', log: buildLog(), say: sandbox.stub(),
+        drsClient, siteId: 'site-123', isPaying: true, log: buildLog(), say: sandbox.stub(),
       });
       expect(result).to.deep.equal({ completed: true });
       expect(drsClient.createSchedule).to.not.have.been.called;
+      expect(drsClient.submitJob).to.not.have.been.called;
     });
   });
 
@@ -5959,6 +6031,89 @@ describe('LLMO Onboarding Functions', () => {
         'prompt_generation_agentic_traffic',
         'prompt_generation_synthetic_personas',
       ]);
+    });
+
+    it('submits one-time runs (no schedules) for a FREE_TRIAL site', async () => {
+      const mockDrsClient = createMockDrsClient(sandbox);
+      const { activateBrandAndGeneratePrompts } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockTierClient: createMockTierClientForTier('FREE_TRIAL', sandbox),
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      await activateBrandAndGeneratePrompts(buildV2Params(context));
+
+      const instance = mockDrsClient.createFrom();
+      // Trial → NO recurring schedules; one on-demand submit per pipeline.
+      expect(instance.createSchedule).to.not.have.been.called;
+      // submitJob = 1 Brandalf + 3 one-shot pipeline runs.
+      expect(instance.submitJob.callCount).to.equal(4);
+      const oneShotCalls = instance.submitJob.getCalls()
+        .filter((c) => c.args[0].source === 'onboarding' && c.args[0].parameters?.siteId === 'site-123');
+      const providerIds = oneShotCalls.map((c) => c.args[0].provider_id);
+      expect(providerIds).to.have.members([
+        'prompt_generation_semrush',
+        'prompt_generation_agentic_traffic',
+        'prompt_generation_synthetic_personas',
+      ]);
+    });
+
+    it('defaults to one-time runs (trial) and WARNs when the tier cannot be read', async () => {
+      const mockDrsClient = createMockDrsClient(sandbox);
+      // TierClient whose entitlement lookup throws → tier indeterminate.
+      const failingTierClient = {
+        createForSite: sandbox.stub().returns({
+          checkValidEntitlement: sandbox.stub().rejects(new Error('tier lookup boom')),
+        }),
+      };
+      const { activateBrandAndGeneratePrompts } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockTierClient: failingTierClient,
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      await activateBrandAndGeneratePrompts(buildV2Params(context));
+
+      const instance = mockDrsClient.createFrom();
+      // Fail-safe: no recurring schedule for a site of unknown paying status.
+      expect(instance.createSchedule).to.not.have.been.called;
+      expect(instance.submitJob.callCount).to.equal(4); // Brandalf + 3 one-shots
+      const warnLogs = context.log.warn.getCalls().map((c) => c.args[0]);
+      expect(warnLogs.some((m) => m.includes('Failed to read LLMO tier for site site-123'))).to.be.true;
+    });
+
+    it('defaults to one-time runs (trial) and WARNs when no entitlement exists', async () => {
+      const mockDrsClient = createMockDrsClient(sandbox);
+      const noEntitlementTierClient = {
+        createForSite: sandbox.stub().returns({
+          checkValidEntitlement: sandbox.stub().resolves({}),
+        }),
+      };
+      const { activateBrandAndGeneratePrompts } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockTierClient: noEntitlementTierClient,
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      await activateBrandAndGeneratePrompts(buildV2Params(context));
+
+      const instance = mockDrsClient.createFrom();
+      expect(instance.createSchedule).to.not.have.been.called;
+      expect(instance.submitJob.callCount).to.equal(4);
+      const warnLogs = context.log.warn.getCalls().map((c) => c.args[0]);
+      expect(warnLogs.some((m) => m.includes('Could not determine LLMO tier for site site-123'))).to.be.true;
     });
 
     it('logs a schedule-registration failure at ERROR with context but still completes onboarding', async () => {

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1868,7 +1868,12 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
       const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
+      // Fake timers (not mockSetTimeoutImmediate) so the settleWithin-wrapped tier
+      // lookup resolves via its fast PAID promise before its 5s cap — an
+      // immediate-firing timer would defeat the race and mis-route to the trial
+      // (one-shot) path. Long best-effort timers (override detect, schedule
+      // registration) are still fast-forwarded by tickAsync below.
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
       const mockComposeBaseURL = createMockComposeBaseURL();
       const { mockClient: sharePointClient } = createMockSharePointClient(
         sinon,
@@ -1910,7 +1915,16 @@ describe('LLMO Onboarding Functions', () => {
         imsOrgId: 'ABC123@AdobeOrg',
       };
 
-      const result = await performLlmoOnboardingWithMocks(params, context);
+      let result;
+      try {
+        const pending = performLlmoOnboardingWithMocks(params, context);
+        // Fast-forward every best-effort settleWithin timer, flushing microtasks
+        // between ticks so the fast-resolving stubs (tier, DRS) win their races.
+        await clock.tickAsync(60000);
+        result = await pending;
+      } finally {
+        clock.restore();
+      }
 
       expect(mockDrsClient.createFrom().submitJob).to.have.been.calledWith(
         sinon.match({
@@ -6143,10 +6157,12 @@ describe('LLMO Onboarding Functions', () => {
       // All three providers are surfaced, none swallowed. Filter by the
       // schedule-failure message instead of asserting a bare calledThrice, so an
       // unrelated future ERROR log in V2 onboarding does not break this test.
-      const scheduleFailureLogs = errorLogs.filter((m) => m.includes('Failed to register DRS'));
+      const scheduleFailureLogs = errorLogs.filter((m) => m.includes('Failed to run/register DRS'));
       expect(scheduleFailureLogs).to.have.lengthOf(3);
+      // Paying path → the wording reads "(schedule)", the failing createSchedule branch.
+      expect(semrushLog).to.include('(schedule)');
       // Operator gets a Slack warning per failed schedule (manual-trigger signal).
-      expect(params.say).to.have.been.calledWithMatch(/Failed to register DRS .*schedule/);
+      expect(params.say).to.have.been.calledWithMatch(/Failed to run\/register DRS .*\(schedule\)/);
       // Brandalf still fired — the schedule failures did not abort onboarding.
       expect(mockDrsClient.createFrom().submitJob).to.have.been.calledOnce;
     });
@@ -6262,6 +6278,74 @@ describe('LLMO Onboarding Functions', () => {
       } finally {
         clock.restore();
       }
+    });
+
+    it('defaults to the trial (one-shot) path when the tier lookup times out', async () => {
+      // isPayingLlmoSite hits a hung tier service: the entitlement promise is
+      // pending (not rejected), so isPayingLlmoSite's internal try/catch never
+      // fires. The settleWithin(TIER_LOOKUP_TIMEOUT_MS) cap must fall back to
+      // false (trial) → one-shot submitJob per pipeline, no recurring schedules.
+      const clock = sandbox.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        const mockDrsClient = createMockDrsClient(sandbox);
+        const hangingTierClient = {
+          createForSite: sandbox.stub().returns({
+            // never settles → forces the settleWithin timeout branch
+            checkValidEntitlement: sandbox.stub().returns(new Promise(() => {})),
+          }),
+        };
+        const { activateBrandAndGeneratePrompts } = await esmock(
+          '../../../src/controllers/llmo/llmo-onboarding.js',
+          createCommonEsmockDependencies({
+            mockDrsClient,
+            mockTierClient: hangingTierClient,
+            mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+          }),
+        );
+        const context = buildV2Context();
+        const params = buildV2Params(context);
+        const pending = activateBrandAndGeneratePrompts(params);
+        // Advance past the tier-lookup cap (and any sibling settleWithin timers),
+        // flushing microtasks between ticks.
+        await clock.tickAsync(60000);
+        await pending;
+
+        const instance = mockDrsClient.createFrom();
+        // Timed-out tier lookup → treated as trial: no recurring schedule, one-shot
+        // submitJob per pipeline (plus the Brandalf submit).
+        expect(instance.createSchedule).to.not.have.been.called;
+        expect(instance.submitJob.callCount).to.equal(4);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('logs a trial one-shot submit failure with "(one-shot run)" wording', async () => {
+      // Trial path: the per-pipeline failure is a submitJob (one-shot), not a
+      // createSchedule — the log/Slack wording must reflect that branch.
+      const err = new Error('DRS POST /jobs failed');
+      err.status = 502;
+      const mockDrsClient = createMockDrsClient(sandbox, {
+        submitJob: sandbox.stub().rejects(err),
+      });
+      const { activateBrandAndGeneratePrompts } = await esmock(
+        '../../../src/controllers/llmo/llmo-onboarding.js',
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockTierClient: createMockTierClientForTier('FREE_TRIAL', sandbox),
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      const params = buildV2Params(context);
+      await activateBrandAndGeneratePrompts(params);
+
+      const errorLogs = context.log.error.getCalls().map((c) => c.args[0]);
+      const oneShotLogs = errorLogs.filter((m) => m.includes('Failed to run/register DRS') && m.includes('(one-shot run)'));
+      // All three trial pipelines surfaced the one-shot failure, none swallowed.
+      expect(oneShotLogs).to.have.lengthOf(3);
+      expect(params.say).to.have.been.calledWithMatch(/Failed to run\/register DRS .*\(one-shot run\)/);
     });
   });
 });


### PR DESCRIPTION
## What

Differentiates DRS prompt-suggestion behavior by customer LLMO entitlement tier at onboarding (V2 path, `activateBrandAndGeneratePrompts`):

- **Paying customers (LLMO tier = `PAID`)** → register the recurring DRS schedule with an immediate first run (existing behavior: `createSchedule({..., triggerImmediately: true})`).
- **Trial / non-paying (`FREE_TRIAL`, or anything not `PAID`)** → run each pipeline **once**, no recurring schedule: `submitJob({ provider_id, source: 'onboarding', priority: 'HIGH', parameters: { siteId } })`. The three providers (`prompt_generation_semrush`, `prompt_generation_agentic_traffic`, `prompt_generation_synthetic_personas`) are on-demand-capable, so a one-shot job is valid.

## Tier read

The tier is read via `TierClient.createForSite(context, site, LLMO_PRODUCT_CODE)` → `checkValidEntitlement()` → `entitlement.getTier()`, compared against `EntitlementModel.TIERS.PAID`. This is wrapped in a new `isPayingLlmoSite(site, context)` helper.

## Safe default

If the tier cannot be determined — the entitlement is absent, or the lookup throws — `isPayingLlmoSite` returns `false` (trial behavior) and logs a **WARN**. A site whose paying status is unknown never gets a recurring, fleet-wide Fargate schedule; it only gets a bounded one-shot run.

The per-pipeline best-effort error semantics (ERROR-log with `provider_id`+`site_id`, never abort onboarding) and the `settleWithin` timeout WARN at the call site are preserved unchanged for **both** paths.

## Follow-up

The companion **trial → paid upgrade trigger** (registering the recurring schedule when a trial site upgrades to paid) is a separate follow-up — research in progress.

## Tests

- `PAID` site → `createSchedule` per pipeline, `submitJob` not called for these providers.
- `FREE_TRIAL` site → one-shot `submitJob` per pipeline, `createSchedule` not called.
- Tier-read failure and no-entitlement → default to one-shot, WARN logged, onboarding still completes.
- Existing prompt-suggestion tests adjusted to the new tier-aware shape (paying + trial variants, one-shot submit-failure propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Spec

Design spec (incl. the Tier gating section): [`docs/specs/2026-07-16-prompt-suggestion-schedules-onboarding.md`](https://github.com/adobe/spacecat-api-service/blob/feat/prompt-suggestion-tier/docs/specs/2026-07-16-prompt-suggestion-schedules-onboarding.md).

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```