### PR TITLE
fix(sites): map config ValidationError to 400 on PATCH /sites

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -1112,7 +1112,14 @@ function SitesController(ctx, log, env) {
       if (auditTargetURLsResult?.normalized !== undefined) {
         merged.auditTargetURLs = auditTargetURLsResult.normalized;
       }
-      site.setConfig(merged);
+      try {
+        site.setConfig(merged);
+      } catch (error) {
+        if (error?.name === 'ValidationError') {
+          return badRequest(error.message);
+        }
+        throw error;
+      }
       updates = true;
     }
 

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -20,6 +20,7 @@ import {
   notFound,
   ok,
 } from '@adobe/spacecat-shared-http-utils';
+import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 import {
   hasText,
   isBoolean,
@@ -63,6 +64,8 @@ import { listViewableResourceIds } from '../support/state-access-mapping-utils.j
 import { requirePostgrestForFacsMappings } from '../support/postgrest-availability.js';
 import { isFacsRebacResource } from '../routes/facs-capabilities.js';
 import { ASO_PRODUCT_CODE, STATUSES as PLG_STATUSES } from './plg/plg-onboarding/constants.js';
+
+const VALIDATION_ERROR_NAME = 'ValidationError';
 
 /**
  * Builds the standard resolve-site success payload.
@@ -1115,8 +1118,11 @@ function SitesController(ctx, log, env) {
       try {
         site.setConfig(merged);
       } catch (error) {
-        if (error?.name === 'ValidationError') {
-          return badRequest(error.message);
+        if (error?.name === VALIDATION_ERROR_NAME) {
+          // cleanupHeaderValue strips chars HTTP headers can't carry (CR/LF and
+          // non-ASCII that would otherwise throw ERR_INVALID_CHAR); the Joi error
+          // message can echo back arbitrary request input.
+          return badRequest(cleanupHeaderValue(error.message || 'Invalid config').slice(0, 500));
         }
         throw error;
       }

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -4784,6 +4784,43 @@ describe('Sites Controller', () => {
     expect(mergedConfig).to.deep.equal({ slack: { channel: '#new' } });
   });
 
+  it('returns 400 when site.setConfig throws a ValidationError', async () => {
+    const site = sites[0];
+    site.getConfig = sandbox.stub().returns(null);
+    const validationError = new Error('Invalid config for Site: "llmo.showWww" must be a boolean');
+    validationError.name = 'ValidationError';
+    site.setConfig = sandbox.stub().throws(validationError);
+    site.save = sandbox.stub().resolves(site);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: { llmo: { showWww: 'not-a-boolean' } },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(400);
+    const body = await response.json();
+    expect(body.message).to.equal(validationError.message);
+    expect(site.save).to.have.not.been.called;
+  });
+
+  it('rethrows a non-ValidationError from site.setConfig', async () => {
+    const site = sites[0];
+    site.getConfig = sandbox.stub().returns(null);
+    site.setConfig = sandbox.stub().throws(new Error('unexpected boom'));
+    site.save = sandbox.stub().resolves(site);
+
+    await expect(sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: { slack: { channel: '#new' } },
+      },
+      ...defaultAuthAttributes,
+    })).to.be.rejectedWith('unexpected boom');
+  });
+
   it('sets config when toDynamoItem returns null for existing config', async () => {
     const site = sites[0];
     site.getConfig = sandbox.stub().returns({ something: true });

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -4806,6 +4806,28 @@ describe('Sites Controller', () => {
     expect(site.save).to.have.not.been.called;
   });
 
+  it('sanitizes control characters in the ValidationError message before returning it', async () => {
+    const site = sites[0];
+    site.getConfig = sandbox.stub().returns(null);
+    const validationError = new Error('Invalid config for Site: bad value\r\nX-Injected: true');
+    validationError.name = 'ValidationError';
+    site.setConfig = sandbox.stub().throws(validationError);
+    site.save = sandbox.stub().resolves(site);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: { llmo: { showWww: 'not-a-boolean' } },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(400);
+    const body = await response.json();
+    expect(body.message).to.not.contain('\r');
+    expect(body.message).to.not.contain('\n');
+  });
+
   it('rethrows a non-ValidationError from site.setConfig', async () => {
     const site = sites[0];
     site.getConfig = sandbox.stub().returns(null);


### PR DESCRIPTION
## Summary
Companion to adobe/spacecat-shared#1852, which adds schema enforcement to `Site.setConfig()` (gated behind `CONFIG_VALIDATION_ENFORCEMENT`, default `warn` — no behavior change until flipped). Once enforced, an invalid config throws a `ValidationError`; this handler previously had no catch for it, so it would escape `PATCH /sites/{id}` as an unhandled 500 instead of a clean 400.

Wraps `site.setConfig(merged)` in a try/catch, mapping `error.name === 'ValidationError'` to `badRequest(error.message)` — the exact same pattern already used in `suggestions.js`/`opportunities.js`/`fixes.js` for their `setStatus`-guarded saves.

## Context
Found while manually verifying the `showWww` display fix (#2937/#2943): `PATCH /sites/{id}` with an invalid `config.llmo.showWww` value returned 200 and silently stored the bad value. That's fixed at the schema-enforcement layer in spacecat-shared#1852; this PR ensures the error surfaces cleanly to API callers once enforcement is turned on.

## Test plan
- [x] New tests: 400 on `ValidationError`, rethrow (uncaught) for any other error type
- [x] `npx mocha test/controllers/sites.test.js` — 423 passing
- [x] `npm test` — 16190 passing
- [x] `npx eslint src/controllers/sites.js test/controllers/sites.test.js` — clean