### PR TITLE
feat: map platform values sent to Semrush elements api for brand presence data

### DIFF
--- a/src/support/elements/constants.js
+++ b/src/support/elements/constants.js
@@ -24,6 +24,7 @@ export const ELEMENT_MODELS = Object.freeze([
   'deepseek',
   'search-gpt',
   'perplexity',
+  'chatgpt-paid',
 ]);
 
 /**
@@ -33,19 +34,17 @@ export const ELEMENT_MODELS = Object.freeze([
  * SpaceCat side.
  *
  * Only entries whose names DIFFER are listed. Codes that are already identical to a
- * Semrush model (`google-ai-overview`, `google-ai-mode`, `perplexity`) and any
- * Semrush-only model with no UI counterpart (`grok-3`, `open-evidence`,
- * `claude-sonnet-4`, `deepseek`) need no entry — {@link resolveElementModel} passes
- * them through unchanged.
- *
- * TODO(LLMO-6011): confirm the two ChatGPT tier mappings with product — `openai`
- * (ChatGPT Paid) → `gpt-5` and `chatgpt` (ChatGPT Free) → `search-gpt` are best-guess.
+ * Semrush model (`google-ai-overview`, `google-ai-mode`, `perplexity`, `deepseek`)
+ * and any Semrush-only model with no UI counterpart (`open-evidence`) need no
+ * entry — {@link resolveElementModel} passes them through unchanged.
  */
 export const PLATFORM_TO_ELEMENT_MODEL = Object.freeze({
   copilot: 'microsoft-copilot',
   gemini: 'gemini-2.5-flash',
-  openai: 'gpt-5',
+  openai: 'chatgpt-paid',
   chatgpt: 'search-gpt',
+  grok: 'grok-3',
+  anthropic: 'claude-sonnet-4',
 });
 
 /**

--- a/test/support/elements/definitions/brands.test.js
+++ b/test/support/elements/definitions/brands.test.js
@@ -41,7 +41,7 @@ describe('brands definitions', () => {
 
     it('accepts the platform alias and translates it', () => {
       const payload = buildBrandsPayload({ platform: 'openai' });
-      expect(payload.filters.advanced.filters[0].val).to.equal('gpt-5');
+      expect(payload.filters.advanced.filters[0].val).to.equal('chatgpt-paid');
     });
 
     it('sets comparison_data_formatting to union', () => {

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -73,7 +73,7 @@ describe('topics definitions', () => {
 
     it('accepts the platform alias and translates it', () => {
       const payload = buildTopicsPayload({ platform: 'openai' });
-      expect(payload.filters.advanced.filters[0].val).to.equal('gpt-5');
+      expect(payload.filters.advanced.filters[0].val).to.equal('chatgpt-paid');
     });
 
     it('sets comparison_data_formatting to union', () => {


### PR DESCRIPTION
### `src/support/elements/constants.js`
- Added `chatgpt-paid` to `ELEMENT_MODELS` — it's a real Semrush model but was previously missing from the valid-models list entirely.
- `PLATFORM_TO_ELEMENT_MODEL`:
  - Added `grok: 'grok-3'` — previously unmapped, so selecting **Grok** silently fell back to the default model (`search-gpt`) with no error.
  - Added `anthropic: 'claude-sonnet-4'` — previously unmapped, so selecting **Claude** silently fell back to `search-gpt` as well.
  - Changed `openai: 'gpt-5'` → `openai: 'chatgpt-paid'` — resolves the prior `TODO(LLMO-6011)` best-guess; confirmed against the actual Semrush model catalog (`chatgpt-paid` = "ChatGPT (Paid)").
- Removed the stale TODO comment and updated the doc comment listing which codes need no explicit map entry.

This affects all three Serenity brand-presence endpoints that route through `resolveElementModel` (`market-tracking-trends`, `sentiment-overview`, `stats`) — `model`/`platform` query params are both already accepted at the controller layer (`model || platform`), so no controller changes were needed.

### `test/support/elements/definitions/brands.test.js`
- Updated the `openai` platform-alias test to expect `chatgpt-paid` instead of `gpt-5`.

### `test/support/elements/definitions/topics.test.js`
- Same update: `openai` platform-alias test now expects `chatgpt-paid`.

**Verification:** full `npm test` suite passes (15,262 tests), lint clean.

**Note for reviewer:** this fixes a real user-facing bug — selecting Grok or Claude in the Brand Presence platform filter previously returned ChatGPT data with no indication of the mismatch.