### PR TITLE
fix: bypass auto_fix subService gate for non-ASO products (LLMO-6553)

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -58,7 +58,7 @@ import {
   getIsSummitPlgEnabled,
   isViewAsTrialRequest,
 } from '../support/utils.js';
-import AccessControlUtil from '../support/access-control-util.js';
+import AccessControlUtil, { X_PRODUCT_HEADER } from '../support/access-control-util.js';
 import { redactFeedbackContent } from '../support/feedback-redaction.js';
 import { CAP_FIX_ENTITY_CREATE, CAP_SUGGESTION_WRITE } from '../routes/capability-constants.js';
 import { grantSuggestionsForOpportunity } from '../support/grant-suggestions-handler.js';
@@ -1309,10 +1309,17 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Site not found');
     }
 
+    // The 'auto_fix' subService maps to the `dx_aem_perf_auto_fix` user scope, which is only
+    // minted for ASO product logins. LLMO logins never carry this scope, so gating LLMO autofix
+    // on it always yields a 403 (LLMO-6553). Only enforce the subService for ASO; for any other
+    // product, fall back to plain org-membership access.
+    const xProduct = context.pathInfo?.headers?.[X_PRODUCT_HEADER];
+    const autoFixSubService = xProduct === 'ASO' ? 'auto_fix' : '';
+
     const s2sResult = await accessControlUtil.hasS2SCapability(CAP_FIX_ENTITY_CREATE);
     if (s2sResult.allowed) {
       ctx.log?.info(`[acl] S2S auto-fix granted - clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId}`);
-    } else if (!await accessControlUtil.hasAccess(site, 'auto_fix')) {
+    } else if (!await accessControlUtil.hasAccess(site, autoFixSubService)) {
       if (s2sResult.reason !== 'not-s2s') {
         ctx.log?.info(`[acl] Denied PATCH auto-fix - reason=${s2sResult.reason} clientId=${s2sResult.clientId || 'n/a'} consumerId=${s2sResult.consumerId || 'n/a'}`);
       }

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -6656,6 +6656,8 @@ describe('Suggestions Controller', () => {
         data: {
           suggestionIds: [SUGGESTION_IDS[0]],
         },
+        // ASO exercises the auto_fix subService gate (LLMO-6553 scopes it to ASO)
+        pathInfo: { headers: { 'x-product': 'ASO' } },
       });
 
       expect(response.status).to.equal(403);
@@ -6712,6 +6714,8 @@ describe('Suggestions Controller', () => {
           suggestionIds: [SUGGESTION_IDS[0]],
         },
         ...context,
+        // ASO exercises the auto_fix subService gate (LLMO-6553 scopes it to ASO)
+        pathInfo: { headers: { 'x-product': 'ASO' } },
       });
 
       // Should proceed to next checks (not forbidden)

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -4281,6 +4281,32 @@ describe('Suggestions Controller', () => {
       sandbox.restore();
     });
 
+    it('bypasses the auto_fix subService for non-ASO products so LLMO logins are not 403d (LLMO-6553)', async () => {
+      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+        pathInfo: { headers: { 'x-product': 'LLMO' } },
+      });
+
+      expect(response.status).to.equal(403);
+      expect(hasAccessStub).to.have.been.calledWithExactly(sinon.match.any, '');
+    });
+
+    it('enforces the auto_fix subService for the ASO product', async () => {
+      const hasAccessStub = sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+        pathInfo: { headers: { 'x-product': 'ASO' } },
+      });
+
+      expect(response.status).to.equal(403);
+      expect(hasAccessStub).to.have.been.calledWithExactly(sinon.match.any, 'auto_fix');
+    });
+
     it('proceeds with autofix when summit-plg is enabled and all suggestions are granted', async () => {
       opportunity.getType = sandbox.stub().returns('meta-tags');
       mockSuggestionGrant.splitSuggestionsByGrantStatus.resolves({


### PR DESCRIPTION
## Problem

The auto-fix endpoint (`PATCH /sites/{siteId}/opportunities/{opportunityId}/suggestions/auto-fix`) returns a **403** for users who authenticate via **LLMO**:

```json
{ "message": "User does not belong to the organization or does not have sufficient permissions" }
```

Reported against the Adobe Showcase Org — see [LLMO-6553](https://jira.corp.adobe.com/browse/LLMO-6553).

## Root cause

`autofixSuggestions` in `src/controllers/suggestions.js` gated access with:

```js
accessControlUtil.hasAccess(site, 'auto_fix')
```

When a `subService` is supplied, `AccessControlUtil.hasAccess()` requires the `dx_aem_perf_auto_fix` **user scope**:

```js
return hasOrgAccess && authInfo.hasScope('user', `${SERVICE_CODE}_${subService}`);
```

That scope (and its `auto_fix` profile) is only minted when the user logs in through **ASO** (`dx_aem_perf`). LLMO logins never carry it, so the check fails even for users who legitimately belong to the org.

## Fix

Make the `auto_fix` subService gate ASO-specific. Read the `x-product` header and only pass the `'auto_fix'` subService when the product is `ASO`; for any other product (LLMO) fall back to plain org-membership access via `hasAccess(site)`.

```js
const xProduct = context.pathInfo?.headers?.[X_PRODUCT_HEADER];
const autoFixSubService = xProduct === 'ASO' ? 'auto_fix' : '';
...
} else if (!await accessControlUtil.hasAccess(site, autoFixSubService)) {
```

Org membership is still enforced in every case; only the ASO-specific extra scope requirement is scoped to ASO. The S2S capability path is unchanged.

## Testing

- Added two unit tests in `test/controllers/suggestions.test.js`:
  - non-ASO product (LLMO) → `hasAccess` called without a subService (bypass)
  - ASO product → `hasAccess` still called with `'auto_fix'` (enforcement preserved)
- `npx mocha test/controllers/suggestions.test.js -g "auto-fix suggestions"` → 66 passing
- ESLint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)