### PR TITLE
feat(serenity): per-item source passthrough for SR Track flow (LLMO-6556)

### DIFF
--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -645,8 +645,12 @@ export function normalizePromptInput(input) {
   // default (`config` for the human dialog) applies downstream. Present ⇒ must be
   // a known producer from SOURCE_VALUES; unknown slugs are rejected 400 so a caller
   // can only SELECT from the server's vocabulary, never invent one.
+  // FIX (review Should-Fix #1): gate on nullish, not `!== undefined`. An explicit
+  // JSON `source: null` means "no override" (a client serializing an optional
+  // field), so it must fall through to the batch default — not 400 with a
+  // misleading "must be one of …". Only a non-nullish value is validated.
   let source;
-  if (input?.source !== undefined) {
+  if (input?.source != null) {
     const canon = canonicalizeSource(input.source);
     if (!canon || !SOURCE_VALUES.includes(canon)) {
       return { value: null, reason: `source must be one of ${SOURCE_VALUES.join(', ')}` };

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -820,7 +820,10 @@ export function makePromptTagInjector(
     // on both means UPDATE — leave the producer alone (fixed at creation). Cache
     // is keyed on (projectId, source) so a mixed-surface batch resolves each
     // producer's tag independently. Stripped by resolved id, never by name.
-    const itemSource = input.source || sourceValue;
+    // `??` not `||` (MysticatBot nit): `normalizePromptInput` yields a valid slug
+    // or `undefined`, so "absent means use the batch default" is exactly the
+    // nullish-coalesce contract.
+    const itemSource = input.source ?? sourceValue;
     if (itemSource) {
       const key = `${projectId} ${itemSource}`;
       let pending = sourceCache.get(key);

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -23,6 +23,7 @@ import { invalidateTagCacheForProject } from './markets.js';
 import { resolveTypeValueInjection, resolveIntentValueInjection, resolveServerOwnedValueInjection } from '../tag-tree.js';
 import {
   DIMENSION, ORIGIN_VALUE, INTENT_VALUE, PROXY_CREATE_SOURCE_VALUE,
+  canonicalizeSource, SOURCE_VALUES,
 } from '../prompt-tags.js';
 import { classifyPromptIntents } from '../intent-classification.js';
 
@@ -640,9 +641,21 @@ export function normalizePromptInput(input) {
       reason: 'tagIds must be a non-empty array of upstream tag ids',
     };
   }
+  // source — per-item override for the Track flow (LLMO-6556). Absent ⇒ the batch
+  // default (`config` for the human dialog) applies downstream. Present ⇒ must be
+  // a known producer from SOURCE_VALUES; unknown slugs are rejected 400 so a caller
+  // can only SELECT from the server's vocabulary, never invent one.
+  let source;
+  if (input?.source !== undefined) {
+    const canon = canonicalizeSource(input.source);
+    if (!canon || !SOURCE_VALUES.includes(canon)) {
+      return { value: null, reason: `source must be one of ${SOURCE_VALUES.join(', ')}` };
+    }
+    source = canon;
+  }
   return {
     value: {
-      text, languageCode, geoTargetId, tagIds,
+      text, languageCode, geoTargetId, tagIds, ...(source !== undefined && { source }),
     },
     reason: null,
   };
@@ -740,7 +753,7 @@ export async function createOnePrompt(transport, semrushWorkspaceId, projectId, 
  *   / `sourceValue` are the derived `origin` / `source` to inject on CREATE; omit
  *   each on UPDATE so that dimension is left untouched.
  * @returns {(projectId: string, input: { text: string, geoTargetId: number,
- *   tagIds: string[] }) =>
+ *   tagIds: string[], source?: string }) =>
  *   Promise<{ text: string, geoTargetId: number, tagIds: string[] }>}
  */
 export function makePromptTagInjector(
@@ -798,21 +811,25 @@ export function makePromptTagInjector(
       tagIds = [...tagIds.filter((id) => !valueTagIds.includes(id)), computedId];
     }
 
-    // source — CREATE only, same asymmetry as origin. `sourceValue` unset means
-    // UPDATE: leave the producer alone (fixed at creation). Stripped by resolved id
-    // beneath the `source` root, never by name (a category may be `gsc`).
-    if (sourceValue) {
-      let pending = sourceCache.get(projectId);
+    // source — CREATE only, same asymmetry as origin. Per-item `input.source`
+    // (Track flow, LLMO-6556) overrides the batch default (`sourceValue`); absent
+    // on both means UPDATE — leave the producer alone (fixed at creation). Cache
+    // is keyed on (projectId, source) so a mixed-surface batch resolves each
+    // producer's tag independently. Stripped by resolved id, never by name.
+    const itemSource = input.source || sourceValue;
+    if (itemSource) {
+      const key = `${projectId} ${itemSource}`;
+      let pending = sourceCache.get(key);
       if (!pending) {
         pending = resolveServerOwnedValueInjection(
           transport,
           semrushWorkspaceId,
           projectId,
           DIMENSION.SOURCE,
-          sourceValue,
+          itemSource,
           log,
         );
-        sourceCache.set(projectId, pending);
+        sourceCache.set(key, pending);
       }
       const { computedId, valueTagIds } = await pending;
       tagIds = [...tagIds.filter((id) => !valueTagIds.includes(id)), computedId];

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -2942,6 +2942,37 @@ describe('handlers/prompts.js — per-item source override (LLMO-6556)', () => {
       expect(out.tagIds).to.deep.equal([TAG_IDS.sourceSemrush]);
       expect(transport.listProjectTags).to.not.have.been.called;
     });
+
+    // ADDED (MysticatBot suggestion): the cache-HIT path — the stated purpose of
+    // the (projectId, source) re-key. Two cards with the SAME producer resolve it
+    // ONCE (no new reads on the repeat), while a DIFFERENT producer re-keys and
+    // does resolve again — proving the key includes `source`, not just the project.
+    it('serves a repeat (projectId, source) from the cache and re-keys a new source', async () => {
+      const transport = { listProjectTags: makeListProjectTagsStub() };
+      const inject = makePromptTagInjector(transport, WORKSPACE, undefined, fakeLog(), {
+        sourceValue: 'config',
+      });
+
+      await inject('proj-1', {
+        text: 'a', geoTargetId: 2840, tagIds: [], source: 'semrush',
+      });
+      const readsAfterFirst = transport.listProjectTags.callCount;
+      expect(readsAfterFirst).to.be.greaterThan(0);
+
+      // Same (project, source) => cache hit, no additional reads.
+      await inject('proj-1', {
+        text: 'b', geoTargetId: 2840, tagIds: [], source: 'semrush',
+      });
+      expect(transport.listProjectTags.callCount).to.equal(readsAfterFirst);
+
+      // Different source (`config`, also pre-minted) => cache miss because the key
+      // is re-keyed on source, so it resolves again: more reads than the semrush-only
+      // count. Proves the cache distinguishes producers within one project.
+      await inject('proj-1', {
+        text: 'c', geoTargetId: 2840, tagIds: [], source: 'config',
+      });
+      expect(transport.listProjectTags.callCount).to.be.greaterThan(readsAfterFirst);
+    });
   });
 });
 

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -22,6 +22,7 @@ import {
   handleUpdatePrompt,
   handleBulkDeletePrompts,
   makePromptTagInjector,
+  normalizePromptInput,
   makeIntentInjector,
   validateDeferPublish,
   reconcilePublishErrors,
@@ -2860,6 +2861,86 @@ describe('handlers/prompts.js — origin derivation (origin-dimension.md §3)', 
       // Same project => served from the per-project origin cache, no new reads.
       expect(transport.listProjectTags.callCount).to.equal(readsAfterFirst);
       expect(transport.createProjectTags).to.not.have.been.called;
+    });
+  });
+});
+
+// Per-item `source` override for the SR Track flow (LLMO-6556): a card may name
+// its real producing surface, validated against the closed SOURCE_VALUES.
+describe('handlers/prompts.js — per-item source override (LLMO-6556)', () => {
+  const base = {
+    text: 'hi', languageCode: 'en', geoTargetId: 2840, tagIds: ['t1'],
+  };
+
+  describe('normalizePromptInput source validation', () => {
+    it('passes a valid source through, canonicalized', () => {
+      const { value, reason } = normalizePromptInput({ ...base, source: 'Semrush' });
+      expect(reason).to.equal(null);
+      expect(value.source).to.equal('semrush');
+    });
+
+    it('rejects an unknown source (closed vocabulary — select, never invent)', () => {
+      const { value, reason } = normalizePromptInput({ ...base, source: 'not-a-producer' });
+      expect(value).to.equal(null);
+      expect(reason).to.match(/^source must be one of /);
+    });
+
+    it('treats an absent source as no override (no source key on the value)', () => {
+      const { value, reason } = normalizePromptInput({ ...base });
+      expect(reason).to.equal(null);
+      expect(value).to.not.have.property('source');
+    });
+
+    it('treats an explicit null source as absent, not a 400 (review Should-Fix #1)', () => {
+      const { value, reason } = normalizePromptInput({ ...base, source: null });
+      expect(reason).to.equal(null);
+      expect(value).to.not.have.property('source');
+    });
+  });
+
+  describe('makePromptTagInjector per-item source', () => {
+    const injectorWithDefault = () => makePromptTagInjector(
+      { listProjectTags: makeListProjectTagsStub() },
+      WORKSPACE,
+      undefined,
+      fakeLog(),
+      { sourceValue: 'config' },
+    );
+
+    it('per-item source overrides the batch default', async () => {
+      const out = await injectorWithDefault()('proj-1', {
+        text: 'x', geoTargetId: 2840, tagIds: [], source: 'semrush',
+      });
+      expect(out.tagIds).to.include(TAG_IDS.sourceSemrush);
+      expect(out.tagIds).to.not.include(TAG_IDS.sourceConfig);
+    });
+
+    it('falls back to the batch default when no per-item source', async () => {
+      const out = await injectorWithDefault()('proj-1', {
+        text: 'x', geoTargetId: 2840, tagIds: [],
+      });
+      expect(out.tagIds).to.include(TAG_IDS.sourceConfig);
+      expect(out.tagIds).to.not.include(TAG_IDS.sourceSemrush);
+    });
+
+    it('resolves each producer independently in a mixed-surface batch', async () => {
+      const inject = injectorWithDefault();
+      const tracked = await inject('proj-1', {
+        text: 'a', geoTargetId: 2840, tagIds: [], source: 'semrush',
+      });
+      const dflt = await inject('proj-1', { text: 'b', geoTargetId: 2840, tagIds: [] });
+      expect(tracked.tagIds).to.include(TAG_IDS.sourceSemrush);
+      expect(dflt.tagIds).to.include(TAG_IDS.sourceConfig);
+    });
+
+    it('leaves source untouched on UPDATE (no batch default, no per-item source)', async () => {
+      const transport = { listProjectTags: makeListProjectTagsStub() };
+      const inject = makePromptTagInjector(transport, WORKSPACE, undefined, fakeLog());
+      const out = await inject('proj-1', {
+        text: 'x', geoTargetId: 2840, tagIds: [TAG_IDS.sourceSemrush],
+      });
+      expect(out.tagIds).to.deep.equal([TAG_IDS.sourceSemrush]);
+      expect(transport.listProjectTags).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
## Summary

- `normalizePromptInput` now accepts an optional `source` field per item, validates it through `canonicalizeSource` + `SOURCE_VALUES` (caller selects from the closed vocabulary, never invents), and passes it through.
- `makePromptTagInjector` re-keys `sourceCache` on `(projectId, source)` so mixed-surface batches each resolve their own producer tag independently via `input.source || sourceValue`.
- Human-dialog Create sites are unaffected — they continue passing `config` as the batch default; only Track cards with an explicit `source` override the batch default.

## Motivation

The SR "Track" flow previously stamped every tracked prompt with `source=config`, the human-dialog constant. This broke attribution for SR cards whose producing system is `semrush`, `gsc`, `citation-attempt`, or `synthetic-personas`. The elmo half (project-elmo-ui#TBD) sends each card's real producing surface; this PR is the server-side receiver.

## Design note

This relaxes the "source is server-owned" invariant from WP-S2: the caller now selects from the closed `SOURCE_VALUES` vocabulary instead of always taking the batch default. The server still validates — unknown slugs are rejected 400 — so a caller can select a known producer but never invent one.

## Test plan

- [ ] `npm run type-check` — clean (both tiers)
- [ ] `npm test` — all tests pass
- [ ] Track flow smoke-test: confirm a tracked SR card with `source: 'semrush'` stamps the correct tag (not `config`)
- [ ] Human-dialog Create: confirm `source` is still `config` (no per-item override sent)

Closes LLMO-6556
