### PR TITLE
fix(serenity): request prompt metadata and use the real sort keys on by_tags (LLMO-6289)

### DIFF
--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -58,6 +58,9 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 /** @typedef {Parameters<PeTransport['updateCompetitors']>[0]['body']} CiCompetitorsBody */
 /** @typedef {CiCompetitorsBody['ci_competitors']} CiCompetitors */
 /** @typedef {Parameters<PeTransport['updatePromptTags']>[0]['body']['items']} PromptTagUpdates */
+/** @typedef {Parameters<PeTransport['listPromptsByTagIds']>[0]['body']} PromptsListBody */
+/** @typedef {Parameters<PeTransport['patchPromptsMetadataBatch']>[0]['body']} MetadataBatchBody */
+/** @typedef {MetadataBatchBody['items'][number]['metadata']} PromptMetadataPatch */
 
 /**
  * The `resources` allocation object shared by the v2 child-create and the v2 resources
@@ -95,29 +98,6 @@ const DEFAULT_TIMEOUT_MS = 15_000;
  * argument count and argument types on every call made through it.
  *
  * @typedef {ReturnType<typeof createSerenityTransport>} SerenityTransport
- */
-
-/**
- * The Project Engine facade EXTENDED with the v3 prompt-authorship-metadata
- * write surface (LLMO-6289). WP2 re-vendors the client so the generated
- * `SerenityProjectEngineTransport` carries these operations natively; until that
- * release lands (this WP's merge gate — the dependency is bumped to the
- * WP2-released version before merge), they are declared here as a local
- * intersection so the single transport boundary type-checks under `// @ts-check`
- * against the currently-installed client. Method names/shapes track the routes
- * the revised ADR pins (spec §13 item 1):
- *   - createPromptsWithMetadata → POST  /v3 prompts        { items:[{name,metadata}], tag_ids }
- *   - patchPrompt               → PATCH /v3 prompts/{id}          { name?, metadata? }
- *   - patchPromptMetadata       → PATCH /v3 prompts/{id}/metadata { <merge-patch> }
- *   - patchPromptsMetadataBatch → PATCH /v3 prompts/metadata      { items:[{id,metadata}] }
- * WP2's generated types supersede this typedef verbatim on the dep bump.
- *
- * @typedef {ReturnType<typeof createSerenityProjectEngineTransport> & {
- *   createPromptsWithMetadata: (init: any) => Promise<any>,
- *   patchPrompt: (init: any) => Promise<any>,
- *   patchPromptMetadata: (init: any) => Promise<any>,
- *   patchPromptsMetadataBatch: (init: any) => Promise<any>,
- * }} ProjectEngineTransportWithMetadata
  */
 
 /**
@@ -392,9 +372,7 @@ export function createSerenityTransport({ env, imsToken }) {
   // client's internal.js (library defaults: maxRetries 2, retryBaseDelayMs 200;
   // per-attempt timeout via the injected `createTimeoutFetch`, since the retry
   // layer wraps it and calls it once per attempt).
-  const projects = /** @type {ProjectEngineTransportWithMetadata} */ (
-    createSerenityProjectEngineTransport(projectEngineOptions)
-  );
+  const projects = createSerenityProjectEngineTransport(projectEngineOptions);
 
   // Raw Project Engine client, ONLY for GET /v1/workspaces/{id}/brand-topics: the
   // facade does not expose a brand-topics method yet (it is in-spec — the future
@@ -434,13 +412,23 @@ export function createSerenityTransport({ env, imsToken }) {
      * that an unpublished draft reads as 0 prompts), never treat empty as missing.
      *
      * METADATA (LLMO-6289): WP0 added an Adobe-owned `metadata` column carried
-     * INLINE on each item of this read (`AIOPromptWithStatus.metadata`), and made
-     * this the sortable list path — the legacy "Semrush rejects sort_field /
-     * sort_dir here" note no longer holds for `sort` / `order`. `sort` is
-     * allow-listed to `metadata.created_at` / `metadata.updated_at` by the
-     * caller (handlers/prompts.js `resolveSort`) BEFORE it reaches here. Both are
-     * sent ONLY when a sort is requested, so an unsorted read is byte-for-byte the
-     * legacy call. Every other field stays restricted to what upstream documents.
+     * INLINE on each item of this read (`AIOPromptWithStatus.metadata`), but it is
+     * OPT-IN and the switch is the `include_metadata` QUERY parameter — NOT a body
+     * field. Without it upstream omits the `metadata` key from every item and
+     * answers 200, which a consumer cannot tell apart from "every prompt is
+     * genuinely unstamped". It is therefore sent UNCONDITIONALLY here rather than
+     * exposed as a per-call option — a caller that forgets to opt in gets data that
+     * is indistinguishable from unstamped, and the cost of always asking is four
+     * short strings per item.
+     *
+     * SORT: the wire keys are `sort_field` / `sort_dir` in the request BODY
+     * (`model.AIOPromptsListRequest`). Unknown body keys are ignored with a 200, so
+     * a wrong name is a silent no-op, not an error. `sort` is allow-listed to
+     * `metadata.created_at` / `metadata.updated_at` by the caller
+     * (handlers/prompts.js `resolveSort`) BEFORE it reaches here and is mapped onto
+     * `sort_field` at this boundary. Both are sent ONLY when a sort is requested,
+     * so an unsorted read carries neither key. Every other field stays restricted
+     * to what upstream documents.
      *
      * @param {string} semrushWorkspaceId
      * @param {string} projectId
@@ -450,11 +438,19 @@ export function createSerenityTransport({ env, imsToken }) {
      * @param {number} [body.limit]
      * @param {string} [body.search]
      * @param {boolean} [body.unassigned]
-     * @param {string} [body.sort] - allow-listed metadata sort field (LLMO-6289).
-     * @param {string} [body.order] - `asc` / `desc`; sent only with `sort`.
+     * @param {string} [body.sort] - allow-listed metadata sort field (LLMO-6289),
+     *   sent upstream as `sort_field`.
+     * @param {string} [body.order] - `asc` / `desc`, sent upstream as `sort_dir`;
+     *   sent only alongside `sort`.
      */
     async listPromptsByTags(semrushWorkspaceId, projectId, body) {
-      /** @type {Record<string, unknown>} */
+      // Annotated with the GENERATED body type, and built without an object
+      // spread, so both halves of the wire contract are enforced by tsc: a
+      // misspelled key is TS2353 on the literal / TS2339 on the assignment below,
+      // and a wrong value type is TS2322. Keep it spread-free — a spread disables
+      // excess-property checking, which is what lets a misspelled key reach the
+      // wire, where upstream ignores it with a 200 rather than refusing it.
+      /** @type {PromptsListBody} */
       const requestBody = {
         tag_ids: body?.tag_ids ?? [],
         page: body?.page ?? 1,
@@ -463,16 +459,16 @@ export function createSerenityTransport({ env, imsToken }) {
         unassigned: body?.unassigned,
       };
       if (body?.sort) {
-        requestBody.sort = body.sort;
-        requestBody.order = body.order;
+        requestBody.sort_field = body.sort;
+        requestBody.sort_dir = body.order;
       }
       return projects.listPromptsByTagIds(
         {
-          params: { path: { id: semrushWorkspaceId, project_id: projectId } },
-          // WP2's regenerated by_tags body carries sort/order + returns metadata;
-          // cast at this one boundary until the dep bump (see the file-level
-          // ProjectEngineTransportWithMetadata typedef).
-          body: /** @type {any} */ (requestBody),
+          params: {
+            path: { id: semrushWorkspaceId, project_id: projectId },
+            query: { include_metadata: true },
+          },
+          body: requestBody,
         },
       );
     },
@@ -585,23 +581,30 @@ export function createSerenityTransport({ env, imsToken }) {
 
     /**
      * PATCH /v3/.../aio/prompts/metadata — BATCH metadata merge-patch across many
-     * prompts in ONE upstream transaction (LLMO-6289). Body: `{ items: [{ id,
-     * metadata }] }`, each `metadata` an independent RFC 7396 merge. The batch is
-     * ATOMIC upstream: a CHECK violation on ANY item (e.g. a `created_by` /
-     * `updated_by` longer than 100 chars) rolls the WHOLE batch back and answers
+     * prompts in ONE upstream transaction (LLMO-6289). Body: `{ items: [{
+     * prompt_id, metadata }] }` (`model.PatchAIOPromptsBatchItem` — the id key is
+     * `prompt_id`, NOT `id`), each `metadata` an independent RFC 7396 merge. The
+     * batch is ATOMIC upstream: a CHECK violation on ANY item (e.g. a `created_by`
+     * / `updated_by` longer than 100 chars) rolls the WHOLE batch back and answers
      * 400 — so callers must isolate a deterministic offender rather than retry the
-     * batch whole. Nothing else in this WP calls it; it exposes the batch write
-     * surface the ADR pins for bulk stampers.
+     * batch whole. No caller yet; it exposes the batch write surface the ADR pins
+     * for bulk stampers.
      *
      * @param {string} semrushWorkspaceId
      * @param {string} projectId
-     * @param {Array<{ id: string, metadata: object }>} items
+     * @param {Array<{ promptId: string, metadata: PromptMetadataPatch }>} items -
+     *   camelCase in, mapped onto the upstream `prompt_id` key here.
      */
     async patchPromptsMetadataBatch(semrushWorkspaceId, projectId, items) {
       return projects.patchPromptsMetadataBatch(
         {
           params: { path: { id: semrushWorkspaceId, project_id: projectId } },
-          body: { items },
+          body: {
+            items: items.map(({ promptId, metadata }) => ({
+              prompt_id: promptId,
+              metadata,
+            })),
+          },
         },
       );
     },

--- a/test/support/serenity/rest-transport-metadata.test.js
+++ b/test/support/serenity/rest-transport-metadata.test.js
@@ -106,18 +106,24 @@ describe('Semrush REST transport — v3 metadata write surface (LLMO-6289)', () 
     });
   });
 
-  it('patchPromptsMetadataBatch PATCHes /metadata with { items:[{id,metadata}] }', async () => {
+  it('patchPromptsMetadataBatch PATCHes /metadata with { items:[{prompt_id,metadata}] }', async () => {
     const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
-    const items = [
-      { id: 'p1', metadata: { updated_by: 'u1' } },
-      { id: 'p2', metadata: { updated_by: 'u2' } },
-    ];
 
-    await transport.patchPromptsMetadataBatch(WS, PID, items);
+    await transport.patchPromptsMetadataBatch(WS, PID, [
+      { promptId: 'p1', metadata: { updated_by: 'u1' } },
+      { promptId: 'p2', metadata: { updated_by: 'u2' } },
+    ]);
 
+    // The upstream id key is `prompt_id` (model.PatchAIOPromptsBatchItem); an
+    // item keyed `id` carries no prompt reference upstream at all.
     expect(facade.patchPromptsMetadataBatch).to.have.been.calledOnceWithExactly({
       params: { path: { id: WS, project_id: PID } },
-      body: { items },
+      body: {
+        items: [
+          { prompt_id: 'p1', metadata: { updated_by: 'u1' } },
+          { prompt_id: 'p2', metadata: { updated_by: 'u2' } },
+        ],
+      },
     });
   });
 });

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -14,10 +14,7 @@ import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import {
-  ProjectEngineApiError,
-  createSerenityProjectEngineTransport,
-} from '@adobe/spacecat-shared-project-engine-client';
+import { ProjectEngineApiError } from '@adobe/spacecat-shared-project-engine-client';
 
 import {
   createSerenityTransport,
@@ -723,7 +720,20 @@ describe('Semrush REST transport', () => {
       expect(body.limit).to.equal(200);
     });
 
-    it('does not forward sort_field / sort_dir — Semrush rejects them on this endpoint', async () => {
+    it('opts into metadata via the include_metadata QUERY parameter on every call', async () => {
+      fetchStub.resolves(fetchOk({ items: [] }));
+      const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
+
+      await transport.listPromptsByTags(WORKSPACE_ID, PROJECT_ID, { page: 1 });
+
+      const call = await callOf(fetchStub);
+      // Upstream reads the flag off the query string only: in the body it is
+      // ignored with a 200 and every item comes back without its `metadata` key.
+      expect(new URL(call.url).searchParams.get('include_metadata')).to.equal('true');
+      expect(JSON.parse(call.body)).to.not.have.property('include_metadata');
+    });
+
+    it('ignores caller-supplied wire keys — only the transport builds the body', async () => {
       fetchStub.resolves(fetchOk({ items: [] }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
@@ -740,7 +750,7 @@ describe('Semrush REST transport', () => {
       expect(body.search).to.equal('photoshop');
     });
 
-    it('forwards sort + order on the with-metadata list path (LLMO-6289)', async () => {
+    it('maps sort/order onto the sort_field/sort_dir wire keys (LLMO-6289)', async () => {
       fetchStub.resolves(fetchOk({ items: [] }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
@@ -751,11 +761,15 @@ describe('Semrush REST transport', () => {
 
       const call = await callOf(fetchStub);
       const body = JSON.parse(call.body);
-      expect(body.sort).to.equal('metadata.updated_at');
-      expect(body.order).to.equal('desc');
+      expect(body.sort_field).to.equal('metadata.updated_at');
+      expect(body.sort_dir).to.equal('desc');
+      // `sort` / `order` are this transport's own param names, never wire keys —
+      // upstream ignores them silently, so sending them sorts nothing.
+      expect(body).to.not.have.property('sort');
+      expect(body).to.not.have.property('order');
     });
 
-    it('omits sort/order entirely when no sort is requested (byte-for-byte legacy call)', async () => {
+    it('omits both sort keys entirely when no sort is requested', async () => {
       fetchStub.resolves(fetchOk({ items: [] }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 
@@ -763,8 +777,8 @@ describe('Semrush REST transport', () => {
 
       const call = await callOf(fetchStub);
       const body = JSON.parse(call.body);
-      expect(body).to.not.have.property('sort');
-      expect(body).to.not.have.property('order');
+      expect(body).to.not.have.property('sort_field');
+      expect(body).to.not.have.property('sort_dir');
     });
   });
 
@@ -1736,50 +1750,5 @@ describe('Semrush REST transport', () => {
         expect(params.get('country')).to.equal('');
       });
     });
-  });
-});
-
-// WP2 MERGE GATE (LLMO-6289) — structural, not social. WP1's write paths call the
-// v3 authorship-metadata facade on the REAL Project Engine client at RUNTIME
-// (createPromptsWithMetadata / patchPrompt / patchPromptMetadata /
-// patchPromptsMetadataBatch — see rest-transport.js). The installed client does
-// not expose them yet; they arrive with WP2's client re-vendor + dep bump, and
-// the app transport only *type*-checks today via the local
-// `ProjectEngineTransportWithMetadata` cast. If WP1 merged and deployed against
-// the current client, every native prompt write would throw
-// `TypeError: <method> is not a function` in production — the exact "green in
-// tests (mocked transport), broken in prod (real client lacks the method)" class
-// the repo guards against (SITES-45260; see CLAUDE.md "Lambda Bundle Constraints").
-// This test FAILS until the installed client carries all four methods, so CI
-// cannot go green — and this PR cannot merge clean — before the WP2 dependency
-// bump lands. It self-heals (delete this block + the file-level typedef) the
-// moment the bumped client ships the facade. REMOVING THIS GATE (this block + the
-// `ProjectEngineTransportWithMetadata` typedef in rest-transport.js) is part of
-// WP2's definition-of-done (LLMO-6289) — it must be torn down with the dep bump,
-// not left behind to fail forever.
-describe('WP2 merge gate — Project Engine v3 authorship-metadata facade', () => {
-  const V3_METADATA_METHODS = [
-    'createPromptsWithMetadata',
-    'patchPrompt',
-    'patchPromptMetadata',
-    'patchPromptsMetadataBatch',
-  ];
-
-  it('the installed @adobe/spacecat-shared-project-engine-client exposes every v3 write method (bump before merge)', () => {
-    // Introspection only — the fetch seam rejects so a stray call fails loudly
-    // rather than hitting the network; we never invoke a method here.
-    const transport = createSerenityProjectEngineTransport({
-      baseUrl: 'https://wp2-merge-gate.invalid',
-      authToken: 'gate',
-      fetch: () => Promise.reject(new Error('WP2 gate: introspection only, never called')),
-    });
-    const missing = V3_METADATA_METHODS.filter((m) => typeof transport[m] !== 'function');
-    expect(
-      missing,
-      `Project Engine client is missing v3 facade method(s): [${missing.join(', ')}]. `
-        + 'Bump @adobe/spacecat-shared-project-engine-client to the WP2 release that vendors '
-        + 'them before merging WP1 (LLMO-6289) — deploying against the current client would '
-        + 'throw "is not a function" on every native prompt write.',
-    ).to.deep.equal([]);
   });
 });

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -733,7 +733,7 @@ describe('Semrush REST transport', () => {
       expect(JSON.parse(call.body)).to.not.have.property('include_metadata');
     });
 
-    it('ignores caller-supplied wire keys — only the transport builds the body', async () => {
+    it('does not forward caller-supplied sort_field / sort_dir — only `sort` maps to them', async () => {
       fetchStub.resolves(fetchOk({ items: [] }));
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

Corrects three request-shape defects on the Semrush `by_tags` prompt read and the batch metadata PATCH, so prompt authorship metadata is actually returned, the "Last modified" sort actually sorts, and the batch stamp surface addresses prompts by the key upstream defines.

## 2. Reasoning

Prompt authorship metadata is written correctly — a prompt created through the UI carries all four `created_*` / `updated_*` values upstream — but the Prompt Library renders an em dash in every authorship column. The read side never asks for the data.

`include_metadata` is a **query** parameter on `by_tags`. It was never sent. Upstream's response to a request that omits it is a 200 with the `metadata` key absent from every item, so `buildPromptDto`'s `metadata?.created_at ?? null` mapped all four DTO fields to `null`. The UI's em dash — its correct rendering for an un-backfilled prompt — became indistinguishable from a stamped one.

Two more defects of the same kind sit next to it. The body's sort keys are `sort_field` / `sort_dir` (`model.AIOPromptsListRequest`); we sent `sort` / `order`, and upstream ignores unknown body keys with a 200, so the server-side sort was a silent no-op. The batch metadata PATCH keys its items `prompt_id` (`model.PatchAIOPromptsBatchItem`); we sent `id`, which carries no prompt reference at all.

All three shared one enabler: the request bodies at this boundary were passed through an `any` cast, so nothing compared them against the generated contract. Now that the vendored client ships the v3 facade natively, the cast has no remaining purpose.

## 3. High-level overview of the changes

**Prompt authorship metadata is returned.** The `by_tags` read sends `include_metadata=true` as a query parameter on every call. Before: `metadata` absent from every item, all four DTO authorship fields `null`, em dashes in the Prompt Library for prompts that are correctly stamped. After: stamped prompts show their real author and timestamps; genuinely un-backfilled prompts still show an em dash, which is now the only thing an em dash means.

The flag is sent unconditionally rather than exposed as a per-call option. A caller that forgets to opt in receives data that cannot be told apart from unstamped data — the failure has no signal — and the cost of always asking is four short strings per item. This also covers the tag-walk readers (`listTagsForProject`, `countPublishedPrompts`), which ignore the field.

**Server-side prompt sorting works.** The transport keeps `sort` / `order` as its own parameter names — the public API query parameters and the `resolveSort` allow-list are unchanged — and maps them onto `sort_field` / `sort_dir` at the wire boundary. Before: "Last modified" returned the default order. After: it sorts. No change to any caller or to the OpenAPI contract.

**The batch metadata PATCH addresses prompts correctly.** Items are keyed `prompt_id`. The method takes `{ promptId, metadata }` in camelCase, consistent with the rest of the transport's JS-facing API, and maps to the upstream key internally. This surface has no caller yet, so the defect was latent rather than live.

**The boundary is type-enforced instead of cast away.** The `ProjectEngineTransportWithMetadata` intersection typedef and its `any` cast are gone — the vendored client's generated types now cover the v3 facade — so request shapes at this boundary derive from the generated contract, matching how the rest of this file already treats Semrush shapes. The list body is annotated with the generated type and built without an object spread, because a spread suppresses excess-property checking and is exactly what lets a misspelled key through. A wrong key name or value type at this call site is now a compile error.

Consequently the WP2 dependency gate is retired. It asserted at runtime that the installed client exposes the four v3 write methods; with the cast removed, the strict type-check tier reports a missing method directly against the real client type, which is a stronger and earlier check than the introspection test it replaces.

## 4. Required information

- Jira / issue: LLMO-6289 — https://jira.corp.adobe.com/browse/LLMO-6289
- GitHub issue: https://github.com/adobe/spacecat-api-service/issues/2954 — this PR delivers both source fixes that issue pins down; its remaining integration coverage is not in this diff (see section 8), so the issue stays open.
- ADR(s): `docs/decisions/006-serenity-v1-v2-read-drift.md` (the `by_tags` live-layer read this fix extends), `docs/decisions/005-opt-in-type-checking.md` (the type-checking scope the boundary now leans on)

## 5. Affected / used mysticat-workspace projects

- **project-elmo-ui** — consumer, no change needed. Its Prompt Library authorship columns and CSV export read the four DTO fields this PR starts populating; they render an em dash today purely because the values arrive `null`. The columns begin showing real data as soon as this deploys, with no UI change.
- **spacecat-shared** — contract. The Project Engine mock's `by_tags` handler implements no sort logic, so it cannot distinguish the corrected sort keys from the ignored ones; teaching it that contract is tracked in https://github.com/adobe/spacecat-shared/issues/1856. The same mock IS faithful on `include_metadata`, which is why the metadata half of this change is coverable today and the sort half is not.
- **mysticat-data-service** — contract only. Its migration CLI speaks the same upstream surface and already sends `include_metadata` and `prompt_id` correctly; no change is required there, and nothing in this PR alters what the CLI writes.

## 6. Additional information outside the code

All three request shapes were confirmed against the live upstream API on an internal test workspace, before and after the fix:

- **The write path was already correct; the read was not.** A prompt created through the UI carries all four `created_*` / `updated_*` values upstream. Reading that same prompt with `include_metadata` on the query string returns the metadata block; reading it the way this service did returns the item with no `metadata` key at all.
- **Passing the flag in the body does not work.** The item then comes back with `metadata: null` — which reads as "this prompt is unstamped" rather than as a rejected request. Worth knowing, because it is the more misleading of the two failure modes.
- **Sort keys.** With `sort_field` / `sort_dir` the prompts come back ordered by `metadata.updated_at` as intended. With `sort` / `order` the response is byte-identical to an unsorted read.
- **Batch item key.** `model.PatchAIOPromptsBatchItem` in the vendored `/v3` contract requires `prompt_id`; `id` is not a member.

Probing the create path required writing one throwaway prompt to a test project; it was deleted afterwards and the project re-verified back at its original contents.

Operationally worth knowing, independent of this PR: prompts migrated before the authorship stamp shipped carry no metadata upstream, so they will keep reading as four nulls until a backfill runs. This fix makes that state visible rather than hiding it behind the same em dash a stamped prompt produced.

## 7. Test plan

Verified beyond unit tests: the live upstream probes in section 6 establish the corrected request shapes against the real API, which is the part unit tests cannot prove — a mocked transport is happy with either spelling. The type-level claims were checked by deliberately reintroducing each defect and confirming the strict tier now reports it, rather than accepting it as it did behind the `any` cast.

Integration coverage: the metadata half is covered by the read-path assertions landing against the Project Engine mock, which gates the inline `metadata` block on the query parameter and omits the key entirely when it is absent — so those assertions genuinely fail without this fix. The sort half is deliberately not asserted in the integration suite: the mock returns store order regardless of the keys sent, so an ordering assertion would pass with the wrong keys too and prove nothing. Ordering coverage waits on the mock work in https://github.com/adobe/spacecat-shared/issues/1856; until then the outgoing request shape is guarded by unit assertion.

**dev** — this branch was deployed to the shared `dev-branches` environment and exercised end to end there: creating a prompt through `POST /serenity/prompts` and reading it back through the list endpoint returns populated `createdAt` / `createdBy` / `updatedAt` / `updatedBy`, where the same read previously returned four nulls for a stamped prompt. The probe prompt was deleted and the slice re-verified afterwards.

**prod** — open the Prompt Library for a Serenity brand with prompts created after the authorship stamp shipped; the authorship columns should show a real user and timestamp instead of em dashes. Prompts created before it legitimately stay em-dashed. The read is additive: a prompt with no metadata upstream still yields `null` fields and the same em dash shown today, so a brand whose prompts all predate the stamp looks unchanged.

## 8. Deployment & merge order

- https://github.com/adobe/spacecat-api-service/pull/2956 — related, no ordering constraint. It adds the authorship-metadata IT coverage and touches only `test/it/**`; this PR touches only `src/` and `test/support/**`. Disjoint files, both based on `main`, so they merge in either order. Between them they satisfy the metadata half of issue 2954.
- https://github.com/adobe/spacecat-shared/issues/1856 — follow-up, does not block this PR. Once the mock honours `sort_field` / `sort_dir` and ships, this repo bumps the client and the ordering coverage that issue 2954 asks for becomes writable. Shipping the transport fix ahead of that is deliberate: it corrects production behaviour now, and the mock's sort blindness means no integration test regresses either way.

No deploy sequencing is required — the change is additive on the read path and needs no coordinated release with elmo-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
