### PR TITLE
feat(serenity): make the per-brand AI ceiling bindable + tunable via Vault (LLMO-6190 gate)

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -64,7 +64,7 @@ import {
 } from '../support/serenity/handlers/tags.js';
 import { ensureSubworkspace, decommissionBrandWorkspace } from '../support/serenity/workspace-lifecycle.js';
 import { isSerenityActiveForOrg } from '../support/serenity/serenity-active.js';
-import { isDynamicAllocationEnabled } from '../support/serenity/dynamic-allocation-active.js';
+import { isDynamicAllocationEnabled, resolveBrandAiCeiling } from '../support/serenity/dynamic-allocation-active.js';
 import { MAX_TOPICS_ON_CREATE } from '../support/serenity/brand-provisioning.js';
 import { marketForGeoTargetId } from '../support/serenity/locations.js';
 import { brandNeedles, classifyBrandedTag } from '../support/serenity/branded-classifier.js';
@@ -448,6 +448,12 @@ function SerenityController(context, log, env) {
   // handlers front through a no-op guard (byte-for-byte pre-PR behavior).
   const dynamicAllocationEnabled = (ctx) => isDynamicAllocationEnabled(ctx?.env || env);
 
+  // Global per-brand AI ceiling (LLMO-6190 flag-flip gate) — a runaway backstop, the SAME value
+  // for every brand, resolved from Vault off the same per-request env as the kill-switch above.
+  // `undefined` when unset → the guard keeps its non-binding default (byte-for-byte today). Passed
+  // as a plain object alongside `dynamicAllocation` at each guard-building handler call site.
+  const brandAiCeiling = (ctx) => resolveBrandAiCeiling(ctx?.env || env, log);
+
   /** Loads the Brand model instance (for subworkspace-mode write/lifecycle flows). */
   async function loadBrand(ctx, brandUuid) {
     const Brand = ctx?.dataAccess?.Brand;
@@ -537,6 +543,7 @@ function SerenityController(context, log, env) {
           {
             dynamicAllocation: dynamicAllocationEnabled(ctx),
             parentWorkspaceId: auth.parentWorkspaceId ?? '',
+            ceiling: brandAiCeiling(ctx),
           },
         )
         : await handleCreatePrompts(
@@ -772,6 +779,7 @@ function SerenityController(context, log, env) {
             // Dynamic-allocation kill-switch. The JIT top-up units pool is the org parent passed
             // positionally above (auth.parentWorkspaceId) — not duplicated in this options bag.
             dynamicAllocation: dynamicAllocationEnabled(ctx),
+            ceiling: brandAiCeiling(ctx),
           },
         );
         // Mirror this market as a SpaceCat Site (+ brand_sites link), once its
@@ -1117,6 +1125,7 @@ function SerenityController(context, log, env) {
           {
             dynamicAllocation: dynamicAllocationEnabled(ctx),
             parentWorkspaceId: auth.parentWorkspaceId ?? '',
+            ceiling: brandAiCeiling(ctx),
           },
         )
         : await handleUpdateModels(
@@ -1402,6 +1411,7 @@ function SerenityController(context, log, env) {
               dataAccess: { BrandSemrushProject: ctx.dataAccess.BrandSemrushProject },
               // JIT units pool = the org parent passed positionally above; not duplicated here.
               dynamicAllocation: dynamicAllocationEnabled(ctx),
+              ceiling: brandAiCeiling(ctx),
             },
           );
         } catch (e) {

--- a/src/support/serenity/dynamic-allocation-active.js
+++ b/src/support/serenity/dynamic-allocation-active.js
@@ -56,6 +56,63 @@ export function isDynamicAllocationEnabled(env) {
 }
 
 /**
+ * Env/Vault keys for the global per-brand AI ceiling (LLMO-6190 flag-flip gate, §8). One flat
+ * scalar per dimension at `dx_mysticat/<env>/api-service`, each independently optional. The
+ * ceiling here is a RUNAWAY BACKSTOP — "the largest plausible legitimate single-brand demand", the
+ * SAME value for every brand — NOT a per-org pool fraction (a fraction false-fails a legitimate
+ * heavy-but-feasible split; the transfer's own `orgPoolExhausted` 422 stays the demand-aware
+ * contention gate) and NOT per-customer config (that data model is deliberately deferred — see
+ * serenity-docs brand-semrush-dynamic-resource-allocation.md §7). The number itself is a product
+ * decision set in Vault; this module only reads whatever is present.
+ * @type {{ projects: string, prompts: string }}
+ */
+export const BRAND_AI_CEILING_ENV_FLAGS = Object.freeze({
+  projects: 'SERENITY_BRAND_AI_CEILING_PROJECTS',
+  prompts: 'SERENITY_BRAND_AI_CEILING_PROMPTS',
+});
+
+/**
+ * Resolves the per-brand AI ceiling from the request env. FAIL-SAFE, mirroring the kill-switch's
+ * "anything non-canonical → safe default" philosophy: a missing key leaves that dimension
+ * unenforced, and a present-but-unparseable / non-positive value (a Vault typo like `5o00`, `-1`,
+ * `0`, `abc`) is logged loudly and likewise left unenforced — a misconfiguration can never break a
+ * customer write, it only fails to bind (the warning + a bind-check during the flip catch that).
+ * Only a clean positive integer binds. `parseInt` is deliberately NOT used (it would silently
+ * accept `5o00` as `5`, a dangerously low cap); the value must be all digits.
+ *
+ * Returns `undefined` when NEITHER dimension resolves, so {@link createHeadroomGuard} keeps its
+ * byte-for-byte non-binding `DEFAULT_BRAND_AI_CEILING` default; otherwise a partial
+ * `{ projects?, prompts? }` carrying only the cleanly-parsed dimensions (an unset/invalid
+ * dimension stays unenforced — `ensureAiHeadroom` only gates a dimension whose cap is a number).
+ * @param {object} [env] - the request env (`context.env`).
+ * @param {any} [log]
+ * @returns {{ projects?: number, prompts?: number } | undefined}
+ */
+export function resolveBrandAiCeiling(env, log) {
+  /** @type {{ projects?: number, prompts?: number }} */
+  const ceiling = {};
+  for (const dim of /** @type {Array<'projects'|'prompts'>} */ (['projects', 'prompts'])) {
+    const flag = BRAND_AI_CEILING_ENV_FLAGS[dim];
+    const raw = env?.[flag];
+    if (raw === undefined || raw === null || String(raw).trim() === '') {
+      // Unset — leave this dimension unenforced (silent; this is the normal pre-rollout state).
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const text = String(raw).trim();
+    const parsed = /^\d+$/.test(text) ? Number(text) : NaN;
+    if (Number.isInteger(parsed) && parsed > 0) {
+      ceiling[dim] = parsed;
+    } else {
+      log?.warn?.('SERENITY_ALLOC ignoring malformed brand-AI-ceiling env value — dimension left unenforced', {
+        dim, flag, raw: text,
+      });
+    }
+  }
+  return (ceiling.projects === undefined && ceiling.prompts === undefined) ? undefined : ceiling;
+}
+
+/**
  * @typedef {object} HeadroomGuard
  * @property {boolean} enabled whether JIT top-up is active for this request.
  * @property {(need?: import('./resource-manager.js').Dims,
@@ -93,9 +150,10 @@ export function isDynamicAllocationEnabled(env) {
  * @param {boolean} opts.enabled - the global kill-switch value for this request.
  * @param {string} [opts.subWorkspaceId] - the sub-workspace being written to (`auth.workspaceId`).
  * @param {string} [opts.parentWorkspaceId] - the org parent workspace (`auth.parentWorkspaceId`).
- * @param {import('./resource-manager.js').Blocks} [opts.ceiling] - per-brand ceiling (default
- *   {@link DEFAULT_BRAND_AI_CEILING} — a placeholder; pass an explicit value to override once a
- *   real per-brand number exists).
+ * @param {Partial<import('./resource-manager.js').Blocks>} [opts.ceiling] - per-brand ceiling,
+ *   resolved from Vault via {@link resolveBrandAiCeiling} and threaded by the controller. Partial:
+ *   a dimension may be omitted, leaving it unenforced. When omitted entirely, defaults to the
+ *   non-binding {@link DEFAULT_BRAND_AI_CEILING} placeholder (byte-for-byte today's behavior).
  * @param {import('./resource-manager.js').Blocks} [opts.blocks] - grace blocks (optional).
  * @param {Partial<typeof DEFAULT_RETRY_ON_QUOTA>} [opts.retryOnQuota] - poll-retry shape override
  *   for `retryOnQuota` (tests inject a fake `sleep` + tiny `backoffMs`/`totalBudgetMs`; production

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -503,6 +503,9 @@ async function generateAndAttachPrompts(transport, workspaceId, projectId, {
  *   `ensureSubworkspace` is skipped. When false, byte-for-byte the pre-this-PR behavior.
  *   (The units pool for JIT sizing is the positional `parentWorkspaceId` arg — the same id given
  *   to `ensureSubworkspace` — so it is not duplicated in this options bag.)
+ * @param {Partial<import('../resource-manager.js').Blocks>} [options.ceiling] - per-brand AI
+ *   ceiling (LLMO-6190 flag-flip gate), resolved from Vault by the controller and passed through to
+ *   `createHeadroomGuard`. Omitted → non-binding default. No-op when `dynamicAllocation` is false.
  * @param {object} [options.env] - environment (Azure OpenAI creds), threaded into
  *   intent classification when `generateTopics` is set (serenity-docs#32).
  * @param {number} [options.writeDeadline] - shared request-write deadline; defaults
@@ -526,6 +529,7 @@ export async function handleCreateMarketSubworkspace(
     publishMode = 'require',
     dataAccess = null,
     dynamicAllocation = false,
+    ceiling = undefined,
     env = null,
     writeDeadline = computeWriteDeadline(),
   } = {},
@@ -568,7 +572,9 @@ export async function handleCreateMarketSubworkspace(
   // it; OFF (or a missing parent) yields a no-op guard so the flag-OFF path issues zero reads.
   const headroom = createHeadroomGuard(
     transport,
-    { enabled: dynamicAllocation, subWorkspaceId: workspaceId, parentWorkspaceId },
+    {
+      enabled: dynamicAllocation, subWorkspaceId: workspaceId, parentWorkspaceId, ceiling,
+    },
     log,
   );
 
@@ -1090,13 +1096,16 @@ export async function handleListModelsSubworkspace(transport, workspaceId, query
  *   ADD, and release the freed units after it on a net REMOVAL. Lives at this mode-guarded caller,
  *   NOT inside the shared `syncModelsForProject`, so flat mode is untouched (byte-for-byte).
  * @param {string} [options.parentWorkspaceId=''] - org parent/master workspace id (units pool).
+ * @param {Partial<import('../resource-manager.js').Blocks>} [options.ceiling] - per-brand AI
+ *   ceiling (LLMO-6190 flag-flip gate), resolved from Vault by the controller and passed to
+ *   `createHeadroomGuard`. Omitted → non-binding default. No-op when `dynamicAllocation` is false.
  */
 export async function handleUpdateModelsSubworkspace(
   transport,
   workspaceId,
   body,
   log,
-  { dynamicAllocation = false, parentWorkspaceId = '' } = {},
+  { dynamicAllocation = false, parentWorkspaceId = '', ceiling = undefined } = {},
 ) {
   const geoTargetId = normalizeGeoTargetId(Number(body?.geoTargetId));
   const languageCode = normalizeLanguageCode(body?.languageCode);
@@ -1128,7 +1137,9 @@ export async function handleUpdateModelsSubworkspace(
   // that are handed back after it. No-op when OFF (guarded on `enabled` → zero extra reads).
   const headroom = createHeadroomGuard(
     transport,
-    { enabled: dynamicAllocation, subWorkspaceId: workspaceId, parentWorkspaceId },
+    {
+      enabled: dynamicAllocation, subWorkspaceId: workspaceId, parentWorkspaceId, ceiling,
+    },
     log,
   );
   let netDelta = 0;

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -40,6 +40,8 @@ import { redactUpstreamMessage } from '../rest-transport.js';
 import { createHeadroomGuard } from '../dynamic-allocation-active.js';
 import { classifyPromptIntents } from '../intent-classification.js';
 
+/** @typedef {import('../resource-manager.js').Blocks} Blocks */
+
 /**
  * Subworkspace-mode prompt handlers (serenity dual-mode, subworkspace path). Behaviourally
  * identical to the flat-mode prompt handlers EXCEPT for how a `(geoTargetId,
@@ -132,7 +134,11 @@ export async function handleCreatePromptsSubworkspace(
   classifyPromptType,
   env,
   writeDeadline,
-  { dynamicAllocation = false, parentWorkspaceId = '' } = {},
+  {
+    dynamicAllocation = false,
+    parentWorkspaceId = '',
+    ceiling = /** @type {Partial<Blocks> | undefined} */ (undefined),
+  } = {},
 ) {
   const inputs = Array.isArray(body?.prompts) ? body.prompts : [];
   if (inputs.length === 0) {
@@ -184,7 +190,9 @@ export async function handleCreatePromptsSubworkspace(
   // under). No-op when the flag is OFF.
   const headroom = createHeadroomGuard(
     transport,
-    { enabled: dynamicAllocation, subWorkspaceId: workspaceId, parentWorkspaceId },
+    {
+      enabled: dynamicAllocation, subWorkspaceId: workspaceId, parentWorkspaceId, ceiling,
+    },
     log,
   );
   await headroom.ensure({ prompts: inputs.length }, { includeDrafted: true });

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1438,6 +1438,9 @@ describe('SerenityController', () => {
           dataAccess: { BrandSemrushProject: ctx.dataAccess.BrandSemrushProject },
           // Dynamic-allocation kill-switch defaults OFF (env unset) — the guard is a no-op.
           dynamicAllocation: false,
+          // Per-brand AI ceiling (LLMO-6190 gate): undefined when no ceiling env is set — the
+          // guard keeps its non-binding default.
+          ceiling: undefined,
         });
       // The org parent (JIT units pool) is threaded POSITIONALLY (arg index 2), not in the
       // options bag — the same id given to ensureSubworkspace.
@@ -1614,6 +1617,39 @@ describe('SerenityController', () => {
       expect(response.status).to.equal(200);
       expect(handlers.handleCreatePromptsSubworkspace).to.have.been.calledOnce;
       expect(handlers.handleCreatePrompts).to.not.have.been.called;
+    });
+
+    it('createPrompts threads the per-brand AI ceiling (LLMO-6190 gate) from env into the subworkspace handler options', async () => {
+      handlers.handleCreatePromptsSubworkspace.resolves({ created: [], skipped: [], failed: [] });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      await controller.createPrompts(fakeContext({
+        data: { prompts: [] },
+        env: { SERENITY_BRAND_AI_CEILING_PROMPTS: '5000' },
+      }));
+      // options bag is the 8th positional arg (transport, workspaceId, data, log,
+      // classifyPromptType, env, writeDeadline, options).
+      const opts = handlers.handleCreatePromptsSubworkspace.firstCall.args[7];
+      expect(opts.ceiling).to.deep.equal({ prompts: 5000 });
+    });
+
+    it('createPrompts leaves ceiling undefined when no ceiling env is set (byte-for-byte non-binding default)', async () => {
+      handlers.handleCreatePromptsSubworkspace.resolves({ created: [], skipped: [], failed: [] });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      await controller.createPrompts(fakeContext({ data: { prompts: [] } }));
+      const opts = handlers.handleCreatePromptsSubworkspace.firstCall.args[7];
+      expect(opts.ceiling).to.equal(undefined);
+    });
+
+    it('createPrompts FAIL-SAFE: a malformed ceiling env leaves ceiling undefined (never throws)', async () => {
+      handlers.handleCreatePromptsSubworkspace.resolves({ created: [], skipped: [], failed: [] });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.createPrompts(fakeContext({
+        data: { prompts: [] },
+        env: { SERENITY_BRAND_AI_CEILING_PROMPTS: 'not-a-number' },
+      }));
+      expect(response.status).to.equal(200);
+      const opts = handlers.handleCreatePromptsSubworkspace.firstCall.args[7];
+      expect(opts.ceiling).to.equal(undefined);
     });
 
     it('updatePrompt routes to the subworkspace handler in subworkspace mode', async () => {
@@ -2131,6 +2167,8 @@ describe('SerenityController', () => {
         env: {},
         dataAccess: { BrandSemrushProject: ctx.dataAccess.BrandSemrushProject },
         dynamicAllocation: false,
+        // Per-brand AI ceiling (LLMO-6190 gate): undefined when no ceiling env is set.
+        ceiling: undefined,
       };
       const { firstCall, secondCall } = handlers.handleCreateMarketSubworkspace;
       // writeDeadline is computed ONCE at activate entry, so every market in the

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -855,6 +855,7 @@ export default function serenityTests(
 
     afterEach(() => {
       delete process.env.SERENITY_DYNAMIC_ALLOCATION;
+      delete process.env.SERENITY_BRAND_AI_CEILING_PROMPTS;
     });
 
     it('tops up the sub-workspace via a live /resources transfer when a metered write needs headroom', async () => {
@@ -880,6 +881,24 @@ export default function serenityTests(
         prompts: [{ text: 'best trail running shoes?', geoTargetId: US_GEO, languageCode: 'en' }],
       });
       expect(post.status).to.equal(200);
+    });
+
+    it('a binding per-brand ceiling (LLMO-6190 gate) rejects a prompt write that would top up past the cap', async () => {
+      // A low prompts ceiling set in the env (Vault, in prod). The market create tops up PROJECTS
+      // only (the ceiling caps prompts, unset for projects) and publishes empty, so it still
+      // succeeds; the later prompt write needs a PROMPTS top-up from the seeded 0, which rounds to
+      // a whole block (100) and exceeds the cap (50) → brandAiLimit (409), over the wire.
+      process.env.SERENITY_BRAND_AI_CEILING_PROMPTS = '50';
+
+      const created = await getHttpClient().admin.post(`${base}/markets`, {
+        market: 'US', languageCode: 'en', brandDomain: 'example.com', brandNames: ['Test Brand'],
+      });
+      expect(created.status).to.equal(201);
+
+      const post = await getHttpClient().admin.post(`${base}/prompts`, {
+        prompts: [{ text: 'capped by the ceiling', geoTargetId: US_GEO, languageCode: 'en' }],
+      });
+      expect(post.status).to.equal(409);
     });
   });
 }

--- a/test/support/serenity/dynamic-allocation-active.test.js
+++ b/test/support/serenity/dynamic-allocation-active.test.js
@@ -17,7 +17,9 @@ import esmock from 'esmock';
 import {
   isDynamicAllocationEnabled,
   createHeadroomGuard,
+  resolveBrandAiCeiling,
   DYNAMIC_ALLOCATION_ENV_FLAG,
+  BRAND_AI_CEILING_ENV_FLAGS,
 } from '../../../src/support/serenity/dynamic-allocation-active.js';
 import { clearResourceLocks } from '../../../src/support/serenity/resource-lock.js';
 import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
@@ -57,6 +59,52 @@ describe('dynamic-allocation-active — isDynamicAllocationEnabled', () => {
     expect(isDynamicAllocationEnabled({ [DYNAMIC_ALLOCATION_ENV_FLAG]: '1' })).to.equal(false);
     expect(isDynamicAllocationEnabled({ [DYNAMIC_ALLOCATION_ENV_FLAG]: true })).to.equal(false);
     expect(isDynamicAllocationEnabled(undefined)).to.equal(false);
+  });
+});
+
+describe('dynamic-allocation-active — resolveBrandAiCeiling', () => {
+  const PROJECTS = BRAND_AI_CEILING_ENV_FLAGS.projects;
+  const PROMPTS = BRAND_AI_CEILING_ENV_FLAGS.prompts;
+
+  it('returns undefined when neither dimension is set (keeps the guard non-binding default)', () => {
+    expect(resolveBrandAiCeiling(undefined)).to.equal(undefined);
+    expect(resolveBrandAiCeiling({})).to.equal(undefined);
+    expect(resolveBrandAiCeiling({ UNRELATED: '5' })).to.equal(undefined);
+  });
+
+  it('parses a clean positive integer per dimension', () => {
+    expect(resolveBrandAiCeiling({ [PROMPTS]: '5000' })).to.deep.equal({ prompts: 5000 });
+    expect(resolveBrandAiCeiling({ [PROJECTS]: '8' })).to.deep.equal({ projects: 8 });
+    expect(resolveBrandAiCeiling({ [PROJECTS]: '8', [PROMPTS]: '5000' }))
+      .to.deep.equal({ projects: 8, prompts: 5000 });
+  });
+
+  it('leaves a partial ceiling when only one dimension is set (the other stays unenforced)', () => {
+    const c = resolveBrandAiCeiling({ [PROMPTS]: '5000' });
+    expect(c).to.deep.equal({ prompts: 5000 });
+    expect(c).to.not.have.property('projects');
+  });
+
+  it('FAIL-SAFE: a malformed / non-positive value warns and leaves that dimension unenforced (never throws)', () => {
+    const warn = sinon.stub();
+    const spyLog = { info: () => {}, error: () => {}, warn };
+    // parseInt would wrongly accept '5o00' as 5 — the digit-only guard rejects it instead.
+    for (const bad of ['abc', '5o00', '-1', '0', '5.5', '1e3', '  ']) {
+      warn.resetHistory();
+      const c = resolveBrandAiCeiling({ [PROMPTS]: bad }, spyLog);
+      expect(c, `bad value ${JSON.stringify(bad)} must not bind`).to.equal(undefined);
+      // Whitespace-only is "unset" (silent); the rest are malformed (warned).
+      if (bad.trim() !== '') {
+        expect(warn, `bad value ${JSON.stringify(bad)} should warn`).to.have.been.calledOnce;
+      }
+    }
+  });
+
+  it('binds the good dimension and warns on the bad one when mixed', () => {
+    const warn = sinon.stub();
+    const c = resolveBrandAiCeiling({ [PROJECTS]: 'oops', [PROMPTS]: '5000' }, { warn });
+    expect(c).to.deep.equal({ prompts: 5000 });
+    expect(warn).to.have.been.calledOnce;
   });
 });
 
@@ -162,6 +210,72 @@ describe('dynamic-allocation-active — createHeadroomGuard', () => {
     const r = await guard.ensure({ prompts: 5000 });
     expect(r.toppedUp).to.equal(true);
     expect(t.transferWorkspaceResources).to.have.been.calledOnce;
+  });
+
+  it('an explicit BINDING ceiling: a top-up past the cap throws brandAiLimit (409), no transfer', async () => {
+    const t = makeTransport({
+      child: resources(dimObj(0, 0, 0), dimObj(0, 0, 0)),
+      master: resources(dimObj(0, 0, 100), dimObj(0, 0, 800)),
+    });
+    const guard = createHeadroomGuard(
+      t,
+      {
+        enabled: true, subWorkspaceId: CHILD, parentWorkspaceId: MASTER, ceiling: { prompts: 100 },
+      },
+      log,
+    );
+    let caught;
+    try {
+      await guard.ensure({ prompts: 500 }); // target rounds to 500 > cap 100
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught?.code).to.equal('brandAiLimit');
+    expect(caught?.status).to.equal(409);
+    expect(t.transferWorkspaceResources).to.not.have.been.called;
+  });
+
+  it('an explicit ceiling that COVERS the need: tops up normally (does NOT 409)', async () => {
+    const t = makeTransport({
+      child: resources(dimObj(0, 0, 0), dimObj(0, 0, 0)),
+      master: resources(dimObj(0, 0, 100), dimObj(0, 0, 800)),
+    });
+    const guard = createHeadroomGuard(
+      t,
+      {
+        enabled: true, subWorkspaceId: CHILD, parentWorkspaceId: MASTER, ceiling: { prompts: 1000 },
+      },
+      log,
+    );
+    const r = await guard.ensure({ prompts: 500 }); // target 500 <= cap 1000
+    expect(r.toppedUp).to.equal(true);
+    expect(t.transferWorkspaceResources).to.have.been.calledOnce;
+  });
+
+  it('a PARTIAL ceiling binds only its dimension — the unset dimension stays unenforced', async () => {
+    // ceiling only caps prompts; projects has no cap, so a large project top-up is not gated.
+    const t = makeTransport({
+      child: resources(dimObj(0, 0, 0), dimObj(0, 0, 0)),
+      master: resources(dimObj(0, 0, 100), dimObj(0, 0, 800)),
+    });
+    const guard = createHeadroomGuard(
+      t,
+      {
+        enabled: true, subWorkspaceId: CHILD, parentWorkspaceId: MASTER, ceiling: { prompts: 100 },
+      },
+      log,
+    );
+    // projects dimension: no cap present → tops up without a brandAiLimit throw.
+    const rProjects = await guard.ensure({ projects: 5 });
+    expect(rProjects.toppedUp).to.equal(true);
+    // prompts dimension on the same guard: still bound by the cap → throws past it.
+    let caught;
+    try {
+      await guard.ensure({ prompts: 500 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught?.code).to.equal('brandAiLimit');
   });
 });
 

--- a/test/support/serenity/dynamic-allocation-fronting.test.js
+++ b/test/support/serenity/dynamic-allocation-fronting.test.js
@@ -210,6 +210,43 @@ describe('dynamic-allocation fronting — create-prompts', () => {
     );
     expect(t.getWorkspaceResources).to.not.have.been.called;
   });
+
+  it('ON + a binding ceiling (LLMO-6190 gate): a top-up past the cap throws brandAiLimit (409) before any write/transfer', async () => {
+    // Child seeded at zero prompts, so the pre-loop `ensure` must top up; the top-up rounds to a
+    // whole PROMPT_BLOCK (→100) which exceeds the low cap (50) → brandAiLimit, thrown out of the
+    // handler before any metered write or transfer fires.
+    const getWorkspaceResources = sinon.stub();
+    getWorkspaceResources.withArgs(WS).resolves(resources(dimObj(0, 0, 50), dimObj(0, 0, 0)));
+    getWorkspaceResources.withArgs(MASTER).resolves(AMPLE_MASTER);
+    const t = makeTransport({
+      listProjects: sinon.stub().resolves({ items: [proj()] }),
+      getWorkspaceResources,
+    });
+    let caught;
+    try {
+      await handleCreatePromptsSubworkspace(
+        t,
+        WS,
+        {
+          prompts: [{
+            text: 'q', geoTargetId: 2840, languageCode: 'en', tagIds: ['tag-1'],
+          }],
+        },
+        log,
+        undefined, // classifyPromptType
+        undefined, // env
+        undefined, // writeDeadline
+        { dynamicAllocation: true, parentWorkspaceId: MASTER, ceiling: { prompts: 50 } },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught?.code).to.equal('brandAiLimit');
+    expect(caught?.status).to.equal(409);
+    // The child read fed the ceiling check, but the cap fired BEFORE the pool read/transfer.
+    expect(t.getWorkspaceResources).to.have.been.calledWith(WS);
+    expect(t.transferWorkspaceResources).to.not.have.been.called;
+  });
 });
 
 describe('dynamic-allocation fronting — update-models', () => {


### PR DESCRIPTION
## Summary

Closes the mechanism half of the §8 flag-flip gate *"a per-brand ceiling with a BINDING value"* (serenity-docs `brand-semrush-dynamic-resource-allocation.md`). The enforcement mechanism was already merged (`ensureAiHeadroom` throws `brandAiLimit`/409 past the cap), but the shipped `DEFAULT_BRAND_AI_CEILING` is astronomical and **no call site passed a ceiling** — so the gate was definitionally open. This wires the ceiling so it can actually bind, resolved from Vault.

- **`resolveBrandAiCeiling(env)`** (`dynamic-allocation-active.js`, next to `isDynamicAllocationEnabled`) reads `SERENITY_BRAND_AI_CEILING_PROJECTS` / `_PROMPTS` off the same per-request env as the kill-switch. **Fail-safe** (mirrors the kill-switch's "anything non-canonical → safe default"): unset, or a malformed / non-positive value (a Vault typo like `5o00`, `-1`, `0`), is left unenforced and never breaks a customer write. Digit-only parse (`parseInt` would wrongly accept `5o00` as `5`, a dangerously low cap). Returns `undefined` when neither dimension is set → the guard keeps its non-binding default.
- **Controller** threads `ceiling: brandAiCeiling(ctx)` alongside `dynamicAllocation` into the three guard-building subworkspace handlers (create-prompts, create-market ×2, update-models); handlers pass it to `createHeadroomGuard`. Partial ceilings supported (a dimension may be omitted → unenforced).

### Design (settled in discussion)
A **single global backstop, the same for every brand** — "the largest plausible *legitimate* single-brand demand", a runaway circuit-breaker. Deliberately **not** a per-org pool fraction (a fraction false-fails a legitimate `800 + 200`-in-a-`1000`-pool split; `orgPoolExhausted` stays the demand-aware contention gate) and **not** per-customer config (that data model is deferred by the spec). The number itself is a product decision set in Vault later.

**Merging is a no-op**: unset → byte-for-byte today's behavior. The gate fully closes when a value is set in Vault (`dx_mysticat/<env>/api-service`), gated on the usage p99 estimate — a separate, product-owned step, deliberately not in this PR.

## Test plan
- [x] `npm run lint && npm run type-check` clean
- [x] `npm test` — full unit suite green (15843 passing)
- [x] Unit: `resolveBrandAiCeiling` (unset/valid/partial/malformed/mixed) + guard-override (binding cap → `brandAiLimit`, under-cap succeeds, partial ceiling)
- [x] Controller: threads ceiling from env; unset → `undefined`; malformed → `undefined` (never throws)
- [x] Handler→guard fronting: a binding ceiling throws `brandAiLimit` (409) before any write/transfer
- [x] Added an IT case (`test/it/shared/tests/serenity.js`, dynamic-allocation-ON block): low `SERENITY_BRAND_AI_CEILING_PROMPTS` → prompt write 409s over the wire. **Not run locally** (no ECR creds for the data-service image pull); runs in CI's `it-postgres` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)