### PR TITLE
feat: upsert on conflict for state access-mapping create

### DIFF
--- a/docs/openapi/state-access-mappings-api.yaml
+++ b/docs/openapi/state-access-mappings-api.yaml
@@ -59,11 +59,17 @@ state-access-mappings:
   post:
     tags:
       - state-access-mappings
-    summary: Create a state-layer access mapping
+    summary: Create (upsert) a state-layer access mapping
     description: |
       Inserts one `facs_access_mappings` binding row. Capability is
       validated against the product's capability catalog. For `subjectType:
       org`, `subjectId` must equal the caller's canonical org id.
+
+      **Upsert semantics:** when an active binding already exists for the same
+      subject + resource, its `grantedCapabilities` are **overwritten** with the
+      request's set (the given capabilities *replace* the stored ones — this is
+      not a merge) and the endpoint returns `200` with the updated mapping. A
+      brand-new binding returns `201`.
 
       `grantedCapabilities` must be non-empty (a `400` is returned otherwise — to
       remove all access, use `DELETE` on the created row). The product's
@@ -83,6 +89,14 @@ state-access-mappings:
           schema:
             $ref: './schemas.yaml#/StateAccessMappingCreateRequest'
     responses:
+      '200':
+        description: >-
+          An active mapping already existed for this subject and resource; its
+          granted capabilities were overwritten with the request's set (upsert).
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/StateAccessMapping'
       '201':
         description: Mapping created.
         content:
@@ -96,7 +110,9 @@ state-access-mappings:
       '403':
         $ref: './responses.yaml#/403'
       '409':
-        description: Active mapping already exists for this subject and resource.
+        description: >-
+          Rare race: an active mapping existed at insert time but was revoked
+          before its capabilities could be overwritten. Safe to retry.
         content:
           application/json:
             schema:

--- a/src/controllers/state-access-mappings.js
+++ b/src/controllers/state-access-mappings.js
@@ -724,8 +724,10 @@ function StateAccessMappingsController(context) {
         createdBy,
       });
       if (result.created.length === 0 && result.skipped.length > 0) {
-        // Active duplicate already exists. Surface the existing row id for
-        // idempotent client handling — look it up by the natural key.
+        // Active duplicate already exists — upsert semantics: overwrite the
+        // existing binding's capabilities with the request's set rather than
+        // rejecting the call. Look the row up by its natural key, then replace
+        // its capabilities via the same capability-edit RPC PATCH uses.
         const existing = await listFacsAccessMappings(postgrestClient, {
           imsOrgId,
           product,
@@ -736,13 +738,49 @@ function StateAccessMappingsController(context) {
           limit: 1,
         });
         const conflictId = existing[0]?.id ?? null;
-        return createResponse(
-          {
-            message: 'Active access mapping already exists for this subject and resource',
-            id: conflictId,
-          },
-          409,
-        );
+        // Defensive: the active row vanished (revoked) between the insert
+        // conflict and this read. Nothing to update — surface the conflict.
+        if (!conflictId) {
+          return createResponse(
+            {
+              message: 'Active access mapping already exists for this subject and resource',
+              id: null,
+            },
+            409,
+          );
+        }
+        const updated = await updateFacsAccessMappingCapabilities(postgrestClient, {
+          id: conflictId,
+          imsOrgId,
+          product,
+          grantedCapabilities: capabilitiesToStore,
+          updatedBy: createdBy,
+        });
+        if (!updated) {
+          // Same race as above, observed one layer down (the RPC filters on
+          // `revoked_at IS NULL`). Surface the conflict rather than a 500.
+          return createResponse(
+            {
+              message: 'Active access mapping already exists for this subject and resource',
+              id: conflictId,
+            },
+            409,
+          );
+        }
+        await emitAuditEvent(ctx, {
+          imsOrgId,
+          product,
+          operation: 'update_capabilities',
+          outcome: 'allow',
+          statusCode: 200,
+          mappingId: updated.id,
+          bindingSubjectType: updated.subject_type,
+          bindingSubjectId: updated.subject_id,
+          resourceType: updated.resource_type,
+          resourceId: updated.resource_id,
+          grantedCapabilities: capabilitiesToStore,
+        });
+        return ok(toMappingDto(updated));
       }
       const createdRow = result.created[0];
       await emitAuditEvent(ctx, {

--- a/test/controllers/state-access-mappings.test.js
+++ b/test/controllers/state-access-mappings.test.js
@@ -601,7 +601,78 @@ describe('StateAccessMappingsController', () => {
       expect(ctx.log.warn.called).to.be.true;
     });
 
-    it('returns 409 when an active duplicate exists', async () => {
+    it('upserts on active duplicate: overwrites capabilities and returns 200', async () => {
+      const existing = makeRow({ id: 'pre-existing-id' });
+      const updated = makeRow({
+        id: 'pre-existing-id',
+        granted_capabilities: ['llmo/can_configure', 'llmo/can_view'],
+      });
+      const updateStub = sinon.stub().resolves(updated);
+      const { Controller } = await loadController({
+        createFacsAccessMappings: sinon.stub().resolves({
+          created: [],
+          skipped: [{ subject: { type: 'user', id: 'someone@AdobeID' }, reason: 'duplicate' }],
+        }),
+        listFacsAccessMappings: sinon.stub().resolves([existing]),
+        updateFacsAccessMappingCapabilities: updateStub,
+      });
+      const ctx = makeContext({
+        body: { ...validBody, grantedCapabilities: ['llmo/can_configure'] },
+      });
+      const res = await Controller(ctx).createMapping(ctx);
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.id).to.equal('pre-existing-id');
+      // The existing row is updated by id with the request's capability set
+      // (plus the auto-injected can_view baseline).
+      expect(updateStub.calledOnce).to.be.true;
+      expect(updateStub.firstCall.args[1].id).to.equal('pre-existing-id');
+      expect(updateStub.firstCall.args[1].grantedCapabilities)
+        .to.have.members(['llmo/can_configure', 'llmo/can_view']);
+    });
+
+    it('audits an update_capabilities (allow) event on upsert', async () => {
+      const existing = makeRow({ id: 'pre-existing-id' });
+      const { Controller, stubs } = await loadController({
+        createFacsAccessMappings: sinon.stub().resolves({
+          created: [],
+          skipped: [{ subject: { type: 'user', id: 'someone@AdobeID' }, reason: 'duplicate' }],
+        }),
+        listFacsAccessMappings: sinon.stub().resolves([existing]),
+        updateFacsAccessMappingCapabilities: sinon.stub().resolves(existing),
+      });
+      const ctx = makeContext({ body: validBody });
+      const res = await Controller(ctx).createMapping(ctx);
+      expect(res.status).to.equal(200);
+      const event = stubs.insertFacsAccessMappingAuditEvent.firstCall.args[1];
+      expect(event).to.include({
+        product: 'LLMO',
+        operation: 'update_capabilities',
+        outcome: 'allow',
+        mappingId: 'pre-existing-id',
+      });
+    });
+
+    it('returns 409 with null id when conflict lookup misses', async () => {
+      const updateStub = sinon.stub().resolves(null);
+      const { Controller } = await loadController({
+        createFacsAccessMappings: sinon.stub().resolves({
+          created: [],
+          skipped: [{ subject: { type: 'user', id: 'someone@AdobeID' }, reason: 'duplicate' }],
+        }),
+        listFacsAccessMappings: sinon.stub().resolves([]),
+        updateFacsAccessMappingCapabilities: updateStub,
+      });
+      const ctx = makeContext({ body: validBody });
+      const res = await Controller(ctx).createMapping(ctx);
+      const body = await res.json();
+      expect(res.status).to.equal(409);
+      expect(body.id).to.equal(null);
+      // No row id to update — the upsert update is never attempted.
+      expect(updateStub.called).to.be.false;
+    });
+
+    it('returns 409 when the row is revoked between conflict and update', async () => {
       const existing = makeRow({ id: 'pre-existing-id' });
       const { Controller } = await loadController({
         createFacsAccessMappings: sinon.stub().resolves({
@@ -609,27 +680,14 @@ describe('StateAccessMappingsController', () => {
           skipped: [{ subject: { type: 'user', id: 'someone@AdobeID' }, reason: 'duplicate' }],
         }),
         listFacsAccessMappings: sinon.stub().resolves([existing]),
+        // RPC finds no active row (raced revoke) → returns null.
+        updateFacsAccessMappingCapabilities: sinon.stub().resolves(null),
       });
       const ctx = makeContext({ body: validBody });
       const res = await Controller(ctx).createMapping(ctx);
-      expect(res.status).to.equal(409);
       const body = await res.json();
+      expect(res.status).to.equal(409);
       expect(body.id).to.equal('pre-existing-id');
-    });
-
-    it('returns 409 with null id when conflict lookup misses', async () => {
-      const { Controller } = await loadController({
-        createFacsAccessMappings: sinon.stub().resolves({
-          created: [],
-          skipped: [{ subject: { type: 'user', id: 'someone@AdobeID' }, reason: 'duplicate' }],
-        }),
-        listFacsAccessMappings: sinon.stub().resolves([]),
-      });
-      const ctx = makeContext({ body: validBody });
-      const res = await Controller(ctx).createMapping(ctx);
-      const body = await res.json();
-      expect(res.status).to.equal(409);
-      expect(body.id).to.equal(null);
     });
 
     it('returns 500 when the helper throws', async () => {

--- a/test/it/shared/tests/state-access-mappings.js
+++ b/test/it/shared/tests/state-access-mappings.js
@@ -72,7 +72,7 @@ function expectMappingDto(m) {
  *
  * Exercises the full PostgREST round-trip for the hybrid-model state layer:
  * create / list / patch (including empty-to-remove-access) / history, plus
- * validation and the active-duplicate → 409 semantics. The `admin` persona is
+ * validation and the active-duplicate → upsert (overwrite) semantics. The `admin` persona is
  * used throughout because it is an
  * internal identity that bypasses `facsWrapper` — the controller logic and
  * the real `facs_access_mappings` table are what's under test here, not the
@@ -131,17 +131,22 @@ export default function stateAccessMappingsTests(getHttpClient, resetData) {
         expect(res.body.items[0].id).to.equal(created.id);
       });
 
-      it('POST a duplicate active binding returns 409 with the existing id', async () => {
+      it('POST a duplicate active binding upserts: overwrites capabilities (200)', async () => {
         const http = getHttpClient();
         const res = await http.admin.post(BASE, {
           subjectType: 'user',
           subjectId: USER_SUBJECT,
           resourceType: 'brand',
           resourceId: BRAND_RESOURCE_ID,
-          grantedCapabilities: ['llmo/can_view'],
+          // A distinct set from the original create (LLMO_CAPS). The upsert
+          // replaces the stored capabilities on the SAME row (same id); the
+          // baseline can_view is auto-injected.
+          grantedCapabilities: ['llmo/can_configure'],
         });
-        expect(res.status).to.equal(409);
+        expect(res.status).to.equal(200);
         expect(res.body.id).to.equal(created.id);
+        expect(res.body.grantedCapabilities)
+          .to.have.members(['llmo/can_configure', 'llmo/can_view']);
       });
 
       it('PATCH replaces the granted capabilities (200)', async () => {


### PR DESCRIPTION
## What

Makes `POST /state/access-mappings` (`createMapping`) **upsert-natured**. When the DB insert conflicts with an existing active binding for the same subject + resource, instead of returning `409` the endpoint now **overwrites the existing row's `granted_capabilities`** with the request's set and returns `200` with the updated mapping.

## Why

Clients re-issuing a create for an already-bound subject+resource previously had to catch the `409`, then issue a follow-up `PATCH`. Upsert collapses that into a single idempotent call.

## How

On the conflict path (`created.length === 0 && skipped.length > 0`):
1. Look up the existing row by natural key to get its `id` (unchanged).
2. Call `updateFacsAccessMappingCapabilities` — the same SECURITY-DEFINER capability-edit RPC `PATCH` uses — with `capabilitiesToStore` (de-duped request caps + auto-injected `<product>/can_view` baseline).
3. Emit an `update_capabilities` audit event (status 200) and return the updated mapping DTO.
4. **Fail-safe:** if the existing row can't be found, or the RPC finds no active row (the row-revoked-mid-flight race), fall back to the original `409` rather than a 500.

Capabilities are **replaced**, not merged — consistent with `PATCH` semantics.

## Tests
- **Unit** (`test/controllers/state-access-mappings.test.js`): upsert overwrite → 200, audit event assertion, and two `409` race-fallback cases (lookup miss, revoked-before-update). 111 passing.
- **Integration** (`test/it/shared/tests/state-access-mappings.js`): duplicate-POST now asserts 200 + same id + overwritten capabilities.

## Docs
- `docs/openapi/state-access-mappings-api.yaml`: documents upsert semantics, adds `200`, narrows `409` to the revoke race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
