### PR TITLE
fix(serenity): thread dynamic-allocation flag + ceiling into brand onboarding (LLMO-6190)

### DIFF
--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -21,6 +21,7 @@ import { resolveWorkspaceId } from './workspace-resolver.js';
 import { deleteAllProjects, releaseFullAllocation, ensureSubworkspace } from './workspace-lifecycle.js';
 import { handleCreateMarketSubworkspace } from './handlers/markets-subworkspace.js';
 import { computeWriteDeadline } from './intent-classification.js';
+import { isDynamicAllocationEnabled, resolveBrandAiCeiling } from './dynamic-allocation-active.js';
 
 // Brand-create generation policy (tunable). Keep the top N generated topics by
 // search volume; brand-topics returns up to 10 topics x up to 100 prompts each,
@@ -137,6 +138,15 @@ export async function provisionBrandSubworkspace(context, {
   const imsToken = await resolveSemrushImsToken(context, log, 'brand-provisioning');
   const transport = createSerenityTransport({ env: context.env, imsToken });
 
+  // Dynamic-allocation kill-switch + per-brand ceiling (LLMO-6190): brand creation is onboarding,
+  // and §3/§4a of the design require an onboarded-while-ON brand to get a MINIMAL sub-workspace
+  // (JIT top-up on the first metered op), not the flat pre-calculated carve. This was previously
+  // missing here — the flag/ceiling were threaded into every other subworkspace write path
+  // (activate, create-market, create-prompts, update-models) but not brand creation, so a new
+  // brand always got the flat carve even with the flag ON.
+  const dynamicAllocation = isDynamicAllocationEnabled(context.env);
+  const ceiling = resolveBrandAiCeiling(context.env, log);
+
   /** @type {string|null} */
   let capturedWorkspaceId = null;
   const brandStub = {
@@ -221,6 +231,8 @@ export async function provisionBrandSubworkspace(context, {
         publishMode: (Array.isArray(modelIds) && modelIds.length > 0) || generateTopics
           ? 'require'
           : 'best-effort',
+        dynamicAllocation,
+        ceiling,
       },
     );
   } catch (e) {
@@ -301,6 +313,10 @@ export async function provisionBrandSubworkspaceBare(context, {
   const imsToken = await resolveSemrushImsToken(context, log, 'brand-provisioning');
   const transport = createSerenityTransport({ env: context.env, imsToken });
 
+  // Dynamic-allocation kill-switch (LLMO-6190) — see the identical note in
+  // provisionBrandSubworkspace above: onboarding must not silently opt out of JIT allocation.
+  const dynamicAllocation = isDynamicAllocationEnabled(context.env);
+
   /** @type {string|null} */
   let capturedWorkspaceId = null;
   const brandStub = {
@@ -322,7 +338,7 @@ export async function provisionBrandSubworkspaceBare(context, {
       log,
       {},
       null,
-      {},
+      { dynamicAllocation },
     );
     const resolved = hasText(subWorkspaceId) ? subWorkspaceId : capturedWorkspaceId;
     if (!resolved || !hasText(resolved)) {

--- a/test/support/serenity/brand-provisioning.test.js
+++ b/test/support/serenity/brand-provisioning.test.js
@@ -202,11 +202,29 @@ describe('provisionBrandSubworkspace', () => {
       competitors: [],
       env: { SEMRUSH_PROJECTS_BASE_URL: 'https://gw.example' },
       publishMode: 'require',
+      // Dynamic-allocation kill-switch defaults OFF (env unset) and the per-brand ceiling defaults
+      // undefined (no ceiling env set) — onboarding is now threaded the same as every other
+      // subworkspace write path (LLMO-6190).
+      dynamicAllocation: false,
+      ceiling: undefined,
     });
     // The stub drives the sub-workspace title off the brand's name + id.
     expect(brandStub.getName()).to.equal('Acme');
     expect(brandStub.getId()).to.equal('brand-1');
     expect(brandStub.getSemrushSubWorkspaceId()).to.equal(undefined);
+  });
+
+  it('threads the dynamic-allocation flag + per-brand ceiling from env into the handler options (LLMO-6190 — onboarding was previously silently excluded)', async () => {
+    const { provisionBrandSubworkspace } = await loadModule({
+      resolveWorkspaceId, handleCreateMarketSubworkspace,
+    });
+    const ctx = buildContext();
+    ctx.env.SERENITY_DYNAMIC_ALLOCATION = 'true';
+    ctx.env.SERENITY_BRAND_AI_CEILING_PROMPTS = '5000';
+    await provisionBrandSubworkspace(ctx, baseParams);
+    const options = handleCreateMarketSubworkspace.firstCall.args[7];
+    expect(options.dynamicAllocation).to.equal(true);
+    expect(options.ceiling).to.deep.equal({ prompts: 5000 });
   });
 
   it('forwards a caller-supplied writeDeadline to the create handler (computed once at request entry, not defaulted here)', async () => {
@@ -530,6 +548,16 @@ describe('provisionBrandSubworkspaceBare', () => {
     // Success → no allocation release.
     expect(deleteAllProjects).to.not.have.been.called;
     expect(releaseFullAllocation).to.not.have.been.called;
+    // Kill-switch defaults OFF (env unset) — byte-for-byte the pre-fix flat carve.
+    expect(ensureSubworkspace.firstCall.args[7]).to.deep.equal({ dynamicAllocation: false });
+  });
+
+  it('threads the dynamic-allocation flag from env into ensureSubworkspace (LLMO-6190 — onboarding was previously silently excluded)', async () => {
+    const { provisionBrandSubworkspaceBare } = await loadBareModule();
+    const ctx = buildContext();
+    ctx.env.SERENITY_DYNAMIC_ALLOCATION = 'true';
+    await provisionBrandSubworkspaceBare(ctx, bareParams);
+    expect(ensureSubworkspace.firstCall.args[7]).to.deep.equal({ dynamicAllocation: true });
   });
 
   it('falls back to the captured workspace id when ensureSubworkspace returns nothing', async () => {


### PR DESCRIPTION
## Summary

`provisionBrandSubworkspace` / `provisionBrandSubworkspaceBare` (the brand-creation onboarding path, invoked from `controllers/brands.js`'s `createBrandForOrg`) never threaded `SERENITY_DYNAMIC_ALLOCATION` or the per-brand ceiling into `ensureSubworkspace` / `handleCreateMarketSubworkspace`, so a new brand always got the **flat pre-calculated carve** even with the flag ON. Every other subworkspace write path (activate, create-market, create-prompts, update-models) already had this wired — onboarding was the one gap.

This contradicts the `serenity-docs` dynamic-resource-allocation spec, which is explicit that a brand onboarded while the flag is ON gets a **minimal** child that tops up just-in-time (§3, §4a) — the entire flag-flip rollback discussion in §4a assumes this.

## Fix
Resolve `isDynamicAllocationEnabled(context.env)` / `resolveBrandAiCeiling(context.env, log)` — the same helpers the controller already uses — and thread `dynamicAllocation` (+ `ceiling` where a metered write actually happens) through both provisioning entry points, mirroring the existing pattern exactly.

- `provisionBrandSubworkspace` → `dynamicAllocation` + `ceiling` into `handleCreateMarketSubworkspace`'s options.
- `provisionBrandSubworkspaceBare` → `dynamicAllocation` into `ensureSubworkspace`'s options (no metered write here, so no ceiling needed).

Flag-OFF / ceiling-unset behavior is byte-for-byte unchanged (both default off/undefined) — this only changes behavior when the flag is ON, which onboarding was previously silently exempt from.

## Test plan
- [x] `npm run lint && npm run type-check` clean
- [x] `npm test` — full suite green (15845 passing)
- [x] Updated the existing exhaustive-options-bag assertion in `brand-provisioning.test.js` for the new fields
- [x] Added: `provisionBrandSubworkspace` threads flag+ceiling from env into the handler options when set
- [x] Added: `provisionBrandSubworkspaceBare` threads the flag from env into `ensureSubworkspace`'s options when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)