### PR TITLE
fix: title Serenity sub-workspaces with the bare brand name

### DIFF
--- a/docs/specs/2026-06-15-serenity-subworkspace-dual-mode-implementation-plan.md
+++ b/docs/specs/2026-06-15-serenity-subworkspace-dual-mode-implementation-plan.md
@@ -12,10 +12,17 @@
 > `decommissionBrandWorkspace`).
 >
 > **Hardening pass (post-review, gap audit):** five further safety/correctness
-> gaps were closed. (1) The sub-workspace **title now embeds the brand id**
-> (`"<name> [<uuid>]"`) so ambiguous-create recovery cannot adopt a *same-named*
-> brand's workspace; adoption additionally verifies the candidate is
-> **project-empty** before adopting. (2) `ensureSubworkspace` takes an optional
+> gaps were closed. (1) The sub-workspace **title is the brand's bare display
+> name**, which is *not* unique within an org, so ambiguous-create recovery does
+> not key on it alone: `findAdoptableFamilyMatch` **drops every candidate already
+> bound to a different brand** (`brands.semrush_sub_workspace_id`, a UNIQUE
+> column) before applying the match/ambiguity rules, and additionally verifies the
+> candidate is **project-empty** before adopting — together these keep a timed-out
+> create from adopting a *same-named* brand's workspace. Because a bare title can
+> resolve to a workspace this request did not create, `ensureSubworkspace` reports
+> a **freshly-created** workspace via `onWorkspaceCreated` and every failure-
+> compensation path releases only on that signal, never on a merely-adopted
+> workspace. (2) `ensureSubworkspace` takes an optional
 > `reloadPointer` and, on the create path, **re-reads the brand pointer before
 > persisting** — if a concurrent activation already won, it releases its own
 > freshly-created workspace's allocation and adopts the winner (residual race

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1495,6 +1495,13 @@ function BrandsController(ctx, log, env) {
     // sub-workspace was provisioned but the brand row failed to persist, the
     // catch releases the orphaned allocation (see below).
     let provisionedWorkspaceId = null;
+    // True only when provisioning CREATED the sub-workspace upstream. Sub-workspace titles are
+    // bare brand display names, which are not unique within an org, so provisioning may instead
+    // ADOPT an existing same-title workspace — possibly one belonging to a same-named sibling
+    // brand whose own create is still in flight and has not persisted its claim yet. The
+    // compensation in the catch below tears the workspace down, so it must fire only for a
+    // workspace this request actually created.
+    let provisionedWorkspaceWasCreated = false;
 
     try {
       if (!hasText(spaceCatId)) {
@@ -1683,6 +1690,7 @@ function BrandsController(ctx, log, env) {
             writeDeadline,
           }, log);
           provisionedWorkspaceId = provisioned.semrushSubWorkspaceId;
+          provisionedWorkspaceWasCreated = provisioned.createdByThisRequest === true;
           provisionedInitialMarket = {
             projectId: provisioned.projectId,
             geoTargetId: provisioned.geoTargetId,
@@ -1700,6 +1708,7 @@ function BrandsController(ctx, log, env) {
             brandName: brandData.name,
           }, log);
           provisionedWorkspaceId = bare.semrushSubWorkspaceId;
+          provisionedWorkspaceWasCreated = bare.createdByThisRequest === true;
         }
       }
 
@@ -1775,11 +1784,18 @@ function BrandsController(ctx, log, env) {
         emitBrandDemotionBlocked(context, 'createBrand');
       }
       log.error(`Error creating brand for organization ${spaceCatId}:`, error);
-      // Compensation: a sub-workspace was provisioned upstream but the brand row
-      // failed to persist (e.g. a unique-constraint 409 or transient PostgREST
-      // error). Nothing references that workspace, so release its allocation back
-      // to the parent pool (best-effort) rather than leaking it.
-      if (provisionedWorkspaceId && hasText(provisionedWorkspaceId)) {
+      // Compensation: a sub-workspace was CREATED upstream but the brand row failed to
+      // persist (e.g. a unique-constraint 409 or transient PostgREST error). Nothing
+      // references that workspace, so release its allocation back to the parent pool
+      // (best-effort) rather than leaking it.
+      //
+      // Gated on having created it. A workspace that provisioning ADOPTED is not ours to
+      // tear down: titles are bare brand display names, so an adopted workspace can be a
+      // same-named sibling brand's, and the unique-constraint failure that lands us here is
+      // itself the signal that the sibling won the race and legitimately owns it. Releasing
+      // it would delete that live brand's projects and strip its allocation.
+      if (provisionedWorkspaceId && hasText(provisionedWorkspaceId)
+        && provisionedWorkspaceWasCreated) {
         log.error('serenity: brand-create failed after subworkspace provision; releasing orphaned allocation', {
           semrushWorkspaceId: provisionedWorkspaceId,
         });

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -794,6 +794,10 @@ function SerenityController(context, log, env) {
             // positionally above (auth.parentWorkspaceId) — not duplicated in this options bag.
             dynamicAllocation: dynamicAllocationEnabled(ctx),
             ceiling: brandAiCeiling(ctx),
+            // Sub-workspace titles are bare brand names, so ensureSubworkspace needs the Brand
+            // collection to tell this brand's own interrupted create from a same-named sibling
+            // brand's workspace. Only consulted when this brand has no sub-workspace yet.
+            brandCollection: ctx.dataAccess.Brand,
           },
         );
         // Mirror this market as a SpaceCat Site (+ brand_sites link), once its
@@ -1230,6 +1234,7 @@ function SerenityController(context, log, env) {
           brandPointerReloader(ctx, auth.brandUuid),
           {
             dynamicAllocation: dynamicAllocationEnabled(ctx),
+            brandCollection: ctx?.dataAccess?.Brand,
           },
         );
         let pendingActivateSucceeded = true;
@@ -1298,6 +1303,7 @@ function SerenityController(context, log, env) {
           brandPointerReloader(ctx, auth.brandUuid),
           {
             dynamicAllocation: dynamicAllocationEnabled(ctx),
+            brandCollection: ctx?.dataAccess?.Brand,
           },
         );
         let bareSucceeded = true;
@@ -1372,6 +1378,7 @@ function SerenityController(context, log, env) {
         brandPointerReloader(ctx, auth.brandUuid),
         {
           dynamicAllocation: dynamicAllocationEnabled(ctx),
+          brandCollection: ctx?.dataAccess?.Brand,
         },
       );
       // LLMO-6554: resolved ONCE for the whole batch (same brand, so every market

--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -52,15 +52,17 @@ export function initialMarketProjectName(market, languageCode) {
  * quota 405 from publishing surfaces as a 409 "Quota exceeded".
  *
  * The brand row is written by the caller AFTER this resolves, so provisioning is
- * driven through a lightweight brand stub: it supplies the brand's name + the
- * pre-generated id for the "Name [id]" sub-workspace title (the adoption key) and
- * captures the created sub-workspace id. There is no row yet, so the stub's
- * `save` is a no-op — the caller persists the returned id onto the new row.
+ * driven through a lightweight brand stub: it supplies the brand's display name (the
+ * sub-workspace title) plus the pre-generated brand id, and captures the resolved
+ * sub-workspace id. There is no row yet, so the stub's `save` is a no-op — the caller
+ * persists the returned id onto the new row. Because no row exists, this brand cannot yet
+ * claim a sub-workspace, so every claimed family candidate the adoption filter sees belongs
+ * to some other brand.
  *
  * @param {object} context - request context (env, dataAccess, pathInfo headers).
  * @param {object} params
  * @param {string} params.spaceCatId - SpaceCat organization UUID.
- * @param {string} params.brandId - pre-generated brand UUID (sub-workspace title key).
+ * @param {string} params.brandId - pre-generated brand UUID.
  * @param {string} params.brandName - brand display name (sub-workspace title + brand_name).
  * @param {string} params.market - ISO-2 country code for the initial market.
  * @param {string} params.languageCode - BCP-47 language code for the initial market.
@@ -93,11 +95,14 @@ export function initialMarketProjectName(market, languageCode) {
  * @param {object} [log]
  * @returns {Promise<{
  *   semrushSubWorkspaceId: string,
+ *   createdByThisRequest: boolean,
  *   published: boolean,
  *   projectId: string,
  *   geoTargetId: number | null,
  *   languageCode: string,
- * }>} the new sub-workspace id, whether the initial market was published, and
+ * }>} the new sub-workspace id, whether this request CREATED that sub-workspace (as opposed
+ *   to adopting an existing same-title one — the caller's failure compensation must gate on
+ *   it, see {@link provisionBrandSubworkspaceBare}), whether the initial market was published, and
  *   the initial market's identity — deliberately NOT written to
  *   `brand_to_semrush_projects` here (this function runs before the brand row
  *   exists, and the mapping row's FK requires it); the caller writes the
@@ -163,6 +168,12 @@ export async function provisionBrandSubworkspace(context, {
 
   /** @type {string|null} */
   let capturedWorkspaceId = null;
+  // Set ONLY when ensureSubworkspace freshly created the sub-workspace. A workspace it
+  // ADOPTED is not ours to tear down: titles are bare brand names, so an adopted workspace
+  // can belong to a same-named sibling brand whose provisioning is still in flight and has
+  // not yet persisted its claim — emptying it would destroy that brand's live workspace.
+  /** @type {string|null} */
+  let createdWorkspaceId = null;
   const brandStub = {
     getId: () => brandId,
     getName: () => brandName,
@@ -186,19 +197,22 @@ export async function provisionBrandSubworkspace(context, {
   // this point (a failure at/after createProject) or may still be empty (an earlier failure) —
   // deleteAllProjects tolerates both.
   const releaseCapturedOnFailure = async () => {
-    if (!capturedWorkspaceId || !hasText(capturedWorkspaceId)) {
+    // Narrow via a const — a closure-mutated `let` is not narrowed by control flow
+    // (see this dir's CLAUDE.md).
+    const wsId = createdWorkspaceId;
+    if (!wsId || !hasText(wsId)) {
       return;
     }
     try {
-      await deleteAllProjects(transport, capturedWorkspaceId);
-      await releaseFullAllocation(transport, capturedWorkspaceId, parentWorkspaceId, log);
+      await deleteAllProjects(transport, wsId);
+      await releaseFullAllocation(transport, wsId, parentWorkspaceId, log);
       log?.info?.(
         'serenity: emptied sub-workspace after failed brand provisioning — allocation lowered to floor',
-        { semrushWorkspaceId: capturedWorkspaceId },
+        { semrushWorkspaceId: wsId },
       );
     } catch (releaseErr) {
       log?.error?.('serenity: failed to release sub-workspace allocation after failed provisioning', {
-        semrushWorkspaceId: capturedWorkspaceId,
+        semrushWorkspaceId: wsId,
         error: releaseErr?.message,
       });
     }
@@ -250,6 +264,8 @@ export async function provisionBrandSubworkspace(context, {
           : 'best-effort',
         dynamicAllocation,
         ceiling,
+        brandCollection: context?.dataAccess?.Brand,
+        onWorkspaceCreated: (id) => { createdWorkspaceId = id; },
       },
     );
   } catch (e) {
@@ -281,6 +297,9 @@ export async function provisionBrandSubworkspace(context, {
   const resultBody = result.body || {};
   return {
     semrushSubWorkspaceId: capturedWorkspaceId,
+    // See provisionBrandSubworkspaceBare's @returns: the caller's failure compensation must
+    // gate on this so it never tears down a merely-adopted sibling brand's workspace.
+    createdByThisRequest: createdWorkspaceId === capturedWorkspaceId,
     published: Boolean(resultBody.published),
     projectId: String(resultBody.projectId || ''),
     // Absent stays null (not 0) so upsertMappingRow's `!geoTargetId` guard
@@ -305,10 +324,15 @@ export async function provisionBrandSubworkspace(context, {
  * @param {object} context - request context (env, dataAccess, pathInfo headers).
  * @param {object} params
  * @param {string} params.spaceCatId - SpaceCat organization UUID.
- * @param {string} params.brandId - pre-generated brand UUID (sub-workspace title key).
+ * @param {string} params.brandId - pre-generated brand UUID.
  * @param {string} params.brandName - brand display name (sub-workspace title).
  * @param {object} [log]
- * @returns {Promise<{ semrushSubWorkspaceId: string }>} the new sub-workspace id.
+ * @returns {Promise<{ semrushSubWorkspaceId: string, createdByThisRequest: boolean }>} the
+ *   sub-workspace id, plus whether this request CREATED it (as opposed to adopting an existing
+ *   same-title one). The caller's failure compensation must gate on `createdByThisRequest`:
+ *   titles are bare brand names, so an adopted workspace can belong to a same-named sibling
+ *   brand whose own provisioning has not yet persisted its claim, and releasing it would empty
+ *   that brand's live sub-workspace.
  * @throws {ErrorWithStatusCode} on workspace create failure (the caller then skips
  *   the brand write).
  */
@@ -336,6 +360,10 @@ export async function provisionBrandSubworkspaceBare(context, {
 
   /** @type {string|null} */
   let capturedWorkspaceId = null;
+  // Set ONLY when ensureSubworkspace freshly created the sub-workspace — see the identical
+  // note in provisionBrandSubworkspace above for why an ADOPTED one must never be released.
+  /** @type {string|null} */
+  let createdWorkspaceId = null;
   const brandStub = {
     getId: () => brandId,
     getName: () => brandName,
@@ -355,20 +383,31 @@ export async function provisionBrandSubworkspaceBare(context, {
       log,
       {},
       null,
-      { dynamicAllocation },
+      // The brand row does not exist yet on this path (it is written only after a
+      // successful provision), so ANY family candidate the claim lookup finds bound
+      // to a brand is provably another brand's — never this one's.
+      {
+        dynamicAllocation,
+        brandCollection: context?.dataAccess?.Brand,
+        onWorkspaceCreated: (id) => { createdWorkspaceId = id; },
+      },
     );
     const resolved = hasText(subWorkspaceId) ? subWorkspaceId : capturedWorkspaceId;
     if (!resolved || !hasText(resolved)) {
       throw new ErrorWithStatusCode('Semrush provisioning returned no sub-workspace id', 502);
     }
-    return { semrushSubWorkspaceId: resolved };
+    return {
+      semrushSubWorkspaceId: resolved,
+      createdByThisRequest: createdWorkspaceId === resolved,
+    };
   } catch (e) {
-    // Release the just-created (empty) sub-workspace's allocation on failure — the
-    // brand row is never written, so nothing references it. Best-effort; never masks
-    // the original error. deleteAllProjects tolerates an empty workspace.
+    // Release the sub-workspace's allocation on failure — the brand row is never written,
+    // so nothing references it. Best-effort; never masks the original error.
+    // deleteAllProjects tolerates an empty workspace. Only a workspace this request
+    // CREATED is released; an adopted one may be a same-named sibling brand's.
     // Narrow via a const (hasText is not a type guard, and a closure-mutated `let`
     // is not narrowed by control flow — see this dir's CLAUDE.md).
-    const wsId = capturedWorkspaceId;
+    const wsId = createdWorkspaceId;
     if (wsId && hasText(wsId)) {
       try {
         await deleteAllProjects(transport, wsId);

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -506,6 +506,13 @@ async function generateAndAttachPrompts(transport, workspaceId, projectId, {
  * @param {Partial<import('../resource-manager.js').Blocks>} [options.ceiling] - per-brand AI
  *   ceiling (LLMO-6190 flag-flip gate), resolved from Vault by the controller and passed through to
  *   `createHeadroomGuard`. Omitted → non-binding default. No-op when `dynamicAllocation` is false.
+ * @param {object} [options.brandCollection] - the data-access Brand collection, threaded to
+ *   `ensureSubworkspace` on the single-market POST path so its claim filter can tell this
+ *   brand's own interrupted create from a same-named sibling brand's sub-workspace (titles are
+ *   bare brand names). Unused when `preResolvedWorkspaceId` is supplied.
+ * @param {function} [options.onWorkspaceCreated] - forwarded to `ensureSubworkspace`; called
+ *   only when the sub-workspace was FRESHLY CREATED here, so the caller's failure compensation
+ *   never tears down a workspace that was merely adopted.
  * @param {object} [options.env] - environment (Azure OpenAI creds), threaded into
  *   intent classification when `generateTopics` is set (serenity-docs#32).
  * @param {number} [options.writeDeadline] - shared request-write deadline; defaults
@@ -528,6 +535,8 @@ export async function handleCreateMarketSubworkspace(
     competitors = [],
     publishMode = 'require',
     dataAccess = null,
+    brandCollection = undefined,
+    onWorkspaceCreated = undefined,
     dynamicAllocation = false,
     ceiling = undefined,
     env = null,
@@ -565,7 +574,7 @@ export async function handleCreateMarketSubworkspace(
       log,
       {},
       reloadPointer,
-      { dynamicAllocation },
+      { dynamicAllocation, brandCollection, onWorkspaceCreated },
     );
 
   // JIT top-up choke point. The sub-workspace id is only known after ensureSubworkspace resolves

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -217,7 +217,7 @@ async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log
   const matches = sameTitle.filter((w, i) => isAdoptable(i));
   const claimedByOthers = sameTitle.filter((w, i) => !isAdoptable(i));
   if (claimedByOthers.length > 0) {
-    log?.info?.('ensureSubworkspace: ignoring same-title family entr(ies) already claimed by another brand', {
+    log?.info?.('ensureSubworkspace: ignoring same-title family entries already claimed by another brand', {
       parentWorkspaceId,
       title,
       claimedCount: claimedByOthers.length,

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -77,34 +77,31 @@ function assertNotParent(workspaceId, parentWorkspaceId) {
   }
 }
 
-// The sub-workspace title must be UNIQUE per brand within the org parent: it is
-// the ONLY key ambiguous-create recovery (adoptFromFamily) has to match a
-// timed-out create against the parent's family listing. Brand DISPLAY names are
-// NOT unique within an org, so a name-only title would let one brand adopt a
-// different, same-named brand's sub-workspace after a create timeout - and a
-// later deactivate would then decommission the WRONG brand's live markets.
-// Embed (the first 8 chars of) the immutable brand id so the title stays short
-// in the Semrush UI while remaining collision-free for the adoption match: 8 hex
-// chars is 2^32 of space, far more than a single org's brand count, so the
-// name+suffix pair is still effectively unique per brand.
-const ID_SUFFIX_LEN = 8;
-
+// A brand's sub-workspace is titled with the brand's bare display name — the
+// same convention the migration CLI uses, so a customer sees ONE naming scheme
+// in the Semrush UI regardless of how the brand was onboarded.
+//
+// Brand display names are NOT unique within an org, so the title alone is a weak
+// key for the two adoption paths in ensureSubworkspace. It is deliberately not
+// the only one: findAdoptableFamilyMatch drops every family candidate already
+// bound to a DIFFERENT brand before it counts matches, which is what keeps a
+// timed-out create from adopting a same-named sibling brand's sub-workspace (and
+// a later deactivate from decommissioning the wrong brand's live markets). See
+// the claim filter there for the full rule set.
+//
+// The name is therefore required: an untitled workspace would collide with every
+// other untitled one and is not something adoption could ever disambiguate. Every
+// path reaching here validates the name earlier (brand create 400s without one),
+// so this is defensive-only.
 function subworkspaceTitle(brand) {
   const name = brand?.getName?.();
-  const id = brand?.getId?.();
-  const suffix = hasText(id) ? id.slice(0, ID_SUFFIX_LEN) : '';
-  // The id-suffix is the collision-free key the adoption match depends on (see
-  // the block comment above). Without it the title would not be unique per
-  // brand, so a missing brand id is a hard error, NOT a silent fallback to a
-  // non-unique title that adoption could later mis-match. brandId is always a
-  // UUID on every path that reaches here, so this is defensive-only.
-  if (!hasText(suffix)) {
+  if (!hasText(name)) {
     throw new ErrorWithStatusCode(
-      'Brand sub-workspace title requires a brand id (none resolved)',
+      'Brand sub-workspace title requires a brand name (none resolved)',
       500,
     );
   }
-  return hasText(name) ? `${name} [${suffix}]` : `brand-${suffix}`;
+  return name;
 }
 
 export async function pollUntilCreated(transport, workspaceId, { attempts, intervalMs, sleep }) {
@@ -136,8 +133,42 @@ function familyItems(family) {
 }
 
 /**
+ * Resolves the id of the brand currently bound to `workspaceId`, or `null` when no
+ * brand claims it. `brands.semrush_sub_workspace_id` carries a DB UNIQUE constraint,
+ * so at most one brand can ever be returned.
+ *
+ * @param {object} brandCollection - the data-access Brand collection.
+ * @param {string} [workspaceId]
+ * @returns {Promise<string|null>}
+ */
+async function claimedBrandId(brandCollection, workspaceId) {
+  if (!workspaceId || !hasText(workspaceId)) {
+    return null;
+  }
+  const owner = await brandCollection.findBySemrushSubWorkspaceId(workspaceId);
+  return owner?.getId?.() ?? null;
+}
+
+/**
  * Finds the one adoptable same-title child in the parent's family, or `null` when
- * none exists. "Adoptable" means a `created`, project-empty sub-workspace.
+ * none exists. "Adoptable" means a `created`, project-empty sub-workspace that no
+ * other brand has claimed.
+ *
+ * Claim filter: titles are bare brand display names, which are not unique within an
+ * org (prod carries same-named brand pairs today, some with a sub-workspace already
+ * bound). A candidate whose id is already persisted as another brand's
+ * `semrush_sub_workspace_id` is therefore provably NOT ours — adopting it would graft
+ * this brand onto a sibling's workspace, and the sibling's next deactivate would
+ * decommission markets belonging to both. Such candidates are DROPPED rather than
+ * escalated: dropping lets the proactive path correctly create a fresh workspace, and
+ * lets a genuine lone match still be adopted when a claimed twin sits beside it in the
+ * listing. A candidate claimed by THIS brand stays adoptable — that is a concurrent
+ * request for the same brand, which the caller's `reloadPointer` guard settles.
+ *
+ * The claim lookup is mandatory whenever there is at least one same-title `created`
+ * candidate: without it the title is the only key left, which is exactly the
+ * mis-adoption this filter exists to prevent. A create with no candidates has nothing
+ * to mis-adopt, so it does not need one.
  *
  * Status filter (issue #2718): a Semrush child create can be 200-acked and then
  * fail provisioning asynchronously, leaving a stub permanently stuck at
@@ -157,12 +188,43 @@ function familyItems(family) {
  * @param {string} parentWorkspaceId
  * @param {string} title
  * @param {object} log
+ * @param {object} claim - claim-filter inputs.
+ * @param {object} [claim.brandCollection] - the data-access Brand collection used to
+ *   detect a candidate already bound to another brand.
+ * @param {string} [claim.selfBrandId] - this brand's id; a candidate claimed by it is
+ *   still adoptable.
  * @returns {Promise<object|null>} the sole adoptable family entry, or null.
  */
-async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log) {
+async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log, claim) {
+  const { brandCollection, selfBrandId } = claim;
   const family = await transport.listWorkspaceFamily(parentWorkspaceId);
   const items = familyItems(family);
-  const matches = items.filter((w) => w?.title === title && w?.status === 'created');
+  const sameTitle = items.filter((w) => w?.title === title && w?.status === 'created');
+
+  if (sameTitle.length > 0
+    && typeof brandCollection?.findBySemrushSubWorkspaceId !== 'function') {
+    throw new ErrorWithStatusCode(
+      `Cannot evaluate subworkspace candidates for '${title}': no Brand collection to detect a `
+      + 'candidate already claimed by another brand',
+      500,
+    );
+  }
+  const owners = await Promise.all(
+    sameTitle.map((w) => claimedBrandId(brandCollection, w?.id)),
+  );
+  // One predicate for both partitions so they can never drift apart.
+  const isAdoptable = (i) => !owners[i] || owners[i] === selfBrandId;
+  const matches = sameTitle.filter((w, i) => isAdoptable(i));
+  const claimedByOthers = sameTitle.filter((w, i) => !isAdoptable(i));
+  if (claimedByOthers.length > 0) {
+    log?.info?.('ensureSubworkspace: ignoring same-title family entr(ies) already claimed by another brand', {
+      parentWorkspaceId,
+      title,
+      claimedCount: claimedByOthers.length,
+      claimedIds: claimedByOthers.map((w) => w?.id),
+    });
+  }
+
   if (matches.length === 0) {
     // Surface filtered-out non-`created` same-title stubs (Semrush ack-then-fail
     // zombies) so their accumulation is visible in logs without a manual family
@@ -228,14 +290,23 @@ async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log
 
 /**
  * Ambiguous-create recovery (design §6): a timed-out createSubworkspace is
- * ambiguous (no idempotency key). List the parent's family, match the exact
- * title, and adopt a `created`, project-empty subworkspace. No match → fail (the
- * create was attempted, so a missing entry is an error here, unlike the proactive
- * path where it just means "create one"). Multiple matches → fail with an alert,
- * never guess.
+ * ambiguous (no idempotency key). List the parent's family, match the title among
+ * the candidates no other brand has claimed, and adopt a `created`, project-empty
+ * subworkspace. No match → fail (the create was attempted, so a missing entry is an
+ * error here, unlike the proactive path where it just means "create one"). Multiple
+ * matches → fail with an alert, never guess.
+ *
+ * @param {object} transport
+ * @param {string} parentWorkspaceId
+ * @param {string} title
+ * @param {object} log
+ * @param {object} claim - claim-filter inputs, forwarded to findAdoptableFamilyMatch.
+ * @param {object} [claim.brandCollection]
+ * @param {string} [claim.selfBrandId]
+ * @returns {Promise<object>} the adopted family entry.
  */
-async function adoptFromFamily(transport, parentWorkspaceId, title, log) {
-  const adopted = await findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log);
+async function adoptFromFamily(transport, parentWorkspaceId, title, log, claim) {
+  const adopted = await findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log, claim);
   if (!adopted) {
     throw new ErrorWithStatusCode(
       `Ambiguous subworkspace create for '${title}' and no family match to adopt`,
@@ -359,6 +430,16 @@ export async function releaseFullAllocation(
  * @param {object} [options] - feature-flag toggles for the dual-mode carve.
  * @param {boolean} [options.dynamicAllocation] - when true (LLMO/dynamic-allocation ON), skip
  *   the flat re-grant on an existing sub-workspace; JIT top-up owns sizing. Default false.
+ * @param {object} [options.brandCollection] - the data-access Brand collection. Required on the
+ *   create path whenever the parent family holds a same-title `created` candidate: titles are
+ *   bare brand names, so the claim lookup is what distinguishes our own interrupted create from
+ *   a same-named sibling brand's sub-workspace (see findAdoptableFamilyMatch).
+ * @param {function} [options.onWorkspaceCreated] - called with the sub-workspace id when this
+ *   call FRESHLY CREATED it upstream, and never when it adopted an existing one. Failure
+ *   compensation must key off this rather than off the returned id: a caller that tears down
+ *   an ADOPTED workspace is tearing down a workspace it does not own. Titles are bare brand
+ *   names, so an adopted workspace can belong to a same-named sibling brand whose own
+ *   provisioning is still in flight and has not yet persisted its claim.
  * @returns {Promise<string>} the subworkspace id.
  */
 export async function ensureSubworkspace(
@@ -371,7 +452,7 @@ export async function ensureSubworkspace(
   reloadPointer = null,
   options = {},
 ) {
-  const { dynamicAllocation = false } = options;
+  const { dynamicAllocation = false, brandCollection, onWorkspaceCreated } = options;
   const poll = {
     attempts: timing.attempts ?? DEFAULT_POLL_ATTEMPTS,
     intervalMs: timing.intervalMs ?? DEFAULT_POLL_INTERVAL_MS,
@@ -419,14 +500,20 @@ export async function ensureSubworkspace(
   }
 
   const title = subworkspaceTitle(brand);
+  const claim = { brandCollection, selfBrandId: brand?.getId?.() };
   // Idempotent create-or-adopt (issue #2718): a retry after a partial
-  // provisioning failure must NOT spawn a duplicate same-title stub (titles embed
-  // the brand-id suffix, so a retry collides on title). Check the parent family
-  // for an existing `created`, empty same-title child FIRST and reuse it; only
-  // create when none exists. Failed `not ready` zombies are filtered out by the
-  // status check in findAdoptableFamilyMatch, so they are never reused and never
-  // inflate the ambiguity 409.
-  let created = await findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log);
+  // provisioning failure must NOT spawn a duplicate stub for this brand (a retry
+  // rebuilds the same title). Check the parent family for an existing `created`,
+  // empty, unclaimed same-title child FIRST and reuse it; only create when none
+  // exists. Failed `not ready` zombies are filtered out by the status check in
+  // findAdoptableFamilyMatch, and a same-named SIBLING brand's workspace by the
+  // claim check there, so neither is ever reused nor inflates the ambiguity 409.
+  let created = await findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log, claim);
+  // Provenance, not just identity: everything that later tears this workspace down must know
+  // whether WE brought it into existence. An adopted workspace may belong to a same-named
+  // sibling brand whose provisioning is still in flight (its claim is not persisted yet), so
+  // releasing it would strip a workspace we do not own.
+  let freshlyCreated = false;
   if (!created) {
     try {
       // Carve a fixed allocation (CREATE_ALLOCATION) onto the child so it has the
@@ -438,13 +525,14 @@ export async function ensureSubworkspace(
         title,
         CREATE_ALLOCATION,
       );
+      freshlyCreated = true;
     } catch (e) {
       // 504 = our transport's timeout signal → ambiguous create, recover by
       // adoption. The transport timeout is a SerenityTransportError (status 504),
       // NOT an ErrorWithStatusCode — guard on that so a 504 from our own poll
       // helper (an ErrorWithStatusCode) re-throws instead of re-entering adoption.
       if (!(e instanceof ErrorWithStatusCode) && e?.status === 504) {
-        created = await adoptFromFamily(transport, parentWorkspaceId, title, log);
+        created = await adoptFromFamily(transport, parentWorkspaceId, title, log, claim);
       } else {
         throw e;
       }
@@ -475,18 +563,26 @@ export async function ensureSubworkspace(
   if (typeof reloadPointer === 'function') {
     const concurrent = await reloadPointer();
     if (hasText(concurrent) && concurrent !== workspaceId) {
-      log?.error?.('ensureSubworkspace: concurrent activation won; releasing our orphaned workspace allocation', {
+      log?.error?.('ensureSubworkspace: concurrent activation won; standing down', {
         keptWorkspaceId: concurrent,
-        releasedWorkspaceId: workspaceId,
+        standDownWorkspaceId: workspaceId,
+        // False → we adopted this workspace rather than creating it, so it is not
+        // ours to release; we simply let it be.
+        releasing: freshlyCreated,
       });
       try {
+        // Release ONLY a workspace this call created. An ADOPTED one is not ours to tear down:
+        // titles are bare brand names, so it can be a same-named sibling brand's workspace whose
+        // claim is not persisted yet, and emptying it would destroy that brand's provisioning.
         // The loser's workspace is provably project-empty here — the create-or-adopt path above
         // never creates a project itself (that only happens in the CALLER, strictly after this
         // function returns). Still run deleteAllProjects defensively (cheap, idempotent) so this
-        // stays uniform with the other 3 release sites (LLMO-6189) rather than leaning on that
+        // stays uniform with the other release sites (LLMO-6189) rather than leaning on that
         // invariant holding forever.
-        await deleteAllProjects(transport, workspaceId);
-        await releaseFullAllocation(transport, workspaceId, parentWorkspaceId, log);
+        if (freshlyCreated) {
+          await deleteAllProjects(transport, workspaceId);
+          await releaseFullAllocation(transport, workspaceId, parentWorkspaceId, log);
+        }
       } catch (e) {
         // Best-effort: a failed release leaves the orphan resourced, but we
         // still must NOT clobber the winner's pointer below.
@@ -497,6 +593,10 @@ export async function ensureSubworkspace(
       }
       return concurrent;
     }
+  }
+
+  if (freshlyCreated && typeof onWorkspaceCreated === 'function') {
+    onWorkspaceCreated(workspaceId);
   }
 
   // Persist AFTER the workspace reads back `created` — flips the brand to subworkspace mode.

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -5348,7 +5348,10 @@ describe('Brands Controller', () => {
       });
 
       it('releases the orphaned sub-workspace when the brand row write fails after provisioning', async () => {
-        const provisionStub = sinon.stub().resolves({ semrushSubWorkspaceId: 'ws-orphan' });
+        const provisionStub = sinon.stub().resolves({
+          semrushSubWorkspaceId: 'ws-orphan',
+          createdByThisRequest: true,
+        });
         const releaseStub = sinon.stub().resolves();
         // A routine post-provision DB failure (e.g. unique-constraint 409).
         const upsertStub = sinon.stub().rejects(new Error('duplicate key value violates unique constraint'));
@@ -5377,6 +5380,45 @@ describe('Brands Controller', () => {
         // to the parent pool, not leaked.
         expect(releaseStub.calledOnce).to.equal(true);
         expect(releaseStub.firstCall.args[1]).to.equal('ws-orphan');
+      });
+
+      it('does NOT release a sub-workspace that provisioning only ADOPTED', async () => {
+        // Sub-workspace titles are bare brand display names, which are not unique within
+        // an org. Two same-named brands onboarding concurrently (observed in prod at 0.17s
+        // apart) can both resolve the SAME workspace: the first persists its claim, the
+        // second's brand-row write then fails on the UNIQUE constraint on
+        // brands.semrush_sub_workspace_id. Releasing here would delete the winner's
+        // projects and strip its allocation — on a live, correctly-owned workspace. The
+        // unique-constraint failure is precisely the signal that someone else owns it.
+        const provisionStub = sinon.stub().resolves({
+          semrushSubWorkspaceId: 'ws-adopted',
+          createdByThisRequest: false,
+        });
+        const releaseStub = sinon.stub().resolves();
+        const upsertStub = sinon.stub().rejects(new Error('duplicate key value violates unique constraint'));
+        const Mocked = await esmock('../../src/controllers/brands.js', {
+          '../../src/support/serenity/brand-provisioning.js': {
+            provisionBrandSubworkspace: provisionStub,
+            releaseProvisionedWorkspace: releaseStub,
+          },
+          '../../src/support/serenity/serenity-active.js': { isSerenityActiveForOrg: sinon.stub().resolves(true) },
+          '../../src/support/brands-storage.js': { upsertBrand: upsertStub },
+        });
+        const controller = Mocked.default(context, loggerStub, mockEnv);
+
+        const response = await controller.createBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID },
+          data: { ...semrushData },
+          dataAccess: mockDataAccess,
+          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+        });
+
+        // The create still errors out for this brand...
+        expect(response.status).to.not.equal(201);
+        expect(provisionStub.calledOnce).to.equal(true);
+        // ...but the adopted workspace — the other brand's — is left untouched.
+        expect(releaseStub.called).to.equal(false);
       });
 
       it('returns 400 when semrushMarket lacks a languageCode', async () => {

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1424,9 +1424,13 @@ describe('SerenityController', () => {
       // for the mapping-row upsert (mapping-rows.js).
       // writeDeadline is a request-scoped epoch-ms deadline (dynamic) — asserted
       // as a number, then dropped before the deep-equal.
-      const { writeDeadline, ...marketOptions } = handlers.handleCreateMarketSubworkspace
-        .firstCall.args[7];
+      const {
+        writeDeadline, brandCollection, ...marketOptions
+      } = handlers.handleCreateMarketSubworkspace.firstCall.args[7];
       expect(writeDeadline).to.be.a('number');
+      // Threaded so ensureSubworkspace's claim filter can tell this brand's own
+      // interrupted create from a same-named sibling brand's sub-workspace.
+      expect(brandCollection).to.equal(ctx.dataAccess.Brand);
       expect(marketOptions)
         .to.deep.equal({
           // LLMO-6554: resolved via resolveDefaultModelIds — [] here because the test's
@@ -1785,6 +1789,26 @@ describe('SerenityController', () => {
       const response = await controller.deactivate(fakeContext({ authType: 'jwt' }));
       expect(response.status).to.equal(401);
       expect(decommissionStub).to.not.have.been.called;
+    });
+
+    it('activate threads the Brand collection into ensureSubworkspace so the claim filter can run', async () => {
+      // Sub-workspace titles are bare brand names, so ensureSubworkspace needs the
+      // Brand collection to tell our own interrupted create from a same-named
+      // sibling brand's workspace. Without it the create path 500s on any
+      // same-title family candidate — so the wiring must be pinned, not assumed.
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      const brand = makeBrandModel({ getStatus: () => 'active' });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const ctx = fakeContext({
+        brand,
+        data: { brandDomain: 'x.com', brandNames: ['X'], markets: [{ market: 'us', languageCode: 'en' }] },
+      });
+
+      await controller.activate(ctx);
+
+      expect(ensureSubworkspaceStub).to.have.been.calledOnce;
+      expect(ensureSubworkspaceStub.firstCall.args[7].brandCollection)
+        .to.equal(ctx.dataAccess.Brand);
     });
 
     it('activate ensures the subworkspace ONCE for the batch and creates each market against it', async () => {

--- a/test/support/serenity/brand-provisioning.test.js
+++ b/test/support/serenity/brand-provisioning.test.js
@@ -21,13 +21,27 @@ import {
 import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
 
 const PARENT_WS = 'parent-ws-1111';
+
+// The real ensureSubworkspace (and the create handler that fronts it) reports a FRESHLY
+// CREATED sub-workspace through options.onWorkspaceCreated — that signal, not the returned
+// id, is what gates failure compensation, so the doubles must emit it too. `rest` is the
+// trailing args after (transport, brand); the options bag is the last object in it.
+function notifyCreated(rest, workspaceId) {
+  const options = rest.filter((a) => a && typeof a === 'object').pop();
+  options?.onWorkspaceCreated?.(workspaceId);
+}
 const NEW_WS = 'sub-ws-2222';
+
+// Sentinel for the data-access Brand collection ensureSubworkspace uses to detect a
+// family candidate already claimed by another brand.
+const BRAND_COLLECTION = { name: 'brand-collection' };
 
 function buildContext() {
   return {
     env: { SEMRUSH_PROJECTS_BASE_URL: 'https://gw.example' },
     pathInfo: { headers: { authorization: 'Bearer test-ims-token' } },
     attributes: { authInfo: { getType: () => 'ims' } },
+    dataAccess: { Brand: BRAND_COLLECTION },
   };
 }
 
@@ -83,8 +97,9 @@ describe('provisionBrandSubworkspace', () => {
     resolveWorkspaceId = sinon.stub().resolves(PARENT_WS);
     // Mimic the real handler: ensureSubworkspace would set the brand stub's
     // workspace id, then a project is created. Stub captures that side-effect.
-    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
+    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       return { status: 201, body: { brandId: brand.getId() } };
     });
   });
@@ -95,7 +110,12 @@ describe('provisionBrandSubworkspace', () => {
     });
     const result = await provisionBrandSubworkspace(buildContext(), baseParams);
     expect(result).to.deep.equal({
-      semrushSubWorkspaceId: NEW_WS, published: false, projectId: '', geoTargetId: null, languageCode: 'en',
+      semrushSubWorkspaceId: NEW_WS,
+      createdByThisRequest: true,
+      published: false,
+      projectId: '',
+      geoTargetId: null,
+      languageCode: 'en',
     });
   });
 
@@ -117,8 +137,9 @@ describe('provisionBrandSubworkspace', () => {
 
   it('returns published:true when the initial market was published', async () => {
     // result.body.published truthy → Boolean(...) true branch (line 225).
-    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
+    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       return { status: 201, body: { brandId: brand.getId(), published: true } };
     });
     const { provisionBrandSubworkspace } = await loadModule({
@@ -126,15 +147,21 @@ describe('provisionBrandSubworkspace', () => {
     });
     const result = await provisionBrandSubworkspace(buildContext(), baseParams);
     expect(result).to.deep.equal({
-      semrushSubWorkspaceId: NEW_WS, published: true, projectId: '', geoTargetId: null, languageCode: 'en',
+      semrushSubWorkspaceId: NEW_WS,
+      createdByThisRequest: true,
+      published: true,
+      projectId: '',
+      geoTargetId: null,
+      languageCode: 'en',
     });
   });
 
   it('returns published:false when a successful result carries no body (result.body || {})', async () => {
     // result.body is undefined on the success path → the `|| {}` fallback fires
     // before reading `.published` (line 225 right branch).
-    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
+    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       return { status: 200 };
     });
     const { provisionBrandSubworkspace } = await loadModule({
@@ -142,7 +169,12 @@ describe('provisionBrandSubworkspace', () => {
     });
     const result = await provisionBrandSubworkspace(buildContext(), baseParams);
     expect(result).to.deep.equal({
-      semrushSubWorkspaceId: NEW_WS, published: false, projectId: '', geoTargetId: null, languageCode: 'en',
+      semrushSubWorkspaceId: NEW_WS,
+      createdByThisRequest: true,
+      published: false,
+      projectId: '',
+      geoTargetId: null,
+      languageCode: 'en',
     });
   });
 
@@ -150,8 +182,9 @@ describe('provisionBrandSubworkspace', () => {
     // provisionBrandSubworkspace runs before the brand row is written (a
     // throwaway id), so it can't satisfy the mapping row's FK to brands —
     // the caller (brands.js) writes it once the real row is persisted.
-    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
+    handleCreateMarketSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       return {
         status: 201,
         body: {
@@ -165,6 +198,7 @@ describe('provisionBrandSubworkspace', () => {
     const result = await provisionBrandSubworkspace(buildContext(), baseParams);
     expect(result).to.deep.equal({
       semrushSubWorkspaceId: NEW_WS,
+      createdByThisRequest: true,
       published: false,
       projectId: 'proj-initial',
       geoTargetId: 2840,
@@ -190,9 +224,14 @@ describe('provisionBrandSubworkspace', () => {
     // server-classified `intent` value), then publishes best-effort. The
     // dimension-root taxonomy is provisioned by createMarket itself, so it is not
     // passed through here. writeDeadline is a request-scoped epoch-ms deadline
-    // (dynamic) — asserted as a number, then dropped before the deep-equal.
-    const { writeDeadline, ...restOptions } = options;
+    // (dynamic) — asserted as a number, then dropped before the deep-equal, as are the
+    // two adoption-safety hooks (identity-compared / typed below rather than deep-equalled).
+    const {
+      writeDeadline, brandCollection, onWorkspaceCreated, ...restOptions
+    } = options;
     expect(writeDeadline).to.be.a('number');
+    expect(brandCollection).to.equal(BRAND_COLLECTION);
+    expect(onWorkspaceCreated).to.be.a('function');
     expect(restOptions).to.deep.equal({
       modelIds: ['m-1', 'm-2'],
       generateTopics: true,
@@ -208,7 +247,7 @@ describe('provisionBrandSubworkspace', () => {
       dynamicAllocation: false,
       ceiling: undefined,
     });
-    // The stub drives the sub-workspace title off the brand's name + id.
+    // The stub drives the sub-workspace title off the brand's display name.
     expect(brandStub.getName()).to.equal('Acme');
     expect(brandStub.getId()).to.equal('brand-1');
     expect(brandStub.getSemrushSubWorkspaceId()).to.equal(undefined);
@@ -442,8 +481,9 @@ describe('provisionBrandSubworkspace', () => {
     const transport = makeReleaseTransport({
       listProjects: sinon.stub().resolves({ items: [{ id: 'proj-1' }] }),
     });
-    const handler = sinon.stub().callsFake(async (t, brand) => {
+    const handler = sinon.stub().callsFake(async (t, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       return { status: 502, body: { message: 'upstream blew up' } };
     });
     const mod = await esmock('../../../src/support/serenity/brand-provisioning.js', {
@@ -513,8 +553,9 @@ describe('provisionBrandSubworkspaceBare', () => {
     resolveWorkspaceId = sinon.stub().resolves(PARENT_WS);
     // Like the real ensureSubworkspace, resolve the new sub-workspace id AND set
     // it on the brand stub via setSemrushSubWorkspaceId.
-    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
+    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       return NEW_WS;
     });
     deleteAllProjects = sinon.stub().resolves();
@@ -539,7 +580,7 @@ describe('provisionBrandSubworkspaceBare', () => {
   it('provisions the bare sub-workspace (marketCount 1) and returns its id — no project created', async () => {
     const { provisionBrandSubworkspaceBare } = await loadBareModule();
     const result = await provisionBrandSubworkspaceBare(buildContext(), bareParams);
-    expect(result).to.deep.equal({ semrushSubWorkspaceId: NEW_WS });
+    expect(result).to.deep.equal({ semrushSubWorkspaceId: NEW_WS, createdByThisRequest: true });
     // Carved for a single future project (marketCount = 1), against the org parent.
     expect(ensureSubworkspace).to.have.been.calledOnce;
     expect(ensureSubworkspace.firstCall.args[0]).to.equal(TRANSPORT);
@@ -549,7 +590,12 @@ describe('provisionBrandSubworkspaceBare', () => {
     expect(deleteAllProjects).to.not.have.been.called;
     expect(releaseFullAllocation).to.not.have.been.called;
     // Kill-switch defaults OFF (env unset) — byte-for-byte the pre-fix flat carve.
-    expect(ensureSubworkspace.firstCall.args[7]).to.deep.equal({ dynamicAllocation: false });
+    // The Brand collection is threaded through so the claim filter can run, and the
+    // created-vs-adopted callback so failure compensation can gate on provenance.
+    const options = ensureSubworkspace.firstCall.args[7];
+    expect(options.dynamicAllocation).to.equal(false);
+    expect(options.brandCollection).to.equal(BRAND_COLLECTION);
+    expect(options.onWorkspaceCreated).to.be.a('function');
   });
 
   it('threads the dynamic-allocation flag from env into ensureSubworkspace (LLMO-6190 — onboarding was previously silently excluded)', async () => {
@@ -557,18 +603,21 @@ describe('provisionBrandSubworkspaceBare', () => {
     const ctx = buildContext();
     ctx.env.SERENITY_DYNAMIC_ALLOCATION = 'true';
     await provisionBrandSubworkspaceBare(ctx, bareParams);
-    expect(ensureSubworkspace.firstCall.args[7]).to.deep.equal({ dynamicAllocation: true });
+    const options = ensureSubworkspace.firstCall.args[7];
+    expect(options.dynamicAllocation).to.equal(true);
+    expect(options.brandCollection).to.equal(BRAND_COLLECTION);
   });
 
   it('falls back to the captured workspace id when ensureSubworkspace returns nothing', async () => {
     // Sets the stub id but returns undefined → resolved via capturedWorkspaceId.
-    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
+    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       return undefined;
     });
     const { provisionBrandSubworkspaceBare } = await loadBareModule();
     const result = await provisionBrandSubworkspaceBare(buildContext(), bareParams);
-    expect(result).to.deep.equal({ semrushSubWorkspaceId: NEW_WS });
+    expect(result).to.deep.equal({ semrushSubWorkspaceId: NEW_WS, createdByThisRequest: true });
   });
 
   it('throws 502 when neither a returned nor a captured sub-workspace id is available', async () => {
@@ -585,8 +634,9 @@ describe('provisionBrandSubworkspaceBare', () => {
   });
 
   it('releases the captured sub-workspace allocation when ensureSubworkspace throws after creating it', async () => {
-    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
-      brand.setSemrushSubWorkspaceId(NEW_WS); // created upstream...
+    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
+      brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS); // created upstream...
       throw new SerenityTransportError(502, 'settle timeout'); // ...then failed
     });
     const { provisionBrandSubworkspaceBare } = await loadBareModule();
@@ -618,8 +668,9 @@ describe('provisionBrandSubworkspaceBare', () => {
   });
 
   it('swallows a release failure (logs at error) and re-throws the original error', async () => {
-    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand) => {
+    ensureSubworkspace = sinon.stub().callsFake(async (transport, brand, ...rest) => {
       brand.setSemrushSubWorkspaceId(NEW_WS);
+      notifyCreated(rest, NEW_WS);
       throw new SerenityTransportError(502, 'settle timeout');
     });
     deleteAllProjects = sinon.stub().rejects(new Error('release network error'));
@@ -827,8 +878,9 @@ describe('defensive branch coverage', () => {
       // releaseCapturedOnFailure, AND emptying the workspace's projects (deleteAllProjects,
       // the first step of any release attempt post-LLMO-6189) throws.
       const listProjects = sinon.stub().rejects(new Error('release network error'));
-      const handler = sinon.stub().callsFake(async (transport, brand) => {
+      const handler = sinon.stub().callsFake(async (transport, brand, ...rest) => {
         brand.setSemrushSubWorkspaceId(NEW_WS);
+        notifyCreated(rest, NEW_WS);
         return { status: 422, body: {} };
       });
       const log = { error: sinon.stub(), info: sinon.stub() };
@@ -870,8 +922,9 @@ describe('defensive branch coverage', () => {
     it('uses fallback message when result has no body.message', async () => {
       // Line 196: result.body?.message || 'Failed to provision Semrush sub-workspace'
       // right side fires when body.message is absent/falsy.
-      const handler = sinon.stub().callsFake(async (transport, brand) => {
+      const handler = sinon.stub().callsFake(async (transport, brand, ...rest) => {
         brand.setSemrushSubWorkspaceId(NEW_WS);
+        notifyCreated(rest, NEW_WS);
         return { status: 422, body: {} };
       });
       const mod = await esmock('../../../src/support/serenity/brand-provisioning.js', {
@@ -897,8 +950,9 @@ describe('defensive branch coverage', () => {
 
     it('uses fallback message when result has no body at all', async () => {
       // result.body is undefined -> result.body?.message = undefined -> fallback.
-      const handler = sinon.stub().callsFake(async (transport, brand) => {
+      const handler = sinon.stub().callsFake(async (transport, brand, ...rest) => {
         brand.setSemrushSubWorkspaceId(NEW_WS);
+        notifyCreated(rest, NEW_WS);
         return { status: 500 };
       });
       const mod = await esmock('../../../src/support/serenity/brand-provisioning.js', {

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -14,6 +14,7 @@ import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { hasText } from '@adobe/spacecat-shared-utils';
 
 import {
   ensureSubworkspace,
@@ -32,12 +33,42 @@ use(sinonChai);
 const PARENT_WS = 'bb0f4e1c-8bb1-402e-88f2-f68618ea7397';
 const SUB_WS = 'subworkspace-ws-1';
 const BRAND_ID = 'e48e9db4-3101-4237-8075-a9132333e8c2';
-// The sub-workspace title embeds the first 8 chars of the immutable brand id for
-// per-brand uniqueness (so ambiguous-create recovery cannot adopt a same-named
-// brand's workspace) while keeping the Semrush UI title short.
-const EXPECTED_TITLE = `Adobe Express [${BRAND_ID.slice(0, 8)}]`;
+// The sub-workspace is titled with the brand's bare display name — the same
+// convention the migration CLI uses, so a customer sees one naming scheme in the
+// Semrush UI. Uniqueness for adoption comes from the claim filter, not the title.
+const EXPECTED_TITLE = 'Adobe Express';
+const OTHER_BRAND_ID = '3b1a7f6e-0c42-4f18-9a55-7d2e6c4b8a10';
 const NOOP_TIMING = { intervalMs: 0, sleep: () => Promise.resolve() };
 const log = { info: () => {}, error: () => {}, warn: () => {} };
+
+// Data-access Brand collection stub backing the claim filter. `claims` maps a
+// workspace id to the brand id currently bound to it (`brands.semrush_sub_workspace_id`);
+// any id not listed is unclaimed.
+function makeBrandCollection(claims = {}) {
+  return {
+    findBySemrushSubWorkspaceId: sinon.stub().callsFake(
+      async (workspaceId) => (hasText(claims[workspaceId])
+        ? { getId: () => claims[workspaceId] }
+        : null),
+    ),
+  };
+}
+
+// A create-path ensureSubworkspace call whose family candidates are all unclaimed —
+// the common case. Tests that exercise the claim filter itself pass their own
+// makeBrandCollection({...}) instead.
+function ensureWithUnclaimedFamily(transport, brand) {
+  return ensureSubworkspace(
+    transport,
+    brand,
+    PARENT_WS,
+    1,
+    log,
+    NOOP_TIMING,
+    null,
+    { brandCollection: makeBrandCollection() },
+  );
+}
 
 function makeTransport(overrides = {}) {
   return {
@@ -164,7 +195,7 @@ describe('workspace-lifecycle', () => {
       const listWorkspaceFamily = sinon.stub();
       listWorkspaceFamily.onFirstCall().resolves([]);
       listWorkspaceFamily.onSecondCall().resolves([
-        { id: 'other-ws', title: 'Some Other Brand [11111111]', status: 'created' },
+        { id: 'other-ws', title: 'Some Other Brand', status: 'created' },
         { id: 'adopted-ws', title: EXPECTED_TITLE, status: 'created' },
       ]);
       const transport = makeTransport({
@@ -173,7 +204,7 @@ describe('workspace-lifecycle', () => {
       });
       const brand = makeBrand();
 
-      const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+      const result = await ensureWithUnclaimedFamily(transport, brand);
 
       expect(result).to.equal('adopted-ws');
       expect(transport.createSubworkspace).to.have.been.calledOnce;
@@ -193,8 +224,7 @@ describe('workspace-lifecycle', () => {
       });
       const brand = makeBrand();
 
-      await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
-        .to.be.rejectedWith(/refusing to adopt/);
+      await expect(ensureWithUnclaimedFamily(transport, brand)).to.be.rejectedWith(/refusing to adopt/);
       expect(transport.createSubworkspace).to.not.have.been.called;
       expect(brand.setSemrushSubWorkspaceId).to.not.have.been.called;
     });
@@ -205,22 +235,294 @@ describe('workspace-lifecycle', () => {
       });
       const brand = makeBrand();
 
-      await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
-        .to.be.rejectedWith(/sole family match has no id/);
+      await expect(ensureWithUnclaimedFamily(transport, brand)).to.be.rejectedWith(/sole family match has no id/);
       expect(transport.createSubworkspace).to.not.have.been.called;
       expect(transport.listProjects).to.not.have.been.called;
     });
 
-    it('hard-fails (never builds a non-unique title) when the brand has no id', async () => {
-      // The id-suffix is the collision-free adoption key; without it the title
-      // would not be unique per brand, so provisioning must refuse rather than
-      // fall back to a name-only title that adoption could later mis-match.
+    it('hard-fails (never builds an untitled workspace) when the brand has no name', async () => {
+      // The title IS the brand's display name; an untitled workspace would collide
+      // with every other untitled one and is not something adoption could ever
+      // disambiguate. Refuse rather than create one.
       const transport = makeTransport();
-      const brand = makeBrand({ id: null });
+      const brand = makeBrand({ name: null });
 
       await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
-        .to.be.rejectedWith(/requires a brand id/);
+        .to.be.rejectedWith(/requires a brand name/);
       expect(transport.createSubworkspace).to.not.have.been.called;
+    });
+
+    it('hard-fails on an empty-string brand name', async () => {
+      const transport = makeTransport();
+      const brand = makeBrand({ name: '' });
+
+      await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
+        .to.be.rejectedWith(/requires a brand name/);
+      expect(transport.createSubworkspace).to.not.have.been.called;
+    });
+
+    describe('claim filter (same-named sibling brands)', () => {
+      it('does NOT adopt a same-title workspace already bound to another brand; creates a fresh one', async () => {
+        // Titles are bare brand names and names are not unique within an org (prod
+        // carries same-named pairs today, some already holding a sub-workspace). The
+        // sibling's workspace is empty and `created`, so title+status+empty alone
+        // would adopt it — the claim lookup is what keeps this brand off it.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'sibling-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          log,
+          NOOP_TIMING,
+          null,
+          { brandCollection: makeBrandCollection({ 'sibling-ws': OTHER_BRAND_ID }) },
+        );
+
+        expect(result).to.equal(SUB_WS);
+        expect(transport.createSubworkspace).to.have.been.calledOnce;
+        expect(brand.setSemrushSubWorkspaceId).to.have.been.calledOnceWithExactly(SUB_WS);
+      });
+
+      it('adopts the one unclaimed match when a claimed same-title sibling shares the listing', async () => {
+        // Dropping claimed candidates (rather than escalating to the ambiguity 409)
+        // is what keeps a genuine lone match adoptable beside a sibling's workspace.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'sibling-ws', title: EXPECTED_TITLE, status: 'created' },
+            { id: 'ours-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          log,
+          NOOP_TIMING,
+          null,
+          { brandCollection: makeBrandCollection({ 'sibling-ws': OTHER_BRAND_ID }) },
+        );
+
+        expect(result).to.equal('ours-ws');
+        expect(transport.createSubworkspace).to.not.have.been.called;
+      });
+
+      it('still adopts a candidate claimed by THIS brand (concurrent request for the same brand)', async () => {
+        // A parallel request for the same brand may have persisted the pointer while
+        // we were listing. That workspace IS ours — adopt it rather than creating a
+        // duplicate; the caller's reloadPointer guard settles the race afterwards.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'ours-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          log,
+          NOOP_TIMING,
+          null,
+          { brandCollection: makeBrandCollection({ 'ours-ws': BRAND_ID }) },
+        );
+
+        expect(result).to.equal('ours-ws');
+        expect(transport.createSubworkspace).to.not.have.been.called;
+      });
+
+      it('502s on the 504-recovery path when the only same-title match belongs to another brand', async () => {
+        // The create timed out AND the sole candidate is a sibling's — we cannot
+        // tell whether our create landed, so fail rather than adopt the sibling's.
+        const listWorkspaceFamily = sinon.stub();
+        listWorkspaceFamily.onFirstCall().resolves([]);
+        listWorkspaceFamily.onSecondCall().resolves([
+          { id: 'sibling-ws', title: EXPECTED_TITLE, status: 'created' },
+        ]);
+        const transport = makeTransport({
+          createSubworkspace: sinon.stub().rejects(new SerenityTransportError(504, 'timeout')),
+          listWorkspaceFamily,
+        });
+        const brand = makeBrand();
+
+        await expect(ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          log,
+          NOOP_TIMING,
+          null,
+          { brandCollection: makeBrandCollection({ 'sibling-ws': OTHER_BRAND_ID }) },
+        )).to.be.rejectedWith(/no family match to adopt/);
+      });
+
+      it('logs the claimed candidates it ignored', async () => {
+        const localLog = { info: sinon.spy(), error: sinon.spy(), warn: sinon.spy() };
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'sibling-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        await ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          localLog,
+          NOOP_TIMING,
+          null,
+          { brandCollection: makeBrandCollection({ 'sibling-ws': OTHER_BRAND_ID }) },
+        );
+
+        const logged = localLog.info.getCalls()
+          .find((c) => /already claimed by another brand/.test(c.args[0]));
+        expect(logged, 'expected a claimed-candidate log line').to.exist;
+        expect(logged.args[1]).to.include({ claimedCount: 1 });
+        expect(logged.args[1].claimedIds).to.deep.equal(['sibling-ws']);
+      });
+
+      it('500s rather than evaluating a same-title candidate without a Brand collection', async () => {
+        // Fail-closed: with no claim lookup the bare title is the only key left,
+        // which is exactly the mis-adoption the filter exists to prevent.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'some-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING))
+          .to.be.rejectedWith(/no Brand collection/);
+        expect(transport.createSubworkspace).to.not.have.been.called;
+      });
+
+      it('propagates a claim-lookup failure instead of creating blindly (fail-safe)', async () => {
+        // If the data layer cannot tell us who owns the candidate we cannot tell our
+        // own create from a sibling's, and creating anyway would spawn the duplicate
+        // stub the proactive check exists to prevent. Fail rather than guess.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'some-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+        const brandCollection = {
+          findBySemrushSubWorkspaceId: sinon.stub().rejects(new Error('postgrest unavailable')),
+        };
+
+        await expect(ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING, null, { brandCollection })).to.be.rejectedWith(/postgrest unavailable/);
+        expect(transport.createSubworkspace).to.not.have.been.called;
+      });
+
+      it('reports a FRESHLY CREATED workspace through onWorkspaceCreated', async () => {
+        // Failure compensation keys off this signal rather than the returned id, so it
+        // must fire for a workspace this call brought into existence.
+        const transport = makeTransport();
+        const brand = makeBrand();
+        const onWorkspaceCreated = sinon.spy();
+
+        const result = await ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          log,
+          NOOP_TIMING,
+          null,
+          { brandCollection: makeBrandCollection(), onWorkspaceCreated },
+        );
+
+        expect(result).to.equal(SUB_WS);
+        expect(onWorkspaceCreated).to.have.been.calledOnceWithExactly(SUB_WS);
+      });
+
+      it('does NOT report an ADOPTED workspace through onWorkspaceCreated', async () => {
+        // The whole point of the signal: an adopted workspace may be a same-named sibling
+        // brand's whose claim is not persisted yet. A caller that tore it down on failure
+        // would delete that brand's projects and strip its allocation.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'adopted-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+        const onWorkspaceCreated = sinon.spy();
+
+        const result = await ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          log,
+          NOOP_TIMING,
+          null,
+          { brandCollection: makeBrandCollection(), onWorkspaceCreated },
+        );
+
+        expect(result).to.equal('adopted-ws');
+        expect(transport.createSubworkspace).to.not.have.been.called;
+        expect(onWorkspaceCreated).to.not.have.been.called;
+      });
+
+      it('a concurrency loser does NOT release a workspace it merely adopted', async () => {
+        // Losing the pointer race releases OUR workspace back to the parent pool — but only
+        // when we created it. Releasing an adopted one would strip a workspace owned by
+        // whoever actually created it.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'adopted-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+        const reloadPointer = sinon.stub().resolves('winner-ws');
+
+        const result = await ensureSubworkspace(
+          transport,
+          brand,
+          PARENT_WS,
+          1,
+          log,
+          NOOP_TIMING,
+          reloadPointer,
+          { brandCollection: makeBrandCollection() },
+        );
+
+        expect(result).to.equal('winner-ws');
+        // No teardown of the adopted workspace.
+        expect(transport.deleteProject).to.not.have.been.called;
+        expect(transport.transferWorkspaceResources).to.not.have.been.called;
+        expect(brand.setSemrushSubWorkspaceId).to.not.have.been.called;
+      });
+
+      it('needs no Brand collection when the family holds no same-title candidate', async () => {
+        // Nothing to mis-adopt → the lookup is not required, so a clean first create
+        // is unaffected.
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: 'unrelated-ws', title: 'Some Other Brand', status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+
+        expect(result).to.equal(SUB_WS);
+        expect(transport.createSubworkspace).to.have.been.calledOnce;
+      });
     });
 
     it('fails with an ambiguousWorkspace alert on multiple CREATED family matches', async () => {
@@ -234,7 +536,7 @@ describe('workspace-lifecycle', () => {
       });
       const brand = makeBrand();
 
-      const promise = ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+      const promise = ensureWithUnclaimedFamily(transport, brand);
       await expect(promise).to.be.rejected;
       try {
         await promise;
@@ -285,7 +587,7 @@ describe('workspace-lifecycle', () => {
         });
         const brand = makeBrand();
 
-        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+        const result = await ensureWithUnclaimedFamily(transport, brand);
 
         expect(result).to.equal('existing-ws');
         expect(transport.createSubworkspace).to.not.have.been.called;
@@ -321,7 +623,7 @@ describe('workspace-lifecycle', () => {
         });
         const brand = makeBrand();
 
-        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+        const result = await ensureWithUnclaimedFamily(transport, brand);
 
         expect(result).to.equal('good-ws');
         expect(transport.createSubworkspace).to.not.have.been.called;
@@ -706,31 +1008,6 @@ describe('workspace-lifecycle', () => {
     });
   });
   describe('defensive branch coverage', () => {
-    describe('ensureSubworkspace - subworkspaceTitle else branch (brand with id but no name)', () => {
-      it('creates a workspace titled brand-<suffix> when the brand has no name', async () => {
-        // subworkspaceTitle: hasText(name) is false -> uses the brand-<suffix> template (line 94).
-        const transport = makeTransport();
-        const brand = makeBrand({ name: null });
-
-        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
-
-        expect(result).to.equal(SUB_WS);
-        const [, actualTitle] = transport.createSubworkspace.firstCall.args;
-        expect(actualTitle).to.equal(`brand-${BRAND_ID.slice(0, 8)}`);
-      });
-
-      it('creates a workspace titled brand-<suffix> when the brand name is empty string', async () => {
-        const transport = makeTransport();
-        const brand = makeBrand({ name: '' });
-
-        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
-
-        expect(result).to.equal(SUB_WS);
-        const [, actualTitle] = transport.createSubworkspace.firstCall.args;
-        expect(actualTitle).to.equal(`brand-${BRAND_ID.slice(0, 8)}`);
-      });
-    });
-
     describe('adoptFromFamily - listWorkspaceFamily resolves non-array', () => {
       it('throws when listWorkspaceFamily returns a non-array body ({})', async () => {
         // familyItems guard: a non-array response (null / malformed) → [] → no match.
@@ -756,7 +1033,7 @@ describe('workspace-lifecycle', () => {
         });
         const brand = makeBrand();
 
-        const result = await ensureSubworkspace(transport, brand, PARENT_WS, 1, log, NOOP_TIMING);
+        const result = await ensureWithUnclaimedFamily(transport, brand);
 
         expect(result).to.equal('adopted-ws');
         expect(transport.createSubworkspace).to.not.have.been.called;


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Serenity sub-workspaces are now titled with the brand's bare display name on every provisioning path, and adoption during create-recovery keys on the brand's persisted workspace claim instead of on the title.

## 2. Reasoning
Sub-workspaces created through the UI were titled `<brand name> [<first 8 chars of brand id>]`, while ones created by the migration CLI were titled with the bare brand name. Customers saw both conventions side by side in the Semrush UI, and the id suffix means nothing to them.

The suffix was not decoration. The title is the only key two recovery paths in `ensureSubworkspace` have: ambiguous-create recovery after a 504 (`createSubworkspace` has no idempotency key, so a timed-out create is ambiguous and the parent's family listing is matched by title), and the idempotent create-or-adopt reuse from issue 2718 (an existing `created`, project-empty same-title child is reused so a retry after a partial provisioning failure does not spawn a duplicate stub). Brand display names are not unique within an org, so simply deleting the suffix would let one brand adopt a different, same-named brand's sub-workspace — and a later deactivate would then decommission the wrong brand's live markets.

Create timeouts are being hit in practice on the brand-create path, which is exactly when the title match runs.

## 3. High-level overview of the changes

**Titles.** Sub-workspace titles are the brand's bare display name, matching what the migration CLI already produces. Existing sub-workspaces keep their current titles — no retroactive rename is implied. The construction guard moves with the title: a missing brand *name* is now the hard error, replacing the old missing-brand-*id* error, because an untitled workspace is the thing adoption could never disambiguate.

**Adoption no longer trusts the title alone.** Before applying the match, ambiguity and emptiness rules, `findAdoptableFamilyMatch` drops every family candidate whose id is already persisted as another brand's `semrush_sub_workspace_id`. Candidates are dropped rather than escalated to an error, which keeps two existing behaviours intact: the proactive path still creates a fresh workspace when the only same-title candidate belongs to a sibling, and a genuine lone match is still adoptable when a claimed twin sits beside it in the listing. A candidate claimed by the *same* brand stays adoptable — that is a concurrent request for that brand, which the existing `reloadPointer` guard settles. The lookup is required whenever a same-title candidate exists and fails closed when it is unavailable, since without it the bare title would be the only key left.

**Failure compensation now gates on provenance.** Because a bare title can resolve to a workspace this request did not create, `ensureSubworkspace` reports a *freshly created* sub-workspace through a new `onWorkspaceCreated` signal, and every teardown path keys off that rather than off the resolved id — the concurrency-loser release, both brand-provisioning cleanups, and the brand-create compensation in the brands controller.

This closes a destructive path that dropping the suffix would otherwise have opened: two same-named brands onboarding concurrently can resolve the same workspace, the first persists its claim, and the second's brand-row write then fails on the UNIQUE constraint on `brands.semrush_sub_workspace_id`. The old compensation treated the workspace as its own orphan and would delete its projects and strip its allocation — on a live workspace correctly owned by the other brand. The unique-constraint failure is precisely the signal that someone else owns it.

Operationally visible: ignored claimed candidates are logged with their ids, and the concurrency-loser log now states whether it is releasing or standing down.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/2915 — Closes #2915
- Implementation plan: `docs/specs/2026-06-15-serenity-subworkspace-dual-mode-implementation-plan.md` (hardening-pass note updated in this PR to describe the adoption key)
- Other: https://github.com/adobe/project-elmo-ui/pull/2493 — brand and market split UI, where the inconsistency was noticed

## 5. Affected / used mysticat-workspace projects
- `mysticat-data-service` — contract, unchanged. Its migration CLI (`scripts/serenity_migration/executor.py`) already matches child workspaces by bare title (`_child_workspaces_by_title`) and accepts the collision risk because it works from a planned batch of known, deduplicated brand names. This PR brings the API-service path onto the same titles, so both sides now produce and match one convention. The CLI's own matching is untouched.

## 6. Additional information outside the code
Verified against the production database rather than assumed:

- **Same-named brands within one org are real.** Of 5767 brands, 12 org+name duplicate pairs exist today. In three of them one twin already holds a sub-workspace (`behr`, `test`, `toyota gazoo racing`) — the exact shape the claim filter has to handle.
- **The race the provenance gate closes is real, not theoretical.** Creation-timestamp deltas within those duplicate pairs include two at **0.17 seconds** (`bitdefender`, `under armour`) and two more within 11–25 seconds, so concurrent onboarding of identically-named brands in the same org demonstrably happens.
- **The UNIQUE constraint the design leans on exists.** `brands_semrush_sub_workspace_id_key`, `CREATE UNIQUE INDEX … USING btree (semrush_sub_workspace_id)` — confirmed live, so at most one brand can ever claim a workspace and the claim lookup resolves unambiguously.

## 7. Test plan

**Locally.** The PostgreSQL integration suite (`test/it/postgres/serenity.test.js`), which drives the Semrush vendor mock containers over real HTTPS and exercises activate end to end, **could not be run in this session** — the ECR image pull returns 403 because the local AWS token had expired, and refreshing it needs an interactive browser login. That suite runs in CI (`it-postgres: true`), so it gates this PR there; it is called out here rather than left implied.

**Reviewer focus.** The adoption rules are the risky surface: whether dropping (rather than erroring on) claimed candidates is right for both the proactive and the 504-recovery paths, and whether gating teardown on created-vs-adopted leaves any workspace genuinely leaked.

**On dev.**
1. Create a brand in an org that already has an active brand with the same display name. Confirm the new sub-workspace appears in the Semrush UI titled with the bare brand name, and that it is a *new* workspace — not the existing twin's.
2. Check the API-service logs for `ensureSubworkspace: ignoring same-title family entr(ies) already claimed by another brand`, carrying the skipped workspace id.
3. Confirm the pre-existing twin's workspace is untouched: its projects and its allocation are unchanged.
4. Re-run a brand create that fails after provisioning (for example by forcing the brand-row write to fail) and confirm that a workspace the request *created* is still released back to the parent pool, so the compensation has not been disabled wholesale.

**Known residual.** Two same-named brands provisioning concurrently before either persists its pointer can still resolve the same workspace. The unique constraint makes that a clean failure for the losing request instead of two brands sharing a workspace, and the provenance gate ensures the loser leaves the winner's workspace intact. Fully closing it needs an idempotency key or a client-supplied correlation id on `createSubworkspace` from Semrush, which is outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
