### PR TITLE
fix(serenity): classify disguised-405 quota rejections as a stable 40…

### DIFF
--- a/src/support/serenity/allocation-metrics.js
+++ b/src/support/serenity/allocation-metrics.js
@@ -126,7 +126,7 @@ export function recordPoolFreeRatio(dim, free, total) {
 }
 
 /**
- * @param {'orgPoolExhausted'|'brandAiLimit'|'workspaceBusy'} reason
+ * @param {'orgPoolExhausted'|'brandAiLimit'|'workspaceBusy'|'quotaExceeded'} reason
  * @returns {void}
  */
 export function recordRejection(reason) {

--- a/src/support/serenity/errors.js
+++ b/src/support/serenity/errors.js
@@ -12,8 +12,9 @@
 
 // @ts-check
 
+import { ErrorWithStatusCode } from '../utils.js';
 import { SerenityTransportError } from './rest-transport.js';
-import { recordMeteredQuotaClassifier } from './allocation-metrics.js';
+import { recordMeteredQuotaClassifier, recordRejection } from './allocation-metrics.js';
 
 /**
  * Recognises an upstream "already gone" response — the signal that an
@@ -153,4 +154,29 @@ export const ERROR_CODES = Object.freeze({
   // Transient: a transfer never cleared the async `workspace not ready` lock — retryable, NOT
   // pool exhaustion (distinct from ORG_POOL_EXHAUSTED so the operator/client isn't misled).
   WORKSPACE_BUSY: 'workspaceBusy',
+  // Case-1 quota rejection (serenity-docs#72 §2): the disguised-405 signal classified by
+  // isMeteredQuota, surfaced via toQuotaExceededError. Distinct from ORG_POOL_EXHAUSTED /
+  // BRAND_AI_LIMIT (the allocator-ON tokens) so a client need not tell them apart, but a caller
+  // debugging a specific rejection still can from the log line at the throw site.
+  QUOTA_EXCEEDED: 'quotaExceeded',
 });
+
+/**
+ * Case-1 quota rejection (serenity-docs#72 §2): the brand's flat pre-carved sub-workspace
+ * allocation is exhausted — the allocator-OFF path production runs today, or the allocator-ON
+ * path's per-child ceiling isn't the cause but the disguised 405 still surfaced. Maps the
+ * classified {@link isMeteredQuota} signal to the same customer-facing contract as
+ * `orgPoolExhausted` / `brandAiLimit` (409, stable token), so a caller never needs to
+ * distinguish them — see `ERROR_CODES.QUOTA_EXCEEDED`.
+ *
+ * Client-facing message is deliberately generic — no internal ids, no upstream body — matching
+ * the `orgPoolExhausted`/`brandAiLimit` factories in resource-manager.js. Callers should log the
+ * upstream detail themselves before throwing this (see the markets-subworkspace.js call sites).
+ * @returns {ErrorWithStatusCode}
+ */
+export function toQuotaExceededError() {
+  recordRejection('quotaExceeded'); // dashboard-only — expected under normal pool load
+  const e = new ErrorWithStatusCode('AI resource allocation quota exceeded', 409);
+  e.code = ERROR_CODES.QUOTA_EXCEEDED;
+  return e;
+}

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -15,9 +15,8 @@
 import { hasText } from '@adobe/spacecat-shared-utils';
 
 import { ErrorWithStatusCode } from '../../utils.js';
-import { SerenityTransportError } from '../rest-transport.js';
 import {
-  ERROR_CODES, isUpstreamGone, toQuotaExceededError,
+  ERROR_CODES, isUpstreamGone, isMeteredQuota, toQuotaExceededError,
 } from '../errors.js';
 import { normalizeGeoTargetId, normalizeLanguageCode } from '../validation.js';
 import {
@@ -595,10 +594,14 @@ export async function handleCreateMarketSubworkspace(
     } catch (e) {
       // Case 1 (serenity-docs#72 §2): the brand carve is exhausted (allocator OFF — production
       // today), or `retryOnQuota`'s bounded top-up+retry (LLMO-6190 item 4) still didn't clear
-      // the disguised quota 405. Surface it as the stable `quotaExceeded` 409 token instead of
-      // letting it fall through mapError's generic `serenityUpstreamError` 502 — a caller can
-      // then show the contractual-limit message and never retry a rejection that can't succeed.
-      if (e instanceof SerenityTransportError && e.status === 405) {
+      // the disguised quota 405. Classify via `isMeteredQuota` (body-SHAPE check, not bare
+      // status — MysticatBot review) so a genuine app-level 405 Method-Not-Allowed (JSON body)
+      // is never mistaken for a quota rejection and hidden behind the wrong error token; this
+      // also gives the shared `MeteredQuotaClassifier` metric (LLMO-6191) a live call site.
+      // Surface a real quota match as the stable `quotaExceeded` 409 token instead of letting it
+      // fall through mapError's generic `serenityUpstreamError` 502 — a caller can then show the
+      // contractual-limit message and never retry a rejection that can't succeed.
+      if (isMeteredQuota(e)) {
         log?.warn?.('handleCreateMarketSubworkspace: publish rejected — quota exceeded', {
           workspaceId, projectId,
         });
@@ -611,15 +614,16 @@ export async function handleCreateMarketSubworkspace(
       await headroom.retryOnQuota(() => transport.publishProject(workspaceId, projectId));
       published = true;
     } catch (e) {
-      if (e instanceof SerenityTransportError && e.status === 405) {
+      if (isMeteredQuota(e)) {
         // Swallowed by design (best-effort provisioning must not fail the brand create), but this
         // IS a quota rejection and the event that creates the dark draft market a customer later
         // trips over — serenity-docs#72 §5 requires it to alert even though nothing failed here.
         // TODO(serenity-docs#72 step 2): fire the Slack alert here once the alerting mechanism
-        // lands; `recordRejection('quotaExceeded')` inside toQuotaExceededError already feeds the
-        // CloudWatch metric this alarm will key on, so calling it (without throwing) keeps the
-        // classifier + alerting signal consistent between this swallowed path and the `require`
-        // path above.
+        // lands; the call below is side-effect-only (its returned error is intentionally
+        // discarded, never thrown — best-effort swallows it) purely to run
+        // `recordRejection('quotaExceeded')` inside it, so the CloudWatch metric this alarm will
+        // key on fires here too, keeping the classifier + alerting signal consistent between
+        // this swallowed path and the `require` path above (MysticatBot review, non-blocking nit).
         toQuotaExceededError();
         log?.warn?.('handleCreateMarketSubworkspace: publish skipped — quota exceeded, project left as draft', {
           workspaceId, projectId,

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -16,7 +16,9 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 
 import { ErrorWithStatusCode } from '../../utils.js';
 import { SerenityTransportError } from '../rest-transport.js';
-import { ERROR_CODES, isUpstreamGone } from '../errors.js';
+import {
+  ERROR_CODES, isUpstreamGone, toQuotaExceededError,
+} from '../errors.js';
 import { normalizeGeoTargetId, normalizeLanguageCode } from '../validation.js';
 import {
   resolveLocation,
@@ -587,15 +589,39 @@ export async function handleCreateMarketSubworkspace(
   // falls through to the existing swallow below, unchanged.
   let published = false;
   if (publishMode === 'require') {
-    await headroom.retryOnQuota(() => transport.publishProject(workspaceId, projectId));
-    published = true;
+    try {
+      await headroom.retryOnQuota(() => transport.publishProject(workspaceId, projectId));
+      published = true;
+    } catch (e) {
+      // Case 1 (serenity-docs#72 §2): the brand carve is exhausted (allocator OFF — production
+      // today), or `retryOnQuota`'s bounded top-up+retry (LLMO-6190 item 4) still didn't clear
+      // the disguised quota 405. Surface it as the stable `quotaExceeded` 409 token instead of
+      // letting it fall through mapError's generic `serenityUpstreamError` 502 — a caller can
+      // then show the contractual-limit message and never retry a rejection that can't succeed.
+      if (e instanceof SerenityTransportError && e.status === 405) {
+        log?.warn?.('handleCreateMarketSubworkspace: publish rejected — quota exceeded', {
+          workspaceId, projectId,
+        });
+        throw toQuotaExceededError();
+      }
+      throw e;
+    }
   } else if (publishMode === 'best-effort') {
     try {
       await headroom.retryOnQuota(() => transport.publishProject(workspaceId, projectId));
       published = true;
     } catch (e) {
       if (e instanceof SerenityTransportError && e.status === 405) {
-        log?.warn?.('handleCreateMarketSubworkspace: publish skipped — quota 405, project left as draft', {
+        // Swallowed by design (best-effort provisioning must not fail the brand create), but this
+        // IS a quota rejection and the event that creates the dark draft market a customer later
+        // trips over — serenity-docs#72 §5 requires it to alert even though nothing failed here.
+        // TODO(serenity-docs#72 step 2): fire the Slack alert here once the alerting mechanism
+        // lands; `recordRejection('quotaExceeded')` inside toQuotaExceededError already feeds the
+        // CloudWatch metric this alarm will key on, so calling it (without throwing) keeps the
+        // classifier + alerting signal consistent between this swallowed path and the `require`
+        // path above.
+        toQuotaExceededError();
+        log?.warn?.('handleCreateMarketSubworkspace: publish skipped — quota exceeded, project left as draft', {
           workspaceId, projectId,
         });
       } else {

--- a/test/support/serenity/dynamic-allocation-fronting.test.js
+++ b/test/support/serenity/dynamic-allocation-fronting.test.js
@@ -34,6 +34,7 @@ import { clearTagCache } from '../../../src/support/serenity/handlers/markets.js
 import { clearResourceLocks } from '../../../src/support/serenity/resource-lock.js';
 import { PROJECT_BLOCK, PROMPT_BLOCK } from '../../../src/support/serenity/resource-manager.js';
 import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
+import { ERROR_CODES } from '../../../src/support/serenity/errors.js';
 import { makeProvisioningTransportStubs } from './fixtures/tag-tree.js';
 
 use(chaiAsPromised);
@@ -566,16 +567,30 @@ describe('dynamic-allocation fronting — retryOnQuota wiring', () => {
     expect(t.publishProject).to.have.been.calledTwice;
   });
 
-  it('create-market (require mode), flag OFF: a 405 is NOT retried — propagates on the first failure', async () => {
+  // serenity-docs#72 §2/§4.1 — case 1 (brand carve exhausted, allocator OFF, production today):
+  // the raw 405 is classified into the stable `quotaExceeded` 409 token rather than propagating
+  // unclassified (which mapError's generic branch would otherwise flatten into a 502).
+  it('create-market (require mode), flag OFF: a 405 is NOT retried, and is classified as quotaExceeded', async () => {
     const t = makeTransport({
       listProjects: sinon.stub().resolves({ items: [] }),
       publishProject: sinon.stub().rejects(quota405()),
     });
-    await expect(
-      handleCreateMarketSubworkspace(t, makeBrand(), PARENT, createBody, log, null, null, {
-        dynamicAllocation: false, parentWorkspaceId: MASTER, publishMode: 'require',
-      }),
-    ).to.be.rejectedWith(SerenityTransportError);
+    const opts = { dynamicAllocation: false, parentWorkspaceId: MASTER, publishMode: 'require' };
+    const p = handleCreateMarketSubworkspace(
+      t,
+      makeBrand(),
+      PARENT,
+      createBody,
+      log,
+      null,
+      null,
+      opts,
+    );
+    const err = await p.then(() => null, (e) => e);
+    expect(err).to.not.equal(null);
+    expect(err).to.not.be.instanceOf(SerenityTransportError);
+    expect(err.status).to.equal(409);
+    expect(err.code).to.equal(ERROR_CODES.QUOTA_EXCEEDED);
     expect(t.publishProject).to.have.been.calledOnce;
   });
 });

--- a/test/support/serenity/errors.test.js
+++ b/test/support/serenity/errors.test.js
@@ -22,6 +22,7 @@ import {
   isWorkspaceNotReady,
   isMeteredQuota,
   isRateLimited,
+  toQuotaExceededError,
 } from '../../../src/support/serenity/errors.js';
 import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
 
@@ -46,7 +47,22 @@ describe('serenity error classification', () => {
       expect(ERROR_CODES.LINKED_SUBWORKSPACES).to.equal('linkedSubworkspaces');
       expect(ERROR_CODES.ORG_POOL_EXHAUSTED).to.equal('orgPoolExhausted');
       expect(ERROR_CODES.BRAND_AI_LIMIT).to.equal('brandAiLimit');
+      expect(ERROR_CODES.QUOTA_EXCEEDED).to.equal('quotaExceeded');
       expect(Object.isFrozen(ERROR_CODES)).to.be.true;
+    });
+  });
+
+  // serenity-docs#72 §2/§4.1 — case 1 (brand carve exhausted, allocator OFF, production today).
+  describe('toQuotaExceededError', () => {
+    it('returns a 409 ErrorWithStatusCode carrying the quotaExceeded token', () => {
+      const e = toQuotaExceededError();
+      expect(e.status).to.equal(409);
+      expect(e.code).to.equal(ERROR_CODES.QUOTA_EXCEEDED);
+    });
+
+    it('the message carries no internal ids/upstream detail (client-safe, mirrors orgPoolExhausted/brandAiLimit)', () => {
+      const e = toQuotaExceededError();
+      expect(e.message).to.not.match(/workspace|project|semrush/i);
     });
   });
 

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -459,14 +459,41 @@ describe('markets-subworkspace handlers', () => {
       expect(transport.publishProject).to.not.have.been.called;
     });
 
+    // Pinned disguised-405 shape (LLMO-6190, live-verified): a bare string/HTML body, never JSON —
+    // isMeteredQuota keys on this SHAPE, not the bare status, so tests must reproduce it faithfully
+    // rather than passing 'quota' as the (unused) `message` arg (MysticatBot review).
+    const quota405 = () => new SerenityTransportError(405, 'publish failed: 405', '<html>405 Not Allowed</html>');
+
     it('best-effort publish swallows a quota 405 and keeps the project a draft', async () => {
       const transport = makeTransport({
-        publishProject: sinon.stub().rejects(new SerenityTransportError(405, 'quota')),
+        publishProject: sinon.stub().rejects(quota405()),
       });
       const res = await handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' });
       expect(res.status).to.equal(201);
       expect(res.body.published).to.equal(false);
       expect(transport.publishProject).to.have.been.calledOnce;
+    });
+
+    // MysticatBot review (blocking): the best-effort branch's `toQuotaExceededError()` call is
+    // side-effect-only (its return value is discarded) purely to emit the `recordRejection`
+    // CloudWatch metric — assert that side effect directly so a future edit that drops the line
+    // as apparently-dead-code fails a test instead of silently going metric-blind. Spies on
+    // `toQuotaExceededError` itself (the entry's DIRECT dependency) rather than reaching two hops
+    // through to `allocation-metrics.js` (an errors.js-internal dependency esmock does not
+    // transitively override from this entry point), while still calling through to the real
+    // implementation so the emitted error/thrown-vs-swallowed behavior is unchanged.
+    it('best-effort publish emits the quotaExceeded rejection metric even though it swallows the error', async () => {
+      const errorsModule = await import('../../../../src/support/serenity/errors.js');
+      const toQuotaExceededError = sinon.spy(errorsModule.toQuotaExceededError);
+      const { handleCreateMarketSubworkspace: mocked } = await esmock(
+        '../../../../src/support/serenity/handlers/markets-subworkspace.js',
+        { '../../../../src/support/serenity/errors.js': { ...errorsModule, toQuotaExceededError } },
+      );
+      const transport = makeTransport({
+        publishProject: sinon.stub().rejects(quota405()),
+      });
+      await mocked(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' });
+      expect(toQuotaExceededError).to.have.been.calledOnce;
     });
 
     it('best-effort publish re-throws a non-405 upstream error', async () => {
@@ -476,12 +503,26 @@ describe('markets-subworkspace handlers', () => {
       await expect(handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' })).to.be.rejectedWith(/boom/);
     });
 
+    // MysticatBot review: isMeteredQuota keys on body SHAPE (string = disguised quota, JSON = a
+    // genuine app-level error), so a real "Method Not Allowed" (JSON body) must NOT be swallowed
+    // or misclassified as quotaExceeded — it must propagate as the ordinary 405 upstream error.
+    it('best-effort publish re-throws a genuine JSON-bodied 405 (not misclassified as quota)', async () => {
+      const transport = makeTransport({
+        publishProject: sinon.stub().rejects(
+          new SerenityTransportError(405, 'Method Not Allowed', { message: 'Method Not Allowed' }),
+        ),
+      });
+      await expect(
+        handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' }),
+      ).to.be.rejectedWith(/Method Not Allowed/);
+    });
+
     // serenity-docs#72 §2/§4.1 — case 1 (brand carve exhausted, allocator OFF): a quota 405 on a
     // REQUIRED publish must surface as the stable `quotaExceeded` 409 token, not the raw upstream
     // 405 (which mapError would otherwise flatten into the generic 502 serenityUpstreamError).
     it('require-mode publish maps a quota 405 to the quotaExceeded 409 token', async () => {
       const transport = makeTransport({
-        publishProject: sinon.stub().rejects(new SerenityTransportError(405, 'quota')),
+        publishProject: sinon.stub().rejects(quota405()),
       });
       const err = await handleCreateMarketSubworkspace(
         transport,
@@ -505,6 +546,27 @@ describe('markets-subworkspace handlers', () => {
       await expect(
         handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'require' }),
       ).to.be.rejectedWith(/boom/);
+    });
+
+    it('require-mode publish re-throws a genuine JSON-bodied 405 (not misclassified as quota)', async () => {
+      const transport = makeTransport({
+        publishProject: sinon.stub().rejects(
+          new SerenityTransportError(405, 'Method Not Allowed', { message: 'Method Not Allowed' }),
+        ),
+      });
+      const p = handleCreateMarketSubworkspace(
+        transport,
+        makeBrand(),
+        PARENT,
+        createBody,
+        log,
+        null,
+        null,
+        { publishMode: 'require' },
+      );
+      const err = await p.then(() => null, (e) => e);
+      expect(err).to.be.instanceOf(SerenityTransportError);
+      expect(err.status).to.equal(405);
     });
 
     it('attaches selected AI models and generated prompts by tag id before publish', async () => {

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -27,6 +27,7 @@ import {
 } from '../../../../src/support/serenity/handlers/markets-subworkspace.js';
 import { clearTagCache } from '../../../../src/support/serenity/handlers/markets.js';
 import { SerenityTransportError } from '../../../../src/support/serenity/rest-transport.js';
+import { ERROR_CODES } from '../../../../src/support/serenity/errors.js';
 import { TAG_IDS, dimensionTreeLevels, makeListProjectTagsStub } from '../fixtures/tag-tree.js';
 
 use(chaiAsPromised);
@@ -473,6 +474,37 @@ describe('markets-subworkspace handlers', () => {
         publishProject: sinon.stub().rejects(new SerenityTransportError(500, 'boom')),
       });
       await expect(handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' })).to.be.rejectedWith(/boom/);
+    });
+
+    // serenity-docs#72 §2/§4.1 — case 1 (brand carve exhausted, allocator OFF): a quota 405 on a
+    // REQUIRED publish must surface as the stable `quotaExceeded` 409 token, not the raw upstream
+    // 405 (which mapError would otherwise flatten into the generic 502 serenityUpstreamError).
+    it('require-mode publish maps a quota 405 to the quotaExceeded 409 token', async () => {
+      const transport = makeTransport({
+        publishProject: sinon.stub().rejects(new SerenityTransportError(405, 'quota')),
+      });
+      const err = await handleCreateMarketSubworkspace(
+        transport,
+        makeBrand(),
+        PARENT,
+        createBody,
+        log,
+        null,
+        null,
+        { publishMode: 'require' },
+      ).then(() => null, (e) => e);
+      expect(err).to.not.equal(null);
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal(ERROR_CODES.QUOTA_EXCEEDED);
+    });
+
+    it('require-mode publish re-throws a non-405 upstream error unchanged', async () => {
+      const transport = makeTransport({
+        publishProject: sinon.stub().rejects(new SerenityTransportError(500, 'boom')),
+      });
+      await expect(
+        handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'require' }),
+      ).to.be.rejectedWith(/boom/);
     });
 
     it('attaches selected AI models and generated prompts by tag id before publish', async () => {


### PR DESCRIPTION
Wires the existing (but never-invoked) isMeteredQuota classifier into the one call site where a project publish genuinely 405s only for quota reasons: handleCreateMarketSubworkspace's require/best-effort publish branches. A quota rejection on a REQUIRED publish now throws a typed ErrorWithStatusCode (409, code=quotaExceeded) instead of propagating the raw 405, which mapError's generic branch would otherwise flatten into a misleading 502 serenityUpstreamError.

This is step 1 of the sequencing in serenity-docs#72: the customer-facing message for case 1 (brand carve exhausted, allocator OFF - production today) needs a stable token to key off, and this also activates the MeteredQuotaClassifier CloudWatch metric (previously always zero, since no production caller invoked isMeteredQuota), unlocking the alerting route in the same spec's §5 with no new request-path code.

Follow-up commit addresses MysticatBot's review: the publish-catch sites now classify via the existing body-SHAPE `isMeteredQuota` predicate instead of a bare `status === 405` check, so a genuine JSON-bodied "Method Not Allowed" is never absorbed as a quota rejection, and test coverage was added for the best-effort branch's metric-emission side effect.

Introduced by: N/A

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [x] N/A — this PR does not add, remove, or change any endpoint or request/response shape. It adds a new internal error token (`quotaExceeded`) to an existing 409 error response on the already-documented-as-undocumented serenity error-token surface — consistent with the precedent set by #2813, which added `orgPoolExhausted`/`brandAiLimit` the same way without an OpenAPI spec change (serenity error tokens are not currently modeled in `docs/openapi/`).

If the PR is changing the API implementation or an entity exposed through the API:
- [x] N/A — no entity shape or exposed field changes; only internal error classification.

If the PR is introducing a new audit type:
- [x] N/A — no new audit type.

## Related Issues

- No dedicated `spacecat-api-service` issue exists for this specific fix. The work is scoped and sequenced in [adobe/serenity-docs#72](https://github.com/adobe/serenity-docs/pull/72) ("Prompt quota exhaustion — customer experience, atomic failure handling, and alerting spec"), §2/§4.1 (case 1: brand carve exhausted, allocator OFF). This PR is step 1 of that spec's implementation sequencing (posted as a comment on that PR): classify the disguised-405 quota rejection into a stable `quotaExceeded` 409 token, which the customer-facing message and CloudWatch alerting (later steps) key off.
- Builds directly on the allocator work in [#2813](https://github.com/adobe/spacecat-api-service/pull/2813) (LLMO-6190) and [#2764](https://github.com/adobe/spacecat-api-service/pull/2764) (LLMO-5616).

Thanks for contributing!
