### PR TITLE
chore(deps): bump project-engine-client to 1.15.0 (LLMO-6274)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@adobe/spacecat-shared-http-utils": "1.34.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.14.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.15.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -6586,9 +6586,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.14.0.tgz",
-      "integrity": "sha512-PVbki/71b/4ZjMV/S4X2iSFBCBDa7OBVhCFSzo5g3EDSOlmAhq/76EkpUTYFoKM7oZz/RB8KRlIBLKjRbWb7Fw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.15.0.tgz",
+      "integrity": "sha512-Hkhcu+OuviG9/2TuIrKcTXsFfIxvryMZ05S5N7pgrhWyKM1dBmXkB6pkC2VFZAIOmdp/dat0gsPOpomrMetmfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-http-utils": "1.34.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.14.0",
+    "@adobe/spacecat-shared-project-engine-client": "1.15.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",


### PR DESCRIPTION
## What

Bumps `@adobe/spacecat-shared-project-engine-client` **1.14.0 → 1.15.0** (package.json + lockfile only).

## Why

This is the dependency bump #2862 (WP-O2a) **explicitly deferred** — *"the PE-client dependency bump to the WP-O1 release is deferred until that release exists."* WP-O1 is now released (1.15.0), so this lands it.

It unblocks the **it-postgres serenity gate-3** validation of the tolerant `origin`/`source` authorship-root resolver. The IT harness pins the Semrush mock image tag to the **installed** client version (`test/it/postgres/setup.js` → `SERENITY_PE_MOCK_TAG`, exact match, no fallback). The `origin` root rename + `legacy-source-workspace` seed that the gate-3 cases run against shipped only in **1.15.0** (WP-O1, spacecat-shared `3ead32b` / LLMO-6273). While main pinned 1.14.0, the harness pulled the pre-rename mock and gate-3 could not be exercised (the renamed `['category','intent','origin','type']` assertion would fail; no legacy fixture to adopt).

With this bump the harness derives `SERENITY_PE_MOCK_TAG=1.15.0`, so the CI `it-postgres` job now exercises:
- existing `origin` root resolves;
- legacy `source` root (children ⊆ `{ai,human}`) **adopted in place**, no 2nd root minted;
- fresh project mints `origin`;
- membership (not set-equality) assertions in `childrenAreAuthorship`.

## Risk

**Mock-only release.** 1.15.0 over 1.14.0 touched only the package's `mock/` dir — the client runtime and typings are unchanged, so there is no production behavior change (no coordinated merge window needed, unlike the rename in #2862). Lockfile delta is the single package entry.

## Verification

- `npm run type-check` ✅ (clean)
- Lockfile + `node_modules` resolve to 1.15.0 ✅
- Real gate-3 e2e validation runs here in CI (`it-postgres` has ECR access for the private data-service image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)