### PR TITLE
feat: 'run impact measurement' Slack command (dispatches to llmo-experimentation-engine)

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -64,6 +64,7 @@ import togglePathSuggestions from './commands/toggle-path-suggestions.js';
 import getPathSuggestionsStatus from './commands/get-path-suggestions-status.js';
 import brandClaims from './commands/toggle-brand-claims.js';
 import runBrandClaims from './commands/run-brand-claims.js';
+import runImpactMeasurement from './commands/run-impact-measurement.js';
 
 /**
  * Returns all commands.
@@ -126,4 +127,5 @@ export default (context) => [
   getPathSuggestionsStatus(context),
   brandClaims(context),
   runBrandClaims(context),
+  runImpactMeasurement(context),
 ];

--- a/src/support/slack/commands/run-impact-measurement.js
+++ b/src/support/slack/commands/run-impact-measurement.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasText, isNonEmptyArray, isValidUrl } from '@adobe/spacecat-shared-utils';
+
+import BaseCommand from './base.js';
+import {
+  extractURLFromSlackInput,
+  postErrorMessage,
+  postSiteNotFoundMessage,
+} from '../../../utils/slack/base.js';
+
+const PHRASES = ['run impact measurement'];
+
+// SQS message type dispatched to the llmo-experimentation-engine's handler registry. The engine
+// looks up its handler by this `type` and runs the impact-measurement workflow for the experiment.
+const MESSAGE_TYPE = 'run-impact-measurement';
+
+/**
+ * Manually triggers the impact-measurement workflow for a geo-experiment. The command resolves the
+ * site by domain, picks the target experiment, and enqueues a message onto the
+ * llmo-experimentation-engine queue — the engine then runs the workflow end-to-end for that
+ * experiment (trigger Mystique task, poll, store insights, complete).
+ *
+ * @param {object} context - The command context ({ dataAccess, sqs, env, log }).
+ * @returns {object} The command object.
+ */
+function RunImpactMeasurementCommand(context) {
+  const baseCommand = BaseCommand({
+    id: 'run-impact-measurement',
+    name: 'Run Impact Measurement',
+    description: 'Manually trigger the impact-measurement workflow for a geo-experiment (dispatched to the llmo-experimentation-engine).',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {site} [experimentId]`,
+  });
+
+  const {
+    dataAccess, sqs, env, log,
+  } = context;
+  const { Site, GeoExperiment } = dataAccess;
+
+  /**
+   * Resolve the target experiment: the explicit id when provided (validated against the site), else
+   * the site's single experiment. Returns { experiment } on success, or { error } (a user message).
+   */
+  const resolveExperiment = async (site, experimentId) => {
+    if (hasText(experimentId)) {
+      const experiment = await GeoExperiment.findById(experimentId);
+      if (!experiment || experiment.getSiteId() !== site.getId()) {
+        return { error: `:warning: No geo-experiment \`${experimentId}\` found for this site.` };
+      }
+      return { experiment };
+    }
+
+    const { data: experiments } = await GeoExperiment.allBySiteId(site.getId());
+    if (!isNonEmptyArray(experiments)) {
+      return { error: ':warning: No geo-experiments found for this site.' };
+    }
+    if (experiments.length > 1) {
+      const list = experiments
+        .map((e) => `• \`${e.getId()}\` — ${e.getName?.() ?? 'experiment'} (${e.getStatus?.() ?? 'unknown'})`)
+        .join('\n');
+      return { error: `:warning: Multiple geo-experiments found — re-run with an experiment id:\n${list}` };
+    }
+    return { experiment: experiments[0] };
+  };
+
+  const handleExecution = async (args, slackContext) => {
+    const { say } = slackContext;
+
+    try {
+      const [baseURLInput, experimentId] = args;
+      const baseURL = extractURLFromSlackInput(baseURLInput);
+
+      if (!isValidUrl(baseURL)) {
+        await say(baseCommand.usage());
+        return;
+      }
+
+      const queueUrl = env?.LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL;
+      if (!hasText(queueUrl)) {
+        await say(':warning: The experimentation-engine queue is not configured (LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL).');
+        return;
+      }
+
+      const site = await Site.findByBaseURL(baseURL);
+      if (!site) {
+        await postSiteNotFoundMessage(say, baseURL);
+        return;
+      }
+
+      const { experiment, error } = await resolveExperiment(site, experimentId);
+      if (error) {
+        await say(error);
+        return;
+      }
+
+      const message = {
+        type: MESSAGE_TYPE,
+        siteId: site.getId(),
+        geoExperimentId: experiment.getId(),
+      };
+      await sqs.sendMessage(queueUrl, message);
+
+      log.info(`[run-impact-measurement] enqueued for site=${site.getId()} experiment=${experiment.getId()}`);
+      await say(`:white_check_mark: Impact measurement triggered for experiment \`${experiment.getId()}\` (${baseURL}). The experimentation engine will run the workflow.`);
+    } catch (error) {
+      log.error('Error triggering impact measurement:', error);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+}
+
+export default RunImpactMeasurementCommand;

--- a/test/support/slack/commands/run-impact-measurement.test.js
+++ b/test/support/slack/commands/run-impact-measurement.test.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+
+import RunImpactMeasurementCommand from '../../../../src/support/slack/commands/run-impact-measurement.js';
+
+use(sinonChai);
+
+const QUEUE = 'engineQueueUrl';
+
+describe('RunImpactMeasurementCommand', () => {
+  let context;
+  let slackContext;
+  let dataAccess;
+  let sqs;
+
+  const makeSite = (id = 'site-1') => ({ getId: () => id });
+  const makeExperiment = (overrides = {}) => ({
+    getId: () => 'exp-1',
+    getSiteId: () => 'site-1',
+    getName: () => 'Exp One',
+    getStatus: () => 'IN_PROGRESS',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    dataAccess = {
+      Site: { findByBaseURL: sinon.stub() },
+      GeoExperiment: { findById: sinon.stub(), allBySiteId: sinon.stub() },
+    };
+    sqs = { sendMessage: sinon.stub().resolves() };
+    context = {
+      dataAccess,
+      sqs,
+      env: { LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: QUEUE },
+      log: { info: sinon.stub(), error: sinon.stub() },
+    };
+    slackContext = { say: sinon.stub().resolves() };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('accepts its trigger phrase', () => {
+    const cmd = RunImpactMeasurementCommand(context);
+    expect(cmd.accepts('run impact measurement https://example.com')).to.be.true;
+    expect(cmd.accepts('run something else')).to.be.false;
+  });
+
+  it('shows usage when the URL is invalid', async () => {
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['not-a-url'], slackContext);
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(slackContext.say).to.have.been.called;
+  });
+
+  it('warns when the engine queue is not configured', async () => {
+    context.env = {};
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com'], slackContext);
+    expect(slackContext.say).to.have.been.calledWithMatch(/queue is not configured/);
+    expect(sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('reports when the site is not found', async () => {
+    dataAccess.Site.findByBaseURL.resolves(null);
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com'], slackContext);
+    expect(sqs.sendMessage).to.not.have.been.called;
+    expect(slackContext.say).to.have.been.called;
+  });
+
+  it('warns when an explicit experiment id is not found for the site', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.findById.resolves(null);
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com', 'missing-id'], slackContext);
+    expect(slackContext.say).to.have.been.calledWithMatch(/No geo-experiment `missing-id`/);
+    expect(sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('warns when the explicit experiment belongs to a different site', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.findById.resolves(makeExperiment({ getSiteId: () => 'other-site' }));
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com', 'exp-1'], slackContext);
+    expect(slackContext.say).to.have.been.calledWithMatch(/No geo-experiment `exp-1`/);
+    expect(sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('warns when the site has no experiments', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.allBySiteId.resolves({ data: [] });
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com'], slackContext);
+    expect(slackContext.say).to.have.been.calledWithMatch(/No geo-experiments found/);
+    expect(sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('lists experiments and asks for an id when the site has multiple', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.allBySiteId.resolves({
+      data: [makeExperiment(), makeExperiment({ getId: () => 'exp-2' })],
+    });
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com'], slackContext);
+    expect(slackContext.say).to.have.been.calledWithMatch(/Multiple geo-experiments/);
+    expect(sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('dispatches to the engine queue for the single experiment', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.allBySiteId.resolves({ data: [makeExperiment()] });
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com'], slackContext);
+    expect(sqs.sendMessage).to.have.been.calledOnceWith(QUEUE, {
+      type: 'run-impact-measurement',
+      siteId: 'site-1',
+      geoExperimentId: 'exp-1',
+    });
+    expect(slackContext.say).to.have.been.calledWithMatch(/Impact measurement triggered/);
+  });
+
+  it('dispatches for an explicitly-provided experiment id', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.findById.resolves(makeExperiment());
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com', 'exp-1'], slackContext);
+    expect(dataAccess.GeoExperiment.allBySiteId).to.not.have.been.called;
+    expect(sqs.sendMessage).to.have.been.calledOnceWith(QUEUE, {
+      type: 'run-impact-measurement',
+      siteId: 'site-1',
+      geoExperimentId: 'exp-1',
+    });
+  });
+
+  it('handles experiments without name/status accessors in the multi list', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.allBySiteId.resolves({
+      data: [
+        { getId: () => 'exp-1' },
+        { getId: () => 'exp-2' },
+      ],
+    });
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com'], slackContext);
+    expect(slackContext.say).to.have.been.calledWithMatch(/Multiple geo-experiments/);
+  });
+
+  it('posts an error message when dispatch throws', async () => {
+    dataAccess.Site.findByBaseURL.resolves(makeSite());
+    dataAccess.GeoExperiment.allBySiteId.resolves({ data: [makeExperiment()] });
+    sqs.sendMessage.rejects(new Error('sqs down'));
+    const cmd = RunImpactMeasurementCommand(context);
+    await cmd.handleExecution(['https://www.example.com'], slackContext);
+    expect(context.log.error).to.have.been.called;
+    expect(slackContext.say).to.have.been.called;
+  });
+});


### PR DESCRIPTION
## What

Adds a `run impact measurement` Slack command that lets us **manually trigger the impact-measurement workflow** for a geo-experiment on demand.

```
run impact measurement {site} [experimentId]
```

- Resolves the site by domain (`Site.findByBaseURL`).
- Picks the target experiment: the explicit `experimentId` when given (validated against the site), otherwise the site's single geo-experiment. If the site has **multiple** experiments and no id is given, it lists them and asks for one.
- **Dispatches to the `llmo-experimentation-engine`** by enqueuing a message on its queue — the engine then runs the workflow end-to-end for that experiment (trigger the Mystique task, poll, store insights, complete). The api-service only sends the message; it does not call Mystique itself.

Message shape sent to the engine queue:
```json
{ "type": "run-impact-measurement", "siteId": "…", "geoExperimentId": "…" }
```
The engine dispatches on `type` via its handler registry.

## Prerequisites (separate work, out of scope here)

This is the **api-service side only**, per the requested scope. For the end-to-end flow to work, two companion pieces are needed:

1. **Engine handler** — `llmo-experimentation-engine` must register a `run-impact-measurement` handler in its (currently empty) `HANDLERS` registry that runs the impact-measurement workflow for the given `geoExperimentId`.
2. **Queue provisioning** — `LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL` must be set (the engine's inbound SQS queue). The command guards on this and reports a clear message when it's unset.

## Test plan

- [x] Unit tests (12) — invalid URL, unconfigured queue, site-not-found, explicit-id mismatch / wrong-site, no / one / multiple experiments, success dispatch (implicit + explicit id), error path. **100% coverage** on the new command.
- [x] Lint + strict type-check pass.
- [ ] Manual: `run impact measurement https://<domain>` in Slack once the engine handler + queue are in place.
