### PR TITLE
fix(sites): restrict provisioning-managed LLMO config fields on site update

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -65,6 +65,7 @@ import { listViewableResourceIds } from '../support/state-access-mapping-utils.j
 import { requirePostgrestForFacsMappings } from '../support/postgrest-availability.js';
 import { isFacsRebacResource } from '../routes/facs-capabilities.js';
 import { ASO_PRODUCT_CODE, STATUSES as PLG_STATUSES } from './plg/plg-onboarding/constants.js';
+import { guardProvisioningLlmoFields } from '../support/llmo-config-guards.js';
 
 const VALIDATION_ERROR_NAME = 'ValidationError';
 
@@ -1130,6 +1131,13 @@ function SitesController(ctx, log, env) {
           ...existingConfig.llmo,
           ...requestBody.config.llmo,
         };
+      }
+      if (merged.llmo) {
+        merged.llmo = guardProvisioningLlmoFields(
+          merged.llmo,
+          existingConfig?.llmo,
+          accessControlUtil.hasAdminAccess(),
+        );
       }
       // Reject malformed `llmo.detectedCdn` (array, stringified array, display name) before
       // persisting. `Config()` would otherwise swallow the schema error and store the raw value,

--- a/src/support/llmo-config-guards.js
+++ b/src/support/llmo-config-guards.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// llmo config fields only privileged callers may write.
+export const PROVISIONING_OWNED_LLMO_FIELDS = ['cdnlogsFilter', 'cdnBucketConfig'];
+
+/**
+ * For non-privileged callers, restores the fields in PROVISIONING_OWNED_LLMO_FIELDS to their
+ * stored values (or removes them when none was stored). Privileged callers get the object
+ * unchanged. Input is not mutated.
+ *
+ * @param {object|undefined} incomingLlmo  llmo object from the request
+ * @param {object|undefined} existingLlmo  llmo object already stored
+ * @param {boolean} privileged             whether the caller may write these fields
+ * @returns {object|undefined}             sanitized llmo object
+ */
+export function guardProvisioningLlmoFields(incomingLlmo, existingLlmo, privileged) {
+  if (!incomingLlmo || privileged) {
+    return incomingLlmo;
+  }
+
+  let sanitized = incomingLlmo;
+  for (const field of PROVISIONING_OWNED_LLMO_FIELDS) {
+    if (field in sanitized) {
+      // Copy lazily, only when we actually need to change something.
+      if (sanitized === incomingLlmo) {
+        sanitized = { ...incomingLlmo };
+      }
+      const stored = existingLlmo?.[field];
+      if (stored === undefined) {
+        delete sanitized[field];
+      } else {
+        sanitized[field] = stored;
+      }
+    }
+  }
+  return sanitized;
+}

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -5017,6 +5017,97 @@ describe('Sites Controller', () => {
     });
   });
 
+  it('preserves the stored llmo cdnlogsFilter when a non-privileged caller patches config', async () => {
+    const site = sites[0];
+    const existingConfig = Config({
+      llmo: {
+        dataFolder: '/data',
+        brand: 'Test',
+        cdnlogsFilter: [{ key: 'url', value: ['/keep'], type: 'include' }],
+      },
+    });
+    site.getConfig = sandbox.stub().returns(existingConfig);
+    site.setConfig = sandbox.stub();
+    site.save = sandbox.stub().resolves(site);
+    sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+    sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(false);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: {
+          llmo: {
+            dataFolder: '/data',
+            brand: 'Test',
+            cdnlogsFilter: [{ key: 'url', value: ['/other'], type: 'exclude' }],
+          },
+        },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(200);
+    const mergedConfig = site.setConfig.firstCall.args[0];
+    // Incoming value is ignored; the stored value remains in place.
+    expect(mergedConfig.llmo.cdnlogsFilter).to.deep.equal([{ key: 'url', value: ['/keep'], type: 'include' }]);
+  });
+
+  it('drops an llmo cdnlogsFilter a non-privileged caller adds when none is stored', async () => {
+    const site = sites[0];
+    const existingConfig = Config({ llmo: { dataFolder: '/data', brand: 'Test' } });
+    site.getConfig = sandbox.stub().returns(existingConfig);
+    site.setConfig = sandbox.stub();
+    site.save = sandbox.stub().resolves(site);
+    sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+    sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(false);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: {
+          llmo: {
+            dataFolder: '/data',
+            brand: 'Test',
+            cdnlogsFilter: [{ key: 'url', value: ['/new'], type: 'include' }],
+          },
+        },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(200);
+    const mergedConfig = site.setConfig.firstCall.args[0];
+    expect(mergedConfig.llmo).to.not.have.property('cdnlogsFilter');
+    expect(mergedConfig.llmo.brand).to.equal('Test');
+  });
+
+  it('allows a privileged caller to set the llmo cdnlogsFilter', async () => {
+    const site = sites[0];
+    const existingConfig = Config({ llmo: { dataFolder: '/data', brand: 'Test' } });
+    site.getConfig = sandbox.stub().returns(existingConfig);
+    site.setConfig = sandbox.stub();
+    site.save = sandbox.stub().resolves(site);
+    // defaultAuthAttributes carries an admin JWT, so hasAdminAccess() is true.
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        config: {
+          llmo: {
+            dataFolder: '/data',
+            brand: 'Test',
+            cdnlogsFilter: [{ key: 'url', value: ['/admin'], type: 'include' }],
+          },
+        },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(200);
+    const mergedConfig = site.setConfig.firstCall.args[0];
+    expect(mergedConfig.llmo.cdnlogsFilter).to.deep.equal([{ key: 'url', value: ['/admin'], type: 'include' }]);
+  });
+
   describe('auditTargetURLs validation', () => {
     it('returns bad request when manual URL hostname does not match site base URL', async () => {
       const site = sites[0];

--- a/test/support/llmo-config-guards.test.js
+++ b/test/support/llmo-config-guards.test.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import { guardProvisioningLlmoFields } from '../../src/support/llmo-config-guards.js';
+
+describe('guardProvisioningLlmoFields', () => {
+  it('returns undefined when incoming llmo is undefined', () => {
+    expect(guardProvisioningLlmoFields(undefined, { cdnlogsFilter: [{ key: 'url' }] }, false))
+      .to.equal(undefined);
+  });
+
+  it('returns the object unchanged for a privileged caller', () => {
+    const incoming = { cdnlogsFilter: [{ key: 'incoming' }] };
+    expect(guardProvisioningLlmoFields(incoming, { cdnlogsFilter: [{ key: 'stored' }] }, true))
+      .to.equal(incoming);
+  });
+
+  it('preserves the stored values when a non-admin tries to change provisioning fields', () => {
+    const incoming = { brand: 'b', cdnlogsFilter: [{ key: 'incoming' }] };
+    const existing = { cdnlogsFilter: [{ key: 'stored' }] };
+    const result = guardProvisioningLlmoFields(incoming, existing, false);
+    expect(result).to.not.equal(incoming); // copied, not mutated
+    expect(result.brand).to.equal('b'); // untouched field kept
+    expect(result.cdnlogsFilter).to.deep.equal([{ key: 'stored' }]);
+    expect(incoming.cdnlogsFilter).to.deep.equal([{ key: 'incoming' }]); // input not mutated
+  });
+
+  it('drops a provisioning field a non-admin tries to add when none was stored', () => {
+    const incoming = { brand: 'b', cdnlogsFilter: [{ key: 'incoming' }] };
+    const result = guardProvisioningLlmoFields(incoming, { brand: 'b' }, false);
+    expect(result).to.not.have.property('cdnlogsFilter');
+    expect(result.brand).to.equal('b');
+  });
+
+  it('is a no-op for a non-admin when no provisioning fields are present', () => {
+    const incoming = { brand: 'b', questions: { Human: [] } };
+    const result = guardProvisioningLlmoFields(incoming, { brand: 'a' }, false);
+    expect(result).to.equal(incoming); // no copy needed
+  });
+
+  it('handles missing existing llmo (drops all managed fields)', () => {
+    const incoming = { cdnlogsFilter: [{ key: 'y' }], cdnBucketConfig: { orgId: 'x' } };
+    const result = guardProvisioningLlmoFields(incoming, undefined, false);
+    expect(result).to.not.have.property('cdnlogsFilter');
+    expect(result).to.not.have.property('cdnBucketConfig');
+  });
+});


### PR DESCRIPTION
## What

Adds an access-control check on the full-site update endpoint (`PATCH /sites/:siteId`) so that only privileged callers may set or change the provisioning-managed LLMO configuration fields. Non-privileged callers keep whatever is currently stored (or none, if unset); privileged callers are unaffected.

## Why

These fields are owned by the provisioning flow and should not be writable by ordinary callers through the general site-update path. This aligns that path with the dedicated LLMO config endpoints, which already enforce the same privilege level.

## Changes

- New helper `src/support/llmo-config-guards.js` that returns the sanitized config for a caller.
- Wired into `updateSite` after the existing config merge.
- Unit tests for the helper and controller tests covering the privileged and non-privileged paths.

## Testing

- `npm test` (unit + controller); lint clean.