### PR TITLE
chore(LLMO-5751): bump spacecat-shared-tokowaka-client to 1.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8764,7 +8764,7 @@
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client": {
       "version": "1.23.0",
-      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.23.0.tgz",
       "integrity": "sha512-kRp2zLp1UFJN+n/csI6ukYWZUq7Ne+5ecmiz82dbl10lgI61WdW4L6kyeACJFQ2C8ZBNVIl0mq0B7RhEkzwbNw==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@adobe/spacecat-shared-slack-client": "1.6.7",
         "@adobe/spacecat-shared-ticket-client": "^1.0.4",
         "@adobe/spacecat-shared-tier-client": "1.5.1",
-        "@adobe/spacecat-shared-tokowaka-client": "1.21.1",
+        "@adobe/spacecat-shared-tokowaka-client": "1.23.0",
         "@adobe/spacecat-shared-user-manager-client": "1.5.0",
         "@adobe/spacecat-shared-utils": "1.124.1",
         "@adobe/spacecat-shared-vault-secrets": "1.3.5",
@@ -8763,9 +8763,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-tokowaka-client": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.21.1.tgz",
-      "integrity": "sha512-yd7+pXjTTasalIp2KvP/FqakjA9TrcuErcbKo2P8dkXbTNLZPbXHeOfhE2VrQsPC953ZqP4BAxirapohQQcOhA==",
+      "version": "1.23.0",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/@adobe/spacecat-shared-tokowaka-client/-/spacecat-shared-tokowaka-client-1.23.0.tgz",
+      "integrity": "sha512-kRp2zLp1UFJN+n/csI6ukYWZUq7Ne+5ecmiz82dbl10lgI61WdW4L6kyeACJFQ2C8ZBNVIl0mq0B7RhEkzwbNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@adobe/spacecat-shared-slack-client": "1.6.7",
     "@adobe/spacecat-shared-ticket-client": "^1.0.4",
     "@adobe/spacecat-shared-tier-client": "1.5.1",
-    "@adobe/spacecat-shared-tokowaka-client": "1.21.1",
+    "@adobe/spacecat-shared-tokowaka-client": "1.23.0",
     "@adobe/spacecat-shared-user-manager-client": "1.5.0",
     "@adobe/spacecat-shared-utils": "1.124.1",
     "@adobe/spacecat-shared-vault-secrets": "1.3.5",


### PR DESCRIPTION
## Summary
- Bumps \`@adobe/spacecat-shared-tokowaka-client\` from \`1.21.1\` → \`1.23.0\`
- Picks up [adobe/spacecat-shared#1848](https://github.com/adobe/spacecat-shared/pull/1848): clear \`LAST_MOD_MISSING\` \`edgeOptimizeStatus\` on redeploy, matching the existing \`STALE\`-clearing behaviour in \`#deployPerUrlSuggestions\`

## Test plan
- [ ] CI passes
- [ ] No functional changes in this repo — pure dependency bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)