### PR TITLE
fix: updated backoffice link in PLG notification according to the env

### DIFF
--- a/src/controllers/plg/plg-onboarding/notifications.js
+++ b/src/controllers/plg/plg-onboarding/notifications.js
@@ -113,7 +113,10 @@ export async function postPlgOnboardingNotification(onboarding, context, hints =
       const asoUrl = `${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${siteId}`;
       message += `\n• *ASO Link:* ${asoUrl}`;
     }
-    const backofficeUrl = `${experienceUrl}/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/${siteId}`;
+    const isProd = env.AWS_ENV === 'prod' || env.ENV === 'prod';
+    const backofficeUrl = isProd
+      ? `https://experience.adobe.com/#/@sitesinternal/custom-apps/245265-EssDeveloperUI/#/sites/${siteId}`
+      : `https://experience-stage.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/${siteId}`;
     message += `\n• *Backoffice Link:* ${backofficeUrl}`;
   }
 

--- a/test/controllers/plg/plg-onboarding/notifications.test.js
+++ b/test/controllers/plg/plg-onboarding/notifications.test.js
@@ -150,7 +150,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include(TEST_ORG_ID);
       expect(message).to.include(TEST_SITE_ID);
       expect(message).to.not.include('ASO Link');
-      expect(message).to.include(`https://experience.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/${TEST_SITE_ID}`);
+      expect(message).to.include(`https://experience-stage.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/${TEST_SITE_ID}`);
     });
 
     it('posts notification with botBlocker type but no ipsToAllowlist', async () => {
@@ -287,7 +287,7 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include(TEST_ORG_ID);
       expect(message).to.include(TEST_SITE_ID);
       expect(message).to.include(`https://experience.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
-      expect(message).to.include(`https://experience.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/${TEST_SITE_ID}`);
+      expect(message).to.include(`https://experience-stage.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/${TEST_SITE_ID}`);
     });
 
     it('uses custom EXPERIENCE_URL for ASO link when provided', async () => {
@@ -307,6 +307,25 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       expect(message).to.include(`https://experience-stage.adobe.com/?organizationId=${TEST_ORG_ID}#/sites-optimizer/sites/${TEST_SITE_ID}`);
       expect(message).to.include(`https://experience-stage.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/${TEST_SITE_ID}`);
       expect(message).to.not.include('https://experience.adobe.com/');
+    });
+
+    it('uses prod backoffice link when AWS_ENV is prod', async () => {
+      const onboarding = createMockOnboarding({
+        status: 'ONBOARDED',
+        organizationId: TEST_ORG_ID,
+        siteId: TEST_SITE_ID,
+      });
+
+      const ctx = buildSlackContext(onboarding);
+      ctx.env = { ...ctx.env, AWS_ENV: 'prod' };
+
+      await SlackControllerFactory({ log: mockLog }).onboard(ctx);
+
+      expect(postSlackMessageStub).to.have.been.called;
+      const [, message] = postSlackMessageStub.firstCall.args;
+      expect(message).to.include(`https://experience.adobe.com/#/@sitesinternal/custom-apps/245265-EssDeveloperUI/#/sites/${TEST_SITE_ID}`);
+      expect(message).to.not.include('aem-sites-engineering');
+      expect(message).to.not.include('24749-EssDeveloperUI');
     });
 
     it('posts notification with fast onboarded note via fast path (PRE_ONBOARDING + siteId)', async () => {


### PR DESCRIPTION
## fix: use environment-specific backoffice link in PLG onboarding notifications

The PLG onboarding Slack notification always linked to the stage Backoffice app (`experience-stage.adobe.com`, `@aem-sites-engineering`), even when running in prod. The Backoffice URL now branches on `AWS_ENV`/`ENV`:

- **prod**: `https://experience.adobe.com/#/@sitesinternal/custom-apps/245265-EssDeveloperUI/#/sites/{siteId}`
- **non-prod**: `https://experience-stage.adobe.com/#/@aem-sites-engineering/custom-apps/24749-EssDeveloperUI/#/sites/{siteId}`

The ASO link is unaffected (still driven by `EXPERIENCE_URL`).


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
