### PR TITLE
fix(serenity): wrap delete-market releaseAiSurplus in withResourceLock

### DIFF
--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -856,9 +856,11 @@ export async function handleCreateMarketSubworkspace(
  * (our own `deleteProject` succeeded, or it 404'd because the upstream was already gone) leaves the
  * project truly absent, so both are treated identically: release fires after the try/catch, not
  * just on the success leg. Same shape as the model-removal seam
- * (`handleUpdateModelsSubworkspace`): inline, fail-fast (`releaseAiSurplus({ failFast: true })`),
- * best-effort (its own internal try/catch swallows expected transport/pool failures — a release
- * hiccup must never fail an otherwise-successful DELETE), post-delete. No-op when the flag is OFF.
+ * (`handleUpdateModelsSubworkspace`): per-child `withResourceLock`-wrapped (LLMO-6191 item 3,
+ * closing the same same-container absolute-set race the sibling call site closes), fail-fast
+ * (`releaseAiSurplus({ failFast: true })`), best-effort (its own internal try/catch swallows
+ * expected transport/pool failures — a release hiccup must never fail an otherwise-successful
+ * DELETE), post-delete. No-op when the flag is OFF.
  *
  * @param {object} transport - Serenity transport (Semrush proxy client).
  * @param {string|null} workspaceId - sub-workspace id the market's project lives in.
@@ -907,11 +909,21 @@ export async function handleDeleteMarketSubworkspace(
     // `resolveProject` above already resolved a project against `workspaceId`, so it is a real,
     // non-blank id here; releaseAiSurplus's own requireWorkspaceId re-asserts this at runtime —
     // narrow the (JSDoc-optional) `string|null` param for tsc, which cannot infer that.
-    await releaseAiSurplus(transport, {
-      subWorkspaceId: /** @type {string} */ (workspaceId),
-      floor: { projects: PROJECT_BLOCK, prompts: PROMPT_BLOCK },
-      failFast: true,
-    }, log);
+    //
+    // Wrapped in `withResourceLock` (LLMO-6191 item 3), mirroring `handleUpdateModelsSubworkspace`:
+    // `releaseAiSurplus` does the same read-then-absolute-set as `ensureAiHeadroom`, so an
+    // in-flight `ensure`/release for this SAME child in this same warm container must not race
+    // this one — both go through the one per-child lock. This closes the same-container half of
+    // the absolute-set race; the cross-container half is the deferred distributed lock (see
+    // docs/decisions/007-cross-container-resource-lock.md).
+    await withResourceLock(
+      /** @type {string} */ (workspaceId),
+      () => releaseAiSurplus(transport, {
+        subWorkspaceId: /** @type {string} */ (workspaceId),
+        floor: { projects: PROJECT_BLOCK, prompts: PROMPT_BLOCK },
+        failFast: true,
+      }, log),
+    );
   }
   return { status: 204, deletedSiteId };
 }

--- a/test/support/serenity/dynamic-allocation-fronting.test.js
+++ b/test/support/serenity/dynamic-allocation-fronting.test.js
@@ -483,6 +483,45 @@ describe('dynamic-allocation fronting — delete-market release', () => {
     });
   });
 
+  it('ON + two concurrent deletes on the SAME child: releases are serialized through withResourceLock '
+    + '(LLMO-6191 item 3), matching handleUpdateModelsSubworkspace — no interleaved read/write', async () => {
+    // Without the lock, both releases' getWorkspaceResources reads would fire before either
+    // transferWorkspaceResources write (the read-then-absolute-set race the lock closes). Hold the
+    // first call's write open with a deferred promise so a second, concurrent call to the SAME
+    // workspace can only start its own read/write pair once the first has fully settled.
+    let resolveFirstTransfer;
+    const firstTransferGate = new Promise((resolve) => {
+      resolveFirstTransfer = resolve;
+    });
+    const callOrder = [];
+    const getWorkspaceResources = sinon.stub().callsFake(async () => {
+      callOrder.push('read');
+      return RELEASABLE_CHILD;
+    });
+    const transferWorkspaceResources = sinon.stub().callsFake(async () => {
+      callOrder.push('write-start');
+      if (callOrder.filter((e) => e === 'write-start').length === 1) {
+        await firstTransferGate;
+      }
+      callOrder.push('write-end');
+      return null;
+    });
+    const t = makeDeleteTransport({ getWorkspaceResources, transferWorkspaceResources });
+
+    const p1 = handleDeleteMarketSubworkspace(t, WS, 2840, 'en', log, { dynamicAllocation: true });
+    // Let the first call's release reach its (gated) write before starting the second.
+    await new Promise((resolve) => {
+      setTimeout(() => resolve(), 0);
+    });
+    const p2 = handleDeleteMarketSubworkspace(t, WS, 2840, 'en', log, { dynamicAllocation: true });
+    // The second call's read must NOT have fired yet — it is queued behind the first call's whole
+    // critical section (read + write), not just its read.
+    expect(callOrder).to.deep.equal(['read', 'write-start']);
+    resolveFirstTransfer();
+    await Promise.all([p1, p2]);
+    expect(callOrder).to.deep.equal(['read', 'write-start', 'write-end', 'read', 'write-start', 'write-end']);
+  });
+
   it('ON + upstream deleteProject 404s (already gone): release still fires (project is confirmed gone either way)', async () => {
     const t = makeDeleteTransport({
       deleteProject: sinon.stub().rejects(new SerenityTransportError(404, 'gone', null)),


### PR DESCRIPTION
## Summary

- `handleDeleteMarketSubworkspace` released freed AI units back to the parent pool via a bare `releaseAiSurplus` call, unwrapped by any per-child lock.
- Its sibling, `handleUpdateModelsSubworkspace`, already wraps the same kind of `releaseAiSurplus` call in `withResourceLock` (LLMO-6191 item 3) to close a same-container race: two concurrent operations on the same child sub-workspace can each read a stale `total` and then each write an absolute value, with the later write clobbering the earlier one's update.
- Same race exists at the delete-market call site — it just wasn't closed there. This PR wraps `handleDeleteMarketSubworkspace`'s `releaseAiSurplus` call in `withResourceLock` the same way, keyed on the sub-workspace id, mirroring `handleUpdateModelsSubworkspace` as the reference implementation.
- No behavior change beyond adding the lock: same fail-fast, best-effort semantics, same args to `releaseAiSurplus`.

## Test plan

- [x] Added a unit test in `test/support/serenity/dynamic-allocation-fronting.test.js` asserting two concurrent `handleDeleteMarketSubworkspace` calls against the same child are serialized (the second call's `getWorkspaceResources` read does not fire until the first call's full read+write critical section has settled).
- [x] `npx mocha test/support/serenity/dynamic-allocation-fronting.test.js test/support/serenity/handlers/markets-subworkspace.test.js test/support/serenity/resource-lock.test.js` — 139 passing.
- [x] `npx eslint` on both changed files — clean.
- [x] `npm run type-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)