### PR TITLE
fix: restrict LLMO CDN config endpoints to administrator access

### DIFF
--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -856,8 +856,8 @@ function LlmoController(ctx) {
       }
       const { site, config } = siteValidation;
 
-      if (!await accessControlUtil.hasLlmoCapabilityForSite(site)) {
-        return forbidden(accessControlUtil.llmoForbiddenMessage('Only LLMO administrators can update the CDN logs filter'));
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only administrators can update the CDN logs filter');
       }
 
       if (!isObject(data)) {
@@ -890,8 +890,8 @@ function LlmoController(ctx) {
       }
       const { site, config } = siteValidation;
 
-      if (!await accessControlUtil.hasLlmoCapabilityForSite(site)) {
-        return forbidden(accessControlUtil.llmoForbiddenMessage('Only LLMO administrators can update the CDN bucket config'));
+      if (!accessControlUtil.hasAdminAccess()) {
+        return forbidden('Only administrators can update the CDN bucket config');
       }
 
       if (!isObject(data)) {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -2796,9 +2796,9 @@ describe('LlmoController', () => {
       },
     );
 
-    it('should return 403 when user is not LLMO administrator', async () => {
+    it('should return 403 when user is not an administrator', async () => {
       const LlmoControllerNoAdmin = await esmock('../../../src/controllers/llmo/llmo.js', {
-        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true, true, false),
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true, false, false),
         '@adobe/spacecat-shared-http-utils': mockHttpUtils,
         '../../../src/support/cached-response.js': mockCachedResponse,
         ...getCommonMocks(),
@@ -2809,7 +2809,7 @@ describe('LlmoController', () => {
 
       expect(result.status).to.equal(403);
       const responseBody = await result.json();
-      expect(responseBody.message).to.equal('Only LLMO administrators can update the CDN logs filter');
+      expect(responseBody.message).to.equal('Only administrators can update the CDN logs filter');
     });
 
     describe('patchLlmoCdnBucketConfig', () => {
@@ -2864,9 +2864,9 @@ describe('LlmoController', () => {
         },
       );
 
-      it('should return 403 when user is not LLMO administrator', async () => {
+      it('should return 403 when user is not an administrator', async () => {
         const LlmoControllerNoAdmin = await esmock('../../../src/controllers/llmo/llmo.js', {
-          '../../../src/support/access-control-util.js': createMockAccessControlUtil(true, true, false),
+          '../../../src/support/access-control-util.js': createMockAccessControlUtil(true, false, false),
           '@adobe/spacecat-shared-http-utils': mockHttpUtils,
           '../../../src/support/cached-response.js': mockCachedResponse,
           ...getCommonMocks(),
@@ -2877,7 +2877,7 @@ describe('LlmoController', () => {
 
         expect(result.status).to.equal(403);
         const responseBody = await result.json();
-        expect(responseBody.message).to.equal('Only LLMO administrators can update the CDN bucket config');
+        expect(responseBody.message).to.equal('Only administrators can update the CDN bucket config');
       });
     });
   });


### PR DESCRIPTION
Aligns two LLMO CDN configuration endpoints (`PATCH /sites/:siteId/llmo/cdn-logs-filter` and `PATCH /sites/:siteId/llmo/cdn-logs-bucket-config`) with our other admin-gated configuration endpoints by requiring administrator access.

- Gate both handlers on `accessControlUtil.hasAdminAccess()`.
- Update the corresponding controller tests.

Tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)