### PR TITLE
fix: comparisonValue null for missing KPI headline data | LLMO-6562

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12026,11 +12026,15 @@ SerenityKpiHeadline:
       maximum: 1
       description: The metric's value for the current (requested) period, a 0-1 fraction.
     comparisonValue:
-      type: number
+      type: [number, 'null']
       format: double
       minimum: 0
       maximum: 1
-      description: The metric's value for the immediately preceding period of equal length, a 0-1 fraction.
+      description: |
+        The metric's value for the immediately preceding period of equal length, a 0-1
+        fraction. `null` when Semrush has no data for that period (e.g. it predates data
+        collection) — distinct from a real 0%; consumers should render this as "no
+        comparison available" rather than computing a delta against 0.
 SerenityKpiHeadlines:
   type: object
   description: |

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -2139,7 +2139,9 @@ v2-serenity-source-visibility-headline:
       sequential upstream lookup before the KPI element itself can be called —
       isolating it keeps that lookup from doubling the other two cards'
       worst-case latency. A brand with no registered URLs returns
-      `{ value: 0, comparisonValue: 0 }`.
+      `{ value: 0, comparisonValue: null }` — no measurement exists for either
+      period, so `comparisonValue` uses the same "no data" convention as a
+      missing Semrush comparison value.
 
       Date range is optional and defaults to a 28-day trailing window. Both
       `startDate` and `endDate` must be supplied together or not at all — a

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -1626,8 +1626,8 @@ export default function ElementsController(context, log, env) {
           .filter(hasText);
         if (projectIds.length === 0) {
           return cachedOk({
-            shareOfVoice: { value: 0, comparisonValue: 0 },
-            brandVisibility: { value: 0, comparisonValue: 0 },
+            shareOfVoice: { value: 0, comparisonValue: null },
+            brandVisibility: { value: 0, comparisonValue: null },
           });
         }
       }
@@ -1718,7 +1718,7 @@ export default function ElementsController(context, log, env) {
           .map((p) => p.semrushProjectId)
           .filter(hasText);
         if (projectIds.length === 0) {
-          return cachedOk({ value: 0, comparisonValue: 0 });
+          return cachedOk({ value: 0, comparisonValue: null });
         }
       }
 

--- a/src/support/elements/definitions/kpi-headlines.js
+++ b/src/support/elements/definitions/kpi-headlines.js
@@ -185,9 +185,6 @@ export function transformKpiHeadlineResponse(raw) {
   const comparisonValue = previous?.secondaryValue;
   return {
     value: typeof value === 'number' ? value : 0,
-    // null (not 0) when Semrush has no data for the comparison period (e.g. a comparison
-    // window predating data collection) — a real 0% and "no data" must stay distinguishable
-    // so consumers can show "N/A" instead of computing a fake delta against a 0 baseline.
     comparisonValue: typeof comparisonValue === 'number' ? comparisonValue : null,
   };
 }

--- a/src/support/elements/definitions/kpi-headlines.js
+++ b/src/support/elements/definitions/kpi-headlines.js
@@ -171,10 +171,12 @@ export function buildSourceVisibilityPayload({
  * `previous` entries were verified identical live, but matched by `period`
  * rather than positionally — a positional `[0]` read would silently return the
  * wrong figure if the two ever diverge or the array is ever reordered upstream.
- * Defaults to 0 when a field is missing.
+ * `value` defaults to 0 when missing; `comparisonValue` is `null` (not 0) when Semrush has
+ * no numeric data for the comparison period, so callers can distinguish "no data" from a
+ * real 0% and show e.g. "N/A" instead of computing a fake delta against a 0 baseline.
  *
  * @param {object} raw - Raw response from the Elements API.
- * @returns {{ value: number, comparisonValue: number }}
+ * @returns {{ value: number, comparisonValue: number | null }}
  */
 export function transformKpiHeadlineResponse(raw) {
   const value = raw?.blocks?.mainValue?.[0]?.mainValue;
@@ -183,6 +185,9 @@ export function transformKpiHeadlineResponse(raw) {
   const comparisonValue = previous?.secondaryValue;
   return {
     value: typeof value === 'number' ? value : 0,
-    comparisonValue: typeof comparisonValue === 'number' ? comparisonValue : 0,
+    // null (not 0) when Semrush has no data for the comparison period (e.g. a comparison
+    // window predating data collection) — a real 0% and "no data" must stay distinguishable
+    // so consumers can show "N/A" instead of computing a fake delta against a 0 baseline.
+    comparisonValue: typeof comparisonValue === 'number' ? comparisonValue : null,
   };
 }

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -910,9 +910,11 @@ export function createElementsService(transport, log) {
      *
      * A brand with no registered URLs has nothing to scope
      * `KPI_SOURCE_VISIBILITY` by (an empty `CBF_brand_urls` OR-filter is
-     * unscoped/undefined behavior upstream) — returns a zeroed result rather
-     * than issuing that call, mirroring the empty-projects guards elsewhere in
-     * this service.
+     * unscoped/undefined behavior upstream) — returns `{ value: 0, comparisonValue: null }`
+     * rather than issuing that call (no real measurement exists either period,
+     * so `comparisonValue` stays `null` — same "no data" convention as
+     * {@link transformKpiHeadlineResponse}), mirroring the empty-projects
+     * guards elsewhere in this service.
      *
      * @param {string} workspaceId - Semrush workspace UUID.
      * @param {object} params
@@ -939,7 +941,7 @@ export function createElementsService(transport, log) {
       );
       const brandUrls = transformBrandUrlsResponse(brandUrlsRaw);
       if (brandUrls.length === 0) {
-        return { value: 0, comparisonValue: 0 };
+        return { value: 0, comparisonValue: null };
       }
       const raw = await transport.fetchElement(
         workspaceId,

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -866,8 +866,8 @@ export function createElementsService(transport, log) {
      * @param {string} [params.projectId] - Single Semrush project UUID (one region).
      * @param {string[]} [params.projectIds] - All the brand's project UUIDs (aggregate).
      * @returns {Promise<{
-     *   shareOfVoice: {value: number, comparisonValue: number},
-     *   brandVisibility: {value: number, comparisonValue: number},
+     *   shareOfVoice: {value: number, comparisonValue: number | null},
+     *   brandVisibility: {value: number, comparisonValue: number | null},
      * }>}
      */
     async getKpiHeadlines(workspaceId, {
@@ -921,7 +921,7 @@ export function createElementsService(transport, log) {
      * @param {string} params.startDate / params.endDate - Required YYYY-MM-DD (main period).
      * @param {string} [params.projectId] - Single Semrush project UUID (one region).
      * @param {string[]} [params.projectIds] - All the brand's project UUIDs (aggregate).
-     * @returns {Promise<{value: number, comparisonValue: number}>}
+     * @returns {Promise<{value: number, comparisonValue: number | null}>}
      */
     async getSourceVisibilityHeadline(workspaceId, {
       brandName, model, platform, startDate, endDate, projectId, projectIds,

--- a/test/support/elements/definitions/kpi-headlines.test.js
+++ b/test/support/elements/definitions/kpi-headlines.test.js
@@ -193,20 +193,34 @@ describe('kpi-headlines definitions', () => {
       expect(transformKpiHeadlineResponse(raw).comparisonValue).to.equal(0.3927);
     });
 
-    it('defaults to 0 when mainValue/secondaryValue are missing', () => {
-      const zeroed = { value: 0, comparisonValue: 0 };
-      expect(transformKpiHeadlineResponse({ blocks: {} })).to.deep.equal(zeroed);
-      expect(transformKpiHeadlineResponse(undefined)).to.deep.equal(zeroed);
+    it('defaults value to 0 and comparisonValue to null when mainValue/secondaryValue are missing', () => {
+      const defaults = { value: 0, comparisonValue: null };
+      expect(transformKpiHeadlineResponse({ blocks: {} })).to.deep.equal(defaults);
+      expect(transformKpiHeadlineResponse(undefined)).to.deep.equal(defaults);
     });
 
-    it('defaults to 0 for a non-numeric mainValue/secondaryValue', () => {
+    it('defaults value to 0 and comparisonValue to null for a non-numeric mainValue/secondaryValue', () => {
       const raw = {
         blocks: {
           mainValue: [{ mainValue: 'not-a-number' }],
-          secondaryValue: [{ period: 'previous', secondaryValue: null }],
+          secondaryValue: [{ period: 'previous', secondaryValue: 'not-a-number' }],
         },
       };
-      expect(transformKpiHeadlineResponse(raw)).to.deep.equal({ value: 0, comparisonValue: 0 });
+      expect(transformKpiHeadlineResponse(raw)).to.deep.equal({ value: 0, comparisonValue: null });
+    });
+
+    it('returns comparisonValue: null (not 0) when Semrush has no data for the comparison period', () => {
+      const raw = {
+        blocks: {
+          mainValue: [{ mainValue: 0.3726 }],
+          secondaryValue: [
+            { period: 'current', secondaryValue: null },
+            { period: 'previous', secondaryValue: null },
+          ],
+        },
+      };
+      expect(transformKpiHeadlineResponse(raw))
+        .to.deep.equal({ value: 0.3726, comparisonValue: null });
     });
   });
 });

--- a/test/support/elements/definitions/kpi-headlines.test.js
+++ b/test/support/elements/definitions/kpi-headlines.test.js
@@ -222,5 +222,16 @@ describe('kpi-headlines definitions', () => {
       expect(transformKpiHeadlineResponse(raw))
         .to.deep.equal({ value: 0.3726, comparisonValue: null });
     });
+
+    it('returns comparisonValue: null when secondaryValue has no "previous" entry (find() miss)', () => {
+      const raw = {
+        blocks: {
+          mainValue: [{ mainValue: 0.3726 }],
+          secondaryValue: [{ period: 'current', secondaryValue: 0.3927 }],
+        },
+      };
+      expect(transformKpiHeadlineResponse(raw))
+        .to.deep.equal({ value: 0.3726, comparisonValue: null });
+    });
   });
 });

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -779,7 +779,7 @@ describe('createElementsService', () => {
       const result = await service.getSourceVisibilityHeadline('ws-1', {
         brandName: 'Lovesac', startDate: '2026-06-25', endDate: '2026-07-24',
       });
-      expect(result).to.deep.equal({ value: 0, comparisonValue: 0 });
+      expect(result).to.deep.equal({ value: 0, comparisonValue: null });
       expect(transport.fetchElement).to.have.been.calledOnce;
     });
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [x] make sure you update the API specification and the examples to reflect the changes.

## Summary

Fixes a correctness gap in the LLMO-6515 `kpi-headlines`/`source-visibility-headline` endpoints (spacecat-api-service PR #2902). `transformKpiHeadlineResponse` coerced a missing/non-numeric Semrush `secondaryValue` to `0`, indistinguishable from a real 0%. Verified live via Chrome DevTools against the production Brand Presence MFE: for a 6-month date range, Semrush returns `secondaryValue: null` for the comparison period (it predates data collection), and the MFE correctly renders "N/A" for the trend badge in that case. Our endpoints should expose the same signal instead of silently defaulting to 0, which would make a consumer compute a fake "+100%" delta against a fabricated 0 baseline.

## Changes

- `transformKpiHeadlineResponse` (src/support/elements/definitions/kpi-headlines.js) now returns `comparisonValue: null` (not `0`) when Semrush's value isn't a finite number
- Updated JSDoc return types on `transformKpiHeadlineResponse`, `getKpiHeadlines`, and `getSourceVisibilityHeadline` (elements-service.js) to `comparisonValue: number | null`
- `SerenityKpiHeadline` OpenAPI schema's `comparisonValue` changed from `type: number` to `type: [number, 'null']` (this repo's OpenAPI 3.1 nullable convention)
- Updated/added unit tests in kpi-headlines.test.js covering the null-data case explicitly
- Guard-clause early returns (empty projectIds / no registered brand URLs) also now return `comparisonValue: null` for consistency (triage follow-up)

## Related Issues

https://jira.corp.adobe.com/browse/LLMO-6562
Follow-up from LLMO-6515 (merged #2902) / LLMO-6516 (frontend consumer, project-elmo-ui#2554, merged)

## Testing the PR changes

- `npx mocha test/support/elements/definitions/kpi-headlines.test.js test/support/elements/elements-service.test.js` — 65 passing
- `npm test` — full suite, 15,989 passing
- `npm run docs:lint` — 0 errors (same 211 pre-existing warnings baseline as origin/main, unrelated to this change)