### PR TITLE
fix: worker deploy job missing HLX_AWS_REGION for hedy's --aws-region resolution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,11 @@ jobs:
         run: npm run ${{ inputs.environment == 'dev' && 'deploy-dev:worker' || 'deploy-stage:worker' }}
         env:
           AWS_REGION: us-east-1
+          # hedy resolves --aws-region from this HLX_-prefixed env var, not
+          # AWS_REGION/AWS_DEFAULT_REGION (those only configure the AWS SDK
+          # client) - the reusable service-ci workflow sets this at its own
+          # workflow level, which this repo-local job doesn't inherit.
+          HLX_AWS_REGION: us-east-1
           AWS_ACCOUNT_ID: ${{ inputs.environment == 'dev' && secrets.AWS_ACCOUNT_ID_DEV || secrets.AWS_ACCOUNT_ID_STAGE }}
           VPC_SUBNET_1: ${{ secrets.VPC_SUBNET_1 }}
           VPC_SUBNET_2: ${{ secrets.VPC_SUBNET_2 }}


### PR DESCRIPTION
## Summary
- The first `workflow_dispatch` run of the `deploy-worker` job added in #2935 failed with `Error: AWS target needs --aws-region`.
- `hedy` (helix-deploy) resolves `--aws-region` from an `HLX_AWS_REGION`-prefixed env var — not `AWS_REGION`/`AWS_DEFAULT_REGION`, which only configure the AWS SDK client used to make the actual API calls. Confirmed by checking `@adobe/helix-deploy`'s `AWSConfig.js` (option defined with `default: ''`, no env fallback) and by diffing against a successful `ci / deploy-stage` run's logs, which show `HLX_AWS_REGION` being set — that's set at the *reusable* `service-ci.yaml` workflow's own top-level `env:` block, which `deploy-worker` (a job in this repo's own `ci.yaml`, not part of that reusable workflow) doesn't inherit.
- Adds `HLX_AWS_REGION: us-east-1` alongside the existing `AWS_REGION: us-east-1` in the deploy step's env.

## Context
Follow-up to [#2935](https://github.com/adobe/spacecat-api-service/pull/2935). Found by actually running `gh workflow run ci.yaml -f environment=dev` and inspecting the failure logs.

## Test plan
- [x] YAML parses cleanly
- [x] Confirmed the missing-region error and the `HLX_AWS_REGION` fix locally against a manual `hedy` invocation (adding `--aws-region` directly gets past this exact error)
- [ ] `gh workflow run ci.yaml -f environment=dev` deploys `spacecat-services--serenity-job-runner` successfully (to be run once this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)