### PR TITLE
fix(serenity): skip sub-workspace settle poll on bare brand create (LLMO-6569)

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -1230,6 +1230,12 @@ function SerenityController(context, log, env) {
           brandPointerReloader(ctx, auth.brandUuid),
           {
             dynamicAllocation: dynamicAllocationEnabled(ctx),
+            // createReadiness 'skip' (LLMO-6569): pending→active is sub-workspace-only — no project
+            // or prompts are created here — so skip the up-to-30s settle poll. This is the path
+            // where a poll timeout otherwise leaves the brand row present but its sub-workspace
+            // pointer unwritten (the "created upstream, never linked" orphan); persisting the
+            // pointer immediately closes that window. Self-heals on retry, but the user ate a 504.
+            createReadiness: 'skip',
           },
         );
         let pendingActivateSucceeded = true;
@@ -1298,6 +1304,10 @@ function SerenityController(context, log, env) {
           brandPointerReloader(ctx, auth.brandUuid),
           {
             dynamicAllocation: dynamicAllocationEnabled(ctx),
+            // createReadiness 'skip' (LLMO-6569): bare reactivation of an already-active brand is
+            // sub-workspace-only (no project/prompts), so skip the settle poll — same safety and
+            // orphan-window rationale as the pending→active branch above.
+            createReadiness: 'skip',
           },
         );
         let bareSucceeded = true;

--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -348,11 +348,14 @@ export async function provisionBrandSubworkspaceBare(context, {
     // marketCount = 1: the bare sub-workspace is carved for a single future project
     // (the first market the user adds). ensureSubworkspace returns the new id.
     // createReadiness: 'skip' (LLMO-6569) — this path creates NO project/prompts, so nothing
-    // downstream needs a settled workspace. Skipping the up-to-30s settle poll persists the brand's
-    // sub-workspace pointer immediately (closing the orphan window that left brands unlinked when
-    // the poll blew the ~15s Fastly edge budget) and lets the workspace settle asynchronously; the
-    // first market-add later settles it via the existing-sub-workspace branch before creating a
-    // project. This is Rainer's point #1 ("we don't create markets in that").
+    // downstream needs a settled workspace. Skipping the up-to-30s settle poll lets the
+    // sub-workspace pointer be captured/persisted immediately (instead of after the poll) and lets
+    // the workspace settle asynchronously; the first market-add later settles it before creating a
+    // project. Pre-fix, a poll timeout here fired BEFORE the id was captured, so the failure
+    // cleanup saw a null id and no-op'd — leaking the sub-workspace upstream (holding its full
+    // CREATE_ALLOCATION) with no brand row yet referencing it. (The "created upstream but never
+    // linked" orphan is the ACTIVATE variant, where the brand row already exists — see
+    // serenity.js.) This is Rainer's point #1 ("we don't create markets in that").
     const subWorkspaceId = await ensureSubworkspace(
       transport,
       brandStub,

--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -347,6 +347,12 @@ export async function provisionBrandSubworkspaceBare(context, {
   try {
     // marketCount = 1: the bare sub-workspace is carved for a single future project
     // (the first market the user adds). ensureSubworkspace returns the new id.
+    // createReadiness: 'skip' (LLMO-6569) — this path creates NO project/prompts, so nothing
+    // downstream needs a settled workspace. Skipping the up-to-30s settle poll persists the brand's
+    // sub-workspace pointer immediately (closing the orphan window that left brands unlinked when
+    // the poll blew the ~15s Fastly edge budget) and lets the workspace settle asynchronously; the
+    // first market-add later settles it via the existing-sub-workspace branch before creating a
+    // project. This is Rainer's point #1 ("we don't create markets in that").
     const subWorkspaceId = await ensureSubworkspace(
       transport,
       brandStub,
@@ -355,7 +361,7 @@ export async function provisionBrandSubworkspaceBare(context, {
       log,
       {},
       null,
-      { dynamicAllocation },
+      { dynamicAllocation, createReadiness: 'skip' },
     );
     const resolved = hasText(subWorkspaceId) ? subWorkspaceId : capturedWorkspaceId;
     if (!resolved || !hasText(resolved)) {

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -361,12 +361,14 @@ export async function releaseFullAllocation(
  *   the flat re-grant on an existing sub-workspace; JIT top-up owns sizing. Default false.
  * @param {'poll'|'skip'} [options.createReadiness] - how the fresh-CREATE path gates on the new
  *   sub-workspace settling to `created` (LLMO-6569). 'poll' (default): up to ~30s settle poll —
- *   the legacy behaviour, kept for every caller that creates a project/prompts against the
- *   workspace in THIS request (brand-create-with-market, activate). 'skip': no readiness gate at
- *   all — for callers that create NOTHING against the workspace in this request (bare brand
- *   create), so the pointer persists immediately and the workspace settles asynchronously (the
- *   first market-add later settles it via the existing-sub-workspace branch before creating a
- *   project). Only affects the create path; the existing-sub-workspace branch is unchanged.
+ *   the legacy behaviour, kept for callers that create a project/prompts against the workspace in
+ *   THIS request (brand-create-with-market, and the market/project-creating activation branch), so
+ *   the write does not race a not-yet-`created` workspace. 'skip': no readiness gate at all — for
+ *   sub-workspace-only callers that create NOTHING against the workspace in this request (bare
+ *   brand create, and the sub-workspace-only activate branches — pending→active and bare
+ *   reactivation), so the pointer persists immediately and the workspace settles asynchronously (a
+ *   later market-add settles it via the existing-sub-workspace branch before creating a project).
+ *   Only affects the create path; the existing-sub-workspace branch is unchanged.
  * @returns {Promise<string>} the subworkspace id.
  */
 export async function ensureSubworkspace(
@@ -516,7 +518,10 @@ export async function ensureSubworkspace(
     }
   }
 
-  // Persist AFTER the workspace reads back `created` — flips the brand to subworkspace mode.
+  // Persist the pointer — this flips the brand into subworkspace mode. On 'poll' the workspace has
+  // already read back `created` above; on 'skip' (LLMO-6569) we persist WITHOUT waiting for settle,
+  // because the caller creates nothing against the workspace in this request, so readiness is not
+  // required here — the workspace settles asynchronously.
   brand.setSemrushSubWorkspaceId(workspaceId);
   await brand.save();
   // Invalidate the resolver's brand cache so the next request sees subworkspace mode

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -340,8 +340,8 @@ export async function releaseFullAllocation(
  *                         the transfer contract is Gate-A-pinned). Note a
  *                         deactivated brand has a NULL column (deactivate clears
  *                         it), so it takes the create path below, not this one.
- *   - no column, create → create subworkspace → poll `created` → persist the column
- *                         AFTER it reads back created.
+ *   - no column, create → create subworkspace → gate on `created` per `createReadiness`
+ *                         (poll / skip) → persist the column.
  *   - create timeout    → adopt from the parent family by exact title.
  *
  * Persisting the column flips the brand into subworkspace mode (resolveBrandWorkspace).
@@ -359,6 +359,14 @@ export async function releaseFullAllocation(
  * @param {object} [options] - feature-flag toggles for the dual-mode carve.
  * @param {boolean} [options.dynamicAllocation] - when true (LLMO/dynamic-allocation ON), skip
  *   the flat re-grant on an existing sub-workspace; JIT top-up owns sizing. Default false.
+ * @param {'poll'|'skip'} [options.createReadiness] - how the fresh-CREATE path gates on the new
+ *   sub-workspace settling to `created` (LLMO-6569). 'poll' (default): up to ~30s settle poll —
+ *   the legacy behaviour, kept for every caller that creates a project/prompts against the
+ *   workspace in THIS request (brand-create-with-market, activate). 'skip': no readiness gate at
+ *   all — for callers that create NOTHING against the workspace in this request (bare brand
+ *   create), so the pointer persists immediately and the workspace settles asynchronously (the
+ *   first market-add later settles it via the existing-sub-workspace branch before creating a
+ *   project). Only affects the create path; the existing-sub-workspace branch is unchanged.
  * @returns {Promise<string>} the subworkspace id.
  */
 export async function ensureSubworkspace(
@@ -371,7 +379,7 @@ export async function ensureSubworkspace(
   reloadPointer = null,
   options = {},
 ) {
-  const { dynamicAllocation = false } = options;
+  const { dynamicAllocation = false, createReadiness = 'poll' } = options;
   const poll = {
     attempts: timing.attempts ?? DEFAULT_POLL_ATTEMPTS,
     intervalMs: timing.intervalMs ?? DEFAULT_POLL_INTERVAL_MS,
@@ -459,7 +467,16 @@ export async function ensureSubworkspace(
   // never persist the parent as the brand's sub-workspace.
   assertNotParent(workspaceId, parentWorkspaceId);
 
-  await pollUntilCreated(transport, workspaceId, poll);
+  // LLMO-6569: the fresh sub-workspace settle poll (up to 30×1s) was the top cause of the ~15s
+  // Fastly edge timeout, and — sitting between the create above and the pointer persist below — its
+  // timeout was exactly what orphaned brands (workspace created upstream, pointer never written).
+  // 'skip' lets a caller that creates NOTHING against the workspace in this request (bare brand
+  // create) persist the pointer immediately and let the workspace settle asynchronously; the first
+  // market-add later settles it (existing-sub-workspace branch) before creating a project. Any
+  // other value keeps the legacy poll. See @param options.createReadiness.
+  if (createReadiness !== 'skip') {
+    await pollUntilCreated(transport, workspaceId, poll);
+  }
 
   // Concurrency guard (defense-in-depth against a lost-update orphan): a
   // parallel activate / createMarket for the SAME brand may have created and

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2031,6 +2031,8 @@ describe('SerenityController', () => {
       expect(markets).to.deep.equal([]);
       // Sub-workspace ensured once; NO project, NO body-driven market path.
       expect(ensureSubworkspaceStub).to.have.been.calledOnce;
+      // Sub-workspace-only → skips the settle poll (LLMO-6569).
+      expect(ensureSubworkspaceStub.firstCall.args[7]).to.have.property('createReadiness', 'skip');
       expect(handlers.handleCreateMarketSubworkspace).to.not.have.been.called;
       expect(updateBrandStub).to.not.have.been.called;
       expect(brand.setStatus).to.have.been.calledWith('active');
@@ -2070,6 +2072,8 @@ describe('SerenityController', () => {
       const { status } = await readBody(response);
       expect(status).to.equal('active');
       expect(ensureSubworkspaceStub).to.have.been.calledOnce;
+      // Bare reactivation is sub-workspace-only → skips the settle poll (LLMO-6569).
+      expect(ensureSubworkspaceStub.firstCall.args[7]).to.have.property('createReadiness', 'skip');
     });
 
     it('activate prefers body markets + brandDomain over the stash, and clears the stash when its market is provisioned', async () => {

--- a/test/support/serenity/brand-provisioning.test.js
+++ b/test/support/serenity/brand-provisioning.test.js
@@ -548,8 +548,11 @@ describe('provisionBrandSubworkspaceBare', () => {
     // Success → no allocation release.
     expect(deleteAllProjects).to.not.have.been.called;
     expect(releaseFullAllocation).to.not.have.been.called;
-    // Kill-switch defaults OFF (env unset) — byte-for-byte the pre-fix flat carve.
-    expect(ensureSubworkspace.firstCall.args[7]).to.deep.equal({ dynamicAllocation: false });
+    // Kill-switch defaults OFF (env unset). createReadiness 'skip' (LLMO-6569): the bare path
+    // creates no project/prompts, so it skips the up-to-30s settle poll and persists the pointer
+    // immediately (closing the orphan window that left brands unlinked on a Fastly edge timeout).
+    expect(ensureSubworkspace.firstCall.args[7])
+      .to.deep.equal({ dynamicAllocation: false, createReadiness: 'skip' });
   });
 
   it('threads the dynamic-allocation flag from env into ensureSubworkspace (LLMO-6190 — onboarding was previously silently excluded)', async () => {
@@ -557,7 +560,8 @@ describe('provisionBrandSubworkspaceBare', () => {
     const ctx = buildContext();
     ctx.env.SERENITY_DYNAMIC_ALLOCATION = 'true';
     await provisionBrandSubworkspaceBare(ctx, bareParams);
-    expect(ensureSubworkspace.firstCall.args[7]).to.deep.equal({ dynamicAllocation: true });
+    expect(ensureSubworkspace.firstCall.args[7])
+      .to.deep.equal({ dynamicAllocation: true, createReadiness: 'skip' });
   });
 
   it('falls back to the captured workspace id when ensureSubworkspace returns nothing', async () => {

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -154,6 +154,34 @@ describe('workspace-lifecycle', () => {
       expect(brand.save).to.have.been.calledOnce;
     });
 
+    it('createReadiness "skip": creates and persists WITHOUT the settle poll (LLMO-6569 bare path)', async () => {
+      const transport = makeTransport();
+      // A not-ready workspace would make the legacy poll spin (and time out); 'skip' must not probe
+      // getWorkspaceStatus at all — it persists the pointer immediately and lets it settle async.
+      transport.getWorkspaceStatus.resolves({ status: 'not ready' });
+      const brand = makeBrand();
+
+      const result = await ensureSubworkspace(
+        transport,
+        brand,
+        PARENT_WS,
+        1,
+        log,
+        NOOP_TIMING,
+        null,
+        { createReadiness: 'skip' },
+      );
+
+      expect(result).to.equal(SUB_WS);
+      expect(transport.createSubworkspace)
+        .to.have.been.calledOnceWithExactly(PARENT_WS, EXPECTED_TITLE, CREATE_ALLOCATION);
+      // The whole point of the fix: no settle poll on the create path.
+      expect(transport.getWorkspaceStatus).to.not.have.been.called;
+      // Pointer still persisted immediately, closing the orphan window.
+      expect(brand.setSemrushSubWorkspaceId).to.have.been.calledOnceWithExactly(SUB_WS);
+      expect(brand.save).to.have.been.calledOnce;
+    });
+
     it('adopts a unique created family match after a create timeout (504 recovery preserved)', async () => {
       // True 504-recovery: at proactive-check time nothing is adoptable yet, the
       // create then times out (504) although it actually succeeded upstream, and


### PR DESCRIPTION
## What & why

In Serenity/Semrush mode, sub-workspace-only provisioning frequently times out at the ~15s Fastly first-byte edge budget. The cause: after creating a sub-workspace we wait for it to settle to `status === 'created'` before continuing — a poll of up to **30 × 1s ≈ 30s** (`pollUntilCreated` in `workspace-lifecycle.js`).

For **sub-workspace-only** provisioning (no project, no prompts created in the request), that wait is pure dead weight — nothing downstream needs a settled workspace — and the poll sits between the upstream sub-workspace create and the DB pointer persist, so a timeout there strands the sub-workspace. The exact symptom differs by path:

- **Bare brand create** (`provisionBrandSubworkspaceBare`): the brand row doesn't exist yet, and `capturedWorkspaceId` was only set *after* the poll — so a pre-fix poll timeout **leaked the sub-workspace upstream** (holding its full `CREATE_ALLOCATION`) with no brand row referencing it, and the failure cleanup no-op'd on the null id.
- **Sub-workspace-only activate** (pending→active, bare reactivation): the brand row already exists and `ensureSubworkspace` owns the pointer write — so a poll timeout left the row present with its sub-workspace pointer **never written** ("created upstream, never linked"). Self-heals on retry, but the user still eats the 504.

## Change

- `ensureSubworkspace` gains a `createReadiness: 'poll' | 'skip'` option (default `'poll'` — every caller that creates a project/prompts in the same request is byte-for-byte unchanged).
- `'skip'` bypasses the settle poll on the fresh-create path and persists the pointer immediately; the workspace settles asynchronously (a later market-add settles it via the existing-sub-workspace branch before creating a project).
- Passed by the **three sub-workspace-only callers**: `provisionBrandSubworkspaceBare`, and the two activate branches in `serenity.js` (pending→active, bare reactivation).

## Scope

Only sub-workspace-only paths use `'skip'`. The **create-with-market** path (and the market/project-creating activation branch) keep `'poll'` on purpose — they create a project/prompts immediately, so a fail-fast there would be unsafe: with no persisted brand row yet, a retry can't re-adopt a still-settling workspace (`findAdoptableFamilyMatch` only adopts `created` children) and would leak orphaned sub-workspaces. Those paths are handled separately.

## Known limitation

Persisting the pointer before the workspace settles opens a narrow race: a deactivate issued seconds after a bare create → `decommissionBrandWorkspace` → `releaseFullAllocation` → `transferWorkspaceResources` has no `isWorkspaceNotReady` retry (unlike `resource-manager.js`'s `transferAndSettle`). The window is seconds and the failure is a clean retryable error, not corruption — noted for the record, not blocking.

## Testing

- `workspace-lifecycle.test.js`: new `createReadiness: 'skip'` case (no `getWorkspaceStatus` poll, pointer persisted immediately); the default `'poll'` create+poll+persist path is still pinned.
- `serenity.test.js`: the two sub-workspace-only activate tests now assert `createReadiness: 'skip'`.
- `brand-provisioning.test.js`: bare-provisioning options-bag assertions updated.
- `npm run type-check` ✅ · `npm run lint` ✅ · `npm test` ✅ (16,034 passing, 100% coverage gate).

## Links

- Jira: https://jira.corp.adobe.com/browse/LLMO-6569

🤖 Generated with [Claude Code](https://claude.com/claude-code)