### PR TITLE
fix(deps): bump @adobe/spacecat-shared-data-access to 4.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "4.15.1",
+        "@adobe/spacecat-shared-data-access": "4.15.2",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.1.tgz",
-      "integrity": "sha512-PxrlbtxibRqTstqW4iszQDUz8R+v/jZmZu8hYkreGs8dUG2vg2VICYuaeUQSdx2MsU2JJ/4IhPuJHd/bmk5Gag==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.2.tgz",
+      "integrity": "sha512-IbQBL6IpkvQMSkLhAwGWyxOGjVVPFLaQcEbeolV59xZU7WndAACVUeTOKJHUeFnqM3LhuT2DwJRDGctvAOGXlg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "4.15.1",
+    "@adobe/spacecat-shared-data-access": "4.15.2",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",


### PR DESCRIPTION
## Summary
Bumps `@adobe/spacecat-shared-data-access` from `4.15.1` to `4.15.2` to pick up `Site.setConfig()`'s schema-validation guard (adobe/spacecat-shared#1852, merged). This is the companion this repo's `ValidationError` → `400` handling (#2944, already merged) needs to actually have a `ValidationError` to catch.

## Context
No behavior change on deploy — `CONFIG_VALIDATION_ENFORCEMENT` defaults to `warn` in the shared package, so `Site.setConfig()` won't throw until that's explicitly flipped to `enforce` in this service's environment config.

## Test plan
- [x] Verified `guardConfigValidation`/`config-validation-guard.js` present in the published 4.15.2 package
- [x] `npm test` — 16295 passing