### PR TITLE
fix(serenity): gate the Semrush error allowance behind the serenity_ui org flag | LLMO-6565

### DIFF
--- a/docs/openapi/brands-v2-api.yaml
+++ b/docs/openapi/brands-v2-api.yaml
@@ -187,9 +187,10 @@ v2-brand-for-org:
       '401':
         description: |
           Upstream authorization failed. The org carries the `LLMO/serenity_ui`
-          feature flag and the caller could not be authenticated to Semrush for the
-          re-sync (no or expired promise token). The brand row may already be
-          committed; the re-sync did not run.
+          feature flag and the caller could not be authenticated to the upstream
+          provider for the re-sync — the request carried no usable IMS user token,
+          or the token had expired. The brand row may already be committed; the
+          re-sync did not run.
       '403':
         description: |
           Forbidden. One of:

--- a/docs/openapi/brands-v2-api.yaml
+++ b/docs/openapi/brands-v2-api.yaml
@@ -173,7 +173,9 @@ v2-brand-for-org:
         description: |
           Brand updated successfully. For a sub-workspace brand the body may include:
           - `semrushSyncPending: true` when the row persisted but the Semrush re-sync
-            failed (Semrush unavailable or user not provisioned).
+            failed (Semrush unavailable or user not provisioned). Only for an org
+            still inside the Semrush migration window — with the `LLMO/serenity_ui`
+            feature flag on, that same failure is reported as 401/403/502 instead.
           - `semrushRejectedAliases` listing per-market aliases Semrush refused during
             an otherwise successful re-sync.
         content:
@@ -182,14 +184,23 @@ v2-brand-for-org:
               $ref: './schemas.yaml#/V2BrandUpdateResponse'
       '400':
         $ref: './responses.yaml#/400'
+      '401':
+        description: |
+          Upstream authorization failed. The org carries the `LLMO/serenity_ui`
+          feature flag and the caller could not be authenticated to Semrush for the
+          re-sync (no or expired promise token). The brand row may already be
+          committed; the re-sync did not run.
       '403':
         description: |
-          Forbidden. Either the user does not have access to this organization, OR
-          the edit would re-sync a sub-workspace brand to Semrush (a URL, competitor,
-          or alias change on a brand carrying a `semrushWorkspaceId`) while the
-          org-wide serenity feature flag (`LLMO/serenity`) is inactive — the edit is
-          refused rather than left to drift (body message: "Serenity is not active
-          for this organization").
+          Forbidden. One of:
+          - the user does not have access to this organization;
+          - the edit would re-sync a sub-workspace brand to Semrush (a URL,
+            competitor, or alias change on a brand carrying a `semrushWorkspaceId`)
+            while the org-wide serenity feature flag (`LLMO/serenity`) is inactive —
+            the edit is refused rather than left to drift (body message: "Serenity is
+            not active for this organization");
+          - the org carries the `LLMO/serenity_ui` feature flag and Semrush refused
+            the re-sync for the calling user (not provisioned in Semrush).
       '404':
         description: Organization or brand not found
       '409':
@@ -203,6 +214,12 @@ v2-brand-for-org:
             $ref: './headers.yaml#/xError'
       '500':
         $ref: './responses.yaml#/500'
+      '502':
+        description: |
+          Upstream request failed. The org carries the `LLMO/serenity_ui` feature
+          flag and the Semrush re-sync failed for a reason other than authorization
+          (timeout, network, upstream error). The brand row may already be committed;
+          the Semrush side does not reflect the edit.
       '503':
         description: PostgREST unavailable (DATA_SERVICE_PROVIDER=postgres required)
   delete:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -7823,6 +7823,9 @@ V2BrandUpdateResponse:
             re-sync failed (transient upstream error or user not provisioned in
             Semrush). The edit is persisted; Semrush will be reconciled via
             `--reconcile` migration once the underlying issue is resolved.
+            Returned only for organizations still inside the Semrush migration
+            window. An org carrying the `LLMO/serenity_ui` feature flag gets the
+            upstream failure reported instead (401/403/502), never this field.
         semrushRejectedAliases:
           type: array
           description: >-

--- a/docs/serenity.md
+++ b/docs/serenity.md
@@ -135,6 +135,66 @@ The same helper gates the Semrush **side-effects** on the v2 brand endpoints
 - `DELETE` and status-transition have no Semrush side-effect, so they are
   ungated.
 
+## Migration-window flag (`LLMO/serenity_ui`)
+
+A second org-wide flag, `feature_flags` row keyed `(organization_id,
+product='LLMO', flag_name='serenity_ui')`, marks an org as **past** the Semrush
+migration. The name is snake_case because it has to be: `feature_flags` carries
+`CHECK (flag_name ~ '^[a-z][a-z0-9_]*$')`, so a hyphenated variant cannot be
+stored and any client matching on a hyphenated name never matches. The frontend
+reads it from `GET /organizations/:id/feature-flags/llmo` to pin the org to the
+Serenity UI and hide the classic/Serenity switcher; the backend reads it via
+`isSerenityUiActiveForOrg(ctx, spaceCatId, log)` in
+`src/support/serenity/serenity-active.js` (same cache and TTLs as the activation
+flag, default **OFF**).
+
+Backend meaning: **whether a Semrush failure on a brand edit is reported or
+absorbed.**
+
+During the migration an org's LLMO users may have no Semrush user record at all.
+Semrush binds the forwarded IMS token to a Semrush user before executing, so for
+those users it answers 4xx on every call, permanently — no retry the caller can
+make will clear it, and JIT provisioning from IMS claims was declined. Reporting
+that on a brand edit would tell the customer their edit failed when the row did
+persist. So `PATCH /v2/orgs/:org/brands/:brandId` absorbs it: the pre-write
+self-referential-competitor guard degrades to a brand-URL-only reserved set, and
+the post-commit re-sync returns `200 { semrushSyncPending: true }`.
+
+An org on the Serenity UI is past that window — its users are provisioned in
+Semrush — so a failure there is a real fault, not migration noise. With the flag
+on, both call sites propagate instead: the guard failure rejects the write before
+the row is touched, and a re-sync failure maps through `createErrorResponse` to
+401/403 (upstream authorization) or 502 (everything else). The row stays
+committed either way; the flag decides whether the divergence is reported.
+
+The combined contract, given the activation flag is on (it gates the route
+entirely — see above):
+
+| `LLMO/serenity` | `LLMO/serenity_ui` | Semrush failure on a brand edit |
+| --- | --- | --- |
+| on | off | absorbed — `200` with `semrushSyncPending: true` |
+| on | on | reported — `401` / `403` / `502` |
+
+Both classes are logged either way, at `warn` with `permanent: true` for 401/403
+and at `error` otherwise, under `serenity: brand-edit Semrush re-sync failed
+after row commit`. api-service prod logs are effectively absent from Splunk, so
+enumerate drifted brands from CloudWatch Logs Insights on the api-service prod
+Lambda log group.
+
+Flip it with the same admin endpoint as the activation flag:
+
+```bash
+# Stop absorbing Semrush failures for an org (org is fully migrated)
+curl -X PUT "${API_BASE}/organizations/${ORG_ID}/feature-flags/llmo/serenity_ui" \
+  -H "x-api-key: ${SPACECAT_ADMIN_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"value": true}'
+
+# Back to absorbing (org still has unprovisioned Semrush users)
+curl -X DELETE "${API_BASE}/organizations/${ORG_ID}/feature-flags/llmo/serenity_ui" \
+  -H "x-api-key: ${SPACECAT_ADMIN_KEY}"
+```
+
 ## Endpoint surface
 
 All endpoints require `Authorization: Bearer <ims_user_token>` and `organization:read` (GET) or `organization:write` (mutating) capability. The `:brandId` path param is UUID-only on this surface — name-based brand lookup is rejected with 400. The slice key for everything is `(brandId, geoTargetId, languageCode)`; the upstream workspace id and per-project upstream identifier are resolved server-side and never leak into request/response shapes.

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1917,12 +1917,19 @@ function BrandsController(ctx, log, env) {
       // memo also pins one answer for the whole request, so the pre-write
       // competitor guard and the post-commit re-sync below cannot disagree and
       // half-absorb an edit.
-      let serenityUiFlag;
-      const shouldSurfaceSemrushErrors = () => {
-        if (serenityUiFlag === undefined) {
-          serenityUiFlag = isSerenityUiActiveForOrg(context, spaceCatId, log);
+      let serenityUiFlagPromise;
+      /**
+       * MUST be awaited — this returns the memoised PROMISE, not a boolean, so a
+       * bare `if (resolveSurfaceSemrushErrors())` is always truthy and would
+       * silently surface every Semrush error regardless of the flag.
+       *
+       * @returns {Promise<boolean>} `true` when Semrush failures must be reported.
+       */
+      const resolveSurfaceSemrushErrors = () => {
+        if (serenityUiFlagPromise === undefined) {
+          serenityUiFlagPromise = isSerenityUiActiveForOrg(context, spaceCatId, log);
         }
-        return serenityUiFlag;
+        return serenityUiFlagPromise;
       };
 
       // LLMO-5645: a region must not be removed from a brand while prompts still
@@ -1996,7 +2003,7 @@ function BrandsController(ctx, log, env) {
             // Logged before the rethrow either way: the outer catch only sees a
             // generic "Error updating brand", so this is the sole record of which
             // Semrush workspace and which pre-write step failed.
-            const rejectingWrite = await shouldSurfaceSemrushErrors();
+            const rejectingWrite = await resolveSurfaceSemrushErrors();
             log.warn('serenity: competitor-guard project listing failed', {
               brandId,
               semrushSubWorkspaceId: brandState.semrushSubWorkspaceId,
@@ -2051,7 +2058,7 @@ function BrandsController(ctx, log, env) {
       // surface as a 5xx on an edit that did persist. The response carries
       // semrushSyncPending:true so the divergence is visible to the caller, and the
       // error log below carries the context needed to enumerate and recover drifted
-      // brands. For an org on the Serenity UI (see shouldSurfaceSemrushErrors) the
+      // brands. For an org on the Serenity UI (see resolveSurfaceSemrushErrors) the
       // failure is reported instead — that org's users are provisioned in Semrush, so
       // a failure is a real fault rather than expected migration noise.
       const urlsTouched = updates.urls !== undefined
@@ -2148,7 +2155,7 @@ function BrandsController(ctx, log, env) {
             stack: syncError?.stack,
             permanent: isPermanent,
           });
-          if (await shouldSurfaceSemrushErrors()) {
+          if (await resolveSurfaceSemrushErrors()) {
             // The org is on the Serenity UI: its users are provisioned in Semrush, so
             // this is a genuine upstream failure and the caller is told. The row stays
             // committed either way — the difference is whether the divergence is

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -72,7 +72,7 @@ import { isSemrushTransportError, unwrapTransportCause } from '../support/sereni
 import { syncBrandUrlsAcrossMarkets } from '../support/serenity/brand-urls.js';
 import { syncBrandAliasesAcrossMarkets } from '../support/serenity/brand-aliases.js';
 import { resolveProjects } from '../support/serenity/resolve-projects.js';
-import { isSerenityActiveForOrg } from '../support/serenity/serenity-active.js';
+import { isSerenityActiveForOrg, isSerenityUiActiveForOrg } from '../support/serenity/serenity-active.js';
 import {
   buildReservedDomains,
   dropReservedCompetitors,
@@ -1903,6 +1903,28 @@ function BrandsController(ctx, log, env) {
         }
       }
 
+      // LLMO-6565 migration-window allowance. A Semrush failure on this edit is
+      // absorbed — the row is committed and the response carries
+      // semrushSyncPending — only while the org is still migrating: its LLMO users
+      // may have no Semrush user record yet, so Semrush answers 4xx on every call
+      // made on their behalf and no retry the caller can make will clear it. An org
+      // pinned to the Serenity UI is past that window, its users are provisioned, so
+      // a Semrush failure there is a real error and propagates to the caller.
+      //
+      // Resolved lazily, and at most once per request: only an actual Semrush
+      // failure needs the answer, so the happy path — and every flat-mode brand
+      // edit, which never reaches a Semrush call at all — pays no flag read. The
+      // memo also pins one answer for the whole request, so the pre-write
+      // competitor guard and the post-commit re-sync below cannot disagree and
+      // half-absorb an edit.
+      let serenityUiFlag;
+      const shouldSurfaceSemrushErrors = () => {
+        if (serenityUiFlag === undefined) {
+          serenityUiFlag = isSerenityUiActiveForOrg(context, spaceCatId, log);
+        }
+        return serenityUiFlag;
+      };
+
       // LLMO-5645: a region must not be removed from a brand while prompts still
       // use it — DRS schedules off each prompt's `regions`, so dropping a brand
       // region would orphan those prompts on a market the brand no longer
@@ -1961,20 +1983,32 @@ function BrandsController(ctx, log, env) {
         if (hasText(brandState?.semrushSubWorkspaceId)) {
           // Semrush brand: market/project domains come from the project listing.
           // List once and stash for the post-commit re-sync (see prefetchedProjects).
-          // Best-effort: if the listing fails (e.g. user not provisioned in Semrush),
-          // degrade to brand-URL-only reserved set and log — the self-reference guard
-          // is a data-quality nicety and must not block the competitor write entirely.
+          // Best-effort for a migrating org: if the listing fails (e.g. user not
+          // provisioned in Semrush), degrade to brand-URL-only reserved set and log —
+          // the self-reference guard is a data-quality nicety and must not block the
+          // competitor write entirely. For an org on the Serenity UI the failure is
+          // real and rejects the write before the row is touched.
           try {
             const imsToken = await resolveSemrushImsToken(context, log, 'brands');
             const transport = createSerenityTransport({ env: context.env, imsToken });
             prefetchedProjects = await resolveProjects(transport, brandState.semrushSubWorkspaceId);
           } catch (guardError) {
-            log.warn('serenity: competitor-guard project listing failed; degrading to brand-URL-only reserved set', {
+            // Logged before the rethrow either way: the outer catch only sees a
+            // generic "Error updating brand", so this is the sole record of which
+            // Semrush workspace and which pre-write step failed.
+            const rejectingWrite = await shouldSurfaceSemrushErrors();
+            log.warn('serenity: competitor-guard project listing failed', {
               brandId,
               semrushSubWorkspaceId: brandState.semrushSubWorkspaceId,
               status: guardError?.status,
               message: guardError?.message,
+              // true → the write is rejected; false → degraded to the reserved set
+              // built from the brand's own URLs alone, and the write proceeds.
+              rejectingWrite,
             });
+            if (rejectingWrite) {
+              throw guardError;
+            }
           }
           reservedDomains = buildReservedDomains(
             (prefetchedProjects ?? []).map((p) => p?.domain),
@@ -2012,11 +2046,14 @@ function BrandsController(ctx, log, env) {
       // every market/project (region-filtered per market). Skipped for flat-mode
       // brands and unrelated edits. One transport shared across all three syncs.
       //
-      // Best-effort, matching the create path: the brand row is already committed
-      // when this block runs, so a re-sync failure must not surface as a 5xx on an
-      // edit that did persist. The response carries semrushSyncPending:true so the
-      // divergence is visible to the caller, and the error log below carries the
-      // context needed to enumerate and recover drifted brands.
+      // For a migrating org this is best-effort, matching the create path: the brand
+      // row is already committed when this block runs, so a re-sync failure must not
+      // surface as a 5xx on an edit that did persist. The response carries
+      // semrushSyncPending:true so the divergence is visible to the caller, and the
+      // error log below carries the context needed to enumerate and recover drifted
+      // brands. For an org on the Serenity UI (see shouldSurfaceSemrushErrors) the
+      // failure is reported instead — that org's users are provisioned in Semrush, so
+      // a failure is a real fault rather than expected migration noise.
       const urlsTouched = updates.urls !== undefined
         || updates.socialAccounts !== undefined
         || updates.earnedContent !== undefined;
@@ -2111,6 +2148,15 @@ function BrandsController(ctx, log, env) {
             stack: syncError?.stack,
             permanent: isPermanent,
           });
+          if (await shouldSurfaceSemrushErrors()) {
+            // The org is on the Serenity UI: its users are provisioned in Semrush, so
+            // this is a genuine upstream failure and the caller is told. The row stays
+            // committed either way — the difference is whether the divergence is
+            // reported or absorbed. createErrorResponse maps the status and keeps the
+            // internal gateway URL out of the response. Any partial rejectedAliases
+            // are dropped with the body; the log above carries the same context.
+            throw syncError;
+          }
           // Preserve any partial rejectedAliases collected before the throw so
           // the UI can still warn about aliases that were refused by Semrush.
           return ok({

--- a/src/support/serenity/serenity-active.js
+++ b/src/support/serenity/serenity-active.js
@@ -30,13 +30,30 @@ export const SERENITY_FEATURE_FLAG_PRODUCT = 'LLMO';
 export const SERENITY_FEATURE_FLAG_NAME = 'serenity';
 
 /**
- * Module-scoped TTL+size-bounded cache for the org-wide serenity flag value,
- * mirroring the workspace-resolver cache (warm Lambda containers reuse module
- * state, so a Map here amortises the PostgREST flag read over the container's
- * lifetime). A `true` value caches for the positive TTL; a `false`/absent value
- * caches for the shorter negative TTL so flipping an org ON during rollout
- * takes effect within ~NEG_TTL_MS instead of the full positive window. Reuses
- * the resolver's TTL/size constants to stay in lockstep with it.
+ * The org-wide switch that pins the org's UI to the Serenity experience, set by
+ * the same `feature_flags` table row shape as `serenity` above and read by the
+ * frontend from `GET /organizations/:id/feature-flags/llmo` (LLMO-6565).
+ *
+ * On the backend it marks an org as past the migration window: its users are
+ * provisioned in Semrush, so a Semrush failure on a brand edit is a real error
+ * to surface rather than expected migration noise to absorb. See
+ * `isSerenityUiActiveForOrg`.
+ *
+ * snake_case is mandatory, not stylistic: `feature_flags` carries a CHECK
+ * constraint `flag_name ~ '^[a-z][a-z0-9_]*$'` (and `isValidFeatureFlagName`
+ * mirrors it), so a hyphenated name cannot be stored at all. Clients matching on
+ * this flag must use the same spelling.
+ */
+export const SERENITY_UI_FEATURE_FLAG_NAME = 'serenity_ui';
+
+/**
+ * Module-scoped TTL+size-bounded cache for the org-wide flag values, mirroring
+ * the workspace-resolver cache (warm Lambda containers reuse module state, so a
+ * Map here amortises the PostgREST flag read over the container's lifetime). A
+ * `true` value caches for the positive TTL; a `false`/absent value caches for
+ * the shorter negative TTL so flipping an org ON during rollout takes effect
+ * within ~NEG_TTL_MS instead of the full positive window. Reuses the resolver's
+ * TTL/size constants to stay in lockstep with it.
  *
  * Exported clear is for unit tests; production code should not call it.
  */
@@ -44,16 +61,15 @@ const flagCache = new Map();
 
 /**
  * Composite cache key (org + product + flag), not the bare `spaceCatId`, so the
- * Map is collision-proof if this same shape is ever reused to cache a second
- * flag. Today this module reads exactly one flag (`LLMO/serenity`), so the
- * product/flag segments are constant — but keying on the full identity keeps the
- * cache correct-by-construction rather than relying on "only one consumer".
+ * Map stays collision-proof now that this module caches more than one flag per
+ * organization.
  *
  * @param {string} spaceCatId - SpaceCat organization UUID.
+ * @param {string} flagName - Feature-flag name within the LLMO product.
  * @returns {string} The cache key.
  */
-function flagCacheKey(spaceCatId) {
-  return `${spaceCatId}::${SERENITY_FEATURE_FLAG_PRODUCT}::${SERENITY_FEATURE_FLAG_NAME}`;
+function flagCacheKey(spaceCatId, flagName) {
+  return `${spaceCatId}::${SERENITY_FEATURE_FLAG_PRODUCT}::${flagName}`;
 }
 
 export function clearSerenityFlagCache() {
@@ -74,37 +90,31 @@ function evictIfNeeded() {
 }
 
 /**
- * Central predicate: is the Semrush-backed "serenity" experience active for an
- * organization? Reads the org-wide `LLMO/serenity` feature flag (cached).
- *
- * This is the org-level rollout half of serenity activation. The serenity
- * controller composes it with the per-brand workspace resolution
- * (`resolveBrandWorkspace`), so a route is served only when BOTH this flag is
- * ON *and* a Semrush workspace resolves for the brand — i.e. "flag AND
- * workspace". A missing flag row, a `false` row, an unavailable PostgREST
- * client, or a transient read error all resolve to `false` (default OFF), so an
- * org is never silently activated.
+ * Reads one cached org-wide `LLMO/<flagName>` feature flag. A missing flag row, a
+ * `false` row, an unavailable PostgREST client, or a transient read error all
+ * resolve to `false` (default OFF), so a flag is never silently on.
  *
  * @param {object} ctx - Request context (uses
  *   `ctx.dataAccess.services.postgrestClient`).
  * @param {string} spaceCatId - SpaceCat organization UUID.
+ * @param {string} flagName - Feature-flag name within the LLMO product.
  * @param {object} [log] - Optional logger (used to surface a missing client /
  *   a read error without throwing on this hot path).
- * @returns {Promise<boolean>} `true` only when the org-wide serenity flag is on.
+ * @returns {Promise<boolean>} `true` only when the flag row exists and is `true`.
  */
-export async function isSerenityActiveForOrg(ctx, spaceCatId, log) {
+async function readCachedOrgFlag(ctx, spaceCatId, flagName, log) {
   if (!hasText(spaceCatId)) {
     return false;
   }
 
   const postgrestClient = ctx?.dataAccess?.services?.postgrestClient;
   if (!postgrestClient?.from) {
-    log?.warn?.('[serenity] isSerenityActiveForOrg: PostgREST client unavailable — treating serenity as inactive');
+    log?.warn?.(`[serenity] readCachedOrgFlag: PostgREST client unavailable — treating ${flagName} as off`);
     return false;
   }
 
   const now = Date.now();
-  const cacheKey = flagCacheKey(spaceCatId);
+  const cacheKey = flagCacheKey(spaceCatId, flagName);
   const cached = flagCache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
     return cached.value;
@@ -115,13 +125,13 @@ export async function isSerenityActiveForOrg(ctx, spaceCatId, log) {
     raw = await readFeatureFlag({
       organizationId: spaceCatId,
       product: SERENITY_FEATURE_FLAG_PRODUCT,
-      flagName: SERENITY_FEATURE_FLAG_NAME,
+      flagName,
       postgrestClient,
     });
   } catch (e) {
-    // Fail safe (inactive) on a transient read error, and do NOT cache it so a
+    // Fail safe (off) on a transient read error, and do NOT cache it so a
     // recovered DB takes effect on the very next call rather than after a TTL.
-    log?.error?.(`[serenity] isSerenityActiveForOrg: failed to read serenity flag for org ${spaceCatId}: ${e?.message}`);
+    log?.error?.(`[serenity] readCachedOrgFlag: failed to read ${flagName} flag for org ${spaceCatId}: ${e?.message}`);
     return false;
   }
 
@@ -131,4 +141,51 @@ export async function isSerenityActiveForOrg(ctx, spaceCatId, log) {
   evictIfNeeded();
   flagCache.set(cacheKey, { value, expiresAt: now + (value ? CACHE_TTL_MS : NEG_TTL_MS) });
   return value;
+}
+
+/**
+ * Central predicate: is the Semrush-backed "serenity" experience active for an
+ * organization? Reads the org-wide `LLMO/serenity` feature flag (cached).
+ *
+ * This is the org-level rollout half of serenity activation. The serenity
+ * controller composes it with the per-brand workspace resolution
+ * (`resolveBrandWorkspace`), so a route is served only when BOTH this flag is
+ * ON *and* a Semrush workspace resolves for the brand — i.e. "flag AND
+ * workspace". Anything short of an explicit `true` resolves to `false`, so an
+ * org is never silently activated.
+ *
+ * @param {object} ctx - Request context (uses
+ *   `ctx.dataAccess.services.postgrestClient`).
+ * @param {string} spaceCatId - SpaceCat organization UUID.
+ * @param {object} [log] - Optional logger (used to surface a missing client /
+ *   a read error without throwing on this hot path).
+ * @returns {Promise<boolean>} `true` only when the org-wide serenity flag is on.
+ */
+export async function isSerenityActiveForOrg(ctx, spaceCatId, log) {
+  return readCachedOrgFlag(ctx, spaceCatId, SERENITY_FEATURE_FLAG_NAME, log);
+}
+
+/**
+ * Is the organization pinned to the Serenity UI? Reads the org-wide
+ * `LLMO/serenity_ui` feature flag (cached).
+ *
+ * Backend meaning: the org is past the Semrush migration window. During the
+ * migration an org's LLMO users may have no Semrush user record at all, so
+ * Semrush answers 4xx on every call made on their behalf and brand edits absorb
+ * that failure rather than reporting a write that did persist as broken. Once
+ * this flag is on, that allowance ends and Semrush failures surface to the
+ * caller — see the re-sync block in `src/controllers/brands.js`.
+ *
+ * Reads `false` unless the flag row is explicitly `true`, so the absorbing
+ * behaviour stays the default for every org still mid-migration.
+ *
+ * @param {object} ctx - Request context (uses
+ *   `ctx.dataAccess.services.postgrestClient`).
+ * @param {string} spaceCatId - SpaceCat organization UUID.
+ * @param {object} [log] - Optional logger (used to surface a missing client /
+ *   a read error without throwing on this hot path).
+ * @returns {Promise<boolean>} `true` only when the org-wide serenity_ui flag is on.
+ */
+export async function isSerenityUiActiveForOrg(ctx, spaceCatId, log) {
+  return readCachedOrgFlag(ctx, spaceCatId, SERENITY_UI_FEATURE_FLAG_NAME, log);
 }

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -6161,6 +6161,9 @@ describe('Brands Controller', () => {
       // Serenity active by default so a sync-field edit reaches the re-sync block.
       // The inactive case overrides this to assert the gate rejects.
       isSerenityActiveForOrg = sinon.stub().resolves(true),
+      // Serenity-UI OFF by default: the org is mid-migration, so Semrush failures
+      // are absorbed. Tests that assert failures propagate override this to true.
+      isSerenityUiActiveForOrg = sinon.stub().resolves(false),
       // Only override when a test supplies one; otherwise the real
       // support/utils.js#resolveSemrushImsToken runs (its own decode/exchange
       // logic is covered directly in test/support/utils.test.js).
@@ -6180,7 +6183,10 @@ describe('Brands Controller', () => {
         // removedCompetitorDomains is left REAL so the diff logic is exercised.
         '../../src/support/serenity/competitor-benchmarks.js': { syncCompetitorBenchmarksAcrossMarkets },
         '../../src/support/serenity/brand-aliases.js': { syncBrandAliasesAcrossMarkets },
-        '../../src/support/serenity/serenity-active.js': { isSerenityActiveForOrg },
+        '../../src/support/serenity/serenity-active.js': {
+          isSerenityActiveForOrg,
+          isSerenityUiActiveForOrg,
+        },
       };
       if (resolveSemrushImsToken) {
         overrides['../../src/support/utils.js'] = { resolveSemrushImsToken };
@@ -6929,6 +6935,188 @@ describe('Brands Controller', () => {
       const body = await response.json();
       expect(body).to.include({ semrushSyncPending: true });
       expect(body.semrushRejectedAliases).to.deep.equal(rejected);
+    });
+
+    describe('LLMO-6565: the serenity_ui flag ends the migration-window allowance', () => {
+      // Contract: serenity ON + serenity_ui OFF (mid-migration) absorbs a Semrush
+      // failure — covered by the LLMO-6545 cases above, which run on the helper's
+      // default of serenity_ui OFF. serenity ON + serenity_ui ON reports it: that
+      // org's users are provisioned in Semrush, so a failure is a real fault.
+      const SUB_WORKSPACE_BRAND = {
+        id: BRAND_UUID,
+        semrushSubWorkspaceId: 'ws-9',
+        urls: [{ value: 'https://acme.com' }],
+        socialAccounts: [],
+        earnedContent: [],
+      };
+
+      function urlEditRequest() {
+        return {
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+          data: { urls: [{ value: 'https://acme.com' }] },
+          dataAccess: mockDataAccess,
+          pathInfo: { headers: { authorization: 'Bearer tok' } },
+          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+        };
+      }
+
+      it('reports a Semrush 403 on the post-commit re-sync instead of semrushSyncPending', async () => {
+        // The unprovisioned-user case the allowance existed for. With the flag on it
+        // is a 403 the customer is meant to see, not drift to absorb silently.
+        const updateBrandStub = sinon.stub().resolves(SUB_WORKSPACE_BRAND);
+        const controller = await buildUpdateController({
+          updateBrand: updateBrandStub,
+          syncBrandUrlsAcrossMarkets: sinon.stub().rejects(
+            new SerenityTransportError(403, 'Semrush PUT https://gw.internal/x failed: 403', {}),
+          ),
+          createSerenityTransport: sinon.stub().returns({
+            name: 't', listProjects: sinon.stub().resolves({ items: [] }),
+          }),
+          isSerenityUiActiveForOrg: sinon.stub().resolves(true),
+        });
+
+        const response = await controller.updateBrandForOrg(urlEditRequest());
+
+        expect(response.status).to.equal(403);
+        const body = await response.json();
+        expect(body.semrushSyncPending).to.equal(undefined);
+        // The row is still committed — the flag changes what the caller is told,
+        // not whether the write happened.
+        expect(updateBrandStub).to.have.been.calledOnce;
+        // The breadcrumb for drift recovery is emitted on both paths.
+        expect(loggerStub.warn).to.have.been.calledWithMatch(
+          'serenity: brand-edit Semrush re-sync failed after row commit',
+        );
+        // The gateway URL stays out of the response on this path too.
+        expect(JSON.stringify(body)).to.not.contain('gw.internal');
+        expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
+      });
+
+      it('reports a non-auth Semrush failure as 502', async () => {
+        const controller = await buildUpdateController({
+          updateBrand: sinon.stub().resolves(SUB_WORKSPACE_BRAND),
+          syncBrandUrlsAcrossMarkets: sinon.stub().rejects(
+            new SerenityTransportError(503, 'Semrush PUT https://gw.internal/x failed: 503', {}),
+          ),
+          createSerenityTransport: sinon.stub().returns({
+            name: 't', listProjects: sinon.stub().resolves({ items: [] }),
+          }),
+          isSerenityUiActiveForOrg: sinon.stub().resolves(true),
+        });
+
+        const response = await controller.updateBrandForOrg(urlEditRequest());
+
+        expect(response.status).to.equal(502);
+        expect((await response.json()).message).to.equal('Upstream request failed');
+      });
+
+      it('rejects the write when the pre-write competitor guard listing fails', async () => {
+        // Mid-migration this degrades to a brand-URL-only reserved set and the write
+        // proceeds. With the flag on the listing failure is real, so the write must
+        // not happen at all — no row is touched.
+        const updateBrandStub = sinon.stub().resolves({
+          ...SUB_WORKSPACE_BRAND,
+          competitors: [{ name: 'Rival', url: 'https://rival.com' }],
+        });
+        const controller = await buildUpdateController({
+          updateBrand: updateBrandStub,
+          getBrandById: sinon.stub().resolves({
+            id: BRAND_UUID,
+            baseUrl: 'https://acme.com',
+            urls: [],
+            semrushSubWorkspaceId: 'ws-9',
+          }),
+          createSerenityTransport: sinon.stub().returns({
+            name: 't',
+            listProjects: sinon.stub().rejects(
+              new SerenityTransportError(403, 'Semrush GET https://gw.internal/x failed: 403', {}),
+            ),
+          }),
+          isSerenityUiActiveForOrg: sinon.stub().resolves(true),
+        });
+
+        const response = await controller.updateBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+          data: { competitors: [{ name: 'Rival', url: 'https://rival.com' }] },
+          dataAccess: mockDataAccess,
+          pathInfo: { headers: { authorization: 'Bearer tok' } },
+          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+        });
+
+        expect(response.status).to.equal(403);
+        expect(updateBrandStub).to.not.have.been.called;
+        // The outer catch only logs a generic "Error updating brand", so the guard's
+        // own warn is the sole record of which workspace and which step failed. It
+        // must survive the rethrow, flagged as having rejected the write.
+        expect(loggerStub.warn).to.have.been.calledWithMatch(
+          'serenity: competitor-guard project listing failed',
+          sinon.match({ semrushSubWorkspaceId: 'ws-9', rejectingWrite: true }),
+        );
+      });
+
+      it('does not read the flag when no Semrush call fails', async () => {
+        // The flag only decides how a failure is reported, so a successful edit —
+        // and every flat-mode brand edit, which reaches no Semrush call at all —
+        // must not pay the flag read. Most orgs are not on Serenity, so this is the
+        // common path.
+        const flagStub = sinon.stub().resolves(true);
+        const controller = await buildUpdateController({
+          updateBrand: sinon.stub().resolves(SUB_WORKSPACE_BRAND),
+          createSerenityTransport: sinon.stub().returns({
+            name: 't', listProjects: sinon.stub().resolves({ items: [] }),
+          }),
+          isSerenityUiActiveForOrg: flagStub,
+        });
+
+        const response = await controller.updateBrandForOrg(urlEditRequest());
+
+        expect(response.status).to.equal(200);
+        expect(flagStub).to.not.have.been.called;
+      });
+
+      it('reads the flag once when both the guard and the re-sync fail', async () => {
+        // One answer pinned per request: the guard and the re-sync must not disagree
+        // and leave an edit half-absorbed.
+        const flagStub = sinon.stub().resolves(false);
+        const controller = await buildUpdateController({
+          updateBrand: sinon.stub().resolves({
+            ...SUB_WORKSPACE_BRAND,
+            competitors: [{ name: 'Rival', url: 'https://rival.com' }],
+          }),
+          getBrandById: sinon.stub().resolves({
+            id: BRAND_UUID,
+            baseUrl: 'https://acme.com',
+            urls: [],
+            semrushSubWorkspaceId: 'ws-9',
+          }),
+          syncCompetitorBenchmarksAcrossMarkets: sinon.stub().rejects(
+            new SerenityTransportError(403, 'Semrush PUT https://gw.internal/x failed: 403', {}),
+          ),
+          createSerenityTransport: sinon.stub().returns({
+            name: 't',
+            listProjects: sinon.stub().rejects(
+              new SerenityTransportError(403, 'Semrush GET https://gw.internal/x failed: 403', {}),
+            ),
+          }),
+          isSerenityUiActiveForOrg: flagStub,
+        });
+
+        const response = await controller.updateBrandForOrg({
+          ...context,
+          params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+          data: { competitors: [{ name: 'Rival', url: 'https://rival.com' }] },
+          dataAccess: mockDataAccess,
+          pathInfo: { headers: { authorization: 'Bearer tok' } },
+          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+        });
+
+        // Flag off → both failures absorbed, and the flag was resolved exactly once.
+        expect(response.status).to.equal(200);
+        expect(await response.json()).to.include({ semrushSyncPending: true });
+        expect(flagStub).to.have.been.calledOnce;
+      });
     });
 
     it('returns 409 when demoting an active brand to pending (LLMO-5587)', async () => {

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -7008,7 +7008,37 @@ describe('Brands Controller', () => {
         const response = await controller.updateBrandForOrg(urlEditRequest());
 
         expect(response.status).to.equal(502);
-        expect((await response.json()).message).to.equal('Upstream request failed');
+        const body = await response.json();
+        expect(body.message).to.equal('Upstream request failed');
+        // Same redaction guarantee as the 403 path: the generic 502 message must
+        // not carry the internal gateway URL embedded in the upstream error.
+        expect(JSON.stringify(body)).to.not.contain('gw.internal');
+        expect(response.headers.get('x-error') || '').to.not.contain('gw.internal');
+      });
+
+      it('reports a 401 when the caller cannot be authenticated to Semrush', async () => {
+        // resolveSemrushImsToken throws ErrorWithStatusCode(401) for an expired
+        // promise-token exchange or a non-IMS bearer. It sits inside the re-sync
+        // try, so mid-migration it soft-fails like any other re-sync failure; with
+        // the flag on it maps through to the 401 the OpenAPI spec documents.
+        const updateBrandStub = sinon.stub().resolves(SUB_WORKSPACE_BRAND);
+        const controller = await buildUpdateController({
+          updateBrand: updateBrandStub,
+          createSerenityTransport: sinon.stub().returns({
+            name: 't', listProjects: sinon.stub().resolves({ items: [] }),
+          }),
+          resolveSemrushImsToken: sinon.stub().rejects(
+            Object.assign(new Error('Invalid or expired promise token'), { status: 401 }),
+          ),
+          isSerenityUiActiveForOrg: sinon.stub().resolves(true),
+        });
+
+        const response = await controller.updateBrandForOrg(urlEditRequest());
+
+        expect(response.status).to.equal(401);
+        expect((await response.json()).message).to.equal('Invalid or expired promise token');
+        // The row still committed — only the re-sync failed.
+        expect(updateBrandStub).to.have.been.calledOnce;
       });
 
       it('rejects the write when the pre-write competitor guard listing fails', async () => {
@@ -7080,6 +7110,13 @@ describe('Brands Controller', () => {
         // One answer pinned per request: the guard and the re-sync must not disagree
         // and leave an edit half-absorbed.
         const flagStub = sinon.stub().resolves(false);
+        // The guard and the re-sync each list the sub-workspace's projects. The
+        // guard's listing failure leaves nothing prefetched, so the re-sync lists
+        // again and fails there too — before it reaches any per-entity sync. Two
+        // calls on this stub is therefore the proof that BOTH catch blocks ran.
+        const listProjectsStub = sinon.stub().rejects(
+          new SerenityTransportError(403, 'Semrush GET https://gw.internal/x failed: 403', {}),
+        );
         const controller = await buildUpdateController({
           updateBrand: sinon.stub().resolves({
             ...SUB_WORKSPACE_BRAND,
@@ -7091,14 +7128,9 @@ describe('Brands Controller', () => {
             urls: [],
             semrushSubWorkspaceId: 'ws-9',
           }),
-          syncCompetitorBenchmarksAcrossMarkets: sinon.stub().rejects(
-            new SerenityTransportError(403, 'Semrush PUT https://gw.internal/x failed: 403', {}),
-          ),
           createSerenityTransport: sinon.stub().returns({
             name: 't',
-            listProjects: sinon.stub().rejects(
-              new SerenityTransportError(403, 'Semrush GET https://gw.internal/x failed: 403', {}),
-            ),
+            listProjects: listProjectsStub,
           }),
           isSerenityUiActiveForOrg: flagStub,
         });
@@ -7116,6 +7148,10 @@ describe('Brands Controller', () => {
         expect(response.status).to.equal(200);
         expect(await response.json()).to.include({ semrushSyncPending: true });
         expect(flagStub).to.have.been.calledOnce;
+        // Both call sites really were reached — without this the single flag read
+        // would prove nothing about the memo, since a handler that short-circuited
+        // before the re-sync would also read the flag exactly once.
+        expect(listProjectsStub).to.have.been.calledTwice;
       });
     });
 

--- a/test/it/shared/tests/feature-flags.js
+++ b/test/it/shared/tests/feature-flags.js
@@ -120,6 +120,47 @@ export default function featureFlagsTests(
         );
         expect(res.status).to.equal(400);
       });
+
+      // LLMO-6565. The brand-edit Semrush error allowance is gated on
+      // `LLMO/serenity_ui` (see isSerenityUiActiveForOrg), so that flag name must
+      // actually be storable. `feature_flags` carries
+      // CHECK (flag_name ~ '^[a-z][a-z0-9_]*$') and isValidFeatureFlagName mirrors
+      // it, and NOTHING on the read path validates the name — a hyphenated variant
+      // resolves to `false` forever with no error surfaced anywhere, which is
+      // indistinguishable from "the flag is simply off". Only a write against real
+      // Postgres proves the spelling, which is why this is an IT and not a unit test.
+      it('accepts serenity_ui and rejects the hyphenated serenity-ui (LLMO-6565)', async () => {
+        const { baseUrl, adminToken } = getServerInfo();
+
+        const ok = await putFlag(
+          baseUrl,
+          adminToken,
+          `/organizations/${ORG_1_ID}/feature-flags/llmo/serenity_ui`,
+          { value: true },
+        );
+        expect(ok.status).to.be.oneOf([200, 201]);
+        expect(ok.body.flagName).to.equal('serenity_ui');
+        expect(ok.body.flagValue).to.equal(true);
+
+        // Read it back through the same storage helper isSerenityUiActiveForOrg
+        // uses, so the controller's gate is reading a row that genuinely persisted.
+        const dbValue = await readFeatureFlag({
+          organizationId: ORG_1_ID,
+          product: 'LLMO',
+          flagName: 'serenity_ui',
+          postgrestClient: getPostgrestClient(),
+        });
+        expect(dbValue).to.equal(true);
+
+        // The hyphenated spelling is refused outright — it can never become a row.
+        const hyphenated = await putFlag(
+          baseUrl,
+          adminToken,
+          `/organizations/${ORG_1_ID}/feature-flags/llmo/serenity-ui`,
+          { value: true },
+        );
+        expect(hyphenated.status).to.equal(400);
+      });
     });
 
     // ── GET /organizations/:orgId/feature-flags?product=LLMO ──

--- a/test/support/serenity/serenity-active.test.js
+++ b/test/support/serenity/serenity-active.test.js
@@ -175,3 +175,80 @@ describe('isSerenityActiveForOrg', () => {
     });
   });
 });
+
+describe('isSerenityUiActiveForOrg', () => {
+  let readFeatureFlagStub;
+  let isSerenityActiveForOrg;
+  let isSerenityUiActiveForOrg;
+  let clearSerenityFlagCache;
+  let SERENITY_UI_FEATURE_FLAG_NAME;
+
+  beforeEach(async () => {
+    readFeatureFlagStub = sinon.stub();
+    const mod = await esmock('../../../src/support/serenity/serenity-active.js', {
+      '../../../src/support/feature-flags-storage.js': {
+        readFeatureFlag: readFeatureFlagStub,
+      },
+    });
+    ({
+      isSerenityActiveForOrg,
+      isSerenityUiActiveForOrg,
+      clearSerenityFlagCache,
+      SERENITY_UI_FEATURE_FLAG_NAME,
+    } = mod);
+    clearSerenityFlagCache();
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('exposes the org-wide LLMO/serenity_ui flag identity', () => {
+    expect(SERENITY_UI_FEATURE_FLAG_NAME).to.equal('serenity_ui');
+  });
+
+  it('returns true when the flag is true and reads it with the right key', async () => {
+    readFeatureFlagStub.resolves(true);
+    expect(await isSerenityUiActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(true);
+    expect(readFeatureFlagStub.firstCall.args[0]).to.include({
+      organizationId: ORG,
+      product: 'LLMO',
+      flagName: 'serenity_ui',
+    });
+  });
+
+  it('defaults OFF for an absent row, a false row, a blank org and a read error', async () => {
+    const log = fakeLog();
+    readFeatureFlagStub.resolves(null);
+    expect(await isSerenityUiActiveForOrg(fakeCtx(), ORG, log)).to.equal(false);
+    clearSerenityFlagCache();
+    readFeatureFlagStub.resolves(false);
+    expect(await isSerenityUiActiveForOrg(fakeCtx(), ORG, log)).to.equal(false);
+    expect(await isSerenityUiActiveForOrg(fakeCtx(), '', log)).to.equal(false);
+    clearSerenityFlagCache();
+    readFeatureFlagStub.rejects(new Error('boom'));
+    expect(await isSerenityUiActiveForOrg(fakeCtx(), ORG, log)).to.equal(false);
+  });
+
+  it('returns false and warns when the PostgREST client is unavailable', async () => {
+    const log = fakeLog();
+    expect(await isSerenityUiActiveForOrg({ dataAccess: { services: {} } }, ORG, log))
+      .to.equal(false);
+    expect(readFeatureFlagStub).to.not.have.been.called;
+    expect(log.warn).to.have.been.calledOnce;
+  });
+
+  it('caches per flag, so one flag never reads the other cached value', async () => {
+    // Same org, different flag: the composite cache key must keep them apart —
+    // otherwise an org that is serenity-active would read as serenity_ui too.
+    readFeatureFlagStub.withArgs(sinon.match({ flagName: 'serenity' })).resolves(true);
+    readFeatureFlagStub.withArgs(sinon.match({ flagName: 'serenity_ui' })).resolves(false);
+
+    expect(await isSerenityActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(true);
+    expect(await isSerenityUiActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(false);
+    expect(readFeatureFlagStub).to.have.been.calledTwice;
+
+    // Both are now cached independently — no further reads, same answers.
+    expect(await isSerenityActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(true);
+    expect(await isSerenityUiActiveForOrg(fakeCtx(), ORG, fakeLog())).to.equal(false);
+    expect(readFeatureFlagStub).to.have.been.calledTwice;
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

Puts the Semrush-failure allowance on brand edits behind a new org-level `LLMO/serenity_ui` feature flag. An org still inside the Semrush migration keeps today's behaviour (the failure is absorbed); an org pinned to the Serenity UI gets the failure reported.

## 2. Reasoning

`PATCH /v2/orgs/{org}/brands/{brandId}` currently absorbs Semrush failures: the brand row commits, the response comes back `200` with `semrushSyncPending: true`, and the Semrush side quietly diverges. That was introduced to unblock brand edits for migrated orgs whose LLMO users have no Semrush user record at all — Semrush binds the forwarded IMS token to a Semrush user before executing, and JIT provisioning from IMS claims was declined, so for those users Semrush answers 4xx on every call, permanently. Reporting that would tell the customer their edit failed when the row did persist.

That is a migration-window allowance, not a permanent contract. Once an org is fully migrated its users are provisioned in Semrush, and from that point a Semrush failure is a real fault that the customer needs to see rather than expected migration noise to swallow. The `serenity_ui` flag is exactly the marker for "this org is past the migration" — it is what pins the org's UI to Serenity and hides the classic/Serenity switcher — so it is the right switch to end the allowance.

## 3. High-level overview of the changes

The org-wide flag reader in `src/support/serenity/serenity-active.js` becomes generic over the flag name (its cache key was already composite, built for exactly this) and gains a second predicate for `LLMO/serenity_ui`, sharing the same cache, TTLs and default-OFF failure behaviour as the existing activation flag: a missing row, a `false` row, an absent PostgREST client and a transient read error all resolve to off.

Behaviour delta on the brand-edit path, given `LLMO/serenity` is on (it gates the route entirely, unchanged):

| `LLMO/serenity_ui` | Semrush failure on a brand edit |
| --- | --- |
| off (default, every org today) | absorbed — `200` with `semrushSyncPending: true` |
| on | reported — `401` / `403` / `502` |

Both places that swallow a Semrush failure are re-armed together, off a single answer pinned for the whole request, so an edit can never end up half-absorbed:

- the **pre-write** self-referential-competitor guard, which lists the brand's Semrush projects to build the reserved-domain set. Absorbed, it degrades to a reserved set built from the brand's own URLs alone and the write proceeds. Reported, it rejects the write before the row is touched.
- the **post-commit** re-sync. Absorbed, it returns the committed row with `semrushSyncPending: true`. Reported, it rethrows into the controller's error mapper — `401`/`403` pass through, everything else maps to `502`, and the internal gateway URL stays out of both the body and the `x-error` header on this path as it does on the others.

The row stays committed either way. The flag changes only what the caller is told, never whether the write happened — worth being explicit about, because a reported failure now means "your edit persisted but Semrush does not reflect it", not "nothing happened". The drift breadcrumb (`serenity: brand-edit Semrush re-sync failed after row commit`, warn with `permanent: true` for 401/403, error otherwise) is emitted on both paths, and the competitor guard's own log now carries whether it rejected the write or degraded — without it the outer handler would log only a generic brand-update error with no Semrush context.

The flag is resolved lazily, only once a Semrush call has actually failed. Failures are rare and most brand edits are flat-mode or non-Serenity, so the common path pays no flag read at all.

No behaviour changes for any org today: nothing sets `serenity_ui` yet, and it defaults off.

## 4. Required information

- Jira / issue: LLMO-6565 — https://jira.corp.adobe.com/browse/LLMO-6565
- Design of record: there is no separate spec document for this change — the design was agreed on the Jira ticket and the linked Slack thread. The resulting contract is written down in `docs/serenity.md` (section "Migration-window flag (`LLMO/serenity_ui`)"), which this PR adds: the flag's backend meaning, the two-flag truth table, both re-armed call sites, and the rollout procedure.
- Other: frontend half — https://github.com/adobe/project-elmo-ui/pull/2565 ; the change being gated — https://github.com/adobe/spacecat-api-service/pull/2907

## 5. Affected / used mysticat-workspace projects

- **project-elmo-ui** — contract. It is the other consumer of this flag and must match the spelling: its open PR introduces the constant as `serenity-ui`, which cannot work (see section 6). It needs to read `serenity_ui`.
- **mysticat-data-service** — contract, unchanged. Owns the `feature_flags` table and the CHECK constraint that fixes the flag-name spelling.

## 6. Additional information outside the code

Queried mysticat-prod directly to settle the flag name, because LLMO-6565 specifies `serenity-ui` and states the backend already emits it. Neither holds.

The table rejects the hyphenated name outright. `pg_constraint` for `feature_flags_flag_name_valid` in prod:

`CHECK ((char_length(flag_name) <= 255) AND (flag_name <> '') AND (flag_name ~ '^[a-z][a-z0-9_]*$'))`

Snake_case only — a row named `serenity-ui` can never be inserted, and `isValidFeatureFlagName` in this repo mirrors the same regex so the admin write endpoint rejects it before the database ever sees it. A client matching on the hyphenated name would read `false` forever with no error surfaced anywhere, which reads as "the flag is simply off".

Nor does the flag exist yet under any spelling. Grouping every row in prod `feature_flags` returns exactly three names, all under product LLMO: `brandalf` (1096 orgs, 1092 on), `brandalf_migration` (27 orgs, 1 on), `serenity` (83 orgs, 83 on). Enabling this for an org therefore needs a flag row created first — it is not already being emitted.

This PR uses `serenity_ui` on both counts.

## 7. Test plan

Not verified against a live environment this session — the reported path needs an org carrying a flag that does not exist in any environment yet, and a Semrush call that actually fails for the calling user. Both halves were exercised against the controller instead: the absorbed path (unchanged), the reported path for an authorization failure, a non-auth upstream failure and a failed token exchange, the pre-write guard rejecting rather than degrading, that the flag is not read when nothing fails, and that one answer is pinned when both call sites fail.

The flag name itself is covered against a real database rather than a mock, because that is where it can actually go wrong: nothing on the read path validates a flag name, so a wrong spelling resolves to `false` forever and looks exactly like the flag being off. The integration test writes `serenity_ui` through the admin endpoint, reads it back through the same storage helper the controller's gate uses, and asserts the hyphenated spelling is refused. An endpoint-level integration test for the 401/502 responses is not reachable today — the brands integration suite uses flat-mode brands only, and the Semrush vendor mock has no failure-injection control, so there is no way to make the re-sync fail from inside the harness.

Verifying on dev, once deployed:

1. Pick a Serenity-active org and a sub-workspace brand under it. Confirm the current behaviour first: edit the brand's URLs as a user who is not provisioned in Semrush and observe `200` with `semrushSyncPending: true`.
2. Turn the flag on: `PUT /organizations/{orgId}/feature-flags/llmo/serenity_ui` with `{"value": true}` and an admin key.
3. Allow up to the negative cache TTL (30s) for warm containers to pick up the flip.
4. Repeat the same edit. Expect `403` rather than `200`, no `semrushSyncPending` in the body, and no internal gateway URL in the body or the `x-error` header. Confirm the row still shows the edit — the write persists on both paths.
5. Edit `competitors` on the same brand. Expect the write to be rejected before the row is touched (the pre-write guard), i.e. the brand row is unchanged afterwards.
6. `DELETE` the same flag path and confirm the org falls back to the absorbed behaviour.

Prod rollout is the same sequence, but only for an org that is genuinely past the migration — turning it on for an org that still has unprovisioned Semrush users would start failing their brand edits, which is exactly what the allowance exists to prevent.

## 8. Deployment & merge order

- https://github.com/adobe/project-elmo-ui/pull/2565 — related. Introduces the frontend half of the same flag, currently spelled `serenity-ui`. It needs to move to `serenity_ui` or it will never match a stored row.
- https://github.com/adobe/spacecat-api-service/pull/2907 — already merged. This PR gates the behaviour that one introduced.

Ordering is unconstrained: the flag defaults off, so this can merge and deploy on its own with no behaviour change for any org. The real sequence is operational — the elmo PR must agree on the spelling, and a `serenity_ui` flag row must be created for an org before either side changes behaviour for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


