### PR TITLE
fix: validate temporalCondition strictly to close SQL injection in paid traffic endpoints | VULN-37317

### DIFF
--- a/src/controllers/paid/traffic.js
+++ b/src/controllers/paid/traffic.js
@@ -329,6 +329,7 @@ function TrafficController(context, log, env) {
 
     const parsedTemporalCondition = parseTemporalCondition(decodedTemporalCondition);
     if (!parsedTemporalCondition) {
+      log.info(`Rejected request with invalid temporalCondition | siteId: ${siteId} | reason: failed strict parse/shape validation | requestId: ${requestId}`);
       return badRequest('Invalid temporal condition');
     }
 

--- a/src/controllers/paid/traffic.js
+++ b/src/controllers/paid/traffic.js
@@ -88,6 +88,51 @@ function validateTemporalParams({ year, week, month }) {
 
 const isTrue = (value) => value === true || value === 'true' || value === '1' || value === 1;
 
+// Matches a single "(week=W AND year=Y)" clause (week/year order and internal
+// whitespace both flexible) with numeric-only operands.
+const TEMPORAL_CLAUSE_PATTERN = /^\(\s*(?:week\s*=\s*(\d{1,2})\s*AND\s*year\s*=\s*(\d{4})|year\s*=\s*(\d{4})\s*AND\s*week\s*=\s*(\d{1,2}))\s*\)$/i;
+
+// The documented use case is a 4-week window (see docs/openapi/site-paid.yaml); this
+// caps clause count well above that to block resource-abuse via a huge OR-chain
+// while still allowing legitimate callers plenty of headroom.
+const MAX_TEMPORAL_CLAUSES = 8;
+
+/**
+ * Strictly parses a client-supplied temporal condition string into a list of
+ * {week, year} integer pairs, rejecting anything that doesn't match the exact
+ * expected shape. This is the only path by which the value is later used to
+ * build the Athena SQL WHERE clause, so no attacker-controlled text ever
+ * reaches the query - only integers we validated and re-serialize ourselves.
+ * @param {string} decodedTemporalCondition - Decoded temporalCondition query param
+ * @returns {Array<{week: number, year: number}>|null} Parsed pairs, or null if invalid
+ */
+function parseTemporalCondition(decodedTemporalCondition) {
+  const clauses = decodedTemporalCondition.split(/\s+OR\s+/i);
+  if (clauses.length > MAX_TEMPORAL_CLAUSES) {
+    return null;
+  }
+
+  const parsed = [];
+
+  for (const clause of clauses) {
+    const match = TEMPORAL_CLAUSE_PATTERN.exec(clause.trim());
+    if (!match) {
+      return null;
+    }
+
+    const week = Number(match[1] ?? match[4]);
+    const year = Number(match[2] ?? match[3]);
+
+    if (week < 1 || week > 53 || year < 2000 || year > 2100) {
+      return null;
+    }
+
+    parsed.push({ week, year });
+  }
+
+  return parsed;
+}
+
 function TrafficController(context, log, env) {
   const { dataAccess, s3 } = context;
   const { Site } = dataAccess;
@@ -282,10 +327,15 @@ function TrafficController(context, log, env) {
 
     const decodedTemporalCondition = decodeURIComponent(temporalCondition);
 
-    if (!decodedTemporalCondition.includes('week')
-      || !decodedTemporalCondition.includes('year')) {
+    const parsedTemporalCondition = parseTemporalCondition(decodedTemporalCondition);
+    if (!parsedTemporalCondition) {
       return badRequest('Invalid temporal condition');
     }
+
+    // Rebuilt from validated integers only - never from the raw client string.
+    const safeTemporalCondition = parsedTemporalCondition
+      .map(({ week, year }) => `(week=${week} AND year=${year})`)
+      .join(' OR ');
 
     const tableName = `${rumMetricsDatabase}.${rumMetricsCompactTable}`;
 
@@ -296,7 +346,7 @@ function TrafficController(context, log, env) {
     const query = getTop3PagesWithBounceGapTemplate({
       siteId,
       tableName,
-      temporalCondition: decodedTemporalCondition,
+      temporalCondition: safeTemporalCondition,
       dimensionColumns,
       groupBy: dimensionColumns,
       dimensionColumnsPrefixed,
@@ -305,7 +355,7 @@ function TrafficController(context, log, env) {
 
     log.info(`getTop3PagesWithBounceGapTemplate Query: ${query}`);
 
-    const description = `fetch top 3 pages traffic data db: ${rumMetricsDatabase}| siteKey: ${siteId} | temporalCondition: ${decodedTemporalCondition} | groupBy: [${dimensions.join(', ')}] `;
+    const description = `fetch top 3 pages traffic data db: ${rumMetricsDatabase}| siteKey: ${siteId} | temporalCondition: ${safeTemporalCondition} | groupBy: [${dimensions.join(', ')}] `;
 
     // first try to get from cache
     const { cachedResultUrl, cacheKey, outPrefix } = await tryGetCacheResult(

--- a/test/controllers/paid/traffic.test.js
+++ b/test/controllers/paid/traffic.test.js
@@ -1265,14 +1265,26 @@ describe('Paid TrafficController', async () => {
       expect(mockAthenaQuery).to.not.have.been.called;
     });
 
-    it('accepts temporalCondition at the maximum allowed clause count', async () => {
-      const clauses = Array.from({ length: 8 }, (_, i) => `(week=${(i % 53) + 1} AND year=2024)`);
+    it('accepts temporalCondition at the maximum allowed clause count (mixed week/year ordering)', async () => {
+      const weeks = Array.from({ length: 8 }, (_, i) => (i % 53) + 1);
+      // Alternate week-first / year-first clauses so both branches of the
+      // regex's alternation (and both capture-group pairs) are exercised.
+      const clauses = weeks.map((week, i) => (
+        i % 2 === 0 ? `(week=${week} AND year=2024)` : `(year=2024 AND week=${week})`
+      ));
       mockContext.data.temporalCondition = encodeURIComponent(clauses.join(' OR '));
       mockAthenaQuery.resolves([]);
       const controller = TrafficController(mockContext, mockLog, mockEnv);
       const res = await controller.getImpactByPage();
       expect(res.status).to.equal(200);
       expect(mockAthenaQuery).to.have.been.calledOnce;
+
+      // Regardless of the original clauses' ordering, the query must only ever
+      // contain the canonical week-first form rebuilt from validated integers.
+      const expectedSafeCondition = weeks.map((week) => `(week=${week} AND year=2024)`).join(' OR ');
+      const queryArg = mockAthenaQuery.firstCall.args[0];
+      expect(queryArg).to.include(expectedSafeCondition);
+      expect(queryArg).to.not.include('year=2024 AND week');
     });
 
     it('returns cached result if available for impact endpoints', async () => {

--- a/test/controllers/paid/traffic.test.js
+++ b/test/controllers/paid/traffic.test.js
@@ -1234,6 +1234,47 @@ describe('Paid TrafficController', async () => {
       expect(body.message).to.equal('Invalid temporal condition');
     });
 
+    it('rejects SQL injection payload via temporalCondition (HackerOne #3880600 / VULN-37317)', async () => {
+      // Boolean-oracle payload from the report: satisfies the old substring
+      // check (contains "week" and "year") but injects a live SQL expression.
+      mockContext.data.temporalCondition = encodeURIComponent("year = 2026 AND week = 29 AND IF(1 = 1, CAST('n4z8c6q2' AS INTEGER), 1) = 1");
+      const controller = TrafficController(mockContext, mockLog, mockEnv);
+      const res = await controller.getImpactByPage();
+      expect(res.status).to.equal(400);
+      const body = await res.json();
+      expect(body.message).to.equal('Invalid temporal condition');
+      expect(mockAthenaQuery).to.not.have.been.called;
+    });
+
+    it('rejects closing-parenthesis / OR escape attempt via temporalCondition', async () => {
+      mockContext.data.temporalCondition = encodeURIComponent('(week=1 AND year=2024)) OR (1=1) --');
+      const controller = TrafficController(mockContext, mockLog, mockEnv);
+      const res = await controller.getImpactByPage();
+      expect(res.status).to.equal(400);
+      expect(mockAthenaQuery).to.not.have.been.called;
+    });
+
+    it('rejects temporalCondition with an excessive number of OR-joined clauses', async () => {
+      const clauses = Array.from({ length: 9 }, (_, i) => `(week=${(i % 53) + 1} AND year=2024)`);
+      mockContext.data.temporalCondition = encodeURIComponent(clauses.join(' OR '));
+      const controller = TrafficController(mockContext, mockLog, mockEnv);
+      const res = await controller.getImpactByPage();
+      expect(res.status).to.equal(400);
+      const body = await res.json();
+      expect(body.message).to.equal('Invalid temporal condition');
+      expect(mockAthenaQuery).to.not.have.been.called;
+    });
+
+    it('accepts temporalCondition at the maximum allowed clause count', async () => {
+      const clauses = Array.from({ length: 8 }, (_, i) => `(week=${(i % 53) + 1} AND year=2024)`);
+      mockContext.data.temporalCondition = encodeURIComponent(clauses.join(' OR '));
+      mockAthenaQuery.resolves([]);
+      const controller = TrafficController(mockContext, mockLog, mockEnv);
+      const res = await controller.getImpactByPage();
+      expect(res.status).to.equal(200);
+      expect(mockAthenaQuery).to.have.been.calledOnce;
+    });
+
     it('returns cached result if available for impact endpoints', async () => {
       mockS3.send.callsFake((cmd) => {
         if (cmd.constructor && cmd.constructor.name === 'HeadObjectCommand') {


### PR DESCRIPTION
## What & why
[VULN-37317](https://jira.corp.adobe.com/browse/VULN-37317) — Authenticated SQL injection on `/api/v1/sites/{siteId}/traffic/paid/impact-by-page` via `temporalCondition`.

`fetchTop3PagesTrafficData` (and every endpoint routed through it) built its Athena SQL query by interpolating the `temporalCondition` query param directly into the `WHERE` clause, validated only by checking the decoded string contained the substrings `"week"` and `"year"`. HackerOne report #3880600 showed this could be bypassed with a boolean-oracle payload (`IF(1=1, CAST('n4z8c6q2' AS INTEGER), 1) = 1`) to blind-inject SQL, and the same shape (closing paren + `OR`) could in principle escape the site-scoped filter for cross-tenant disclosure. This PR closes that path by parsing the parameter into validated integers and rebuilding the SQL fragment server-side, so no attacker-controlled text ever reaches the query.

## Scope
- `parseTemporalCondition` (`src/controllers/paid/traffic.js`) replaces the substring check with a regex-anchored parse of `(week=N AND year=N)` clauses (either order, flexible whitespace, digits-only operands), returning `null` for anything that doesn't match exactly — including the reported exploit payload and a closing-paren/`OR` escape attempt.
- The Athena `WHERE` fragment is rebuilt as `(week=${week} AND year=${year})` joined by `OR`, from the parsed integers only — the raw client string is no longer used in the query, the log line, or the query description.
- `MAX_TEMPORAL_CLAUSES` (8) caps the number of `OR`-joined clauses, closing a secondary "query resource abuse" angle the same report called out — the documented use case (`docs/openapi/site-paid.yaml`) is a 4-week window, so 8 leaves headroom without allowing an unbounded chain.
- Applies to all five endpoints that route through `fetchTop3PagesTrafficData`: `getImpactByPage`, `getImpactByPageTrafficType`, `getImpactByPageDevice`, `getImpactByPageTrafficTypeDevice`, `getTrafficLossByDevices`.

## Deferred / out of scope
- `traffic-tools.js`'s `getPredominantTraffic` builds its own `temporalCondition` server-side (`generateTemporalCondition()`) and never accepts client input for it — unaffected by the report, not touched here.
- No OpenAPI/contract change — the parameter's shape and semantics for legitimate callers are unchanged; only invalid or malicious input is now rejected (`400 Invalid temporal condition`) instead of reaching Athena.

## Tests
Extended `test/controllers/paid/traffic.test.js` with four new cases: rejects the reported exploit payload (asserts `400` and that Athena is never called), rejects a closing-paren/`OR` escape attempt, rejects a `temporalCondition` over the 8-clause cap, and accepts one exactly at the cap. Full suite: **86 passing**. Lint clean on both changed files (aside from pre-existing CRLF/header-year noise unrelated to this diff).
