### PR TITLE
fix(deps): bump @adobe/spacecat-shared-data-access to 4.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "4.15.0",
+        "@adobe/spacecat-shared-data-access": "4.15.1",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.0.tgz",
-      "integrity": "sha512-mc+0vzQdJPQGes833MMFLWAxm50VdrCK/YoO2GsWlvL4dv/Ft2L+IUC4jGJKYy945aFWauCMqPXgJeGx/aGMMA==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.1.tgz",
+      "integrity": "sha512-PxrlbtxibRqTstqW4iszQDUz8R+v/jZmZu8hYkreGs8dUG2vg2VICYuaeUQSdx2MsU2JJ/4IhPuJHd/bmk5Gag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "4.14.0",
+        "@adobe/spacecat-shared-data-access": "4.15.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.14.0.tgz",
-      "integrity": "sha512-2htDYzhU/tfFGhqDmV9PDTfuqsMjSHMnrxtSMFNeLKUSALkTzKLXXTPR9wME/mhp1V7x0lKiI6bW32QiD9GECw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.0.tgz",
+      "integrity": "sha512-mc+0vzQdJPQGes833MMFLWAxm50VdrCK/YoO2GsWlvL4dv/Ft2L+IUC4jGJKYy945aFWauCMqPXgJeGx/aGMMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "4.15.0",
+    "@adobe/spacecat-shared-data-access": "4.15.1",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "4.14.0",
+    "@adobe/spacecat-shared-data-access": "4.15.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",


### PR DESCRIPTION
## Summary
Follow-up to #2937, which bumped to `4.14.0` — but that version was published 2026-07-27, two days *before* adobe/spacecat-shared#1850 (the `showWww` schema field) merged on 2026-07-29. `4.14.0` doesn't contain the field.

Updated to `4.15.1` (a newer patch release with an unrelated fix — `cdnlogsFilter` key validation, spacecat-shared#1851 — that still carries `showWww`), rather than staying pinned to `4.15.0` now that a newer patch is available.

Caught the original 4.14.0 mismatch by testing locally against the running dev server: with `4.14.0` installed, `config.js` had no `showWww` reference at all; confirmed present from `4.15.0` onward.

## Test plan
- [x] Verified locally: `grep showWww node_modules/@adobe/spacecat-shared-data-access/src/models/site/config.js` — absent in 4.14.0, present in 4.15.0/4.15.1
- [x] `npm test` — 16188 passing