### PR TITLE
feat(llmo-akamai): CUSTOM-default OAE onboarding (PUT deploy + caching/scope gates)

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -6486,7 +6486,9 @@ akamai-property-ref:
       minimum: 0
       description: >-
         Optional position among the existing (non-managed) top-level rules to insert the managed
-        wrapper at. Defaults to 0 (before everything); clamped to the number of existing children.
+        wrapper at. Defaults to appending AFTER all existing children (so the Optimize-at-Edge
+        origin/cacheId win, since Akamai is last-match-wins); an explicit value is clamped to the
+        number of existing children.
     baseVersion:
       type: integer
       minimum: 1

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -6201,8 +6201,10 @@ site-llmo-akamai-deploy:
     operationId: deployLlmoAkamai
     summary: Create a new property version with the Edge Optimize rules
     description: |
-      Creates a NEW property version from the latest, merges the managed Edge Optimize rules into
-      it, and PUTs the rule tree with Akamai-side validation. Does NOT activate — activation is a
+      Creates a NEW property version from `baseVersion` (default: latest), merges the managed Edge
+      Optimize rules into it, and PUTs the rule tree with Akamai-side validation. Only supported for
+      properties whose default origin uses "Choose Your Own" (CUSTOM) SSL verification; a property on
+      "Use Platform Settings" is rejected with `400`. Does NOT activate — activation is a
       separate, explicit step. Guarded so the target property must serve the site's own domain on an
       active hostname. Idempotent by rule name: the merge replaces any previously-managed rules
       rather than duplicating them.
@@ -6485,6 +6487,12 @@ akamai-property-ref:
       description: >-
         Optional position among the existing (non-managed) top-level rules to insert the managed
         wrapper at. Defaults to 0 (before everything); clamped to the number of existing children.
+    baseVersion:
+      type: integer
+      minimum: 1
+      description: >-
+        (deploy only) Optional property version to copy the new version from. Defaults to the
+        property's latest version.
 
 akamai-property:
   type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,13 @@
         "@adobe/helix-universal-logger": "3.0.29",
         "@adobe/mysticat-shared-seo-client": "1.3.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
-        "@adobe/spacecat-shared-akamai-client": "1.1.0",
+        "@adobe/spacecat-shared-akamai-client": "https://gist.githubusercontent.com/ABHA61/8b997b63f4899a50df67073df4d2c1d2/raw/0adc628ab30acd38c16179f034bf5f9dac52ee9c/adobe-spacecat-shared-akamai-client-1.1.0.tgz",
         "@adobe/spacecat-shared-athena-client": "1.9.12",
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
         "@adobe/spacecat-shared-data-access": "4.9.0",
-        "@adobe/spacecat-shared-drs-client": "^1.14.0",
+        "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
@@ -1438,8 +1438,8 @@
     },
     "node_modules/@adobe/spacecat-shared-akamai-client": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-akamai-client/-/spacecat-shared-akamai-client-1.1.0.tgz",
-      "integrity": "sha512-3lyigREwWOMDPxbuVuqwnoUX7cWn0T9un7/jMveS7cYQOCdFX3g94j/K8qd64bHFgn33xpLiD/4MhnKO64xj7Q==",
+      "resolved": "https://gist.githubusercontent.com/ABHA61/8b997b63f4899a50df67073df4d2c1d2/raw/0adc628ab30acd38c16179f034bf5f9dac52ee9c/adobe-spacecat-shared-akamai-client-1.1.0.tgz",
+      "integrity": "sha512-X5a2v5OSRF2rm1PQ86bJ2/04N6OPa0CKZPl/3i9BVXPeDQefesPUUOruRAGePdlvs5c2Doukv6wutCtC8W1veA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.122.1"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@adobe/helix-universal-logger": "3.0.29",
     "@adobe/mysticat-shared-seo-client": "1.3.1",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
-    "@adobe/spacecat-shared-akamai-client": "1.1.0",
+    "@adobe/spacecat-shared-akamai-client": "https://gist.githubusercontent.com/ABHA61/8b997b63f4899a50df67073df4d2c1d2/raw/0adc628ab30acd38c16179f034bf5f9dac52ee9c/adobe-spacecat-shared-akamai-client-1.1.0.tgz",
     "@adobe/spacecat-shared-athena-client": "1.9.12",
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",

--- a/src/controllers/llmo/llmo-akamai-utils.js
+++ b/src/controllers/llmo/llmo-akamai-utils.js
@@ -37,6 +37,11 @@ const LOOP_GUARD_HEADER = 'x-edgeoptimize-api-key';
 // same header name.
 const FAILOVER_MARKER_HEADER = 'x-edgeoptimize-request';
 
+// PMUSER flag flipped TRUE when the Site Failover rule fires (worker 4xx/5xx or origin timeout).
+// It does not affect routing or caching — it's an observability marker so a failover event is
+// identifiable in Akamai logs / DataStream. Mirrors the POC's v38 rule tree for parity.
+const FAILOVER_FLAG_VARIABLE = 'PMUSER_EDGE_OPTIMIZE_FAILOVER';
+
 // Stable defaults for the managed rule config. These mirror the doc 1:1 and are service-owned
 // (not caller-supplied); only the per-site hostname and the LLMO API key are injected at runtime
 // via buildRuleConfig.
@@ -252,7 +257,11 @@ export function buildSiteFailoverRule(cfg) {
     name: 'Site Failover Behavior',
     criteria: [criterionMatchResponseCode(400, 599), criterionOriginTimeout()],
     criteriaMustSatisfy: 'any',
-    behaviors: [behaviorFailActionAlternateHostname(cfg.failover.alternateHostname)],
+    behaviors: [
+      // Flag the failover for observability (Akamai logs), then fail over. Mirrors POC v38.
+      behaviorSetVariable(FAILOVER_FLAG_VARIABLE, 'TRUE'),
+      behaviorFailActionAlternateHostname(cfg.failover.alternateHostname),
+    ],
     children: [],
     comments: 'Managed by Adobe LLM Optimizer (Optimize at Edge). On origin failure, fails over '
       + "to the property's normal origin so the end user still gets a response.",
@@ -405,13 +414,24 @@ function managedCacheKeyVariable(varName) {
   };
 }
 
+// The failover flag PMUSER_* declaration (default FALSE; flipped TRUE by the Site Failover rule).
+function managedFailoverVariable() {
+  return {
+    name: FAILOVER_FLAG_VARIABLE,
+    value: 'FALSE',
+    description: 'Edge Optimize failover flag (managed by Adobe LLM Optimizer)',
+    hidden: false,
+    sensitive: false,
+  };
+}
+
 // PMUSER_* variables must be declared in the rule tree's `variables` list. Mutates the given
 // variables array in place (the caller owns a freshly-cloned tree), returning it for convenience.
-function ensureVariableDeclared(variables, varName) {
-  if (variables.some((v) => v?.name === varName)) {
+function ensureVariableDeclared(variables, variable) {
+  if (variables.some((v) => v?.name === variable.name)) {
     return variables;
   }
-  variables.push(managedCacheKeyVariable(varName));
+  variables.push(variable);
   return variables;
 }
 
@@ -443,7 +463,8 @@ export function mergeIntoTree(ruleTree, cfg, insertIndex) {
   if (!Array.isArray(root.variables)) {
     root.variables = [];
   }
-  ensureVariableDeclared(root.variables, cfg.cacheKeyVariable.name);
+  ensureVariableDeclared(root.variables, managedCacheKeyVariable(cfg.cacheKeyVariable.name));
+  ensureVariableDeclared(root.variables, managedFailoverVariable());
 
   const managedNames = new Set([
     cfg.ruleNames.parent,
@@ -540,13 +561,21 @@ export function buildRuleTreePatch(ruleTree, cfg, insertIndex) {
     });
   }
 
-  // 2. Declare the PMUSER cache-key variable if the tree doesn't already have it. `add` to a
-  //    missing `/rules/variables` would fail, so create the array when absent.
-  const varName = cfg.cacheKeyVariable.name;
+  // 2. Declare the PMUSER variables the managed rules depend on (cache key + failover flag) if the
+  //    tree doesn't already have them. `add` to a missing `/rules/variables` would fail, so create
+  //    the array when absent.
+  const managedVars = [
+    managedCacheKeyVariable(cfg.cacheKeyVariable.name),
+    managedFailoverVariable(),
+  ];
   if (!Array.isArray(root.variables)) {
-    ops.push({ op: 'add', path: '/rules/variables', value: [managedCacheKeyVariable(varName)] });
-  } else if (!root.variables.some((v) => v?.name === varName)) {
-    ops.push({ op: 'add', path: '/rules/variables/-', value: managedCacheKeyVariable(varName) });
+    ops.push({ op: 'add', path: '/rules/variables', value: managedVars });
+  } else {
+    managedVars.forEach((v) => {
+      if (!root.variables.some((existing) => existing?.name === v.name)) {
+        ops.push({ op: 'add', path: '/rules/variables/-', value: v });
+      }
+    });
   }
 
   return ops;
@@ -599,17 +628,25 @@ export function redactApiKey(tree) {
  *   `!defaultRuleHasCaching(ruleTree)`: only add Caching when the property's default rule has none
  *   (so Cache ID Modification validates). When the default already caches, leave it OFF so the OAE
  *   rule inherits the property's HTML no-store instead of overriding it.
+ * @param {string} [params.originHostname] - the Edge Optimize worker host to route AI-bot traffic
+ *   to. Defaults to the prod worker; pass `env.EDGE_OPTIMIZE_EDGE_DOMAIN` so a dev/stage deployment
+ *   routes to dev/stage.edgeoptimize.net. The `matchSan` (`*.edgeoptimize.net`) covers all three.
  * @returns {object} config consumable by buildParentRule/mergeIntoTree
  */
-export function buildRuleConfig({ hostname, apiKey, addCaching = false }) {
+export function buildRuleConfig({
+  hostname, apiKey, addCaching = false, originHostname,
+}) {
   const d = EDGE_OPTIMIZE_DEFAULTS;
+  const resolvedOriginHost = (typeof originHostname === 'string' && originHostname.trim())
+    ? originHostname.trim()
+    : d.origin.hostname;
   return {
     match: {
       userAgents: [...d.userAgents],
       fileExtensions: [...d.fileExtensions],
       hostnames: [hostname],
     },
-    origin: { ...d.origin },
+    origin: { ...d.origin, hostname: resolvedOriginHost },
     cacheKeyVariable: { ...d.cacheKeyVariable },
     incomingRequestHeaders: {
       ...d.incomingRequestHeaders,

--- a/src/controllers/llmo/llmo-akamai-utils.js
+++ b/src/controllers/llmo/llmo-akamai-utils.js
@@ -96,7 +96,10 @@ const criterionUserAgent = (userAgents) => ({
   name: 'userAgent',
   options: {
     matchOperator: 'IS_ONE_OF',
-    values: [...userAgents],
+    // Wildcard each value (*GPTBot* etc.) so it matches real-world agent strings like
+    // "Mozilla/5.0 ... GPTBot/1.2", not only an exact "GPTBot". matchWildcard treats a value with
+    // no '*' as an exact match, which would miss almost every real bot request.
+    values: userAgents.map((ua) => (String(ua).includes('*') ? ua : `*${ua}*`)),
     matchCaseSensitive: false,
     matchWildcard: true,
   },
@@ -186,6 +189,24 @@ const behaviorCacheId = (variableName) => ({
   options: { rule: 'INCLUDE_VARIABLE', variableName },
 });
 
+// "Caching Rules" -> Honor origin Cache-Control and Expires (the doc's step-4 config). Cache ID
+// Modification requires a Caching behavior in scope. Added to the OAE rule ONLY when the property's
+// DEFAULT rule has none (see cfg.addCaching): if the default already provides one, adding it here
+// overrides the property's HTML no-store and makes the optimized path cacheable — serving a stale
+// passthrough copy to bots.
+const behaviorCaching = () => ({
+  name: 'caching',
+  options: {
+    behavior: 'CACHE_CONTROL_AND_EXPIRES',
+    mustRevalidate: false,
+    defaultTtl: '1d',
+    honorPrivate: false,
+    honorMustRevalidate: false,
+    enhancedRfcSupport: false,
+    cacheControlDirectives: '',
+  },
+});
+
 // Every request-header criterion we emit is a presence check (EXISTS / DOES_NOT_EXIST): PAPI
 // ignores value/match flags for those, and including them wouldn't match what PAPI itself emits.
 const criterionRequestHeader = (header, matchOperator) => ({
@@ -257,6 +278,12 @@ export function buildRoutingRule(cfg) {
   (cfg.removeIncomingResponseHeaders || []).forEach((header) => {
     behaviors.push(behaviorRemoveIncomingResponseHeader(header));
   });
+  // Caching goes BEFORE cacheId. Only add it when the property's default rule has no Caching of its
+  // own (cfg.addCaching) — cacheId needs a Caching behavior in scope, but adding one when the
+  // default already provides it overrides the property's HTML no-store and breaks bot delivery.
+  if (cfg.addCaching) {
+    behaviors.push(behaviorCaching());
+  }
   behaviors.push(behaviorCacheId(cfg.cacheKeyVariable.name));
 
   if (cfg.wafBypass?.enabled) {
@@ -562,9 +589,13 @@ export function redactApiKey(tree) {
  * @param {object} params
  * @param {string} params.hostname - the site's (normalized) hostname
  * @param {string} params.apiKey - the site's LLMO API key
+ * @param {boolean} [params.addCaching=false] - add a Caching behavior to the OAE rule. Set this to
+ *   `!defaultRuleHasCaching(ruleTree)`: only add Caching when the property's default rule has none
+ *   (so Cache ID Modification validates). When the default already caches, leave it OFF so the OAE
+ *   rule inherits the property's HTML no-store instead of overriding it.
  * @returns {object} config consumable by buildParentRule/mergeIntoTree
  */
-export function buildRuleConfig({ hostname, apiKey }) {
+export function buildRuleConfig({ hostname, apiKey, addCaching = false }) {
   const d = EDGE_OPTIMIZE_DEFAULTS;
   return {
     match: {
@@ -582,5 +613,6 @@ export function buildRuleConfig({ hostname, apiKey }) {
     removeIncomingResponseHeaders: [...d.removeIncomingResponseHeaders],
     ruleNames: { ...d.ruleNames },
     failover: { alternateHostname: hostname },
+    addCaching,
   };
 }

--- a/src/controllers/llmo/llmo-akamai-utils.js
+++ b/src/controllers/llmo/llmo-akamai-utils.js
@@ -423,7 +423,10 @@ function ensureVariableDeclared(variables, varName) {
  * flat (non-wrapped) layout, so upgrading is clean.
  *
  * `insertIndex` positions the wrapper among the *existing* (non-managed) children:
- * 0 = before everything (default), length = after everything.
+ * 0 = before everything, length = after everything. The default (no/blank/garbage index) is
+ * AFTER everything: the wrapper's `origin` + `cacheId` are last-match-wins on Akamai, so it must
+ * sit below the stock delivery rules (Offload origin, Increase availability, …) — otherwise a
+ * later sibling clobbers the OAE origin override and cache isolation and bots never get routed.
  *
  * @param {object} ruleTree - the property's current rule tree ({ rules: {...} })
  * @param {object} cfg
@@ -452,9 +455,11 @@ export function mergeIntoTree(ruleTree, cfg, insertIndex) {
   const children = (root.children || []).filter((c) => !managedNames.has((c?.name ?? '').trim()));
 
   const n = Math.trunc(Number(insertIndex));
-  // Non-numeric / NaN (e.g. a direct caller passing garbage) clamps to 0 rather than corrupting
-  // the slice; the controller already rejects malformed values with a 400 before reaching here.
-  const idx = Number.isFinite(n) ? Math.max(0, Math.min(n, children.length)) : 0;
+  // Default to LAST (children.length): only a finite, in-range index moves the wrapper earlier; a
+  // missing/blank/garbage value (the wizard sends none) appends after all existing children so the
+  // OAE origin + cacheId win on Akamai (siblings evaluate top-down, last match wins). The
+  // controller already rejects malformed values with a 400 before reaching here.
+  const idx = Number.isFinite(n) ? Math.max(0, Math.min(n, children.length)) : children.length;
   root.children = [...children.slice(0, idx), buildParentRule(cfg), ...children.slice(idx)];
   return tree;
 }
@@ -522,10 +527,11 @@ export function buildRuleTreePatch(ruleTree, cfg, insertIndex) {
       .forEach((i) => ops.push({ op: 'remove', path: `/rules/children/${i}` }));
 
     // After those removals run, the array is exactly the non-managed children in their original
-    // order, so clamp insertIndex against that length (mirrors mergeIntoTree). NaN/garbage -> 0.
+    // order, so clamp insertIndex against that length (mirrors mergeIntoTree). Default (no/blank/
+    // garbage index) appends last so the OAE origin + cacheId win (Akamai is last-match-wins).
     const nonManagedCount = children.length - managedIndexes.length;
     const n = Math.trunc(Number(insertIndex));
-    const idx = Number.isFinite(n) ? Math.max(0, Math.min(n, nonManagedCount)) : 0;
+    const idx = Number.isFinite(n) ? Math.max(0, Math.min(n, nonManagedCount)) : nonManagedCount;
     ops.push({
       op: 'add',
       // `-` appends; a numeric index inserts before it. Append when idx lands at/after the end.

--- a/src/controllers/llmo/llmo-akamai-utils.js
+++ b/src/controllers/llmo/llmo-akamai-utils.js
@@ -204,6 +204,9 @@ const behaviorCaching = () => ({
   options: {
     behavior: 'CACHE_CONTROL_AND_EXPIRES',
     mustRevalidate: false,
+    // Fallback TTL used ONLY when the origin response omits Cache-Control/Expires (the doc's
+    // Honor-origin config). AI-bot responses normally carry the worker's no-store, so this is a
+    // safety net, not the common path — bounded to 1 day to avoid indefinitely caching a bad reply.
     defaultTtl: '1d',
     honorPrivate: false,
     honorMustRevalidate: false,

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -50,6 +50,16 @@ const IN_FLIGHT_ACTIVATION_STATUSES = new Set([
   'NEW', 'PENDING', 'ZONE_1', 'ZONE_2', 'ZONE_3', 'ACTIVE',
 ]);
 
+// Recovery only adopts a listed activation if it was submitted very recently — otherwise a failed
+// activate (e.g. 403/429 that never queued anything) could match an unrelated older activation for
+// the same version+network (e.g. one triggered manually in Property Manager) and falsely report
+// success. The activation we just submitted has a submitDate within seconds.
+const RECOVERY_RECENCY_MS = 5 * 60 * 1000;
+const isRecentlySubmitted = (activation) => {
+  const ts = Date.parse(activation?.submitDate || activation?.updateDate || '');
+  return Number.isFinite(ts) && (Date.now() - ts) < RECOVERY_RECENCY_MS;
+};
+
 // Akamai PAPI identifiers. Boundary validation (defense-in-depth): the shared client also encodes
 // these into the path, but rejecting a malformed id here gives the caller a clean 400 instead of a
 // 502 from PAPI.
@@ -587,9 +597,11 @@ function LlmoAkamaiController(ctx) {
     if (insertIndexError) {
       return insertIndexError;
     }
-    // Optional: copy from a specific version instead of the latest.
+    // Optional: copy from a specific version instead of the latest. PAPI versions start at 1, so
+    // reject 0 here (it passes DECIMAL_INT_RE) for a clean 400 instead of an opaque PAPI 404/500 —
+    // mirrors the version check in activate.
     if (rawBaseVersion !== undefined && rawBaseVersion !== null && rawBaseVersion !== ''
-      && !DECIMAL_INT_RE.test(String(rawBaseVersion))) {
+      && (!DECIMAL_INT_RE.test(String(rawBaseVersion)) || Number(rawBaseVersion) < 1)) {
       return badRequest('baseVersion must be a positive integer');
     }
     const siteId = site.getId();
@@ -777,7 +789,8 @@ function LlmoAkamaiController(ctx) {
           const recovered = await client.latestActivation(propertyId, contractId, groupId, network);
           if (recovered
             && Number(recovered.propertyVersion) === Number(version)
-            && IN_FLIGHT_ACTIVATION_STATUSES.has(String(recovered.status || '').toUpperCase())) {
+            && IN_FLIGHT_ACTIVATION_STATUSES.has(String(recovered.status || '').toUpperCase())
+            && isRecentlySubmitted(recovered)) {
             // Only hand back a real (numeric) id; a just-queued activation can still be a
             // placeholder ("atv_null") — return null so the UI polls by network for it.
             const recoveredId = REAL_ACTIVATION_ID_RE.test(recovered.activationId || '')
@@ -801,7 +814,9 @@ function LlmoAkamaiController(ctx) {
             });
           }
         } catch (recoverErr) {
-          log.warn(auditLine(context, 'activate', 'recover-failed', {
+          // Double failure (activate POST AND the recovery probe both failed) — log at error level
+          // for alerting visibility; the caller still gets the sanitized activation error below.
+          log.error(auditLine(context, 'activate', 'recover-failed', {
             siteId, propertyId, version, network, error: recoverErr?.message,
           }));
         }

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -50,16 +50,6 @@ const IN_FLIGHT_ACTIVATION_STATUSES = new Set([
   'NEW', 'PENDING', 'ZONE_1', 'ZONE_2', 'ZONE_3', 'ACTIVE',
 ]);
 
-// Recovery only adopts a listed activation if it was submitted very recently — otherwise a failed
-// activate (e.g. 403/429 that never queued anything) could match an unrelated older activation for
-// the same version+network (e.g. one triggered manually in Property Manager) and falsely report
-// success. The activation we just submitted has a submitDate within seconds.
-const RECOVERY_RECENCY_MS = 5 * 60 * 1000;
-const isRecentlySubmitted = (activation) => {
-  const ts = Date.parse(activation?.submitDate || activation?.updateDate || '');
-  return Number.isFinite(ts) && (Date.now() - ts) < RECOVERY_RECENCY_MS;
-};
-
 // Akamai PAPI identifiers. Boundary validation (defense-in-depth): the shared client also encodes
 // these into the path, but rejecting a malformed id here gives the caller a clean 400 instead of a
 // 502 from PAPI.
@@ -787,10 +777,14 @@ function LlmoAkamaiController(ctx) {
       if (version !== undefined) {
         try {
           const recovered = await client.latestActivation(propertyId, contractId, groupId, network);
+          // A matching in-flight/active activation for this EXACT version+network means the
+          // version is (being) activated on that network — the desired end state — so report
+          // success regardless of age. We intentionally do NOT gate on submit recency: that made
+          // re-activating an already-active version (Akamai 422 already-activated) surface as a
+          // false "activation failed". The version match is the correct guard.
           if (recovered
             && Number(recovered.propertyVersion) === Number(version)
-            && IN_FLIGHT_ACTIVATION_STATUSES.has(String(recovered.status || '').toUpperCase())
-            && isRecentlySubmitted(recovered)) {
+            && IN_FLIGHT_ACTIVATION_STATUSES.has(String(recovered.status || '').toUpperCase())) {
             // Only hand back a real (numeric) id; a just-queued activation can still be a
             // placeholder ("atv_null") — return null so the UI polls by network for it.
             const recoveredId = REAL_ACTIVATION_ID_RE.test(recovered.activationId || '')

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -369,7 +369,7 @@ function LlmoAkamaiController(ctx) {
    *
    * @returns {{ cfg: object } | { error: Response }}
    */
-  const buildCfgFromTree = (host, apiKey, ruleTree) => {
+  const buildCfgFromTree = (host, apiKey, ruleTree, edgeDomain) => {
     const ssl = getDefaultOriginSsl(ruleTree);
     if (!ssl || ssl.verificationMode !== 'CUSTOM') {
       const mode = ssl?.verificationMode || 'an unknown mode';
@@ -381,7 +381,13 @@ function LlmoAkamaiController(ctx) {
       };
     }
     const addCaching = !defaultRuleHasCaching(ruleTree);
-    return { cfg: buildRuleConfig({ hostname: host, apiKey, addCaching }) };
+    // originHostname routes AI-bot traffic to the env-appropriate Edge Optimize worker
+    // (dev/stage/live.edgeoptimize.net) via EDGE_OPTIMIZE_EDGE_DOMAIN; falls back to prod default.
+    return {
+      cfg: buildRuleConfig({
+        hostname: host, apiKey, addCaching, originHostname: edgeDomain,
+      }),
+    };
   };
 
   /**
@@ -479,7 +485,8 @@ function LlmoAkamaiController(ctx) {
       } = await client.getRuleTree(propertyId, version, contractId, groupId);
 
       // Enforce the CUSTOM-default scope gate and decide the caching behavior from the actual tree.
-      const { cfg, error: gateError } = buildCfgFromTree(host, apiKey, ruleTree);
+      const edgeDomain = context.env?.EDGE_OPTIMIZE_EDGE_DOMAIN;
+      const { cfg, error: gateError } = buildCfgFromTree(host, apiKey, ruleTree, edgeDomain);
       if (gateError) {
         return gateError;
       }
@@ -613,7 +620,8 @@ function LlmoAkamaiController(ctx) {
         contractId,
         groupId,
       );
-      const { cfg, error: gateError } = buildCfgFromTree(host, apiKey, ruleTree);
+      const edgeDomain = context.env?.EDGE_OPTIMIZE_EDGE_DOMAIN;
+      const { cfg, error: gateError } = buildCfgFromTree(host, apiKey, ruleTree, edgeDomain);
       if (gateError) {
         return gateError;
       }

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -57,6 +57,11 @@ const PROPERTY_ID_RE = /^prp_[A-Za-z0-9]+$/;
 const CONTRACT_ID_RE = /^ctr_[A-Za-z0-9-]+$/;
 const GROUP_ID_RE = /^grp_[A-Za-z0-9]+$/;
 const ACTIVATION_ID_RE = /^atv_[A-Za-z0-9]+$/;
+// A *real* Akamai activation id is numeric (atv_20135679). A just-queued activation can appear in
+// the activations list before Akamai assigns its id — the placeholder serializes as "atv_null",
+// which passes ACTIVATION_ID_RE but is not pollable. Use this stricter check when recovering an id
+// so we never hand the UI an unpollable placeholder (it polls by network until a real id appears).
+const REAL_ACTIVATION_ID_RE = /^atv_[0-9]+$/;
 // SSRF guard: the client builds `https://${host}/...` from x-akamai-host, so restrict it to Akamai
 // EdgeGrid hosts. The `.akamaiapis.net` suffix + this charset reject IP literals, ports (no ':'),
 // and paths (no '/'), so a caller cannot point server-side requests at an arbitrary host.
@@ -773,19 +778,24 @@ function LlmoAkamaiController(ctx) {
           if (recovered
             && Number(recovered.propertyVersion) === Number(version)
             && IN_FLIGHT_ACTIVATION_STATUSES.has(String(recovered.status || '').toUpperCase())) {
+            // Only hand back a real (numeric) id; a just-queued activation can still be a
+            // placeholder ("atv_null") — return null so the UI polls by network for it.
+            const recoveredId = REAL_ACTIVATION_ID_RE.test(recovered.activationId || '')
+              ? recovered.activationId
+              : null;
             log.info(auditLine(context, 'activate', 'recovered', {
               siteId,
               propertyId,
               version,
               network,
-              activationId: recovered.activationId,
+              activationId: recoveredId,
               status: recovered.status,
             }));
             return ok({
               propertyId,
               version,
               network,
-              activationId: recovered.activationId,
+              activationId: recoveredId,
               activationLink: null,
               recovered: true,
             });

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -15,11 +15,13 @@ import {
 } from '@adobe/spacecat-shared-http-utils';
 import { hasText } from '@adobe/spacecat-shared-utils';
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
-import AkamaiClient, { normalizeDomain } from '@adobe/spacecat-shared-akamai-client';
+import AkamaiClient, {
+  normalizeDomain, defaultRuleHasCaching, getDefaultOriginSsl,
+} from '@adobe/spacecat-shared-akamai-client';
 import TokowakaClient from '@adobe/spacecat-shared-tokowaka-client';
 import AccessControlUtil from '../../support/access-control-util.js';
 import {
-  buildRuleConfig, mergeIntoTree, buildRuleTreePatch, managedRuleNames, redactApiKey,
+  buildRuleConfig, mergeIntoTree, managedRuleNames, redactApiKey,
 } from './llmo-akamai-utils.js';
 
 // EdgeGrid credentials are CLIENT-SUPPLIED per request (never persisted, never logged): the caller
@@ -198,7 +200,7 @@ function LlmoAkamaiController(ctx) {
     // "-> 404" and mis-map a genuine 5xx. Take the FIRST such token, which is the real status.
     const status = Number(message.match(/-> (\d{3}):/)?.[1]);
     // Surface a version the operation may have already created before a later call threw (e.g.
-    // deploy created a new version, then patchRuleTree failed) so the caller can find/clean it up.
+    // deploy created a new version, then updateRuleTree failed) so the caller can find/clean it up.
     const extra = fields.newVersion !== undefined ? { newVersion: fields.newVersion } : {};
     if (status === 401) {
       return unauthorized('Akamai authentication failed');
@@ -319,9 +321,10 @@ function LlmoAkamaiController(ctx) {
   };
 
   /**
-   * Resolves the merged rule config for a site (defaults + site hostname + LLMO API key), or a
-   * response when the API key is unavailable.
-   * @returns {Promise<{ cfg: object } | { error: Response }>}
+   * Resolves the site's onboarding inputs (normalized hostname + LLMO API key), or a response when
+   * either is unavailable. The final rule config is built later (buildCfgFromTree) — it depends on
+   * the property's rule tree (SSL scope gate + whether to add a Caching behavior).
+   * @returns {Promise<{ host: string, apiKey: string } | { error: Response }>}
    */
   const resolveRuleConfig = async (site, context) => {
     const host = siteHostname(site);
@@ -340,7 +343,36 @@ function LlmoAkamaiController(ctx) {
     if (!hasText(apiKey)) {
       return { error: internalServerError('LLMO API key not configured for this site') };
     }
-    return { cfg: buildRuleConfig({ hostname: host, apiKey }) };
+    return { host, apiKey };
+  };
+
+  /**
+   * Builds the managed rule config from the property's rule tree, enforcing the CUSTOM-default
+   * scope gate and deciding whether the OAE rule needs its own Caching behavior.
+   *
+   * - Scope gate: Optimize at Edge currently supports only properties whose default origin uses
+   *   "Choose Your Own" (CUSTOM) SSL verification. The OAE origin uses CUSTOM (Match SAN), which
+   *   PAPI rejects as incompatible when the default rule is on "Use Platform Settings".
+   * - Caching: Cache ID Modification requires a Caching behavior in scope. Add one to the OAE rule
+   *   ONLY when the default rule has none — otherwise (the common case) inherit the default's
+   *   caching, because adding a Caching behavior to the OAE rule overrides the property's HTML
+   *   no-store and makes the optimized path cacheable (serving stale/passthrough content to bots).
+   *
+   * @returns {{ cfg: object } | { error: Response }}
+   */
+  const buildCfgFromTree = (host, apiKey, ruleTree) => {
+    const ssl = getDefaultOriginSsl(ruleTree);
+    if (!ssl || ssl.verificationMode !== 'CUSTOM') {
+      const mode = ssl?.verificationMode || 'an unknown mode';
+      return {
+        error: badRequest(
+          'Optimize at Edge onboarding requires the property\'s default origin to use '
+          + `"Choose Your Own" (CUSTOM) SSL verification; this property uses ${mode}.`,
+        ),
+      };
+    }
+    const addCaching = !defaultRuleHasCaching(ruleTree);
+    return { cfg: buildRuleConfig({ hostname: host, apiKey, addCaching }) };
   };
 
   /**
@@ -419,7 +451,7 @@ function LlmoAkamaiController(ctx) {
       return refError;
     }
 
-    const { cfg, error: cfgError } = await resolveRuleConfig(site, context);
+    const { host, apiKey, error: cfgError } = await resolveRuleConfig(site, context);
     if (cfgError) {
       return cfgError;
     }
@@ -434,26 +466,31 @@ function LlmoAkamaiController(ctx) {
     try {
       const version = await client.getLatestVersion(propertyId, contractId, groupId);
       const {
-        ruleTree, ruleFormat, etag,
+        ruleTree, ruleFormat,
       } = await client.getRuleTree(propertyId, version, contractId, groupId);
+
+      // Enforce the CUSTOM-default scope gate and decide the caching behavior from the actual tree.
+      const { cfg, error: gateError } = buildCfgFromTree(host, apiKey, ruleTree);
+      if (gateError) {
+        return gateError;
+      }
       const merged = mergeIntoTree(ruleTree, cfg, insertIndex);
 
-      // Validate the exact change deploy will make: dry-run the same JSON Patch. PAPI applies it to
-      // the STORED tree and returns errors/warnings without saving, so Review reflects the real
-      // deploy outcome. (mergeIntoTree alone only echoes the base version's GET-time warnings — a
-      // merged tree can look clean here yet be rejected at deploy.)
-      const ops = buildRuleTreePatch(ruleTree, cfg, insertIndex);
+      // Validate the exact change deploy will make: dry-run the full-tree PUT. PAPI validates the
+      // submitted tree and returns errors/warnings without persisting. A dry-run PUT still needs an
+      // EDITABLE version, so if `version` is activated it 403s — fall back to the base tree's
+      // warnings and flag the preview unvalidated (deploy validates on its own new version anyway).
       let errors = [];
       let warnings = [];
       let validated = true;
       try {
-        const dryRun = await client.patchRuleTree(
+        const dryRun = await client.updateRuleTree(
           propertyId,
           version,
           contractId,
           groupId,
-          ops,
-          etag,
+          merged,
+          ruleFormat,
           { dryRun: true },
         );
         errors = dryRun?.errors || [];
@@ -498,12 +535,13 @@ function LlmoAkamaiController(ctx) {
 
   /**
    * POST /sites/:siteId/llmo/cdn-onboard/akamai/deploy
-   * Body: { propertyId, contractId, groupId, insertIndex? }
-   * Creates a NEW property version from the latest and applies the managed rules to it via a JSON
-   * Patch (PAPI-side validation) — a delta so existing behaviors are never re-serialized. Does NOT
-   * activate (that is a separate, explicit step). Guarded so the target property must serve the
-   * site's own domain. Idempotent by rule name (trimmed): re-running replaces any previously
-   * managed rules rather than duplicating them.
+   * Body: { propertyId, contractId, groupId, insertIndex?, baseVersion? }
+   * Creates a NEW property version from `baseVersion` (default: latest) and applies the managed
+   * rules via a full-tree PUT with PAPI-side validation, pinning the base version's ruleFormat.
+   * Supported only for properties whose default origin uses CUSTOM SSL verification (scope gate).
+   * Does NOT activate (a separate, explicit step). Guarded so the target property must serve the
+   * site's own domain. Idempotent by rule name (trimmed): re-running replaces prior managed rules
+   * rather than duplicating them.
    */
   const deploy = async (context) => {
     const result = await getSiteAndCheckAccess(context);
@@ -523,10 +561,15 @@ function LlmoAkamaiController(ctx) {
     }
 
     const { propertyId, contractId, groupId } = ref;
-    const { insertIndex } = context.data;
+    const { insertIndex, baseVersion: rawBaseVersion } = context.data;
     const insertIndexError = validateInsertIndex(insertIndex);
     if (insertIndexError) {
       return insertIndexError;
+    }
+    // Optional: copy from a specific version instead of the latest.
+    if (rawBaseVersion !== undefined && rawBaseVersion !== null && rawBaseVersion !== ''
+      && !DECIMAL_INT_RE.test(String(rawBaseVersion))) {
+      return badRequest('baseVersion must be a positive integer');
     }
     const siteId = site.getId();
 
@@ -537,7 +580,7 @@ function LlmoAkamaiController(ctx) {
       return guard;
     }
 
-    const { cfg, error: cfgError } = await resolveRuleConfig(site, context);
+    const { host, apiKey, error: cfgError } = await resolveRuleConfig(site, context);
     if (cfgError) {
       return cfgError;
     }
@@ -547,29 +590,38 @@ function LlmoAkamaiController(ctx) {
     // Hoisted so the catch can report it: createVersion may succeed before a later call throws.
     let newVersion;
     try {
-      const baseVersion = await client.getLatestVersion(propertyId, contractId, groupId);
-      newVersion = await client.createVersion(propertyId, baseVersion, contractId, groupId);
-      // Build the patch against the NEW version's own tree (a clone of baseVersion): stable
-      // indices, no concurrent editors, and its etag guards the PATCH via If-Match. Applying only
-      // these deltas leaves every existing behavior as PAPI stored it — no full-tree re-write.
-      const { ruleTree, etag } = await client.getRuleTree(
+      const baseVersion = (rawBaseVersion !== undefined && rawBaseVersion !== null && rawBaseVersion !== '')
+        ? Number(rawBaseVersion)
+        : await client.getLatestVersion(propertyId, contractId, groupId);
+
+      // Read the base version's tree first so we can enforce the CUSTOM-default scope gate and
+      // decide caching BEFORE creating a version — a rejected onboarding then leaves no orphan
+      // version behind. The new version is a clone of baseVersion, so merging the base tree and
+      // PUTting it into the new version is equivalent, and pins the base version's ruleFormat.
+      const { ruleTree, ruleFormat } = await client.getRuleTree(
         propertyId,
-        newVersion,
+        baseVersion,
         contractId,
         groupId,
       );
-      const ops = buildRuleTreePatch(ruleTree, cfg, insertIndex);
-      const patchResult = await client.patchRuleTree(
+      const { cfg, error: gateError } = buildCfgFromTree(host, apiKey, ruleTree);
+      if (gateError) {
+        return gateError;
+      }
+      const merged = mergeIntoTree(ruleTree, cfg, insertIndex);
+
+      newVersion = await client.createVersion(propertyId, baseVersion, contractId, groupId);
+      const putResult = await client.updateRuleTree(
         propertyId,
         newVersion,
         contractId,
         groupId,
-        ops,
-        etag,
+        merged,
+        ruleFormat,
       );
 
-      const papiErrors = patchResult?.errors || [];
-      const warnings = patchResult?.warnings || [];
+      const papiErrors = putResult?.errors || [];
+      const warnings = putResult?.warnings || [];
       if (papiErrors.length > 0) {
         log.error(auditLine(context, 'deploy', 'papi-rejected', {
           siteId, propertyId, newVersion, errorCount: papiErrors.length,
@@ -668,6 +720,9 @@ function LlmoAkamaiController(ctx) {
         contractId,
         groupId,
         network,
+        // Akamai's version author is the API credential; attribute the human operator in the
+        // activation note so it shows in Property Manager's Activation History.
+        `Optimize at Edge — onboarded by ${notifyEmail} via Adobe LLM Optimizer`,
       );
       const activationId = AkamaiClient.activationIdFromLink(activationLink);
       if (!hasText(activationId)) {

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -41,6 +41,15 @@ const REQUIRED_CRED_KEYS = ['host', 'clientToken', 'clientSecret', 'accessToken'
 
 const NETWORKS = ['STAGING', 'PRODUCTION'];
 
+// Akamai activation statuses that mean the submit actually succeeded (in flight or already live).
+// Used to recover from an activate POST that errored client-side — the PAPI activation call
+// regularly exceeds the client request timeout on large rule trees (Akamai re-validates the whole
+// tree), and a retry then returns `422 already-activated`; in BOTH cases Akamai has already QUEUED
+// the activation, so we report success and let the UI poll instead of showing a false failure.
+const IN_FLIGHT_ACTIVATION_STATUSES = new Set([
+  'NEW', 'PENDING', 'ZONE_1', 'ZONE_2', 'ZONE_3', 'ACTIVE',
+]);
+
 // Akamai PAPI identifiers. Boundary validation (defense-in-depth): the shared client also encodes
 // these into the path, but rejecting a malformed id here gives the caller a clean 400 instead of a
 // 502 from PAPI.
@@ -744,6 +753,40 @@ function LlmoAkamaiController(ctx) {
       // surface a caller error rather than a PAPI failure.
       if (/notifyEmails/.test(e?.message || '')) {
         return badRequest('notifyEmails is required to activate');
+      }
+      // The activation POST regularly errors client-side even though Akamai queued the activation:
+      // a large rule tree makes PAPI exceed the client request timeout, and any retry then returns
+      // `422 already-activated`. Before surfacing a failure, look for an in-flight (or freshly
+      // active) activation for this exact version+network and, if found, report success so the UI
+      // polls it. Genuine failures (no matching activation) still fall through to the error.
+      if (version !== undefined) {
+        try {
+          const recovered = await client.latestActivation(propertyId, contractId, groupId, network);
+          if (recovered
+            && Number(recovered.propertyVersion) === Number(version)
+            && IN_FLIGHT_ACTIVATION_STATUSES.has(String(recovered.status || '').toUpperCase())) {
+            log.info(auditLine(context, 'activate', 'recovered', {
+              siteId,
+              propertyId,
+              version,
+              network,
+              activationId: recovered.activationId,
+              status: recovered.status,
+            }));
+            return ok({
+              propertyId,
+              version,
+              network,
+              activationId: recovered.activationId,
+              activationLink: null,
+              recovered: true,
+            });
+          }
+        } catch (recoverErr) {
+          log.warn(auditLine(context, 'activate', 'recover-failed', {
+            siteId, propertyId, version, network, error: recoverErr?.message,
+          }));
+        }
       }
       return papiErrorResponse(e, 'activation', context, { siteId, propertyId });
     }

--- a/test/controllers/llmo/llmo-akamai-utils.test.js
+++ b/test/controllers/llmo/llmo-akamai-utils.test.js
@@ -65,7 +65,11 @@ describe('llmo-akamai-utils', () => {
     });
 
     it('matches AI-bot user agents and HTML/extensionless files', () => {
-      expect(findCriterion(routing, 'userAgent').options.matchWildcard).to.equal(true);
+      const ua = findCriterion(routing, 'userAgent');
+      expect(ua.options.matchWildcard).to.equal(true);
+      // Values are wildcarded (*GPTBot*) so they match real UA strings, not only an exact "GPTBot".
+      expect(ua.options.values).to.include('*GPTBot*');
+      expect(ua.options.values.every((v) => v.startsWith('*') && v.endsWith('*'))).to.equal(true);
       const ext = findCriterion(routing, 'fileExtension');
       expect(ext.options.values).to.include('EMPTY_STRING');
       expect(ext.options.values).to.include('html');

--- a/test/controllers/llmo/llmo-akamai-utils.test.js
+++ b/test/controllers/llmo/llmo-akamai-utils.test.js
@@ -187,10 +187,13 @@ describe('llmo-akamai-utils', () => {
       };
     });
 
-    it('inserts the managed wrapper as the first child by default and declares the cache variable', () => {
+    it('appends the managed wrapper as the LAST child by default and declares the cache variable', () => {
       const merged = mergeIntoTree(baseTree, cfg);
-      expect(merged.rules.children[0].name).to.equal(cfg.ruleNames.parent);
-      expect(merged.rules.children.map((c) => c.name)).to.include('Existing Rule');
+      const names = merged.rules.children.map((c) => c.name);
+      // OAE origin + cacheId are last-match-wins on Akamai, so the wrapper must sit after the
+      // existing delivery rules or a later sibling clobbers its origin override.
+      expect(names[names.length - 1]).to.equal(cfg.ruleNames.parent);
+      expect(names).to.include('Existing Rule');
       const declared = merged.rules.variables.some((v) => v.name === cfg.cacheKeyVariable.name);
       expect(declared).to.equal(true);
     });
@@ -236,7 +239,7 @@ describe('llmo-akamai-utils', () => {
       };
       const merged = mergeIntoTree(flatTree, cfg);
       const names = merged.rules.children.map((c) => c.name);
-      expect(names).to.deep.equal([cfg.ruleNames.parent, 'Existing Rule']);
+      expect(names).to.deep.equal(['Existing Rule', cfg.ruleNames.parent]);
     });
 
     it('honors insertIndex, clamped to the existing children length', () => {
@@ -280,7 +283,8 @@ describe('llmo-akamai-utils', () => {
       };
       const ops = buildRuleTreePatch(tree, cfg);
       expect(removeOps(ops)).to.have.length(0);
-      const add = ops.find((o) => o.op === 'add' && o.path === '/rules/children/0');
+      // Default appends after the existing children (last), so the op targets `-`, not index 0.
+      const add = ops.find((o) => o.op === 'add' && o.path === '/rules/children/-');
       expect(add).to.exist;
       expect(add.value.name).to.equal(cfg.ruleNames.parent);
       const varOp = ops.find((o) => o.path === '/rules/variables/-');
@@ -346,12 +350,12 @@ describe('llmo-akamai-utils', () => {
       expect(varOp.value).to.be.an('array').with.length(1);
     });
 
-    it('clamps a non-numeric insertIndex to 0', () => {
+    it('appends via `-` for a non-numeric insertIndex (falls back to the default)', () => {
       const tree = {
         rules: { name: 'default', children: [{ name: 'A' }], variables: [{ name: cfg.cacheKeyVariable.name }] },
       };
       const ops = buildRuleTreePatch(tree, cfg, 'nope');
-      expect(addChildOps(ops)[0].path).to.equal('/rules/children/0');
+      expect(addChildOps(ops)[0].path).to.equal('/rules/children/-');
     });
 
     it('clamps a negative insertIndex to 0', () => {
@@ -422,11 +426,12 @@ describe('llmo-akamai-utils', () => {
       expect(merged.rules.children[0].name).to.equal(cfg.ruleNames.parent);
     });
 
-    it('clamps a non-numeric insertIndex to 0', () => {
+    it('appends the wrapper last for a non-numeric insertIndex (falls back to the default)', () => {
       const cfg = base();
       const tree = { rules: { name: 'default', children: [{ name: 'A' }], variables: [] } };
       const merged = mergeIntoTree(tree, cfg, 'nope');
-      expect(merged.rules.children[0].name).to.equal(cfg.ruleNames.parent);
+      const names = merged.rules.children.map((c) => c.name);
+      expect(names[names.length - 1]).to.equal(cfg.ruleNames.parent);
     });
   });
 

--- a/test/controllers/llmo/llmo-akamai-utils.test.js
+++ b/test/controllers/llmo/llmo-akamai-utils.test.js
@@ -42,6 +42,20 @@ describe('llmo-akamai-utils', () => {
       expect(cfg.origin.hostname).to.equal('live.edgeoptimize.net');
     });
 
+    it('routes to the given originHostname (env EDGE_OPTIMIZE_EDGE_DOMAIN) over the default', () => {
+      const cfg = buildRuleConfig({
+        hostname: HOSTNAME, apiKey: API_KEY, originHostname: 'dev.edgeoptimize.net',
+      });
+      expect(cfg.origin.hostname).to.equal('dev.edgeoptimize.net');
+      // matchSan still covers all envs, so CUSTOM cert validation works for dev/stage/live.
+      expect(cfg.origin.matchSan).to.equal('*.edgeoptimize.net');
+    });
+
+    it('falls back to the default origin for a blank/whitespace originHostname', () => {
+      const cfg = buildRuleConfig({ hostname: HOSTNAME, apiKey: API_KEY, originHostname: '   ' });
+      expect(cfg.origin.hostname).to.equal('live.edgeoptimize.net');
+    });
+
     it('does not mutate the frozen defaults', () => {
       const cfg = buildRuleConfig({ hostname: HOSTNAME, apiKey: API_KEY });
       cfg.match.userAgents.push('EvilBot');
@@ -127,7 +141,11 @@ describe('llmo-akamai-utils', () => {
       expect(findBehavior(rule, 'advanced')).to.equal(undefined);
       const failAction = findBehavior(rule, 'failAction');
       expect(failAction.options.contentHostname).to.equal(HOSTNAME);
-      expect(rule.behaviors).to.have.length(1);
+      // A setVariable flips the failover observability flag TRUE, then the GA failAction runs.
+      expect(rule.behaviors).to.have.length(2);
+      const setVar = findBehavior(rule, 'setVariable');
+      expect(setVar.options.variableName).to.equal('PMUSER_EDGE_OPTIMIZE_FAILOVER');
+      expect(setVar.options.variableValue).to.equal('TRUE');
     });
   });
 
@@ -260,7 +278,11 @@ describe('llmo-akamai-utils', () => {
     it('creates a variables array when the tree has none', () => {
       const treeNoVars = { rules: { name: 'default', children: [] } };
       const merged = mergeIntoTree(treeNoVars, cfg);
-      expect(merged.rules.variables).to.be.an('array').with.length(1);
+      // Declares both managed PMUSER vars: the cache key and the failover flag.
+      expect(merged.rules.variables).to.be.an('array').with.length(2);
+      const names = merged.rules.variables.map((v) => v.name);
+      expect(names).to.include(cfg.cacheKeyVariable.name);
+      expect(names).to.include('PMUSER_EDGE_OPTIMIZE_FAILOVER');
     });
 
     it('throws when the tree has no top-level rules object', () => {
@@ -296,11 +318,14 @@ describe('llmo-akamai-utils', () => {
         rules: {
           name: 'default',
           children: [{ name: 'Existing' }, { name: 'Optimize at Edge ' }],
-          variables: [{ name: cfg.cacheKeyVariable.name, value: '' }],
+          variables: [
+            { name: cfg.cacheKeyVariable.name, value: '' },
+            { name: 'PMUSER_EDGE_OPTIMIZE_FAILOVER', value: 'FALSE' },
+          ],
         },
       };
       const ops = buildRuleTreePatch(tree, cfg);
-      // The trailing-space rule is at index 1 and must be removed; no variable op (already there).
+      // Trailing-space rule at index 1 is removed; no variable op (both vars already present).
       expect(removeOps(ops).map((o) => o.path)).to.deep.equal(['/rules/children/1']);
       expect(ops.some((o) => o.path.startsWith('/rules/variables'))).to.equal(false);
       expect(addChildOps(ops)[0].value.name).to.equal(cfg.ruleNames.parent);
@@ -347,7 +372,9 @@ describe('llmo-akamai-utils', () => {
     it('creates the variables array when the tree has none', () => {
       const ops = buildRuleTreePatch({ rules: { name: 'default', children: [] } }, cfg);
       const varOp = ops.find((o) => o.path === '/rules/variables');
-      expect(varOp.value).to.be.an('array').with.length(1);
+      // Both managed PMUSER vars: cache key + failover flag.
+      expect(varOp.value).to.be.an('array').with.length(2);
+      expect(varOp.value.map((v) => v.name)).to.include('PMUSER_EDGE_OPTIMIZE_FAILOVER');
     });
 
     it('appends via `-` for a non-numeric insertIndex (falls back to the default)', () => {

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -24,8 +24,20 @@ const GROUP_ID = 'grp_18385';
 const LLMO_API_KEY = 'llmo-api-key-xyz';
 const CALLER_EMAIL = 'onboarder@adobe.com';
 
-// A minimal but valid PAPI rule tree the client returns from getRuleTree.
-const RULE_TREE = { rules: { name: 'default', children: [{ name: 'Existing' }], variables: [] } };
+// A minimal but valid PAPI rule tree the client returns from getRuleTree. The default rule has a
+// CUSTOM origin (passes the onboarding scope gate) and its own Caching behavior (so the OAE rule is
+// built WITHOUT adding a Caching behavior of its own — the common/tokowaka case).
+const RULE_TREE = {
+  rules: {
+    name: 'default',
+    behaviors: [
+      { name: 'origin', options: { verificationMode: 'CUSTOM' } },
+      { name: 'caching', options: { behavior: 'CACHE_CONTROL_AND_EXPIRES' } },
+    ],
+    children: [{ name: 'Existing' }],
+    variables: [],
+  },
+};
 
 describe('LlmoAkamaiController', () => {
   let sandbox;
@@ -228,16 +240,18 @@ describe('LlmoAkamaiController', () => {
       expect(body.latestVersion).to.equal(7);
       expect(body.currentChildRules).to.deep.equal(['Existing']);
       expect(body.mergedChildRules[0]).to.equal('Optimize at Edge');
-      // plan dry-runs the exact patch it would deploy, without creating a version.
+      // plan dry-runs the exact full-tree PUT it would deploy, without creating a version.
       expect(mockAkamaiClient.createVersion).to.not.have.been.called;
-      expect(mockAkamaiClient.patchRuleTree).to.have.been.calledOnce;
-      expect(mockAkamaiClient.patchRuleTree.firstCall.args[6]).to.deep.equal({ dryRun: true });
+      expect(mockAkamaiClient.updateRuleTree).to.have.been.calledOnce;
+      expect(mockAkamaiClient.updateRuleTree.firstCall.args[6]).to.deep.equal({ dryRun: true });
       expect(body.validated).to.equal(true);
       expect(body.errors).to.deep.equal([]);
     });
 
-    it('surfaces dry-run validation errors and warnings from the patch deploy would apply', async () => {
-      mockAkamaiClient.patchRuleTree.resolves({ errors: [{ detail: 'bad' }], warnings: [{ detail: 'w' }] });
+    it('surfaces dry-run validation errors and warnings the PUT deploy would apply', async () => {
+      mockAkamaiClient.updateRuleTree.resolves({
+        errors: [{ detail: 'bad' }], warnings: [{ detail: 'w' }],
+      });
       const res = await controller.plan(withData(propertyRef));
       const body = await res.json();
       expect(res.status).to.equal(200);
@@ -247,7 +261,7 @@ describe('LlmoAkamaiController', () => {
     });
 
     it('degrades to validated:false (200) when the dry-run itself cannot run', async () => {
-      mockAkamaiClient.patchRuleTree.rejects(new Error('PAPI PATCH /x -> 409: conflict'));
+      mockAkamaiClient.updateRuleTree.rejects(new Error('PAPI PUT /x -> 403: already-activated'));
       const res = await controller.plan(withData(propertyRef));
       const body = await res.json();
       expect(res.status).to.equal(200);
@@ -281,23 +295,22 @@ describe('LlmoAkamaiController', () => {
   });
 
   describe('deploy', () => {
-    it('creates a new version, applies the rules via a JSON patch, and returns it', async () => {
+    it('creates a new version, applies the rules via a full-tree PUT, and returns it', async () => {
       const res = await controller.deploy(withData(propertyRef));
       const body = await res.json();
       expect(res.status).to.equal(200);
       expect(body.baseVersion).to.equal(7);
       expect(body.newVersion).to.equal(8);
-      // The patch is built against and applied to the NEW version, guarded by its etag; the old
-      // full-tree PUT is no longer used.
-      expect(mockAkamaiClient.getRuleTree).to.have.been.calledWith(PROPERTY_ID, 8);
-      expect(mockAkamaiClient.patchRuleTree).to.have.been.calledOnce;
-      const [, version, , , ops, etag] = mockAkamaiClient.patchRuleTree.firstCall.args;
+      // The tree is read from the BASE version (for the scope gate + merge), then the merged tree
+      // is PUT into the NEW version, pinning the base version's ruleFormat.
+      expect(mockAkamaiClient.getRuleTree).to.have.been.calledWith(PROPERTY_ID, 7);
+      expect(mockAkamaiClient.updateRuleTree).to.have.been.calledOnce;
+      const [, version, , , merged, ruleFormat] = mockAkamaiClient.updateRuleTree.firstCall.args;
       expect(version).to.equal(8);
-      // v8's etag (from the fresh getRuleTree(8)), not the latest-version (v7) etag.
-      expect(etag).to.equal('etag-8');
-      const addParent = ops.find((o) => o.op === 'add' && o.value?.name === 'Optimize at Edge');
-      expect(addParent).to.exist;
-      expect(mockAkamaiClient.updateRuleTree).to.not.have.been.called;
+      expect(ruleFormat).to.equal('v2024-01-01');
+      const parent = merged.rules.children.find((c) => c.name === 'Optimize at Edge');
+      expect(parent).to.exist;
+      expect(mockAkamaiClient.patchRuleTree).to.not.have.been.called;
     });
 
     it('blocks deploy when the property does not serve the site domain', async () => {
@@ -310,7 +323,7 @@ describe('LlmoAkamaiController', () => {
     });
 
     it('returns 422 when PAPI rejects the rule tree', async () => {
-      mockAkamaiClient.patchRuleTree.resolves({ errors: [{ title: 'bad' }], warnings: [] });
+      mockAkamaiClient.updateRuleTree.resolves({ errors: [{ title: 'bad' }], warnings: [] });
       const res = await controller.deploy(withData(propertyRef));
       const body = await res.json();
       expect(res.status).to.equal(422);
@@ -323,12 +336,84 @@ describe('LlmoAkamaiController', () => {
       expect(res.status).to.equal(403);
     });
 
-    it('reports the created newVersion when patch throws after createVersion', async () => {
-      mockAkamaiClient.patchRuleTree.rejects(new Error('PAPI PATCH /x -> 500: boom'));
+    it('reports the created newVersion when the PUT throws after createVersion', async () => {
+      mockAkamaiClient.updateRuleTree.rejects(new Error('PAPI PUT /x -> 500: boom'));
       const res = await controller.deploy(withData(propertyRef));
       const body = await res.json();
       expect(res.status).to.equal(502);
       expect(body.newVersion).to.equal(8);
+    });
+
+    it('accepts an explicit baseVersion and copies from it', async () => {
+      const res = await controller.deploy(withData({ ...propertyRef, baseVersion: 5 }));
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.baseVersion).to.equal(5);
+      expect(mockAkamaiClient.getRuleTree).to.have.been.calledWith(PROPERTY_ID, 5);
+      expect(mockAkamaiClient.createVersion).to.have.been.calledWith(PROPERTY_ID, 5);
+      // Default (latest) is not consulted when baseVersion is given.
+      expect(mockAkamaiClient.getLatestVersion).to.not.have.been.called;
+    });
+
+    it('rejects a non-integer baseVersion', async () => {
+      const res = await controller.deploy(withData({ ...propertyRef, baseVersion: '1e3' }));
+      expect(res.status).to.equal(400);
+      expect(mockAkamaiClient.createVersion).to.not.have.been.called;
+    });
+  });
+
+  describe('CUSTOM scope gate + caching decision', () => {
+    // Default rule origin is PLATFORM_SETTINGS -> onboarding is not supported.
+    const platformTree = {
+      rules: {
+        name: 'default',
+        behaviors: [{ name: 'origin', options: { verificationMode: 'PLATFORM_SETTINGS' } }],
+        children: [],
+        variables: [],
+      },
+    };
+
+    it('deploy rejects (400) a property whose default origin is not CUSTOM', async () => {
+      mockAkamaiClient.getRuleTree.resolves({ ruleTree: platformTree, ruleFormat: 'latest' });
+      const res = await controller.deploy(withData(propertyRef));
+      expect(res.status).to.equal(400);
+      // Gate runs before any mutation.
+      expect(mockAkamaiClient.createVersion).to.not.have.been.called;
+      expect(mockAkamaiClient.updateRuleTree).to.not.have.been.called;
+    });
+
+    it('plan rejects (400) a property whose default origin is not CUSTOM', async () => {
+      mockAkamaiClient.getRuleTree.resolves({ ruleTree: platformTree, ruleFormat: 'latest' });
+      const res = await controller.plan(withData(propertyRef));
+      expect(res.status).to.equal(400);
+    });
+
+    it('adds a Caching behavior to the OAE rule ONLY when the default rule has none', async () => {
+      // Default tree here (RULE_TREE) HAS caching -> OAE routing rule must NOT add its own.
+      await controller.deploy(withData(propertyRef));
+      const withCaching = mockAkamaiClient.updateRuleTree.firstCall.args[4];
+      const routingA = withCaching.rules.children
+        .find((c) => c.name === 'Optimize at Edge').children
+        .find((c) => c.name === 'Optimize at Edge Routing');
+      expect(routingA.behaviors.some((b) => b.name === 'caching')).to.equal(false);
+
+      // A default rule WITHOUT caching -> OAE routing rule adds one so cacheId validates.
+      mockAkamaiClient.updateRuleTree.resetHistory();
+      const noCacheTree = {
+        rules: {
+          name: 'default',
+          behaviors: [{ name: 'origin', options: { verificationMode: 'CUSTOM' } }],
+          children: [],
+          variables: [],
+        },
+      };
+      mockAkamaiClient.getRuleTree.resolves({ ruleTree: noCacheTree, ruleFormat: 'latest' });
+      await controller.deploy(withData(propertyRef));
+      const noCache = mockAkamaiClient.updateRuleTree.firstCall.args[4];
+      const routingB = noCache.rules.children
+        .find((c) => c.name === 'Optimize at Edge').children
+        .find((c) => c.name === 'Optimize at Edge Routing');
+      expect(routingB.behaviors.some((b) => b.name === 'caching')).to.equal(true);
     });
   });
 
@@ -343,6 +428,14 @@ describe('LlmoAkamaiController', () => {
       // notifyEmails is derived server-side from the caller's trial_email.
       expect(mockAkamaiClient.activate)
         .to.have.been.calledWith(PROPERTY_ID, 7, CONTRACT_ID, GROUP_ID, 'STAGING');
+    });
+
+    it('passes an activation note attributing the caller', async () => {
+      await controller.activate(withData(propertyRef));
+      const note = mockAkamaiClient.activate.firstCall.args[5];
+      expect(note).to.be.a('string');
+      expect(note).to.contain('Optimize at Edge');
+      expect(note).to.contain('via Adobe LLM Optimizer');
     });
 
     it('activates a specific version when provided', async () => {
@@ -617,15 +710,21 @@ describe('LlmoAkamaiController', () => {
     });
 
     it('plan tolerates a rule tree whose root has no children', async () => {
-      mockAkamaiClient.getRuleTree.resolves({ ruleTree: { rules: { name: 'default' } }, ruleFormat: 'latest' });
+      const bareTree = {
+        rules: {
+          name: 'default',
+          behaviors: [{ name: 'origin', options: { verificationMode: 'CUSTOM' } }],
+        },
+      };
+      mockAkamaiClient.getRuleTree.resolves({ ruleTree: bareTree, ruleFormat: 'latest' });
       const res = await controller.plan(withData(propertyRef));
       const body = await res.json();
       expect(res.status).to.equal(200);
       expect(body.currentChildRules).to.deep.equal([]);
     });
 
-    it('deploy treats an empty patchRuleTree response as success', async () => {
-      mockAkamaiClient.patchRuleTree.resolves(undefined);
+    it('deploy treats an empty updateRuleTree response as success', async () => {
+      mockAkamaiClient.updateRuleTree.resolves(undefined);
       const res = await controller.deploy(withData(propertyRef));
       expect(res.status).to.equal(200);
     });

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -504,6 +504,43 @@ describe('LlmoAkamaiController', () => {
       expect(capturedClientConfig.clientToken).to.equal('ctok');
       expect(capturedClientConfig.accessToken).to.equal('atok');
     });
+
+    it('recovers to 200 when the POST errors (timeout/422) but Akamai queued the activation', async () => {
+      mockAkamaiClient.activate.rejects(
+        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations request failed: '
+          + 'Request timeout after 10000ms'),
+      );
+      mockAkamaiClient.latestActivation.resolves({
+        activationId: 'atv_777', status: 'PENDING', propertyVersion: 7,
+      });
+      const res = await controller.activate(withData(propertyRef));
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.activationId).to.equal('atv_777');
+      expect(body.recovered).to.equal(true);
+      expect(mockAkamaiClient.latestActivation)
+        .to.have.been.calledWith(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
+    });
+
+    it('surfaces the error when the POST fails and no matching activation is in flight', async () => {
+      mockAkamaiClient.activate.rejects(
+        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations -> 500: boom'),
+      );
+      mockAkamaiClient.latestActivation.resolves(undefined);
+      const res = await controller.activate(withData(propertyRef));
+      expect(res.status).to.equal(502);
+    });
+
+    it('does not recover when the in-flight activation is for a different version', async () => {
+      mockAkamaiClient.activate.rejects(
+        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations -> 422: already-activated'),
+      );
+      mockAkamaiClient.latestActivation.resolves({
+        activationId: 'atv_x', status: 'PENDING', propertyVersion: 999,
+      });
+      const res = await controller.activate(withData(propertyRef));
+      expect(res.status).to.equal(502);
+    });
   });
 
   describe('activationStatus', () => {

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -541,6 +541,16 @@ describe('LlmoAkamaiController', () => {
       const res = await controller.activate(withData(propertyRef));
       expect(res.status).to.equal(502);
     });
+
+    it('surfaces the original error when the recovery lookup itself fails', async () => {
+      mockAkamaiClient.activate.rejects(
+        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations request failed: '
+          + 'Request timeout after 10000ms'),
+      );
+      mockAkamaiClient.latestActivation.rejects(new Error('listActivations failed'));
+      const res = await controller.activate(withData(propertyRef));
+      expect(res.status).to.equal(502);
+    });
   });
 
   describe('activationStatus', () => {

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -362,6 +362,13 @@ describe('LlmoAkamaiController', () => {
       expect(res.status).to.equal(400);
       expect(mockAkamaiClient.createVersion).to.not.have.been.called;
     });
+
+    it('rejects baseVersion 0 (PAPI versions start at 1)', async () => {
+      const res = await controller.deploy(withData({ ...propertyRef, baseVersion: 0 }));
+      expect(res.status).to.equal(400);
+      expect(mockAkamaiClient.getRuleTree).to.not.have.been.called;
+      expect(mockAkamaiClient.createVersion).to.not.have.been.called;
+    });
   });
 
   describe('CUSTOM scope gate + caching decision', () => {
@@ -511,7 +518,7 @@ describe('LlmoAkamaiController', () => {
           + 'Request timeout after 10000ms'),
       );
       mockAkamaiClient.latestActivation.resolves({
-        activationId: 'atv_777', status: 'PENDING', propertyVersion: 7,
+        activationId: 'atv_777', status: 'PENDING', propertyVersion: 7, submitDate: new Date().toISOString(),
       });
       const res = await controller.activate(withData(propertyRef));
       const body = await res.json();
@@ -522,6 +529,21 @@ describe('LlmoAkamaiController', () => {
         .to.have.been.calledWith(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
     });
 
+    it('does NOT recover a stale activation (submitDate older than the recency window)', async () => {
+      mockAkamaiClient.activate.rejects(
+        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations -> 500: boom'),
+      );
+      // Same version+network but submitted an hour ago (e.g. a manual activation) — not ours.
+      mockAkamaiClient.latestActivation.resolves({
+        activationId: 'atv_777',
+        status: 'PENDING',
+        propertyVersion: 7,
+        submitDate: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      });
+      const res = await controller.activate(withData(propertyRef));
+      expect(res.status).to.equal(502);
+    });
+
     it('recovers with a null activationId when Akamai has not yet assigned one (placeholder)', async () => {
       mockAkamaiClient.activate.rejects(
         new Error('PAPI POST /papi/v1/properties/prp_1253269/activations request failed: '
@@ -529,7 +551,7 @@ describe('LlmoAkamaiController', () => {
       );
       // A just-queued activation appears in the list as "atv_null" before the id is assigned.
       mockAkamaiClient.latestActivation.resolves({
-        activationId: 'atv_null', status: 'PENDING', propertyVersion: 7,
+        activationId: 'atv_null', status: 'PENDING', propertyVersion: 7, submitDate: new Date().toISOString(),
       });
       const res = await controller.activate(withData(propertyRef));
       const body = await res.json();

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -529,19 +529,23 @@ describe('LlmoAkamaiController', () => {
         .to.have.been.calledWith(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
     });
 
-    it('does NOT recover a stale activation (submitDate older than the recency window)', async () => {
+    it('recovers an already-active version regardless of age (422 already-activated)', async () => {
+      // Re-activating an already-ACTIVE version returns 422 already-activated; the version is live
+      // on the network (the goal), so we report success even though it was submitted long ago.
       mockAkamaiClient.activate.rejects(
-        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations -> 500: boom'),
+        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations -> 422: already-activated'),
       );
-      // Same version+network but submitted an hour ago (e.g. a manual activation) — not ours.
       mockAkamaiClient.latestActivation.resolves({
-        activationId: 'atv_777',
-        status: 'PENDING',
+        activationId: 'atv_20135944',
+        status: 'ACTIVE',
         propertyVersion: 7,
         submitDate: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
       });
       const res = await controller.activate(withData(propertyRef));
-      expect(res.status).to.equal(502);
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.recovered).to.equal(true);
+      expect(body.activationId).to.equal('atv_20135944');
     });
 
     it('recovers with a null activationId when Akamai has not yet assigned one (placeholder)', async () => {

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -239,7 +239,9 @@ describe('LlmoAkamaiController', () => {
       expect(res.status).to.equal(200);
       expect(body.latestVersion).to.equal(7);
       expect(body.currentChildRules).to.deep.equal(['Existing']);
-      expect(body.mergedChildRules[0]).to.equal('Optimize at Edge');
+      // The OAE wrapper is appended LAST so its origin + cacheId win (Akamai is last-match-wins).
+      expect(body.mergedChildRules).to.deep.equal(['Existing', 'Optimize at Edge']);
+      expect(body.mergedChildRules[body.mergedChildRules.length - 1]).to.equal('Optimize at Edge');
       // plan dry-runs the exact full-tree PUT it would deploy, without creating a version.
       expect(mockAkamaiClient.createVersion).to.not.have.been.called;
       expect(mockAkamaiClient.updateRuleTree).to.have.been.calledOnce;

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -522,6 +522,23 @@ describe('LlmoAkamaiController', () => {
         .to.have.been.calledWith(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
     });
 
+    it('recovers with a null activationId when Akamai has not yet assigned one (placeholder)', async () => {
+      mockAkamaiClient.activate.rejects(
+        new Error('PAPI POST /papi/v1/properties/prp_1253269/activations request failed: '
+          + 'Request timeout after 10000ms'),
+      );
+      // A just-queued activation appears in the list as "atv_null" before the id is assigned.
+      mockAkamaiClient.latestActivation.resolves({
+        activationId: 'atv_null', status: 'PENDING', propertyVersion: 7,
+      });
+      const res = await controller.activate(withData(propertyRef));
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.recovered).to.equal(true);
+      // Placeholder id is not pollable — return null so the UI polls by network instead.
+      expect(body.activationId).to.equal(null);
+    });
+
     it('surfaces the error when the POST fails and no matching activation is in flight', async () => {
       mockAkamaiClient.activate.rejects(
         new Error('PAPI POST /papi/v1/properties/prp_1253269/activations -> 500: boom'),


### PR DESCRIPTION
Squash-collapses the OAE onboarding work onto a fresh `feat/akamai-oae-automation` branch (cut from `main`) so the review PR (`feat/akamai-oae-automation` → `main`) shows a single commit for senior review.

**Squash-merge** this PR — that puts one commit on `feat/akamai-oae-automation`. Full context lives in the automation → main review PR.