### PR TITLE
fix(user-details): resolve the caller's own profile without the admin gate (LLMO-6290)

### DIFF
--- a/src/controllers/user-details.js
+++ b/src/controllers/user-details.js
@@ -71,11 +71,13 @@ function UserDetailsController(ctx) {
    * Returning the caller's own claims discloses nothing new: it is the identity
    * they authenticated with. Other users' details stay admin-gated.
    *
-   * `profile.email` is deliberately NOT a source for the email field — on both
-   * the JWT and the IMS profile that claim carries the IMS user GUID rather than
-   * an RFC-5322 address (same reason llmo-akamai.js `getCallerEmail` prefers
-   * `trial_email` / `preferred_username`), and a GUID in an email column is worse
-   * than an empty one.
+   * `profile.email` is deliberately NOT a source for the EMAIL field — on both
+   * the JWT and the IMS profile that claim carries the IMS user id rather than an
+   * RFC-5322 address (same reason llmo-akamai.js `getCallerEmail` prefers
+   * `trial_email` / `preferred_username`), and an id in an email column is worse
+   * than an empty one. It IS a source for the id itself, inside
+   * {@link resolveCallerImsUserId} — the two uses pull opposite ways on the same
+   * claim, which is exactly why the id resolution lives in one shared place.
    *
    * @param {string} externalUserId - The requested external user ID.
    * @param {string} organizationId - The organization ID the request addresses.
@@ -88,6 +90,9 @@ function UserDetailsController(ctx) {
       return null;
     }
 
+    // Invariant: a non-null id means the profile chain resolved, so this second
+    // traversal cannot throw — no optional chaining needed (unlike the defensive
+    // shared helper above, which is reached with an arbitrary context).
     const profile = ctx.attributes.authInfo.getProfile();
     const email = [profile.trial_email, profile.preferred_username].find((v) => hasText(v));
     return {
@@ -102,25 +107,37 @@ function UserDetailsController(ctx) {
    * Resolves the details of a user who has no TrialUser row: the caller's own
    * identity comes from their auth profile, anyone else's from IMS and only for
    * an admin requestor.
+   *
+   * Reports which of the three paths answered alongside the details, so the bulk
+   * caller can count IMS calls it actually made. `source: 'ims'` means the
+   * upstream call was issued — including when it threw, since a failed call still
+   * consumed IMS capacity; the self and placeholder paths issue none. That count
+   * is the operational signal for IMS volume, so it must not absorb the two paths
+   * that never leave the process.
+   *
    * @param {string} externalUserId - The external user ID to resolve.
    * @param {string} organizationId - The organization ID for fallback.
-   * @returns {Promise<Object>} User details object.
+   * @returns {Promise<{details: Object, source: 'self'|'placeholder'|'ims'}>}
+   *   The user details and which path produced them.
    */
   const fetchNonTrialUserDetails = async (externalUserId, organizationId) => {
     const own = resolveCallerOwnDetails(externalUserId, organizationId);
     if (own) {
       log.debug(`Resolved the caller's own details from the auth profile for ${externalUserId}`);
-      return own;
+      return { details: own, source: 'self' };
     }
 
     // Check if requestor has admin access
     if (!accessControlUtil.hasAdminReadAccess()) {
       log.debug(`User is not admin, returning system defaults for ${externalUserId}`);
       return {
-        firstName: 'system',
-        lastName: '-',
-        email: '',
-        organizationId,
+        details: {
+          firstName: 'system',
+          lastName: '-',
+          email: '',
+          organizationId,
+        },
+        source: 'placeholder',
       };
     }
 
@@ -129,16 +146,22 @@ function UserDetailsController(ctx) {
       log.debug(`Admin user requesting details for ${externalUserId}, attempting IMS fallback`);
       const imsProfile = await imsClient.getImsAdminProfile(externalUserId);
       return {
-        ...toProfileShape(imsProfile),
-        organizationId,
+        details: {
+          ...toProfileShape(imsProfile),
+          organizationId,
+        },
+        source: 'ims',
       };
     } catch (error) {
       log.warn(`Failed to fetch user details from IMS for ${externalUserId}: ${error.message}`);
       return {
-        firstName: '-',
-        lastName: '-',
-        email: '',
-        organizationId,
+        details: {
+          firstName: '-',
+          lastName: '-',
+          email: '',
+          organizationId,
+        },
+        source: 'ims',
       };
     }
   };
@@ -186,7 +209,10 @@ function UserDetailsController(ctx) {
         };
       } else {
         // User not found in trial users - own profile, else IMS if admin
-        userDetails = await fetchNonTrialUserDetails(externalUserId, organizationId);
+        ({ details: userDetails } = await fetchNonTrialUserDetails(
+          externalUserId,
+          organizationId,
+        ));
       }
 
       return ok(userDetails);
@@ -245,9 +271,14 @@ function UserDetailsController(ctx) {
           };
         } else {
           // User not found in trial users - own profile, else IMS if admin
-          imsCallCount += 1;
           // eslint-disable-next-line no-await-in-loop
-          const details = await fetchNonTrialUserDetails(externalUserId, organizationId);
+          const { details, source } = await fetchNonTrialUserDetails(
+            externalUserId,
+            organizationId,
+          );
+          if (source === 'ims') {
+            imsCallCount += 1;
+          }
           userDetailsMap[externalUserId] = details;
         }
       }

--- a/src/controllers/user-details.js
+++ b/src/controllers/user-details.js
@@ -24,6 +24,7 @@ import {
 } from '@adobe/spacecat-shared-utils';
 
 import AccessControlUtil from '../support/access-control-util.js';
+import { resolveCallerImsUserId } from '../support/utils.js';
 
 // IMS GUID format: <hex>@<alphanumeric-with-dots>
 const IMS_USER_ID_RE = /^[A-Za-z0-9]+@[A-Za-z0-9.]+$/;
@@ -57,12 +58,61 @@ function UserDetailsController(ctx) {
   const accessControlUtil = AccessControlUtil.fromContext(ctx);
 
   /**
-   * Helper function to fetch user details from IMS if user is admin.
-   * @param {string} externalUserId - The external user ID to fetch from IMS.
+   * Resolves the CALLER'S OWN details from their auth profile, bypassing both the
+   * TrialUser lookup and the admin-gated IMS fallback. The id is resolved with
+   * {@link resolveCallerImsUserId} — the same helper the server-owned authorship
+   * stamp uses to decide what to write — so an id this service stamped is exactly
+   * the id it can resolve back here.
+   *
+   * Without this, a non-admin caller who is not a TrialUser row cannot see their
+   * own name — not even against records they authored themselves, whose
+   * server-stamped `createdBy`/`updatedBy` is exactly this id. They get the
+   * `system` placeholder below, which the UI renders as an unresolved member.
+   * Returning the caller's own claims discloses nothing new: it is the identity
+   * they authenticated with. Other users' details stay admin-gated.
+   *
+   * `profile.email` is deliberately NOT a source for the email field — on both
+   * the JWT and the IMS profile that claim carries the IMS user GUID rather than
+   * an RFC-5322 address (same reason llmo-akamai.js `getCallerEmail` prefers
+   * `trial_email` / `preferred_username`), and a GUID in an email column is worse
+   * than an empty one.
+   *
+   * @param {string} externalUserId - The requested external user ID.
+   * @param {string} organizationId - The organization ID the request addresses.
+   * @returns {Object|null} the caller's own details, or null when the requested
+   *   id is not the caller's own.
+   */
+  const resolveCallerOwnDetails = (externalUserId, organizationId) => {
+    const callerUserId = resolveCallerImsUserId(ctx);
+    if (callerUserId === null || callerUserId !== externalUserId) {
+      return null;
+    }
+
+    const profile = ctx.attributes.authInfo.getProfile();
+    const email = [profile.trial_email, profile.preferred_username].find((v) => hasText(v));
+    return {
+      firstName: profile.first_name || profile.given_name || '-',
+      lastName: profile.last_name || profile.family_name || '-',
+      email: email ?? '',
+      organizationId,
+    };
+  };
+
+  /**
+   * Resolves the details of a user who has no TrialUser row: the caller's own
+   * identity comes from their auth profile, anyone else's from IMS and only for
+   * an admin requestor.
+   * @param {string} externalUserId - The external user ID to resolve.
    * @param {string} organizationId - The organization ID for fallback.
    * @returns {Promise<Object>} User details object.
    */
-  const fetchFromImsIfAdmin = async (externalUserId, organizationId) => {
+  const fetchNonTrialUserDetails = async (externalUserId, organizationId) => {
+    const own = resolveCallerOwnDetails(externalUserId, organizationId);
+    if (own) {
+      log.debug(`Resolved the caller's own details from the auth profile for ${externalUserId}`);
+      return own;
+    }
+
     // Check if requestor has admin access
     if (!accessControlUtil.hasAdminReadAccess()) {
       log.debug(`User is not admin, returning system defaults for ${externalUserId}`);
@@ -135,8 +185,8 @@ function UserDetailsController(ctx) {
           organizationId: trialUser.getOrganizationId(),
         };
       } else {
-        // User not found in trial users - try IMS if admin
-        userDetails = await fetchFromImsIfAdmin(externalUserId, organizationId);
+        // User not found in trial users - own profile, else IMS if admin
+        userDetails = await fetchNonTrialUserDetails(externalUserId, organizationId);
       }
 
       return ok(userDetails);
@@ -194,10 +244,10 @@ function UserDetailsController(ctx) {
             organizationId: trialUser.getOrganizationId(),
           };
         } else {
-          // User not found in trial users - try IMS if admin
+          // User not found in trial users - own profile, else IMS if admin
           imsCallCount += 1;
           // eslint-disable-next-line no-await-in-loop
-          const details = await fetchFromImsIfAdmin(externalUserId, organizationId);
+          const details = await fetchNonTrialUserDetails(externalUserId, organizationId);
           userDetailsMap[externalUserId] = details;
         }
       }

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -14,7 +14,7 @@
 
 import { hasText } from '@adobe/spacecat-shared-utils';
 
-import { ErrorWithStatusCode } from '../../utils.js';
+import { ErrorWithStatusCode, resolveCallerImsUserId } from '../../utils.js';
 import { redactUpstreamMessage } from '../rest-transport.js';
 import { ERROR_CODES, isMeteredQuota, isUpstreamGone } from '../errors.js';
 import { alertQuotaRejection, alertRollbackFailure } from '../quota-alerts.js';
@@ -77,9 +77,11 @@ export const CALLER_ID_MAX_LENGTH = 100;
  * from `authInfo.getProfile()` — NEVER from the bearer forwarded upstream, whose
  * principal can differ from the caller after the promise-token exchange.
  *
- * `user_id` is preferred; `sub` is the fallback (both IMS profile claims). A
- * missing/blank identity becomes the literal `unknown` (the spec's NULL-author
- * sentinel, resolved to a display name downstream). Capped at
+ * The id itself comes from {@link resolveCallerImsUserId} — shared with the
+ * `/organizations/{id}/userDetails` read path, so the id stamped here is the id
+ * that path can resolve back to a name. A missing/blank identity becomes the
+ * literal `unknown` (the spec's NULL-author sentinel, resolved to a display name
+ * downstream). Capped at
  * {@link CALLER_ID_MAX_LENGTH} so a pathological claim can never trip the
  * upstream length CHECK (which would 400 the write / roll a batch back).
  *
@@ -95,9 +97,7 @@ export const CALLER_ID_MAX_LENGTH = 100;
  * @returns {string} the caller id, `unknown` when unresolved, ≤100 chars.
  */
 export function resolveCallerId(ctx) {
-  const profile = ctx?.attributes?.authInfo?.getProfile?.();
-  const raw = profile?.user_id ?? profile?.sub;
-  const id = hasText(raw) ? String(raw) : 'unknown';
+  const id = resolveCallerImsUserId(ctx) ?? 'unknown';
   return id.slice(0, CALLER_ID_MAX_LENGTH);
 }
 

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -800,31 +800,37 @@ export async function exchangePromiseToken(context, promiseToken) {
 /**
  * The authenticated caller's own IMS user id, read from their auth profile.
  *
- * `user_id` (raw-IMS profiles) is preferred, `sub` (SpaceCat JWT session token)
- * is the fallback. This is the SINGLE definition of "who is calling" for
- * identity that is written into data and later read back for display:
- * server-owned authorship stamps (`createdBy` / `updatedBy`) resolve the id to
- * write through here, and `/organizations/{id}/userDetails` resolves the caller's
- * own id through here as well. Both sides moving together is what keeps a stamped
- * id resolvable — reading a different claim on either side silently degrades
- * authorship to an unresolved author.
+ * `user_id`, then `sub`, then `email` — three carriers of the SAME value, in
+ * decreasing directness. All three matter, because which ones are populated
+ * depends on the auth handler: a SpaceCat JWT carries the id on `sub` AND
+ * `email` (the auth service deliberately puts the IMS user id, not the real
+ * address, in the `email` claim), while `AdobeImsHandler` deletes `user_id` from
+ * the profile it builds and leaves the id only on `email`. `email` therefore is
+ * NOT a human address here — it is the platform's user-id alias, which is why
+ * the pre-existing writers of `prompts.updated_by` (`brands.js`) and the api-key
+ * surface read it directly (see the ASO-607 rationale in
+ * `support/api-key-ims-handler.js`). For the caller's human address use
+ * `trial_email` / `preferred_username` instead — never this id.
+ *
+ * This is the SINGLE definition of "who is calling" for identity that is written
+ * into data and later read back for display: server-owned authorship stamps
+ * (`createdBy` / `updatedBy`) resolve the id to write through here, and
+ * `/organizations/{id}/userDetails` resolves the caller's own id through here as
+ * well. Both sides moving together is what keeps a stamped id resolvable —
+ * reading a different claim on either side silently degrades authorship to an
+ * unresolved author.
  *
  * NOT the identity to forward upstream (that is a token, see
  * {@link resolveSemrushImsToken}) and NOT an authorization signal — a caller is
  * already authenticated by the time this runs; an unresolvable identity is a
  * display concern, never an access decision.
  *
- * `profile.email` is deliberately not a source: on both the JWT and the IMS
- * profile that claim carries the IMS user id, so it adds nothing here, while on
- * other profile shapes it carries a human address and would put an email address
- * where an opaque id belongs.
- *
  * @param {object} context - The request context.
  * @returns {string|null} The caller's IMS user id, or null when unresolvable.
  */
 export function resolveCallerImsUserId(context) {
   const profile = context?.attributes?.authInfo?.getProfile?.();
-  const raw = profile?.user_id ?? profile?.sub;
+  const raw = profile?.user_id ?? profile?.sub ?? profile?.email;
   return hasText(raw) ? String(raw) : null;
 }
 

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -798,6 +798,37 @@ export async function exchangePromiseToken(context, promiseToken) {
 }
 
 /**
+ * The authenticated caller's own IMS user id, read from their auth profile.
+ *
+ * `user_id` (raw-IMS profiles) is preferred, `sub` (SpaceCat JWT session token)
+ * is the fallback. This is the SINGLE definition of "who is calling" for
+ * identity that is written into data and later read back for display:
+ * server-owned authorship stamps (`createdBy` / `updatedBy`) resolve the id to
+ * write through here, and `/organizations/{id}/userDetails` resolves the caller's
+ * own id through here as well. Both sides moving together is what keeps a stamped
+ * id resolvable — reading a different claim on either side silently degrades
+ * authorship to an unresolved author.
+ *
+ * NOT the identity to forward upstream (that is a token, see
+ * {@link resolveSemrushImsToken}) and NOT an authorization signal — a caller is
+ * already authenticated by the time this runs; an unresolvable identity is a
+ * display concern, never an access decision.
+ *
+ * `profile.email` is deliberately not a source: on both the JWT and the IMS
+ * profile that claim carries the IMS user id, so it adds nothing here, while on
+ * other profile shapes it carries a human address and would put an email address
+ * where an opaque id belongs.
+ *
+ * @param {object} context - The request context.
+ * @returns {string|null} The caller's IMS user id, or null when unresolvable.
+ */
+export function resolveCallerImsUserId(context) {
+  const profile = context?.attributes?.authInfo?.getProfile?.();
+  const raw = profile?.user_id ?? profile?.sub;
+  return hasText(raw) ? String(raw) : null;
+}
+
+/**
  * Resolves the IMS access token to forward to the Semrush gateway for a request.
  *
  * Preferred path: the caller sends `x-promise-token` (minted by POST /auth/v2/promise).

--- a/test/controllers/user-details.test.js
+++ b/test/controllers/user-details.test.js
@@ -482,7 +482,7 @@ describe('User Details Controller', () => {
   describe('caller self-resolution', () => {
     // The caller's own IMS user id: enterprise-org shaped, the same shape the
     // authorship stamp writes and the UI sends back for resolution.
-    const callerUserId = 'EB1C272069C3BA930A495FB6@62f93e086160d306495eb8.e';
+    const callerUserId = 'C0FFEE0011223344AABBCCDD@1122334455667788990011.e';
 
     const controllerWithCallerProfile = (profile) => UserDetailsController({
       dataAccess: mockDataAccess,

--- a/test/controllers/user-details.test.js
+++ b/test/controllers/user-details.test.js
@@ -17,6 +17,7 @@ import sinon from 'sinon';
 
 import UserDetailsController from '../../src/controllers/user-details.js';
 import AccessControlUtil from '../../src/support/access-control-util.js';
+import { resolveCallerId } from '../../src/support/serenity/handlers/prompts.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -471,6 +472,185 @@ describe('User Details Controller', () => {
 
       expect(result.status).to.equal(500);
       expect(mockLog.error).to.have.been.called;
+    });
+  });
+
+  // A caller must be able to see their OWN name/email even when they are neither
+  // an admin nor a TrialUser row — otherwise server-stamped authorship
+  // (createdBy/updatedBy) on records they authored themselves renders as an
+  // unresolved member in the UI. The id compared here is the one the authorship
+  // stamp writes: `user_id ?? sub` off the auth profile.
+  describe('caller self-resolution', () => {
+    // The caller's own IMS user id: enterprise-org shaped, the same shape the
+    // authorship stamp writes and the UI sends back for resolution.
+    const callerUserId = 'EB1C272069C3BA930A495FB6@62f93e086160d306495eb8.e';
+
+    const controllerWithCallerProfile = (profile) => UserDetailsController({
+      dataAccess: mockDataAccess,
+      imsClient: mockImsClient,
+      log: mockLog,
+      attributes: { authInfo: { getProfile: () => profile } },
+    });
+
+    // The claims a SpaceCat JWT session token carries: `sub` is the IMS user id,
+    // `email` is that same id (NOT an address), and the human address rides
+    // `preferred_username` / `trial_email`.
+    const jwtProfile = {
+      sub: callerUserId,
+      email: callerUserId,
+      first_name: 'Rainer',
+      last_name: 'Friederich',
+      preferred_username: 'someone@example.com',
+    };
+
+    it('resolves the caller own details from a JWT profile without an IMS call', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(false);
+      const selfController = controllerWithCallerProfile(jwtProfile);
+      context.params = { organizationId, externalUserId: callerUserId };
+
+      const result = await selfController.getUserDetailsByExternalUserId(context);
+
+      expect(result.status).to.equal(200);
+      expect(mockImsClient.getImsAdminProfile).to.not.have.been.called;
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        firstName: 'Rainer',
+        lastName: 'Friederich',
+        email: 'someone@example.com',
+        organizationId,
+      });
+    });
+
+    it('resolves the caller own details in bulk alongside other unresolvable ids', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(false);
+      const selfController = controllerWithCallerProfile(jwtProfile);
+      context.params = { organizationId };
+      context.data = { userIds: [callerUserId, 'someone-else@AdobeOrg'] };
+
+      const result = await selfController.getUserDetailsInBulk(context);
+
+      expect(result.status).to.equal(200);
+      expect(mockImsClient.getImsAdminProfile).to.not.have.been.called;
+      const body = await result.json();
+      expect(body[callerUserId]).to.deep.equal({
+        firstName: 'Rainer',
+        lastName: 'Friederich',
+        email: 'someone@example.com',
+        organizationId,
+      });
+      // Another user's details stay admin-gated.
+      expect(body['someone-else@AdobeOrg']).to.deep.equal({
+        firstName: 'system',
+        lastName: '-',
+        email: '',
+        organizationId,
+      });
+    });
+
+    it('resolves the caller own id from the user_id claim of an IMS profile', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(false);
+      const selfController = controllerWithCallerProfile({
+        user_id: callerUserId,
+        given_name: 'Rainer',
+        family_name: 'Friederich',
+        trial_email: 'someone@example.com',
+      });
+      context.params = { organizationId, externalUserId: callerUserId };
+
+      const result = await selfController.getUserDetailsByExternalUserId(context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        firstName: 'Rainer',
+        lastName: 'Friederich',
+        email: 'someone@example.com',
+        organizationId,
+      });
+    });
+
+    it('never surfaces the IMS user id as the caller email', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(false);
+      // `email` carrying the IMS user id is the normal JWT/IMS shape, and is the
+      // only address-looking claim here — it must not reach the email field.
+      const selfController = controllerWithCallerProfile({
+        sub: callerUserId,
+        email: callerUserId,
+      });
+      context.params = { organizationId, externalUserId: callerUserId };
+
+      const result = await selfController.getUserDetailsByExternalUserId(context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        firstName: '-',
+        lastName: '-',
+        email: '',
+        organizationId,
+      });
+    });
+
+    // The round trip that matters in production: the id the authorship stamp
+    // writes must be an id this endpoint can resolve. If either side ever reads a
+    // different claim, the stamp keeps working and only the display degrades — so
+    // pin the two together rather than each in isolation.
+    it('resolves the exact id the authorship stamp writes for the same caller', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(false);
+      const ctx = {
+        dataAccess: mockDataAccess,
+        imsClient: mockImsClient,
+        log: mockLog,
+        attributes: { authInfo: { getProfile: () => jwtProfile } },
+      };
+      const stampedCreatedBy = resolveCallerId(ctx);
+      expect(stampedCreatedBy).to.equal(callerUserId);
+
+      context.params = { organizationId, externalUserId: stampedCreatedBy };
+
+      const result = await UserDetailsController(ctx).getUserDetailsByExternalUserId(context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body.firstName).to.equal('Rainer');
+      expect(body.lastName).to.equal('Friederich');
+      expect(body.email).to.equal('someone@example.com');
+    });
+
+    it('leaves another user unresolved for a non-admin caller', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(false);
+      const selfController = controllerWithCallerProfile(jwtProfile);
+      context.params = { organizationId, externalUserId: 'someone-else@AdobeOrg' };
+
+      const result = await selfController.getUserDetailsByExternalUserId(context);
+
+      expect(result.status).to.equal(200);
+      expect(mockImsClient.getImsAdminProfile).to.not.have.been.called;
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        firstName: 'system',
+        lastName: '-',
+        email: '',
+        organizationId,
+      });
+    });
+
+    it('falls back to the admin IMS lookup when the caller has no resolvable identity', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(true);
+      const selfController = controllerWithCallerProfile({ email: 'ignored@example.com' });
+      context.params = { organizationId, externalUserId: 'someone-else@AdobeOrg' };
+
+      const result = await selfController.getUserDetailsByExternalUserId(context);
+
+      expect(result.status).to.equal(200);
+      expect(mockImsClient.getImsAdminProfile).to.have.been.calledWith('someone-else@AdobeOrg');
+      const body = await result.json();
+      expect(body).to.deep.equal({
+        firstName: 'IMS',
+        lastName: 'User',
+        email: 'imsuser@example.com',
+        organizationId,
+      });
     });
   });
 

--- a/test/controllers/user-details.test.js
+++ b/test/controllers/user-details.test.js
@@ -402,9 +402,8 @@ describe('User Details Controller', () => {
 
       expect(result.status).to.equal(200);
       expect(mockImsClient.getImsAdminProfile).to.not.have.been.called;
-      expect(mockLog.info).to.have.been.calledWith(
-        'Fetched user details from IMS 1 times for organization 123e4567-e89b-12d3-a456-426614174000',
-      );
+      // No IMS call was made, so the IMS-volume log must stay silent.
+      expect(mockLog.info).to.not.have.been.called;
       const body = await result.json();
       expect(body['not-found-user@AdobeOrg']).to.deep.equal({
         firstName: 'system',
@@ -547,6 +546,34 @@ describe('User Details Controller', () => {
       });
     });
 
+    // The IMS-call counter feeds the "Fetched user details from IMS N times" log,
+    // which is the operational signal for IMS volume — a path that never leaves
+    // the process must not inflate it.
+    it('does not count self-resolved or placeholder answers as IMS calls', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(false);
+      const selfController = controllerWithCallerProfile(jwtProfile);
+      context.params = { organizationId };
+      context.data = { userIds: [callerUserId, 'someone-else@AdobeOrg'] };
+
+      await selfController.getUserDetailsInBulk(context);
+
+      expect(mockLog.info).to.not.have.been.called;
+    });
+
+    it('counts only the answers that actually called IMS', async () => {
+      mockAccessControlUtil.hasAdminReadAccess.returns(true);
+      const selfController = controllerWithCallerProfile(jwtProfile);
+      context.params = { organizationId };
+      context.data = { userIds: [callerUserId, 'someone-else@AdobeOrg'] };
+
+      await selfController.getUserDetailsInBulk(context);
+
+      expect(mockImsClient.getImsAdminProfile).to.have.been.calledOnceWith('someone-else@AdobeOrg');
+      expect(mockLog.info).to.have.been.calledWith(
+        `Fetched user details from IMS 1 times for organization ${organizationId}`,
+      );
+    });
+
     it('resolves the caller own id from the user_id claim of an IMS profile', async () => {
       mockAccessControlUtil.hasAdminReadAccess.returns(false);
       const selfController = controllerWithCallerProfile({
@@ -637,7 +664,7 @@ describe('User Details Controller', () => {
 
     it('falls back to the admin IMS lookup when the caller has no resolvable identity', async () => {
       mockAccessControlUtil.hasAdminReadAccess.returns(true);
-      const selfController = controllerWithCallerProfile({ email: 'ignored@example.com' });
+      const selfController = controllerWithCallerProfile({});
       context.params = { organizationId, externalUserId: 'someone-else@AdobeOrg' };
 
       const result = await selfController.getUserDetailsByExternalUserId(context);

--- a/test/it/postgres/seed-data/trial-users.js
+++ b/test/it/postgres/seed-data/trial-users.js
@@ -19,9 +19,13 @@ import {
 } from '../../shared/seed-ids.js';
 
 export const trialUsers = [
+  // `external_user_id` is what the userDetails lookup matches on; without it the
+  // trial branch can never resolve this row and every request falls through to the
+  // non-trial path.
   {
     id: TRIAL_USER_1_ID,
     email_id: TRIAL_USER_1_EMAIL,
+    external_user_id: TRIAL_USER_1_EMAIL,
     organization_id: ORG_1_ID,
     status: 'INVITED',
   },

--- a/test/it/postgres/user-details.test.js
+++ b/test/it/postgres/user-details.test.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ctx } from './harness.js';
+import { resetPostgres } from './seed.js';
+import userDetailsTests from '../shared/tests/user-details.js';
+
+userDetailsTests(() => ctx.httpClient, resetPostgres);

--- a/test/it/shared/auth.js
+++ b/test/it/shared/auth.js
@@ -19,6 +19,10 @@ import {
   CONSUMER_2_CLIENT_ID,
   CONSUMER_2_IMS_ORG_ID,
   BRAND_MANAGER_SUBJECT,
+  ENTERPRISE_USER_ID,
+  ENTERPRISE_USER_EMAIL,
+  ENTERPRISE_USER_FIRST_NAME,
+  ENTERPRISE_USER_LAST_NAME,
 } from './seed-ids.js';
 
 const ISSUER = 'https://spacecat.experiencecloud.live';
@@ -142,6 +146,34 @@ export async function createFacsManagerToken() {
     is_admin: false,
     is_llmo_administrator: false,
     facs_permissions: ['llmo/can_manage_users', 'aso/can_manage_users'],
+    tenants: [{
+      id: IMS_ORG_IDENT,
+      subServices: [],
+      entitlement: {},
+    }],
+  });
+}
+
+/**
+ * Enterprise (non-trial) ORG_1 member. Claim shape is copied from what
+ * spacecat-auth-service actually mints for an enterprise login: no `user_id` at
+ * all, the IMS user id duplicated across `sub` and `email`, the real address in
+ * `preferred_username` / `trial_email`, and both the snake_case and OIDC name
+ * claims populated. The other personas here use an address as `sub`, which cannot
+ * exercise the id-vs-address distinction this persona exists to prove.
+ */
+export async function createEnterpriseUserToken() {
+  return signToken({
+    sub: ENTERPRISE_USER_ID,
+    email: ENTERPRISE_USER_ID,
+    preferred_username: ENTERPRISE_USER_EMAIL,
+    trial_email: ENTERPRISE_USER_EMAIL,
+    first_name: ENTERPRISE_USER_FIRST_NAME,
+    given_name: ENTERPRISE_USER_FIRST_NAME,
+    last_name: ENTERPRISE_USER_LAST_NAME,
+    family_name: ENTERPRISE_USER_LAST_NAME,
+    is_admin: false,
+    is_llmo_administrator: false,
     tenants: [{
       id: IMS_ORG_IDENT,
       subServices: [],
@@ -306,7 +338,7 @@ export async function createS2SConsumerReadAllToken() {
 
 export async function createAllTokens() {
   const [
-    admin, user, trialUser, llmoAdmin,
+    admin, user, trialUser, llmoAdmin, enterpriseUser,
     delegatedUser, delegatedUserTruncated, delegatedUserNoSource,
     readOnlyAdmin, brandManager, facsManager,
     s2sConsumerReadOnly, s2sConsumerReadAll, s2sConsumerUnknown,
@@ -315,6 +347,7 @@ export async function createAllTokens() {
     createUserToken(),
     createTrialUserToken(),
     createLlmoAdminToken(),
+    createEnterpriseUserToken(),
     createDelegatedUserToken(),
     createDelegatedUserTruncatedToken(),
     createDelegatedUserNoSourceToken(),
@@ -330,6 +363,7 @@ export async function createAllTokens() {
     user,
     trialUser,
     llmoAdmin,
+    enterpriseUser,
     delegatedUser,
     delegatedUserTruncated,
     delegatedUserNoSource,

--- a/test/it/shared/http-client.js
+++ b/test/it/shared/http-client.js
@@ -68,12 +68,14 @@ function detectProduct(method, path) {
  *
  * @param {string} baseUrl - The dev server base URL (e.g., http://localhost:3002)
  * @param {{ admin: string, user: string, trialUser: string, llmoAdmin: string,
+ *   enterpriseUser: string,
  *   delegatedUser: string,
  *   delegatedUserTruncated: string, delegatedUserNoSource: string,
  *   readOnlyAdmin: string,
  *   s2sConsumerReadOnly: string, s2sConsumerReadAll: string,
  *   s2sConsumerUnknown: string }} tokens - JWT tokens
  * @returns {{ admin: object, user: object, trialUser: object, llmoAdmin: object,
+ *   enterpriseUser: object,
  *   delegatedUser: object,
  *   delegatedUserTruncated: object, delegatedUserNoSource: object,
  *   readOnlyAdmin: object,
@@ -136,6 +138,7 @@ export function createHttpClient(baseUrl, tokens) {
     user: makeMethods(tokens.user),
     trialUser: makeMethods(tokens.trialUser),
     llmoAdmin: makeMethods(tokens.llmoAdmin),
+    enterpriseUser: makeMethods(tokens.enterpriseUser),
     delegatedUser: makeMethods(tokens.delegatedUser),
     delegatedUserTruncated: makeMethods(tokens.delegatedUserTruncated),
     delegatedUserNoSource: makeMethods(tokens.delegatedUserNoSource),

--- a/test/it/shared/seed-ids.js
+++ b/test/it/shared/seed-ids.js
@@ -84,6 +84,19 @@ export const SERENITY_MOCK_PROJECT_ID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e';
 // irrelevant to its use here as a UM workspace id metered via `__quota`.
 export const SERENITY_ORG_PARENT_WS_ID = SERENITY_MOCK_PROJECT_ID;
 
+// ── Enterprise (non-trial) org member ──
+// A plain ORG_1 member with no TrialUser row — the population the prompt-library
+// authorship columns resolve. Its identifiers mirror a real spacecat session JWT:
+// the id is an IMS GUID that appears as BOTH `sub` and `email` (the auth service
+// puts the user id, not the address, in `email`), while the real address is carried
+// only by `preferred_username` / `trial_email`. Deliberately NOT seeded into
+// trial-users.js — a TrialUser row would resolve it via the trial branch and the
+// self-resolution path under test would never be reached.
+export const ENTERPRISE_USER_ID = 'C0FFEE0011223344AABBCCDD@1122334455667788990011.e';
+export const ENTERPRISE_USER_EMAIL = 'enterprise-member@example.com';
+export const ENTERPRISE_USER_FIRST_NAME = 'Enterprise';
+export const ENTERPRISE_USER_LAST_NAME = 'Member';
+
 // ── FACS state-layer managers (hybrid-model §8.3) ──
 // The brandManager persona holds state-layer `llmo/can_manage_users` on
 // MANAGED_BRAND_ID only (seeded in facs-access-mappings.js). It has an EMPTY

--- a/test/it/shared/tests/user-details.js
+++ b/test/it/shared/tests/user-details.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  ORG_1_ID,
+  ORG_2_ID,
+  NON_EXISTENT_ORG_ID,
+  TRIAL_USER_1_EMAIL,
+  ENTERPRISE_USER_ID,
+  ENTERPRISE_USER_EMAIL,
+  ENTERPRISE_USER_FIRST_NAME,
+  ENTERPRISE_USER_LAST_NAME,
+} from '../seed-ids.js';
+
+const OTHER_USER_ID = 'AAAA111122223344BBBBCCDD@1122334455667788990011.e';
+
+/**
+ * Shared user-details endpoint tests.
+ *
+ * Exercises GET /organizations/:organizationId/userDetails/:externalUserId and
+ * POST /organizations/:organizationId/userDetails through the real auth stack, so
+ * the claim precedence is proven against a signed-and-validated token rather than a
+ * hand-built profile object. The `enterpriseUser` persona carries the claim shape
+ * spacecat-auth-service actually mints (no `user_id`; the IMS id in both `sub` and
+ * `email`; the address only in `preferred_username` / `trial_email`), which is what
+ * makes the id-vs-address assertions below meaningful.
+ *
+ * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
+ * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
+ */
+export default function userDetailsTests(getHttpClient, resetData) {
+  describe('User Details', () => {
+    before(() => resetData());
+
+    describe('GET /organizations/:organizationId/userDetails/:externalUserId', () => {
+      it('enterpriseUser: resolves their own details from the auth profile', async () => {
+        const http = getHttpClient();
+        const res = await http.enterpriseUser.get(
+          `/organizations/${ORG_1_ID}/userDetails/${ENTERPRISE_USER_ID}`,
+        );
+        expect(res.status).to.equal(200);
+        expect(res.body).to.deep.equal({
+          firstName: ENTERPRISE_USER_FIRST_NAME,
+          lastName: ENTERPRISE_USER_LAST_NAME,
+          email: ENTERPRISE_USER_EMAIL,
+          organizationId: ORG_1_ID,
+        });
+      });
+
+      it('enterpriseUser: never surfaces the IMS id as the email address', async () => {
+        // The regression this guards: `email` on the JWT carries the IMS user id, so
+        // sourcing the response's email field from it would put an id in an email column.
+        const http = getHttpClient();
+        const res = await http.enterpriseUser.get(
+          `/organizations/${ORG_1_ID}/userDetails/${ENTERPRISE_USER_ID}`,
+        );
+        expect(res.status).to.equal(200);
+        expect(res.body.email).to.not.equal(ENTERPRISE_USER_ID);
+        expect(res.body.email).to.contain('@example.com');
+      });
+
+      it('enterpriseUser: still gets the placeholder for another user', async () => {
+        // Resolving arbitrary ids stays admin-gated — the caller-self path must not
+        // widen into a general-purpose id-to-name lookup.
+        const http = getHttpClient();
+        const res = await http.enterpriseUser.get(
+          `/organizations/${ORG_1_ID}/userDetails/${OTHER_USER_ID}`,
+        );
+        expect(res.status).to.equal(200);
+        expect(res.body.firstName).to.equal('system');
+        expect(res.body.email).to.equal('');
+      });
+
+      it('trialUser: a seeded TrialUser row still wins over the self path', async () => {
+        const http = getHttpClient();
+        const res = await http.trialUser.get(
+          `/organizations/${ORG_1_ID}/userDetails/${TRIAL_USER_1_EMAIL}`,
+        );
+        expect(res.status).to.equal(200);
+        expect(res.body.email).to.equal(TRIAL_USER_1_EMAIL);
+        expect(res.body.organizationId).to.equal(ORG_1_ID);
+      });
+
+      it('enterpriseUser: returns 403 for an org without access', async () => {
+        const http = getHttpClient();
+        const res = await http.enterpriseUser.get(
+          `/organizations/${ORG_2_ID}/userDetails/${ENTERPRISE_USER_ID}`,
+        );
+        expect(res.status).to.equal(403);
+      });
+
+      it('enterpriseUser: returns 404 for a non-existent org', async () => {
+        const http = getHttpClient();
+        const res = await http.enterpriseUser.get(
+          `/organizations/${NON_EXISTENT_ORG_ID}/userDetails/${ENTERPRISE_USER_ID}`,
+        );
+        expect(res.status).to.equal(404);
+      });
+    });
+
+    describe('POST /organizations/:organizationId/userDetails', () => {
+      it('enterpriseUser: resolves own id and gates the other in one batch', async () => {
+        const http = getHttpClient();
+        const res = await http.enterpriseUser.post(
+          `/organizations/${ORG_1_ID}/userDetails`,
+          { userIds: [ENTERPRISE_USER_ID, OTHER_USER_ID] },
+        );
+        expect(res.status).to.equal(200);
+
+        expect(res.body[ENTERPRISE_USER_ID]).to.deep.equal({
+          firstName: ENTERPRISE_USER_FIRST_NAME,
+          lastName: ENTERPRISE_USER_LAST_NAME,
+          email: ENTERPRISE_USER_EMAIL,
+          organizationId: ORG_1_ID,
+        });
+        expect(res.body[OTHER_USER_ID].firstName).to.equal('system');
+        expect(res.body[OTHER_USER_ID].email).to.equal('');
+      });
+
+      it('enterpriseUser: returns 400 for an empty userIds array', async () => {
+        const http = getHttpClient();
+        const res = await http.enterpriseUser.post(
+          `/organizations/${ORG_1_ID}/userDetails`,
+          { userIds: [] },
+        );
+        expect(res.status).to.equal(400);
+      });
+    });
+  });
+}

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -35,6 +35,7 @@ import {
   sendAutofixMessage,
   isViewAsTrialRequest,
   getImsUserTokenStrict,
+  resolveCallerImsUserId,
   sendGlobalImportRunMessage,
   triggerGlobalImportRun,
 } from '../../src/support/utils.js';
@@ -1562,6 +1563,39 @@ describe('utils', () => {
       expect(payload.relationshipContext).to.deep.equal({ fixTargetPageId: 'page-123' });
       expect(payload).to.have.property('customData');
       expect(payload.customData).to.deep.equal({ key: 'value' });
+    });
+  });
+
+  describe('resolveCallerImsUserId', () => {
+    const withProfile = (profile) => ({
+      attributes: { authInfo: { getProfile: () => profile } },
+    });
+
+    it('prefers the user_id claim over sub', () => {
+      expect(resolveCallerImsUserId(withProfile({ user_id: 'user-123', sub: 'sub-x' })))
+        .to.equal('user-123');
+    });
+
+    it('falls back to sub — the claim a SpaceCat JWT session token carries', () => {
+      expect(resolveCallerImsUserId(withProfile({ sub: 'sub-x' }))).to.equal('sub-x');
+    });
+
+    it('ignores the email claim, which carries the IMS user id rather than an address', () => {
+      expect(resolveCallerImsUserId(withProfile({ email: 'someone@example.com' }))).to.equal(null);
+    });
+
+    it('returns null for an empty claim', () => {
+      expect(resolveCallerImsUserId(withProfile({ user_id: '', sub: '' }))).to.equal(null);
+    });
+
+    it('returns null when there is no profile, authInfo, or context', () => {
+      expect(resolveCallerImsUserId(withProfile(undefined))).to.equal(null);
+      expect(resolveCallerImsUserId({ attributes: {} })).to.equal(null);
+      expect(resolveCallerImsUserId(undefined)).to.equal(null);
+    });
+
+    it('returns null for a non-string claim', () => {
+      expect(resolveCallerImsUserId(withProfile({ user_id: 12345 }))).to.equal(null);
     });
   });
 

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -1580,12 +1580,22 @@ describe('utils', () => {
       expect(resolveCallerImsUserId(withProfile({ sub: 'sub-x' }))).to.equal('sub-x');
     });
 
-    it('ignores the email claim, which carries the IMS user id rather than an address', () => {
-      expect(resolveCallerImsUserId(withProfile({ email: 'someone@example.com' }))).to.equal(null);
+    // The IMS handler deletes user_id from the profile it builds and leaves the
+    // id only on `email`, so this is the sole carrier for an IMS-authenticated
+    // caller — and it is an id, not a human address.
+    it('falls back to the email claim, the platform user-id alias', () => {
+      expect(resolveCallerImsUserId(withProfile({ email: 'ims-user-9@AdobeID' })))
+        .to.equal('ims-user-9@AdobeID');
+    });
+
+    it('prefers sub over email when both are present', () => {
+      expect(resolveCallerImsUserId(withProfile({ sub: 'sub-x', email: 'sub-x' })))
+        .to.equal('sub-x');
     });
 
     it('returns null for an empty claim', () => {
-      expect(resolveCallerImsUserId(withProfile({ user_id: '', sub: '' }))).to.equal(null);
+      expect(resolveCallerImsUserId(withProfile({ user_id: '', sub: '', email: '' })))
+        .to.equal(null);
     });
 
     it('returns null when there is no profile, authInfo, or context', () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
`/organizations/{organizationId}/userDetails` (single and bulk) now resolves the **caller's own** details from their auth profile, without an IMS call and without the admin gate. Everyone else's details stay admin-gated, and the claim that identifies "who is calling" is now read in exactly one place, shared with the server-owned authorship stamp.

## 2. Reasoning
A prompt created through the Serenity prompt library in prod rendered its author as an unresolved member ("Unknown member", empty email) minutes after the authorship-metadata feature went live. The stamp itself was correct: the create was JWT-authenticated and `created_by` / `updated_by` carried the author's real IMS user id — confirmed in prod CloudWatch, where the table's `userDetails` lookup asked for exactly that id and answered `User is not admin, returning system defaults`.

The gap is on the read side. `userDetails` resolves a display name only for a `TrialUser` row or an admin requestor; every other caller gets the `system` placeholder, which the UI renders as an unresolved member. So a non-admin enterprise user cannot see their own name — not even on content they authored themselves seconds earlier, where the stamped id *is* their own id.

Returning a caller their own claims discloses nothing new: it is the identity they authenticated with. Resolving *other* users stays admin-only, which is deliberate — the id is caller-supplied, so an ungated lookup would let any authenticated caller resolve arbitrary IMS ids to names and emails.

## 3. High-level overview of the changes
Behaviour delta on `GET /organizations/{organizationId}/userDetails/{externalUserId}` and `POST /organizations/{organizationId}/userDetails`:

- **Before:** a requested id with no `TrialUser` row resolved to a real profile only for an admin requestor (via the IMS admin profile lookup). Everyone else — including a caller asking about themselves — received `{ firstName: 'system', lastName: '-', email: '' }`.
- **After:** if the requested id is the caller's own, the response is built from their own auth-profile claims — no IMS call, no admin gate. Any other id keeps the previous behaviour exactly: `TrialUser` row, else admin IMS lookup, else the `system` placeholder.

Response shape is unchanged, so the UI's existing resolution path needs no change: a freshly authored record now shows the author's name and email instead of an unresolved member.

Three details worth reviewing deliberately:

- **One reader for the caller identity.** `resolveCallerImsUserId` (`src/support/utils.js`) is now the single definition of the claim precedence: `user_id`, else `sub`, else `email`. The authorship stamp resolves the id it *writes* through it, and this endpoint resolves the caller's own id through it as well. Previously the two sides each read the claims independently — which is precisely how a stamp can keep working while only the display degrades, silently.
- **`email` is an id here, not an address** — and both facts matter in the same file. The auth service deliberately puts the IMS user id (not the real address) in the JWT `email` claim, and `AdobeImsHandler` deletes `user_id` from the profile it builds, leaving `email` the only carrier for an IMS-authenticated caller; this is the same claim the pre-existing writers of `prompts.updated_by` read, and prod rows carry ids of exactly that shape. So `email` participates in resolving the **id**, while the **email field** of the response is sourced only from `trial_email` / `preferred_username` and returns empty rather than putting an id in an email column.
- **The IMS-call counter now counts IMS calls.** The bulk path's counter — which feeds the "Fetched user details from IMS N times" log used to reason about IMS volume — incremented for every non-TrialUser id, including the non-admin placeholder path that never calls IMS (pre-existing) and now the self path. `fetchNonTrialUserDetails` reports which path answered, and only a real IMS call is counted (a call that threw still counts; it consumed capacity). An existing test had frozen the inflated behaviour in place while simultaneously asserting IMS was never called — that assertion was corrected rather than worked around.

## 4. Required information
- Jira / issue: LLMO-6290 (prompt authorship metadata — display/resolution side), follow-up to LLMO-6289 (server-owned stamp + list read)
- Spec: https://github.com/adobe/serenity-docs/pull/35 — `docs/prompt-management/prompt-authorship-metadata.md` (author = one opaque id per side, resolved to a display name at read time via `userDetails`)

## 5. Affected / used mysticat-workspace projects
- **project-elmo-ui** — consumer, unchanged. Its `userUtils` resolution and the Serenity prompt-library authorship columns are the caller of this endpoint; they benefit without a code change (the response shape is identical). Note the label distinction it makes: the literal `unknown` sentinel renders as "Unknown", whereas an unresolved real enterprise-org id renders as "Unknown member" — the symptom here was the latter.
- **spacecat-auth-service** — contract, unchanged. It mints the SpaceCat session JWT whose `sub` and `email` claims both carry the IMS user id this endpoint now matches against; a change to those claims would break both the stamp and this resolution together.

## 6. Additional information outside the code
Verified in prod (CloudWatch `/aws/lambda/spacecat-services--api-service`, profile `spacecat-prod`, `us-east-1`) rather than inferred:

- The prompt create at `2026-07-29T20:36:07Z` on org `cb9df376-a5d8-47e3-94f5-d9687a376eed` / brand `019f37d0-dfda-79e1-9e6c-e932f0f805c5` logged `Authenticated with jwt` — so authorship resolved from the session JWT, and the promise token was used only for the upstream Semrush hop.
- The prompt-library render at `2026-07-30T04:59:04Z` issued `POST /organizations/cb9df376…/userDetails` for exactly one id — a real enterprise-org IMS user id — and logged `User is not admin, returning system defaults for <id>`. That is the failure this PR removes, and it also rules out the `unknown` sentinel as the cause: the UI filters that sentinel out before the lookup, so a sentinel would never have reached the endpoint.

Useful for future triage: DEBUG lines are emitted in prod, so `filter-log-events` on `returning system defaults` shows precisely which ids a lookup could not resolve.

The claim shape this endpoint depends on was confirmed against a live production session token, not only against the minting code: the payload carries no `user_id` at all, the IMS user id in both `sub` and `email`, the real address in `trial_email` / `preferred_username`, and populated `first_name` / `last_name`. That is what makes the fallback order safe and the response's email field correct.

The claim precedence was also checked against what the rest of the service already writes, rather than assumed: prod `prompts.updated_by` holds IMS user ids in the same `<hex>@<hex>.e` shape (written from `profile.email` by the v2 prompts path), while `prompts.created_by` has never carried a user id at all — every recent row is null, the only non-null values being batch markers. So Serenity authorship writes into an identifier namespace that already exists in prod, which is what makes `userDetails` the right resolver for it.

## 7. Test plan
- Locally: exercised through the controller, including the round trip that matters in production — the id the authorship stamp resolves for a given caller is fed straight into the `userDetails` read path for the same caller and must come back as that caller's name and email. Also covered: bulk requests mixing the caller's own id with another user's (own resolved, other still gated), the IMS-profile claim shape, and the case where the only address-looking claim is the IMS GUID (email must stay empty).
- Integration: both endpoints now run against the real auth stack and PostgreSQL, so the claim precedence is proven against a signed-and-validated token instead of a hand-built profile object. This required a new `enterpriseUser` persona — every pre-existing persona uses an address as `sub`, so none of them could exercise the id-vs-address distinction the self-resolution path depends on. Writing it surfaced two things a unit test structurally cannot see: the router does not URL-decode path params (so a client that percent-encodes the `@` in an IMS id silently gets the placeholder — the UI is unaffected, it calls the bulk endpoint), and `TRIAL_USER_1` was seeded without the `external_user_id` the lookup matches on, so the trial branch could never resolve it and every request fell through to the non-trial path.
- dev: open the Serenity prompt library as a **non-admin** user on a sub-workspace brand, create a prompt, and confirm the Updated by / Email columns show that user's own name and email instead of an unresolved member. Then confirm a row authored by a *different* org member without a trial-user record still shows the unresolved label for that same non-admin viewer — the gate for other users is intentionally unchanged.
- prod: after deploy, repeat the create-and-read check on the LLMO-Dev-2 brand used above. Absence of `returning system defaults` for the viewer's own id in the api-service log group is the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
