### PR TITLE
fix(serenity): finish LLMO-6190 headroom wiring (unbreak type-check + build)

### DIFF
--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -224,7 +224,7 @@ function validateCreateBody(body) {
 async function generateAndAttachPrompts(transport, workspaceId, projectId, {
   domain, country, topicCap = 0, brandNames = [], provisioned, env,
   writeDeadline = computeWriteDeadline(),
-}, log) {
+}, log, headroom) {
   const raw = await transport.getBrandTopics(workspaceId, { domain, country });
   let topics = [];
   if (Array.isArray(raw)) {
@@ -312,6 +312,13 @@ async function generateAndAttachPrompts(transport, workspaceId, projectId, {
       });
     }
   }
+
+  // PROMPT metering seam (Rainer, live-verified LLMO-6190): front headroom sized
+  // on the real generated prompt count (`texts.size`) BEFORE the metered
+  // `createPromptsByIds` writes below — the disguised-quota 405 fires there, not
+  // at publish. No-op when the flag is OFF; NOT optional-chained, a caller that
+  // forgets to thread the guard must fail loud.
+  await headroom.ensure({ prompts: texts.size }, { includeDrafted: true });
 
   for (const { items, tagIds } of byTagSet.values()) {
     // eslint-disable-next-line no-await-in-loop

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -242,20 +242,6 @@ export async function handleCreatePromptsSubworkspace(
     invalidateTagCacheForProject(workspaceId, pid);
   }
 
-  // PROMPT metering seam: the just-created prompts are drafted synchronously across the affected
-  // projects of THIS child; size headroom from `used + drafted` (includeDrafted, staleness-immune)
-  // before the publish. One workspace-level top-up covers all affected projects (the allocation is
-  // per sub-workspace, not per project). No-op when the flag is OFF; skipped when nothing was
-  // created so the OFF path and the empty path issue zero headroom reads.
-  if (affectedProjectIds.length > 0) {
-    const headroom = createHeadroomGuard(
-      transport,
-      { enabled: dynamicAllocation, subWorkspaceId: workspaceId, parentWorkspaceId },
-      log,
-    );
-    await headroom.ensure({}, { includeDrafted: true });
-  }
-
   if (deferPublish) {
     log?.info?.('serenity create-prompts (subworkspace): deferPublish set — prompts written as draft, publish skipped', {
       workspaceId, created: created.length, skipped: skipped.length, failed: failed.length,

--- a/test/support/serenity/handlers/prompts-subworkspace.test.js
+++ b/test/support/serenity/handlers/prompts-subworkspace.test.js
@@ -202,7 +202,9 @@ describe('prompts-subworkspace handlers', () => {
         prompts: [{
           text: 'p', tagIds: ['tag-1'], geoTargetId: 2840, languageCode: 'en',
         }],
-      }, log, undefined, { dynamicAllocation: true, parentWorkspaceId: 'parent-ws' });
+      }, log, undefined, undefined, undefined, {
+        dynamicAllocation: true, parentWorkspaceId: 'parent-ws',
+      });
       expect(result.created).to.have.length(1);
       expect(transport.getWorkspaceResources).to.have.been.calledOnceWith(WS);
       expect(transport.getWorkspaceResources)


### PR DESCRIPTION
## Summary

The `feat/serenity-intent-classification` branch shipped the LLMO-6190 dynamic-allocation headroom guard **half-wired**, which is why the branch's own CI (PR #2785) and the stacked edit-path PR #2875 are both red. This fixes the base breakage. Base is `feat/serenity-intent-classification`, not `main`.

### What was broken (reproduced on the pristine base)
- `type-check`: `markets-subworkspace.js` — `generateAndAttachPrompts`'s JSDoc documents a required `headroom` param and the caller passes it, but the function never declared/used it (TS8024 + TS2554: 6 args to a 5-param fn).
- `ci / build` (eslint): `prompts-subworkspace.js:251` — a second `headroom` guard shadowed the one at line 171 (`no-shadow`).
- test: `handleCreatePromptsSubworkspace` dynamic-allocation test failed — its options object was passed in the `env` positional slot instead of the 8th, so the guard was never enabled.

### Fixes
1. **`markets-subworkspace.js`** — add `headroom` as the 6th param to `generateAndAttachPrompts` and front `headroom.ensure({ prompts: texts.size }, { includeDrafted: true })` before the metered `createPromptsByIds` write loop (the metered write is the create, not publish). Matches the JSDoc + the `prompts-subworkspace.js` twin. No-op when the flag is OFF.
2. **`prompts-subworkspace.js`** — ⚠️ **behavior change, please scrutinize:** removed the redundant pre-publish `ensure` (which re-created a second guard → the `no-shadow`, and issued a second `getWorkspaceResources` read). The LLMO-6190 design meters **once before the write** (test title: "front headroom before the write, *not just before publish*"; assertion: `getWorkspaceResources` called **once**, before `createPromptsByIds`). The pre-write `ensure` at line 176 already reserves the whole batch, so the pre-publish read was a pre-LLMO-6190 leftover. If a second pre-publish top-up is intentional, this is the line to push back on.
3. **`prompts-subworkspace.test.js`** — fixed the stale positional call (options → 8th slot) to match the controller + signature.

### Verification
Type-check clean, lint clean. Combined with PR #2875, the three serenity handler test suites are **223 passing / 0 failing**.

### ⚠️ Interdependency with #2875
This PR and #2875 are complementary — the feature branch is broken in two places and each PR fixes one, so **neither is green alone**; both must merge for `feat/serenity-intent-classification` (and PR #2785) to go green. Verified locally that edit-path + headroom together are fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)