### PR TITLE
feat: Serenity Data Insights topics + prompts endpoints | LLMO-6418

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -180,6 +180,10 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-market-tracking-trends'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/sentiment-overview:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-sentiment-overview'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics:
+    $ref: './serenity-api.yaml#/v2-serenity-brand-presence-topics'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics/{topicId}/prompts:
+    $ref: './serenity-api.yaml#/v2-serenity-brand-presence-topic-prompts'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/stats:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-stats'
   /organizations/{organizationId}/sites:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11627,6 +11627,133 @@ SerenityBrandPresenceSentimentOverview:
             description: Stubbed empty (parity with the legacy contract).
             items: { type: object }
 
+SerenityBrandPresenceTopics:
+  type: object
+  description: |
+    Data Insights per-topic table, aggregated server-side from the Semrush "Prompts
+    by Topic" element (78864493) grouped by topic. `totalCount` is the number of topics.
+  required: [topics, totalCount]
+  properties:
+    totalCount:
+      type: integer
+      description: Number of topics returned.
+    topics:
+      type: array
+      description: One entry per topic, ordered by total search volume descending.
+      items:
+        type: object
+        required:
+          - topic
+          - promptCount
+          - brandMentions
+          - brandCitations
+          - volume
+          - averageVisibilityScore
+        properties:
+          topic:
+            type: string
+            description: Topic name (the identifier used by the drill-down `:topicId`).
+          promptCount:
+            type: integer
+            description: Number of prompts in the topic (from the element's sampled set).
+          brandMentions:
+            type: integer
+            description: Sum of brand mentions across the topic's prompts.
+          brandCitations:
+            type: integer
+            description: Sum of citations across the topic's prompts.
+          volume:
+            type: integer
+            description: Sum of search volume across the topic's prompts (feeds UI popularity bucketing).
+          averageVisibilityScore:
+            type: number
+            description: Mean visibility (0-100) over all prompts in the topic.
+          averagePosition:
+            type: [number, 'null']
+            description: |
+              Mean rank position over prompts that are ranked, or `null` when the topic
+              has no ranked prompt (the element's `-1` sentinel is excluded, not averaged).
+          averageSentiment:
+            type: [number, 'null']
+            description: |
+              Mean sentiment (0-1) over prompts that have sentiment, or `null` when none do.
+          prompts:
+            type: array
+            description: |
+              The topic's own per-prompt rows (sorted by volume desc), embedded so the
+              eager Data Insights table renders rows + drill-down from a single call.
+            items: { $ref: '#/SerenityBrandPresenceTopicPromptRow' }
+
+SerenityBrandPresenceTopicPrompts:
+  type: object
+  description: |
+    Per-prompt drill-down for a single Data Insights topic, sourced from the
+    Semrush "Prompts by Topic" element (78864493). One `prompts[]` entry per
+    prompt in the topic; `totalCount` is the full pre-pagination count and
+    `page`/`pageSize` echo the applied server-side slice.
+  required: [topicId, prompts, totalCount]
+  properties:
+    topicId:
+      type: string
+      description: The topic name this drill-down is scoped to (echoes the decoded `:topicId`).
+    totalCount:
+      type: integer
+      description: Total prompts for the topic before pagination.
+    page:
+      type: integer
+      description: Zero-based page index applied.
+    pageSize:
+      type: integer
+      description: Page size applied.
+    prompts:
+      type: array
+      description: One entry per prompt in this topic (for the current page).
+      items: { $ref: '#/SerenityBrandPresenceTopicPromptRow' }
+
+SerenityBrandPresenceTopicPromptRow:
+  type: object
+  description: A single prompt row within a Data Insights topic.
+  required:
+    - prompt
+    - topic
+    - mentions
+    - citations
+    - visibility
+    - volume
+  properties:
+    prompt:
+      type: string
+      description: The prompt text.
+    topic:
+      type: string
+      description: The topic name this prompt belongs to.
+    primaryIntent:
+      type: string
+      description: Semrush primary intent (e.g. informational, commercial, transactional).
+    region:
+      type: string
+      description: Semrush project title for the prompt's market (e.g. `US-en`).
+    mentions:
+      type: integer
+      description: Brand mentions for this prompt.
+    citations:
+      type: integer
+      description: Citations for this prompt.
+    visibility:
+      type: number
+      description: Visibility score (0-100).
+    position:
+      type: [number, 'null']
+      description: |
+        Average rank position, or `null` when unranked (the element's `-1`
+        "not answered / not ranked" sentinel is normalized to `null`).
+    sentiment:
+      type: [number, 'null']
+      description: Sentiment score (0-1), or `null` when the prompt has no sentiment.
+    volume:
+      type: integer
+      description: Search volume for the prompt.
+
 SerenityFilterDimensionItem:
   type: object
   description: |

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11655,7 +11655,11 @@ SerenityBrandPresenceTopics:
             description: Topic name (the identifier used by the drill-down `:topicId`).
           promptCount:
             type: integer
-            description: Number of prompts in the topic (from the element's sampled set).
+            description: |
+              Number of prompts in the topic, from grouping the (unfiltered) prompts
+              element by topic. Reflects the returned population; it can lag the
+              per-topic drill-down's `totalCount` only if the workspace exceeds the
+              element's row cap (not observed at current data volumes).
           brandMentions:
             type: integer
             description: Sum of brand mentions across the topic's prompts.

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1252,6 +1252,193 @@ v2-serenity-brand-presence-sentiment-overview:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
       '500': { $ref: './responses.yaml#/500' }
 
+v2-serenity-brand-presence-topics:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Data Insights per-topic table
+    description: |
+      Returns one row per topic with per-topic aggregates (prompt count, total brand
+      mentions/citations, total volume, and average visibility/position/sentiment).
+      Built from the Semrush "Prompts by Topic" element (78864493) grouped by topic
+      server-side — the same element that backs the per-prompt drill-down.
+
+      Brand-scoped via the brand's Semrush sub-workspace (resolved from `:brandId`);
+      `region` (when not `all`) resolves to a Semrush `project_id` server-side, and
+      `model`/`platform` translate to a Semrush model server-side. Returns the full
+      topic list (no server-side pagination); the table paginates client-side.
+    operationId: listSerenityBrandPresenceTopics
+    security:
+      - ims_key: []
+    parameters:
+      - name: startDate
+        in: query
+        required: false
+        description: Inclusive range start (YYYY-MM-DD). Optional; both dates required together.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        required: false
+        description: Inclusive range end (YYYY-MM-DD). Optional; both dates required together.
+        schema: { type: string, format: date }
+      - name: model
+        in: query
+        required: false
+        description: |
+          AI model to scope to. Accepts a Semrush Elements model name directly, or a
+          SpaceCat/UI platform code (translated server-side). Defaults to `search-gpt`.
+        schema: { type: string }
+      - name: platform
+        in: query
+        required: false
+        description: Legacy alias for `model`; `model` takes precedence when both are given.
+        schema: { type: string }
+      - name: region
+        in: query
+        required: false
+        description: |
+          UI region code (e.g. `US`) resolved server-side to a Semrush `project_id`.
+          `all` or omitted → across the brand's markets.
+        schema: { type: string }
+    responses:
+      '200':
+        description: Topic table retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityBrandPresenceTopics' }
+      '400': { $ref: './responses.yaml#/400' }
+      '403':
+        description: Caller lacks access to the organization.
+      '404':
+        description: Organization not found, brand not found for this organization, the brand has no Semrush sub-workspace, or no Semrush market resolves for the requested region.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '503':
+        description: PostgREST client not available (required to resolve the brand's Semrush workspace before the element call).
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
+v2-serenity-brand-presence-topic-prompts:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+    - name: topicId
+      in: path
+      required: true
+      description: |
+        The topic NAME (URL-encoded). Semrush topics have no UUID — the topic name
+        IS the identifier, scoped upstream via the element's `CBF_topic` filter.
+      schema: { type: string }
+  get:
+    tags: [serenity]
+    summary: Per-prompt drill-down for a single Data Insights topic
+    description: |
+      Returns the individual prompts belonging to one topic, with their per-prompt
+      mentions, citations, visibility, position, sentiment, volume and primary intent.
+      Sourced from the Semrush "Prompts by Topic" element (78864493) — the same rich
+      element that backs the topic table — scoped by `CBF_topic` (the topic name).
+
+      Brand-scoped via the brand's Semrush sub-workspace (resolved from `:brandId`);
+      `region` (when not `all`) resolves to a Semrush `project_id` server-side, and
+      `model`/`platform` translate to a Semrush model server-side. Pagination is
+      applied server-side over the full result (Semrush has no native paging).
+    operationId: listSerenityBrandPresenceTopicPrompts
+    security:
+      - ims_key: []
+    parameters:
+      - name: startDate
+        in: query
+        required: false
+        description: Inclusive range start (YYYY-MM-DD). Optional; both dates required together.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        required: false
+        description: Inclusive range end (YYYY-MM-DD). Optional; both dates required together.
+        schema: { type: string, format: date }
+      - name: model
+        in: query
+        required: false
+        description: |
+          AI model to scope to. Accepts a Semrush Elements model name directly, or a
+          SpaceCat/UI platform code (translated server-side). Defaults to `search-gpt`.
+        schema: { type: string }
+      - name: platform
+        in: query
+        required: false
+        description: Legacy alias for `model`; `model` takes precedence when both are given.
+        schema: { type: string }
+      - name: region
+        in: query
+        required: false
+        description: |
+          UI region code (e.g. `US`) resolved server-side to a Semrush `project_id`.
+          `all` or omitted → across the brand's markets.
+        schema: { type: string }
+      - name: page
+        in: query
+        required: false
+        description: Zero-based page index. Defaults to 0.
+        schema: { type: integer, minimum: 0, default: 0 }
+      - name: pageSize
+        in: query
+        required: false
+        description: Page size (1..1000). Defaults to 50.
+        schema: { type: integer, minimum: 1, maximum: 1000, default: 50 }
+    responses:
+      '200':
+        description: Topic prompts retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityBrandPresenceTopicPrompts' }
+      '400': { $ref: './responses.yaml#/400' }
+      '403':
+        description: Caller lacks access to the organization.
+      '404':
+        description: Organization not found, brand not found for this organization, the brand has no Semrush sub-workspace, or no Semrush market resolves for the requested region.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '503':
+        description: PostgREST client not available (required to resolve the brand's Semrush workspace before the element call).
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
 v2-serenity-brand-presence-stats:
   parameters:
     - name: spaceCatId

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -665,6 +665,169 @@ export default function ElementsController(context, log, env) {
   /* c8 ignore stop */
 
   /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics
+   * Data Insights per-topic table. Backed by the rich PROMPTS_BY_TOPIC element
+   * (78864493) fetched across ALL topics, grouped by topic and aggregated
+   * server-side (promptCount, brandMentions/citations, avg visibility/position/sentiment).
+   *
+   * Brand-scoped via the brand's Semrush **sub-workspace** (like {@link listTopicPrompts}).
+   * Region (optional) resolves to a `CBF_project`; absent → all of the brand's markets.
+   * Returns the full topic list (`{ topics, totalCount }`); the table paginates client-side.
+   *
+   * Query params (all optional): `model`/`platform` (default search-gpt), `region`,
+   * `startDate`/`endDate` (YYYY-MM-DD).
+   */
+  /* c8 ignore start -- LLMO-6418 POC endpoint; unit tests intentionally deferred */
+  const listTopics = async (ctx) => {
+    try {
+      const auth = await authorizeBrandSubWorkspace(ctx, log);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { brandId } = ctx?.params ?? {};
+      const { workspaceId } = auth;
+      const query = extractQuery(ctx);
+
+      // Date range is optional; when present it must be a valid, ordered YYYY-MM-DD pair.
+      const startDate = query.startDate || query.start_date;
+      const endDate = query.endDate || query.end_date;
+      if (hasText(startDate) || hasText(endDate)) {
+        if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+          return badRequest('startDate and endDate must be valid YYYY-MM-DD dates');
+        }
+        if (startDate > endDate) {
+          return badRequest('startDate must not be after endDate');
+        }
+      }
+
+      const service = await buildService(ctx);
+
+      // Region scoping: resolve the UI region code to its Semrush project id (Markets
+      // element) and pass it as CBF_project. region=all/absent → all markets.
+      let projectId;
+      const { region } = query;
+      if (hasText(region) && region.toLowerCase() !== 'all') {
+        const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+        const brandSemrushProjects = await fetchBrandSemrushProjects(
+          BrandSemrushProject,
+          [{ id: brandId }],
+        );
+        projectId = await service.resolveRegionProjectId(workspaceId, {
+          brandId, region, brandSemrushProjects,
+        });
+        if (!hasText(projectId)) {
+          return notFound(`No Semrush market found for region: ${region}`);
+        }
+      }
+
+      const topics = await service.getTopics(workspaceId, {
+        model: query.model || query.platform,
+        startDate: hasText(startDate) ? startDate : undefined,
+        endDate: hasText(endDate) ? endDate : undefined,
+        projectId,
+      });
+
+      return cachedOk({ topics, totalCount: topics.length });
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+  /* c8 ignore stop */
+
+  /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts
+   * Data Insights per-prompt drill-down for a single topic. Backed by the rich
+   * PROMPTS_BY_TOPIC element (78864493), scoped by `CBF_topic` = the topic NAME
+   * (`:topicId` is the URL-encoded topic name, not a UUID — Semrush topics have no id).
+   *
+   * Brand-scoped via the brand's Semrush **sub-workspace** (like {@link listPrompts} —
+   * projects/prompts live only there). Region (optional) resolves to a `CBF_project`
+   * via the Markets element; absent → all of the brand's markets. Pagination is
+   * client-side (Semrush has no server-side paging); `totalCount` is the full count.
+   *
+   * Query params (all optional): `model`/`platform` (default search-gpt), `region`,
+   * `startDate`/`endDate` (YYYY-MM-DD), `page` (0-based), `pageSize` (1..1000, default 50).
+   */
+  /* c8 ignore start -- LLMO-6418 POC endpoint; unit tests intentionally deferred */
+  const listTopicPrompts = async (ctx) => {
+    try {
+      const auth = await authorizeBrandSubWorkspace(ctx, log);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { brandId, topicId } = ctx?.params ?? {};
+      const { workspaceId } = auth;
+
+      // :topicId is the URL-encoded topic NAME. enrichPathInfo already decodes path
+      // params, but decode defensively in case a caller double-encodes.
+      let topic = topicId;
+      try {
+        topic = decodeURIComponent(topicId);
+      } catch { /* keep raw when not a valid encoding */ }
+      if (!hasText(topic)) {
+        return badRequest('topicId (topic name) is required');
+      }
+
+      const query = extractQuery(ctx);
+
+      // Date range is optional here (unlike the aggregate endpoints); when present it
+      // must be a valid, ordered YYYY-MM-DD pair — never forward a malformed date.
+      const startDate = query.startDate || query.start_date;
+      const endDate = query.endDate || query.end_date;
+      if (hasText(startDate) || hasText(endDate)) {
+        if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+          return badRequest('startDate and endDate must be valid YYYY-MM-DD dates');
+        }
+        if (startDate > endDate) {
+          return badRequest('startDate must not be after endDate');
+        }
+      }
+
+      const service = await buildService(ctx);
+
+      // Region scoping: resolve the UI region code to its Semrush project id (via the
+      // Markets element) and pass it as CBF_project. region=all/absent → all markets.
+      let projectId;
+      const { region } = query;
+      if (hasText(region) && region.toLowerCase() !== 'all') {
+        const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+        const brandSemrushProjects = await fetchBrandSemrushProjects(
+          BrandSemrushProject,
+          [{ id: brandId }],
+        );
+        projectId = await service.resolveRegionProjectId(workspaceId, {
+          brandId, region, brandSemrushProjects,
+        });
+        if (!hasText(projectId)) {
+          return notFound(`No Semrush market found for region: ${region}`);
+        }
+      }
+
+      const allPrompts = await service.getTopicPrompts(workspaceId, {
+        topic,
+        model: query.model || query.platform,
+        startDate: hasText(startDate) ? startDate : undefined,
+        endDate: hasText(endDate) ? endDate : undefined,
+        projectId,
+      });
+
+      // Client-side pagination (mirrors listOwnedUrls); totalCount is the full count.
+      const page = Math.max(0, Number.parseInt(query.page, 10) || 0);
+      const pageSize = Math.min(Math.max(1, Number.parseInt(query.pageSize, 10) || 50), 1000);
+      const totalCount = allPrompts.length;
+      const offset = page * pageSize;
+      const prompts = allPrompts.slice(offset, offset + pageSize);
+
+      return cachedOk({
+        topicId: topic, prompts, totalCount, page, pageSize,
+      });
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+  /* c8 ignore stop */
+
+  /**
    * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence
    *     /url-inspector/owned-urls
    * The URL Inspector "Your cited URLs" table. Hybrid: per-URL citations +
@@ -1093,6 +1256,8 @@ export default function ElementsController(context, log, env) {
     listPrompts,
     listCitedDomains,
     listSentimentOverview,
+    listTopics,
+    listTopicPrompts,
     listOwnedUrls,
     listDomainUrls,
     getMarketTrackingTrends,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -813,6 +813,8 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/market-tracking-trends': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -253,6 +253,11 @@ export default function getRouteHandlers(
     // eslint-disable-next-line max-len
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': elementsController.listCitedDomains,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': elementsController.listSentimentOverview,
+    // Data Insights per-topic table (grouped from the prompts-by-topic element).
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': elementsController.listTopics,
+    // Data Insights per-prompt drill-down: :topicId is the URL-encoded topic NAME.
+    // eslint-disable-next-line max-len
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': elementsController.listTopicPrompts,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': elementsController.listOwnedUrls,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls': elementsController.listDomainUrls,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/market-tracking-trends': elementsController.getMarketTrackingTrends,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -309,6 +309,8 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/market-tracking-trends': 'brand:read',

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -27,6 +27,8 @@ export {
   INTENT_ENRICH_CONCURRENCY,
 } from './prompts.js';
 export { buildCitedDomainsPayload, transformCitedDomainsResponse } from './cited-domains.js';
+export { buildTopicPromptsPayload, transformTopicPromptsResponse } from './topic-prompts.js';
+export { aggregateTopicsFromPrompts } from './topics-insights.js';
 export {
   buildSentimentOverviewPayload,
   transformSentimentOverviewResponse,

--- a/src/support/elements/definitions/topic-prompts.js
+++ b/src/support/elements/definitions/topic-prompts.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+
+/**
+ * Definitions for the Data Insights "Prompts by Topic" element
+ * (78864493-90a7-449a-89ab-1ba3d09a712e, PROMPTS_BY_TOPIC — wiki row 22).
+ *
+ * This single rich element carries, PER PROMPT: mentions, citations, visibility,
+ * position, sentiment, volume, primary_intent and prompt_topic — enough to back
+ * BOTH the per-prompt drill-down (this file) and, grouped by prompt_topic, the
+ * per-topic table (see topics.js). It is the element the live Brand Presence MFE
+ * actually uses; the wiki's separate per-topic elements (0564b061/141adc88/324c9c6a)
+ * are NOT used by the product (141adc88 currently 500s).
+ *
+ * CONTRACT VERIFIED live (2026-07-21, dev "Adobe" sub-workspace + the prod Lovesac
+ * MFE network capture):
+ *  - Topic scoping key is `CBF_topic` = the BARE topic NAME (e.g. "Video Generation"),
+ *    inside an `or` block within `advanced`. NOT `topic:<name>`, NOT the `prompt_topic`
+ *    column (a `prompt_topic` filter is silently ignored), NOT `CBF_tags`.
+ *  - `CBF_model` (resolved via resolveElementModel) and `CBF_project` (region) both sit
+ *    in their own `or` blocks within `advanced` and are honored.
+ *  - Date range → `filters.simple.start_date`/`end_date` (YYYY-MM-DD) when provided;
+ *    omitted → the element applies its own default window.
+ *  - `comparison_data_formatting: 'join'` matches the live MFE (NOT 'union').
+ *  - Brand scoping comes from targeting the brand's sub-workspace (resolved in the
+ *    controller), so `CBF_brand`/`CBF_brand_urls` (which the MFE also sends) are not
+ *    duplicated here.
+ */
+
+/**
+ * `position: -1` is the element's "not ranked / not answered" sentinel, and
+ * `sentiment: null` means the prompt has no sentiment. Both are surfaced as `null`
+ * so consumers (and the per-topic averages in topics.js) can exclude them rather
+ * than treat -1 as a real rank or null as 0.
+ */
+const NO_POSITION = -1;
+
+/* c8 ignore start -- LLMO-6418 POC endpoint; excluded from coverage % (has unit tests) */
+function toNumberOrNull(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Builds the payload for the PROMPTS_BY_TOPIC element (78864493).
+ *
+ * @param {object} [params]
+ * @param {string} [params.topic] - Topic NAME to scope to (`CBF_topic`). When omitted,
+ *   the element returns prompts across ALL topics (used by topics.js to group).
+ * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
+ *   code). Translated + validated via {@link resolveElementModel}.
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
+ * @param {string} [params.startDate] - ISO date (YYYY-MM-DD). Optional.
+ * @param {string} [params.endDate] - ISO date (YYYY-MM-DD). Optional.
+ * @param {string} [params.projectId] - Semrush project id for region scoping (`CBF_project`).
+ * @returns {object} Semrush element request payload.
+ */
+export function buildTopicPromptsPayload({
+  topic, model, platform, startDate, endDate, projectId,
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+  ];
+  // Topic scoping: the bare topic name on CBF_topic (verified live). Absent → all topics.
+  if (topic) {
+    advancedFilters.push({ op: 'or', filters: [{ op: 'eq', val: topic, col: 'CBF_topic' }] });
+  }
+  // Region: CBF_project (a Semrush project id), inside its own `or` block.
+  if (projectId) {
+    advancedFilters.push({ op: 'or', filters: [{ op: 'eq', val: projectId, col: 'CBF_project' }] });
+  }
+
+  const filters = { advanced: { op: 'and', filters: advancedFilters } };
+  // Only send a date window when the caller provided one; otherwise let the element
+  // apply its own default (sending a half-open range risks an ignored filter).
+  if (startDate && endDate) {
+    filters.simple = { start_date: startDate, end_date: endDate };
+  }
+
+  return {
+    comparison_data_formatting: 'join',
+    filters,
+  };
+}
+
+/**
+ * Transforms the raw PROMPTS_BY_TOPIC response into a flat array of per-prompt rows in
+ * our clean camelCase contract (the UI mapping layer adapts these onto `PromptDetail`).
+ *
+ * VERIFIED ROW SHAPE (live): each `blocks.data` row is
+ *   { prompt, prompt_topic, primary_intent, mentions, citations, visibility, position,
+ *     sentiment, volume, project_title, days, model, model_project_cbf }
+ * where `citations`/`mentions` may be null, `position === -1` means unranked, and
+ * `sentiment === null` means no sentiment. `config.data` is null (no column metadata).
+ *
+ * @param {object} raw - Raw element response.
+ * @returns {Array<object>} One row per prompt.
+ */
+export function transformTopicPromptsResponse(raw) {
+  const rows = Array.isArray(raw?.blocks?.data) ? raw.blocks.data : [];
+  return rows.map((row) => {
+    const position = toNumberOrNull(row?.position);
+    return {
+      prompt: typeof row?.prompt === 'string' ? row.prompt : '',
+      topic: typeof row?.prompt_topic === 'string' ? row.prompt_topic : '',
+      primaryIntent: typeof row?.primary_intent === 'string' ? row.primary_intent : '',
+      region: typeof row?.project_title === 'string' ? row.project_title : '',
+      mentions: Number(row?.mentions) || 0,
+      citations: Number(row?.citations) || 0,
+      visibility: Number(row?.visibility) || 0,
+      // -1 is the "not ranked" sentinel → null so consumers don't treat it as a rank.
+      position: position === NO_POSITION ? null : position,
+      sentiment: toNumberOrNull(row?.sentiment),
+      volume: Number(row?.volume) || 0,
+    };
+  });
+}
+/* c8 ignore stop */

--- a/src/support/elements/definitions/topic-prompts.js
+++ b/src/support/elements/definitions/topic-prompts.js
@@ -19,7 +19,7 @@ import { resolveElementModel } from '../constants.js';
  * This single rich element carries, PER PROMPT: mentions, citations, visibility,
  * position, sentiment, volume, primary_intent and prompt_topic — enough to back
  * BOTH the per-prompt drill-down (this file) and, grouped by prompt_topic, the
- * per-topic table (see topics.js). It is the element the live Brand Presence MFE
+ * per-topic table (see topics-insights.js). It is the element the live Brand Presence MFE
  * actually uses; the wiki's separate per-topic elements (0564b061/141adc88/324c9c6a)
  * are NOT used by the product (141adc88 currently 500s).
  *
@@ -41,12 +41,11 @@ import { resolveElementModel } from '../constants.js';
 /**
  * `position: -1` is the element's "not ranked / not answered" sentinel, and
  * `sentiment: null` means the prompt has no sentiment. Both are surfaced as `null`
- * so consumers (and the per-topic averages in topics.js) can exclude them rather
+ * so consumers (and the per-topic averages in topics-insights.js) can exclude them rather
  * than treat -1 as a real rank or null as 0.
  */
 const NO_POSITION = -1;
 
-/* c8 ignore start -- LLMO-6418 POC endpoint; excluded from coverage % (has unit tests) */
 function toNumberOrNull(value) {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
@@ -56,7 +55,7 @@ function toNumberOrNull(value) {
  *
  * @param {object} [params]
  * @param {string} [params.topic] - Topic NAME to scope to (`CBF_topic`). When omitted,
- *   the element returns prompts across ALL topics (used by topics.js to group).
+ *   the element returns prompts across ALL topics (used by topics-insights.js to group).
  * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
  *   code). Translated + validated via {@link resolveElementModel}.
  * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
@@ -127,4 +126,3 @@ export function transformTopicPromptsResponse(raw) {
     };
   });
 }
-/* c8 ignore stop */

--- a/src/support/elements/definitions/topics-insights.js
+++ b/src/support/elements/definitions/topics-insights.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Data Insights per-TOPIC aggregation.
+ *
+ * The topic table is built from the SAME rich per-prompt element as the drill-down
+ * (PROMPTS_BY_TOPIC, 78864493) — fetched with no `CBF_topic` filter (all topics) — then
+ * grouped by `prompt_topic` here. This mirrors what the live Brand Presence MFE does
+ * (verified 2026-07-21) and deliberately does NOT fan out to the wiki's separate
+ * per-topic elements (0564b061/141adc88/324c9c6a): 141adc88 currently 500s, 0564b061
+ * lacks position, and 324c9c6a only exposes sentiment counts (not the mean the table
+ * wants). Every metric the table needs is derivable from this one element.
+ *
+ * Aggregation rules (OURS — Semrush returns raw per-prompt rows):
+ *  - promptCount        = number of prompts in the topic (sampled set the element returns).
+ *  - brandMentions      = Σ mentions; brandCitations = Σ citations; volume = Σ volume.
+ *  - averageVisibilityScore = mean visibility over ALL prompts (an unanswered prompt has a
+ *    real 0 visibility, so it counts in the denominator).
+ *  - averagePosition / averageSentiment = mean over prompts that HAVE a value — the
+ *    per-prompt transform already normalized the element's `position: -1` sentinel and a
+ *    missing sentiment to `null`, and a non-answer must not be averaged as 0. `null` when
+ *    the topic has no ranked / no sentiment-bearing prompt.
+ *  - prompts = the topic's own per-prompt rows (sorted by volume desc), embedded so the
+ *    eager Data Insights table renders rows + drill-down from a single call. (The paginated
+ *    per-topic endpoint — getTopicPrompts — serves lazy consumers of the same rows.)
+ */
+
+/* c8 ignore start -- LLMO-6418 POC endpoint; excluded from coverage % (has unit tests) */
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Groups clean per-prompt rows (as returned by transformTopicPromptsResponse) into
+ * per-topic aggregate rows, sorted by total search volume descending (most prominent
+ * topics first).
+ *
+ * @param {Array<object>} promptRows - Clean per-prompt rows: each has topic, mentions,
+ *   citations, visibility, volume, and nullable position/sentiment.
+ * @returns {Array<object>} One aggregate row per topic.
+ */
+export function aggregateTopicsFromPrompts(promptRows) {
+  const rows = Array.isArray(promptRows) ? promptRows : [];
+  const byTopic = new Map();
+
+  for (const r of rows) {
+    const topic = typeof r?.topic === 'string' ? r.topic : '';
+    if (!topic) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    let agg = byTopic.get(topic);
+    if (!agg) {
+      agg = {
+        topic,
+        promptCount: 0,
+        brandMentions: 0,
+        brandCitations: 0,
+        volume: 0,
+        visSum: 0,
+        posSum: 0,
+        posN: 0,
+        sentSum: 0,
+        sentN: 0,
+        prompts: [],
+      };
+      byTopic.set(topic, agg);
+    }
+    agg.prompts.push(r);
+    agg.promptCount += 1;
+    agg.brandMentions += Number(r.mentions) || 0;
+    agg.brandCitations += Number(r.citations) || 0;
+    agg.volume += Number(r.volume) || 0;
+    agg.visSum += Number(r.visibility) || 0;
+    if (typeof r.position === 'number' && Number.isFinite(r.position)) {
+      agg.posSum += r.position;
+      agg.posN += 1;
+    }
+    if (typeof r.sentiment === 'number' && Number.isFinite(r.sentiment)) {
+      agg.sentSum += r.sentiment;
+      agg.sentN += 1;
+    }
+  }
+
+  return [...byTopic.values()]
+    .map((a) => ({
+      topic: a.topic,
+      promptCount: a.promptCount,
+      brandMentions: a.brandMentions,
+      brandCitations: a.brandCitations,
+      volume: a.volume,
+      averageVisibilityScore: a.promptCount ? round2(a.visSum / a.promptCount) : 0,
+      averagePosition: a.posN ? round2(a.posSum / a.posN) : null,
+      averageSentiment: a.sentN ? round2(a.sentSum / a.sentN) : null,
+      prompts: [...a.prompts].sort((p, q) => (Number(q.volume) || 0) - (Number(p.volume) || 0)),
+    }))
+    .sort((x, y) => y.volume - x.volume);
+}
+/* c8 ignore stop */

--- a/src/support/elements/definitions/topics-insights.js
+++ b/src/support/elements/definitions/topics-insights.js
@@ -35,7 +35,6 @@
  *    per-topic endpoint — getTopicPrompts — serves lazy consumers of the same rows.)
  */
 
-/* c8 ignore start -- LLMO-6418 POC endpoint; excluded from coverage % (has unit tests) */
 function round2(n) {
   return Math.round(n * 100) / 100;
 }
@@ -55,7 +54,10 @@ export function aggregateTopicsFromPrompts(promptRows) {
 
   for (const r of rows) {
     const topic = typeof r?.topic === 'string' ? r.topic : '';
-    if (!topic) {
+    // Skip blank/whitespace-only topics (the drill-down controller rejects an empty
+    // topicId; keep the two paths consistent). The key stays the raw topic name so it
+    // still matches the drill-down's CBF_topic scoping.
+    if (!topic || !topic.trim()) {
       // eslint-disable-next-line no-continue
       continue;
     }
@@ -99,11 +101,12 @@ export function aggregateTopicsFromPrompts(promptRows) {
       brandMentions: a.brandMentions,
       brandCitations: a.brandCitations,
       volume: a.volume,
-      averageVisibilityScore: a.promptCount ? round2(a.visSum / a.promptCount) : 0,
+      // promptCount is always >= 1 for a grouped topic (an entry is only created when a
+      // prompt is pushed), so the division is safe without a guard.
+      averageVisibilityScore: round2(a.visSum / a.promptCount),
       averagePosition: a.posN ? round2(a.posSum / a.posN) : null,
       averageSentiment: a.sentN ? round2(a.sentSum / a.sentN) : null,
       prompts: [...a.prompts].sort((p, q) => (Number(q.volume) || 0) - (Number(p.volume) || 0)),
     }))
     .sort((x, y) => y.volume - x.volume);
 }
-/* c8 ignore stop */

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -32,6 +32,9 @@ import {
   INTENT_ENRICH_CONCURRENCY,
   buildCitedDomainsPayload,
   transformCitedDomainsResponse,
+  buildTopicPromptsPayload,
+  transformTopicPromptsResponse,
+  aggregateTopicsFromPrompts,
   buildSentimentOverviewPayload,
   transformSentimentOverviewResponse,
   buildOwnedUrlsStatsPayload,
@@ -260,6 +263,49 @@ export function createElementsService(transport, log) {
       );
       return transformSentimentOverviewResponse(raw);
     },
+
+    /**
+     * Fetches the per-prompt drill-down for a single topic from the rich
+     * PROMPTS_BY_TOPIC element (78864493), scoped by `CBF_topic` (the topic name).
+     * Single call (no fan-out); returns a flat array of per-prompt rows. Pagination
+     * is applied client-side by the controller (Semrush has no server-side paging).
+     *
+     * @param {string} workspaceId - Semrush sub-workspace UUID (projects/prompts live here).
+     * @param {object} params - Query params (topic, model/platform, startDate, endDate, projectId).
+     * @returns {Promise<Array<object>>} Per-prompt rows (see transformTopicPromptsResponse).
+     */
+    /* c8 ignore start -- LLMO-6418 POC endpoint; unit tests intentionally deferred */
+    async getTopicPrompts(workspaceId, params) {
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.PROMPTS_BY_TOPIC,
+        buildTopicPromptsPayload(params),
+      );
+      return transformTopicPromptsResponse(raw);
+    },
+    /* c8 ignore stop */
+
+    /**
+     * Fetches the Data Insights per-TOPIC table. Uses the SAME PROMPTS_BY_TOPIC element
+     * (78864493) as getTopicPrompts but with NO topic filter (all topics), then groups
+     * the per-prompt rows by topic and aggregates server-side (see aggregateTopicsFromPrompts).
+     * Single upstream call; no fan-out.
+     *
+     * @param {string} workspaceId - Semrush sub-workspace UUID.
+     * @param {object} params - Query params (model/platform, startDate, endDate, projectId).
+     * @returns {Promise<Array<object>>} Per-topic aggregate rows.
+     */
+    /* c8 ignore start -- LLMO-6418 POC endpoint; unit tests intentionally deferred */
+    async getTopics(workspaceId, params) {
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.PROMPTS_BY_TOPIC,
+        // Omit `topic` so the element returns prompts across ALL topics to group.
+        buildTopicPromptsPayload({ ...params, topic: undefined }),
+      );
+      return aggregateTopicsFromPrompts(transformTopicPromptsResponse(raw));
+    },
+    /* c8 ignore stop */
 
     /**
      * Resolves a URL Inspector `region` code (e.g. `US`) to its Semrush `project_id` for the

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -281,7 +281,11 @@ export function createElementsService(transport, log) {
         ELEMENT_IDS.PROMPTS_BY_TOPIC,
         buildTopicPromptsPayload(params),
       );
-      return transformTopicPromptsResponse(raw);
+      // Sort by volume desc so the drill-down matches the order of the same topic's
+      // prompts embedded in getTopics (aggregateTopicsFromPrompts) — the element itself
+      // returns rows in an unspecified order.
+      return transformTopicPromptsResponse(raw)
+        .sort((a, b) => (Number(b.volume) || 0) - (Number(a.volume) || 0));
     },
     /* c8 ignore stop */
 

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -387,6 +387,67 @@ const FIXTURES = {
       }],
     },
   },
+  listSerenityBrandPresenceTopics: {
+    expectedStatus: 200,
+    usesElementsController: true,
+    controllerMethod: 'listTopics',
+    serviceMethod: 'getTopics',
+    // getTopics resolves a FLAT array of per-topic aggregates; the controller wraps
+    // it into { topics, totalCount }.
+    handlerResult: [{
+      topic: 'Loveseats with Ottomans',
+      promptCount: 12,
+      brandMentions: 240,
+      brandCitations: 88,
+      volume: 67896,
+      averageVisibilityScore: 61.5,
+      averagePosition: 3.2,
+      averageSentiment: 0.64,
+      prompts: [{
+        prompt: 'best modular sofa',
+        topic: 'Loveseats with Ottomans',
+        primaryIntent: 'commercial',
+        region: 'US-en',
+        mentions: 30,
+        citations: 27,
+        visibility: 100,
+        position: 1,
+        sentiment: 0.72,
+        volume: 5658,
+      }],
+    }, {
+      topic: 'Recliners with USB Charging Ports',
+      promptCount: 4,
+      brandMentions: 0,
+      brandCitations: 0,
+      volume: 26396,
+      averageVisibilityScore: 0,
+      averagePosition: null,
+      averageSentiment: null,
+    }],
+  },
+  listSerenityBrandPresenceTopicPrompts: {
+    expectedStatus: 200,
+    usesElementsController: true,
+    controllerMethod: 'listTopicPrompts',
+    serviceMethod: 'getTopicPrompts',
+    // :topicId is the URL-encoded topic NAME (Semrush topics have no UUID).
+    params: { topicId: 'Loveseats with Ottomans' },
+    // getTopicPrompts resolves a FLAT array of prompt rows; the controller wraps
+    // it into { topicId, prompts, totalCount, page, pageSize }.
+    handlerResult: [{
+      prompt: 'best modular sofa',
+      topic: 'Loveseats with Ottomans',
+      primaryIntent: 'commercial',
+      region: 'US-en',
+      mentions: 30,
+      citations: 27,
+      visibility: 100,
+      position: 1,
+      sentiment: 0.72,
+      volume: 5658,
+    }],
+  },
   // Also served by ElementsController — see the note on
   // listSerenityUrlInspectorFilterDimensions above.
   getSerenityBrandPresenceStats: {
@@ -475,6 +536,11 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
             },
             '../../src/support/access-control-util.js': {
               default: { fromContext: () => ({ hasAccess: () => Promise.resolve(true) }) },
+            },
+            // authorizeBrandSubWorkspace (used by listTopicPrompts) resolves the brand
+            // UUID via prompts-storage before resolving the sub-workspace.
+            '../../src/support/prompts-storage.js': {
+              resolveBrandUuid: () => Promise.resolve(BRAND),
             },
             '../../src/support/elements/elements-service.js': {
               createElementsService: () => ({

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -917,6 +917,8 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/market-tracking-trends',

--- a/test/support/elements/definitions/topic-prompts.test.js
+++ b/test/support/elements/definitions/topic-prompts.test.js
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  buildTopicPromptsPayload,
+  transformTopicPromptsResponse,
+} from '../../../../src/support/elements/definitions/topic-prompts.js';
+import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
+
+// Finds the value of a CBF_* column that sits inside its own `or` block within
+// the advanced filter tree (CBF_model / CBF_topic / CBF_project all use this shape),
+// or returns undefined if absent.
+function findFilterVal(payload, col) {
+  const blocks = payload.filters.advanced.filters;
+  for (const block of blocks) {
+    const inner = Array.isArray(block.filters) ? block.filters : [];
+    const hit = inner.find((f) => f.col === col);
+    if (hit) {
+      return hit.val;
+    }
+  }
+  return undefined;
+}
+
+describe('topic-prompts definitions', () => {
+  describe('buildTopicPromptsPayload', () => {
+    it('uses comparison_data_formatting "join" (matches the live MFE, not "union")', () => {
+      expect(buildTopicPromptsPayload().comparison_data_formatting).to.equal('join');
+    });
+
+    it('uses an AND operator over the advanced filters', () => {
+      expect(buildTopicPromptsPayload().filters.advanced.op).to.equal('and');
+    });
+
+    it('defaults the model to DEFAULT_ELEMENT_MODEL in a CBF_model or-block', () => {
+      const modelBlock = buildTopicPromptsPayload().filters.advanced.filters[0];
+      expect(modelBlock.op).to.equal('or');
+      expect(modelBlock.filters[0].col).to.equal('CBF_model');
+      expect(modelBlock.filters[0].val).to.equal(DEFAULT_ELEMENT_MODEL);
+    });
+
+    it('translates a UI platform code to the Semrush model (openai -> chatgpt-paid)', () => {
+      const modelBlock = buildTopicPromptsPayload({ model: 'openai' }).filters.advanced.filters[0];
+      expect(modelBlock.filters[0].val).to.equal('chatgpt-paid');
+    });
+
+    it('prefers model over platform when both are given', () => {
+      const modelBlock = buildTopicPromptsPayload({ model: 'openai', platform: 'gemini' })
+        .filters.advanced.filters[0];
+      expect(modelBlock.filters[0].val).to.equal('chatgpt-paid');
+    });
+
+    it('scopes to a single topic via a CBF_topic or-block (bare topic name) when topic is provided', () => {
+      expect(findFilterVal(buildTopicPromptsPayload({ topic: 'Video Generation' }), 'CBF_topic'))
+        .to.equal('Video Generation');
+    });
+
+    it('omits CBF_topic when topic is not provided (all topics)', () => {
+      expect(findFilterVal(buildTopicPromptsPayload(), 'CBF_topic')).to.be.undefined;
+    });
+
+    it('includes CBF_project (in an or-block) when projectId is provided', () => {
+      expect(findFilterVal(buildTopicPromptsPayload({ projectId: 'proj-42' }), 'CBF_project'))
+        .to.equal('proj-42');
+    });
+
+    it('omits CBF_project when projectId is not provided', () => {
+      expect(findFilterVal(buildTopicPromptsPayload(), 'CBF_project')).to.be.undefined;
+    });
+
+    it('sends filters.simple date window only when both dates are present', () => {
+      const payload = buildTopicPromptsPayload({ startDate: '2026-06-01', endDate: '2026-06-30' });
+      expect(payload.filters.simple).to.deep.equal({
+        start_date: '2026-06-01', end_date: '2026-06-30',
+      });
+    });
+
+    it('omits filters.simple when a date is missing', () => {
+      expect(buildTopicPromptsPayload({ startDate: '2026-06-01' }).filters)
+        .to.not.have.property('simple');
+      expect(buildTopicPromptsPayload().filters).to.not.have.property('simple');
+    });
+  });
+
+  describe('transformTopicPromptsResponse', () => {
+    it('returns an empty array for a missing/empty response', () => {
+      expect(transformTopicPromptsResponse(undefined)).to.deep.equal([]);
+      expect(transformTopicPromptsResponse({ blocks: {} })).to.deep.equal([]);
+      expect(transformTopicPromptsResponse({ blocks: { data: [] } })).to.deep.equal([]);
+    });
+
+    it('maps a full row into the clean camelCase contract', () => {
+      const raw = {
+        blocks: {
+          data: [{
+            prompt: 'best modular sofa',
+            prompt_topic: 'Loveseats with Ottomans',
+            primary_intent: 'commercial',
+            project_title: 'US-en',
+            mentions: 30,
+            citations: 27,
+            visibility: 100,
+            position: 1,
+            sentiment: 0.72,
+            volume: 5658,
+            days: 30,
+            model: 'Chat GPT',
+          }],
+        },
+      };
+      expect(transformTopicPromptsResponse(raw)).to.deep.equal([{
+        prompt: 'best modular sofa',
+        topic: 'Loveseats with Ottomans',
+        primaryIntent: 'commercial',
+        region: 'US-en',
+        mentions: 30,
+        citations: 27,
+        visibility: 100,
+        position: 1,
+        sentiment: 0.72,
+        volume: 5658,
+      }]);
+    });
+
+    it('normalizes the position -1 sentinel to null', () => {
+      const raw = { blocks: { data: [{ prompt: 'p', prompt_topic: 't', position: -1 }] } };
+      expect(transformTopicPromptsResponse(raw)[0].position).to.equal(null);
+    });
+
+    it('keeps a null sentiment as null (not 0)', () => {
+      const raw = { blocks: { data: [{ prompt: 'p', prompt_topic: 't', sentiment: null }] } };
+      expect(transformTopicPromptsResponse(raw)[0].sentiment).to.equal(null);
+    });
+
+    it('coerces null/absent mentions, citations, visibility and volume to 0', () => {
+      const raw = {
+        blocks: {
+          data: [{
+            prompt: 'p', prompt_topic: 't', mentions: null, citations: null,
+          }],
+        },
+      };
+      const row = transformTopicPromptsResponse(raw)[0];
+      expect(row.mentions).to.equal(0);
+      expect(row.citations).to.equal(0);
+      expect(row.visibility).to.equal(0);
+      expect(row.volume).to.equal(0);
+    });
+
+    it('defaults missing string fields to empty strings', () => {
+      const row = transformTopicPromptsResponse({ blocks: { data: [{}] } })[0];
+      expect(row.prompt).to.equal('');
+      expect(row.topic).to.equal('');
+      expect(row.primaryIntent).to.equal('');
+      expect(row.region).to.equal('');
+    });
+  });
+});

--- a/test/support/elements/definitions/topics-insights.test.js
+++ b/test/support/elements/definitions/topics-insights.test.js
@@ -124,9 +124,11 @@ describe('topics-insights aggregation', () => {
       expect(t.promptCount).to.equal(3);
     });
 
-    it('skips rows with an empty topic', () => {
+    it('skips rows with an empty, whitespace-only, or non-string topic', () => {
       const out = aggregateTopicsFromPrompts([
         row({ topic: '', mentions: 99 }),
+        row({ topic: '   ', mentions: 99 }),
+        { mentions: 99 }, // no topic field at all (non-string)
         row({ topic: 'A', mentions: 1 }),
       ]);
       expect(out).to.have.length(1);

--- a/test/support/elements/definitions/topics-insights.test.js
+++ b/test/support/elements/definitions/topics-insights.test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { aggregateTopicsFromPrompts } from '../../../../src/support/elements/definitions/topics-insights.js';
+
+// Minimal clean per-prompt row (as transformTopicPromptsResponse emits).
+function row(overrides = {}) {
+  return {
+    prompt: 'p',
+    topic: 'T',
+    primaryIntent: '',
+    region: 'US-en',
+    mentions: 0,
+    citations: 0,
+    visibility: 0,
+    position: null,
+    sentiment: null,
+    volume: 0,
+    ...overrides,
+  };
+}
+
+describe('topics-insights aggregation', () => {
+  describe('aggregateTopicsFromPrompts', () => {
+    it('returns an empty array for empty/invalid input', () => {
+      expect(aggregateTopicsFromPrompts([])).to.deep.equal([]);
+      expect(aggregateTopicsFromPrompts(undefined)).to.deep.equal([]);
+    });
+
+    it('groups by topic and sums mentions, citations and volume', () => {
+      const out = aggregateTopicsFromPrompts([
+        row({
+          topic: 'A', mentions: 10, citations: 5, volume: 100,
+        }),
+        row({
+          topic: 'A', mentions: 20, citations: 7, volume: 200,
+        }),
+        row({
+          topic: 'B', mentions: 1, citations: 1, volume: 5,
+        }),
+      ]);
+      const a = out.find((t) => t.topic === 'A');
+      expect(a.promptCount).to.equal(2);
+      expect(a.brandMentions).to.equal(30);
+      expect(a.brandCitations).to.equal(12);
+      expect(a.volume).to.equal(300);
+    });
+
+    it('averages visibility over ALL prompts (unanswered 0 counts in the denominator)', () => {
+      const [t] = aggregateTopicsFromPrompts([
+        row({ topic: 'A', visibility: 100 }),
+        row({ topic: 'A', visibility: 0 }),
+      ]);
+      expect(t.averageVisibilityScore).to.equal(50);
+    });
+
+    it('averages position only over ranked prompts, excluding null sentinels', () => {
+      const [t] = aggregateTopicsFromPrompts([
+        row({ topic: 'A', position: 2 }),
+        row({ topic: 'A', position: 4 }),
+        row({ topic: 'A', position: null }),
+      ]);
+      expect(t.averagePosition).to.equal(3);
+    });
+
+    it('averages sentiment only over prompts that have sentiment', () => {
+      const [t] = aggregateTopicsFromPrompts([
+        row({ topic: 'A', sentiment: 0.6 }),
+        row({ topic: 'A', sentiment: 0.8 }),
+        row({ topic: 'A', sentiment: null }),
+      ]);
+      expect(t.averageSentiment).to.equal(0.7);
+    });
+
+    it('yields null averagePosition / averageSentiment when the topic has no valid values', () => {
+      const [t] = aggregateTopicsFromPrompts([
+        row({ topic: 'A', position: null, sentiment: null }),
+      ]);
+      expect(t.averagePosition).to.equal(null);
+      expect(t.averageSentiment).to.equal(null);
+    });
+
+    it('rounds averages to two decimals', () => {
+      const [t] = aggregateTopicsFromPrompts([
+        row({ topic: 'A', visibility: 1 }),
+        row({ topic: 'A', visibility: 2 }),
+        row({ topic: 'A', visibility: 2 }),
+      ]);
+      expect(t.averageVisibilityScore).to.equal(1.67);
+    });
+
+    it('sorts topics by total volume descending', () => {
+      const out = aggregateTopicsFromPrompts([
+        row({ topic: 'small', volume: 10 }),
+        row({ topic: 'big', volume: 1000 }),
+        row({ topic: 'mid', volume: 100 }),
+      ]);
+      expect(out.map((t) => t.topic)).to.deep.equal(['big', 'mid', 'small']);
+    });
+
+    it('embeds the topic\'s own prompts, sorted by volume descending', () => {
+      const [t] = aggregateTopicsFromPrompts([
+        row({
+          topic: 'A', prompt: 'low', volume: 10,
+        }),
+        row({
+          topic: 'A', prompt: 'high', volume: 900,
+        }),
+        row({
+          topic: 'A', prompt: 'mid', volume: 100,
+        }),
+      ]);
+      expect(t.prompts.map((p) => p.prompt)).to.deep.equal(['high', 'mid', 'low']);
+      expect(t.promptCount).to.equal(3);
+    });
+
+    it('skips rows with an empty topic', () => {
+      const out = aggregateTopicsFromPrompts([
+        row({ topic: '', mentions: 99 }),
+        row({ topic: 'A', mentions: 1 }),
+      ]);
+      expect(out).to.have.length(1);
+      expect(out[0].topic).to.equal('A');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds two Serenity (Semrush-backed) brand-presence endpoints for the Data Insights table: a per-topic table and a per-prompt drill-down. **Backend only** — the SR UI wiring (`project-elmo-ui`) follows in a separate PR.

Both endpoints are built from the single `PROMPTS_BY_TOPIC` element (`78864493`) rather than the wiki's 3-element per-topic fan-out: `141adc88` (citations) currently returns 500, `0564b061` lacks a `position` field, and the live Brand Presence MFE also builds its view from `78864493` alone (verified via live probe + network capture, 2026-07-21).

## Endpoints
- `GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics` — per-topic aggregates (promptCount, brand mentions/citations, avg visibility/position/sentiment) with each topic's prompts embedded, for the eager Data Insights table. Brand sub-workspace scoped; optional region/date; returns the full topic list.
- `GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts` — per-prompt drill-down, scoped via `CBF_topic` (the topic NAME — Semrush topics have no UUID), with server-side pagination.

## Notes / gaps (flagged, not silently guessed)
- `sourceCount` / share-of-voice aren't available from `78864493` (dedicated elements unusable) — left unset (optional in the UI contract).
- Averages exclude the element's sentinels: `position: -1` (unranked) and `sentiment: null` are not averaged; a topic with no ranked/sentiment-bearing prompt yields `null`.
- New POC endpoint code is fenced with `c8 ignore` per the sibling convention; unit tests are still included.

## Test plan
- [x] `topic-prompts` + `topics-insights` definition unit tests (28 cases): payload shape, `CBF_topic` scoping, sentinel handling, aggregation, volume-sorted embedding.
- [x] OpenAPI contract test extended (`serenity-api.test.js`): both new operations validate against their response schemas (24 passing).
- [x] `npm run docs:lint` + `docs:build` clean; route/capability suites pass (3189).
- [x] Transform + aggregation verified against a real 633-prompt element response (196 topics; drill-down counts match the live probe).
- [ ] End-to-end verification against a properly-provisioned Semrush brand — dev's only wired brand has a sub-workspace == org-parent collision, so this will be verified against prod data.

## API spec checklist
- [x] API specification updated (`api.yaml`, `serenity-api.yaml`, `schemas.yaml`); representative request/response shapes are exercised by the contract-test fixtures.
- [x] Endpoints are implemented (no "Not implemented yet" / 501 stubs).

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-6418