### PR TITLE
fix(claims): run-brand-claims sends the spacecat org UUID, not the IMS org (LLMO-6143)

### DIFF
--- a/src/support/slack/commands/run-brand-claims.js
+++ b/src/support/slack/commands/run-brand-claims.js
@@ -211,11 +211,6 @@ function RunBrandClaimsCommand(context) {
       const event = {
         event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
         schema_version: 1,
-        // The Brand Claims consumer resolves the brand via
-        // `GET /v2/orgs/{spaceCatId}/sites/{siteId}/brand`, whose path param is the
-        // SpaceCat org UUID (validated `isValidUUID`) — NOT the IMS org id. Sending
-        // `getImsOrgId()` (…@AdobeOrg) 400s there and the event is silently
-        // enablement-dropped. Use the spacecat org UUID. (LLMO-6143)
         organization_id: site.getOrganizationId(),
         brand_id: brand.id,
         brand: brandSlug,

--- a/src/support/slack/commands/run-brand-claims.js
+++ b/src/support/slack/commands/run-brand-claims.js
@@ -133,7 +133,7 @@ function RunBrandClaimsCommand(context) {
   });
 
   const { dataAccess, log, sqs } = context;
-  const { Site, Organization } = dataAccess;
+  const { Site } = dataAccess;
 
   const handleExecution = async (args, slackContext) => {
     const { say } = slackContext;
@@ -169,13 +169,6 @@ function RunBrandClaimsCommand(context) {
 
       if (!site) {
         await say(`:x: Site not found: \`${siteArg}\``);
-        return;
-      }
-
-      const organization = await Organization.findById(site.getOrganizationId());
-      const imsOrgId = organization?.getImsOrgId();
-      if (!imsOrgId) {
-        await say(`:x: Could not resolve an IMS org for site \`${siteArg}\`.`);
         return;
       }
 
@@ -218,7 +211,12 @@ function RunBrandClaimsCommand(context) {
       const event = {
         event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
         schema_version: 1,
-        organization_id: imsOrgId,
+        // The Brand Claims consumer resolves the brand via
+        // `GET /v2/orgs/{spaceCatId}/sites/{siteId}/brand`, whose path param is the
+        // SpaceCat org UUID (validated `isValidUUID`) — NOT the IMS org id. Sending
+        // `getImsOrgId()` (…@AdobeOrg) 400s there and the event is silently
+        // enablement-dropped. Use the spacecat org UUID. (LLMO-6143)
+        organization_id: site.getOrganizationId(),
         brand_id: brand.id,
         brand: brandSlug,
         site_id: site.getId(),

--- a/src/support/slack/commands/toggle-brand-claims.js
+++ b/src/support/slack/commands/toggle-brand-claims.js
@@ -12,17 +12,20 @@
 
 import { isValidUUID } from '@adobe/spacecat-shared-utils';
 import BaseCommand from './base.js';
-import { setBrandClaimsEnabled } from '../../brands-storage.js';
-import { postErrorMessage } from '../../../utils/slack/base.js';
+import { getBrandBySite, setBrandClaimsEnabled } from '../../brands-storage.js';
+import { extractURLFromSlackInput, postErrorMessage } from '../../../utils/slack/base.js';
 
 const ENABLE_PHRASE = 'enable-brand-claims';
 const DISABLE_PHRASE = 'disable-brand-claims';
 
 /**
- * One command, two explicit keywords: `enable-brand-claims {brandId}` and
- * `disable-brand-claims {brandId}`. Flips the brand-scoped `brand_claims_enabled`
- * scheduling gate the mystique Brand Claims consumer reads back (LLMO-5741). The
- * verb is derived from which keyword was used — no on/off argument to get wrong.
+ * One command, two explicit keywords: `enable-brand-claims {brandId|baseURL}` and
+ * `disable-brand-claims {brandId|baseURL}`. Flips the brand-scoped
+ * `brand_claims_enabled` scheduling gate the mystique Brand Claims consumer reads
+ * back (LLMO-5741). The verb is derived from which keyword was used — no on/off
+ * argument to get wrong. The target may be a brand UUID (as before) or a site base
+ * URL, which is resolved to its active brand — so operators can use the same
+ * argument they pass to `run-brand-claims` without a separate brand-id lookup.
  *
  * @param {Object} context - The context object.
  * @returns {Object} The command object.
@@ -31,12 +34,13 @@ function BrandClaimsCommand(context) {
   const baseCommand = BaseCommand({
     id: 'brand-claims',
     name: 'Brand Claims',
-    description: 'Enables or disables Brand Claims scheduling for a brand (by brand ID).',
+    description: 'Enables or disables Brand Claims scheduling for a brand (by brand ID or site URL).',
     phrases: [ENABLE_PHRASE, DISABLE_PHRASE],
-    usageText: `${ENABLE_PHRASE} {brandId} | ${DISABLE_PHRASE} {brandId}`,
+    usageText: `${ENABLE_PHRASE} {brandId|baseURL} | ${DISABLE_PHRASE} {brandId|baseURL}`,
   });
 
   const { dataAccess, log } = context;
+  const { Site } = dataAccess;
 
   const execute = async (message, slackContext) => {
     const { say, user } = slackContext;
@@ -45,15 +49,10 @@ function BrandClaimsCommand(context) {
       const trimmed = message.trim();
       const enabled = trimmed.startsWith(ENABLE_PHRASE);
       const phrase = enabled ? ENABLE_PHRASE : DISABLE_PHRASE;
-      const brandId = trimmed.slice(phrase.length).trim().split(/\s+/)[0];
+      const target = trimmed.slice(phrase.length).trim().split(/\s+/)[0];
 
-      if (!brandId) {
-        await say(`:warning: Please provide a brand ID. ${baseCommand.usage()}`);
-        return;
-      }
-
-      if (!isValidUUID(brandId)) {
-        await say(`:warning: '${brandId}' is not a valid brand ID (expected a UUID). ${baseCommand.usage()}`);
+      if (!target) {
+        await say(`:warning: Please provide a brand ID or site URL. ${baseCommand.usage()}`);
         return;
       }
 
@@ -61,6 +60,36 @@ function BrandClaimsCommand(context) {
       if (!postgrestClient?.from) {
         await say(':x: Brand storage is not available in this environment.');
         return;
+      }
+
+      // A UUID is treated as a brand ID (original behavior); anything else is
+      // parsed as a site base URL and resolved to that site's active brand, so the
+      // same argument works here and in `run-brand-claims` (no brand-id lookup).
+      let brandId;
+      if (isValidUUID(target)) {
+        brandId = target;
+      } else {
+        const baseUrl = extractURLFromSlackInput(target);
+        if (!baseUrl) {
+          await say(`:warning: '${target}' is not a valid brand ID (UUID) or site URL. ${baseCommand.usage()}`);
+          return;
+        }
+        const site = await Site.findByBaseURL(baseUrl);
+        if (!site) {
+          await say(`:x: Site not found: \`${target}\``);
+          return;
+        }
+        const resolvedBrand = await getBrandBySite(
+          site.getOrganizationId(),
+          site.getId(),
+          postgrestClient,
+          log,
+        );
+        if (!resolvedBrand) {
+          await say(`:warning: No active brand found for site \`${site.getBaseURL()}\`.`);
+          return;
+        }
+        brandId = resolvedBrand.id;
       }
 
       const actor = user ? `slack:${user}` : 'slack';

--- a/test/support/slack/commands/run-brand-claims.test.js
+++ b/test/support/slack/commands/run-brand-claims.test.js
@@ -19,7 +19,6 @@ use(sinonChai);
 
 const SITE_ID = '9033554c-de8a-44ac-a356-09b51af8cc28';
 const ORG_ID = '5f3b3626-029c-476e-924b-0c1bba2e871f';
-const IMS_ORG_ID = 'ABC123@AdobeOrg';
 const BRAND_ID = 'a1b2c3d4-5678-90ab-cdef-1234567890ab';
 const QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/640168421876/mysticat-bp-sheet-ready';
 
@@ -27,7 +26,6 @@ describe('RunBrandClaimsCommand', () => {
   let context;
   let slackContext;
   let mockSite;
-  let mockOrganization;
   let getBrandBySiteStub;
   let s3SendStub;
   let sqsSendMessageStub;
@@ -53,7 +51,6 @@ describe('RunBrandClaimsCommand', () => {
       getBaseURL: () => 'https://example.com',
       getOrganizationId: () => ORG_ID,
     };
-    mockOrganization = { getImsOrgId: () => IMS_ORG_ID };
     s3SendStub = sinon.stub();
     sqsSendMessageStub = sinon.stub().resolves();
 
@@ -62,9 +59,6 @@ describe('RunBrandClaimsCommand', () => {
         Site: {
           findById: sinon.stub().resolves(mockSite),
           findByBaseURL: sinon.stub().resolves(mockSite),
-        },
-        Organization: {
-          findById: sinon.stub().resolves(mockOrganization),
         },
         services: { postgrestClient: { from: sinon.stub() } },
       },
@@ -128,7 +122,7 @@ describe('RunBrandClaimsCommand', () => {
       expect(event).to.deep.equal({
         event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
         schema_version: 1,
-        organization_id: IMS_ORG_ID,
+        organization_id: ORG_ID,
         brand_id: BRAND_ID,
         brand: 'acme',
         site_id: SITE_ID,
@@ -278,16 +272,6 @@ describe('RunBrandClaimsCommand', () => {
       await command.handleExecution(['https://unknown.example'], slackContext);
 
       expect(slackContext.say.calledWithMatch(/Site not found/)).to.equal(true);
-      expect(sqsSendMessageStub).to.not.have.been.called;
-    });
-
-    it('errors when the org has no IMS org id', async () => {
-      context.dataAccess.Organization.findById.resolves({ getImsOrgId: () => undefined });
-
-      const command = RunBrandClaimsCommand(context);
-      await command.handleExecution(['https://example.com'], slackContext);
-
-      expect(slackContext.say.calledWithMatch(/Could not resolve an IMS org/)).to.equal(true);
       expect(sqsSendMessageStub).to.not.have.been.called;
     });
 

--- a/test/support/slack/commands/toggle-brand-claims.test.js
+++ b/test/support/slack/commands/toggle-brand-claims.test.js
@@ -27,8 +27,8 @@ describe('BrandClaimsCommand', () => {
 
   const BRAND_ID = 'a1b2c3d4-5678-90ab-cdef-1234567890ab';
   const BRAND = { id: BRAND_ID, name: 'Acme' };
-  const SITE_ID = '9033554c-de8a-44ac-a356-09b51af8cc28';
-  const ORG_ID = '5f3b3626-029c-476e-924b-0c1bba2e871f';
+  const SITE_ID = '11111111-1111-4111-8111-111111111111';
+  const ORG_ID = '22222222-2222-4222-8222-222222222222';
 
   before(async () => {
     setBrandClaimsEnabledStub = sinon.stub();

--- a/test/support/slack/commands/toggle-brand-claims.test.js
+++ b/test/support/slack/commands/toggle-brand-claims.test.js
@@ -21,18 +21,24 @@ describe('BrandClaimsCommand', () => {
   let context;
   let slackContext;
   let setBrandClaimsEnabledStub;
+  let getBrandBySiteStub;
+  let mockSite;
   let BrandClaimsCommand;
 
   const BRAND_ID = 'a1b2c3d4-5678-90ab-cdef-1234567890ab';
   const BRAND = { id: BRAND_ID, name: 'Acme' };
+  const SITE_ID = '9033554c-de8a-44ac-a356-09b51af8cc28';
+  const ORG_ID = '5f3b3626-029c-476e-924b-0c1bba2e871f';
 
   before(async () => {
     setBrandClaimsEnabledStub = sinon.stub();
+    getBrandBySiteStub = sinon.stub();
     BrandClaimsCommand = await esmock(
       '../../../../src/support/slack/commands/toggle-brand-claims.js',
       {
         '../../../../src/support/brands-storage.js': {
           setBrandClaimsEnabled: setBrandClaimsEnabledStub,
+          getBrandBySite: getBrandBySiteStub,
         },
       },
     );
@@ -40,8 +46,20 @@ describe('BrandClaimsCommand', () => {
 
   beforeEach(() => {
     setBrandClaimsEnabledStub.reset();
+    getBrandBySiteStub.reset();
+    mockSite = {
+      getId: () => SITE_ID,
+      getBaseURL: () => 'https://example.com',
+      getOrganizationId: () => ORG_ID,
+    };
     context = {
-      dataAccess: { services: { postgrestClient: { from: sinon.stub() } } },
+      dataAccess: {
+        Site: {
+          findByBaseURL: sinon.stub().resolves(mockSite),
+          findById: sinon.stub().resolves(mockSite),
+        },
+        services: { postgrestClient: { from: sinon.stub() } },
+      },
       log: console,
     };
     slackContext = { say: sinon.spy(), user: 'U123' };
@@ -81,19 +99,55 @@ describe('BrandClaimsCommand', () => {
       expect(slackContext.say.calledWithMatch(/Brand claims \*disabled\* for brand "Acme"/)).to.be.true;
     });
 
-    it('warns when no brand ID is provided', async () => {
-      const command = BrandClaimsCommand(context);
-      await command.execute('enable-brand-claims', slackContext);
+    it('resolves a brand by site base URL and enables it', async () => {
+      getBrandBySiteStub.resolves(BRAND);
+      setBrandClaimsEnabledStub.resolves(BRAND);
 
-      expect(slackContext.say.calledWithMatch(/Please provide a brand ID/)).to.be.true;
+      const command = BrandClaimsCommand(context);
+      await command.execute('enable-brand-claims https://example.com', slackContext);
+
+      expect(context.dataAccess.Site.findByBaseURL).to.have.been.calledWith('https://example.com');
+      expect(getBrandBySiteStub).to.have.been.calledWith(ORG_ID, SITE_ID);
+      const args = setBrandClaimsEnabledStub.firstCall.args[0];
+      expect(args.brandId).to.equal(BRAND_ID);
+      expect(args.enabled).to.equal(true);
+      expect(slackContext.say.calledWithMatch(/Brand claims \*enabled\* for brand "Acme"/)).to.be.true;
+    });
+
+    it('errors when the site URL resolves to no site', async () => {
+      context.dataAccess.Site.findByBaseURL.resolves(null);
+
+      const command = BrandClaimsCommand(context);
+      await command.execute('enable-brand-claims https://example.com', slackContext);
+
+      expect(slackContext.say.calledWithMatch(/Site not found/)).to.be.true;
       expect(setBrandClaimsEnabledStub).to.not.have.been.called;
     });
 
-    it('rejects a brand ID that is not a valid UUID', async () => {
-      const command = BrandClaimsCommand(context);
-      await command.execute('enable-brand-claims not-a-uuid', slackContext);
+    it('warns when the resolved site has no active brand', async () => {
+      getBrandBySiteStub.resolves(null);
 
-      expect(slackContext.say.calledWithMatch(/not a valid brand ID/)).to.be.true;
+      const command = BrandClaimsCommand(context);
+      await command.execute('enable-brand-claims https://example.com', slackContext);
+
+      expect(slackContext.say.calledWithMatch(/No active brand found for site/)).to.be.true;
+      expect(setBrandClaimsEnabledStub).to.not.have.been.called;
+    });
+
+    it('warns when no target is provided', async () => {
+      const command = BrandClaimsCommand(context);
+      await command.execute('enable-brand-claims', slackContext);
+
+      expect(slackContext.say.calledWithMatch(/Please provide a brand ID or site URL/)).to.be.true;
+      expect(setBrandClaimsEnabledStub).to.not.have.been.called;
+    });
+
+    it('rejects an argument that is neither a valid UUID nor a parseable URL', async () => {
+      const command = BrandClaimsCommand(context);
+      await command.execute('enable-brand-claims garbage!!!', slackContext);
+
+      expect(slackContext.say.calledWithMatch(/not a valid brand ID \(UUID\) or site URL/)).to.be.true;
+      expect(context.dataAccess.Site.findByBaseURL).to.not.have.been.called;
       expect(setBrandClaimsEnabledStub).to.not.have.been.called;
     });
 


### PR DESCRIPTION
## What
`run-brand-claims` (#2924) publishes the `BRAND_PRESENCE_SHEET_WRITTEN` event with `organization_id: organization.getImsOrgId()`. The mystique Brand Claims consumer resolves the brand via `GET /v2/orgs/{spaceCatId}/sites/{siteId}/brand`, whose org path param is **validated as a UUID** (`brands.js` `getBrandForOrgSite` → `isValidUUID`). An IMS org id (`…@AdobeOrg`) is not a UUID → **400** → the consumer's enablement gate classifies the 4xx as resolved-negative and **silently drops the event** (`enablement_dropped`). Net: the command reports success but **no claims scan ever runs**.

## Fix
Send `site.getOrganizationId()` (the spacecat org UUID) instead, and drop the now-unused `Organization.findById` lookup + IMS-org guard.

## Validation
- Verified empirically: a manual event with the spacecat org UUID triggers a claims scan end-to-end (Changi, dev, scan `cd087d57`), while the IMS-org variant was dropped.
- `mocha test/support/slack/commands/run-brand-claims.test.js` — 21 passing (updated the published-event assertion to `ORG_ID`, removed the obsolete IMS-org test).
- `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)