### PR TITLE
fix(test): create sinon fakes per test, not at module scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,14 @@ describe('Sites Controller', () => {
 });
 ```
 
+**Build every fake inside `beforeEach`, on a per-test sandbox** — never at module scope. A fake created at module scope is registered on sinon's *default* sandbox, and `sinon.restore()` in **any** other spec file empties that sandbox's fake collection. From then on `sinon.reset()` silently stops clearing the fake and its call history accumulates across the tests in your file, so an assertion like `getCalls().find(...)` starts reading an earlier test's call. Cleanup in your own `afterEach` does not protect you — the fake is created in the wrong place, not cleaned up in the wrong place.
+
+`mocha --parallel` (what `npm test` and CI run) gives each spec file its own process, so no other file's `sinon.restore()` can reach it and the whole failure mode is invisible. It appears only in serial runs — including the scoped single-file and single-directory runs under **Single Test Execution** above.
+
+A fake declared directly in a `describe` body is shared the same way, because mocha evaluates suite callbacks during collection, before any test runs. Assertions that scan call history — `getCalls().find(...)`, `calledOnce` — are the ones that break under sharing.
+
+A `no-restricted-syntax` rule in `eslint.config.js` fails the build on `sinon.stub/spy/fake/mock/createStubInstance/useFakeTimers()` evaluated at module load in `test/**/*.js`, in both the `sinon.stub()` and bare `stub()` call shapes. It catches the module-scope form only. The `describe`-body form is long-established style in this suite and is not enforced; nor can a syntactic rule see a fake built by a helper that is itself *called* at module load. Build fakes in `beforeEach` and none of these distinctions arise.
+
 **Tools**:
 - **Mocha**: Test runner
 - **Chai**: Assertions (`expect`, `chai-as-promised`)
@@ -634,6 +642,8 @@ For this repo:
 - Verify stubs are restored in `afterEach`
 - Use `esmock` for ES module mocking
 - Check test fixtures match current schema
+
+**A test that passes alone and fails in a serial run** (or passes under `npm test` and fails under `npx mocha <dir>/*.test.js`): look for a fake built at module scope rather than in `beforeEach`. Its call history survives across the tests in the file once another spec calls `sinon.restore()` — see the sandbox rules under **Standard Test Pattern**. The reverse pairing, green in serial and red in parallel, is a different problem: cross-file order dependence or a shared external resource.
 
 ### Debugging
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,33 @@
 import { defineConfig, globalIgnores } from '@eslint/config-helpers'
 import {recommended, source, test} from '@adobe/eslint-config-helix';
 
+// A sinon fake created at module scope lands on sinon's default sandbox and
+// outlives every test in the file. Any other spec calling `sinon.restore()`
+// drops it from that sandbox's collection, after which `sinon.reset()` no
+// longer clears it and call history accumulates across tests — a failure that
+// surfaces only in serial runs, never under `mocha --parallel` (issue 2932).
+const FAKE_FACTORY = '/^(stub|spy|fake|mock|createStubInstance|useFakeTimers)$/';
+// Both call shapes the repo uses: `sinon.stub()` and, via
+// `import sinon, { stub } from 'sinon'`, a bare `stub()`.
+const SINON_FAKE = `CallExpression[callee.object.name='sinon'][callee.property.name=${FAKE_FACTORY}]`;
+const BARE_FAKE = `CallExpression[callee.type='Identifier'][callee.name=${FAKE_FACTORY}]`;
+// `:not(:function *)` narrows these to fakes evaluated at module load. A fake
+// built inside a factory function is created per call and is not the hazard,
+// so it must not be flagged. This is a lexical test, not an execution-timing
+// one, so it cannot see a fake built by a helper that is itself called at
+// module load — build fakes in `beforeEach` and the distinction never arises.
+//
+// A fake declared directly in a `describe` body shares the hazard — mocha
+// evaluates suite callbacks during collection, so it too is created once for
+// the whole suite. That form is not covered here: it is long-established style
+// in this suite (hundreds of call sites), so enforcing it is a migration of its
+// own rather than something this rule can turn on. What is covered is the shape
+// that actually broke, and the one a new file is most likely to reach for.
+const SINON_SHARED_FAKE = `${SINON_FAKE}:not(:function *), ${BARE_FAKE}:not(:function *)`;
+const SINON_SHARED_FAKE_MESSAGE = 'Create sinon fakes per test, inside beforeEach, on a '
+  + 'sandbox from sinon.createSandbox() that afterEach restores. A fake created at module '
+  + 'scope is shared by every test in the file.';
+
 export default defineConfig([
   globalIgnores([
     '.vscode/*',
@@ -43,6 +70,16 @@ export default defineConfig([
     rules: {
       'no-console': 'off',
       'func-names': 'off',
+      'no-restricted-syntax': [
+        'error',
+        'ForInStatement',
+        'LabeledStatement',
+        'WithStatement',
+        {
+          selector: SINON_SHARED_FAKE,
+          message: SINON_SHARED_FAKE_MESSAGE,
+        },
+      ],
     },
   },
 ]);

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -2363,10 +2363,9 @@ describe('llmo-agentic-traffic — rotation (demo sites)', () => {
   let clock;
   beforeEach(() => {
     setUpAuthStubs();
-    clock = sinon.useFakeTimers({ now: Date.UTC(2026, 6, 6), toFake: ['Date'] });
+    clock = sandbox.useFakeTimers({ now: Date.UTC(2026, 6, 6), toFake: ['Date'] });
   });
   afterEach(() => {
-    clock.restore();
     sandbox.restore();
   });
 
@@ -2440,7 +2439,7 @@ describe('llmo-agentic-traffic — rotation (demo sites)', () => {
     // now=2026-07-13 (phase 1) ⇒ P0=Jun 15, window Jun 15–Jul 12. The last two slots
     // (j2,j3 = Jun 29–Jul 12) map to frozen weeks {3,0} → 2 non-contiguous segments.
     clock.restore();
-    clock = sinon.useFakeTimers({ now: Date.UTC(2026, 6, 13), toFake: ['Date'] });
+    clock = sandbox.useFakeTimers({ now: Date.UTC(2026, 6, 13), toFake: ['Date'] });
     const client = createMockClient({
       rpc_agentic_traffic_by_region: { data: [{ region: 'US', total_hits: 10 }], error: null },
     });

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -181,25 +181,26 @@ function makeExportContext(overrides = {}) {
   });
 }
 
-// Resolves with the same shape as the real getSiteAndValidateAccess so that
-// withAgenticTrafficAuth forwards { site, organization } to handlerFn as siteContext.
-const stubbedValidateAccess = sinon.stub().resolves({
-  site: { getOrganizationId: () => 'org-1' },
-  organization: { getId: () => 'org-1' },
-});
+let sandbox;
+let stubbedValidateAccess;
+
+// Fresh sandbox per test, so neither call history nor a per-test behaviour
+// override can reach the next test. `stubbedValidateAccess` resolves with the
+// same shape as the real getSiteAndValidateAccess, so withAgenticTrafficAuth
+// forwards { site, organization } to handlerFn as siteContext.
+function setUpAuthStubs() {
+  sandbox = sinon.createSandbox();
+  stubbedValidateAccess = sandbox.stub().resolves({
+    site: { getOrganizationId: () => 'org-1' },
+    organization: { getId: () => 'org-1' },
+  });
+}
 
 describe('llmo-agentic-traffic', () => {
-  const sandbox = sinon.createSandbox();
+  beforeEach(setUpAuthStubs);
 
   afterEach(() => {
     sandbox.restore();
-    // reset() clears call history AND any per-test behaviour overrides;
-    // then re-apply the default so subsequent tests get the site context.
-    stubbedValidateAccess.reset();
-    stubbedValidateAccess.resolves({
-      site: { getOrganizationId: () => 'org-1' },
-      organization: { getId: () => 'org-1' },
-    });
   });
 
   // ── Shared: PostgREST availability ──────────────────────────────────────────
@@ -2361,9 +2362,13 @@ describe('llmo-agentic-traffic — rotation (demo sites)', () => {
 
   let clock;
   beforeEach(() => {
+    setUpAuthStubs();
     clock = sinon.useFakeTimers({ now: Date.UTC(2026, 6, 6), toFake: ['Date'] });
   });
-  afterEach(() => clock.restore());
+  afterEach(() => {
+    clock.restore();
+    sandbox.restore();
+  });
 
   const assertCannedDates = (client) => {
     expect(client.rpc).to.have.been.called;

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -1463,13 +1463,11 @@ describe('llmo-referral-traffic — rotation (demo sites)', () => {
     conversion_rate: 0.03,
   };
 
-  let clock;
   beforeEach(() => {
     setUpAuthStubs();
-    clock = sinon.useFakeTimers({ now: Date.UTC(2026, 6, 6), toFake: ['Date'] });
+    sandbox.useFakeTimers({ now: Date.UTC(2026, 6, 6), toFake: ['Date'] });
   });
   afterEach(() => {
-    clock.restore();
     sandbox.restore();
   });
 

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -108,18 +108,24 @@ function makeContext(overrides = {}) {
   };
 }
 
-const stubbedValidateAccess = sinon.stub().resolves({
-  site: { getOrganizationId: () => 'org-1' },
-  organization: { getId: () => 'org-1' },
-});
+let sandbox;
+let stubbedValidateAccess;
+
+// Fresh sandbox per test, so neither call history nor a per-test behaviour
+// override can reach the next test.
+function setUpAuthStubs() {
+  sandbox = sinon.createSandbox();
+  stubbedValidateAccess = sandbox.stub().resolves({
+    site: { getOrganizationId: () => 'org-1' },
+    organization: { getId: () => 'org-1' },
+  });
+}
 
 describe('llmo-referral-traffic', () => {
+  beforeEach(setUpAuthStubs);
+
   afterEach(() => {
-    stubbedValidateAccess.reset();
-    stubbedValidateAccess.resolves({
-      site: { getOrganizationId: () => 'org-1' },
-      organization: { getId: () => 'org-1' },
-    });
+    sandbox.restore();
   });
 
   // ── auth / PostgREST availability ──────────────────────────────────────────
@@ -1459,9 +1465,13 @@ describe('llmo-referral-traffic — rotation (demo sites)', () => {
 
   let clock;
   beforeEach(() => {
+    setUpAuthStubs();
     clock = sinon.useFakeTimers({ now: Date.UTC(2026, 6, 6), toFake: ['Date'] });
   });
-  afterEach(() => clock.restore());
+  afterEach(() => {
+    clock.restore();
+    sandbox.restore();
+  });
 
   const assertCannedDates = (client) => {
     expect(client.rpc).to.have.been.called;

--- a/test/controllers/llmo/llmo-sheet-write.test.js
+++ b/test/controllers/llmo/llmo-sheet-write.test.js
@@ -77,8 +77,10 @@ describe('llmo-sheet-write', () => {
   });
 
   afterEach(() => {
-    // sandbox.restore() clears the per-test log fakes; sinon.restore() clears
-    // the ad hoc sinon.stub() calls the tests below make on the default sandbox.
+    // sandbox.restore() releases the per-test log fakes. sinon.restore() stays
+    // for the ad hoc sinon.stub() calls the tests below make on the default
+    // sandbox: those are built per test and are not the cross-file hazard, so
+    // they are left as they are rather than migrated in this change.
     sandbox.restore();
     sinon.restore();
   });

--- a/test/controllers/llmo/llmo-sheet-write.test.js
+++ b/test/controllers/llmo/llmo-sheet-write.test.js
@@ -62,15 +62,26 @@ const buildStubClient = ({ initialBuffer, exists = true }) => {
   };
 };
 
-const log = {
-  info: sinon.stub(),
-  warn: sinon.stub(),
-  error: sinon.stub(),
-  debug: sinon.stub(),
-};
+let sandbox;
+let log;
 
 describe('llmo-sheet-write', () => {
-  afterEach(() => sinon.restore());
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    };
+  });
+
+  afterEach(() => {
+    // sandbox.restore() clears the per-test log fakes; sinon.restore() clears
+    // the ad hoc sinon.stub() calls the tests below make on the default sandbox.
+    sandbox.restore();
+    sinon.restore();
+  });
 
   describe('sharepointPathFor / publishPathFor', () => {
     it('builds SharePoint and publish paths with sheetType', () => {
@@ -323,7 +334,11 @@ describe('llmo-sheet-write', () => {
       sharepointPath: '/sites/elmo-ui-data/customer/strategic-recommendations/strategic-recommendations-template.xlsx',
       publishPath: 'customer/strategic-recommendations/strategic-recommendations-template.json',
     };
-    const baseEnv = { env: { ADMIN_HLX_API_KEY: 'k' }, log };
+    let baseEnv;
+
+    beforeEach(() => {
+      baseEnv = { env: { ADMIN_HLX_API_KEY: 'k' }, log };
+    });
 
     it('updates the matching row, uploads the new workbook, and republishes', async () => {
       const initialBuffer = await buildWorkbookBuffer(sheets());
@@ -633,7 +648,11 @@ describe('llmo-sheet-write', () => {
       sharepointPath: '/sites/elmo-ui-data/customer/strategic-recommendations/strategic-recommendations-template.xlsx',
       publishPath: 'customer/strategic-recommendations/strategic-recommendations-template.json',
     };
-    const baseEnv = { env: { ADMIN_HLX_API_KEY: 'k' }, log };
+    let baseEnv;
+
+    beforeEach(() => {
+      baseEnv = { env: { ADMIN_HLX_API_KEY: 'k' }, log };
+    });
 
     it('applies multiple updates across worksheets in a single round-trip', async () => {
       const initialBuffer = await buildWorkbookBuffer(sheets());

--- a/test/controllers/project.test.js
+++ b/test/controllers/project.test.js
@@ -68,7 +68,10 @@ const sites = [
   console,
 ));
 
-const organization = new Organization(
+// Built fresh per test: several specs assign onto these instances
+// (project.save, project.remove), so a shared instance would carry one test's
+// stubs into the next.
+const buildOrganization = () => new Organization(
   {
     entities: {
       organization: {
@@ -93,7 +96,7 @@ const organization = new Organization(
   console,
 );
 
-const project = new Project(
+const buildProject = () => new Project(
   {
     entities: {
       project: {
@@ -135,8 +138,13 @@ describe('Projects Controller', () => {
   let mockDataAccess;
   let context;
   let projectsController;
+  let organization;
+  let project;
 
   beforeEach(() => {
+    organization = buildOrganization();
+    project = buildProject();
+
     mockDataAccess = {
       Project: {
         create: stub().resolves(project),

--- a/test/support/serenity/async-intent-classification.test.js
+++ b/test/support/serenity/async-intent-classification.test.js
@@ -14,9 +14,8 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import esmock from 'esmock';
 
-const log = {
-  info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
-};
+let sandbox;
+let log;
 
 async function loadWith({ createIntentClassifierStub, classifyIntentsStub }) {
   return esmock('../../../src/support/serenity/async-intent-classification.js', {
@@ -29,15 +28,21 @@ async function loadWith({ createIntentClassifierStub, classifyIntentsStub }) {
 
 describe('async-intent-classification.js — classifyPromptIntentsUnbounded (serenity-docs#33)', () => {
   beforeEach(() => {
-    log.info.resetHistory();
-    log.warn.resetHistory();
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   it('returns an empty map for no texts, without constructing a classifier', async () => {
-    const createIntentClassifierStub = sinon.stub();
+    const createIntentClassifierStub = sandbox.stub();
     const { classifyPromptIntentsUnbounded } = await loadWith({
       createIntentClassifierStub,
-      classifyIntentsStub: sinon.stub(),
+      classifyIntentsStub: sandbox.stub(),
     });
 
     const result = await classifyPromptIntentsUnbounded([], { log });
@@ -48,8 +53,8 @@ describe('async-intent-classification.js — classifyPromptIntentsUnbounded (ser
 
   it('leaves every text unclassified (null) when Azure is not configured', async () => {
     const { classifyPromptIntentsUnbounded } = await loadWith({
-      createIntentClassifierStub: sinon.stub().returns(null),
-      classifyIntentsStub: sinon.stub(),
+      createIntentClassifierStub: sandbox.stub().returns(null),
+      classifyIntentsStub: sandbox.stub(),
     });
 
     const result = await classifyPromptIntentsUnbounded(['a', 'b'], { log });
@@ -59,9 +64,9 @@ describe('async-intent-classification.js — classifyPromptIntentsUnbounded (ser
   });
 
   it('resolves on the first round without retrying when everything classifies', async () => {
-    const classifyIntentsStub = sinon.stub().resolves(new Map([['a', 'Task'], ['b', 'Commercial']]));
+    const classifyIntentsStub = sandbox.stub().resolves(new Map([['a', 'Task'], ['b', 'Commercial']]));
     const { classifyPromptIntentsUnbounded } = await loadWith({
-      createIntentClassifierStub: sinon.stub().returns(() => 'Task'),
+      createIntentClassifierStub: sandbox.stub().returns(() => 'Task'),
       classifyIntentsStub,
     });
 
@@ -73,11 +78,11 @@ describe('async-intent-classification.js — classifyPromptIntentsUnbounded (ser
   });
 
   it('retries only the still-unresolved subset on a later round, with no per-round timeout', async () => {
-    const classifyIntentsStub = sinon.stub();
+    const classifyIntentsStub = sandbox.stub();
     classifyIntentsStub.onCall(0).resolves(new Map([['a', 'Task']])); // 'b' unresolved
     classifyIntentsStub.onCall(1).resolves(new Map([['b', 'Commercial']]));
     const { classifyPromptIntentsUnbounded } = await loadWith({
-      createIntentClassifierStub: sinon.stub().returns(() => 'Task'),
+      createIntentClassifierStub: sandbox.stub().returns(() => 'Task'),
       classifyIntentsStub,
     });
 
@@ -93,9 +98,9 @@ describe('async-intent-classification.js — classifyPromptIntentsUnbounded (ser
   });
 
   it('leaves a text explicitly null (never defaults) once maxAttempts is exhausted', async () => {
-    const classifyIntentsStub = sinon.stub().resolves(new Map()); // never resolves 'a'
+    const classifyIntentsStub = sandbox.stub().resolves(new Map()); // never resolves 'a'
     const { classifyPromptIntentsUnbounded } = await loadWith({
-      createIntentClassifierStub: sinon.stub().returns(() => null),
+      createIntentClassifierStub: sandbox.stub().returns(() => null),
       classifyIntentsStub,
     });
 
@@ -107,9 +112,9 @@ describe('async-intent-classification.js — classifyPromptIntentsUnbounded (ser
   });
 
   it('dedupes texts before classifying', async () => {
-    const classifyIntentsStub = sinon.stub().resolves(new Map([['a', 'Task']]));
+    const classifyIntentsStub = sandbox.stub().resolves(new Map([['a', 'Task']]));
     const { classifyPromptIntentsUnbounded } = await loadWith({
-      createIntentClassifierStub: sinon.stub().returns(() => 'Task'),
+      createIntentClassifierStub: sandbox.stub().returns(() => 'Task'),
       classifyIntentsStub,
     });
 

--- a/test/support/serenity/intent-classification.test.js
+++ b/test/support/serenity/intent-classification.test.js
@@ -19,6 +19,9 @@ import { PER_CALL_MS } from '../../../src/support/serenity/intent-taxonomy.js';
 import { classifyIntents as realClassifyIntents } from '../../../src/support/intent-classifier.js';
 import { resolveEnvironment as realResolveEnvironment } from '../../../src/support/metrics-emf.js';
 
+// Assigned per test in beforeEach. The loader helpers below build their fakes on
+// `sandbox`, so they are callable only from inside a test or hook — never at
+// module load or in a describe body, where `sandbox` is still undefined.
 let sandbox;
 let log;
 

--- a/test/support/serenity/intent-classification.test.js
+++ b/test/support/serenity/intent-classification.test.js
@@ -19,15 +19,14 @@ import { PER_CALL_MS } from '../../../src/support/serenity/intent-taxonomy.js';
 import { classifyIntents as realClassifyIntents } from '../../../src/support/intent-classifier.js';
 import { resolveEnvironment as realResolveEnvironment } from '../../../src/support/metrics-emf.js';
 
-const log = {
-  info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
-};
+let sandbox;
+let log;
 
 // Shared EMF spy; a fresh reference per load so assertions target one call log.
 let emitMetricSpy;
 
 function metricsMock() {
-  emitMetricSpy = sinon.spy();
+  emitMetricSpy = sandbox.spy();
   return {
     '../../../src/support/metrics-emf.js': {
       emitMetric: emitMetricSpy,
@@ -46,8 +45,8 @@ function emittedMetric(name) {
 async function loadWithClassifier({ classify, classifyIntentsStub } = {}) {
   return esmock('../../../src/support/serenity/intent-classification.js', {
     '../../../src/support/intent-classifier.js': {
-      createIntentClassifier: sinon.stub().returns(classify),
-      classifyIntents: classifyIntentsStub || sinon.stub().resolves(new Map()),
+      createIntentClassifier: sandbox.stub().returns(classify),
+      classifyIntents: classifyIntentsStub || sandbox.stub().resolves(new Map()),
     },
     ...metricsMock(),
   });
@@ -78,12 +77,19 @@ async function loadWithRealBatch({ classifyByText }) {
 }
 
 describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)', () => {
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    };
+  });
+
   afterEach(() => {
-    sinon.reset();
+    sandbox.restore();
   });
 
   it('returns an empty map for an empty/falsy text list without touching the classifier', async () => {
-    const classifyIntentsStub = sinon.stub();
+    const classifyIntentsStub = sandbox.stub();
     const { classifyPromptIntents } = await loadWithClassifier({
       classify: () => {}, classifyIntentsStub,
     });
@@ -93,7 +99,7 @@ describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)'
   });
 
   it('treats a null/undefined texts argument as empty', async () => {
-    const classifyIntentsStub = sinon.stub();
+    const classifyIntentsStub = sandbox.stub();
     const { classifyPromptIntents } = await loadWithClassifier({
       classify: () => {}, classifyIntentsStub,
     });
@@ -105,7 +111,7 @@ describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)'
   });
 
   it('hard skip-gate: defaults everything and logs budget_skipped when no room at entry, without constructing a classifier', async () => {
-    const classifyIntentsStub = sinon.stub();
+    const classifyIntentsStub = sandbox.stub();
     const { classifyPromptIntents, computeWriteDeadline } = await loadWithClassifier({
       classify: () => {}, classifyIntentsStub,
     });
@@ -146,7 +152,7 @@ describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)'
   });
 
   it('uses the first-pass classification result and counts classified_ok, no retry when everything resolves', async () => {
-    const classifyIntentsStub = sinon.stub().resolves(new Map([
+    const classifyIntentsStub = sandbox.stub().resolves(new Map([
       ['a', 'Task'], ['b', 'Commercial'],
     ]));
     const { classifyPromptIntents } = await loadWithClassifier({
@@ -162,7 +168,7 @@ describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)'
   });
 
   it('retries once for unresolved texts when the budget allows, and uses the retry result on success', async () => {
-    const classifyIntentsStub = sinon.stub();
+    const classifyIntentsStub = sandbox.stub();
     classifyIntentsStub.onCall(0).resolves(new Map([['a', 'Task']])); // 'b' left unresolved
     classifyIntentsStub.onCall(1).resolves(new Map([['b', 'Navigational']]));
     const { classifyPromptIntents } = await loadWithClassifier({
@@ -179,7 +185,7 @@ describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)'
   });
 
   it('defaults to Informational when the retry also fails to resolve a text', async () => {
-    const classifyIntentsStub = sinon.stub();
+    const classifyIntentsStub = sandbox.stub();
     classifyIntentsStub.onCall(0).resolves(new Map()); // nothing resolved
     classifyIntentsStub.onCall(1).resolves(new Map()); // retry also resolves nothing
     const { classifyPromptIntents } = await loadWithClassifier({
@@ -195,14 +201,14 @@ describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)'
 
   it('skips the retry (defaults immediately) when the deadline has no room left for a second call', async () => {
     const t0 = 1_000_000_000;
-    const clock = sinon.useFakeTimers(t0);
+    const clock = sandbox.useFakeTimers(t0);
     try {
       // Entry hard-skip-gate passes (remaining ≈ PER_CALL_MS + 50ms of slack), but
       // the mocked first-pass classify call "spends" 60ms of wall-clock via the
       // fake timer, so by the time the retry-gate check runs, remaining budget has
       // dropped below PER_CALL_MS — the retry is skipped, not attempted.
       const deadline = t0 + CREATE_PUBLISH_RESERVE_MS + PER_CALL_MS + 50;
-      const classifyIntentsStub = sinon.stub().callsFake(async () => {
+      const classifyIntentsStub = sandbox.stub().callsFake(async () => {
         clock.tick(60);
         return new Map(); // nothing resolved on the first pass
       });
@@ -220,12 +226,19 @@ describe('intent-classification.js — classifyPromptIntents (serenity-docs#32)'
 });
 
 describe('intent-classification.js — observability (serenity-docs#32)', () => {
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    };
+  });
+
   afterEach(() => {
-    sinon.reset();
+    sandbox.restore();
   });
 
   it('emits IntentOutcome counters dimensioned by WritePath + Workspace, and IntentValueDistribution by WritePath', async () => {
-    const classifyIntentsStub = sinon.stub().resolves(new Map([
+    const classifyIntentsStub = sandbox.stub().resolves(new Map([
       ['a', 'Task'], ['b', 'Task'], ['c', 'Commercial'],
     ]));
     const { classifyPromptIntents } = await loadWithClassifier({
@@ -364,7 +377,7 @@ describe('intent-classification.js — observability (serenity-docs#32)', () => 
 
   it('emits per-call latency (p50/p95), a per-call timeout tally, and a prod repeated-invoke-failure signal', async () => {
     const t0 = 1_000_000_000;
-    const clock = sinon.useFakeTimers(t0);
+    const clock = sandbox.useFakeTimers(t0);
     try {
       // Every call "spends" the full per-call budget and resolves null → a
       // heuristic timeout, and no text ever resolves → repeated-invoke-failure.
@@ -414,10 +427,10 @@ describe('intent-classification.js — observability (serenity-docs#32)', () => 
   });
 
   it('never throws into the classify path when emitMetric itself throws', async () => {
-    const classifyIntentsStub = sinon.stub().resolves(new Map([['a', 'Task']]));
+    const classifyIntentsStub = sandbox.stub().resolves(new Map([['a', 'Task']]));
     const mod = await esmock('../../../src/support/serenity/intent-classification.js', {
       '../../../src/support/intent-classifier.js': {
-        createIntentClassifier: sinon.stub().returns(() => {}),
+        createIntentClassifier: sandbox.stub().returns(() => {}),
         classifyIntents: classifyIntentsStub,
       },
       '../../../src/support/metrics-emf.js': {

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -18,10 +18,10 @@ import esmock from 'esmock';
 
 use(sinonChai);
 
-// Mock TierClient at the top level
-const mockTierClient = {
-  createForSite: sinon.stub(),
-};
+// Mock TierClient at the top level. The object identity has to stay stable —
+// esmock injects this very reference into the module under test in the before()
+// hook below — so only the fake on it is replaced, fresh in each beforeEach.
+const mockTierClient = {};
 
 // Import RunAuditCommand with mocked TierClient
 let RunAuditCommand;
@@ -73,11 +73,10 @@ describe('RunAuditCommand', () => {
     };
     slackContext = { say: sinon.spy() };
 
-    // Reset and set default behavior for TierClient mock.
+    // Default behaviour for the TierClient mock.
     // The Slack run-audit handler checks `siteEnrollment` (matching the audit-worker's
     // downstream gate); `entitlement` is intentionally not consulted.
-    mockTierClient.createForSite.reset();
-    mockTierClient.createForSite.resolves({
+    mockTierClient.createForSite = sinon.stub().resolves({
       checkValidEntitlement: sinon.stub().resolves({ siteEnrollment: { id: 'enr-123' } }),
     });
   });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Test-suite fix: seven spec files built their sinon fakes at module scope, where the fakes are shared across every test in the file. They now build them per test on a dedicated sandbox, and a lint rule keeps the pattern from returning.

## 2. Reasoning
`test/support/serenity/intent-classification.test.js` passed under `npm test` and failed whenever the serenity suite ran serially — which is what a developer does when scoping a run to the files they touched.

Three facts compose. A sinon fake created at module scope is registered on sinon's default sandbox. `sinon.restore()` empties that sandbox's fake collection, so any fake registered before that call stops being tracked and every later `sinon.reset()` silently becomes a no-op for it. Sixty-one spec files in this suite call `sinon.restore()`. When any of them runs first in the same process, the failing file's `afterEach` quietly stops clearing its logger stubs and call history accumulates across its own tests.

The assertion then reads the wrong call: it scans for the *first* log matching a soft-failure pattern, and with history retained that is an earlier test's log carrying two samples rather than its own carrying ten.

CI never saw this. `npm test` runs `mocha --parallel`, giving each spec file its own process and its own default sandbox, so no other file's `sinon.restore()` can reach it. The bug is invisible to CI by construction and appears only in serial runs.

## 3. High-level overview of the changes
No production source is touched; this changes test setup, a lint rule, and the contributor documentation.

**Fake lifetime.** Before, the affected files created stubs once at module load and relied on `afterEach` to clear them — a contract that another file could silently void. After, each file creates its fakes inside `beforeEach` on a sandbox from `sinon.createSandbox()` and restores that sandbox in `afterEach`. Nothing survives a test boundary, so no other file's cleanup can reach them.

**Blast radius was wider than the issue reported.** The issue found one file by scanning for module-scope fakes *plus* reliance on `sinon.reset()`. Scanning for module-load fakes generally found six more carrying the same latent shape — including `async-intent-classification.test.js` with a byte-identical logger-stub construction, and `llmo-sheet-write.test.js`, which calls `sinon.restore()` in its own `afterEach` while holding module-scope stubs. None were failing yet; all could fail the same way once assertions or file ordering shifted.

Two of those files needed more than a mechanical move:

- `llmo-sheet-write.test.js` built a context object in a `describe` body that closed over the logger. Mocha evaluates suite callbacks during collection, before any hook runs, so that object captured the fake before it existed. It is now assembled per test.
- `project.test.js` shared two model instances across tests that individual specs assign onto. They are now built per test from factory functions, so one test's assignment cannot reach the next.

`run-audit.test.js` keeps its mock object's identity stable, because esmock injects that exact reference into the module under test; only the fake on it is replaced per test.

**Guard rail.** A `no-restricted-syntax` rule in the test override rejects sinon fakes evaluated at module load, covering both the `sinon.stub()` and the bare `stub()` call shape this suite uses via a named import. The rule deliberately does not fire on fakes built inside factory functions, which are created per call and are not the hazard.

**Documentation.** `CLAUDE.md` now states the sandbox rule and the mechanism behind it in the Standard Test Pattern section, and the troubleshooting section gains the symptom that identifies this class: a test that passes alone and fails in a serial run.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/2932

Closes #2932

## 6. Additional information outside the code
Verification done in-session, beyond running the suites:

- **The mechanism was reproduced in isolation** rather than taken from the issue. A standalone script confirmed that `sinon.reset()` clears a fake normally, and that after an intervening `sinon.restore()` the same `reset()` leaves call history intact.
- **The same script showed the issue's suggested fix keeps the trap one level in.** A dedicated sandbox is immune to *other* files' `sinon.restore()`, but calling `sandbox.restore()` on that sandbox disarms its own later `sandbox.reset()` in exactly the same way. The per-test sandbox used here avoids this, since the sandbox is never reused after being restored.
- **The lint selector was measured, not assumed.** An early, broader form flagged sites inside module-scope factory functions — fakes created per call, not the hazard. The selector was narrowed and re-measured against the whole test tree until every remaining hit was a genuine module-load fake, then widened to the bare-`stub()` call shape after finding a file that imports it that way.
- **A per-file before/after comparison** was taken by stashing the change, so each converted file's result could be checked against its own pre-change state rather than against expectation.
- **One scoping decision worth flagging.** A fake declared directly in a `describe` body carries the same hazard, since suite callbacks also run once at collection. Extending the rule to cover that form was implemented and measured: it flags several hundred existing sites across the suite. That form is long-established style here, so enforcing it is a migration in its own right and is out of scope for this fix; the rule covers the module-scope form that actually broke, and the limitation is recorded in both the rule's comment and `CLAUDE.md` rather than left silent.

Unrelated pre-existing condition, noted because it shows up in a full local run: `npm test` reports one uncaught error from a missing `@aws-sdk/client-dynamodb`, an undeclared electrodb peer dependency absent from local `node_modules`. It is present identically before this change and is untouched here.

## 7. Test plan
This change has no runtime surface — it alters when test doubles are constructed, plus a lint rule and documentation. There is nothing to exercise on a deployed environment, and no eph/dev/stage/prod verification applies.

To verify locally:

- Reproduce the original failure on `main` by running the two files together serially, mapping-rows first, then intent-classification. The soft-failure sample assertion fails there and passes on this branch.
- Run the serenity suite serially over its full glob. This is the run the issue describes and the one CI's parallel mode cannot represent.
- Run each of the seven changed spec files on its own, and then together, to confirm neither isolation nor co-execution changes their results.
- Confirm the guard rail bites: add a module-scope `sinon.stub()` to any file under `test/` and check that lint rejects it, then move it into `beforeEach` and check that it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
