### PR TITLE
fix: send category without prefix appended in the elements

### DIFF
--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1242,8 +1242,8 @@ v2-serenity-brand-presence-sentiment-overview:
         in: query
         required: false
         description: |
-          Category label sent to Semrush as a `category__<label>` tag. `category`
-          is accepted as an alias.
+          Full `category__<label>` tag value (caller includes the `category__`
+          prefix), sent to Semrush as-is. `category` is accepted as an alias.
         schema: { type: string }
     responses:
       '200':
@@ -1726,7 +1726,7 @@ v2-serenity-url-inspector-stats:
       - name: categoryId
         in: query
         required: false
-        description: Category label, mapped to a Semrush tag (`category__<label>`).
+        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is.
         schema: { type: string }
       - name: category
         in: query
@@ -1839,7 +1839,7 @@ v2-serenity-url-inspector-prompts-count:
       - name: categoryId
         in: query
         required: false
-        description: Category label, mapped to a Semrush tag (`category__<label>`).
+        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is.
         schema: { type: string }
       - name: category
         in: query

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -1447,11 +1447,13 @@ export default function ElementsController(context, log, env) {
         workspaceId, query, service, projectIds,
       } = scope;
 
+      // category already carries the `category__<label>` prefix from the caller;
+      // sent through as-is, not re-prefixed.
       const category = query.categoryId || query.category;
       const { count: totalPrompts } = await service.getPrompts(workspaceId, {
         model: query.model,
         platform: query.platform,
-        tags: category ? [`category__${category}`] : [],
+        tags: category ? [category] : [],
         projectIds,
       });
 

--- a/src/support/elements/definitions/cited-domains.js
+++ b/src/support/elements/definitions/cited-domains.js
@@ -47,7 +47,8 @@ function defaultDateRange() {
  * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
  * @param {string} [params.startDate] - ISO date (YYYY-MM-DD). Defaults to 28 days ago.
  * @param {string} [params.endDate] - ISO date (YYYY-MM-DD). Defaults to today.
- * @param {string} [params.category] - Category label, pushed as the tag `category__<label>`.
+ * @param {string} [params.category] - Full `category__<label>` tag value, sent
+ *   as-is (callers already include the `category__` prefix).
  * @param {string} [params.projectId] - Semrush project id for region scoping (top-level).
  */
 export function buildCitedDomainsPayload({
@@ -64,10 +65,10 @@ export function buildCitedDomainsPayload({
     { op: 'lte', val: end, col: 'CBF_date__end' },
   ];
   // Category is a namespaced Semrush tag (`category__<label>`). Verified honored by this
-  // element (unlike region/brand/content-type filters, which it ignores). The label is
-  // sent straight through, e.g. category=Firefly → tag `category__Firefly`.
+  // element (unlike region/brand/content-type filters, which it ignores). Callers already
+  // include the `category__` prefix, so the value is sent straight through unmodified.
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: category, col: 'CBF_tags' });
   }
 
   return {

--- a/src/support/elements/definitions/domain-urls.js
+++ b/src/support/elements/definitions/domain-urls.js
@@ -31,7 +31,8 @@ import { resolveElementModel } from '../constants.js';
  * @param {string} [params.platform] - Legacy alias for `model`; `model` wins.
  * @param {string} params.startDate - ISO date (YYYY-MM-DD).
  * @param {string} params.endDate - ISO date (YYYY-MM-DD).
- * @param {string} [params.category] - Category label → tag `category__<label>`.
+ * @param {string} [params.category] - Full `category__<label>` tag value, sent
+ *   as-is (callers already include the `category__` prefix).
  * @param {string} [params.projectId] - Semrush project id (region scope, top-level).
  */
 export function buildDomainUrlsPayload({
@@ -44,7 +45,7 @@ export function buildDomainUrlsPayload({
     { op: 'lte', val: endDate, col: 'CBF_date__end' },
   ];
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: category, col: 'CBF_tags' });
   }
   return {
     ...(projectId && { project_id: projectId }),

--- a/src/support/elements/definitions/owned-urls.js
+++ b/src/support/elements/definitions/owned-urls.js
@@ -20,7 +20,7 @@ import { dateToIsoWeek } from '../week-utils.js';
  * `table`). One row per cited URL in the (project, date, model) scope.
  *
  * Same filter shape as cited-domains (date in BOTH simple + advanced, CBF_model
- * in an `or` block, category as a `category__<label>` tag, region via top-level
+ * in an `or` block, category as a `CBF_tags` tag, region via top-level
  * `project_id`). `startDate`/`endDate` are required (validated in the controller).
  * The element does NOT honor a server-side content-type filter, so the
  * `domain_type='Owned'` selection is applied client-side in the transform.
@@ -30,7 +30,8 @@ import { dateToIsoWeek } from '../week-utils.js';
  * @param {string} [params.platform] - Legacy alias for `model`; `model` wins.
  * @param {string} params.startDate - ISO date (YYYY-MM-DD).
  * @param {string} params.endDate - ISO date (YYYY-MM-DD).
- * @param {string} [params.category] - Category label → tag `category__<label>`.
+ * @param {string} [params.category] - Full `category__<label>` tag value, sent
+ *   as-is (callers already include the `category__` prefix).
  * @param {string} [params.projectId] - Semrush project id (region scope, top-level).
  */
 export function buildOwnedUrlsStatsPayload({
@@ -43,7 +44,7 @@ export function buildOwnedUrlsStatsPayload({
     { op: 'lte', val: endDate, col: 'CBF_date__end' },
   ];
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: category, col: 'CBF_tags' });
   }
   return {
     ...(projectId && { project_id: projectId }),
@@ -75,7 +76,7 @@ export function buildOwnedUrlsTrendPayload({
     { op: 'lte', val: endDate, col: 'CBF_date__end' },
   ];
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: category, col: 'CBF_tags' });
   }
   return {
     ...(projectId && { project_id: projectId }),

--- a/src/support/elements/definitions/sentiment-overview.js
+++ b/src/support/elements/definitions/sentiment-overview.js
@@ -57,7 +57,8 @@ function defaultDateRange() {
  *  - `CBF_model` sits inside an `or` block within `advanced`.
  *  - Region scoping → `CBF_project` (Semrush project id) inside an `or` block within
  *    `advanced` (NOT a top-level `project_id`, which this element ignores).
- *  - `category` (when present) → the namespaced tag `category__<label>` on `CBF_tags`.
+ *  - `category` (when present) → sent as-is on `CBF_tags` (callers already include the
+ *    `category__<label>` prefix).
  *  - Cited Domains' `comparison_data_formatting: 'union'` and top-level `project_id` are
  *    intentionally NOT sent — this element ignores both (confirmed via the MFE probe).
  *  - Brand scoping comes from the request targeting the brand's sub-workspace (resolved in
@@ -70,7 +71,8 @@ function defaultDateRange() {
  * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
  * @param {string} [params.startDate] - ISO date (YYYY-MM-DD). Defaults to 28 days ago.
  * @param {string} [params.endDate] - ISO date (YYYY-MM-DD). Defaults to today.
- * @param {string} [params.category] - Category label, pushed as the tag `category__<label>`.
+ * @param {string} [params.category] - Full `category__<label>` tag value, sent
+ *   as-is (callers already include the `category__` prefix).
  * @param {string} [params.projectId] - Semrush project id for region scoping (as `CBF_project`).
  */
 export function buildSentimentOverviewPayload({
@@ -90,7 +92,7 @@ export function buildSentimentOverviewPayload({
     advancedFilters.push({ op: 'or', filters: [{ op: 'eq', val: projectId, col: 'CBF_project' }] });
   }
   if (category) {
-    advancedFilters.push({ op: 'eq', val: `category__${category}`, col: 'CBF_tags' });
+    advancedFilters.push({ op: 'eq', val: category, col: 'CBF_tags' });
   }
 
   return {

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -1437,8 +1437,8 @@ describe('ElementsController', () => {
       expect(params.projectIds).to.deep.equal(['proj-us']);
     });
 
-    it('passes categoryId through as a prefixed category__ tag', async () => {
-      const ctx = promptsCountCtx({ url: promptsCountUrl('?categoryId=Firefly') });
+    it('passes categoryId through as-is (already prefixed by the caller)', async () => {
+      const ctx = promptsCountCtx({ url: promptsCountUrl('?categoryId=category__Firefly') });
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       await ctrl.getUrlInspectorPromptsCount(ctx);
       const [, params] = serviceStub.getPrompts.firstCall.args;

--- a/test/support/elements/definitions/sentiment-overview.test.js
+++ b/test/support/elements/definitions/sentiment-overview.test.js
@@ -81,8 +81,8 @@ describe('sentiment-overview definitions', () => {
       expect(findProjectFilterVal(buildSentimentOverviewPayload())).to.be.undefined;
     });
 
-    it('pushes a namespaced category tag onto CBF_tags when category is provided', () => {
-      const payload = buildSentimentOverviewPayload({ category: 'travel' });
+    it('pushes the category tag onto CBF_tags as-is when category is provided', () => {
+      const payload = buildSentimentOverviewPayload({ category: 'category__travel' });
       const tagFilter = payload.filters.advanced.filters
         .find((f) => f.col === 'CBF_tags');
       expect(tagFilter).to.deep.include({ op: 'eq', val: 'category__travel', col: 'CBF_tags' });


### PR DESCRIPTION
## Summary

Fixes a double-prefixing bug in the `category`/`categoryId` filter across `/serenity/brand-presence/*` endpoints. Callers already send the fully-namespaced Semrush tag value (e.g. `category=category__Living+Room+Furniture+Retail`), but the payload builders were unconditionally re-adding the `category__` prefix before sending it to the Semrush Elements API — producing a mismatched, never-matching tag (`category__category__...`) that silently returned empty/incorrect results instead of erroring.

## Root Cause

Six code paths built the Semrush `CBF_tags` filter as `` `category__${category}` `` regardless of whether the incoming value already carried the prefix. Since the query param is passed straight through from the caller with no stripping anywhere upstream, any already-prefixed input got double-prefixed.

## Fix

Stop re-adding the `category__` prefix — pass the `category` value through to Semrush as-is.

## Endpoints Fixed

| Endpoint | Builder / call site |
|---|---|
| `GET /serenity/brand-presence/url-inspector/stats` | `buildOwnedUrlsStatsPayload` |
| `GET /serenity/brand-presence/url-inspector/owned-urls` | `buildOwnedUrlsStatsPayload` + `buildOwnedUrlsTrendPayload` |
| `GET /serenity/brand-presence/url-inspector/domain-urls` | `buildDomainUrlsPayload` |
| `GET /serenity/brand-presence/url-inspector/cited-domainsoad` |
| `GET /serenity/brand-presence/url-inspector/prompts/count` | inline `tags` array in `getUrlInspectorPromptsCount` |
| `GET /serenity/brand-presence/sentiment-overview` | `buildSentimentOverviewPayload` |               

                                   
**Not affected:**
- `GET /serenity/brand-presence/stats` — accepts `categoryId`/`category` for parity with the Postgres-RPC reference endpoint, but it's a documented no-op (never forwarded to Semrush).
- `GET /serenity/brand-presence/kpi-headlines`, `source-visibility-headline` — no `category` param at all.
- All other serenity endpoints (`weeks`, `prompts`, `topics`, `topics/:topicId/prompts`, `market-tracking-trends`, `competitor-summary`,
`filter-dimensions`) don't accept a `category` filter.

## Files Changed

- `src/support/elements/definitions/owned-urls.js`
- `src/support/elements/definitions/domain-urls.js`
- `src/support/elements/definitions/cited-domains.js`
- `src/support/elements/definitions/sentiment-overview.js`
- `src/controllers/elements.js`
- `docs/openapi/serenity-api.yaml` — updated `category`/`cans to reflect the new pass-through contract
- `test/support/elements/definitions/sentiment-overview.test.js`
- `test/controllers/elements.test.js`

## Behavior Change (Breaking for Un-prefixed Callers)

Callers must now send the **full** `category__<label>` value. A bare label with no prefix will no longer be tagged/matched at all (previously it was auto-prefixed; now it's sent verbatim). This matches how the UI/consuming clients already construct the value (confirmed via a real production
request).

## Test Plan

- [x] `npx mocha 'test/support/elements/**/*.test.js'` — 326 passing
- [x] `npx mocha test/support/elements/definitions/sentimenntrollers/elements.test.js` — 155 passing
- [x] `npx eslint` clean on all changed files