### PR TITLE
refactor(serenity): classify ProjectEngineApiError directly, retire the adaptPE adapter (LLMO-6386)

### DIFF
--- a/docs/serenity.md
+++ b/docs/serenity.md
@@ -282,7 +282,7 @@ linked Site per distinct market domain.)
 | 502 | `{ error: "serenityUpstreamError", message }` | Upstream returned a non-2xx; provider-specific detail is logged server-side, not echoed to the client |
 | 500 | `{ message }` | Unexpected error; logged with stack via `log.error` |
 
-`SerenityTransportError` from `src/support/serenity/rest-transport.js` carries the upstream `status` and `body` for server-side logging; the 502 envelope deliberately does not echo provider details.
+Upstream failures surface as one of two typed errors, both carrying the upstream `status` and `body` for server-side logging and both classified by `isSemrushTransportError` (`src/support/serenity/errors.js`): **`ProjectEngineApiError`** (from the shared `@adobe/spacecat-shared-project-engine-client` facade) for Project Engine calls, and **`SerenityTransportError`** (`src/support/serenity/rest-transport.js`) for the User Manager and brand-topics calls. On a Project Engine no-HTTP-response failure (timeout / network / missing-token 401) the original throw is carried as `.cause` and unwrapped at the error→HTTP seam so auth stays 401 and timeouts stay 502. The 502 envelope deliberately does not echo provider details.
 
 ## Observability (Splunk)
 

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -242,7 +242,7 @@ function BrandsController(ctx, log, env) {
     // Not a Semrush transport error: an app-level ErrorWithStatusCode (has `.status`), or a bare
     // Error whose safe message passes through. `err` is unwrapTransportCause's `unknown` return;
     // mirror the original any-typed access to `.status`/`.message` on the (unwrapped) error.
-    const appErr = /** @type {any} */ (err);
+    const appErr = /** @type {{ status?: number; message?: string }} */ (err);
     if (appErr.status) {
       return createResponse({ message: appErr.message }, appErr.status, {
         [HEADER_ERROR]: appErr.message,

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -65,7 +65,8 @@ import { isFacsRebacResource } from '../routes/facs-capabilities.js';
 import { provisionBrandSubworkspace, releaseProvisionedWorkspace } from '../support/serenity/brand-provisioning.js';
 import { ensureMarketSite } from '../support/serenity/site-linkage.js';
 import { upsertMappingRow, linkSiteToLiveRows } from '../support/serenity/mapping-rows.js';
-import { createSerenityTransport, SerenityTransportError } from '../support/serenity/rest-transport.js';
+import { createSerenityTransport } from '../support/serenity/rest-transport.js';
+import { isSemrushTransportError, unwrapTransportCause } from '../support/serenity/errors.js';
 import { syncBrandUrlsAcrossMarkets } from '../support/serenity/brand-urls.js';
 import { syncBrandAliasesAcrossMarkets } from '../support/serenity/brand-aliases.js';
 import { resolveProjects } from '../support/serenity/resolve-projects.js';
@@ -226,17 +227,28 @@ function BrandsController(ctx, log, env) {
     // workspace/project UUIDs); never echo it to the client (body or x-error
     // header). Return a generic message and keep the detail to the log. Mirrors
     // the serenity controller's mapError hygiene.
-    if (error instanceof SerenityTransportError) {
-      const status = (error.status === 401 || error.status === 403) ? error.status : 502;
+    //
+    // A Project Engine call throws ProjectEngineApiError directly (LLMO-6386, adaptPE retired). On
+    // its no-HTTP-response path (timeout / exhausted network / missing-IMS-token 401) status is
+    // `undefined` and the original throw is carried as `.cause`; unwrap it — exactly as the retired
+    // adaptPE boundary rethrew that cause — so the auth 401 keeps mapping to 401 rather than
+    // flattening to the generic 502. See unwrapTransportCause (errors.js).
+    const err = unwrapTransportCause(error);
+    if (isSemrushTransportError(err)) {
+      const status = (err.status === 401 || err.status === 403) ? err.status : 502;
       const message = status === 502 ? 'Upstream request failed' : 'Upstream authorization failed';
       return createResponse({ message }, status, { [HEADER_ERROR]: message });
     }
-    if (error.status) {
-      return createResponse({ message: error.message }, error.status, {
-        [HEADER_ERROR]: error.message,
+    // Not a Semrush transport error: an app-level ErrorWithStatusCode (has `.status`), or a bare
+    // Error whose safe message passes through. `err` is unwrapTransportCause's `unknown` return;
+    // mirror the original any-typed access to `.status`/`.message` on the (unwrapped) error.
+    const appErr = /** @type {any} */ (err);
+    if (appErr.status) {
+      return createResponse({ message: appErr.message }, appErr.status, {
+        [HEADER_ERROR]: appErr.message,
       });
     }
-    return internalServerError(error.message);
+    return internalServerError(appErr.message);
   }
 
   function validateBrandGuidanceFields(brandData = {}) {

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -18,7 +18,8 @@ import {
 import { hasText, isNonEmptyObject, isValidUUID } from '@adobe/spacecat-shared-utils';
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 
-import { createSerenityTransport, SerenityTransportError } from '../support/serenity/rest-transport.js';
+import { createSerenityTransport } from '../support/serenity/rest-transport.js';
+import { isSemrushTransportError, unwrapTransportCause } from '../support/serenity/errors.js';
 import {
   resolveBrandWorkspace,
   clearBrandWorkspaceCache,
@@ -163,26 +164,33 @@ function mapError(e, log) {
       status,
     );
   }
-  if (e instanceof SerenityTransportError) {
-    log.error('Serenity upstream error', e);
-    if (e.status === 401 || e.status === 403) {
-      // Do NOT echo e.message here: the transport error message embeds the full
+  // A Project Engine call now throws ProjectEngineApiError directly (LLMO-6386, adaptPE retired).
+  // On its no-HTTP-response path (per-attempt timeout / exhausted network / a missing-IMS-token
+  // 401) the status is `undefined` and the original throw is carried as `.cause` — the retired
+  // adaptPE boundary used to rethrow that cause, so unwrap it here to keep the mapping below
+  // yielding the SAME HTTP code (auth → 401, timeout → 502, raw network → 500). A bare undefined
+  // status would otherwise flatten all three to 502, silently regressing the auth response.
+  const err = unwrapTransportCause(e);
+  if (isSemrushTransportError(err)) {
+    log.error('Serenity upstream error', err);
+    if (err.status === 401 || err.status === 403) {
+      // Do NOT echo err.message here: the transport error message embeds the full
       // gateway URL (internal host + workspace/project UUIDs). Return a generic
       // message and keep the detail to the log.error above (matches the 502 branch).
       return createResponse(
-        { error: errorTokenForStatus(e.status), message: 'Upstream authorization failed' },
-        e.status,
+        { error: errorTokenForStatus(err.status), message: 'Upstream authorization failed' },
+        err.status,
       );
     }
-    if (e.status === 409) {
+    if (err.status === 409) {
       // An upstream refusal of a conflicting write (e.g. a prompt rename onto a
       // sibling prompt's exact text — serenity-docs#63) is the caller's to act
       // on, not an upstream outage: surface the status and the `conflict` token
       // instead of flattening it into the generic 502. Message stays redacted
       // for the same reason as the 401/403 branch above.
       return createResponse(
-        { error: errorTokenForStatus(e.status), message: 'Upstream rejected the request as a conflict' },
-        e.status,
+        { error: errorTokenForStatus(err.status), message: 'Upstream rejected the request as a conflict' },
+        err.status,
       );
     }
     return createResponse({
@@ -190,7 +198,7 @@ function mapError(e, log) {
       message: 'Upstream request failed',
     }, 502);
   }
-  log.error('Serenity controller error', e);
+  log.error('Serenity controller error', err);
   return createResponse(
     { error: 'internalServerError', message: 'Internal server error' },
     500,
@@ -213,7 +221,9 @@ function mapError(e, log) {
  * SECURITY MODEL — this proxy is NOT the auth boundary; Semrush is. The bearer
  * we forward is validated AGAIN by the real Semrush gateway on every upstream
  * call (it rejects an invalid/expired/forged token with 401/403, which the
- * transport surfaces as a SerenityTransportError). This local check is only a
+ * transport surfaces as a typed Semrush error — ProjectEngineApiError for a
+ * Project Engine call, SerenityTransportError for a User Manager one — both
+ * classified by isSemrushTransportError). This local check is only a
  * fail-fast + shape guard so we do not forward a token Semrush will obviously
  * reject; it never substitutes for the upstream's own validation.
  *

--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -15,7 +15,8 @@
 import { hasText } from '@adobe/spacecat-shared-utils';
 
 import { ErrorWithStatusCode, resolveSemrushImsToken } from '../utils.js';
-import { createSerenityTransport, SerenityTransportError } from './rest-transport.js';
+import { createSerenityTransport } from './rest-transport.js';
+import { isSemrushTransportError } from './errors.js';
 import { resolveWorkspaceId } from './workspace-resolver.js';
 import { deleteAllProjects, releaseFullAllocation } from './workspace-lifecycle.js';
 import { handleCreateMarketSubworkspace } from './handlers/markets-subworkspace.js';
@@ -223,7 +224,7 @@ export async function provisionBrandSubworkspace(context, {
     // A bare upstream 405 is Semrush's disguised quota rejection (a prompt write
     // or publish that exceeds the child's metered quota — workspace doc §5).
     // Surface it as a clear "Quota exceeded" instead of the cryptic 405/nginx body.
-    if (e instanceof SerenityTransportError && e.status === 405) {
+    if (isSemrushTransportError(e) && e.status === 405) {
       throw new ErrorWithStatusCode('Quota exceeded', 409);
     }
     throw e;

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -14,7 +14,7 @@
 
 import { hasText } from '@adobe/spacecat-shared-utils';
 
-import { SerenityTransportError } from './rest-transport.js';
+import { isSemrushTransportError } from './errors.js';
 import { resolveProjects } from './resolve-projects.js';
 
 /**
@@ -231,7 +231,7 @@ export async function ensureOwnBrandBenchmark(transport, workspaceId, projectId,
   } catch (e) {
     // 409 = the benchmark already exists (race / duplicate brand name). Fall
     // through to re-list + match rather than failing the URL attach.
-    if (!(e instanceof SerenityTransportError && e.status === 409)) {
+    if (!(isSemrushTransportError(e) && e.status === 409)) {
       throw e;
     }
   }
@@ -300,7 +300,7 @@ export async function republishBestEffort(transport, workspaceId, projectId, log
   try {
     await transport.publishProject(workspaceId, projectId);
   } catch (e) {
-    if (e instanceof SerenityTransportError && e.status === 405) {
+    if (isSemrushTransportError(e) && e.status === 405) {
       log?.warn?.('brand-urls: republish skipped — quota 405, project left as draft', {
         workspaceId, projectId,
       });

--- a/src/support/serenity/errors.js
+++ b/src/support/serenity/errors.js
@@ -12,21 +12,66 @@
 
 // @ts-check
 
+import { ProjectEngineApiError } from '@adobe/spacecat-shared-project-engine-client';
 import { ErrorWithStatusCode } from '../utils.js';
 import { SerenityTransportError } from './rest-transport.js';
 import { recordMeteredQuotaClassifier, recordRejection } from './allocation-metrics.js';
+
+/**
+ * The single type guard every Semrush error classifier gates on. A failing Semrush call now
+ * surfaces as ONE of two typed errors, and both carry the same classification-relevant fields
+ * (`.status` — number|undefined — and `.body`):
+ *   - Project Engine calls (the ~28 project/prompt/benchmark ops routed through the shared facade)
+ *     throw `ProjectEngineApiError` directly (LLMO-6386, retiring the old adaptPE boundary);
+ *   - the User Manager (`users.*`) sub-workspace lifecycle calls and the raw `brand-topics`
+ *     (`projectsRaw`) call still throw the transport's own `SerenityTransportError` (via `unwrap`).
+ * Every classifier below keys ONLY on `.status`/`.body`, never on the concrete type, so widening
+ * the guard here recognises both without changing a single classification outcome.
+ * @param {unknown} e
+ * @returns {e is (SerenityTransportError | ProjectEngineApiError)}
+ */
+export function isSemrushTransportError(e) {
+  return e instanceof SerenityTransportError || e instanceof ProjectEngineApiError;
+}
+
+/**
+ * Unwraps a network/timeout/auth Project Engine failure to the original error it wraps, for the
+ * error→HTTP mapping layer ONLY (the controllers' `mapError` / `createErrorResponse`).
+ *
+ * A Project Engine call with no HTTP response (per-attempt timeout, exhausted network, or the
+ * shared `authToken` getter refusing a missing IMS token) surfaces as a `ProjectEngineApiError`
+ * whose `status` is `undefined` and whose `.cause` is the original throw — `createTimeoutFetch`'s
+ * 504 `SerenityTransportError`, `authToken`'s 401 `SerenityTransportError`, or a raw network Error.
+ * The retired `adaptPE` boundary used to rethrow that `.cause` directly, so the controller mapped
+ * it by the cause's status (auth → 401, timeout → 502, raw network → 500). This helper reproduces
+ * that unwrap so those HTTP codes are preserved EXACTLY — without it, a bare `undefined` status
+ * flattens every one of them to 502 and an auth failure would silently regress from 401 to 502.
+ *
+ * Only applied at the HTTP-mapping seam: the status-driven classifiers never fire on these causes
+ * (their statuses are 504/401/network, none of the 404/422/405/429 triggers), so widening the
+ * classifiers alone leaves their outcomes unchanged and does not need this. A
+ * `ProjectEngineApiError` that DID carry an HTTP status, a `SerenityTransportError`, and every
+ * other error pass through unchanged.
+ * @param {unknown} e
+ * @returns {unknown}
+ */
+export function unwrapTransportCause(e) {
+  return e instanceof ProjectEngineApiError && e.status === undefined && e.cause != null
+    ? e.cause
+    : e;
+}
 
 /**
  * Recognises an upstream "already gone" response — the signal that an
  * idempotent DELETE-style operation can treat as success without falling
  * through to the generic 502 path.
  *
- * Strict shape: must be a SerenityTransportError AND status === 404.
- * Refuses to match generic Error subclasses or ad-hoc objects whose
- * `.status` happens to equal 404. This is the safe variant — a future
- * library or test stub decorating an unrelated error with `status: 404`
- * cannot silently turn into "upstream-idempotent-success" and swallow
- * a real failure.
+ * Strict shape: must be a Semrush transport error (SerenityTransportError or
+ * ProjectEngineApiError) AND status === 404. Refuses to match generic Error
+ * subclasses or ad-hoc objects whose `.status` happens to equal 404. This is
+ * the safe variant — a future library or test stub decorating an unrelated
+ * error with `status: 404` cannot silently turn into
+ * "upstream-idempotent-success" and swallow a real failure.
  *
  * Used by every "upstream target gone" site in the serenity surface:
  *   - markets.js handleDeleteMarket  (upstream project gone)
@@ -34,15 +79,16 @@ import { recordMeteredQuotaClassifier, recordRejection } from './allocation-metr
  *   - prompts.js handleBulkDeletePrompts  (per-project bucket delete)
  */
 export function isUpstreamGone(e) {
-  return e instanceof SerenityTransportError && e.status === 404;
+  return isSemrushTransportError(e) && e.status === 404;
 }
 
 /**
  * The upstream error body as a lowercased string, for message-based classification. The gateway
  * returns either a JSON `{ message }` object or a bare text/html string (the disguised-405 case);
- * this normalises both so a predicate can match on substrings. Callers guard `instanceof
- * SerenityTransportError` (short-circuit) before calling, so `e` is always a transport error here.
- * @param {SerenityTransportError} e
+ * this normalises both so a predicate can match on substrings. Callers guard
+ * `isSemrushTransportError` (short-circuit) before calling, so `e` is always a Semrush transport
+ * error here.
+ * @param {SerenityTransportError | ProjectEngineApiError} e
  * @returns {string}
  */
 function bodyText(e) {
@@ -65,7 +111,7 @@ function bodyText(e) {
  * @returns {boolean}
  */
 export function isPoolExhausted(e) {
-  return e instanceof SerenityTransportError
+  return isSemrushTransportError(e)
     && e.status === 422
     && bodyText(e).includes('insufficient available units');
 }
@@ -78,7 +124,7 @@ export function isPoolExhausted(e) {
  * @returns {boolean}
  */
 export function isWorkspaceNotReady(e) {
-  return e instanceof SerenityTransportError
+  return isSemrushTransportError(e)
     && e.status === 422
     && bodyText(e).includes('workspace not ready');
 }
@@ -102,7 +148,7 @@ export function isWorkspaceNotReady(e) {
  * @returns {boolean}
  */
 export function isMeteredQuota(e) {
-  if (!(e instanceof SerenityTransportError) || e.status !== 405) {
+  if (!isSemrushTransportError(e) || e.status !== 405) {
     // Not a 405 at all — outside the classifier's domain (the metric's denominator is "how many
     // 405s", not "how many errors of any kind"), so no metric here (MysticatBot review, LLMO-6191):
     // emitting `Matched=false` for every unrelated error (a TypeError, a timeout, a 409, ...) would
@@ -120,7 +166,7 @@ export function isMeteredQuota(e) {
  * @returns {boolean}
  */
 export function isRateLimited(e) {
-  return e instanceof SerenityTransportError && e.status === 429;
+  return isSemrushTransportError(e) && e.status === 429;
 }
 
 /**

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -16,8 +16,7 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 import crypto from 'node:crypto';
 
 import { ErrorWithStatusCode } from '../../utils.js';
-import { ERROR_CODES, isUpstreamGone } from '../errors.js';
-import { SerenityTransportError } from '../rest-transport.js';
+import { ERROR_CODES, isUpstreamGone, isSemrushTransportError } from '../errors.js';
 import { normalizeLanguageCode, normalizeGeoTargetId } from '../validation.js';
 import { resolveLocation } from '../locations.js';
 
@@ -890,7 +889,7 @@ export async function listGlobalModelCatalog(transport) {
       page += 1;
     }
   } catch (e) {
-    if (e instanceof SerenityTransportError && (e.status === 404 || e.status === 405)) {
+    if (isSemrushTransportError(e) && (e.status === 404 || e.status === 405)) {
       rawItems = [];
     } else {
       throw e;
@@ -929,7 +928,7 @@ export async function listLanguageCatalog(transport) {
     const resp = await transport.listLanguages();
     rawItems = Array.isArray(resp?.items) ? resp.items : [];
   } catch (e) {
-    if (e instanceof SerenityTransportError && (e.status === 404 || e.status === 405)) {
+    if (isSemrushTransportError(e) && (e.status === 404 || e.status === 405)) {
       rawItems = [];
     } else {
       throw e;

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -55,19 +55,30 @@ export class SerenityTransportError extends Error {
 }
 
 /**
- * Returns a client-safe message for an error that may be a SerenityTransportError.
- * A SerenityTransportError's message embeds the gateway URL (internal host +
- * workspace/project UUIDs), so it must never be echoed to clients (response
- * bodies, per-item `failed[].message`). App-level errors carry safe messages and
- * pass through unchanged.
+ * Returns a client-safe message for an error that may be a Semrush transport error. Both the
+ * User Manager / brand-topics `SerenityTransportError` (message embeds the gateway URL — internal
+ * host + workspace/project UUIDs) and the Project Engine `ProjectEngineApiError` (message embeds
+ * the service name + method + status, e.g. "Project Engine POST request failed with status 405")
+ * carry internal detail that must never be echoed to clients (response bodies, per-item
+ * `failed[].message`); both are collapsed to the same generic string. App-level errors carry safe
+ * messages and pass through unchanged.
+ *
+ * A Project Engine call with no HTTP response (per-attempt timeout / exhausted network /
+ * missing-IMS-token 401) surfaces as a ProjectEngineApiError with `status === undefined` that wraps
+ * the original throw as `.cause`; the retired adaptPE boundary rethrew that cause, so unwrap it
+ * first — this keeps the redacted string identical to before (auth → "authorization failed",
+ * timeout → "request failed", raw network → the original error's own message).
  */
 export function redactUpstreamMessage(e) {
-  if (e instanceof SerenityTransportError) {
-    return (e.status === 401 || e.status === 403)
+  const err = e instanceof ProjectEngineApiError && e.status === undefined && e.cause != null
+    ? e.cause
+    : e;
+  if (err instanceof SerenityTransportError || err instanceof ProjectEngineApiError) {
+    return (err.status === 401 || err.status === 403)
       ? 'Upstream authorization failed'
       : 'Upstream request failed';
   }
-  return e?.message;
+  return err?.message;
 }
 
 /**
@@ -216,47 +227,6 @@ function unwrap(method, result) {
 }
 
 /**
- * Boundary adapter for the shared Project Engine facade
- * ({@link createSerenityProjectEngineTransport}). The facade already unwraps the 2xx body and
- * throws its own typed `ProjectEngineApiError` on failure; this rethrows that as the transport's
- * existing {@link SerenityTransportError} so the ~42 downstream `instanceof SerenityTransportError`
- * classifiers (allocator / quota / retry — see errors.js) keep working UNCHANGED. Classifiers key
- * on `.status` and `.body`, never on `.message`, so those two are preserved exactly; the message
- * text differs (facade says "Project Engine …" where the old hand-rolled path said "Semrush …"),
- * which is immaterial to classification and redacted from clients by the controller's mapError.
- *
- * @template T
- * @param {Promise<T>} promise a pending facade-method call.
- * @returns {Promise<T>} the facade's unwrapped 2xx body.
- * @throws {SerenityTransportError} for a Project Engine HTTP failure (`status` + `body` preserved
- *   so classifiers match) and for the defensive no-`cause` fallback (502). On the
- *   timeout/auth/network path the original `cause` is rethrown unchanged — a SerenityTransportError
- *   from createTimeoutFetch's 504 / authToken's 401, or a raw network error — and a
- *   non-ProjectEngineApiError is propagated as-is.
- */
-export async function adaptPE(promise) {
-  try {
-    return await promise;
-  } catch (e) {
-    if (e instanceof ProjectEngineApiError) {
-      // HTTP error: preserve the exact status + body the old unwrap threw (classifiers key on
-      // these, never on .message).
-      if (e.status !== undefined) {
-        throw new SerenityTransportError(e.status, e.message, e.body);
-      }
-      // No HTTP response (timeout / auth / network): the facade wraps the original throw as
-      // `cause`, so surface it unchanged to preserve prior behavior (createTimeoutFetch's 504,
-      // authToken's 401, or a raw network error). Defensive fallback: the facade always sets
-      // `cause` on this path today, but if it ever didn't, wrap as a 502 SerenityTransportError
-      // so a bare ProjectEngineApiError can never escape unclassified past the downstream
-      // `instanceof SerenityTransportError` sites.
-      throw e.cause ?? new SerenityTransportError(502, e.message, e.body);
-    }
-    throw e;
-  }
-}
-
-/**
  * Creates the Semrush HTTP client. Each request is authenticated with the
  * caller's IMS bearer token; the Adobe gateway exchanges it server-side for
  * Semrush's internal credential.
@@ -311,9 +281,10 @@ export function createSerenityTransport({ env, imsToken }) {
 
   // Shared Project Engine FACADE (ADR-0001); builds its own typed client over
   // '/enterprise/projects/api' from the same options. Each facade method returns
-  // the unwrapped 2xx body and throws `ProjectEngineApiError` on failure — routed
-  // through `adaptPE` back to `SerenityTransportError` at the boundary so the
-  // downstream classifiers stay untouched. Retry, backoff, and the
+  // the unwrapped 2xx body and throws `ProjectEngineApiError` on failure — surfaced
+  // to callers DIRECTLY (LLMO-6386, retiring the old adaptPE boundary adapter); the
+  // classification + error→HTTP layer recognises it alongside `SerenityTransportError`
+  // via `isSemrushTransportError` (see errors.js). Retry, backoff, and the
   // POST-never-retries-on-5xx idempotency gate are the shared library's contract,
   // not this file's — see createRetryingFetch in spacecat-shared-project-engine-
   // client's internal.js (library defaults: maxRetries 2, retryBaseDelayMs 200;
@@ -326,8 +297,8 @@ export function createSerenityTransport({ env, imsToken }) {
   // 29th facade method — but unshipped as of 1.14.0), so this one call keeps the
   // raw client + the local `unwrap`. Same options as the facade above.
   // TODO(LLMO): once @adobe/spacecat-shared-project-engine-client ships a brand-topics facade
-  // method, retire `projectsRaw` and route brand-topics through `projects` + `adaptPE` like the
-  // other 28 ops (this is the only remaining raw Project Engine caller in this file).
+  // method, retire `projectsRaw` and route brand-topics through `projects` like the other 28 ops
+  // (this is the only remaining raw Project Engine caller in this file).
   const projectsRaw = createSerenityProjectEngineApiClient(projectEngineOptions);
 
   // Typed User Manager client over the sub-workspace lifecycle gateway (same
@@ -363,7 +334,7 @@ export function createSerenityTransport({ env, imsToken }) {
      * the fields the upstream documents as accepted.
      */
     async listPromptsByTags(semrushWorkspaceId, projectId, body) {
-      return adaptPE(projects.listPromptsByTagIds(
+      return projects.listPromptsByTagIds(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           body: {
@@ -374,7 +345,7 @@ export function createSerenityTransport({ env, imsToken }) {
             unassigned: body?.unassigned,
           },
         },
-      ));
+      );
     },
 
     /**
@@ -403,12 +374,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * @param {string[]} tagIds - upstream tag ids attached to EVERY item.
      */
     async createPromptsByIds(semrushWorkspaceId, projectId, items, tagIds) {
-      return adaptPE(projects.createPrompts(
+      return projects.createPrompts(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           body: { items, tag_ids: tagIds },
         },
-      ));
+      );
     },
 
     /**
@@ -416,12 +387,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * this project. Body shape: { ids: [...] }.
      */
     async deletePromptsByIds(semrushWorkspaceId, projectId, ids) {
-      return adaptPE(projects.deletePromptsByIds(
+      return projects.deletePromptsByIds(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           body: { ids },
         },
-      ));
+      );
     },
 
     /**
@@ -441,14 +412,14 @@ export function createSerenityTransport({ env, imsToken }) {
      * @param {string} newName - the prompt's next text.
      */
     async renamePrompt(semrushWorkspaceId, projectId, promptId, newName) {
-      return adaptPE(projects.renamePrompt(
+      return projects.renamePrompt(
         {
           params: {
             path: { id: semrushWorkspaceId, project_id: projectId, prompt_id: promptId },
           },
           body: { new_name: newName },
         },
-      ));
+      );
     },
 
     /**
@@ -467,12 +438,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * @param {Array<{ id: string, references: string[], replace: boolean }>} items
      */
     async updatePromptTagsByIds(semrushWorkspaceId, projectId, items) {
-      return adaptPE(projects.updatePromptTags(
+      return projects.updatePromptTags(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           body: { items },
         },
-      ));
+      );
     },
 
     /**
@@ -481,9 +452,9 @@ export function createSerenityTransport({ env, imsToken }) {
      * this is called.
      */
     async publishProject(semrushWorkspaceId, projectId) {
-      return adaptPE(projects.publishProject(
+      return projects.publishProject(
         { params: { path: { id: semrushWorkspaceId, project_id: projectId } } },
-      ));
+      );
     },
 
     /**
@@ -492,14 +463,14 @@ export function createSerenityTransport({ env, imsToken }) {
      * expects as `CBF_model`.
      */
     async listAiModels(semrushWorkspaceId, projectId, { page = 1, limit = 100 } = {}) {
-      return adaptPE(projects.listAiModels(
+      return projects.listAiModels(
         {
           params: {
             path: { id: semrushWorkspaceId, project_id: projectId },
             query: { page, limit },
           },
         },
-      ));
+      );
     },
 
     /**
@@ -547,7 +518,7 @@ export function createSerenityTransport({ env, imsToken }) {
      * @param {string} [opts.parentId] - upstream tag id to nest the names under.
      */
     async createProjectTags(semrushWorkspaceId, projectId, names, { parentId } = {}) {
-      return adaptPE(projects.createProjectTags(
+      return projects.createProjectTags(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           // Only send parent_id when nesting — an empty string is a no-op
@@ -557,7 +528,7 @@ export function createSerenityTransport({ env, imsToken }) {
             ? { names, parent_id: parentId }
             : { names },
         },
-      ));
+      );
     },
 
     /**
@@ -591,7 +562,7 @@ export function createSerenityTransport({ env, imsToken }) {
         parentId = '', search = '', page = 1, limit = 100, draft,
       } = {},
     ) {
-      return adaptPE(projects.listProjectTags(
+      return projects.listProjectTags(
         {
           params: {
             path: { id: semrushWorkspaceId, project_id: projectId },
@@ -600,7 +571,7 @@ export function createSerenityTransport({ env, imsToken }) {
             },
           },
         },
-      ));
+      );
     },
 
     /**
@@ -637,23 +608,23 @@ export function createSerenityTransport({ env, imsToken }) {
         );
       }
       const body = { name, parent_id: parentId };
-      return adaptPE(projects.updateProjectTag(
+      return projects.updateProjectTag(
         {
           params: {
             path: { id: semrushWorkspaceId, project_id: projectId, tag_id: tagId },
           },
           body,
         },
-      ));
+      );
     },
 
     /**
      * POST /v1/workspaces/{ws}/projects — creates a new Semrush AIO project.
      */
     async createProject(semrushWorkspaceId, body) {
-      return adaptPE(projects.createProject(
+      return projects.createProject(
         { params: { path: { id: semrushWorkspaceId } }, body },
-      ));
+      );
     },
 
     /**
@@ -667,9 +638,9 @@ export function createSerenityTransport({ env, imsToken }) {
      * Callers (handleDeleteMarket) treat upstream 404 as idempotent success.
      */
     async deleteProject(semrushWorkspaceId, projectId) {
-      return adaptPE(projects.deleteProject(
+      return projects.deleteProject(
         { params: { path: { id: semrushWorkspaceId, project_id: projectId } } },
-      ));
+      );
     },
 
     /**
@@ -681,12 +652,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * prod 2026-06-24 (OPTIONS .../projects/{pid} → 405 allow: PATCH, DELETE, GET).
      */
     async updateProject(semrushWorkspaceId, projectId, body) {
-      return adaptPE(projects.updateProject(
+      return projects.updateProject(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           body,
         },
-      ));
+      );
     },
 
     /**
@@ -699,12 +670,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * routes have no v2 variant (v2 ai_models is POST-only) and stay on v1.
      */
     async addAiModel(semrushWorkspaceId, projectId, modelId) {
-      return adaptPE(projects.createAioModel(
+      return projects.createAioModel(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           body: { model_id: modelId },
         },
-      ));
+      );
     },
 
     /**
@@ -713,12 +684,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * `ProjectAIModelResponse`, NOT the catalog `model.id`).
      */
     async deleteAiModelsByIds(semrushWorkspaceId, projectId, ids) {
-      return adaptPE(projects.deleteAiModels(
+      return projects.deleteAiModels(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
           body: { ids },
         },
-      ));
+      );
     },
 
     /**
@@ -728,9 +699,9 @@ export function createSerenityTransport({ env, imsToken }) {
      * Returns {page, total, items: [{id, key, name, icon}]}.
      */
     async listGlobalAiModels({ page = 1, limit = 100 } = {}) {
-      return adaptPE(projects.listGlobalAiModels(
+      return projects.listGlobalAiModels(
         { params: { query: { page, limit } } },
-      ));
+      );
     },
 
     /**
@@ -739,7 +710,7 @@ export function createSerenityTransport({ env, imsToken }) {
      * caller is expected to cache the result (catalog is stable).
      */
     async listLanguages() {
-      return adaptPE(projects.listLanguages({}));
+      return projects.listLanguages({});
     },
 
     // ─────────────────────────────────────────────────────────────────────
@@ -858,9 +829,9 @@ export function createSerenityTransport({ env, imsToken }) {
      * live-view shape with `brand_names: null` for drafts).
      */
     async listProjects(workspaceId) {
-      return adaptPE(projects.listProjects(
+      return projects.listProjects(
         { params: { path: { id: workspaceId }, query: { type: 'ai' } } },
-      ));
+      );
     },
 
     /**
@@ -872,14 +843,14 @@ export function createSerenityTransport({ env, imsToken }) {
      * destructive PUT.
      */
     async getProject(workspaceId, projectId, { draft = true } = {}) {
-      return adaptPE(projects.getProject(
+      return projects.getProject(
         {
           params: {
             path: { id: workspaceId, project_id: projectId },
             query: { draft: String(draft), type: 'ai' },
           },
         },
-      ));
+      );
     },
 
     /**
@@ -891,12 +862,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * resulting { ci_competitors: [...] }.
      */
     async updateCiCompetitors(workspaceId, projectId, ciCompetitors) {
-      return adaptPE(projects.updateCompetitors(
+      return projects.updateCompetitors(
         {
           params: { path: { id: workspaceId, project_id: projectId } },
           body: { ci_competitors: ciCompetitors },
         },
-      ));
+      );
     },
 
     /**
@@ -912,9 +883,9 @@ export function createSerenityTransport({ env, imsToken }) {
      * draft-faithfulness concern here.
      */
     async getInitStatus(workspaceId, projectId) {
-      return adaptPE(projects.getProjectInitStatus(
+      return projects.getProjectInitStatus(
         { params: { path: { id: workspaceId, project_id: projectId } } },
-      ));
+      );
     },
 
     // ─────────────────────────────────────────────────────────────────────
@@ -933,9 +904,9 @@ export function createSerenityTransport({ env, imsToken }) {
      * URL endpoints require. Returns `{ aio_benchmarks: [...] }`.
      */
     async listBenchmarks(workspaceId, projectId) {
-      return adaptPE(projects.listBenchmarks(
+      return projects.listBenchmarks(
         { params: { path: { id: workspaceId, project_id: projectId } } },
-      ));
+      );
     },
 
     /**
@@ -947,12 +918,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * auto-provisioned one (the `benchmark_id` brand URLs must attach to).
      */
     async createBenchmarks(workspaceId, projectId, benchmarks) {
-      return adaptPE(projects.createBenchmarks(
+      return projects.createBenchmarks(
         {
           params: { path: { id: workspaceId, project_id: projectId } },
           body: benchmarks,
         },
-      ));
+      );
     },
 
     /**
@@ -962,12 +933,12 @@ export function createSerenityTransport({ env, imsToken }) {
      * competitor that was removed from the brand.
      */
     async deleteBenchmarks(workspaceId, projectId, ids) {
-      return adaptPE(projects.deleteBenchmarks(
+      return projects.deleteBenchmarks(
         {
           params: { path: { id: workspaceId, project_id: projectId } },
           body: { ids },
         },
-      ));
+      );
     },
 
     /**
@@ -981,14 +952,14 @@ export function createSerenityTransport({ env, imsToken }) {
      * some aliases; read them back from `listBenchmarks` (`rejected_brand_aliases`).
      */
     async updateBenchmark(workspaceId, projectId, benchmarkId, benchmark) {
-      return adaptPE(projects.updateBenchmark(
+      return projects.updateBenchmark(
         {
           params: {
             path: { id: workspaceId, project_id: projectId, benchmark_id: benchmarkId },
           },
           body: benchmark,
         },
-      ));
+      );
     },
 
     /**
@@ -1012,14 +983,14 @@ export function createSerenityTransport({ env, imsToken }) {
      * @param {boolean} [opts.draft=false] - read the draft (pending) view.
      */
     async listBrandUrls(workspaceId, projectId, benchmarkId, { draft = false } = {}) {
-      return adaptPE(projects.listBrandUrls(
+      return projects.listBrandUrls(
         {
           params: {
             path: { id: workspaceId, project_id: projectId, benchmark_id: benchmarkId },
             ...(draft ? { query: { draft: true } } : {}),
           },
         },
-      ));
+      );
     },
 
     /**
@@ -1029,14 +1000,14 @@ export function createSerenityTransport({ env, imsToken }) {
      * duplicated) and counted in the response `existing_count`.
      */
     async createBrandUrls(workspaceId, projectId, benchmarkId, entries) {
-      return adaptPE(projects.createBrandUrls(
+      return projects.createBrandUrls(
         {
           params: {
             path: { id: workspaceId, project_id: projectId, benchmark_id: benchmarkId },
           },
           body: entries,
         },
-      ));
+      );
     },
 
     /**
@@ -1044,14 +1015,14 @@ export function createSerenityTransport({ env, imsToken }) {
      * by id. Body `{ ids: [...] }`. Ids not in this benchmark are ignored.
      */
     async deleteBrandUrls(workspaceId, projectId, benchmarkId, ids) {
-      return adaptPE(projects.deleteBrandUrls(
+      return projects.deleteBrandUrls(
         {
           params: {
             path: { id: workspaceId, project_id: projectId, benchmark_id: benchmarkId },
           },
           body: { ids },
         },
-      ));
+      );
     },
   };
 }

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -70,6 +70,9 @@ export class SerenityTransportError extends Error {
  * timeout → "request failed", raw network → the original error's own message).
  */
 export function redactUpstreamMessage(e) {
+  // NOTE: this mirrors errors.js `unwrapTransportCause` inline ON PURPOSE — importing it here
+  // would create an errors.js ↔ rest-transport.js cycle (errors.js imports SerenityTransportError
+  // from this file). Extracting the shared helper to a leaf module is a follow-up. Keep in sync.
   const err = e instanceof ProjectEngineApiError && e.status === undefined && e.cause != null
     ? e.cause
     : e;

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -15,6 +15,7 @@ import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/confi
 import OrganizationSchema from '@adobe/spacecat-shared-data-access/src/models/organization/organization.schema.js';
 import SiteSchema from '@adobe/spacecat-shared-data-access/src/models/site/site.schema.js';
 import AuthInfo from '@adobe/spacecat-shared-http-utils/src/auth/auth-info.js';
+import { ProjectEngineApiError } from '@adobe/spacecat-shared-project-engine-client';
 
 import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -6220,6 +6221,70 @@ describe('Brands Controller', () => {
       // The internal gateway URL must not leak via body or header.
       expect(JSON.stringify(body)).to.not.contain('gw.internal');
       expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
+    });
+
+    // LLMO-6386: the brand-edit re-sync runs Project Engine calls, which now throw
+    // ProjectEngineApiError directly (adaptPE retired). createErrorResponse must redact it to the
+    // same generic 502 as the SerenityTransportError case — the raw "Project Engine ..." message
+    // (and any body) must never reach the client.
+    it('redacts a ProjectEngineApiError upstream failure to a generic 502 on brand-edit re-sync', async () => {
+      const updateBrandStub = sinon.stub().resolves({
+        id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
+      });
+      const syncStub = sinon.stub().rejects(
+        new ProjectEngineApiError(502, 'POST', { secret: 'leak' }),
+      );
+      const controller = await buildUpdateController({
+        updateBrand: updateBrandStub,
+        syncBrandUrlsAcrossMarkets: syncStub,
+        createSerenityTransport: sinon.stub().returns({ name: 't', listProjects: sinon.stub().resolves({ items: [] }) }),
+      });
+
+      const response = await controller.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { urls: [{ value: 'https://acme.com' }] },
+        dataAccess: mockDataAccess,
+        pathInfo: { headers: { authorization: 'Bearer tok' } },
+        attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(502);
+      const body = await response.json();
+      expect(body.message).to.equal('Upstream request failed');
+      expect(JSON.stringify(body)).to.not.match(/leak/);
+      expect(JSON.stringify(body)).to.not.match(/Project Engine/);
+    });
+
+    // The auth-preservation crux: a no-HTTP-response Project Engine failure (missing IMS token)
+    // is a status-undefined ProjectEngineApiError carrying the 401 SerenityTransportError as
+    // `.cause`. createErrorResponse must unwrap it so the response stays 401 (not flattened).
+    it('unwraps a status-undefined ProjectEngineApiError to preserve the auth 401 on brand-edit re-sync', async () => {
+      const updateBrandStub = sinon.stub().resolves({
+        id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
+      });
+      const authCause = new SerenityTransportError(401, 'Missing IMS bearer token');
+      const syncStub = sinon.stub().rejects(
+        new ProjectEngineApiError(undefined, 'POST', null, { cause: authCause }),
+      );
+      const controller = await buildUpdateController({
+        updateBrand: updateBrandStub,
+        syncBrandUrlsAcrossMarkets: syncStub,
+        createSerenityTransport: sinon.stub().returns({ name: 't', listProjects: sinon.stub().resolves({ items: [] }) }),
+      });
+
+      const response = await controller.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { urls: [{ value: 'https://acme.com' }] },
+        dataAccess: mockDataAccess,
+        pathInfo: { headers: { authorization: 'Bearer tok' } },
+        attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(401);
+      const body = await response.json();
+      expect(body.message).to.equal('Upstream authorization failed');
     });
 
     it('re-syncs CI competitors (with removed domains) when competitors change on a sub-workspace brand', async () => {

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -15,8 +15,14 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
+import { ProjectEngineApiError } from '@adobe/spacecat-shared-project-engine-client';
 import { ErrorWithStatusCode } from '../../src/support/utils.js';
 import { brandPointerReloader } from '../../src/controllers/serenity.js';
+// The REAL transport error type: since LLMO-6386 the controller's mapError classifies via
+// errors.js (isSemrushTransportError), which recognises the real SerenityTransportError /
+// ProjectEngineApiError by `instanceof`. The mapError tests below must feed those real types
+// (a bare mock class would not be recognised → would wrongly fall through to the generic 500).
+import { SerenityTransportError as RealSerenityTransportError } from '../../src/support/serenity/rest-transport.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -208,14 +214,10 @@ describe('SerenityController', () => {
     exchangePromiseTokenStub = sinon.stub().resolves('exchanged-ims-token');
     linkSiteToLiveRowsStub = sinon.stub().resolves();
     tombstoneAllForBrandStub = sinon.stub().resolves();
-    MockTransportError = class extends Error {
-      constructor(status, message, body) {
-        super(message);
-        this.name = 'SerenityTransportError';
-        this.status = status;
-        this.body = body;
-      }
-    };
+    // Alias the REAL SerenityTransportError so instances are recognised by errors.js's
+    // isSemrushTransportError (which mapError now delegates to). Same (status, message, body)
+    // constructor signature the tests already use.
+    MockTransportError = RealSerenityTransportError;
     const MockAccessControlUtil = {
       default: {
         fromContext: () => ({
@@ -884,6 +886,84 @@ describe('SerenityController', () => {
       expect(body.error).to.equal('internalServerError');
       expect(body.message).to.equal('Internal server error');
       expect(log.error).to.have.been.calledWithMatch('Serenity controller error');
+    });
+
+    // LLMO-6386: a Project Engine call now throws ProjectEngineApiError directly (adaptPE gone).
+    // mapError's widened branch must map it to the SAME HTTP envelope the old transport error
+    // produced, redacting the body/message. ProjectEngineApiError does NOT extend
+    // ErrorWithStatusCode, so it correctly reaches the widened branch.
+    it('upstream ProjectEngineApiError (HTTP status) maps to 502 without leaking provider detail', async () => {
+      handlers.handleListMarkets.rejects(new ProjectEngineApiError(503, 'GET', { secret: 'leak' }));
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.listMarkets(fakeContext());
+      expect(response.status).to.equal(502);
+      const body = await readBody(response);
+      expect(body.error).to.equal('serenityUpstreamError');
+      expect(body.message).to.equal('Upstream request failed');
+      expect(JSON.stringify(body)).not.to.match(/leak/);
+      // The raw "Project Engine ..." message must never reach the client.
+      expect(JSON.stringify(body)).not.to.match(/Project Engine/);
+    });
+
+    it('upstream ProjectEngineApiError 401 propagates as 401 authenticationRequired (redacted)', async () => {
+      handlers.handleListMarkets.rejects(new ProjectEngineApiError(401, 'GET', { secret: 'leak' }));
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.listMarkets(fakeContext());
+      expect(response.status).to.equal(401);
+      const body = await readBody(response);
+      expect(body.error).to.equal('authenticationRequired');
+      expect(body.message).to.equal('Upstream authorization failed');
+    });
+
+    it('upstream ProjectEngineApiError 409 propagates as 409 conflict (redacted)', async () => {
+      handlers.handleUpdatePrompt.rejects(new ProjectEngineApiError(409, 'POST', { secret: 'leak' }));
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.updatePrompt(fakeContext({
+        params: { semrushPromptId: 'sem-1' },
+        data: {
+          geoTargetId: 2840, languageCode: 'en', text: 'x', tagIds: ['t1'],
+        },
+      }));
+      expect(response.status).to.equal(409);
+      const body = await readBody(response);
+      expect(body.error).to.equal('conflict');
+      expect(body.message).to.equal('Upstream rejected the request as a conflict');
+    });
+
+    // The behaviour-preservation crux (LLMO-6386): a no-HTTP-response Project Engine failure is a
+    // ProjectEngineApiError with status undefined wrapping the original throw as `.cause`. mapError
+    // must unwrap it so the auth-401 keeps mapping to 401 (NOT flattening to 502) and a timeout 504
+    // still maps to 502 — exactly what the retired adaptPE boundary produced.
+    it('unwraps a status-undefined ProjectEngineApiError to preserve the auth 401 (not 502)', async () => {
+      const authCause = new RealSerenityTransportError(401, 'Missing IMS bearer token');
+      handlers.handleListMarkets.rejects(new ProjectEngineApiError(undefined, 'POST', null, { cause: authCause }));
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.listMarkets(fakeContext());
+      expect(response.status).to.equal(401);
+      const body = await readBody(response);
+      expect(body.error).to.equal('authenticationRequired');
+      expect(body.message).to.equal('Upstream authorization failed');
+    });
+
+    it('maps a status-undefined ProjectEngineApiError wrapping a 504 timeout cause to 502', async () => {
+      const timeoutCause = new RealSerenityTransportError(504, 'Semrush request timed out');
+      handlers.handleListMarkets.rejects(new ProjectEngineApiError(undefined, 'GET', null, { cause: timeoutCause }));
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.listMarkets(fakeContext());
+      expect(response.status).to.equal(502);
+      const body = await readBody(response);
+      expect(body.error).to.equal('serenityUpstreamError');
+    });
+
+    it('maps a status-undefined ProjectEngineApiError wrapping a raw network cause to the generic 500', async () => {
+      const netCause = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' });
+      handlers.handleListMarkets.rejects(new ProjectEngineApiError(undefined, 'GET', null, { cause: netCause }));
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.listMarkets(fakeContext());
+      expect(response.status).to.equal(500);
+      const body = await readBody(response);
+      expect(body.error).to.equal('internalServerError');
+      expect(body.message).to.equal('Internal server error');
     });
 
     it('listTags dispatches to handleListTags and wraps the result in ok()', async () => {

--- a/test/support/serenity/errors.test.js
+++ b/test/support/serenity/errors.test.js
@@ -140,6 +140,12 @@ describe('serenity error classification', () => {
       expect(isPoolExhausted(peErr(500, { message: 'insufficient available units' }))).to.be.false;
     });
 
+    it('isPoolExhausted: matches a bare STRING body (bodyText string path), both error types', () => {
+      // The gateway can return a bare text body (not JSON); bodyText lowercases it and matches.
+      expect(isPoolExhausted(err(422, 'Insufficient Available Units in subscription'))).to.be.true;
+      expect(isPoolExhausted(peErr(422, 'insufficient available units'))).to.be.true;
+    });
+
     it('isWorkspaceNotReady: only the transient 422 lock', () => {
       expect(isWorkspaceNotReady(err(422, { message: 'workspace not ready' }))).to.be.true;
       expect(isWorkspaceNotReady(err(422, { message: 'insufficient available units' }))).to.be.false;

--- a/test/support/serenity/errors.test.js
+++ b/test/support/serenity/errors.test.js
@@ -15,6 +15,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
 
+import { ProjectEngineApiError } from '@adobe/spacecat-shared-project-engine-client';
 import {
   isUpstreamGone,
   ERROR_CODES,
@@ -23,18 +24,74 @@ import {
   isMeteredQuota,
   isRateLimited,
   toQuotaExceededError,
+  isSemrushTransportError,
+  unwrapTransportCause,
 } from '../../../src/support/serenity/errors.js';
 import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
 
 use(sinonChai);
 
+// A Project Engine HTTP failure. The facade throws this directly (LLMO-6386, adaptPE retired);
+// it carries the same `.status`/`.body` the classifiers key on. `method` is immaterial to
+// classification, so a fixed 'POST' is used throughout.
+const peErr = (status, body) => new ProjectEngineApiError(status, 'POST', body);
+
 describe('serenity error classification', () => {
+  // LLMO-6386: a failing Semrush call now surfaces as ONE of two typed errors — Project Engine
+  // ops throw ProjectEngineApiError directly (adaptPE retired), User Manager / brand-topics ops
+  // still throw SerenityTransportError. Every classifier must recognise both and reject everything
+  // else (plain Errors, ad-hoc objects carrying a matching `.status`).
+  describe('isSemrushTransportError', () => {
+    it('matches both Semrush transport error types', () => {
+      expect(isSemrushTransportError(new SerenityTransportError(500, 'boom'))).to.be.true;
+      expect(isSemrushTransportError(peErr(500, null))).to.be.true;
+    });
+    it('rejects plain Errors, ad-hoc objects, and nullish values', () => {
+      expect(isSemrushTransportError(new Error('x'))).to.be.false;
+      expect(isSemrushTransportError(new TypeError('x'))).to.be.false;
+      expect(isSemrushTransportError({ status: 404, body: 'x' })).to.be.false;
+      expect(isSemrushTransportError(null)).to.be.false;
+      expect(isSemrushTransportError(undefined)).to.be.false;
+    });
+  });
+
+  describe('unwrapTransportCause', () => {
+    it('unwraps a status-undefined ProjectEngineApiError to its cause (auth 401 preserved)', () => {
+      const cause = new SerenityTransportError(401, 'missing token');
+      const wrapped = new ProjectEngineApiError(undefined, 'POST', null, { cause });
+      expect(unwrapTransportCause(wrapped)).to.equal(cause);
+    });
+    it('unwraps to a raw network cause (so the generic 500 path is preserved)', () => {
+      const cause = new Error('fetch failed');
+      const wrapped = new ProjectEngineApiError(undefined, 'GET', null, { cause });
+      expect(unwrapTransportCause(wrapped)).to.equal(cause);
+    });
+    it('leaves a ProjectEngineApiError that carried an HTTP status unchanged', () => {
+      const e = peErr(405, '<html>405</html>');
+      expect(unwrapTransportCause(e)).to.equal(e);
+    });
+    it('leaves a status-undefined ProjectEngineApiError with no cause unchanged', () => {
+      const e = new ProjectEngineApiError(undefined, 'POST', null);
+      expect(unwrapTransportCause(e)).to.equal(e);
+    });
+    it('passes a SerenityTransportError and other errors through unchanged', () => {
+      const ste = new SerenityTransportError(504, 'timeout');
+      expect(unwrapTransportCause(ste)).to.equal(ste);
+      const plain = new Error('x');
+      expect(unwrapTransportCause(plain)).to.equal(plain);
+    });
+  });
+
   describe('isUpstreamGone', () => {
     it('matches a SerenityTransportError with status 404', () => {
       expect(isUpstreamGone(new SerenityTransportError(404, 'gone'))).to.be.true;
     });
-    it('rejects non-404 and non-SerenityTransportError shapes', () => {
+    it('matches a ProjectEngineApiError with status 404', () => {
+      expect(isUpstreamGone(peErr(404, { message: 'not found' }))).to.be.true;
+    });
+    it('rejects non-404 and non-transport-error shapes', () => {
       expect(isUpstreamGone(new SerenityTransportError(500, 'boom'))).to.be.false;
+      expect(isUpstreamGone(peErr(500, null))).to.be.false;
       expect(isUpstreamGone({ status: 404 })).to.be.false;
       expect(isUpstreamGone(new Error('x'))).to.be.false;
     });
@@ -77,9 +134,20 @@ describe('serenity error classification', () => {
       expect(isPoolExhausted(new Error('x'))).to.be.false;
     });
 
+    it('isPoolExhausted: also matches a ProjectEngineApiError 422 with the units message', () => {
+      expect(isPoolExhausted(peErr(422, { message: 'insufficient available units' }))).to.be.true;
+      expect(isPoolExhausted(peErr(422, { message: 'workspace not ready' }))).to.be.false;
+      expect(isPoolExhausted(peErr(500, { message: 'insufficient available units' }))).to.be.false;
+    });
+
     it('isWorkspaceNotReady: only the transient 422 lock', () => {
       expect(isWorkspaceNotReady(err(422, { message: 'workspace not ready' }))).to.be.true;
       expect(isWorkspaceNotReady(err(422, { message: 'insufficient available units' }))).to.be.false;
+    });
+
+    it('isWorkspaceNotReady: also matches a ProjectEngineApiError transient 422 lock', () => {
+      expect(isWorkspaceNotReady(peErr(422, { message: 'workspace not ready' }))).to.be.true;
+      expect(isWorkspaceNotReady(peErr(422, { message: 'insufficient available units' }))).to.be.false;
     });
 
     it('isMeteredQuota: keys on body SHAPE, not content — a string body is the disguised quota rejection, a JSON body is a genuine app-level error', () => {
@@ -95,6 +163,16 @@ describe('serenity error classification', () => {
       expect(isMeteredQuota(err(405, { message: 'Quota exceeded' }))).to.be.false;
       expect(isMeteredQuota(err(405, null))).to.be.false;
       expect(isMeteredQuota(err(404, null))).to.be.false;
+    });
+
+    it('isMeteredQuota: same body-SHAPE rule for a ProjectEngineApiError 405', () => {
+      // The disguised-405 quota rejection can now arrive as a ProjectEngineApiError (it is a
+      // metered publish/prompt-write, all Project Engine ops). String body → absorbed; JSON body
+      // → a genuine app-level 405 that is not absorbed.
+      expect(isMeteredQuota(peErr(405, '<html>405 Not Allowed</html>'))).to.be.true;
+      expect(isMeteredQuota(peErr(405, ''))).to.be.false;
+      expect(isMeteredQuota(peErr(405, { message: 'Method Not Allowed' }))).to.be.false;
+      expect(isMeteredQuota(peErr(404, null))).to.be.false;
     });
 
     describe('isMeteredQuota — MeteredQuotaClassifier metric only fires for actual 405s', () => {
@@ -133,6 +211,21 @@ describe('serenity error classification', () => {
     it('isRateLimited: a 429', () => {
       expect(isRateLimited(err(429, null))).to.be.true;
       expect(isRateLimited(err(503, null))).to.be.false;
+    });
+
+    it('isRateLimited: also matches a ProjectEngineApiError 429', () => {
+      expect(isRateLimited(peErr(429, null))).to.be.true;
+      expect(isRateLimited(peErr(503, null))).to.be.false;
+    });
+
+    it('the disguised-405 metric still fires for a ProjectEngineApiError 405', async () => {
+      const recordMeteredQuotaClassifier = sinon.stub();
+      const { isMeteredQuota: mocked } = await esmock(
+        '../../../src/support/serenity/errors.js',
+        { '../../../src/support/serenity/allocation-metrics.js': { recordMeteredQuotaClassifier } },
+      );
+      mocked(peErr(405, '<html>405 Not Allowed</html>'));
+      expect(recordMeteredQuotaClassifier).to.have.been.calledOnceWith(true);
     });
   });
 });

--- a/test/support/serenity/errors.test.js
+++ b/test/support/serenity/errors.test.js
@@ -146,6 +146,12 @@ describe('serenity error classification', () => {
       expect(isPoolExhausted(peErr(422, 'insufficient available units'))).to.be.true;
     });
 
+    it('isPoolExhausted: a null/empty body is not a match (bodyText falsy-body path)', () => {
+      // unwrap normalises an empty upstream body to null; bodyText must yield '' → no match.
+      expect(isPoolExhausted(err(422, null))).to.be.false;
+      expect(isPoolExhausted(peErr(422, null))).to.be.false;
+    });
+
     it('isWorkspaceNotReady: only the transient 422 lock', () => {
       expect(isWorkspaceNotReady(err(422, { message: 'workspace not ready' }))).to.be.true;
       expect(isWorkspaceNotReady(err(422, { message: 'insufficient available units' }))).to.be.false;

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -17,7 +17,6 @@ import sinonChai from 'sinon-chai';
 import { ProjectEngineApiError } from '@adobe/spacecat-shared-project-engine-client';
 
 import {
-  adaptPE,
   createSerenityTransport,
   SerenityTransportError,
   redactUpstreamMessage,
@@ -96,11 +95,18 @@ describe('Semrush REST transport', () => {
   });
 
   describe('auth + base URL', () => {
-    it('throws SerenityTransportError(401) when imsToken is missing on a call', async () => {
+    it('surfaces a missing-imsToken 401 as a ProjectEngineApiError wrapping the auth cause on a PE call', async () => {
+      // LLMO-6386: a Project Engine call throws ProjectEngineApiError directly. The shared
+      // authToken getter still throws SerenityTransportError(401) on a missing token, but that
+      // now happens inside the facade's auth middleware, so it is surfaced as the facade's
+      // no-HTTP-response ProjectEngineApiError (status undefined) carrying the 401 as `.cause`.
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: '' });
-      const promise = transport.publishProject(WORKSPACE_ID, PROJECT_ID);
-      await expect(promise).to.be.rejectedWith(SerenityTransportError);
-      await expect(promise).to.be.rejectedWith(/Missing IMS bearer token/);
+      const err = await transport.publishProject(WORKSPACE_ID, PROJECT_ID).catch((e) => e);
+      expect(err).to.be.instanceOf(ProjectEngineApiError);
+      expect(err.status).to.equal(undefined);
+      expect(err.cause).to.be.instanceOf(SerenityTransportError);
+      expect(err.cause.status).to.equal(401);
+      expect(err.cause.message).to.match(/Missing IMS bearer token/);
     });
 
     it('sends Authorization: Bearer <ims> — no cookie, no Auth-Data-Jwt, no User-Agent', async () => {
@@ -286,15 +292,20 @@ describe('Semrush REST transport', () => {
       expect(call.url).to.include('pid%3Fwith%23hash');
     });
 
-    it('re-throws non-abort fetch errors verbatim (network error, not timeout)', async () => {
+    it('preserves a non-abort fetch error (network error, not timeout) as the PE facade cause', async () => {
+      // createTimeoutFetch re-throws a non-AbortError verbatim; on a PE call (publishProject) the
+      // facade then surfaces it as a status-undefined ProjectEngineApiError carrying the original
+      // network error as `.cause` (LLMO-6386), rather than the raw error escaping directly.
       const netErr = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' });
       fetchStub.rejects(netErr);
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
-      await expect(transport.publishProject(WORKSPACE_ID, PROJECT_ID))
-        .to.be.rejectedWith(/ECONNRESET/);
+      const err = await transport.publishProject(WORKSPACE_ID, PROJECT_ID).catch((e) => e);
+      expect(err).to.be.instanceOf(ProjectEngineApiError);
+      expect(err.status).to.equal(undefined);
+      expect(err.cause).to.equal(netErr);
     });
 
-    it('aborts with SerenityTransportError(504) on fetch timeout', async () => {
+    it('aborts with a 504 SerenityTransportError cause (wrapped in ProjectEngineApiError) on a PE fetch timeout', async () => {
       // fetch never resolves; the transport's AbortController should fire.
       fetchStub.callsFake((_input, init) => new Promise((resolve, reject) => {
         init.signal.addEventListener('abort', () => {
@@ -319,8 +330,11 @@ describe('Semrush REST transport', () => {
         // fires. A synchronous tick would fire against a not-yet-registered timer.
         await clock.tickAsync(20_000); // safely past the 15s default timeout
         const err = await promise.catch((e) => e);
-        expect(err).to.be.instanceOf(SerenityTransportError);
-        expect(err.status).to.equal(504);
+        // PE path: createTimeoutFetch's 504 SerenityTransportError is the facade's `.cause`.
+        expect(err).to.be.instanceOf(ProjectEngineApiError);
+        expect(err.status).to.equal(undefined);
+        expect(err.cause).to.be.instanceOf(SerenityTransportError);
+        expect(err.cause.status).to.equal(504);
       } finally {
         clock.restore();
         global.setTimeout = realSetTimeout;
@@ -446,7 +460,8 @@ describe('Semrush REST transport', () => {
       await clock.tickAsync(60_000);
       const err = await promise;
 
-      expect(err).to.be.instanceOf(SerenityTransportError);
+      // createProject is a Project Engine call → ProjectEngineApiError (LLMO-6386).
+      expect(err).to.be.instanceOf(ProjectEngineApiError);
       expect(err.status).to.equal(500);
       expect(fetchStub.callCount).to.equal(1);
     }));
@@ -515,7 +530,7 @@ describe('Semrush REST transport', () => {
       const err = await promise;
 
       expect(fetchStub.callCount).to.equal(3);
-      expect(err).to.be.instanceOf(SerenityTransportError);
+      expect(err).to.be.instanceOf(ProjectEngineApiError);
       expect(err.status).to.equal(429);
     }));
 
@@ -578,8 +593,11 @@ describe('Semrush REST transport', () => {
       await clock.tickAsync(20_000); // past the 15s per-attempt timeout, once
       const err = await promise;
 
-      expect(err).to.be.instanceOf(SerenityTransportError);
-      expect(err.status).to.equal(504);
+      // PE path: the 504 SerenityTransportError is carried as the facade error's `.cause`.
+      expect(err).to.be.instanceOf(ProjectEngineApiError);
+      expect(err.status).to.equal(undefined);
+      expect(err.cause).to.be.instanceOf(SerenityTransportError);
+      expect(err.cause.status).to.equal(504);
       expect(fetchStub.callCount).to.equal(1);
     }));
 
@@ -597,7 +615,7 @@ describe('Semrush REST transport', () => {
   });
 
   describe('non-2xx upstream', () => {
-    it('throws SerenityTransportError carrying status and parsed body', async () => {
+    it('throws ProjectEngineApiError carrying status and parsed body (PE call)', async () => {
       fetchStub.resolves(fetchFail(502, { code: 'gateway_timeout' }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
@@ -605,7 +623,7 @@ describe('Semrush REST transport', () => {
         await transport.publishProject(WORKSPACE_ID, PROJECT_ID);
         expect.fail('should have thrown');
       } catch (err) {
-        expect(err).to.be.instanceOf(SerenityTransportError);
+        expect(err).to.be.instanceOf(ProjectEngineApiError);
         expect(err.status).to.equal(502);
         expect(err.body).to.deep.equal({ code: 'gateway_timeout' });
       }
@@ -642,7 +660,7 @@ describe('Semrush REST transport', () => {
         await transport.publishProject(WORKSPACE_ID, PROJECT_ID);
         expect.fail('should have thrown');
       } catch (err) {
-        expect(err).to.be.instanceOf(SerenityTransportError);
+        expect(err).to.be.instanceOf(ProjectEngineApiError);
         expect(err.status).to.equal(500);
         expect(err.body).to.equal(null);
       }
@@ -722,12 +740,15 @@ describe('Semrush REST transport', () => {
       expect(result.items).to.deep.equal([{ id: 'new-prompt', name: 'What is Acrobat?' }]);
     });
 
-    it('surfaces an upstream 500 (unresolvable tag id) as a SerenityTransportError', async () => {
+    it('surfaces an upstream 500 (unresolvable tag id) as a ProjectEngineApiError', async () => {
       fetchStub.resolves(fetchFail(500, { message: 'unknown tag id: bogus' }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
       await expect(transport.createPromptsByIds(WORKSPACE_ID, PROJECT_ID, ['x'], ['bogus']))
-        .to.be.rejected.then((err) => expect(err.status).to.equal(500));
+        .to.be.rejected.then((err) => {
+          expect(err).to.be.instanceOf(ProjectEngineApiError);
+          expect(err.status).to.equal(500);
+        });
     });
   });
 
@@ -759,13 +780,13 @@ describe('Semrush REST transport', () => {
       expect(result).to.deep.equal({ id: 'p1', name: 'Next text', is_updated: true });
     });
 
-    it('surfaces the upstream 409 (text collision) as a SerenityTransportError(409)', async () => {
+    it('surfaces the upstream 409 (text collision) as a ProjectEngineApiError(409)', async () => {
       fetchStub.resolves(fetchFail(409, { message: 'conflict' }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
       await expect(transport.renamePrompt(WORKSPACE_ID, PROJECT_ID, 'p1', 'A sibling\'s text'))
         .to.be.rejected.then((err) => {
-          expect(err).to.be.instanceOf(SerenityTransportError);
+          expect(err).to.be.instanceOf(ProjectEngineApiError);
           expect(err.status).to.equal(409);
         });
     });
@@ -1044,12 +1065,12 @@ describe('Semrush REST transport', () => {
       expect(call.body).to.equal(undefined);
     });
 
-    it('throws SerenityTransportError(404) on upstream not-found so callers can treat it as idempotent', async () => {
+    it('throws ProjectEngineApiError(404) on upstream not-found so callers can treat it as idempotent', async () => {
       fetchStub.resolves(fetchFail(404, { message: 'not found' }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
       const promise = transport.deleteProject(WORKSPACE_ID, PROJECT_ID);
-      await expect(promise).to.be.rejectedWith(SerenityTransportError);
+      await expect(promise).to.be.rejectedWith(ProjectEngineApiError);
       try {
         await promise;
       } catch (e) {
@@ -1233,12 +1254,13 @@ describe('Semrush REST transport', () => {
       expect(fetchStub.called).to.equal(false);
     });
 
-    it('surfaces an upstream 404 as a SerenityTransportError', async () => {
+    it('surfaces an upstream 404 as a ProjectEngineApiError', async () => {
       fetchStub.resolves(fetchFail(404, { message: 'not found' }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
       await expect(transport.updateProjectTag(WORKSPACE_ID, PROJECT_ID, 'ghost', { name: 'X', parentId: 'root-1' }))
         .to.be.rejected.then((err) => {
+          expect(err).to.be.instanceOf(ProjectEngineApiError);
           expect(err.status).to.equal(404);
           expect(err.body).to.deep.equal({ message: 'not found' });
         });
@@ -1535,9 +1557,46 @@ describe('Semrush REST transport', () => {
         expect(redactUpstreamMessage(e)).to.equal('Upstream request failed');
       });
 
+      // LLMO-6386: a Project Engine failure now surfaces as ProjectEngineApiError, whose message
+      // embeds the service name + method + status ("Project Engine POST request failed with status
+      // 405"); it must be redacted to the same generic string, never echoed to the client.
+      it('redacts a ProjectEngineApiError by status (401/403 → auth failed, else request failed)', () => {
+        expect(redactUpstreamMessage(new ProjectEngineApiError(401, 'GET', null)))
+          .to.equal('Upstream authorization failed');
+        expect(redactUpstreamMessage(new ProjectEngineApiError(403, 'POST', null)))
+          .to.equal('Upstream authorization failed');
+        expect(redactUpstreamMessage(new ProjectEngineApiError(405, 'POST', '<html>405</html>')))
+          .to.equal('Upstream request failed');
+      });
+
+      it('never leaks the raw "Project Engine ..." message of a ProjectEngineApiError', () => {
+        const e = new ProjectEngineApiError(500, 'POST', { code: 'boom' });
+        expect(redactUpstreamMessage(e)).to.equal('Upstream request failed');
+        expect(redactUpstreamMessage(e)).to.not.match(/Project Engine/);
+      });
+
+      it('unwraps a status-undefined ProjectEngineApiError to its cause before redacting (auth 401)', () => {
+        // Timeout/auth/network PE failure: redact by the wrapped cause's status, matching the
+        // retired adaptPE boundary — a missing-token 401 cause still reads "authorization failed".
+        const authCause = new SerenityTransportError(401, 'Missing IMS bearer token');
+        expect(redactUpstreamMessage(new ProjectEngineApiError(undefined, 'POST', null, { cause: authCause })))
+          .to.equal('Upstream authorization failed');
+        const timeoutCause = new SerenityTransportError(504, 'timed out');
+        expect(redactUpstreamMessage(new ProjectEngineApiError(undefined, 'GET', null, { cause: timeoutCause })))
+          .to.equal('Upstream request failed');
+      });
+
       it('returns e.message unchanged for a plain (non-transport) Error', () => {
         const e = new Error('safe app error message');
         expect(redactUpstreamMessage(e)).to.equal('safe app error message');
+      });
+
+      it('returns the raw network cause message for a status-undefined ProjectEngineApiError wrapping a plain Error', () => {
+        // A raw network error carried as cause is not a Semrush transport type, so (as before the
+        // adaptPE boundary was retired) its own message passes through.
+        const netCause = new Error('fetch failed');
+        expect(redactUpstreamMessage(new ProjectEngineApiError(undefined, 'GET', null, { cause: netCause })))
+          .to.equal('fetch failed');
       });
 
       it('returns undefined when called with null (e?.message is undefined)', () => {
@@ -1545,14 +1604,16 @@ describe('Semrush REST transport', () => {
       });
     });
 
-    describe('unwrap error/data/null fallback (line 159)', () => {
+    describe('local unwrap error/data/null fallback (User Manager / brand-topics path)', () => {
       it('falls through to data then null when the non-2xx error body parses to JSON null', async () => {
-        // openapi-fetch parses a JSON `null` error body to `error === null`
-        // (nullish), so `error ?? data ?? null` evaluates the `data` operand
-        // (also nullish here) and finally the `null` literal — exercising both
-        // right-hand operands of the coalescing chain. (A `''` error body would
-        // short-circuit at `error` since '' is not nullish, which is why the
-        // empty-body test does not reach these branches.)
+        // This exercises the transport's LOCAL `unwrap` — used only by the User Manager (`users.*`)
+        // and brand-topics (`projectsRaw`) paths, which still throw SerenityTransportError
+        // (LLMO-6386 leaves them unchanged). createSubworkspace is a POST (not retried on 5xx), so
+        // a single attempt reaches unwrap. openapi-fetch parses a JSON `null` error body to
+        // `error === null` (nullish), so `error ?? data ?? null` evaluates the `data` operand (also
+        // nullish here) and finally the `null` literal — exercising both right-hand operands of the
+        // coalescing chain. (A `''` error body would short-circuit at `error` since '' is not
+        // nullish, which is why the empty-body test does not reach these branches.)
         fetchStub.resolves(new Response('null', {
           status: 500,
           headers: { 'content-type': 'application/json' },
@@ -1560,30 +1621,33 @@ describe('Semrush REST transport', () => {
         const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
         try {
-          await transport.publishProject(WORKSPACE_ID, PROJECT_ID);
+          await transport.createSubworkspace(PARENT_WS, 'Adobe Express', { ai: { projects: 1, prompts: 1 } });
           expect.fail('should have thrown');
         } catch (err) {
           expect(err).to.be.instanceOf(SerenityTransportError);
           expect(err.status).to.equal(500);
-          // error(null) ?? data(undefined) ?? null → null; line 163 keeps null.
+          // error(null) ?? data(undefined) ?? null → null; unwrap keeps null.
           expect(err.body).to.equal(null);
         }
       });
     });
 
-    describe('createTimeoutFetch re-throws a non-abort error via the wrapped fetch (line 135)', () => {
-      it('propagates a non-AbortError rejection from the wrapped fetch unchanged', async () => {
-        // Drive the timeout-fetch catch with a rejection whose name is NOT
-        // 'AbortError' so the `if` guard is false and `throw e` re-raises the
-        // original error verbatim (no 504 mapping).
+    describe('createTimeoutFetch re-throws a non-abort error via the wrapped fetch', () => {
+      it('propagates a non-AbortError rejection from the wrapped fetch as the facade error cause', async () => {
+        // Drive the timeout-fetch catch with a rejection whose name is NOT 'AbortError' so the
+        // `if` guard is false and `throw e` re-raises the original error verbatim (no 504 mapping).
+        // On a PE call (publishProject) that raw error is not an HTTP response, so the facade
+        // surfaces it as a status-undefined ProjectEngineApiError carrying it as `.cause`
+        // (LLMO-6386); the original error is preserved unchanged there.
         const boom = Object.assign(new Error('EPIPE'), { name: 'TypeError', code: 'EPIPE' });
         fetchStub.rejects(boom);
         const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
         const err = await transport.publishProject(WORKSPACE_ID, PROJECT_ID).catch((e) => e);
-        expect(err).to.equal(boom);
-        expect(err).to.not.be.instanceOf(SerenityTransportError);
-        expect(err.message).to.equal('EPIPE');
+        expect(err).to.be.instanceOf(ProjectEngineApiError);
+        expect(err.status).to.equal(undefined);
+        expect(err.cause).to.equal(boom);
+        expect(err.cause.message).to.equal('EPIPE');
       });
     });
 
@@ -1604,49 +1668,5 @@ describe('Semrush REST transport', () => {
         expect(params.get('country')).to.equal('');
       });
     });
-  });
-});
-
-describe('adaptPE (Project Engine boundary adapter)', () => {
-  it('passes a resolved value through unchanged', async () => {
-    expect(await adaptPE(Promise.resolve({ ok: 1 }))).to.deep.equal({ ok: 1 });
-  });
-
-  it('maps an HTTP ProjectEngineApiError to SerenityTransportError (status + body preserved)', async () => {
-    const body = { message: 'nope' };
-    let err;
-    try {
-      await adaptPE(Promise.reject(new ProjectEngineApiError(404, 'GET', body)));
-    } catch (e) { err = e; }
-    expect(err).to.be.instanceOf(SerenityTransportError);
-    expect(err.status).to.equal(404);
-    expect(err.body).to.deep.equal(body);
-  });
-
-  it('rethrows the original cause on the no-response path (timeout/auth/network)', async () => {
-    const cause = new SerenityTransportError(504, 'timed out');
-    let err;
-    try {
-      await adaptPE(Promise.reject(new ProjectEngineApiError(undefined, 'GET', null, { cause })));
-    } catch (e) { err = e; }
-    expect(err).to.equal(cause);
-  });
-
-  it('defensive fallback: wraps as SerenityTransportError(502) when cause is absent', async () => {
-    let err;
-    try {
-      await adaptPE(Promise.reject(new ProjectEngineApiError(undefined, 'GET', null)));
-    } catch (e) { err = e; }
-    expect(err).to.be.instanceOf(SerenityTransportError);
-    expect(err.status).to.equal(502);
-  });
-
-  it('rethrows a non-ProjectEngineApiError unchanged', async () => {
-    const other = new Error('boom');
-    let err;
-    try {
-      await adaptPE(Promise.reject(other));
-    } catch (e) { err = e; }
-    expect(err).to.equal(other);
   });
 });


### PR DESCRIPTION
## Summary

PR #2863 (LLMO-6379) adopted the shared Project Engine (PE) facade + ADR-0001 ownership boundary, but rethrew the facade's `ProjectEngineApiError` back to the legacy `SerenityTransportError` through an `adaptPE` boundary adapter — purely so the classification + error→HTTP layer could keep gating on `instanceof SerenityTransportError`. This PR **retires that adapter**: PE calls now throw `ProjectEngineApiError` directly, and the classification/mapping layer is broadened to recognise **both** typed errors.

### Shared-predicate approach
`errors.js` gains one predicate that every classifier gates on:

```js
export function isSemrushTransportError(e) {
  return e instanceof SerenityTransportError || e instanceof ProjectEngineApiError;
}
```

Both types carry the same classification-relevant fields (`.status`, `.body`), so `isUpstreamGone`, `isPoolExhausted`, `isWorkspaceNotReady`, `isMeteredQuota` (incl. the 405-only `MeteredQuotaClassifier` metric), `isRateLimited`, and `bodyText` were switched to gate on `isSemrushTransportError` with **no change to any classification logic** — only the type guard widened.

### UM / brand-topics stay on SerenityTransportError
The **User Manager (`users.*`)** sub-workspace lifecycle calls and the **brand-topics (`projectsRaw`)** call still go through the local `unwrap` and throw `SerenityTransportError` — unchanged (the facade doesn't own those gateways). The transport keeps `unwrap`, `SerenityTransportError`, `projectsRaw`, and all `users.*` calls exactly as they were. `adaptPE` is removed and all 28 PE call sites now return the facade result directly.

## Behavior preservation (HTTP responses + classification OUTCOMES)

The observable contract preserved is the **HTTP responses and classification outcomes**, not the internal error-object type.

- **HTTP non-2xx** → `ProjectEngineApiError(status, method, body)` → classifiers match on status/body exactly as before; `mapError` maps it identically (401/403 → that status; 409 → conflict; everything else → 502).
- **Timeout / auth / network** → the facade throws `ProjectEngineApiError` with `status: undefined` and the original throw in `.cause` (`createTimeoutFetch`'s 504 STE, `authToken`'s 401 STE, or a raw network error). The retired `adaptPE` used to **rethrow that `.cause`** on the undefined-status path.

### The auth-401 nuance (flagged and handled)
Without care, a status-undefined `ProjectEngineApiError` would flatten **every** timeout/auth/network failure to 502 — silently regressing the auth response from **401 → 502**. To prevent that, the error→HTTP mapping layer (`serenity.js` `mapError` and `brands.js` `createErrorResponse`) unwraps the cause via a new `unwrapTransportCause(e)` helper **before** classifying — reproducing exactly what `adaptPE` did:

| Failure | old (adaptPE rethrew cause) | new (unwrapTransportCause) |
|---|---|---|
| missing-token 401 (`authToken`) | 401 | **401** ✅ |
| timeout 504 (`createTimeoutFetch`) | 502 | **502** ✅ |
| raw network error | 500 | **500** ✅ |
| HTTP 401/403/409/other | 401/403/409/502 | same ✅ |

The unwrap is applied **only** at the two HTTP-mapping seams. The classifiers deliberately do **not** unwrap: their trigger statuses are 404/422/405/429, and a wrapped cause only ever carries 504/401/network — so none of them ever fired on a cause under `adaptPE` either. Outcomes are identical.

`redactUpstreamMessage` (used for per-item `failed[].message` in bulk prompt ops, a PE path) was also widened + cause-unwrapped, so a PE failure is redacted to the same generic string rather than leaking the raw `"Project Engine POST request failed with status 405"` text to clients.

## `instanceof SerenityTransportError` audit

| Site | PE-reachable? | Action |
|---|---|---|
| `errors.js` × 5 classifiers + `bodyText` | yes | → `isSemrushTransportError` |
| `controllers/serenity.js` `mapError` | yes | → `isSemrushTransportError` + cause-unwrap |
| `controllers/brands.js` `createErrorResponse` | yes | → `isSemrushTransportError` + cause-unwrap |
| `brand-provisioning.js:226` (405 quota, from a PE publish/prompt-write) | yes | → `isSemrushTransportError` |
| `brand-urls.js:234` (409 from `createBenchmarks`) / `:303` (405 from `publishProject`) | yes | → `isSemrushTransportError` |
| `handlers/markets.js:893` (`listGlobalAiModels`) / `:932` (`listLanguages`) | yes | → `isSemrushTransportError` |
| `rest-transport.js` `redactUpstreamMessage` | yes (bulk prompt ops) | widened to both types + cause-unwrap |
| `resource-manager.js:507` (`releaseAiSurplus` best-effort) | **no** — only calls `transferWorkspaceResources` / `getWorkspaceResources` (both UM) | **left as-is** |
| `workspace-lifecycle.js:446` (`e?.status === 504` on `createSubworkspace` timeout) | **no** — `createSubworkspace` is a UM call → still raw `SerenityTransportError(504)` | **left as-is** |

## Files changed
- `src/support/serenity/errors.js` — `isSemrushTransportError` + `unwrapTransportCause`; classifiers widened
- `src/support/serenity/rest-transport.js` — removed `adaptPE` + its 28 call-site wrappers; `redactUpstreamMessage` widened (kept `ProjectEngineApiError` import for it)
- `src/controllers/serenity.js` — `mapError` widened + cause-unwrap
- `src/controllers/brands.js` — `createErrorResponse` widened + cause-unwrap
- `src/support/serenity/brand-provisioning.js`, `brand-urls.js`, `handlers/markets.js` — audited sites switched to `isSemrushTransportError`
- Tests: `errors.test.js`, `rest-transport.test.js`, `controllers/serenity.test.js`, `controllers/brands.test.js`

## Verification
- `npm run lint`: clean
- `tsc -p tsconfig.json`: clean (pre-commit gate)
- `npm test`: **15322 passing / 0 failing**; coverage 99.91% stmts / 98.96% branch (bar 90%). Allocator/quota/retry classifier suites pass. New tests assert each classifier matches a `ProjectEngineApiError`, `mapError`/`createErrorResponse` handle typed PE errors, and the auth-401 cause-unwrap does not regress to 502.

Refs LLMO-6379 / #2863, ADR-0001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)