### PR TITLE
fix(serenity): soft-fail Semrush re-sync on brand URL edit (LLMO-6545)

### DIFF
--- a/docs/openapi/brands-v2-api.yaml
+++ b/docs/openapi/brands-v2-api.yaml
@@ -171,9 +171,11 @@ v2-brand-for-org:
     responses:
       '200':
         description: |
-          Brand updated successfully. For a sub-workspace brand whose edit changed
-          aliases/competitors, the body may include `semrushRejectedAliases` listing
-          per-market aliases Semrush refused during the re-sync.
+          Brand updated successfully. For a sub-workspace brand the body may include:
+          - `semrushSyncPending: true` when the row persisted but the Semrush re-sync
+            failed (Semrush unavailable or user not provisioned).
+          - `semrushRejectedAliases` listing per-market aliases Semrush refused during
+            an otherwise successful re-sync.
         content:
           application/json:
             schema:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -7796,14 +7796,23 @@ V2Brand:
 
 V2BrandUpdateResponse:
   description: >-
-    A brand (as returned by GET) plus, when the edit re-synced aliases/competitors
-    to a sub-workspace brand's Semrush markets and Semrush refused some aliases,
-    the `semrushRejectedAliases` set. The field is omitted when nothing was
-    rejected (or the brand is flat-mode).
+    A brand (as returned by GET) plus optional fields when a sub-workspace brand's
+    Semrush re-sync produced notable results. `semrushSyncPending` is set when the
+    row was committed but the re-sync could not be completed (Semrush unavailable or
+    user not provisioned) — the edit persisted and will be reconciled later.
+    `semrushRejectedAliases` is set when Semrush refused some aliases during an
+    otherwise successful re-sync.
   allOf:
     - $ref: '#/V2Brand'
     - type: object
       properties:
+        semrushSyncPending:
+          type: boolean
+          description: >-
+            Present and `true` when the brand row was committed but the Semrush
+            re-sync failed (transient upstream error or user not provisioned in
+            Semrush). The edit is persisted; Semrush will be reconciled via
+            `--reconcile` migration once the underlying issue is resolved.
         semrushRejectedAliases:
           type: array
           description: >-

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -2071,8 +2071,16 @@ function BrandsController(ctx, log, env) {
             competitorsTouched,
             aliasesTouched,
             status: syncError?.status,
+            message: syncError?.message,
+            stack: syncError?.stack,
           });
-          return ok({ ...updated, semrushSyncPending: true });
+          // Preserve any partial rejectedAliases collected before the throw so
+          // the UI can still warn about aliases that were refused by Semrush.
+          return ok({
+            ...updated,
+            semrushSyncPending: true,
+            ...(rejectedAliases.length > 0 && { semrushRejectedAliases: rejectedAliases }),
+          });
         }
       }
 

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -2061,10 +2061,9 @@ function BrandsController(ctx, log, env) {
             rejectedAliases.push(...(aliasResult?.rejected ?? []));
           }
         } catch (syncError) {
-          // The brand row is already committed; re-sync hard-fails (the brand
-          // must not silently drift out of sync with Semrush). Log the upstream
-          // context (workspace + which sync) so the DB/Semrush divergence is
-          // diagnosable, then rethrow to the handler's catch.
+          // LLMO-6545: Accept drift — DB is already committed so hard-failing returns
+          // a 500 while the edit actually succeeded. Log all context so the divergence
+          // is diagnosable via Splunk and recoverable via --reconcile migration later.
           log.error('serenity: brand-edit Semrush re-sync failed after row commit', {
             brandId,
             semrushSubWorkspaceId: updated.semrushSubWorkspaceId,
@@ -2073,7 +2072,7 @@ function BrandsController(ctx, log, env) {
             aliasesTouched,
             status: syncError?.status,
           });
-          throw syncError;
+          return ok({ ...updated, semrushSyncPending: true });
         }
       }
 

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1945,11 +1945,23 @@ function BrandsController(ctx, log, env) {
         if (hasText(brandState?.semrushSubWorkspaceId)) {
           // Semrush brand: market/project domains come from the project listing.
           // List once and stash for the post-commit re-sync (see prefetchedProjects).
-          const imsToken = await resolveSemrushImsToken(context, log, 'brands');
-          const transport = createSerenityTransport({ env: context.env, imsToken });
-          prefetchedProjects = await resolveProjects(transport, brandState.semrushSubWorkspaceId);
+          // Best-effort: if the listing fails (e.g. user not provisioned in Semrush),
+          // degrade to brand-URL-only reserved set and log — the self-reference guard
+          // is a data-quality nicety and must not block the competitor write entirely.
+          try {
+            const imsToken = await resolveSemrushImsToken(context, log, 'brands');
+            const transport = createSerenityTransport({ env: context.env, imsToken });
+            prefetchedProjects = await resolveProjects(transport, brandState.semrushSubWorkspaceId);
+          } catch (guardError) {
+            log.warn('serenity: competitor-guard project listing failed; degrading to brand-URL-only reserved set', {
+              brandId,
+              semrushSubWorkspaceId: brandState.semrushSubWorkspaceId,
+              status: guardError?.status,
+              message: guardError?.message,
+            });
+          }
           reservedDomains = buildReservedDomains(
-            prefetchedProjects.map((p) => p?.domain),
+            (prefetchedProjects ?? []).map((p) => p?.domain),
             brandOwnUrls,
           );
         } else {
@@ -1979,17 +1991,16 @@ function BrandsController(ctx, log, env) {
         return notFound(`Brand not found: ${brandId}`);
       }
 
-      // Brand-level Semrush re-sync: when an edit changes URL sources or
-      // competitors and the brand is in sub-workspace mode, propagate the change
-      // onto every market/project (region-filtered per market). Skipped for
-      // flat-mode brands and unrelated edits. Hard-fail so the brand never drifts
-      // out of sync silently. One transport for both syncs.
+      // Brand-level Semrush re-sync: when an edit changes URL sources, competitors
+      // or aliases and the brand is in sub-workspace mode, propagate the change onto
+      // every market/project (region-filtered per market). Skipped for flat-mode
+      // brands and unrelated edits. One transport shared across all three syncs.
       //
-      // NOTE (intentional asymmetry vs create): the SAME URL/competitor
-      // propagation is BEST-EFFORT on the create path (handleCreateMarket-
-      // Subworkspace swallows a benchmark hiccup so it cannot strand a
-      // half-provisioned brand) but HARD-FAIL here on edit — an already-live
-      // brand must not silently diverge from Semrush after a row commit.
+      // Best-effort, matching the create path: the brand row is already committed
+      // when this block runs, so a re-sync failure must not surface as a 5xx on an
+      // edit that did persist. The response carries semrushSyncPending:true so the
+      // divergence is visible to the caller, and the error log below carries the
+      // context needed to enumerate and recover drifted brands.
       const urlsTouched = updates.urls !== undefined
         || updates.socialAccounts !== undefined
         || updates.earnedContent !== undefined;
@@ -2063,8 +2074,12 @@ function BrandsController(ctx, log, env) {
         } catch (syncError) {
           // LLMO-6545: Accept drift — DB is already committed so hard-failing returns
           // a 500 while the edit actually succeeded. Log all context so the divergence
-          // is diagnosable via Splunk and recoverable via --reconcile migration later.
-          log.error('serenity: brand-edit Semrush re-sync failed after row commit', {
+          // is diagnosable and recoverable via --reconcile migration later.
+          // 401/403 = permanent (user not provisioned in Semrush — needs manual action).
+          // Other status / no status = transient (network, timeout, upstream hiccup).
+          const isPermanent = syncError?.status === 401 || syncError?.status === 403;
+          const logFn = isPermanent ? log.warn : log.error;
+          logFn('serenity: brand-edit Semrush re-sync failed after row commit', {
             brandId,
             semrushSubWorkspaceId: updated.semrushSubWorkspaceId,
             urlsTouched,
@@ -2073,6 +2088,7 @@ function BrandsController(ctx, log, env) {
             status: syncError?.status,
             message: syncError?.message,
             stack: syncError?.stack,
+            permanent: isPermanent,
           });
           // Preserve any partial rejectedAliases collected before the throw so
           // the UI can still warn about aliases that were refused by Semrush.

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -2009,13 +2009,16 @@ function BrandsController(ctx, log, env) {
       const rejectedAliases = [];
       if ((urlsTouched || competitorsTouched || aliasesTouched)
         && hasText(updated.semrushSubWorkspaceId)) {
-        // Forward only an IMS user token upstream (matches the create path +
-        // the rest of /serenity/*): PATCH /brands is organization:write and thus
-        // S2S-reachable, so prefer an x-promise-token exchange and otherwise
-        // refuse a non-IMS bearer rather than proxy it.
-        const imsToken = await resolveSemrushImsToken(context, log, 'brands');
-        const transport = createSerenityTransport({ env: context.env, imsToken });
         try {
+          // Forward only an IMS user token upstream (matches the create path +
+          // the rest of /serenity/*): PATCH /brands is organization:write and thus
+          // S2S-reachable, so prefer an x-promise-token exchange and otherwise
+          // refuse a non-IMS bearer rather than proxy it. Inside the try because
+          // the row is already committed: a token-resolution 401 here is still a
+          // re-sync failure, and must soft-fail like any other rather than report
+          // an edit that did persist as an auth error.
+          const imsToken = await resolveSemrushImsToken(context, log, 'brands');
+          const transport = createSerenityTransport({ env: context.env, imsToken });
           // List the sub-workspace's projects ONCE and share the result across the
           // URL/competitor/alias syncs below — the listing is stable across the
           // brand-row write above, so this collapses up to three redundant
@@ -2075,7 +2078,9 @@ function BrandsController(ctx, log, env) {
           // LLMO-6545: Accept drift — DB is already committed so hard-failing returns
           // a 500 while the edit actually succeeded. Log all context so the divergence
           // is diagnosable and recoverable via --reconcile migration later.
-          // 401/403 = permanent (user not provisioned in Semrush — needs manual action).
+          // 401/403 = permanent: it needs a human, not a retry — the caller is not
+          // provisioned in Semrush, or could not be authenticated to it at all
+          // (no/expired promise token). Retrying the same request cannot clear it.
           // Other status / no status = transient (network, timeout, upstream hiccup).
           const isPermanent = syncError?.status === 401 || syncError?.status === 403;
           const logFn = isPermanent ? log.warn : log.error;

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -6770,6 +6770,55 @@ describe('Brands Controller', () => {
       );
     });
 
+    it('LLMO-6545: includes both semrushSyncPending and semrushRejectedAliases when alias sync collected rejections before a later sync throws', async () => {
+      // URL sync succeeds, alias sync collects rejected aliases into rejectedAliases[],
+      // then competitor sync throws. The catch must preserve the partial alias rejections
+      // so the UI can still warn the operator which aliases were refused by Semrush.
+      const rejected = [{ name: 'alias-a' }, { name: 'alias-b' }];
+      const updated = {
+        id: BRAND_UUID,
+        semrushSubWorkspaceId: 'ws-9',
+        urls: [],
+        socialAccounts: [],
+        earnedContent: [],
+        competitors: [{ url: 'https://rival.com', regions: ['us'] }],
+        brandAliases: [{ name: 'alias-a' }, { name: 'alias-c' }],
+      };
+      const updateBrandStub = sinon.stub().resolves(updated);
+      // URL sync succeeds; alias sync resolves with rejected aliases; competitor sync throws.
+      const aliasSyncStub = sinon.stub().resolves({ rejected });
+      const competitorSyncStub = sinon.stub().rejects(
+        Object.assign(new Error('Semrush 503'), { status: 503 }),
+      );
+      const controller = await buildUpdateController({
+        updateBrand: updateBrandStub,
+        syncBrandAliasesAcrossMarkets: aliasSyncStub,
+        syncCompetitorBenchmarksAcrossMarkets: competitorSyncStub,
+        createSerenityTransport: sinon.stub().returns({
+          name: 't',
+          listProjects: sinon.stub().resolves({ items: [] }),
+        }),
+        getBrandCompetitors: sinon.stub().resolves([]),
+      });
+
+      const response = await controller.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: {
+          competitors: [{ url: 'https://rival.com', regions: ['us'] }],
+          brandAliases: [{ name: 'alias-a' }, { name: 'alias-c' }],
+        },
+        dataAccess: mockDataAccess,
+        pathInfo: { headers: { authorization: 'Bearer tok' } },
+        attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(200);
+      const body = await response.json();
+      expect(body).to.include({ semrushSyncPending: true });
+      expect(body.semrushRejectedAliases).to.deep.equal(rejected);
+    });
+
     it('returns 409 when demoting an active brand to pending (LLMO-5587)', async () => {
       // beforeEach mock resolves a persisted brand with status 'active'; a generic
       // PATCH carrying status:'pending' must be rejected (and emit BrandDemotionBlocked).

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -6722,6 +6722,43 @@ describe('Brands Controller', () => {
       expect(ciSyncStub).to.not.have.been.called;
     });
 
+    it('LLMO-6545: returns 200 with semrushSyncPending:true when Semrush re-sync fails after DB commit', async () => {
+      // DB write succeeds; Semrush sync throws. Before LLMO-6545 this re-threw
+      // the error (500). After the fix it soft-fails: returns 200 with the
+      // committed row + semrushSyncPending flag, and logs for later recovery.
+      const updated = {
+        id: BRAND_UUID,
+        semrushSubWorkspaceId: 'ws-9',
+        urls: [{ value: 'https://acme.com' }],
+        socialAccounts: [],
+        earnedContent: [],
+      };
+      const updateBrandStub = sinon.stub().resolves(updated);
+      const syncError = Object.assign(new Error('Semrush unavailable'), { status: 503 });
+      const syncStub = sinon.stub().rejects(syncError);
+      const controller = await buildUpdateController({
+        updateBrand: updateBrandStub,
+        syncBrandUrlsAcrossMarkets: syncStub,
+        createSerenityTransport: sinon.stub().returns({ name: 't', listProjects: sinon.stub().resolves({ items: [] }) }),
+      });
+
+      const response = await controller.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { urls: [{ value: 'https://acme.com' }] },
+        dataAccess: mockDataAccess,
+        pathInfo: { headers: { authorization: 'Bearer tok' } },
+        attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(200);
+      expect(response.body).to.deep.include({ semrushSyncPending: true });
+      expect(updateBrandStub).to.have.been.calledOnce;
+      expect(loggerStub.error).to.have.been.calledWithMatch(
+        'serenity: brand-edit Semrush re-sync failed after row commit',
+      );
+    });
+
     it('returns 409 when demoting an active brand to pending (LLMO-5587)', async () => {
       // beforeEach mock resolves a persisted brand with status 'active'; a generic
       // PATCH carrying status:'pending' must be rejected (and emit BrandDemotionBlocked).

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -6734,9 +6734,9 @@ describe('Brands Controller', () => {
     });
 
     it('LLMO-6545: returns 200 with semrushSyncPending:true when Semrush re-sync fails after DB commit', async () => {
-      // DB write succeeds; Semrush sync throws. Before LLMO-6545 this re-threw
-      // the error (500). After the fix it soft-fails: returns 200 with the
-      // committed row + semrushSyncPending flag, and logs for later recovery.
+      // Invariant: DB row is committed before the re-sync block runs. A sync
+      // failure must not surface as a 5xx on an edit that persisted. The response
+      // carries semrushSyncPending:true and the error is logged for recovery.
       const updated = {
         id: BRAND_UUID,
         semrushSubWorkspaceId: 'ws-9',
@@ -7282,6 +7282,62 @@ describe('Brands Controller', () => {
         // No rejected aliases accumulated (aliasResult?.rejected ?? [] → []), so
         // the response omits the semrushRejectedAliases key entirely.
         expect(body.semrushRejectedAliases).to.equal(undefined);
+      });
+
+      it('degrades to brand-URL-only reserved set when the pre-write project listing fails (LLMO-6545)', async () => {
+        // createErrorResponse is still reachable on the pre-write guard path and
+        // must redact internal gateway URLs. This test also verifies that a
+        // SerenityTransportError on the pre-write listing degrades gracefully
+        // (writes proceed, self-ref guard uses brand URLs only) rather than
+        // hard-failing before the DB write.
+        const leakUrl = 'https://gw.internal/enterprise/workspaces/ws-7/projects';
+        const updated = {
+          id: BRAND_UUID,
+          semrushSubWorkspaceId: 'ws-7',
+          competitors: [{ name: 'Rival', url: 'https://rival.com' }],
+          urls: [],
+          socialAccounts: [],
+          earnedContent: [],
+        };
+        const updateBrandStub = sinon.stub().resolves(updated);
+        const getBrandByIdStub = sinon.stub().resolves({
+          id: BRAND_UUID,
+          baseUrl: 'https://acme.com',
+          urls: [],
+          semrushSubWorkspaceId: 'ws-7',
+        });
+        // Pre-write listing fails with a gateway error — must not block the write.
+        const listProjectsStub = sinon.stub().rejects(
+          new SerenityTransportError(502, `GET ${leakUrl} failed: 502`, {}),
+        );
+        const controller = await buildUpdateController({
+          updateBrand: updateBrandStub,
+          getBrandById: getBrandByIdStub,
+          createSerenityTransport: sinon.stub().returns({
+            name: 't', listProjects: listProjectsStub,
+          }),
+        });
+
+        const response = await controller.updateBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+          data: { competitors: [{ name: 'Rival', url: 'https://rival.com' }] },
+          dataAccess: mockDataAccess,
+          pathInfo: { headers: { authorization: 'Bearer tok' } },
+          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+        });
+
+        // Write must succeed despite the listing failure.
+        expect(response.status).to.equal(200);
+        expect(updateBrandStub).to.have.been.calledOnce;
+        // Guard degraded — warn logged.
+        expect(loggerStub.warn).to.have.been.calledWithMatch(
+          'serenity: competitor-guard project listing failed',
+        );
+        // Internal gateway URL must not leak to the client via body or headers.
+        const body = await response.json();
+        expect(JSON.stringify(body)).to.not.contain('gw.internal');
+        expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
       });
     });
   });

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -6467,10 +6467,14 @@ describe('Brands Controller', () => {
       expect(syncStub).to.not.have.been.called;
     });
 
-    it('hard-fails the edit when the brand-URL re-sync fails', async () => {
-      const updateBrandStub = sinon.stub().resolves({
+    it('LLMO-6545: soft-fails (200 + semrushSyncPending) when the brand-URL re-sync fails', async () => {
+      // DB row is already committed when the sync throws; returning a 5xx would
+      // mislead the customer into thinking their edit failed. Accept the drift and
+      // let ops recover via --reconcile migration (Phase 3).
+      const updated = {
         id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
-      });
+      };
+      const updateBrandStub = sinon.stub().resolves(updated);
       const err = new Error('upstream boom');
       err.status = 502;
       const syncStub = sinon.stub().rejects(err);
@@ -6489,7 +6493,8 @@ describe('Brands Controller', () => {
         attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
       });
 
-      expect(response.status).to.equal(502);
+      expect(response.status).to.equal(200);
+      expect(await response.json()).to.include({ semrushSyncPending: true });
       expect(syncStub).to.have.been.calledOnce;
     });
 
@@ -6520,10 +6525,13 @@ describe('Brands Controller', () => {
       expect(syncStub).to.not.have.been.called;
     });
 
-    it('redacts the gateway URL from a Semrush upstream error on brand-edit re-sync', async () => {
-      const updateBrandStub = sinon.stub().resolves({
+    it('LLMO-6545: soft-fails and does not leak the internal gateway URL on a SerenityTransportError re-sync failure', async () => {
+      // Soft-fail means the sync error is swallowed before createErrorResponse,
+      // so the internal gateway URL never reaches the client via body or headers.
+      const updated = {
         id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
-      });
+      };
+      const updateBrandStub = sinon.stub().resolves(updated);
       const leakUrl = 'https://gw.internal/enterprise/workspaces/ws-9/projects/proj-abc/aio';
       const syncStub = sinon.stub().rejects(
         new SerenityTransportError(502, `Semrush POST ${leakUrl} failed: 502`, {}),
@@ -6543,11 +6551,10 @@ describe('Brands Controller', () => {
         attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
       });
 
-      expect(response.status).to.equal(502);
+      expect(response.status).to.equal(200);
       const body = await response.json();
-      expect(body.message).to.equal('Upstream request failed');
+      expect(body).to.include({ semrushSyncPending: true });
       expect(JSON.stringify(body)).to.not.contain('gw.internal');
-      // ...and not via the x-error header either.
       expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
     });
 
@@ -6555,10 +6562,14 @@ describe('Brands Controller', () => {
     // 401/403 is passed through as that status with the 'Upstream authorization
     // failed' message (the true side of the status ternary and the false side of
     // the message ternary; the 502 sides are covered by the redaction test above).
-    it('maps a 401 Semrush upstream error to HTTP 401 + generic auth message', async () => {
-      const updateBrandStub = sinon.stub().resolves({
+    it('LLMO-6545: soft-fails (200 + semrushSyncPending) even on a 401 SerenityTransportError re-sync failure', async () => {
+      // DB row is committed; even a Semrush auth failure should not surface as 4xx
+      // to the customer whose edit succeeded. Soft-fail and log for ops investigation.
+      // The internal gateway URL must not leak in the 200 response either.
+      const updated = {
         id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
-      });
+      };
+      const updateBrandStub = sinon.stub().resolves(updated);
       const leakUrl = 'https://gw.internal/enterprise/workspaces/ws-9/projects/proj-abc/aio';
       const syncStub = sinon.stub().rejects(
         new SerenityTransportError(401, `Semrush POST ${leakUrl} failed: 401`, {}),
@@ -6578,22 +6589,21 @@ describe('Brands Controller', () => {
         attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
       });
 
-      expect(response.status).to.equal(401);
+      expect(response.status).to.equal(200);
       const body = await response.json();
-      expect(body.message).to.equal('Upstream authorization failed');
-      // The internal gateway URL must not leak via body or header.
+      expect(body).to.include({ semrushSyncPending: true });
       expect(JSON.stringify(body)).to.not.contain('gw.internal');
       expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
     });
 
-    // LLMO-6386: the brand-edit re-sync runs Project Engine calls, which now throw
-    // ProjectEngineApiError directly (adaptPE retired). createErrorResponse must redact it to the
-    // same generic 502 as the SerenityTransportError case — the raw "Project Engine ..." message
-    // (and any body) must never reach the client.
-    it('redacts a ProjectEngineApiError upstream failure to a generic 502 on brand-edit re-sync', async () => {
-      const updateBrandStub = sinon.stub().resolves({
+    // LLMO-6386 + LLMO-6545: ProjectEngineApiError on re-sync is soft-failed (DB committed).
+    // The raw "Project Engine ..." message and secret body must never reach the client in the 200;
+    // ok({ ...updated }) contains only the brand row, not the error internals.
+    it('LLMO-6545: soft-fails and does not leak ProjectEngineApiError internals on brand-edit re-sync', async () => {
+      const updated = {
         id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
-      });
+      };
+      const updateBrandStub = sinon.stub().resolves(updated);
       const syncStub = sinon.stub().rejects(
         new ProjectEngineApiError(502, 'POST', { secret: 'leak' }),
       );
@@ -6612,20 +6622,22 @@ describe('Brands Controller', () => {
         attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
       });
 
-      expect(response.status).to.equal(502);
+      expect(response.status).to.equal(200);
       const body = await response.json();
-      expect(body.message).to.equal('Upstream request failed');
+      expect(body).to.include({ semrushSyncPending: true });
       expect(JSON.stringify(body)).to.not.match(/leak/);
       expect(JSON.stringify(body)).to.not.match(/Project Engine/);
     });
 
-    // The auth-preservation crux: a no-HTTP-response Project Engine failure (missing IMS token)
-    // is a status-undefined ProjectEngineApiError carrying the 401 SerenityTransportError as
-    // `.cause`. createErrorResponse must unwrap it so the response stays 401 (not flattened).
-    it('unwraps a status-undefined ProjectEngineApiError to preserve the auth 401 on brand-edit re-sync', async () => {
-      const updateBrandStub = sinon.stub().resolves({
+    // LLMO-6545: a status-undefined ProjectEngineApiError (missing IMS token) carrying a 401 cause
+    // is also soft-failed — DB already committed, so auth failures in the sync path don't block
+    // the customer. The auth issue is logged (status field in the log includes syncError?.status
+    // which is undefined here) and ops can investigate via Splunk.
+    it('LLMO-6545: soft-fails a status-undefined ProjectEngineApiError with 401 cause on brand-edit re-sync', async () => {
+      const updated = {
         id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
-      });
+      };
+      const updateBrandStub = sinon.stub().resolves(updated);
       const authCause = new SerenityTransportError(401, 'Missing IMS bearer token');
       const syncStub = sinon.stub().rejects(
         new ProjectEngineApiError(undefined, 'POST', null, { cause: authCause }),
@@ -6645,9 +6657,8 @@ describe('Brands Controller', () => {
         attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
       });
 
-      expect(response.status).to.equal(401);
-      const body = await response.json();
-      expect(body.message).to.equal('Upstream authorization failed');
+      expect(response.status).to.equal(200);
+      expect(await response.json()).to.include({ semrushSyncPending: true });
     });
 
     it('re-syncs CI competitors (with removed domains) when competitors change on a sub-workspace brand', async () => {
@@ -6752,7 +6763,7 @@ describe('Brands Controller', () => {
       });
 
       expect(response.status).to.equal(200);
-      expect(response.body).to.deep.include({ semrushSyncPending: true });
+      expect(await response.json()).to.include({ semrushSyncPending: true });
       expect(updateBrandStub).to.have.been.calledOnce;
       expect(loggerStub.error).to.have.been.calledWithMatch(
         'serenity: brand-edit Semrush re-sync failed after row commit',

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -5288,6 +5288,65 @@ describe('Brands Controller', () => {
         expect(upsertStub.called).to.equal(false);
       });
 
+      it('redacts the gateway URL from a Semrush upstream error on provisioning', async () => {
+        // A Semrush error's message embeds the internal gateway host plus workspace
+        // and project UUIDs. Provisioning runs unguarded inside createBrandForOrg's
+        // try, so the error reaches createErrorResponse — which must map it to a
+        // generic message and keep the detail in the log, on both the body and the
+        // x-error header.
+        const leakUrl = 'https://gw.internal/enterprise/workspaces/ws-9/projects/proj-abc/aio';
+        const provisionStub = sinon.stub().rejects(
+          new SerenityTransportError(502, `Semrush POST ${leakUrl} failed: 502`, {}),
+        );
+        const upsertStub = sinon.stub().resolves({ id: 'x' });
+        const controller = await buildController({
+          provisionBrandSubworkspace: provisionStub, upsertBrand: upsertStub,
+        });
+
+        const response = await controller.createBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID },
+          data: { ...semrushData },
+          dataAccess: mockDataAccess,
+          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+        });
+
+        expect(response.status).to.equal(502);
+        const body = await response.json();
+        expect(body.message).to.equal('Upstream request failed');
+        expect(JSON.stringify(body)).to.not.contain('gw.internal');
+        expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
+        expect(upsertStub.called).to.equal(false);
+      });
+
+      it('maps a 401 Semrush upstream error on provisioning to HTTP 401 + generic auth message', async () => {
+        // The 401/403 side of createErrorResponse's status ternary: the upstream
+        // status is preserved rather than flattened to 502, and the message is the
+        // generic auth one.
+        const leakUrl = 'https://gw.internal/enterprise/workspaces/ws-9/projects';
+        const provisionStub = sinon.stub().rejects(
+          new SerenityTransportError(401, `Semrush GET ${leakUrl} failed: 401`, {}),
+        );
+        const controller = await buildController({
+          provisionBrandSubworkspace: provisionStub,
+          upsertBrand: sinon.stub().resolves({ id: 'x' }),
+        });
+
+        const response = await controller.createBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID },
+          data: { ...semrushData },
+          dataAccess: mockDataAccess,
+          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+        });
+
+        expect(response.status).to.equal(401);
+        const body = await response.json();
+        expect(body.message).to.equal('Upstream authorization failed');
+        expect(JSON.stringify(body)).to.not.contain('gw.internal');
+        expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
+      });
+
       it('releases the orphaned sub-workspace when the brand row write fails after provisioning', async () => {
         const provisionStub = sinon.stub().resolves({ semrushSubWorkspaceId: 'ws-orphan' });
         const releaseStub = sinon.stub().resolves();
@@ -6498,7 +6557,7 @@ describe('Brands Controller', () => {
       expect(syncStub).to.have.been.calledOnce;
     });
 
-    it('rejects a non-IMS caller on the brand-edit re-sync (never forwards the bearer upstream)', async () => {
+    it('never forwards a non-IMS bearer upstream, and soft-fails the re-sync rather than reporting 401 for a committed edit', async () => {
       const updateBrandStub = sinon.stub().resolves({
         id: BRAND_UUID, semrushSubWorkspaceId: 'ws-9', urls: [], socialAccounts: [], earnedContent: [],
       });
@@ -6519,10 +6578,20 @@ describe('Brands Controller', () => {
         attributes: { authInfo: { getType: () => 'jwt', profile: { email: 'svc@test.com' } } },
       });
 
-      expect(response.status).to.equal(401);
-      // A non-IMS bearer is never built into a transport nor forwarded to Semrush.
+      // Security invariant: a non-IMS bearer is never built into a transport nor
+      // forwarded to Semrush — token resolution refuses it before either happens.
       expect(createTransportStub).to.not.have.been.called;
       expect(syncStub).to.not.have.been.called;
+      // The brand row was committed before the re-sync block, so the refusal is a
+      // re-sync failure like any other: report the persisted edit, flag the drift.
+      expect(updateBrandStub).to.have.been.calledOnce;
+      expect(response.status).to.equal(200);
+      expect(await response.json()).to.include({ semrushSyncPending: true });
+      // 401 is the permanent class — it needs a human, not a retry.
+      expect(loggerStub.warn).to.have.been.calledWithMatch(
+        'serenity: brand-edit Semrush re-sync failed after row commit',
+        sinon.match({ status: 401, permanent: true }),
+      );
     });
 
     it('LLMO-6545: soft-fails and does not leak the internal gateway URL on a SerenityTransportError re-sync failure', async () => {
@@ -7285,11 +7354,14 @@ describe('Brands Controller', () => {
       });
 
       it('degrades to brand-URL-only reserved set when the pre-write project listing fails (LLMO-6545)', async () => {
-        // createErrorResponse is still reachable on the pre-write guard path and
-        // must redact internal gateway URLs. This test also verifies that a
-        // SerenityTransportError on the pre-write listing degrades gracefully
-        // (writes proceed, self-ref guard uses brand URLs only) rather than
-        // hard-failing before the DB write.
+        // A listing failure in the pre-write self-reference guard degrades: the
+        // reserved set falls back to the brand's own URLs and the write proceeds.
+        // The same transport error then also fails the post-commit re-sync, so the
+        // response is the soft-fail 200 — either way the gateway URL embedded in the
+        // error must not reach the client. (The redaction path proper —
+        // createErrorResponse mapping a Semrush error to a generic message — is not
+        // reachable from this handler; it is covered on the create path, where
+        // provisioning errors do escape to the outer catch.)
         const leakUrl = 'https://gw.internal/enterprise/workspaces/ws-7/projects';
         const updated = {
           id: BRAND_UUID,

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -6770,10 +6770,11 @@ describe('Brands Controller', () => {
       );
     });
 
-    it('LLMO-6545: includes both semrushSyncPending and semrushRejectedAliases when alias sync collected rejections before a later sync throws', async () => {
-      // URL sync succeeds, alias sync collects rejected aliases into rejectedAliases[],
-      // then competitor sync throws. The catch must preserve the partial alias rejections
-      // so the UI can still warn the operator which aliases were refused by Semrush.
+    it('LLMO-6545: includes both semrushSyncPending and semrushRejectedAliases when competitor sync collected rejections before alias sync throws', async () => {
+      // Execution order: competitors → aliases. Competitor sync resolves with
+      // rejected entries (pushed into rejectedAliases[]); alias sync then throws.
+      // The catch must preserve the partial rejections so the UI can still warn
+      // the operator which aliases were refused by Semrush.
       const rejected = [{ name: 'alias-a' }, { name: 'alias-b' }];
       const updated = {
         id: BRAND_UUID,
@@ -6785,15 +6786,15 @@ describe('Brands Controller', () => {
         brandAliases: [{ name: 'alias-a' }, { name: 'alias-c' }],
       };
       const updateBrandStub = sinon.stub().resolves(updated);
-      // URL sync succeeds; alias sync resolves with rejected aliases; competitor sync throws.
-      const aliasSyncStub = sinon.stub().resolves({ rejected });
-      const competitorSyncStub = sinon.stub().rejects(
+      // Competitor sync succeeds with rejections; alias sync throws.
+      const competitorSyncStub = sinon.stub().resolves({ rejected });
+      const aliasSyncStub = sinon.stub().rejects(
         Object.assign(new Error('Semrush 503'), { status: 503 }),
       );
       const controller = await buildUpdateController({
         updateBrand: updateBrandStub,
-        syncBrandAliasesAcrossMarkets: aliasSyncStub,
         syncCompetitorBenchmarksAcrossMarkets: competitorSyncStub,
+        syncBrandAliasesAcrossMarkets: aliasSyncStub,
         createSerenityTransport: sinon.stub().returns({
           name: 't',
           listProjects: sinon.stub().resolves({ items: [] }),


### PR DESCRIPTION
## Summary

`PATCH /brands/:id` returned an error when the Semrush re-sync failed after the brand row had already been committed, so an edit that persisted in LLMO was reported to the customer as a failure. This blocked KDDI from saving brand data.

The re-sync is now best-effort, matching the create path. The committed row is returned with `semrushSyncPending: true`, the failure is logged with the context needed to enumerate and recover the drift, and the divergence is reconciled later.

## Root cause

The create path treats Semrush propagation as best-effort so a benchmark hiccup cannot strand a half-provisioned brand. The edit path hard-failed instead, on the reasoning that an already-live brand must not silently diverge from Semrush. That reasoning inverts once the row is written: the DB commit happens before the re-sync block, so the only thing a hard fail changes is what the customer is told about a write that already succeeded.

Three call sites sat outside the re-sync's error handling and produced the same asymmetry:

- the pre-write self-referential-competitor guard, which lists Semrush projects to build the reserved-domain set
- Semrush IMS token resolution for the post-commit re-sync
- transport construction for that re-sync

## Who this affects

The driving failure is **permanent, not transient**. Semrush binds a forwarded IMS token to a Semrush user record by `authId` or email before executing the call, and JIT user provisioning from IMS claims was explicitly declined — users are added to Semrush manually at onboarding. Migrated orgs therefore have LLMO users who edit brand content in LLMO but have no Semrush user record at all, and the observed upstream status for such an identity is 403.

For those users every edit drifts, on every request, indefinitely. Retrying cannot clear it; someone has to provision the user. Transient upstream failures (5xx, timeouts, network) are a separate and much smaller class.

## Changes

**`src/controllers/brands.js`**

- The post-commit re-sync returns `ok({ ...updated, semrushSyncPending: true })` instead of rethrowing. Any `semrushRejectedAliases` collected before the throw are preserved, so a partial result is not discarded.
- Token resolution and transport construction moved inside the re-sync `try`. A 401 there (no or expired promise token, non-IMS bearer) is a re-sync failure like any other and no longer reports an auth error for an edit that persisted. A non-IMS bearer is still refused before any transport is built or forwarded upstream.
- The pre-write competitor guard degrades instead of failing the request: on a listing error it falls back to a brand-URL-only reserved set and logs a warning. The guard is a data-quality nicety, and a Semrush outage should not reject the write outright. The trade-off is explicit — a competitor equal to one of the brand's own market domains can be stored while the listing is unavailable, which the next successful edit re-checks.
- Failures are classified by class. 401/403 logs at `warn` with `permanent: true`; everything else logs at `error`. Both carry `brandId`, `semrushSubWorkspaceId`, which syncs were touched, `status`, `message` and `stack`.

**`docs/openapi/schemas.yaml`, `docs/openapi/brands-v2-api.yaml`**

`semrushSyncPending` documented on `V2BrandUpdateResponse` and in the 200 description, alongside the existing `semrushRejectedAliases`. The semantic is load-bearing: the row persisted and Semrush does not reflect it yet.

## Observability

Recovery reads from **CloudWatch, not Splunk**. Measured on 2026-07-27, api-service prod ships about 7 events per 24h to `index=dx_aem_engineering sourcetype=dx_aem_sites_spacecat_backend_prod`, against 6,920 for content-scraper and 3,599 for audit-worker over the same window, and a search for this log line across `sourcetype=dx_aem_sites_spacecat_*` returns nothing. A Splunk-based enumeration of drifted brands would silently return an empty set. Use CloudWatch Logs Insights against the api-service prod Lambda log group:

```
fields @timestamp, brandId, semrushSubWorkspaceId, urlsTouched, competitorsTouched, aliasesTouched, status, permanent
| filter @message like "serenity: brand-edit Semrush re-sync failed after row commit"
| sort @timestamp desc
```

The permanent class warrants a standing alert: it is not self-healing, it means a named user needs provisioning in Semrush, and it does not carry the noise that would make alerting on transient upstream errors impractical. Filter on `permanent: true` to separate the two. `semrushSyncPending` has no consumer yet — no client currently reads the flag, so today the divergence is visible only in the logs.

## Recovery

Extend the `--reconcile` migration in `mysticat-data-service` to diff and reconcile `brand_urls`, `competitors` and `aliases` per Semrush project. The Semrush client methods already exist (`list_brand_urls`, `create_brand_urls`, and siblings). Tracked on LLMO-6545.

Enqueuing the re-sync for retry alongside the 200, per the repo's queue-based async pattern, would let transient failures self-heal and make `--reconcile` a backstop rather than the only recovery. Tracked as a follow-up on LLMO-6545.

## Testing

- `npx mocha test/controllers/brands.test.js` — 412 passing
- `npx eslint src/controllers/brands.js test/controllers/brands.test.js` — clean
- `npm run type-check` — clean

Covered:

- Semrush re-sync throws after commit gives 200 with `semrushSyncPending: true`
- a partial `semrushRejectedAliases` set collected before the throw survives into the response
- a non-IMS caller never has a bearer built into a transport or forwarded upstream, and the refusal soft-fails at the permanent class rather than returning 401 for a committed edit
- a pre-write listing failure degrades to the brand-URL-only reserved set and the write proceeds
- a Semrush error on the create path is mapped to a generic message, with the internal gateway URL kept out of both the response body and the `x-error` header

## What does not change

- The feature-flag gate (`isSerenityActiveForOrg`) still returns 403 on PATCH when the flag is off.
- The POST create path is untouched; it was already best-effort.
- Serenity activate/deactivate paths are already graceful and self-healing, and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
