### PR TITLE
feat(run-global-import): add --validate-only flag for optimize-at-edge-enabled-marking

### DIFF
--- a/src/support/slack/commands/run-global-import.js
+++ b/src/support/slack/commands/run-global-import.js
@@ -22,6 +22,7 @@ import { triggerGlobalImportRun } from '../../utils.js';
 /* eslint-disable no-useless-escape */
 const PHRASES = ['run global import'];
 const FORCE_FLAG = '--force';
+const VALIDATE_ONLY_FLAG = '--validate-only';
 
 const GLOBAL_IMPORTS = [
   'stale-suggestions-cleanup',
@@ -29,16 +30,17 @@ const GLOBAL_IMPORTS = [
 ];
 
 /**
- * Splits the `--force` flag out of the raw args, wherever it appears, leaving the remaining
- * positional args (importType, site) in order.
+ * Splits the `--force`/`--validate-only` flags out of the raw args, wherever they appear,
+ * leaving the remaining positional args (importType, site) in order.
  *
  * @param {string[]} args - Raw args as provided to the command.
- * @returns {{ positionalArgs: string[], force: boolean }}
+ * @returns {{ positionalArgs: string[], force: boolean, validateOnly: boolean }}
  */
-function splitForceFlag(args) {
-  const positionalArgs = args.filter((a) => a !== FORCE_FLAG);
+function splitFlags(args) {
+  const positionalArgs = args.filter((a) => a !== FORCE_FLAG && a !== VALIDATE_ONLY_FLAG);
   const force = args.includes(FORCE_FLAG);
-  return { positionalArgs, force };
+  const validateOnly = args.includes(VALIDATE_ONLY_FLAG);
+  return { positionalArgs, force, validateOnly };
 }
 
 /**
@@ -58,14 +60,17 @@ function runGlobalImportCommand(context) {
     name: 'Run Global Import',
     description: 'Run a global import job that operates across all data. '
       + 'These imports do not require a specific site URL, but an optional site (URL or ID) '
-      + 'scopes the run to just that one site, and --force skips that handler\'s normal '
-      + 'gating check for it, for handlers that support both.',
+      + 'scopes the run to just that one site, and --force/--validate-only ask that handler '
+      + 'to skip or run only its normal gating check for it, for handlers that support them.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} {importType} [site-url-or-id] [--force]\n\nAvailable types: \`${GLOBAL_IMPORTS.join('\`, \`')}\`\n`
+    usageText: `${PHRASES[0]} {importType} [site-url-or-id] [--force|--validate-only]\n\nAvailable types: \`${GLOBAL_IMPORTS.join('\`, \`')}\`\n`
       + 'Optional site (URL or ID): scope the run to a single site instead of all data '
       + '(currently only `optimize-at-edge-enabled-marking` uses it).\n'
       + '`--force`: requires a site — skips prerender content validation, enabling the site '
-      + 'on the edge request-id check alone. Never touches an already-enabled site.',
+      + 'on the edge request-id check alone. Never touches an already-enabled site.\n'
+      + '`--validate-only`: requires a site — runs only the prerender content check and '
+      + 'records its result, without touching enablement at all. Works even on an '
+      + 'already-enabled site. Cannot be combined with `--force`.',
   });
 
   /**
@@ -79,8 +84,13 @@ function runGlobalImportCommand(context) {
     const config = await Configuration.findLatest();
 
     try {
-      const { positionalArgs, force } = splitForceFlag(args);
+      const { positionalArgs, force, validateOnly } = splitFlags(args);
       const [importType, siteInput] = positionalArgs;
+
+      if (force && validateOnly) {
+        await say(':warning: `--force` and `--validate-only` cannot be used together.');
+        return;
+      }
 
       if (!importType || importType === '') {
         await say(baseCommand.usage());
@@ -120,8 +130,8 @@ function runGlobalImportCommand(context) {
         }
       }
 
-      if (force && !site) {
-        await say(':warning: `--force` requires a site (URL or ID) to scope to — it has no effect on a bulk run.');
+      if ((force || validateOnly) && !site) {
+        await say(':warning: `--force`/`--validate-only` requires a site (URL or ID) to scope to — it has no effect on a bulk run.');
         return;
       }
 
@@ -130,7 +140,9 @@ function runGlobalImportCommand(context) {
         importType,
         slackContext,
         context,
-        { siteId: site?.getId(), force, forcedBy: slackContext.user },
+        {
+          siteId: site?.getId(), force, forcedBy: slackContext.user, validateOnly,
+        },
       );
 
       let message = `:adobe-run: Triggered global import: *${importType}*`;
@@ -139,6 +151,9 @@ function runGlobalImportCommand(context) {
       }
       if (force) {
         message += ' — *force*: skipping prerender content validation.';
+      }
+      if (validateOnly) {
+        message += ' — *validate-only*: running prerender content validation only, not touching enablement.';
       }
       await say(message);
     } catch (error) {

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -252,9 +252,9 @@ export const sendInternalReportRunMessage = async (
 /**
  * Sends a message to run a global import job to the provided SQS queue.
  * Global imports don't require a siteId - they run across all data - but an optional siteId
- * scopes the run to just that one site (e.g. for an ad hoc re-check), and an optional force
- * flag (only meaningful alongside a siteId) tells the target handler to skip whatever gating
- * check it normally requires, when it supports both.
+ * scopes the run to just that one site (e.g. for an ad hoc re-check), and optional force /
+ * validateOnly flags (only meaningful alongside a siteId) tell the target handler to skip, or
+ * run only, whatever gating check it normally requires, when it supports them.
  *
  * @param {Object} sqs - The SQS service object.
  * @param {string} queueUrl - The SQS queue URL.
@@ -263,19 +263,25 @@ export const sendInternalReportRunMessage = async (
  * @param {Object} [options] - Optional single-site scoping.
  * @param {string} [options.siteId] - Site ID to scope the run to a single site.
  * @param {boolean} [options.force] - Skip the handler's normal gating check for that site.
- * @param {string} [options.forcedBy] - Slack user who requested the force run (log context).
+ * @param {boolean} [options.validateOnly] - Run only the handler's validation check for that
+ *   site, without applying whatever result it normally gates.
+ * @param {string} [options.forcedBy] - Slack user who requested the force/validateOnly run
+ *   (log context).
  */
 export const sendGlobalImportRunMessage = async (
   sqs,
   queueUrl,
   importType,
   slackContext,
-  { siteId, force, forcedBy } = {},
+  {
+    siteId, force, forcedBy, validateOnly,
+  } = {},
 ) => sqs.sendMessage(queueUrl, {
   type: importType,
   slackContext,
   ...(siteId && { siteId }),
   ...(force && { force }),
+  ...(validateOnly && { validateOnly }),
   ...(forcedBy && { forcedBy }),
 });
 

--- a/test/support/slack/commands/run-global-import.test.js
+++ b/test/support/slack/commands/run-global-import.test.js
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('RunGlobalImportCommand', () => {
+  let RunGlobalImportCommand;
+  let context;
+  let slackContext;
+  let dataAccessStub;
+  let configStub;
+  let extractURLFromSlackInputStub;
+  let postSiteNotFoundMessageStub;
+  let postErrorMessageStub;
+  let triggerGlobalImportRunStub;
+
+  beforeEach(async () => {
+    extractURLFromSlackInputStub = sinon.stub().returns(null);
+    postSiteNotFoundMessageStub = sinon.stub().resolves();
+    postErrorMessageStub = sinon.stub().callsFake(async (sayFn, err) => {
+      await sayFn(`:x: ${err.message}`);
+    });
+    triggerGlobalImportRunStub = sinon.stub().resolves();
+
+    RunGlobalImportCommand = (await esmock(
+      '../../../../src/support/slack/commands/run-global-import.js',
+      {
+        '../../../../src/utils/slack/base.js': {
+          extractURLFromSlackInput: extractURLFromSlackInputStub,
+          postErrorMessage: postErrorMessageStub,
+          postSiteNotFoundMessage: postSiteNotFoundMessageStub,
+        },
+        '../../../../src/support/utils.js': {
+          triggerGlobalImportRun: triggerGlobalImportRunStub,
+        },
+      },
+    )).default;
+
+    configStub = {
+      getJobs: sinon.stub().returns([
+        { group: 'imports', type: 'stale-suggestions-cleanup' },
+        { group: 'imports', type: 'optimize-at-edge-enabled-marking' },
+      ]),
+    };
+
+    dataAccessStub = {
+      Configuration: {
+        findLatest: sinon.stub().resolves(configStub),
+      },
+      Site: {
+        findByBaseURL: sinon.stub(),
+        findById: sinon.stub(),
+      },
+    };
+
+    context = {
+      log: { error: sinon.spy() },
+      dataAccess: dataAccessStub,
+    };
+
+    slackContext = {
+      say: sinon.stub().resolves(),
+      user: 'jdoe',
+      channelId: 'C123',
+      threadTs: '1712345678.9012',
+    };
+  });
+
+  it('initializes with base command metadata', () => {
+    const command = RunGlobalImportCommand(context);
+    expect(command.id).to.equal('run-global-import');
+    expect(command.name).to.equal('Run Global Import');
+    expect(command.phrases).to.deep.equal(['run global import']);
+  });
+
+  it('shows usage when importType is missing', async () => {
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution([], slackContext);
+
+    expect(slackContext.say).to.have.been.calledOnceWith(command.usage());
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('warns when importType is not a valid global import type', async () => {
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['not-a-real-type'], slackContext);
+
+    expect(slackContext.say.firstCall.args[0]).to.include('not a valid global import type');
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('warns when the import type is not configured', async () => {
+    configStub.getJobs.returns([]);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['stale-suggestions-cleanup'], slackContext);
+
+    expect(slackContext.say.firstCall.args[0]).to.include('is not configured in the system');
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('posts site-not-found when the given site cannot be resolved by URL', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves(null);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', 'example.com'], slackContext);
+
+    expect(postSiteNotFoundMessageStub).to.have.been.calledOnceWith(slackContext.say, 'example.com');
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('posts site-not-found when the given site cannot be resolved by ID', async () => {
+    extractURLFromSlackInputStub.returns(null);
+    dataAccessStub.Site.findById.resolves(null);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', 'site-id-1'], slackContext);
+
+    expect(postSiteNotFoundMessageStub).to.have.been.calledOnceWith(slackContext.say, 'site-id-1');
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('triggers a bulk run (no site) and confirms without a site suffix', async () => {
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['stale-suggestions-cleanup'], slackContext);
+
+    expect(triggerGlobalImportRunStub).to.have.been.calledOnceWith(
+      configStub,
+      'stale-suggestions-cleanup',
+      slackContext,
+      context,
+      {
+        siteId: undefined, force: false, forcedBy: 'jdoe', validateOnly: false,
+      },
+    );
+    expect(slackContext.say.firstCall.args[0]).to.include('Triggered global import: *stale-suggestions-cleanup*');
+    expect(slackContext.say.firstCall.args[0]).not.to.include('force');
+    expect(slackContext.say.firstCall.args[0]).not.to.include('validate-only');
+  });
+
+  it('scopes the run to a single site resolved by URL', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    const mockSite = { getId: () => 'site-1', getBaseURL: () => 'https://example.com' };
+    dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', 'example.com'], slackContext);
+
+    expect(triggerGlobalImportRunStub).to.have.been.calledOnceWith(
+      configStub,
+      'optimize-at-edge-enabled-marking',
+      slackContext,
+      context,
+      {
+        siteId: 'site-1', force: false, forcedBy: 'jdoe', validateOnly: false,
+      },
+    );
+    expect(slackContext.say.firstCall.args[0]).to.include('for site *https://example.com* (`site-1`)');
+  });
+
+  it('rejects --force combined with --validate-only', async () => {
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', 'example.com', '--force', '--validate-only'], slackContext);
+
+    expect(slackContext.say).to.have.been.calledOnceWith(':warning: `--force` and `--validate-only` cannot be used together.');
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('rejects --force without a site', async () => {
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', '--force'], slackContext);
+
+    expect(slackContext.say).to.have.been.calledOnceWith(':warning: `--force`/`--validate-only` requires a site (URL or ID) to scope to — it has no effect on a bulk run.');
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('rejects --validate-only without a site', async () => {
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', '--validate-only'], slackContext);
+
+    expect(slackContext.say).to.have.been.calledOnceWith(':warning: `--force`/`--validate-only` requires a site (URL or ID) to scope to — it has no effect on a bulk run.');
+    expect(triggerGlobalImportRunStub).not.to.have.been.called;
+  });
+
+  it('triggers with force:true and confirms with the force suffix', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    const mockSite = { getId: () => 'site-1', getBaseURL: () => 'https://example.com' };
+    dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', 'example.com', '--force'], slackContext);
+
+    expect(triggerGlobalImportRunStub).to.have.been.calledOnceWith(
+      configStub,
+      'optimize-at-edge-enabled-marking',
+      slackContext,
+      context,
+      {
+        siteId: 'site-1', force: true, forcedBy: 'jdoe', validateOnly: false,
+      },
+    );
+    expect(slackContext.say.firstCall.args[0]).to.include('*force*: skipping prerender content validation.');
+    expect(slackContext.say.firstCall.args[0]).not.to.include('validate-only');
+  });
+
+  it('triggers with validateOnly:true and confirms with the validate-only suffix', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    const mockSite = { getId: () => 'site-1', getBaseURL: () => 'https://example.com' };
+    dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['optimize-at-edge-enabled-marking', 'example.com', '--validate-only'], slackContext);
+
+    expect(triggerGlobalImportRunStub).to.have.been.calledOnceWith(
+      configStub,
+      'optimize-at-edge-enabled-marking',
+      slackContext,
+      context,
+      {
+        siteId: 'site-1', force: false, forcedBy: 'jdoe', validateOnly: true,
+      },
+    );
+    expect(slackContext.say.firstCall.args[0]).to.include('*validate-only*: running prerender content validation only, not touching enablement.');
+    expect(slackContext.say.firstCall.args[0]).not.to.include('*force*');
+  });
+
+  it('parses the flag anywhere in the args, independent of position', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    const mockSite = { getId: () => 'site-1', getBaseURL: () => 'https://example.com' };
+    dataAccessStub.Site.findByBaseURL.resolves(mockSite);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['--validate-only', 'optimize-at-edge-enabled-marking', 'example.com'], slackContext);
+
+    expect(triggerGlobalImportRunStub).to.have.been.calledOnceWith(
+      configStub,
+      'optimize-at-edge-enabled-marking',
+      slackContext,
+      context,
+      {
+        siteId: 'site-1', force: false, forcedBy: 'jdoe', validateOnly: true,
+      },
+    );
+  });
+
+  it('logs and posts an error when Configuration.findLatest throws', async () => {
+    dataAccessStub.Configuration.findLatest.rejects(new Error('db unavailable'));
+    const command = RunGlobalImportCommand(context);
+
+    await expect(command.handleExecution(['optimize-at-edge-enabled-marking'], slackContext))
+      .to.be.rejectedWith('db unavailable');
+  });
+
+  it('logs and posts an error when triggerGlobalImportRun throws', async () => {
+    triggerGlobalImportRunStub.rejects(new Error('sqs failure'));
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['stale-suggestions-cleanup'], slackContext);
+
+    expect(context.log.error).to.have.been.calledOnce;
+    expect(postErrorMessageStub).to.have.been.calledOnce;
+    expect(postErrorMessageStub.firstCall.args[0]).to.equal(slackContext.say);
+    expect(postErrorMessageStub.firstCall.args[1]).to.be.instanceOf(Error);
+  });
+});

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -1796,6 +1796,46 @@ describe('utils', () => {
         siteId: 'site-1',
       });
     });
+
+    it('includes validateOnly and forcedBy in the message when provided', async () => {
+      const sqs = { sendMessage: sinon.stub().resolves() };
+      const slackContext = { channelId: 'C1', threadTs: '123' };
+
+      await sendGlobalImportRunMessage(
+        sqs,
+        'queue-url',
+        'optimize-at-edge-enabled-marking',
+        slackContext,
+        { siteId: 'site-1', validateOnly: true, forcedBy: 'jdoe' },
+      );
+
+      expect(sqs.sendMessage).to.have.been.calledWith('queue-url', {
+        type: 'optimize-at-edge-enabled-marking',
+        slackContext,
+        siteId: 'site-1',
+        validateOnly: true,
+        forcedBy: 'jdoe',
+      });
+    });
+
+    it('omits validateOnly when falsy/absent', async () => {
+      const sqs = { sendMessage: sinon.stub().resolves() };
+      const slackContext = { channelId: 'C1', threadTs: '123' };
+
+      await sendGlobalImportRunMessage(
+        sqs,
+        'queue-url',
+        'optimize-at-edge-enabled-marking',
+        slackContext,
+        { siteId: 'site-1', validateOnly: false },
+      );
+
+      expect(sqs.sendMessage).to.have.been.calledWith('queue-url', {
+        type: 'optimize-at-edge-enabled-marking',
+        slackContext,
+        siteId: 'site-1',
+      });
+    });
   });
 
   describe('triggerGlobalImportRun', () => {


### PR DESCRIPTION
## Summary
- Adds a `--validate-only` flag to `run global import optimize-at-edge-enabled-marking <site>`, scoping the run to a single site and asking `spacecat-import-worker` to run only the prerender content check (no enablement side effects).
- Mutually exclusive with `--force`.
- Threads `validateOnly` through `sendGlobalImportRunMessage`/`triggerGlobalImportRun` alongside the existing `force`/`forcedBy` options.

## Test plan
- [x] `npx mocha --spec=test/support/utils.test.js` — 131 passing
- [x] `npx eslint` on all changed files — clean
- [ ] Manual Slack verification of `run global import optimize-at-edge-enabled-marking <site> --validate-only` against dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)