### PR TITLE
feat(preflight): hostname-membership URL validation per ADR-002 (SITES-48309)

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -34,6 +34,70 @@ export const AUDIT_STEP_SUGGEST = 'suggest';
 
 const ACCESSIBILITY_AUDIT_NAME = 'accessibility';
 
+// SITES-48309: EDS host TLDs we accept as preview/live hostnames when deriving
+// the site's known-hosts set from hlxConfig.rso. Current standard is aem.page
+// (preview) / aem.live (live); hlx.page / hlx.live are the legacy Helix TLDs
+// still in customer configs and worth accepting.
+const EDS_HOST_TLDS = ['aem.page', 'aem.live', 'hlx.page', 'hlx.live'];
+
+/**
+ * Collects the set of hostnames the site is registered under. Used by the v2
+ * preflight endpoint to validate a request's `url` belongs to the specified
+ * `siteId` — per ADR-002 §"POST /sites/:siteId/preflights", which replaces
+ * the v1 `findByPreviewURL`-based lookup with a direct hostname-membership
+ * check (SITES-48309). Returns a Set of lowercased hostnames.
+ *
+ * Sources:
+ *  - `site.getBaseURL()` — primary hostname (e.g. `publish-p...adobeaemcloud.com`
+ *    for AEM CS, custom customer domain or `<site>--<owner>.aem.live` for EDS).
+ *  - `site.getDeliveryConfig().authorURL` — author-tier hostname for AEM CS.
+ *  - For EDS (`hlxConfig.rso` populated): derived `<ref>--<site>--<owner>` and
+ *    `<site>--<owner>` variants on each of `aem.page` / `aem.live` / `hlx.page`
+ *    / `hlx.live`.
+ *
+ * @param {import('@adobe/spacecat-shared-data-access').Site} site
+ * @returns {Set<string>}
+ */
+export function collectSiteKnownHostnames(site) {
+  const hostnames = new Set();
+
+  const safeHost = (url) => {
+    if (!hasText(url)) {
+      return null;
+    }
+    try {
+      return new URL(url).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+  };
+
+  const baseHost = safeHost(site.getBaseURL());
+  if (baseHost) {
+    hostnames.add(baseHost);
+  }
+
+  const deliveryConfig = site.getDeliveryConfig?.() ?? {};
+  const authorHost = safeHost(deliveryConfig.authorURL);
+  if (authorHost) {
+    hostnames.add(authorHost);
+  }
+
+  const hlxConfig = site.getHlxConfig?.() ?? {};
+  const { rso } = hlxConfig;
+  if (rso && hasText(rso.owner) && hasText(rso.site)) {
+    const owner = String(rso.owner).toLowerCase();
+    const repoSite = String(rso.site).toLowerCase();
+    const ref = hasText(rso.ref) ? String(rso.ref).toLowerCase() : 'main';
+    for (const tld of EDS_HOST_TLDS) {
+      hostnames.add(`${ref}--${repoSite}--${owner}.${tld}`);
+      hostnames.add(`${repoSite}--${owner}.${tld}`);
+    }
+  }
+
+  return hostnames;
+}
+
 /**
  * Counts the number of issues for a single preflight audit. Three counting modes:
  *  - accessibility: sum of the integer `occurrences` across opportunities
@@ -558,15 +622,17 @@ function PreflightController(ctx, log, env) {
       return preflightError('PREFLIGHT_INVALID_REQUEST', 'Site organization is missing imsOrgId', 400);
     }
 
-    // Validate the URL belongs to this site
-    let siteByUrl;
-    try {
-      siteByUrl = await dataAccess.Site.findByPreviewURL(previewBaseURL);
-    } catch (e) {
-      log.error(`findByPreviewURL failed for ${previewBaseURL}: ${e.message}`);
-      return preflightError('PREFLIGHT_INTERNAL_ERROR', 'Internal error', 500);
-    }
-    if (!siteByUrl || siteByUrl.getId() !== siteId) {
+    // Validate the URL belongs to this site — SITES-48309.
+    // ADR-002 §"POST /sites/:siteId/preflights": "The controller validates that
+    // the `url` hostname matches one of the site's known hostnames (base URL,
+    // preview URL, or live URL). ... This replaces the implicit validation
+    // previously provided by findByPreviewURL." The v1-style URL→site lookup
+    // rejected legitimate publish-tier AEM CS URLs because its host regex only
+    // matched `author-p<N>-e<M>` prefixes, surfacing as a generic 500 for what
+    // is really a 400-shape validation.
+    const requestHost = new URL(url).hostname.toLowerCase();
+    const knownHosts = collectSiteKnownHostnames(site);
+    if (!knownHosts.has(requestHost)) {
       return preflightError('PREFLIGHT_INVALID_REQUEST', 'URL does not belong to this site', 400);
     }
 

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -34,11 +34,11 @@ export const AUDIT_STEP_SUGGEST = 'suggest';
 
 const ACCESSIBILITY_AUDIT_NAME = 'accessibility';
 
-// SITES-48309: EDS host TLDs we accept as preview/live hostnames when deriving
-// the site's known-hosts set from hlxConfig.rso. Current standard is aem.page
-// (preview) / aem.live (live); hlx.page / hlx.live are the legacy Helix TLDs
-// still in customer configs and worth accepting.
-const EDS_HOST_TLDS = ['aem.page', 'aem.live', 'hlx.page', 'hlx.live'];
+// SITES-48309: EDS host suffixes (second-level domains) we accept as preview /
+// live hostnames when deriving the site's known-hosts set from hlxConfig.rso.
+// Current standard is aem.page (preview) / aem.live (live); hlx.page / hlx.live
+// are the legacy Helix domains still in customer configs and worth accepting.
+const EDS_HOST_SUFFIXES = ['aem.page', 'aem.live', 'hlx.page', 'hlx.live'];
 
 /**
  * Collects the set of hostnames the site is registered under. Used by the v2
@@ -89,7 +89,7 @@ export function collectSiteKnownHostnames(site) {
     const owner = String(rso.owner).toLowerCase();
     const repoSite = String(rso.site).toLowerCase();
     const ref = hasText(rso.ref) ? String(rso.ref).toLowerCase() : 'main';
-    for (const tld of EDS_HOST_TLDS) {
+    for (const tld of EDS_HOST_SUFFIXES) {
       hostnames.add(`${ref}--${repoSite}--${owner}.${tld}`);
       hostnames.add(`${repoSite}--${owner}.${tld}`);
     }
@@ -633,6 +633,13 @@ function PreflightController(ctx, log, env) {
     const requestHost = new URL(url).hostname.toLowerCase();
     const knownHosts = collectSiteKnownHostnames(site);
     if (!knownHosts.has(requestHost)) {
+      // SITES-48309: log the mismatch context so operators debugging a
+      // customer-reported 400 can see the requested hostname vs the site's
+      // registered set without needing to re-derive it from the DB.
+      log.info(
+        `[Preflight] URL hostname mismatch for site ${siteId}: requestHost=${requestHost} `
+        + `knownHostsSize=${knownHosts.size} knownHosts=[${[...knownHosts].sort().join(', ')}]`,
+      );
       return preflightError('PREFLIGHT_INVALID_REQUEST', 'URL does not belong to this site', 400);
     }
 

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -22,6 +22,7 @@ import esmock from 'esmock';
 
 import * as utils from '../../src/support/utils.js';
 import PreflightController, {
+  collectSiteKnownHostnames,
   countIssuesForAudit,
   PREFLIGHT_PROCESS_AUDW,
   PREFLIGHT_PROCESS_MYST,
@@ -1153,7 +1154,8 @@ describe('Preflight Controller', () => {
 
       mockDataAccess.AsyncJob.create = sandbox.stub().resolves(mockJob);
       mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
-      mockDataAccess.Site.findByPreviewURL = sandbox.stub().resolves(mockSite);
+      // SITES-48309: createPreflight no longer calls findByPreviewURL; hostname
+      // validation is now an in-memory check via collectSiteKnownHostnames.
       mockDataAccess.Preflight.create = sandbox.stub().resolves(mockPreflight);
       // SITES-48037: createPreflight resolves imsOrgId via Organization.findById.
       // Re-stub per test to keep the fail-closed cases (null org / null imsOrgId)
@@ -1482,8 +1484,10 @@ describe('Preflight Controller', () => {
         params: { siteId: 'test-site-123' },
         data: { url: 'https://author-p12345-e67890-cmstg.adobeaemcloud.com/us/en.html' },
       });
-      // Not asserting 202 here — downstream mysticat call isn't stubbed for
-      // this fixture. What matters is we DIDN'T get 400 at the hostname check.
+      // Downstream mysticat / promise-token machinery isn't stubbed for this
+      // fixture, so the request will still fail somewhere later — but the
+      // hostname check specifically must NOT be the failure point.
+      expect(response.status).to.not.equal(400);
       const result = await response.json();
       expect(result.errorCode).to.not.equal('PREFLIGHT_INVALID_REQUEST');
     });
@@ -1506,6 +1510,11 @@ describe('Preflight Controller', () => {
         params: { siteId: 'test-site-123' },
         data: { url: 'https://publish-p152454-e364278-cmstg.adobeaemcloud.com/us/en.html' },
       });
+      // Same as above — downstream isn't stubbed, so we can't assert 202
+      // without more setup. What matters is neither the hostname check (400)
+      // nor the "Unsupported preview URL" regression (500) fires.
+      expect(response.status).to.not.equal(400);
+      expect(response.status).to.not.equal(500);
       const result = await response.json();
       expect(result.errorCode).to.not.equal('PREFLIGHT_INVALID_REQUEST');
       expect(result.errorCode).to.not.equal('PREFLIGHT_INTERNAL_ERROR');
@@ -1801,7 +1810,6 @@ describe('Preflight Controller', () => {
         getDeliveryType: () => 'aem_cs',
       };
       mockDataAccess.Site.findById.resolves(aemCsSite);
-      mockDataAccess.Site.findByPreviewURL.resolves(aemCsSite);
 
       const pageAuthStub = sandbox.stub().resolves('customer-site-token');
       const controller = await esmock('../../src/controllers/preflight.js', {
@@ -1961,7 +1969,6 @@ describe('Preflight Controller', () => {
         getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(cwSite);
-      mockDataAccess.Site.findByPreviewURL.resolves(cwSite);
 
       const mockRetrievePageAuth = sandbox.stub().resolves('page-access-token');
       const ControllerWithIms = await esmock('../../src/controllers/preflight.js', {
@@ -2019,7 +2026,6 @@ describe('Preflight Controller', () => {
         getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(csSite);
-      mockDataAccess.Site.findByPreviewURL.resolves(csSite);
       const ControllerWithStubbed = await esmock('../../src/controllers/preflight.js', {
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
@@ -2069,7 +2075,6 @@ describe('Preflight Controller', () => {
         getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(brokenSite);
-      mockDataAccess.Site.findByPreviewURL.resolves(brokenSite);
       const ControllerWithStubbed = await esmock('../../src/controllers/preflight.js', {
         '../../src/support/access-control-util.js': {
           default: { fromContext: () => ({ hasAccess: hasAccessStub }) },
@@ -2115,7 +2120,6 @@ describe('Preflight Controller', () => {
         getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(csSite);
-      mockDataAccess.Site.findByPreviewURL.resolves(csSite);
       const mockRetrievePageAuth = sandbox.stub().rejects(new Error('IMS down'));
       const ControllerWithIms = await esmock('../../src/controllers/preflight.js', {
         '@adobe/spacecat-shared-ims-client': {
@@ -2185,7 +2189,6 @@ describe('Preflight Controller', () => {
         getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(spSite);
-      mockDataAccess.Site.findByPreviewURL.resolves(spSite);
 
       const mockRetrievePageAuth = sandbox.stub().resolves('sp-page-token');
       const ControllerWithIms = await esmock('../../src/controllers/preflight.js', {
@@ -2238,7 +2241,6 @@ describe('Preflight Controller', () => {
         getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(csSite);
-      mockDataAccess.Site.findByPreviewURL.resolves(csSite);
 
       const mockRetrievePageAuth = sandbox.stub().resolves('cs-token');
       const ControllerWithIms = await esmock('../../src/controllers/preflight.js', {
@@ -3114,5 +3116,118 @@ describe('countIssuesForAudit', () => {
       ],
     };
     expect(countIssuesForAudit(audit)).to.equal(45);
+  });
+});
+
+describe('collectSiteKnownHostnames (SITES-48309)', () => {
+  const makeSite = ({ baseURL, deliveryConfig, hlxConfig } = {}) => ({
+    getBaseURL: () => baseURL,
+    getDeliveryConfig: () => deliveryConfig || {},
+    getHlxConfig: () => hlxConfig || {},
+  });
+
+  it('collects the baseURL hostname (lowercased) as the primary known host', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://Publish-P12345-E67890-cmstg.adobeaemcloud.com',
+    }));
+    expect([...hosts]).to.deep.equal(['publish-p12345-e67890-cmstg.adobeaemcloud.com']);
+  });
+
+  it('adds deliveryConfig.authorURL host in addition to baseURL (AEM CS two-tier)', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://publish-p12345-e67890-cmstg.adobeaemcloud.com',
+      deliveryConfig: { authorURL: 'https://author-p12345-e67890-cmstg.adobeaemcloud.com' },
+    }));
+    expect(hosts.has('publish-p12345-e67890-cmstg.adobeaemcloud.com')).to.be.true;
+    expect(hosts.has('author-p12345-e67890-cmstg.adobeaemcloud.com')).to.be.true;
+    expect(hosts.size).to.equal(2);
+  });
+
+  it('derives EDS hostnames from hlxConfig.rso — 8 hostnames (2 patterns × 4 suffixes)', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://wknd.site',
+      hlxConfig: { rso: { owner: 'adobe', site: 'wknd', ref: 'main' } },
+    }));
+    // baseURL host + 8 derived EDS hosts = 9 total.
+    expect(hosts.size).to.equal(9);
+    expect(hosts.has('wknd.site')).to.be.true;
+    // 3-part <ref>--<site>--<owner> on all four suffixes.
+    for (const sfx of ['aem.page', 'aem.live', 'hlx.page', 'hlx.live']) {
+      expect(hosts.has(`main--wknd--adobe.${sfx}`)).to.be.true;
+      // 2-part <site>--<owner> on all four suffixes.
+      expect(hosts.has(`wknd--adobe.${sfx}`)).to.be.true;
+    }
+  });
+
+  it('defaults ref to "main" when rso omits it', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://wknd.site',
+      hlxConfig: { rso: { owner: 'adobe', site: 'wknd' } },
+    }));
+    expect(hosts.has('main--wknd--adobe.aem.page')).to.be.true;
+    expect(hosts.has('main--wknd--adobe.aem.live')).to.be.true;
+  });
+
+  it('honors a non-main ref when rso specifies one', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://wknd.site',
+      hlxConfig: { rso: { owner: 'adobe', site: 'wknd', ref: 'feature-x' } },
+    }));
+    expect(hosts.has('feature-x--wknd--adobe.aem.page')).to.be.true;
+    expect(hosts.has('main--wknd--adobe.aem.page')).to.be.false;
+  });
+
+  it('adds NO EDS hostnames when rso is missing owner', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://wknd.site',
+      hlxConfig: { rso: { site: 'wknd', ref: 'main' } },
+    }));
+    expect([...hosts]).to.deep.equal(['wknd.site']);
+  });
+
+  it('adds NO EDS hostnames when rso is missing site', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://wknd.site',
+      hlxConfig: { rso: { owner: 'adobe', ref: 'main' } },
+    }));
+    expect([...hosts]).to.deep.equal(['wknd.site']);
+  });
+
+  it('lowercases rso components (case-insensitive matching)', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://wknd.site',
+      hlxConfig: { rso: { owner: 'Adobe', site: 'WKND', ref: 'Main' } },
+    }));
+    expect(hosts.has('main--wknd--adobe.aem.page')).to.be.true;
+    expect(hosts.has('Main--WKND--Adobe.aem.page')).to.be.false;
+  });
+
+  it('returns an empty set when the site has no usable hostname sources', () => {
+    // No baseURL, no authorURL, no hlxConfig.rso — degenerate but shouldn\'t throw.
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: null,
+    }));
+    expect(hosts.size).to.equal(0);
+  });
+
+  it('ignores malformed URLs on baseURL / authorURL without throwing', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'not a url',
+      deliveryConfig: { authorURL: 'also not a url' },
+    }));
+    expect(hosts.size).to.equal(0);
+  });
+
+  it('handles a fully-populated site — baseURL + authorURL + rso all present', () => {
+    const hosts = collectSiteKnownHostnames(makeSite({
+      baseURL: 'https://publish-p12345-e67890-cmstg.adobeaemcloud.com',
+      deliveryConfig: { authorURL: 'https://author-p12345-e67890-cmstg.adobeaemcloud.com' },
+      hlxConfig: { rso: { owner: 'adobe', site: 'demo', ref: 'main' } },
+    }));
+    // 2 explicit + 8 derived = 10 hostnames total.
+    expect(hosts.size).to.equal(10);
+    expect(hosts.has('publish-p12345-e67890-cmstg.adobeaemcloud.com')).to.be.true;
+    expect(hosts.has('author-p12345-e67890-cmstg.adobeaemcloud.com')).to.be.true;
+    expect(hosts.has('main--demo--adobe.aem.page')).to.be.true;
   });
 });

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -85,6 +85,14 @@ describe('Preflight Controller', () => {
     getId: () => 'test-site-123',
     getOrganizationId: () => 'org-123',
     getAuthoringType: () => SiteModel.AUTHORING_TYPES.SP,
+    // SITES-48309: the createPreflight hostname-membership check (ADR-002)
+    // reads these getters. Default the site's baseURL to match the
+    // canonical test URL (main--example-site.aem.page) so the majority of
+    // tests that submit that URL still resolve to a "URL belongs to this
+    // site" pass. Per-test AEM CS / EDS site fixtures override as needed.
+    getBaseURL: () => 'https://main--example-site.aem.page',
+    getDeliveryConfig: () => ({}),
+    getHlxConfig: () => ({}),
   };
 
   const preflightId = 'aabbccdd-1234-5678-abcd-111122223333';
@@ -1442,11 +1450,14 @@ describe('Preflight Controller', () => {
       expect(result.errorCode).to.equal('PREFLIGHT_ACCESS_DENIED');
     });
 
-    it('returns 400 when url does not belong to site', async () => {
-      mockDataAccess.Site.findByPreviewURL.resolves(null);
+    it('returns 400 when url hostname is not in the site\'s known-hosts set (SITES-48309)', async () => {
+      // Post-SITES-48309: URL→site validation is a hostname-membership check
+      // against site.getBaseURL() / site.getDeliveryConfig().authorURL / EDS
+      // hostnames derived from hlxConfig.rso — no DB lookup, no findByPreviewURL.
+      // A URL whose hostname isn't in that set → 400 PREFLIGHT_INVALID_REQUEST.
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
+        data: { url: 'https://different-site.example.com/test.html' },
       });
       expect(response.status).to.equal(400);
       const result = await response.json();
@@ -1454,26 +1465,50 @@ describe('Preflight Controller', () => {
       expect(result.message).to.equal('URL does not belong to this site');
     });
 
-    it('returns 400 when url belongs to a different site', async () => {
-      mockDataAccess.Site.findByPreviewURL.resolves({ getId: () => 'different-site-id' });
+    it('accepts author-tier AEM CS URL when site\'s deliveryConfig.authorURL matches (SITES-48309)', async () => {
+      // ADR-002 §"POST /sites/:siteId/preflights" — hostname-membership set
+      // includes deliveryConfig.authorURL so both publish-tier (baseURL) and
+      // author-tier URLs for the same AEM CS site are accepted.
+      const aemCsSite = {
+        getId: () => 'test-site-123',
+        getOrganizationId: () => 'org-123',
+        getAuthoringType: () => SiteModel.AUTHORING_TYPES.SP,
+        getBaseURL: () => 'https://publish-p12345-e67890-cmstg.adobeaemcloud.com',
+        getDeliveryConfig: () => ({ authorURL: 'https://author-p12345-e67890-cmstg.adobeaemcloud.com' }),
+        getHlxConfig: () => ({}),
+      };
+      mockDataAccess.Site.findById.resolves(aemCsSite);
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
+        data: { url: 'https://author-p12345-e67890-cmstg.adobeaemcloud.com/us/en.html' },
       });
-      expect(response.status).to.equal(400);
+      // Not asserting 202 here — downstream mysticat call isn't stubbed for
+      // this fixture. What matters is we DIDN'T get 400 at the hostname check.
       const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_INVALID_REQUEST');
+      expect(result.errorCode).to.not.equal('PREFLIGHT_INVALID_REQUEST');
     });
 
-    it('returns 500 when Site.findByPreviewURL throws', async () => {
-      mockDataAccess.Site.findByPreviewURL.rejects(new Error('DB error'));
+    it('accepts publish-tier AEM CS URL when site\'s baseURL is the publish host (SITES-48309)', async () => {
+      // The immediate scenario that motivated SITES-48309 — a real onboarded
+      // AEM CS site with baseURL on the publish tier. Under the legacy
+      // findByPreviewURL check this returned a generic 500 (Unsupported preview
+      // URL) because the regex only matched `author-p<N>-e<M>`.
+      const aemCsSite = {
+        getId: () => 'test-site-123',
+        getOrganizationId: () => 'org-123',
+        getAuthoringType: () => SiteModel.AUTHORING_TYPES.SP,
+        getBaseURL: () => 'https://publish-p152454-e364278-cmstg.adobeaemcloud.com',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
+      };
+      mockDataAccess.Site.findById.resolves(aemCsSite);
       const response = await preflightController.createPreflight({
         params: { siteId: 'test-site-123' },
-        data: { url: 'https://main--example-site.aem.page/test.html' },
+        data: { url: 'https://publish-p152454-e364278-cmstg.adobeaemcloud.com/us/en.html' },
       });
-      expect(response.status).to.equal(500);
       const result = await response.json();
-      expect(result.errorCode).to.equal('PREFLIGHT_INTERNAL_ERROR');
+      expect(result.errorCode).to.not.equal('PREFLIGHT_INVALID_REQUEST');
+      expect(result.errorCode).to.not.equal('PREFLIGHT_INTERNAL_ERROR');
     });
 
     it('does not consult Configuration / TierClient (eligibility deferred to Mysticat per SITES-46202)', async () => {
@@ -1920,6 +1955,10 @@ describe('Preflight Controller', () => {
         getOrganizationId: () => 'org-123',
         getAuthoringType: () => SiteModel.AUTHORING_TYPES.CS_CW,
         getDeliveryType: () => 'aem_edge',
+        // SITES-48309: hostname-membership stubs (see mockSite header).
+        getBaseURL: () => 'https://main--example-site.aem.page',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(cwSite);
       mockDataAccess.Site.findByPreviewURL.resolves(cwSite);
@@ -1974,6 +2013,10 @@ describe('Preflight Controller', () => {
         getAuthoringType: () => SiteModel.AUTHORING_TYPES.CS,
         getDeliveryType: () => 'aem_cs',
         getOrganizationId: () => 'org-123',
+        // SITES-48309: hostname-membership stubs (see mockSite header).
+        getBaseURL: () => 'https://main--example-site.aem.page',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(csSite);
       mockDataAccess.Site.findByPreviewURL.resolves(csSite);
@@ -2018,6 +2061,12 @@ describe('Preflight Controller', () => {
         getAuthoringType: () => { throw new Error('authoring type lookup failed'); },
         getDeliveryType: () => 'aem_cs',
         getOrganizationId: () => 'org-123',
+        // SITES-48309: hostname-membership stubs — need to be present so the
+        // hostname check runs before resolvePromiseToken (which is where the
+        // authoring-type throw fires and this test exercises).
+        getBaseURL: () => 'https://main--example-site.aem.page',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(brokenSite);
       mockDataAccess.Site.findByPreviewURL.resolves(brokenSite);
@@ -2060,6 +2109,10 @@ describe('Preflight Controller', () => {
         getAuthoringType: () => SiteModel.AUTHORING_TYPES.CS,
         getDeliveryType: () => 'aem_cs',
         getOrganizationId: () => 'org-123',
+        // SITES-48309: hostname-membership stubs (see mockSite header).
+        getBaseURL: () => 'https://main--example-site.aem.page',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(csSite);
       mockDataAccess.Site.findByPreviewURL.resolves(csSite);
@@ -2126,6 +2179,10 @@ describe('Preflight Controller', () => {
         getAuthoringType: () => SiteModel.AUTHORING_TYPES.SP,
         getDeliveryType: () => 'aem_edge',
         getOrganizationId: () => 'org-123',
+        // SITES-48309: hostname-membership stubs (see mockSite header).
+        getBaseURL: () => 'https://main--example-site.aem.page',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(spSite);
       mockDataAccess.Site.findByPreviewURL.resolves(spSite);
@@ -2175,6 +2232,10 @@ describe('Preflight Controller', () => {
         getAuthoringType: () => SiteModel.AUTHORING_TYPES.CS,
         getDeliveryType: () => 'aem_cs',
         getOrganizationId: () => 'org-123',
+        // SITES-48309: hostname-membership stubs (see mockSite header).
+        getBaseURL: () => 'https://main--example-site.aem.page',
+        getDeliveryConfig: () => ({}),
+        getHlxConfig: () => ({}),
       };
       mockDataAccess.Site.findById.resolves(csSite);
       mockDataAccess.Site.findByPreviewURL.resolves(csSite);


### PR DESCRIPTION
## Summary

The v2 preflight endpoint's URL→site validation ([`preflight.js:562-571`](src/controllers/preflight.js#L562-L571)) was still using the v1 `findByPreviewURL` helper as a shortcut:

```js
siteByUrl = await dataAccess.Site.findByPreviewURL(previewBaseURL);
if (!siteByUrl || siteByUrl.getId() !== siteId) {
  return preflightError('PREFLIGHT_INVALID_REQUEST', 'URL does not belong to this site', 400);
}
```

That helper is a v1-style URL→site **lookup** built on host-pattern regex classification. Its AEM CS regex matches only `^author-p<N>-e<M>` — legitimate publish-tier AEM CS URLs (the base URL for those sites) are rejected as `Unsupported preview URL`, which surfaces as a generic 500 `PREFLIGHT_INTERNAL_ERROR` to the caller. This blocked preflight against onboarded AEM CS sites with publish-tier base URLs (e.g. `publish-p152454-e364278-cmstg.adobeaemcloud.com` for the AEM Sites Team org).

[ADR-002 §"POST /sites/:siteId/preflights"](docs/decisions/002-preflight-api-rest-redesign.md#L69-L72) already documented the correct v2 approach:

> The controller validates that the `url` hostname matches one of the site's known hostnames (base URL, preview URL, or live URL). ... This replaces the implicit validation previously provided by `findByPreviewURL`.

The v2 implementer had reused `findByPreviewURL` as a shortcut; this PR replaces it with the direct hostname-membership check the ADR describes.

## Changes

**`src/controllers/preflight.js`**

- New `collectSiteKnownHostnames(site)` helper collects hostnames the site is registered under, from Site entity getters:
  - `site.getBaseURL()` — primary (publish-tier for AEM CS, custom domain or `.aem.live` for EDS)
  - `site.getDeliveryConfig().authorURL` — author-tier for AEM CS
  - For EDS: `hlxConfig.rso` → `<ref>--<site>--<owner>` variants on `.aem.page`, `.aem.live`, `.hlx.page`, `.hlx.live` (also 2-part `<site>--<owner>` forms)
- `createPreflight` replaces the `findByPreviewURL` call with a hostname set-membership check against the site already loaded via `findById(siteId)` at line 511.
- **The v1 controller (`createPreflightJob` at line 243) is unchanged** — v1 accepts URL-only requests and legitimately needs the URL→site lookup.

**`test/controllers/preflight.test.js`**

- Reworked the 3 tests that exercised `findByPreviewURL` error paths. Two of those collapse under the new model into a single "hostname not in known-hosts set" case; the DB-throw case no longer exists (in-memory check). Replaced with:
  - `returns 400 when url hostname is not in the site's known-hosts set (SITES-48309)`
  - `accepts author-tier AEM CS URL when site's deliveryConfig.authorURL matches (SITES-48309)`
  - `accepts publish-tier AEM CS URL when site's baseURL is the publish host (SITES-48309)` — the exact scenario that motivated this PR
- Added `getBaseURL` / `getDeliveryConfig` / `getHlxConfig` stubs to the default `mockSite` and each per-test AEM CS / EDS site fixture so submitted URLs resolve into the known-hosts set.
- All 115 tests pass.

## Benefits

- Preflight accepts publish-tier AEM CS URLs (immediate unblock).
- Correct status codes: hostname not in known-hosts → 400 `PREFLIGHT_INVALID_REQUEST` (previously 500 `PREFLIGHT_INTERNAL_ERROR`).
- **No cross-repo dep bump** — `findByPreviewURL` stays in `spacecat-shared` for v1's continued use.
- Removes an unnecessary DB round-trip per preflight request.
- v2 code now matches v2 design intent (ADR-002 conformance).

## Test plan

- [x] `npx mocha test/controllers/preflight.test.js` — 115/115 pass
- [x] Full `npm test` — pre-existing timeouts in `ai-visibility`, `consentBanner`, `bot-blocker`, `autofix-checks`, etc. reproduce on main HEAD without my changes (Windows-local hook flakiness). No new failures introduced.
- [ ] Post-deploy: retry the SITES-48275 test scenario — `POST /sites/019f600e-cdc2-77a6-9125-eddbf705ea61/preflights` with `url = "https://publish-p152454-e364278-cmstg.adobeaemcloud.com/us/en.html"` should now proceed past the URL-validation step (previously 500'd there).

## Follow-up (separate)

The `Failed to retrieve page authentication: Invalid initialization vector` error surfaced when using the author URL for the same site is a promise-token decryption failure in `retrievePageAuthentication` — likely a KMS-key / dev-config drift specific to this site's onboarding. Orthogonal to this PR; documented as a follow-up on [SITES-48309](https://jira.corp.adobe.com/browse/SITES-48309).

## Related

- [SITES-48309](https://jira.corp.adobe.com/browse/SITES-48309) — this ticket
- [SITES-48275](https://jira.corp.adobe.com/browse/SITES-48275) — AEM CS onboarding gap that surfaced this
- [SITES-48259](https://jira.corp.adobe.com/browse/SITES-48259) — fire-and-forget analyze; the validation cycle we hit this on
- [ADR-002](docs/decisions/002-preflight-api-rest-redesign.md) — v2 preflight redesign; documents this direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)