### PR TITLE
fix: preserve wildcard (*) base URLs in Slack URL input parsing

### DIFF
--- a/src/utils/slack/base.js
+++ b/src/utils/slack/base.js
@@ -31,7 +31,9 @@ export const SLACK_API = 'https://slack.com/api/chat.postMessage';
 export const FALLBACK_SLACK_CHANNEL = 'C060T2PPF8V';
 export const PROFILE_CONFIG_PATH = path.resolve(process.cwd(), 'static/onboard/profiles.json');
 
-const SLACK_URL_FORMAT_REGEX = /(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9.-]+)\.([a-zA-Z]{2,})([/\w.-]*\/?)/;
+// Path segment allows '*' so wildcard base URLs (e.g. https://example.com/en-ge/*) survive
+// intact instead of being silently truncated right before the asterisk.
+const SLACK_URL_FORMAT_REGEX = /(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9.-]+)\.([a-zA-Z]{2,})([/\w.*-]*\/?)/;
 const MAX_TEXT_CHUNK_SIZE = 3000;
 const MAX_CHUNK_SIZE = 25;
 

--- a/test/utils/slack/base.test.js
+++ b/test/utils/slack/base.test.js
@@ -123,6 +123,14 @@ describe('Base Slack Utils', () => {
       expect(extractURLFromSlackInput('get site https://personal.nedbank.co.za/borrow/personal-loans.plain.html/ extra acme.com/', false)).to.equal(`${expected}/`);
       expect(extractURLFromSlackInput('get site <https://personal.nedbank.co.za/borrow/personal-loans.plain.html/> extra acme.com/ <acme.com/> <http://acme.com|acme.com>', false)).to.equal(`${expected}/`);
     });
+
+    it('extractURLFromSlackInput preserves a wildcard base URL instead of truncating it', async () => {
+      const expected = 'https://example.com/en-ge/*';
+
+      expect(extractURLFromSlackInput('set imsorg https://example.com/en-ge/* 908936ED5D35CC220A495CD4@AdobeOrg')).to.equal(expected);
+      expect(extractURLFromSlackInput('set imsorg <https://example.com/en-ge/*> 908936ED5D35CC220A495CD4@AdobeOrg')).to.equal(expected);
+      expect(extractURLFromSlackInput('https://example.com/en-ge/*')).to.equal(expected);
+    });
   });
 
   describe('Messaging Functions', () => {


### PR DESCRIPTION
## Problem

`extractURLFromSlackInput()` (`src/utils/slack/base.js`) resolves a base URL out of free-form Slack text via `SLACK_URL_FORMAT_REGEX`. The path-capturing group only allowed `/`, word characters, `.` and `-`:

```js
/(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9.-]+)\.([a-zA-Z]{2,})([/\w.-]*\/?)/
```

`*` wasn't in that class, so the match stops right before it. Any Slack command that resolves a site by base URL (`set imsorg`, `get site`, `add site`, `toggle`, etc.) silently truncates a wildcard base URL:

```
https://example.com/en-ge/*  →  https://example.com/en-ge/
```

If a sibling site exists with that exact truncated base URL, the command transparently operates on the *wrong* site instead of erroring or no-op'ing. This is exactly what happened in production with a customer site pair (`.../en-ge/*` and `.../en-ge/`) — `set imsorg` on the wildcard site silently updated its non-wildcard sibling instead.

`Site.findByBaseURL()` is an exact-match lookup and `new URL()` / `isValidUrl()` both handle `*` in a path natively, so a wildcard base URL is a legitimate, already-supported value — the bug is purely in this regex's character class.

## Fix

Add `*` to the path character class:

```js
/(?:https?:\/\/)?(?:www\.)?([a-zA-Z0-9.-]+)\.([a-zA-Z]{2,})([/\w.*-]*\/?)/
```

Verified byte-for-byte identical matches against every existing input in `test/utils/slack/base.test.js` (no behavior change for any non-wildcard case, including plain sub-paths like `/en-GE`), plus a new case confirming a wildcard base URL now round-trips intact.

## Testing

- `test/utils/slack/base.test.js` — added `extractURLFromSlackInput preserves a wildcard base URL instead of truncating it`; full file passes (35/35).
- Also ran `test/support/slack/commands/set-ims-org.test.js` and `test/support/slack/commands/add-site.test.js` (consumers of this parser) — 79/79 passing, no regressions.
- `eslint` clean on both changed files.
- Confirmed via `mysticat site list` that no site in the dev environment currently has a wildcard base URL, so a synthetic sandbox test site will be created there to exercise `set imsorg`/`get site` end-to-end before merge.

## Test plan (before merge)

- [ ] Create a sandbox wildcard-base-URL site in dev and exercise `set imsorg <wildcard-url> <imsOrgId>` end-to-end via Slack, confirming only the wildcard site's org changes and its non-wildcard sibling (if any) is untouched.
- [ ] Spot-check another affected command (e.g. `get site <wildcard-url>`) in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
