### PR TITLE
chore(deps): bump @adobe/spacecat-shared-data-access to 4.11.0 (LLMO-6401)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "4.9.0",
+        "@adobe/spacecat-shared-data-access": "4.11.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.9.0.tgz",
-      "integrity": "sha512-yZPVZAUsMNOCmhGPFUK5822u8UGO4VpF8TTmYoAbhlCAqJiOJmxCBY+2cDunAMS1aS1P2dhjcp3btGcJrGxh1Q==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.11.0.tgz",
+      "integrity": "sha512-/Xi8wisTxX68Gy65QQIv2bnvSPPNT3UQw0GBMuMjv4E6tw/B5MXun4SohWFE5aDjZAZKl2ScLmLka6MdgkmFXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "4.9.0",
+    "@adobe/spacecat-shared-data-access": "4.11.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",


### PR DESCRIPTION
## Summary
- Bump `@adobe/spacecat-shared-data-access` from `4.9.0` to `4.11.0` to pick up the `WEEKLY_OFFSITE` job interval added in adobe/spacecat-shared#1834.
- Without this, `Configuration.findLatest()` will fail once `global-config.json` uses `"interval": "weekly-offsite"` for offsite audits (Joi validation rejects unknown intervals).

## Why manual
Renovate has major updates disabled for this package in `renovate.json5`.

## Test plan
- [x] `npm test` passes locally
- [ ] CI green
- [ ] Merge before updating offsite audit intervals in `global-config.json`


Made with [Cursor](https://cursor.com)