### PR TITLE
feat(sites): default missing x-product to ASO on /sites-resolve under SKIP_AUTH

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -1780,7 +1780,16 @@ function SitesController(ctx, log, env) {
     } = context.data;
     const { pathInfo } = context;
     const X_PRODUCT_HEADER = 'x-product';
-    const productCode = pathInfo.headers[X_PRODUCT_HEADER];
+    let productCode = pathInfo.headers[X_PRODUCT_HEADER];
+    // Local-dev affordance (SKIP_AUTH only): the local UI harness may run a UI
+    // build that predates the x-product requirement on /sites-resolve and so omits
+    // the header. When auth is skipped (local only; SKIP_AUTH is never 'true' in a
+    // deployed env), default the product to ASO so the local UI ⇄ local api-service
+    // e2e can resolve a site. Prod keeps enforcing the header contract below.
+    if (!hasText(productCode) && env.SKIP_AUTH === 'true') {
+      productCode = ASO_PRODUCT_CODE;
+      log.info('[resolveSite] SKIP_AUTH local-dev: defaulting missing x-product to ASO');
+    }
     if (!hasText(productCode)) {
       return badRequest('Product code required in x-product header');
     }

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -6726,6 +6726,44 @@ describe('Sites Controller', () => {
       expect(body.message).to.include('Product code required');
     });
 
+    it('defaults a missing x-product to ASO under SKIP_AUTH (local dev) so resolution proceeds', async () => {
+      // Local-dev-only affordance: with auth skipped, a missing x-product header
+      // must NOT short-circuit with "Product code required" - it defaults to ASO
+      // and resolution continues (failing here at the next guard instead).
+      const localController = SitesControllerMocked(
+        context,
+        loggerStub,
+        { ...context.env, SKIP_AUTH: 'true' },
+      );
+      context.pathInfo.headers = {};
+      context.data = {};
+
+      const response = await localController.resolveSite(context);
+
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.not.include('Product code required');
+      expect(body.message).to.include('Either organizationId or imsOrg must be provided');
+    });
+
+    it('still requires x-product when SKIP_AUTH is not exactly "true"', async () => {
+      // The default is strictly gated on SKIP_AUTH === 'true'; any other value
+      // (i.e. every deployed env) keeps enforcing the header contract.
+      const nonLocalController = SitesControllerMocked(
+        context,
+        loggerStub,
+        { ...context.env, SKIP_AUTH: 'false' },
+      );
+      context.pathInfo.headers = {};
+      context.data = {};
+
+      const response = await nonLocalController.resolveSite(context);
+
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.include('Product code required');
+    });
+
     it('should return bad request if no query parameters provided', async () => {
       context.data = {};
       const response = await sitesController.resolveSite(context);


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
`/sites-resolve` defaults a missing `x-product` header to ASO, but only when `SKIP_AUTH === 'true'` (local dev). Deployed environments are unchanged.

## 2. Reasoning
Running the local UI against a local api-service surfaced this: a locally-served ASO UI build can predate the `x-product` requirement on `/sites-resolve` and omit the header, so the endpoint fails with "Product code required" and the UI can never resolve a site locally. Rather than force every local UI checkout to carry the header, default the product locally where auth is already skipped.

## 3. High-level overview of the changes
- In `resolveSite` (`src/controllers/sites.js`), when `x-product` is absent AND `env.SKIP_AUTH === 'true'`, default `productCode` to `ASO_PRODUCT_CODE` and log an info line, instead of returning `badRequest('Product code required in x-product header')`.
- The guard is strict equality on `SKIP_AUTH === 'true'`. `SKIP_AUTH` is only ever set locally (never in a deployed env), so this path cannot activate in dev/stage/prod - the header contract there is byte-for-byte unchanged.
- Behaviour delta: local-only. `POST /sites-resolve` without `x-product` under `SKIP_AUTH` now proceeds to org/site resolution (as ASO) instead of 400ing on the missing header.

## 7. Additional information outside the code
Verified this session end-to-end: with this default in place, the locally-served ASO UI (webpack bundle in the exc-app shell) resolved a site against the local api-service and rendered the opportunity list. Without it, `/sites-resolve` returned "Product code required" and the UI fell back to onboarding.

## 8. Test plan
- Unit (`test/controllers/sites.test.js`, `resolveSite` block): a missing `x-product` under `SKIP_AUTH='true'` no longer returns "Product code required" (resolution proceeds past the product guard); a missing `x-product` when `SKIP_AUTH` is not exactly `'true'` still returns "Product code required". Run: `npx mocha test/controllers/sites.test.js -g "resolveSite"`.
- dev/stage/prod: no behavioural change to verify - `SKIP_AUTH` is unset there, so the pre-existing "Product code required" contract holds. Confirm via any `POST /sites-resolve` without `x-product` still returning 400.