### PR TITLE
feat(configuration): add GET /configurations/versions endpoint

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -94,6 +94,8 @@ paths:
     $ref: './auth-api.yaml#/login'
   /configurations/latest:
     $ref: './configuration-api.yaml#/latest-configuration'
+  /configurations/versions:
+    $ref: './configuration-api.yaml#/configuration-versions'
   /configurations/latest/queues:
     $ref: './configuration-api.yaml#/configuration-queues'
   /configurations/latest/jobs/{jobType}:

--- a/docs/openapi/configuration-api.yaml
+++ b/docs/openapi/configuration-api.yaml
@@ -186,6 +186,119 @@ latest-configuration:
         description: Configuration not found.
       '500':
         $ref: './responses.yaml#/500'
+configuration-versions:
+  get:
+    tags:
+      - configuration
+    summary: List configuration versions (version history)
+    description: |
+      Lists the version history of the global configuration, newest first. Each
+      version corresponds to an S3 object version. Use the returned `versionId`
+      values with `GET /configurations/{version}` or
+      `POST /configurations/{version}/restore`. This removes the need for direct
+      S3/AWS access to discover VersionIds.
+
+      When `detail` is true (default) each version is enriched with
+      `updatedBy`/`updatedAt` read from the object's S3 user-metadata; versions
+      written before that metadata was introduced return `null` for those fields.
+    operationId: listConfigurationVersions
+    security:
+      - admin_key: [ ]
+    parameters:
+      - name: limit
+        in: query
+        required: false
+        description: Maximum number of versions to return (1–100).
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 25
+      - name: keyMarker
+        in: query
+        required: false
+        description: S3 KeyMarker for pagination (from a previous response's nextKeyMarker).
+        schema:
+          type: string
+      - name: versionIdMarker
+        in: query
+        required: false
+        description: S3 VersionIdMarker for pagination (from a previous response's nextVersionIdMarker).
+        schema:
+          type: string
+      - name: detail
+        in: query
+        required: false
+        description: When false, skips updatedBy/updatedAt enrichment for a faster listing.
+        schema:
+          type: boolean
+          default: true
+    responses:
+      '200':
+        description: A page of configuration versions, newest first.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                versions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      versionId:
+                        type: string
+                        example: "EqZSCYxbPdKJ0Xso9QkbS0h0ZfDbhXWe"
+                      lastModified:
+                        type: string
+                        format: date-time
+                        example: "2026-07-23T10:00:00.000Z"
+                      isLatest:
+                        type: boolean
+                        example: true
+                      size:
+                        type: integer
+                        example: 3120487
+                      updatedBy:
+                        type: [string, 'null']
+                        example: "admin@adobe.com"
+                      updatedAt:
+                        type: [string, 'null']
+                        format: date-time
+                        example: "2026-07-23T10:00:00.000Z"
+                isTruncated:
+                  type: boolean
+                  example: false
+                nextKeyMarker:
+                  type: [string, 'null']
+                nextVersionIdMarker:
+                  type: [string, 'null']
+            examples:
+              versions-list:
+                summary: A page of versions
+                value:
+                  versions:
+                    - versionId: "EqZSCYxbPdKJ0Xso9QkbS0h0ZfDbhXWe"
+                      lastModified: "2026-07-23T10:00:00.000Z"
+                      isLatest: true
+                      size: 3120487
+                      updatedBy: "admin@adobe.com"
+                      updatedAt: "2026-07-23T10:00:00.000Z"
+                    - versionId: "SzrMxECGfivkXWmCK2zlmzHrc0BVoSdR"
+                      lastModified: "2026-07-22T09:00:00.000Z"
+                      isLatest: false
+                      size: 3118002
+                      updatedBy: null
+                      updatedAt: null
+                  isTruncated: false
+                  nextKeyMarker: null
+                  nextVersionIdMarker: null
+      '401':
+        $ref: './responses.yaml#/401'
+      '403':
+        $ref: './responses.yaml#/403'
+      '500':
+        $ref: './responses.yaml#/500'
 configuration:
   get:
     tags:

--- a/docs/openapi/configuration-api.yaml
+++ b/docs/openapi/configuration-api.yaml
@@ -240,11 +240,21 @@ configuration-versions:
           application/json:
             schema:
               type: object
+              required:
+                - versions
+                - isTruncated
+                - nextKeyMarker
+                - nextVersionIdMarker
               properties:
                 versions:
                   type: array
                   items:
                     type: object
+                    required:
+                      - versionId
+                      - lastModified
+                      - isLatest
+                      - size
                     properties:
                       versionId:
                         type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "4.11.0",
+        "@adobe/spacecat-shared-data-access": "4.13.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.11.0.tgz",
-      "integrity": "sha512-/Xi8wisTxX68Gy65QQIv2bnvSPPNT3UQw0GBMuMjv4E6tw/B5MXun4SohWFE5aDjZAZKl2ScLmLka6MdgkmFXQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.13.0.tgz",
+      "integrity": "sha512-HOKvfjnUV7mM+YpXQGHN7SaA1k5Evyf0jwXXydVyhOY2Von/mQJUcMzUlyMene7LBRVbCDNORpO93L/0vVwmMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "4.11.0",
+    "@adobe/spacecat-shared-data-access": "4.13.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",

--- a/src/controllers/configuration.js
+++ b/src/controllers/configuration.js
@@ -159,6 +159,49 @@ function ConfigurationController(ctx) {
     }
   };
 
+  /**
+   * Lists configuration versions (S3 object-version history), newest first.
+   * Removes the need for direct S3/AWS access to discover the VersionIds used by
+   * `GET /configurations/:version`, `POST /configurations/:version/restore`, and
+   * offline exports.
+   * @param {UniversalContext} context - Context of the request.
+   * @return {Promise<Response>} Paginated list of configuration versions.
+   */
+  const listVersions = async (context) => {
+    const denied = await authorizeConfigRead(context, 'GET /configurations/versions');
+    if (denied) {
+      return denied;
+    }
+
+    let searchParams;
+    try {
+      searchParams = new URL(context.request.url).searchParams;
+    } catch {
+      searchParams = new URLSearchParams();
+    }
+
+    const rawLimit = searchParams.get('limit');
+    const parsedLimit = Number.parseInt(rawLimit, 10);
+    // Clamp to [1, 100]; fall back to the collection default when unparseable.
+    const limit = Number.isInteger(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), 100)
+      : undefined;
+
+    const keyMarker = searchParams.get('keyMarker') || undefined;
+    const versionIdMarker = searchParams.get('versionIdMarker') || undefined;
+    // Enrichment (updatedBy/updatedAt) is on by default; opt out with detail=false.
+    const detail = searchParams.get('detail') !== 'false';
+
+    const page = await Configuration.listVersions({
+      ...(limit !== undefined ? { limit } : {}),
+      keyMarker,
+      versionIdMarker,
+      detail,
+    });
+
+    return ok(ConfigurationDto.versionsToJSON(page));
+  };
+
   const registerAudit = async (context) => {
     const denied = await authorizeConfigWrite(context, 'POST /configurations/audits', 'Only admins can register audits');
     if (denied) {
@@ -509,6 +552,7 @@ function ConfigurationController(ctx) {
   return {
     getByVersion,
     getLatest,
+    listVersions,
     registerAudit,
     unregisterAudit,
     updateQueues,

--- a/src/controllers/configuration.js
+++ b/src/controllers/configuration.js
@@ -182,20 +182,31 @@ function ConfigurationController(ctx) {
 
     const rawLimit = searchParams.get('limit');
     const parsedLimit = Number.parseInt(rawLimit, 10);
-    // Clamp to [1, 100]; fall back to the collection default when unparseable.
+    // Default 25 (matches the OpenAPI contract), clamped to [1, 100].
     const limit = Number.isInteger(parsedLimit)
       ? Math.min(Math.max(parsedLimit, 1), 100)
-      : undefined;
+      : 25;
 
     const keyMarker = searchParams.get('keyMarker') || undefined;
     const versionIdMarker = searchParams.get('versionIdMarker') || undefined;
+
+    // Defense-in-depth: reject absurdly long pagination markers (endpoint is
+    // admin-gated, but the markers are opaque pass-throughs to S3).
+    const MAX_MARKER_LENGTH = 1024;
+    if ((keyMarker && keyMarker.length > MAX_MARKER_LENGTH)
+      || (versionIdMarker && versionIdMarker.length > MAX_MARKER_LENGTH)) {
+      return badRequest('keyMarker/versionIdMarker exceeds maximum length');
+    }
+
     // Enrichment (updatedBy/updatedAt) is on by default; opt out with detail=false.
     const detail = searchParams.get('detail') !== 'false';
 
+    // Conditional spread so we never hand an explicit `undefined` marker key to
+    // the data-access layer (keeps parity with a possible `'key' in opts` check).
     const page = await Configuration.listVersions({
-      ...(limit !== undefined ? { limit } : {}),
-      keyMarker,
-      versionIdMarker,
+      limit,
+      ...(keyMarker !== undefined ? { keyMarker } : {}),
+      ...(versionIdMarker !== undefined ? { versionIdMarker } : {}),
       detail,
     });
 

--- a/src/dto/configuration.js
+++ b/src/dto/configuration.js
@@ -27,4 +27,25 @@ export const ConfigurationDto = {
     queues: configuration.getQueues(),
     ...(configuration.getSlackRoles() ? { slackRoles: configuration.getSlackRoles() } : {}),
   }),
+
+  /**
+   * Converts a page of configuration versions (from
+   * `ConfigurationCollection.listVersions`) into the API response shape.
+   * @param {{versions: object[], isTruncated: boolean,
+   *   nextKeyMarker: (string|null), nextVersionIdMarker: (string|null)}} page
+   * @returns {object} The version-list response.
+   */
+  versionsToJSON: (page) => ({
+    versions: (page.versions || []).map((version) => ({
+      versionId: version.versionId,
+      lastModified: version.lastModified,
+      isLatest: version.isLatest,
+      size: version.size,
+      ...(version.updatedBy !== undefined ? { updatedBy: version.updatedBy } : {}),
+      ...(version.updatedAt !== undefined ? { updatedAt: version.updatedAt } : {}),
+    })),
+    isTruncated: Boolean(page.isTruncated),
+    nextKeyMarker: page.nextKeyMarker ?? null,
+    nextVersionIdMarker: page.nextVersionIdMarker ?? null,
+  }),
 };

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -238,6 +238,7 @@ const routeFacsCapabilities = {
 
     // System configuration (Configuration model — admin-only)
     'GET /configurations/:version', // admin
+    'GET /configurations/versions', // admin
     'GET /configurations/latest', // admin
     'PATCH /configurations/latest', // admin
     'PATCH /configurations/latest/handlers/:handlerType', // admin

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -237,8 +237,8 @@ const routeFacsCapabilities = {
     'GET /ephemeral-run/batch/:batchId/status', // admin/internal
 
     // System configuration (Configuration model — admin-only)
-    'GET /configurations/:version', // admin
     'GET /configurations/versions', // admin
+    'GET /configurations/:version', // admin
     'GET /configurations/latest', // admin
     'PATCH /configurations/latest', // admin
     'PATCH /configurations/latest/handlers/:handlerType', // admin

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -189,6 +189,9 @@ export default function getRouteHandlers(
     'GET /config/:service/redirects.txt': redirectsController.getRedirects,
     'GET /audits/latest/:auditType': auditsController.getAllLatest,
     'GET /configurations/latest': configurationController.getLatest,
+    // Static route — matched before the dynamic `GET /configurations/:version`
+    // (see src/utils/route-utils.js), so "versions" is never treated as a VersionId.
+    'GET /configurations/versions': configurationController.listVersions,
     'PATCH /configurations/latest': configurationController.updateConfiguration,
     'POST /configurations/:version/restore': configurationController.restoreVersion,
     'GET /configurations/:version': configurationController.getByVersion,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -238,6 +238,7 @@ const routeRequiredCapabilities = {
 
   // Configuration
   'GET /configurations/latest': CAP_CONFIGURATION_READ,
+  'GET /configurations/versions': CAP_CONFIGURATION_READ,
   'PATCH /configurations/latest': CAP_CONFIGURATION_WRITE,
   'POST /configurations/:version/restore': CAP_CONFIGURATION_WRITE,
   'GET /configurations/:version': CAP_CONFIGURATION_READ,

--- a/test/controllers/configurations.test.js
+++ b/test/controllers/configurations.test.js
@@ -110,6 +110,7 @@ describe('Configurations Controller', () => {
   const configurationFunctions = [
     'getLatest',
     'getByVersion',
+    'listVersions',
     'registerAudit',
     'unregisterAudit',
     'updateQueues',
@@ -129,6 +130,29 @@ describe('Configurations Controller', () => {
       Configuration: {
         findLatest: sandbox.stub().resolves(configurations[1]),
         findByVersion: sandbox.stub().resolves(configurations[0]),
+        listVersions: sandbox.stub().resolves({
+          versions: [
+            {
+              versionId: 'v2',
+              lastModified: '2026-07-23T10:00:00.000Z',
+              isLatest: true,
+              size: 3000,
+              updatedBy: 'admin@adobe.com',
+              updatedAt: '2026-07-23T10:00:00.000Z',
+            },
+            {
+              versionId: 'v1',
+              lastModified: '2026-07-22T09:00:00.000Z',
+              isLatest: false,
+              size: 2900,
+              updatedBy: null,
+              updatedAt: null,
+            },
+          ],
+          isTruncated: false,
+          nextKeyMarker: null,
+          nextVersionIdMarker: null,
+        }),
       },
     };
 
@@ -317,6 +341,91 @@ describe('Configurations Controller', () => {
 
     expect(result.status).to.equal(403);
     expect(error).to.have.property('message', 'Only admins can view configurations');
+  });
+
+  describe('listVersions', () => {
+    const reqCtx = (query = '') => ({
+      request: { url: `https://spacecat.experiencecloud.live/api/v1/configurations/versions${query}` },
+    });
+
+    it('lists configuration versions for an admin', async () => {
+      const result = await configurationsController.listVersions(reqCtx());
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Configuration.listVersions).to.have.been.calledOnce;
+      expect(body.versions).to.have.length(2);
+      expect(body.versions[0]).to.deep.equal({
+        versionId: 'v2',
+        lastModified: '2026-07-23T10:00:00.000Z',
+        isLatest: true,
+        size: 3000,
+        updatedBy: 'admin@adobe.com',
+        updatedAt: '2026-07-23T10:00:00.000Z',
+      });
+      expect(body).to.include({ isTruncated: false });
+      expect(body.nextKeyMarker).to.be.null;
+      expect(body.nextVersionIdMarker).to.be.null;
+    });
+
+    it('returns forbidden for non-admin users', async () => {
+      context.attributes.authInfo.withProfile({ is_admin: false });
+      const result = await configurationsController.listVersions(reqCtx());
+      const error = await result.json();
+
+      expect(result.status).to.equal(403);
+      expect(error).to.have.property('message', 'Only admins can view configurations');
+      expect(mockDataAccess.Configuration.listVersions).to.not.have.been.called;
+    });
+
+    it('defaults to detail=true and no limit/markers when no query params', async () => {
+      await configurationsController.listVersions(reqCtx());
+
+      expect(mockDataAccess.Configuration.listVersions).to.have.been.calledWithMatch({
+        detail: true,
+        keyMarker: undefined,
+        versionIdMarker: undefined,
+      });
+      const arg = mockDataAccess.Configuration.listVersions.firstCall.args[0];
+      expect(arg).to.not.have.property('limit');
+    });
+
+    it('passes limit, markers and detail=false from the query string', async () => {
+      await configurationsController.listVersions(
+        reqCtx('?limit=10&keyMarker=km&versionIdMarker=vm&detail=false'),
+      );
+
+      expect(mockDataAccess.Configuration.listVersions).to.have.been.calledWithMatch({
+        limit: 10,
+        keyMarker: 'km',
+        versionIdMarker: 'vm',
+        detail: false,
+      });
+    });
+
+    it('clamps limit above 100 down to 100', async () => {
+      await configurationsController.listVersions(reqCtx('?limit=5000'));
+      expect(mockDataAccess.Configuration.listVersions)
+        .to.have.been.calledWithMatch({ limit: 100 });
+    });
+
+    it('clamps limit below 1 up to 1', async () => {
+      await configurationsController.listVersions(reqCtx('?limit=0'));
+      expect(mockDataAccess.Configuration.listVersions).to.have.been.calledWithMatch({ limit: 1 });
+    });
+
+    it('ignores a non-numeric limit (falls back to collection default)', async () => {
+      await configurationsController.listVersions(reqCtx('?limit=abc'));
+      const arg = mockDataAccess.Configuration.listVersions.firstCall.args[0];
+      expect(arg).to.not.have.property('limit');
+    });
+
+    it('falls back to defaults when context.request is missing', async () => {
+      const result = await configurationsController.listVersions({});
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Configuration.listVersions)
+        .to.have.been.calledWithMatch({ detail: true });
+    });
   });
 
   describe('configuration read - S2S configuration:read capability', () => {

--- a/test/controllers/configurations.test.js
+++ b/test/controllers/configurations.test.js
@@ -378,16 +378,15 @@ describe('Configurations Controller', () => {
       expect(mockDataAccess.Configuration.listVersions).to.not.have.been.called;
     });
 
-    it('defaults to detail=true and no limit/markers when no query params', async () => {
+    it('defaults to limit=25 and detail=true, omitting absent markers, when no query params', async () => {
       await configurationsController.listVersions(reqCtx());
 
-      expect(mockDataAccess.Configuration.listVersions).to.have.been.calledWithMatch({
-        detail: true,
-        keyMarker: undefined,
-        versionIdMarker: undefined,
-      });
+      expect(mockDataAccess.Configuration.listVersions)
+        .to.have.been.calledWithMatch({ limit: 25, detail: true });
+      // Absent markers must be omitted entirely, not passed as explicit undefined.
       const arg = mockDataAccess.Configuration.listVersions.firstCall.args[0];
-      expect(arg).to.not.have.property('limit');
+      expect(arg).to.not.have.property('keyMarker');
+      expect(arg).to.not.have.property('versionIdMarker');
     });
 
     it('passes limit, markers and detail=false from the query string', async () => {
@@ -414,17 +413,38 @@ describe('Configurations Controller', () => {
       expect(mockDataAccess.Configuration.listVersions).to.have.been.calledWithMatch({ limit: 1 });
     });
 
-    it('ignores a non-numeric limit (falls back to collection default)', async () => {
+    it('falls back to the documented default (25) on a non-numeric limit', async () => {
       await configurationsController.listVersions(reqCtx('?limit=abc'));
-      const arg = mockDataAccess.Configuration.listVersions.firstCall.args[0];
-      expect(arg).to.not.have.property('limit');
+      expect(mockDataAccess.Configuration.listVersions).to.have.been.calledWithMatch({ limit: 25 });
+    });
+
+    it('rejects an over-long pagination marker with 400', async () => {
+      const huge = 'x'.repeat(1025);
+      const result = await configurationsController.listVersions(reqCtx(`?keyMarker=${huge}`));
+      const error = await result.json();
+
+      expect(result.status).to.equal(400);
+      expect(error.message).to.match(/exceeds maximum length/);
+      expect(mockDataAccess.Configuration.listVersions).to.not.have.been.called;
     });
 
     it('falls back to defaults when context.request is missing', async () => {
       const result = await configurationsController.listVersions({});
       expect(result.status).to.equal(200);
       expect(mockDataAccess.Configuration.listVersions)
-        .to.have.been.calledWithMatch({ detail: true });
+        .to.have.been.calledWithMatch({ limit: 25, detail: true });
+    });
+
+    it('falls back to defaults when context.request.url is malformed', async () => {
+      const result = await configurationsController.listVersions({ request: { url: 'not-a-valid-url' } });
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Configuration.listVersions)
+        .to.have.been.calledWithMatch({ limit: 25, detail: true });
+    });
+
+    it('propagates a data-access failure (surfaced as 500 by the wrapper)', async () => {
+      mockDataAccess.Configuration.listVersions.rejects(new Error('S3 down'));
+      await expect(configurationsController.listVersions(reqCtx())).to.be.rejectedWith('S3 down');
     });
   });
 

--- a/test/dto/configuration.test.js
+++ b/test/dto/configuration.test.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import { ConfigurationDto } from '../../src/dto/configuration.js';
+
+describe('ConfigurationDto.versionsToJSON', () => {
+  it('maps enriched versions and pagination markers', () => {
+    const page = {
+      versions: [
+        {
+          versionId: 'v2',
+          lastModified: '2026-07-23T10:00:00.000Z',
+          isLatest: true,
+          size: 3000,
+          updatedBy: 'admin@adobe.com',
+          updatedAt: '2026-07-23T10:00:00.000Z',
+        },
+      ],
+      isTruncated: true,
+      nextKeyMarker: 'config/spacecat/global-config.json',
+      nextVersionIdMarker: 'v1',
+    };
+
+    expect(ConfigurationDto.versionsToJSON(page)).to.deep.equal(page);
+  });
+
+  it('omits updatedBy/updatedAt when they are absent (detail=false rows)', () => {
+    const result = ConfigurationDto.versionsToJSON({
+      versions: [{
+        versionId: 'v1', lastModified: 'x', isLatest: false, size: 1,
+      }],
+      isTruncated: false,
+      nextKeyMarker: null,
+      nextVersionIdMarker: null,
+    });
+
+    expect(result.versions[0]).to.not.have.property('updatedBy');
+    expect(result.versions[0]).to.not.have.property('updatedAt');
+  });
+
+  it('preserves explicit null updatedBy/updatedAt (older versions)', () => {
+    const result = ConfigurationDto.versionsToJSON({
+      versions: [{
+        versionId: 'v1', lastModified: 'x', isLatest: false, size: 1, updatedBy: null, updatedAt: null,
+      }],
+    });
+
+    expect(result.versions[0].updatedBy).to.be.null;
+    expect(result.versions[0].updatedAt).to.be.null;
+  });
+
+  it('defaults an empty/absent page to a safe shape', () => {
+    const result = ConfigurationDto.versionsToJSON({});
+    expect(result).to.deep.equal({
+      versions: [],
+      isTruncated: false,
+      nextKeyMarker: null,
+      nextVersionIdMarker: null,
+    });
+  });
+});

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -26,6 +26,7 @@ describe('getRouteHandlers', () => {
     getAll: sinon.stub(),
     getByVersion: sinon.stub(),
     getLatest: sinon.stub(),
+    listVersions: sinon.stub(),
     updateConfiguration: sinon.stub(),
     registerAudit: sinon.stub(),
     unregisterAudit: sinon.stub(),
@@ -704,6 +705,7 @@ describe('getRouteHandlers', () => {
 
     expect(staticRoutes).to.have.all.keys(
       'GET /configurations/latest',
+      'GET /configurations/versions',
       'PATCH /configurations/latest',
       'POST /configurations/audits',
       'PATCH /configurations/sites/audits',
@@ -793,6 +795,7 @@ describe('getRouteHandlers', () => {
     );
 
     expect(staticRoutes['GET /configurations/latest']).to.equal(mockConfigurationController.getLatest);
+    expect(staticRoutes['GET /configurations/versions']).to.equal(mockConfigurationController.listVersions);
     expect(staticRoutes['PATCH /configurations/latest']).to.equal(mockConfigurationController.updateConfiguration);
     expect(staticRoutes['POST /configurations/audits']).to.equal(mockConfigurationController.registerAudit);
     expect(staticRoutes['PATCH /configurations/sites/audits']).to.equal(mockSitesAuditsToggleController.execute);

--- a/test/utils/route-utils.test.js
+++ b/test/utils/route-utils.test.js
@@ -49,6 +49,22 @@ describe('matchPath', () => {
     expect(matchPath('GET', '/about', routeDefinitions)).to.deep.equal({ handler: 'aboutHandler', params: {} });
   });
 
+  it('prefers a static route over a colliding dynamic one (versions vs :version)', () => {
+    const defs = {
+      staticRoutes: { 'GET /configurations/versions': 'listVersionsHandler' },
+      dynamicRoutes: {
+        'GET /configurations/:version': { handler: 'getByVersionHandler', paramNames: ['version'] },
+      },
+    };
+    // The literal "versions" segment must resolve to the static handler, not be
+    // captured as a VersionId by the dynamic route.
+    expect(matchPath('GET', '/configurations/versions', defs))
+      .to.deep.equal({ handler: 'listVersionsHandler', params: {} });
+    // A real VersionId still falls through to the dynamic route.
+    expect(matchPath('GET', '/configurations/abc123', defs))
+      .to.deep.equal({ handler: 'getByVersionHandler', params: { version: 'abc123' } });
+  });
+
   it('matches dynamic routes correctly', () => {
     expect(matchPath('GET', '/users/123', routeDefinitions)).to.deep.equal({ handler: 'userHandler', params: { userId: '123' } });
     expect(matchPath('GET', '/products/456/details', routeDefinitions)).to.deep.equal({ handler: 'productDetailsHandler', params: { productId: '456' } });


### PR DESCRIPTION
## Why

The `spacecat-configuration` admin skill needed **direct S3/AWS-console access** for one remaining task: discovering the config **VersionIds** consumed by `GET /configurations/:version`, `POST /configurations/:version/restore`, and offline exports. Config history lives as S3 object versions with no REST way to list them.

This adds the missing list endpoint so the skill (and any admin) can discover versions through the API — no AWS access required.

## What

`GET /configurations/versions` — lists the config's S3 object-version history, newest first.

- **Static route**, matched before the dynamic `GET /configurations/:version` (added a route-precedence test so "versions" can never be captured as a VersionId).
- Gated by `authorizeConfigRead` (admin OR S2S `configuration:read`), mapped to `CAP_CONFIGURATION_READ`, added to the FACS admin route list (no new `:param`).
- Query params: `limit` (clamped 1–100), `keyMarker`/`versionIdMarker` (pagination), `detail` (default true → `updatedBy`/`updatedAt` enrichment).
- `ConfigurationDto.versionsToJSON`; OpenAPI path + response schema; controller/DTO/route tests.

## ⚠️ Depends on

- adobe/spacecat-shared#1839 (adds `ConfigurationCollection.listVersions`). **Merge/release that first**, then this PR bumps `@adobe/spacecat-shared-data-access` to the released version. Until then CI resolves the dep via the lockfile; the controller tests mock the collection so they don't require the new method at unit-test time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)