### PR TITLE
feat(llmo): log client attribution on brand-presence source fetches

### DIFF
--- a/src/controllers/llmo/llmo-source.js
+++ b/src/controllers/llmo/llmo-source.js
@@ -46,6 +46,22 @@ export const EMPTY_SHEET_PAYLOAD = {
 export const fetchLlmoSource = async (context, url) => {
   const { log, env } = context;
 
+  // Structured, queryable client-attribution signal for every outbound source
+  // fetch (both /llmo/data and /llmo/sheet-data route through here). Emitted at
+  // `info` (NOT debug): prod suppresses debug. `x-client-type` and `referer`
+  // distinguish the calling app (e.g. llmo-spacecat-dashboard vs llm-optimizer-ui)
+  // 1:1 with the fetched `url`, since request headers are otherwise not logged.
+  const headers = context.pathInfo?.headers || {};
+  const authInfo = context.attributes?.authInfo;
+  log.info('llmo_source_client', {
+    event: 'llmo_source_client',
+    url,
+    xClientType: headers['x-client-type'] || null,
+    referer: headers.referer || headers.referrer || null,
+    userAgent: headers['user-agent'] || null,
+    authType: authInfo?.getType?.() || null,
+  });
+
   if (!env.LLMO_HLX_API_KEY) {
     const err = new Error('LLMO_HLX_API_KEY environment variable is not configured');
     err.isConfigError = true;

--- a/src/controllers/llmo/llmo-source.js
+++ b/src/controllers/llmo/llmo-source.js
@@ -46,8 +46,16 @@ export const EMPTY_SHEET_PAYLOAD = {
 export const fetchLlmoSource = async (context, url) => {
   const { log, env } = context;
 
+  if (!env.LLMO_HLX_API_KEY) {
+    const err = new Error('LLMO_HLX_API_KEY environment variable is not configured');
+    err.isConfigError = true;
+    throw err;
+  }
+
   // Structured, queryable client-attribution signal for every outbound source
-  // fetch (both /llmo/data and /llmo/sheet-data route through here). Emitted at
+  // fetch (both /llmo/data and /llmo/sheet-data route through here). Placed
+  // after the config guard so it only fires for fetches that actually proceed
+  // (a missing key throws above and produces no outbound request). Emitted at
   // `info` (NOT debug): prod suppresses debug. `x-client-type` and `referer`
   // distinguish the calling app (e.g. llmo-spacecat-dashboard vs llm-optimizer-ui)
   // 1:1 with the fetched `url`, since request headers are otherwise not logged.
@@ -61,12 +69,6 @@ export const fetchLlmoSource = async (context, url) => {
     userAgent: headers['user-agent'] || null,
     authType: authInfo?.getType?.() || null,
   });
-
-  if (!env.LLMO_HLX_API_KEY) {
-    const err = new Error('LLMO_HLX_API_KEY environment variable is not configured');
-    err.isConfigError = true;
-    throw err;
-  }
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);

--- a/test/controllers/llmo/llmo-source.test.js
+++ b/test/controllers/llmo/llmo-source.test.js
@@ -162,6 +162,46 @@ describe('llmo-source', () => {
     }
   });
 
+  describe('client attribution log (llmo_source_client)', () => {
+    it('logs x-client-type, referer, user-agent and auth identity 1:1 with the url', async () => {
+      tracingFetchStub.resolves(mockResponse({}));
+      context.pathInfo = {
+        headers: {
+          'x-client-type': 'BP Data Quality Monitor - Spacecat/1.0',
+          referer: 'https://llmo-dashboard.adobecqms.net/',
+          'user-agent': 'Mozilla/5.0 Chrome/150.0.0.0',
+        },
+      };
+      context.attributes = {
+        authInfo: { getType: () => 'jwt' },
+      };
+
+      await fetchLlmoSource(context, TEST_URL);
+
+      expect(context.log.info).to.have.been.calledWith('llmo_source_client', {
+        event: 'llmo_source_client',
+        url: TEST_URL,
+        xClientType: 'BP Data Quality Monitor - Spacecat/1.0',
+        referer: 'https://llmo-dashboard.adobecqms.net/',
+        userAgent: 'Mozilla/5.0 Chrome/150.0.0.0',
+        authType: 'jwt',
+      });
+    });
+
+    it('emits nulls (never throws) when headers and authInfo are absent', async () => {
+      tracingFetchStub.resolves(mockResponse({}));
+      await fetchLlmoSource(context, TEST_URL);
+      expect(context.log.info).to.have.been.calledWith('llmo_source_client', {
+        event: 'llmo_source_client',
+        url: TEST_URL,
+        xClientType: null,
+        referer: null,
+        userAgent: null,
+        authType: null,
+      });
+    });
+  });
+
   describe('llmoSourceErrorResponse', () => {
     it('maps isTimeout -> 504 with x-error header', () => {
       const e = new Error('Request timeout after 15000ms');

--- a/test/controllers/llmo/llmo-source.test.js
+++ b/test/controllers/llmo/llmo-source.test.js
@@ -159,6 +159,8 @@ describe('llmo-source', () => {
     } catch (err) {
       expect(err.isConfigError).to.equal(true);
       expect(tracingFetchStub).to.not.have.been.called;
+      // No attribution log for a fetch that never happens (guard precedes it).
+      expect(context.log.info).to.not.have.been.calledWith('llmo_source_client');
     }
   });
 


### PR DESCRIPTION
## What

Adds a structured, queryable `llmo_source_client` info log in `fetchLlmoSource` — the single choke point every brand-presence source fetch goes through (both `/llmo/data` daily-file and `/llmo/sheet-data` weekly routes). It records the outbound `url` alongside the calling client's request headers: `x-client-type`, `referer`, `user-agent`, and the `authType`.

## Why

Brand-presence sheet traffic to the Helix/SharePoint source (`main--project-elmo-ui-data--adobe.aem.live/...`, including bacom) currently cannot be attributed to a specific client from existing logs:
- api-service does not log request headers on this path.
- The inbound sheet route is not captured at the CDN (Fastly access logging is off / the route isn't in the logged stream).

This one line makes attribution possible **1:1** — every source fetch record carries both the fetched URL and the caller's client identity, so in CloudWatch/Coralogix you can tell apart, e.g., `x-client-type: BP Data Quality Monitor - Spacecat/1.0` (llmo-spacecat-dashboard) vs `llm-optimizer-ui` (project-elmo-ui), and `referer` `llmo-dashboard.adobecqms.net` vs `llmo.now`.

Example query:
```
filter event = "llmo_source_client" and url like /bacom/brand-presence/
| stats count(*) by xClientType, referer
```

## Notes

- Log-only, additive — no behavior change. One choke point covers both routes.
- Emitted at `info` (prod suppresses `debug`), matching the existing `logNotProvisioned` convention in this file.
- No user/PII fields (no JWT `sub`) — `x-client-type` + `referer` are sufficient discriminators.
- Unit tests added for populated and absent header/auth cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)