### PR TITLE
fix(llmo): dedupe brand-presence citation counts by execution_id

### DIFF
--- a/src/controllers/llmo/llmo-brand-presence.js
+++ b/src/controllers/llmo/llmo-brand-presence.js
@@ -2611,7 +2611,14 @@ export function aggregateWeeklyDetailStats(rows) {
 
 /**
  * Aggregates source URLs from brand_presence_sources rows joined with source_urls.
- * @param {Array<Object>} sourceRows - Rows with url, hostname, content_type, execution_date, prompt
+ *
+ * Citation/prompt counts are deduplicated by `execution_id`: a single execution can
+ * have multiple brand_presence_sources rows for the same URL (e.g. one row per inline
+ * citation marker in that execution's answer), which would otherwise inflate a URL's
+ * citationCount past the number of executions that actually cite it. Rows without an
+ * execution_id always count (not expected in practice, but keeps this permissive).
+ * @param {Array<Object>} sourceRows - Rows with url, hostname, content_type, execution_date,
+ *   execution_id, prompt
  * @returns {Array<Object>} Deduplicated source entries
  * @internal Exported for testing
  */
@@ -2629,17 +2636,26 @@ export function aggregateDetailSources(sourceRows) {
         hostname: row.hostname || '',
         contentType: row.content_type || '',
         citationCount: 0,
+        seenExecutionIds: new Set(),
         weeks: new Set(),
         prompts: new Map(),
       });
     }
     const s = sourceMap.get(url);
-    s.citationCount += 1;
+
+    const executionId = row.execution_id;
+    const alreadyCountedForExec = Boolean(executionId) && s.seenExecutionIds.has(executionId);
+    if (!alreadyCountedForExec) {
+      s.citationCount += 1;
+      if (executionId) {
+        s.seenExecutionIds.add(executionId);
+      }
+      if (row.prompt) {
+        s.prompts.set(row.prompt, (s.prompts.get(row.prompt) || 0) + 1);
+      }
+    }
     if (row.execution_date) {
       s.weeks.add(weekFromExecDate(row.execution_date));
-    }
-    if (row.prompt) {
-      s.prompts.set(row.prompt, (s.prompts.get(row.prompt) || 0) + 1);
     }
   });
 
@@ -2842,6 +2858,7 @@ function flattenSourceRow(srcRow, execMap) {
     hostname: su.hostname || '',
     content_type: srcRow.content_type || '',
     execution_date: srcRow.execution_date || '',
+    execution_id: srcRow.execution_id || '',
     prompt: exec?.prompt || '',
   };
 }

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -6955,6 +6955,15 @@ describe('llmo-brand-presence', () => {
           url_id: 'u1',
           source_urls: { url: 'https://example.com', hostname: 'example.com' },
         },
+        // Same execution + same URL as a second brand_presence_sources row (e.g. the
+        // AI answer cited example.com twice) — must NOT double-count citationCount.
+        {
+          execution_id: 'exec-1',
+          execution_date: '2026-03-02',
+          content_type: 'web',
+          url_id: 'u1-dup',
+          source_urls: { url: 'https://example.com', hostname: 'example.com' },
+        },
         // null source_urls exercises the || {} fallback in flattenSourceRow
         {
           execution_id: 'exec-1',
@@ -6987,6 +6996,8 @@ describe('llmo-brand-presence', () => {
       expect(body.sources).to.have.lengthOf(2);
       const exampleSource = body.sources.find((s) => s.url === 'https://example.com');
       expect(exampleSource).to.exist;
+      // Only 1 execution (exec-1) exists for this topic, so citationCount must stay 1
+      // even though two brand_presence_sources rows reference it for that execution.
       expect(exampleSource.citationCount).to.equal(1);
     });
 

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -6619,6 +6619,26 @@ describe('llmo-brand-presence', () => {
       ];
       const [entry] = aggregateDetailSources(rows);
       expect(entry.citationCount).to.equal(2);
+      expect(entry.prompts).to.deep.equal([{ prompt: 'q1', count: 2 }]);
+    });
+
+    it('counts each row independently when execution_id is missing', () => {
+      // Rows without an execution_id (not expected in practice) always count,
+      // since there's no id to dedupe against.
+      const rows = [
+        {
+          url: 'https://a.com', hostname: 'a.com', content_type: 'web', execution_date: '2026-03-02', prompt: 'q1',
+        },
+        {
+          url: 'https://a.com', hostname: 'a.com', content_type: 'web', execution_date: '2026-03-02', prompt: 'q1',
+        },
+        {
+          url: 'https://a.com', hostname: 'a.com', content_type: 'web', execution_date: '2026-03-02', execution_id: null, prompt: 'q1',
+        },
+      ];
+      const [entry] = aggregateDetailSources(rows);
+      expect(entry.citationCount).to.equal(3);
+      expect(entry.prompts).to.deep.equal([{ prompt: 'q1', count: 3 }]);
     });
   });
 

--- a/test/controllers/llmo/llmo-brand-presence.test.js
+++ b/test/controllers/llmo/llmo-brand-presence.test.js
@@ -6572,6 +6572,54 @@ describe('llmo-brand-presence', () => {
       ];
       expect(aggregateDetailSources(rows)).to.have.lengthOf(2);
     });
+
+    it('does not double-count citations from multiple rows sharing the same execution_id', () => {
+      // A single execution can produce more than one brand_presence_sources row for
+      // the same URL (e.g. one row per inline citation marker in the answer) —
+      // citationCount must reflect distinct executions, not raw row count.
+      const rows = [
+        {
+          url: 'https://a.com',
+          hostname: 'a.com',
+          content_type: 'web',
+          execution_date: '2026-03-02',
+          execution_id: 'exec-1',
+          prompt: 'q1',
+        },
+        {
+          url: 'https://a.com',
+          hostname: 'a.com',
+          content_type: 'web',
+          execution_date: '2026-03-02',
+          execution_id: 'exec-1',
+          prompt: 'q1',
+        },
+        {
+          url: 'https://a.com',
+          hostname: 'a.com',
+          content_type: 'web',
+          execution_date: '2026-03-02',
+          execution_id: 'exec-1',
+          prompt: 'q1',
+        },
+      ];
+      const [entry] = aggregateDetailSources(rows);
+      expect(entry.citationCount).to.equal(1);
+      expect(entry.prompts).to.deep.equal([{ prompt: 'q1', count: 1 }]);
+    });
+
+    it('counts citations once per distinct execution_id', () => {
+      const rows = [
+        {
+          url: 'https://a.com', hostname: 'a.com', content_type: 'web', execution_date: '2026-03-02', execution_id: 'exec-1', prompt: 'q1',
+        },
+        {
+          url: 'https://a.com', hostname: 'a.com', content_type: 'web', execution_date: '2026-03-09', execution_id: 'exec-2', prompt: 'q1',
+        },
+      ];
+      const [entry] = aggregateDetailSources(rows);
+      expect(entry.citationCount).to.equal(2);
+    });
   });
 
   // ── createTopicDetailHandler ────────────────────────────────────────────────


### PR DESCRIPTION
## What
Fix for inflated brand-presence citation counts on the Postgres-backed prompt/topic detail endpoints, surfaced via project-elmo-ui's URL Inspector showing implausible numbers like 62 "owned citations" against a prompt with only 1 execution.

Root cause (A): `aggregateDetailSources` (`src/controllers/llmo/llmo-brand-presence.js`) counted one citation per `brand_presence_sources` row, not per distinct execution — a single execution can produce multiple rows for the same URL (e.g. one row per inline citation marker in that execution's answer), inflating `citationCount` past the number of executions that actually cite it.

Fix (B): carry `execution_id` through `flattenSourceRow` (it was being dropped before reaching `aggregateDetailSources`), then dedupe both `citationCount` and per-prompt counts in `aggregateDetailSources` by distinct `execution_id` — a URL cited multiple times within one execution's answer now counts once. Rows without an `execution_id` still always count, preserving prior behavior for that (not expected in practice) edge case.

## Tests
Added two cases to the `aggregateDetailSources` suite: no double-counting across multiple rows sharing the same `execution_id`, and correct counting across distinct `execution_id`s. Full `llmo-brand-presence.test.js` suite (515 tests) green locally; eslint clean.

## Related
Related to [LLMO-1933](https://jira.corp.adobe.com/browse/LLMO-1933)
Surfaced while investigating project-elmo-ui's URL Inspector "show only cited executions" work (LLMO-1933) — this bug is separate and backend-only; no frontend change needed once this lands. No GitHub issue filed; described directly here.
