### PR TITLE
feat: auto-assign default AI models when a market is created | LLMO-6554

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -66,6 +66,7 @@ import { ensureSubworkspace, decommissionBrandWorkspace } from '../support/seren
 import { isSerenityActiveForOrg } from '../support/serenity/serenity-active.js';
 import { isDynamicAllocationEnabled, resolveBrandAiCeiling } from '../support/serenity/dynamic-allocation-active.js';
 import { MAX_TOPICS_ON_CREATE } from '../support/serenity/brand-provisioning.js';
+import { resolveDefaultModelIds } from '../support/serenity/default-models.js';
 import { marketForGeoTargetId } from '../support/serenity/locations.js';
 import { brandNeedles, classifyBrandedTag } from '../support/serenity/branded-classifier.js';
 import { computeWriteDeadline } from '../support/serenity/intent-classification.js';
@@ -753,6 +754,18 @@ function SerenityController(context, log, env) {
         // Optional prompt/topic generation for this market, defaulting to off so
         // the endpoint's behavior is unchanged unless the caller opts in.
         const genMarketTopics = effectiveBody.generatePrompts === true;
+        // LLMO-6554: this brand is already active, so its sub-workspace (and
+        // likely other markets) already exists — mirror whichever models those
+        // markets already track, falling back to the canonical net-new default
+        // only if none of them has any (see resolveDefaultModelIds). Without
+        // this, "Add Market" on an active brand attached zero models and the
+        // subsequent publish 405'd as a disguised empty-units quota rejection.
+        const newMarketModelIds = await resolveDefaultModelIds(
+          transport,
+          /** @type {string} */ (auth.workspaceId),
+          auth.brandUuid,
+          log,
+        );
         result = await handleCreateMarketSubworkspace(
           transport,
           brand,
@@ -762,6 +775,7 @@ function SerenityController(context, log, env) {
           null,
           brandPointerReloader(ctx, auth.brandUuid),
           {
+            modelIds: newMarketModelIds,
             generateTopics: genMarketTopics,
             topicCap: genMarketTopics ? MAX_TOPICS_ON_CREATE : 0,
             brandAliases,
@@ -1360,6 +1374,18 @@ function SerenityController(context, log, env) {
           dynamicAllocation: dynamicAllocationEnabled(ctx),
         },
       );
+      // LLMO-6554: resolved ONCE for the whole batch (same brand, so every market
+      // in this request gets the same default) — mirrors whichever models the
+      // brand's existing markets already track, falling back to the canonical
+      // net-new default set when none do. A per-market `modelIds` in the body
+      // still wins when supplied (see marketModelIds below), preserving the
+      // override for any API-driven caller.
+      const defaultModelIds = await resolveDefaultModelIds(
+        transport,
+        workspaceId,
+        brandUuid,
+        log,
+      );
       const results = [];
       for (const m of markets) {
         const createBody = {
@@ -1373,8 +1399,10 @@ function SerenityController(context, log, env) {
         // AI models (LLMs) the draft staged for this market (or that the activate
         // request supplied). handleCreateMarketSubworkspace reads them from its
         // OPTIONS arg (NOT the body) and attaches them to the project before
-        // publish; omitted/empty → none attached.
-        const marketModelIds = Array.isArray(m.modelIds) ? m.modelIds : [];
+        // publish; omitted/empty → the resolved default (LLMO-6554) applies.
+        const marketModelIds = Array.isArray(m.modelIds) && m.modelIds.length > 0
+          ? m.modelIds
+          : defaultModelIds;
         let r;
         try {
           // eslint-disable-next-line no-await-in-loop

--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -22,6 +22,7 @@ import { deleteAllProjects, releaseFullAllocation, ensureSubworkspace } from './
 import { handleCreateMarketSubworkspace } from './handlers/markets-subworkspace.js';
 import { computeWriteDeadline } from './intent-classification.js';
 import { isDynamicAllocationEnabled, resolveBrandAiCeiling } from './dynamic-allocation-active.js';
+import { resolveCanonicalDefaultModelIds } from './default-models.js';
 
 // Brand-create generation policy (tunable). Keep the top N generated topics by
 // search volume; brand-topics returns up to 10 topics x up to 100 prompts each,
@@ -64,7 +65,12 @@ export function initialMarketProjectName(market, languageCode) {
  * @param {string} params.market - ISO-2 country code for the initial market.
  * @param {string} params.languageCode - BCP-47 language code for the initial market.
  * @param {string} params.brandDomain - brand domain for the upstream project.
- * @param {string[]} params.modelIds - AI models (LLMs) to attach to the project.
+ * @param {string[]} [params.modelIds] - AI models (LLMs) to attach to the
+ *   project. This is always the brand's FIRST-EVER market (the sub-workspace
+ *   is freshly created below), so an empty/omitted list resolves to the
+ *   canonical net-new default set (LLMO-6554 / LLMO-6338 — see
+ *   {@link resolveCanonicalDefaultModelIds}) rather than creating a
+ *   zero-model project that can't publish real units.
  * @param {boolean} [params.generateTopics] - when true (default), generate +
  *   attach topics/prompts (top N by volume) at create; when false, create the
  *   project empty (models still attached when supplied).
@@ -137,6 +143,14 @@ export async function provisionBrandSubworkspace(context, {
   // 401ing a non-IMS bearer before it can be proxied upstream.
   const imsToken = await resolveSemrushImsToken(context, log, 'brand-provisioning');
   const transport = createSerenityTransport({ env: context.env, imsToken });
+
+  // LLMO-6554: this is always the brand's FIRST-EVER market (the sub-workspace is
+  // freshly created below), so there is nothing to mirror — an empty/omitted
+  // caller-supplied modelIds resolves straight to the canonical net-new default.
+  // A non-empty caller-supplied list (a future API-driven caller) is honored as-is.
+  const resolvedModelIds = Array.isArray(modelIds) && modelIds.length > 0
+    ? modelIds
+    : await resolveCanonicalDefaultModelIds(transport, log);
 
   // Dynamic-allocation kill-switch + per-brand ceiling (LLMO-6190): brand creation is onboarding,
   // and §3/§4a of the design require an onboarded-while-ON brand to get a MINIMAL sub-workspace
@@ -215,7 +229,7 @@ export async function provisionBrandSubworkspace(context, {
       // every project regardless. With generateTopics=false the project is created
       // empty (no prompts); models are still attached when supplied.
       {
-        modelIds,
+        modelIds: resolvedModelIds,
         generateTopics,
         topicCap: generateTopics ? MAX_TOPICS_ON_CREATE : 0,
         brandAliases,
@@ -227,8 +241,11 @@ export async function provisionBrandSubworkspace(context, {
         // "empty units", which Semrush rejects with a disguised quota 405
         // (workspace doc §5). Tolerate that by leaving it a draft (best-effort)
         // instead of failing the whole create; a project that has models OR
-        // prompts has real units and must publish (require).
-        publishMode: (Array.isArray(modelIds) && modelIds.length > 0) || generateTopics
+        // prompts has real units and must publish (require). resolvedModelIds
+        // is non-empty in the common case (LLMO-6554 default), so this is
+        // 'require' unless the canonical-catalog read itself came up empty.
+        publishMode: (Array.isArray(resolvedModelIds) && resolvedModelIds.length > 0)
+          || generateTopics
           ? 'require'
           : 'best-effort',
         dynamicAllocation,

--- a/src/support/serenity/default-models.js
+++ b/src/support/serenity/default-models.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+import { hasText } from '@adobe/spacecat-shared-utils';
+
+import { listGlobalModelCatalog, listSliceModels } from './handlers/markets.js';
+import { listMarkets } from './subworkspace-projects.js';
+
+/**
+ * Net-new customer base package (LLMO-6338 / LLMO-6554): the AI models a
+ * brand-new Serenity market gets out of the box, before a customer requests
+ * anything extra (Copilot, ChatGPT Paid — opt-in only, never auto-assigned;
+ * see the LLMO-6338 Slack decision thread). Values are Semrush AI-model
+ * catalog `key`s (`SerenityModel.key` — "CBF_model value the Reporting API
+ * expects"), the same taxonomy as `ELEMENT_MODELS` (../elements/constants.js).
+ *
+ * "ChatGPT w/websearch" is Semrush's single search-enabled ChatGPT model,
+ * `search-gpt` — there is no separate free/paid split at the catalog level
+ * (the non-search variant is `gpt-5`, "ChatGPT (No Search)", not part of this
+ * default set). "Google (3)" is AI Overview + AI Mode + the Gemini chatbot.
+ */
+export const NET_NEW_DEFAULT_MODEL_KEYS = Object.freeze([
+  'search-gpt', // ChatGPT w/ web search
+  'google-ai-overview',
+  'google-ai-mode',
+  'gemini-2.5-flash',
+  'claude-sonnet-4',
+  'perplexity',
+  'grok-3',
+  'deepseek',
+]);
+
+/**
+ * Resolves the canonical net-new default model set against the LIVE global
+ * catalog (`GET /serenity/models` with no slice params) by matching `key`
+ * against {@link NET_NEW_DEFAULT_MODEL_KEYS}. A catalog entry missing from the
+ * live response is simply skipped (best-effort) rather than failing the
+ * caller — a partial default is better than none.
+ *
+ * @param {any} transport - Serenity transport.
+ * @param {any} [log]
+ * @returns {Promise<string[]>} catalog model ids (NOT keys) to attach.
+ */
+export async function resolveCanonicalDefaultModelIds(transport, log) {
+  try {
+    const { items } = await listGlobalModelCatalog(transport);
+    return items
+      .filter((m) => hasText(m?.key) && NET_NEW_DEFAULT_MODEL_KEYS.includes(m.key))
+      .map((m) => m.id)
+      .filter(hasText);
+  } catch (e) {
+    log?.warn?.('resolveCanonicalDefaultModelIds: global model catalog read failed (non-fatal)', {
+      error: e?.message,
+    });
+    return [];
+  }
+}
+
+/**
+ * Resolves the model ids (catalog `id`s) to auto-assign to a NEW market on an
+ * EXISTING sub-workspace, so a market is never created with zero models by
+ * default (LLMO-6554 — the gap LLMO-6338 opened by removing manual model
+ * selection without replacing it with an automatic default; see
+ * serenity-docs#72 for the "dark draft market" failure mode this closes).
+ *
+ * Precedence:
+ *   1. Mirror the brand's own existing models: if any of the brand's current
+ *      markets already has ≥1 model attached, reuse THAT market's model set,
+ *      so every market on a brand tracks the same LLMs — a brand provisioned
+ *      with the migrated 10-LLM tier, or one that has since customized its
+ *      set, keeps that set on every new market it adds. Markets are checked in
+ *      listing order until one with a non-empty model set is found (a market
+ *      created before this fix landed may still have zero models).
+ *   2. Canonical net-new default ({@link resolveCanonicalDefaultModelIds}):
+ *      no existing market has any models yet (a brand-new brand's first
+ *      market on this sub-workspace).
+ *
+ * Never throws: any transport failure degrades to an empty list (the caller's
+ * existing empty-modelIds handling takes over), so a catalog/listing hiccup
+ * can't fail an otherwise-successful market create.
+ *
+ * @param {any} transport - Serenity transport.
+ * @param {string} workspaceId - the brand's (already-existing) sub-workspace id.
+ * @param {string} brandId - the brand UUID (threaded through to the slice DTO only).
+ * @param {any} [log]
+ * @returns {Promise<string[]>} catalog model ids to attach.
+ */
+export async function resolveDefaultModelIds(transport, workspaceId, brandId, log) {
+  try {
+    const existingMarkets = await listMarkets(transport, workspaceId, brandId);
+    for (const market of existingMarkets) {
+      if (!hasText(market?.semrushProjectId)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      const { items } = await listSliceModels(transport, workspaceId, market.semrushProjectId);
+      /** @type {string[]} */
+      const ids = [];
+      for (const m of items) {
+        if (m && hasText(m.id)) {
+          ids.push(m.id);
+        }
+      }
+      if (ids.length > 0) {
+        return ids;
+      }
+    }
+  } catch (e) {
+    log?.warn?.('resolveDefaultModelIds: existing-market mirror read failed (non-fatal)', {
+      workspaceId, brandId, error: e?.message,
+    });
+  }
+  return resolveCanonicalDefaultModelIds(transport, log);
+}

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1429,6 +1429,10 @@ describe('SerenityController', () => {
       expect(writeDeadline).to.be.a('number');
       expect(marketOptions)
         .to.deep.equal({
+          // LLMO-6554: resolved via resolveDefaultModelIds — [] here because the test's
+          // transport stub doesn't implement the catalog/listing calls it reads from
+          // (both degrade to an empty best-effort default, never throwing).
+          modelIds: [],
           generateTopics: false,
           topicCap: 0,
           brandAliases: ['Acme Inc', 'ACME'],

--- a/test/support/serenity/default-models.test.js
+++ b/test/support/serenity/default-models.test.js
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import {
+  NET_NEW_DEFAULT_MODEL_KEYS,
+  resolveCanonicalDefaultModelIds,
+  resolveDefaultModelIds,
+} from '../../../src/support/serenity/default-models.js';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+const BRAND = 'brand-1';
+const WORKSPACE = 'workspace-1';
+
+const FULL_CATALOG = [
+  { id: 'cat-search-gpt', key: 'search-gpt', name: 'ChatGPT' },
+  { id: 'cat-gpt-5', key: 'gpt-5', name: 'ChatGPT (No Search)' },
+  { id: 'cat-google-ai-overview', key: 'google-ai-overview', name: 'Google AI Overview' },
+  { id: 'cat-google-ai-mode', key: 'google-ai-mode', name: 'Google AI Mode' },
+  { id: 'cat-gemini', key: 'gemini-2.5-flash', name: 'Gemini' },
+  { id: 'cat-claude', key: 'claude-sonnet-4', name: 'Claude' },
+  { id: 'cat-perplexity', key: 'perplexity', name: 'Perplexity' },
+  { id: 'cat-grok', key: 'grok-3', name: 'Grok' },
+  { id: 'cat-deepseek', key: 'deepseek', name: 'Deepseek' },
+  { id: 'cat-copilot', key: 'microsoft-copilot', name: 'Copilot' },
+  { id: 'cat-open-evidence', key: 'open-evidence', name: 'OpenEvidence' },
+];
+
+function proj({
+  id, geo = 2840, lang = 'en',
+} = {}) {
+  return {
+    id,
+    publish_status: 'live',
+    updated_at: '2026-06-02T00:00:00Z',
+    settings: { ai: { location: { id: geo }, language: { name: lang } } },
+  };
+}
+
+function makeTransport(overrides = {}) {
+  return {
+    listProjects: sinon.stub().resolves({ items: [] }),
+    listGlobalAiModels: sinon.stub().resolves({ items: FULL_CATALOG }),
+    listAiModels: sinon.stub().resolves({ items: [] }),
+    ...overrides,
+  };
+}
+
+function fakeLog() {
+  return {
+    info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(),
+  };
+}
+
+describe('default-models.js', () => {
+  describe('NET_NEW_DEFAULT_MODEL_KEYS', () => {
+    it('is exactly the 8-LLM net-new base package (LLMO-6338)', () => {
+      expect(NET_NEW_DEFAULT_MODEL_KEYS).to.deep.equal([
+        'search-gpt',
+        'google-ai-overview',
+        'google-ai-mode',
+        'gemini-2.5-flash',
+        'claude-sonnet-4',
+        'perplexity',
+        'grok-3',
+        'deepseek',
+      ]);
+    });
+
+    it('never includes the opt-in-only models (Copilot, ChatGPT Paid/No-Search)', () => {
+      expect(NET_NEW_DEFAULT_MODEL_KEYS).to.not.include('microsoft-copilot');
+      expect(NET_NEW_DEFAULT_MODEL_KEYS).to.not.include('gpt-5');
+      expect(NET_NEW_DEFAULT_MODEL_KEYS).to.not.include('chatgpt-paid');
+    });
+  });
+
+  describe('resolveCanonicalDefaultModelIds', () => {
+    it('resolves the 8 default catalog ids from the live global catalog', async () => {
+      const transport = makeTransport();
+      const ids = await resolveCanonicalDefaultModelIds(transport, fakeLog());
+      expect(ids.sort()).to.deep.equal([
+        'cat-claude',
+        'cat-deepseek',
+        'cat-gemini',
+        'cat-google-ai-mode',
+        'cat-google-ai-overview',
+        'cat-grok',
+        'cat-perplexity',
+        'cat-search-gpt',
+      ].sort());
+    });
+
+    it('skips a default key missing from the live catalog (partial default, best-effort)', async () => {
+      const partial = FULL_CATALOG.filter((m) => m.key !== 'deepseek');
+      const transport = makeTransport({
+        listGlobalAiModels: sinon.stub().resolves({ items: partial }),
+      });
+      const ids = await resolveCanonicalDefaultModelIds(transport, fakeLog());
+      expect(ids).to.have.lengthOf(7);
+      expect(ids).to.not.include('cat-deepseek');
+    });
+
+    it('never throws — a catalog read failure resolves to an empty list', async () => {
+      const log = fakeLog();
+      const transport = makeTransport({ listGlobalAiModels: sinon.stub().rejects(new Error('upstream boom')) });
+      const ids = await resolveCanonicalDefaultModelIds(transport, log);
+      expect(ids).to.deep.equal([]);
+      expect(log.warn).to.have.been.calledOnce;
+    });
+  });
+
+  describe('resolveDefaultModelIds', () => {
+    it('falls back to the canonical default when the brand has no existing markets', async () => {
+      const transport = makeTransport();
+      const ids = await resolveDefaultModelIds(transport, WORKSPACE, BRAND, fakeLog());
+      expect(ids).to.have.lengthOf(8);
+      expect(transport.listAiModels).to.not.have.been.called;
+    });
+
+    it('falls back to the canonical default when every existing market has zero models', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p1' }), proj({ id: 'p2', geo: 2276, lang: 'de' })] }),
+        listAiModels: sinon.stub().resolves({ items: [] }),
+      });
+      const ids = await resolveDefaultModelIds(transport, WORKSPACE, BRAND, fakeLog());
+      expect(ids).to.have.lengthOf(8);
+      expect(transport.listAiModels).to.have.been.calledTwice;
+    });
+
+    it('mirrors the first existing market that already has models attached, skipping empty ones', async () => {
+      const listAiModels = sinon.stub();
+      listAiModels.withArgs(WORKSPACE, 'p1').resolves({ items: [] });
+      listAiModels.withArgs(WORKSPACE, 'p2').resolves({
+        items: [
+          { id: 'a1', model: { id: 'cat-copilot', key: 'microsoft-copilot' } },
+          { id: 'a2', model: { id: 'cat-search-gpt', key: 'search-gpt' } },
+        ],
+      });
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p1' }), proj({ id: 'p2', geo: 2276, lang: 'de' })] }),
+        listAiModels,
+      });
+      const ids = await resolveDefaultModelIds(transport, WORKSPACE, BRAND, fakeLog());
+      // Mirrors the 10-LLM migrated tier the existing market tracks, NOT the
+      // 8-LLM net-new default — the canonical catalog is never consulted.
+      expect(ids.sort()).to.deep.equal(['cat-copilot', 'cat-search-gpt'].sort());
+      expect(transport.listGlobalAiModels).to.not.have.been.called;
+    });
+
+    it('skips an existing market with no resolvable semrushProjectId (defensive)', async () => {
+      const noIdProject = proj({ id: undefined, geo: 2276, lang: 'de' });
+      const transport = makeTransport({
+        listProjects: sinon.stub().resolves({ items: [noIdProject] }),
+      });
+      const ids = await resolveDefaultModelIds(transport, WORKSPACE, BRAND, fakeLog());
+      expect(ids).to.have.lengthOf(8);
+      expect(transport.listAiModels).to.not.have.been.called;
+    });
+
+    it('falls back to the canonical default when listing existing markets fails (non-fatal)', async () => {
+      const log = fakeLog();
+      const transport = makeTransport({
+        listProjects: sinon.stub().rejects(new Error('listing boom')),
+      });
+      const ids = await resolveDefaultModelIds(transport, WORKSPACE, BRAND, log);
+      expect(ids).to.have.lengthOf(8);
+      expect(log.warn).to.have.been.calledOnce;
+    });
+
+    it('never throws — every upstream call failing still resolves (to an empty list)', async () => {
+      const transport = makeTransport({
+        listProjects: sinon.stub().rejects(new Error('listing boom')),
+        listGlobalAiModels: sinon.stub().rejects(new Error('catalog boom')),
+      });
+      await expect(resolveDefaultModelIds(transport, WORKSPACE, BRAND, fakeLog()))
+        .to.eventually.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
## Changes Made

Serenity markets were being created with zero AI models attached, because LLMO-6338 removed the manual LLM-picker UI on the assumption that a server-side default would replace it — that default was never implemented. This resulted in publish failing as a disguised quota rejection (`409 quotaExceeded`) whenever a market was added, and `POST /brands` hard-400ing when generating prompts.

- Add `src/support/serenity/default-models.js`: resolves a default `modelIds` list whenever a caller doesn't supply one — mirrors whichever models the brand's other existing markets already track, falling back to the net-new 8-LLM base package (ChatGPT w/ websearch, Google AI Overview, Google AI Mode, Gemini, Claude, Perplexity, Grok, DeepSeek) matched live against the Semrush model catalog.
- Wire the resolver into all 3 places a market gets created: `provisionBrandSubworkspace` (a brand's first-ever market), the ad-hoc `POST /serenity/markets` `createMarket` controller ("Add Market" on an active brand), and `activate()`'s per-market batch loop.
- Migrated/existing customers' separate 10-LLM tier is provisioned by ops runbook/migration scripts outside this repo (per the LLMO-6338 decision thread) — the mirror rule picks that up automatically with no extra tier flag needed.
- Flat/legacy (DRS) mode is untouched — this only affects the Serenity sub-workspace path.

### Related Issues

Relates to LLMO-6554 (closes the default-assignment gap left by LLMO-6338)

## Testing the PR changes

1. `npm run type-check` and `npx eslint` — both clean on the touched files.
2. `npx mocha test/support/serenity/default-models.test.js test/support/serenity/brand-provisioning.test.js test/controllers/serenity.test.js test/support/serenity/handlers/markets-subworkspace.test.js test/support/serenity/handlers/markets.test.js` — all passing, no regressions.
3. Functionally: create a brand-new brand with a Semrush market (or reactivate a pending brand) and confirm its initial market is published with the 8 net-new default models attached (`GET /serenity/models?geoTargetId=...&languageCode=...`).
4. Add a second market to that same brand via "Add Market" and confirm it inherits the same model set as the first market, rather than publishing with zero models.

## Screenshots/Videos

No screenshots available (backend-only change, no UI surface).

## Additional Notes

N/A