### PR TITLE
fix(ci): bump mysticat-ci pin from @v2 to @v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   ci:
-    uses: adobe/mysticat-ci/.github/workflows/service-ci.yaml@v2
+    uses: adobe/mysticat-ci/.github/workflows/service-ci.yaml@v3
     with:
       service-name: api-service
       validate-pr-title: true


### PR DESCRIPTION
## Summary
- Bumps the `service-ci.yaml` pin in `.github/workflows/ci.yaml` from `@v2` to `@v3`.
- `@v2` is a frozen floating tag pointing at an old `mysticat-ci` commit; `main` there has since moved to `v3`, which only adds an optional, default-off `mac-giver-caller` input — no breaking changes for consumers (like this repo) that don't set it.

## Why
Opened as a companion to [adobe/mysticat-ci#22](https://github.com/adobe/mysticat-ci/pull/22), which removes the artificial `needs: build` dependency on the `it-postgres` job (it doesn't consume anything `build` produces). Measured on this repo's PR runs: `build` ~6m13s, `it-postgres` ~6m36s, run sequentially today for ~13min total.

mysticat-ci#22 has merged and shipped as [`v3.1.3`](https://github.com/adobe/mysticat-ci/releases/tag/v3.1.3), with the floating `v3` tag moved to point at it. Re-running this PR's CI confirms the fix: `build` and `it-postgres` now start within 1 second of each other (previously sequential), and the run completed in ~7min total instead of ~13min.

## Test plan
- [x] Confirm CI still passes end-to-end on `@v3` with `vpc-enabled: true`, `it-postgres: true`, `bundle-build: true` (no `mac-giver-caller` set, so behavior should be identical to `@v2` until mysticat-ci#22 lands).
- [x] After mysticat-ci#22 merges and releases, confirm `build` and `it-postgres` start concurrently on this repo's next PR run and total CI time drops as expected.
- [x] Undraft once verified.
