### PR TITLE
fix: return only enabled models in SR platform filter | LLMO-6589

### DIFF
--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -901,11 +901,12 @@ v2-serenity-models:
       AI models configured for that slice's upstream project. `key` is the
       value the Reporting API expects as `CBF_model`.
 
-      **Catalog mode** (neither param present): returns the global catalog of
-      ALL AI models available for tracking via `GET /v1/ai_models` (not
-      workspace-scoped). Falls back to an empty list if the upstream endpoint
-      is unavailable. Use this to populate "available models" selectors in the
-      UI before a market is configured.
+      **Union mode** (neither param present): returns the union of AI models
+      enabled across all the brand's projects — i.e. only the models the brand
+      has data for, deduplicated. Returns an empty list if the brand has no
+      projects. Use this to populate "available models" selectors in the UI.
+      For the brand-independent global catalog, use the org-level
+      `GET /v2/orgs/{spaceCatId}/serenity/models` instead.
 
       Providing exactly one of the two params returns 400.
     operationId: listSerenityModels

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -25,8 +25,8 @@ import {
   defaultMarketName,
   listTagsForProject,
   listProjectTagTree,
-  listGlobalModelCatalog,
   listSliceModels,
+  listUnionModels,
   syncModelsForProject,
   countPublishedPrompts,
   MAX_MODEL_IDS,
@@ -1077,17 +1077,19 @@ export async function handleListTagsSubworkspace(transport, workspaceId, query, 
 }
 
 /**
- * GET /serenity/models (subworkspace). No params → the (workspace-independent) global
- * catalog. With (geoTargetId, languageCode) → models on the slice's project,
- * resolved from the live listing. Partial params → 400. A missing slice returns
- * an empty set, matching the flat-mode models contract.
+ * GET /serenity/models (subworkspace). No params → the union of models enabled
+ * across all the workspace's projects. With (geoTargetId, languageCode) → models
+ * on the slice's project, resolved from the live listing. Partial params → 400. A
+ * missing slice returns an empty set, matching the flat-mode models contract.
  */
 export async function handleListModelsSubworkspace(transport, workspaceId, query, log) {
   const geoTargetId = normalizeGeoTargetId(query?.geoTargetId);
   const languageCode = normalizeLanguageCode(query?.languageCode);
 
   if (geoTargetId === null && languageCode === null) {
-    return listGlobalModelCatalog(transport);
+    const projects = await resolveProjects(transport, workspaceId);
+    const projectIds = projects.map((p) => String(p.id));
+    return listUnionModels(transport, workspaceId, projectIds);
   }
   if (geoTargetId === null || languageCode === null) {
     throw new ErrorWithStatusCode(

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -1088,7 +1088,7 @@ export async function handleListModelsSubworkspace(transport, workspaceId, query
 
   if (geoTargetId === null && languageCode === null) {
     const projects = await resolveProjects(transport, workspaceId);
-    const projectIds = projects.map((p) => String(p.id));
+    const projectIds = projects.filter((p) => p?.id != null).map((p) => String(p.id));
     return listUnionModels(transport, workspaceId, projectIds);
   }
   if (geoTargetId === null || languageCode === null) {

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -985,6 +985,41 @@ export async function listSliceModels(transport, semrushWorkspaceId, projectId) 
 }
 
 /**
+ * Union of the models enabled across a set of projects. Fetches each project's
+ * assigned models (`listSliceModels`) in parallel and dedups by model `key`
+ * (falling back to `id`). Returns `{ items }` in the same shape as
+ * `listSliceModels`/`listGlobalModelCatalog`. An empty/blank project list yields
+ * an empty set — never the global catalog.
+ *
+ * @param {object} transport - Semrush transport.
+ * @param {string} semrushWorkspaceId - Semrush workspace id the projects live in.
+ * @param {Array<string>} projectIds - the Semrush project ids to union over.
+ * @returns {Promise<{ items: Array<{ id: string, key: string, name: (string|null),
+ *   icon: (string|null) }> }>}
+ */
+export async function listUnionModels(transport, semrushWorkspaceId, projectIds) {
+  const ids = [...new Set((projectIds ?? []).filter((id) => hasText(id)).map(String))];
+  if (ids.length === 0) {
+    return { items: [] };
+  }
+  const perProject = await Promise.all(
+    ids.map((projectId) => listSliceModels(transport, semrushWorkspaceId, projectId)),
+  );
+  const byKey = new Map();
+  for (const { items } of perProject) {
+    for (const m of items) {
+      if (m) {
+        const dedupKey = hasText(m.key) ? m.key : m.id;
+        if (!byKey.has(dedupKey)) {
+          byKey.set(dedupKey, m);
+        }
+      }
+    }
+  }
+  return { items: [...byKey.values()] };
+}
+
+/**
  * Counts the project's currently-PUBLISHED prompts (the live layer), by paginating
  * `listPromptsByTags` with an empty tag filter — the same live-layer walk `listTagsForProject`
  * uses, with the same page ceiling. Used by the dynamic allocator to size the prompt re-meter of a
@@ -1047,9 +1082,12 @@ export async function handleListModels(
   const geoTargetId = normalizeGeoTargetId(query?.geoTargetId);
   const languageCode = normalizeLanguageCode(query?.languageCode);
 
-  // No-params path: return global model catalog.
+  // No-params path: return the union of models enabled across all the brand's
+  // projects (not the global catalog — that lives on the org-scoped endpoint).
   if (geoTargetId === null && languageCode === null) {
-    return listGlobalModelCatalog(transport);
+    const rows = await dataAccess.BrandSemrushProject.allByBrandId(brandId);
+    const projectIds = (rows ?? []).map((r) => r.getSemrushProjectId());
+    return listUnionModels(transport, semrushWorkspaceId, projectIds);
   }
 
   // Partial params: both must be provided together.

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -1003,7 +1003,16 @@ export async function listUnionModels(transport, semrushWorkspaceId, projectIds)
     return { items: [] };
   }
   const perProject = await Promise.all(
-    ids.map((projectId) => listSliceModels(transport, semrushWorkspaceId, projectId)),
+    ids.map((projectId) => listSliceModels(transport, semrushWorkspaceId, projectId)
+      .catch((e) => {
+        // Tolerate a stale/deleted project (404/405) — skip it rather than
+        // 500 the whole union, matching the old global-catalog path. Auth and
+        // other errors still propagate.
+        if (isSemrushTransportError(e) && (e.status === 404 || e.status === 405)) {
+          return { items: [] };
+        }
+        throw e;
+      })),
   );
   const byKey = new Map();
   for (const { items } of perProject) {

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -152,12 +152,19 @@ export default function serenityTests(
     // 404 tests above never reach.
     const base = `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/serenity`;
 
-    it('GET /serenity/models returns the workspace AI model catalog', async () => {
+    it('GET /serenity/models returns the union of models across the brand\'s markets', async () => {
+      // No-param brand-scoped models now returns the union of models enabled
+      // across the brand's projects (not the global catalog — that lives on the
+      // org-scoped endpoint asserted above). This seed ships no market slice for
+      // the workspace, so the union is empty — but a 200 with an `items` array
+      // proves the full read chain (relaxed auth → brand resolution →
+      // sub-workspace transport → resolveProjects → mock).
       const res = await getHttpClient().admin.get(`${base}/models`);
       expect(res.status).to.equal(200);
-      expect(res.body.items).to.be.an('array').that.is.not.empty;
-      // Every model carries the id/key/name the UI renders; assert the shape so a
-      // contract drift (renamed field / error body as 200) fails loudly.
+      expect(res.body.items).to.be.an('array');
+      // If any model comes back, it carries the id/key/name the UI renders;
+      // assert the shape so a contract drift (renamed field / error body as 200)
+      // fails loudly.
       res.body.items.forEach((m) => {
         expect(m).to.include.keys('id', 'key', 'name');
         expect(m.id).to.be.a('string');

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -1322,18 +1322,21 @@ describe('markets-subworkspace handlers', () => {
   });
 
   describe('handleListModelsSubworkspace', () => {
-    it('returns the global catalog when called without a slice', async () => {
+    it('unions the models enabled across all the workspace\'s projects when called without a slice', async () => {
+      const listAiModels = sinon.stub();
+      listAiModels.withArgs(WS, 'p-a').resolves({
+        items: [{ id: 'a-1', model: { id: 'm1', key: 'gpt-4o', name: 'GPT-4o' } }],
+      });
+      listAiModels.withArgs(WS, 'p-b').resolves({
+        items: [{ id: 'b-1', model: { id: 'm2', key: 'claude', name: 'Claude' } }],
+      });
       const transport = makeTransport({
-        listGlobalAiModels: sinon.stub().resolves({
-          items: [{ id: 'm1', key: 'gpt-4o', name: 'GPT-4o' }],
-        }),
+        listProjects: sinon.stub().resolves({ items: [proj({ id: 'p-a' }), proj({ id: 'p-b' })] }),
+        listAiModels,
       });
       const result = await handleListModelsSubworkspace(transport, WS, {}, log);
-      expect(result.items).to.deep.equal([{
-        id: 'm1', key: 'gpt-4o', name: 'GPT-4o', icon: null,
-      }]);
-      expect(transport.listGlobalAiModels).to.have.been.called;
-      expect(transport.listAiModels).to.not.have.been.called;
+      expect(result.items.map((m) => m.key)).to.have.members(['gpt-4o', 'claude']);
+      expect(transport.listGlobalAiModels).to.not.have.been.called;
     });
 
     it('returns the slice models when called with geo+lang', async () => {

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -1202,6 +1202,26 @@ describe('handlers/markets.js — handleListTags / handleListModels', () => {
       .to.be.rejectedWith(SerenityTransportError);
   });
 
+  it('listModels (no market) tolerates a 404 from a stale project and unions the rest', async () => {
+    const dataAccess = makeDataAccess([
+      makeProject({ semrushProjectId: 'proj-a', geoTargetId: 2840, languageCode: 'en' }),
+      makeProject({ semrushProjectId: 'proj-stale', geoTargetId: 2250, languageCode: 'fr' }),
+    ]);
+    const listAiModels = sinon.stub();
+    listAiModels.withArgs(WORKSPACE, 'proj-a').resolves({
+      items: [{
+        model: {
+          id: 'm-1', key: 'chatgpt', name: 'ChatGPT', icon: null,
+        },
+      }],
+    });
+    listAiModels.withArgs(WORKSPACE, 'proj-stale')
+      .rejects(new SerenityTransportError(404, 'not found'));
+    const transport = { listAiModels };
+    const result = await handleListModels(transport, dataAccess, BRAND, WORKSPACE, {});
+    expect(result.items.map((m) => m.key)).to.deep.equal(['chatgpt']);
+  });
+
   it('listModels 400s when only one of geoTargetId/languageCode is provided', async () => {
     const dataAccess = makeDataAccess([]);
     await expect(handleListModels({}, dataAccess, BRAND, WORKSPACE, { geoTargetId: 2840 }))

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -1131,99 +1131,74 @@ describe('handlers/markets.js — handleListTags / handleListModels', () => {
     );
   });
 
-  it('listModels (catalog mode) calls listGlobalAiModels and returns items', async () => {
-    const dataAccess = makeDataAccess([]);
-    const transport = {
-      listGlobalAiModels: sinon.stub().resolves({
-        items: [
-          {
-            id: 'cat-gpt-4o', key: 'chatgpt', name: 'ChatGPT', icon: null,
-          },
-          {
-            id: 'cat-claude', key: 'claude', name: 'Claude', icon: null,
-          },
-        ],
-      }),
-    };
+  it('listModels (no market) unions the models enabled across all the brand\'s projects', async () => {
+    const dataAccess = makeDataAccess([
+      makeProject({ semrushProjectId: 'proj-a', geoTargetId: 2840, languageCode: 'en' }),
+      makeProject({ semrushProjectId: 'proj-b', geoTargetId: 2250, languageCode: 'fr' }),
+    ]);
+    const listAiModels = sinon.stub();
+    listAiModels.withArgs(WORKSPACE, 'proj-a').resolves({
+      items: [{
+        model: {
+          id: 'm-1', key: 'chatgpt', name: 'ChatGPT', icon: null,
+        },
+      }],
+    });
+    listAiModels.withArgs(WORKSPACE, 'proj-b').resolves({
+      items: [{
+        model: {
+          id: 'm-2', key: 'claude', name: 'Claude', icon: null,
+        },
+      }],
+    });
+    const transport = { listAiModels };
     const result = await handleListModels(transport, dataAccess, BRAND, WORKSPACE, {});
     expect(result.items).to.have.lengthOf(2);
-    expect(result.items[0].id).to.equal('cat-gpt-4o');
-    expect(transport.listGlobalAiModels).to.have.callCount(1);
+    expect(result.items.map((m) => m.key)).to.have.members(['chatgpt', 'claude']);
+    expect(dataAccess.BrandSemrushProject.allByBrandId).to.have.been.calledOnceWith(BRAND);
   });
 
-  it('listModels (catalog mode) paginates when page 1 is full (100 items)', async () => {
-    const dataAccess = makeDataAccess([]);
-    const page1 = Array.from({ length: 100 }, (_, i) => ({
-      id: `cat-${i}`, key: `model-${i}`, name: null, icon: null,
-    }));
-    const stub = sinon.stub();
-    stub.onFirstCall().resolves({ items: page1 });
-    stub.onSecondCall().resolves({ items: [] });
-    const transport = { listGlobalAiModels: stub };
-    const result = await handleListModels(transport, dataAccess, BRAND, WORKSPACE, {});
-    expect(result.items).to.have.lengthOf(100);
-    expect(stub).to.have.callCount(2);
-  });
-
-  it('listModels (catalog mode) stops at MAX_AI_MODELS_PAGES (5) when upstream always returns full pages', async () => {
-    const dataAccess = makeDataAccess([]);
-    const fullPage = Array.from({ length: 100 }, (_, i) => ({
-      id: `cat-${i}`, key: `model-${i}`, name: null, icon: null,
-    }));
-    // Always return a full page — the ceiling guard must terminate the loop.
-    const stub = sinon.stub().resolves({ items: fullPage });
-    const transport = { listGlobalAiModels: stub };
-    const result = await handleListModels(transport, dataAccess, BRAND, WORKSPACE, {});
-    expect(stub).to.have.callCount(5);
-    expect(result.items).to.have.lengthOf(500);
-  });
-
-  it('listModels (catalog mode) also normalises wrapped assignment items from workspace endpoint', async () => {
-    const dataAccess = makeDataAccess([]);
-    const transport = {
-      listGlobalAiModels: sinon.stub().resolves({
-        items: [
-          {
-            id: 'assign-1',
-            model: {
-              id: 'cat-gpt', key: 'chatgpt', name: 'ChatGPT', icon: null,
-            },
-          },
-        ],
-      }),
+  it('listModels (no market) dedups a model enabled on more than one project', async () => {
+    const dataAccess = makeDataAccess([
+      makeProject({ semrushProjectId: 'proj-a', geoTargetId: 2840, languageCode: 'en' }),
+      makeProject({ semrushProjectId: 'proj-b', geoTargetId: 2250, languageCode: 'fr' }),
+    ]);
+    const shared = {
+      model: {
+        id: 'm-1', key: 'chatgpt', name: 'ChatGPT', icon: null,
+      },
     };
+    const listAiModels = sinon.stub();
+    listAiModels.withArgs(WORKSPACE, 'proj-a').resolves({ items: [shared] });
+    listAiModels.withArgs(WORKSPACE, 'proj-b').resolves({
+      items: [shared, {
+        model: {
+          id: 'm-2', key: 'claude', name: 'Claude', icon: null,
+        },
+      }],
+    });
+    const transport = { listAiModels };
     const result = await handleListModels(transport, dataAccess, BRAND, WORKSPACE, {});
-    expect(result.items).to.have.lengthOf(1);
-    expect(result.items[0].id).to.equal('cat-gpt');
+    expect(result.items).to.have.lengthOf(2);
+    expect(result.items.map((m) => m.key)).to.have.members(['chatgpt', 'claude']);
   });
 
-  it('listModels (catalog mode) returns empty when workspace endpoint responds 404/405', async () => {
+  it('listModels (no market) returns empty (never the global catalog) when the brand has no projects', async () => {
     const dataAccess = makeDataAccess([]);
-    const transport404 = {
-      listGlobalAiModels: sinon.stub().rejects(new SerenityTransportError(404, 'not found')),
-    };
-    const result404 = await handleListModels(transport404, dataAccess, BRAND, WORKSPACE, {});
-    expect(result404).to.deep.equal({ items: [] });
-
-    const transport405 = {
-      listGlobalAiModels: sinon.stub().rejects(new SerenityTransportError(405, 'not allowed')),
-    };
-    const result405 = await handleListModels(transport405, dataAccess, BRAND, WORKSPACE, {});
-    expect(result405).to.deep.equal({ items: [] });
+    const transport = { listAiModels: sinon.stub() };
+    const result = await handleListModels(transport, dataAccess, BRAND, WORKSPACE, {});
+    expect(result).to.deep.equal({ items: [] });
+    expect(transport.listAiModels).to.have.callCount(0);
   });
 
-  it('listModels (catalog mode) propagates auth errors (401/403) from workspace endpoint', async () => {
-    const dataAccess = makeDataAccess([]);
+  it('listModels (no market) propagates auth errors (401/403) from a per-project fetch', async () => {
+    const dataAccess = makeDataAccess([
+      makeProject({ semrushProjectId: 'proj-a', geoTargetId: 2840, languageCode: 'en' }),
+    ]);
     const transport401 = {
-      listGlobalAiModels: sinon.stub().rejects(new SerenityTransportError(401, 'unauthorized')),
+      listAiModels: sinon.stub().rejects(new SerenityTransportError(401, 'unauthorized')),
     };
     await expect(handleListModels(transport401, dataAccess, BRAND, WORKSPACE, {}))
-      .to.be.rejectedWith(SerenityTransportError);
-
-    const transport403 = {
-      listGlobalAiModels: sinon.stub().rejects(new SerenityTransportError(403, 'forbidden')),
-    };
-    await expect(handleListModels(transport403, dataAccess, BRAND, WORKSPACE, {}))
       .to.be.rejectedWith(SerenityTransportError);
   });
 


### PR DESCRIPTION
## Related Issues
[LLMO-6589](https://jira.corp.adobe.com/browse/LLMO-6589)

## Summary
The brand-scoped `GET /v2/orgs/:orgId/brands/:brandId/serenity/models` endpoint returned the global AI model catalog when called without a market. The SR platform filter uses it, so it listed models not enabled on any of the brand's projects. This changes the no-market path to return the union of models enabled across the brand's projects. The global catalog stays available on the org-scoped `GET /v2/orgs/:orgId/serenity/models` endpoint (used by the add-brand wizard).

## Changes
- Add `listUnionModels(transport, workspaceId, projectIds)` in `markets.js`: fetches each project's enabled models in parallel and dedups by model key.
- `handleListModels` no-market path now returns the union across the brand's projects (`allByBrandId` -> per-project `listSliceModels`), not the global catalog.
- `handleListModelsSubworkspace` no-market path returns the union across the workspace's projects (`resolveProjects` -> per-project `listSliceModels`).
- Update handler unit tests and the serenity IT to assert the union behavior.

## Test plan
- [x] `npm run type-check` passes (serenity `// @ts-check` gate).
- [x] `mocha markets.test.js markets-subworkspace.test.js` — 194 passing.
- [x] `mocha serenity.test.js serenity-api.test.js` (controller + OpenAPI) — 246 passing.
- [ ] Serenity IT (`test/it/shared/tests/serenity.js`) runs in CI (needs Docker + Semrush mock locally).

## Notes
- No API-spec change: the response envelope (`{ items: [...] }`) is unchanged; only which models the no-market brand-scoped call returns.
- Companion UI changes (point the SR model hooks at the brand-scoped endpoint) ship in a separate project-elmo-ui PR.

## Deferred follow-ups
- **Concurrency cap on the models fan-out.** `listUnionModels` fires one `listSliceModels` per project via `Promise.all` with no cap. The busiest brand today has 26 projects (`Julius Baer`). Deferred pending a live check of whether that burst trips Semrush throttling; add `p-limit` (~5-8) only if it does. Tracked with LLMO-6589 / raised by MysticatBot.
