### PR TITLE
fix: URL-prompts honors market & category filters | LLMO-6674

### DIFF
--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -978,9 +978,13 @@ export default function ElementsController(context, log, env) {
    * see url-prompts.js). Pagination is client-side; `totalCount` is the full count.
    *
    * Query params: `url` (required, the cited URL), `startDate`/`endDate` (required,
-   * YYYY-MM-DD), `model`/`platform` (optional, default search-gpt). `siteId` is accepted
-   * but ignored (the sub-workspace authorization already scopes to the brand). Returns the
-   * full prompt list in one `{ prompts }` envelope, matching the PG url-prompts endpoint.
+   * YYYY-MM-DD), `model`/`platform` (optional, default search-gpt), `projectId`
+   * (optional, CSV of Semrush project ids — the market filter; each must be owned by the
+   * brand, and the payload fans out per project, see {@link buildUrlPromptsPayload}) and
+   * `category`/`categoryId` (optional, full `category__<label>` tag → `CBF_tags`). `siteId`
+   * is accepted but ignored (the sub-workspace authorization already scopes to the brand).
+   * Returns the full prompt list in one `{ prompts }` envelope, matching the PG
+   * url-prompts endpoint.
    */
   /* c8 ignore start -- LLMO-6620 POC endpoint; unit tests deferred (see url-prompts.js tests) */
   const listUrlPrompts = async (ctx) => {

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -386,10 +386,11 @@ async function authorizeOrg(ctx) {
  *
  * @param {object} ctx - Request context.
  * @param {object} log - Logger (for the misconfiguration alert).
- * @returns {Promise<{workspaceId: string} | {error: Response}>} the brand's
- *   sub-workspace id on success, or a Response on failure (400 non-UUID brandId,
- *   403 no access, 404 org/brand not found or brand has no sub-workspace,
- *   409 sub-workspace misconfigured as the parent).
+ * @returns {Promise<{workspaceId: string, brandUuid: string} | {error: Response}>}
+ *   the brand's sub-workspace id and resolved Postgres brand UUID on success, or a
+ *   Response on failure (400 non-UUID brandId, 403 no access, 404 org/brand not found
+ *   or brand has no sub-workspace, 409 sub-workspace misconfigured as the parent).
+ *   `brandUuid` lets callers run the project-ownership guard (see listUrlPrompts).
  */
 async function authorizeBrandSubWorkspace(ctx, log) {
   const spaceCatId = ctx?.params?.spaceCatId;
@@ -438,7 +439,7 @@ async function authorizeBrandSubWorkspace(ctx, log) {
       ),
     };
   }
-  return { workspaceId };
+  return { workspaceId, brandUuid };
 }
 
 export default function ElementsController(context, log, env) {
@@ -988,7 +989,7 @@ export default function ElementsController(context, log, env) {
       if (auth.error) {
         return auth.error;
       }
-      const { workspaceId } = auth;
+      const { workspaceId, brandUuid } = auth;
 
       const query = extractQuery(ctx);
 
@@ -1020,12 +1021,30 @@ export default function ElementsController(context, log, env) {
         return badRequest(`Date range must not exceed ${MAX_RANGE_DAYS} days`);
       }
 
+      // Market scope: caller-supplied projectId(s) must belong to this brand — mirrors
+      // listOwnedUrls/listDomainUrls — or a caller could scope to another brand's data.
+      // Absent → the aggregate view across the brand's whole sub-workspace.
+      const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+      const brandSemrushProjects = await fetchBrandSemrushProjects(
+        BrandSemrushProject,
+        [{ id: brandUuid }],
+      );
+      const requestedProjectIds = extractProjectIds(query);
+      const ownershipError = checkProjectIdsOwnership(requestedProjectIds, brandSemrushProjects);
+      if (ownershipError) {
+        return ownershipError;
+      }
+
       const service = await buildService(ctx);
       const prompts = await service.getUrlPrompts(workspaceId, {
         url,
         model: query.model || query.platform,
         startDate,
         endDate,
+        // Full `category__<label>` tag, sent as-is (CBF_tags in advanced).
+        category: query.categoryId || query.category,
+        // Fan out per market + union/dedupe by prompt text (element takes one project_id).
+        projectIds: requestedProjectIds,
       });
 
       // Match the PG url-prompts envelope this endpoint will replace: a bare `{ prompts }`

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -45,7 +45,7 @@ export {
   transformOwnedUrlsResponse,
 } from './owned-urls.js';
 export { buildDomainUrlsPayload, transformDomainUrlsResponse } from './domain-urls.js';
-export { buildUrlPromptsPayload, transformUrlPromptsResponse } from './url-prompts.js';
+export { buildUrlPromptsPayload, transformUrlPromptsResponse, mergeUrlPromptsResponses } from './url-prompts.js';
 export { aggregateUrlInspectorStats } from './url-inspector-stats.js';
 export {
   buildMarketMentionsTrendPayload,

--- a/src/support/elements/definitions/url-prompts.js
+++ b/src/support/elements/definitions/url-prompts.js
@@ -114,3 +114,52 @@ export function transformUrlPromptsResponse(raw) {
     closestDate: typeof row?.closest_date === 'string' ? row.closest_date : null,
   }));
 }
+
+/**
+ * Merges the per-market URL_PROMPTS responses (each already run through
+ * {@link transformUrlPromptsResponse}) into one deduped list. The element takes ONE
+ * top-level `project_id` per call, so a multi-market selection fans out one call per
+ * project (see `getUrlPrompts`) and this unions the transformed results. Extracted here
+ * (rather than inlined in the service) to match the sibling merge helpers in
+ * `owned-urls.js` / `cited-domains.js` and to keep the merge unit-testable.
+ *
+ * Dedupe is EXACT-STRING on `prompt` — NO case/whitespace normalization. Distinct
+ * markets are distinct geo+language slices, so a case- or space-differing prompt is a
+ * genuinely different prompt, not a variant to fold together. Rows with an empty
+ * `prompt` are malformed (the element returns one row per real prompt) and are DROPPED,
+ * not collapsed into a single bogus `''` entry that would hide a market's data.
+ *
+ * On collision the FIRST occurrence wins for scalar fields (`sourceTitle`,
+ * `brandMentioned`, ...). This is non-deterministic across markets by design: a URL's
+ * prompt text is the same everywhere, only per-market citation metadata differs, and the
+ * SR dialog shows a single row per prompt. `brands` are unioned and the latest
+ * `closestDate` is kept so "Brands mentioned" / "Last cited" reflect ALL selected markets.
+ *
+ * @param {Array<Array<object>>} perProjectRows - Transformed rows, one array per market.
+ * @returns {Array<object>} Deduped union, in first-seen order.
+ */
+export function mergeUrlPromptsResponses(perProjectRows = []) {
+  const byPrompt = new Map();
+  for (const rows of (Array.isArray(perProjectRows) ? perProjectRows : [])) {
+    for (const row of (Array.isArray(rows) ? rows : [])) {
+      // Drop malformed/blank-prompt rows so multiple markets' blanks don't collapse
+      // into one bogus '' entry (see docstring).
+      if (!row?.prompt) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      const existing = byPrompt.get(row.prompt);
+      if (!existing) {
+        byPrompt.set(row.prompt, { ...row, brands: [...(row.brands ?? [])] });
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // Union brands (dedupe); keep the latest closestDate across markets.
+      existing.brands = [...new Set([...existing.brands, ...(row.brands ?? [])])];
+      if (row.closestDate && (!existing.closestDate || row.closestDate > existing.closestDate)) {
+        existing.closestDate = row.closestDate;
+      }
+    }
+  }
+  return [...byPrompt.values()];
+}

--- a/src/support/elements/definitions/url-prompts.js
+++ b/src/support/elements/definitions/url-prompts.js
@@ -30,6 +30,13 @@ import { resolveElementModel } from '../constants.js';
  *    controller). The live MFE also sends `CBF_brand`, but the url-inspector sibling
  *    definitions (owned-urls / domain-urls / cited-domains) do not duplicate it —
  *    the sub-workspace already scopes the brand — so it is omitted here too.
+ *  - Market scope → the element's TOP-LEVEL `project_id` (like owned-urls), NOT a
+ *    `CBF_project` advanced filter (verified live 2026-07-30: `CBF_project` is a silent
+ *    no-op; a bogus top-level `project_id` → HTTP 422). The element takes ONE project id
+ *    per call, so the service fans out per selected market and unions the results.
+ *  - Category scope → `CBF_tags` (op eq) in the `advanced` block (NOT `simple`, which is a
+ *    no-op), value = the full `category__<label>` tag — same mechanism as owned-urls
+ *    ({@link buildOwnedUrlsStatsPayload}).
  */
 
 /**
@@ -42,23 +49,31 @@ import { resolveElementModel } from '../constants.js';
  * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
  * @param {string} params.startDate - ISO date (YYYY-MM-DD).
  * @param {string} params.endDate - ISO date (YYYY-MM-DD).
+ * @param {string} [params.category] - Full `category__<label>` tag value, sent as-is as a
+ *   `CBF_tags` eq in `advanced` (callers already include the `category__` prefix).
+ * @param {string} [params.projectId] - Semrush project id (market scope, top-level).
  * @returns {object} Semrush element request payload.
  */
 export function buildUrlPromptsPayload({
-  url, model, platform, startDate, endDate,
+  url, model, platform, startDate, endDate, category, projectId,
 } = {}) {
   const resolvedModel = resolveElementModel(model || platform);
+  const advancedFilters = [
+    { op: 'eq', val: resolvedModel, col: 'CBF_model' },
+    { op: 'eq', val: url, col: 'CBF_source' },
+    { op: 'gte', val: startDate, col: 'CBF_date__start' },
+    { op: 'lte', val: endDate, col: 'CBF_date__end' },
+  ];
+  if (category) {
+    advancedFilters.push({ op: 'eq', val: category, col: 'CBF_tags' });
+  }
   return {
+    ...(projectId && { project_id: projectId }),
     filters: {
       simple: { CBF_source: url },
       advanced: {
         op: 'and',
-        filters: [
-          { op: 'eq', val: resolvedModel, col: 'CBF_model' },
-          { op: 'eq', val: url, col: 'CBF_source' },
-          { op: 'gte', val: startDate, col: 'CBF_date__start' },
-          { op: 'lte', val: endDate, col: 'CBF_date__end' },
-        ],
+        filters: advancedFilters,
       },
     },
   };

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -344,21 +344,76 @@ export function createElementsService(transport, log) {
     /**
      * Fetches the URL Inspector details drill-down: the prompts that cited a specific
      * URL, from the URL_PROMPTS element (b4f1ead7), scoped by `CBF_source` (the URL).
-     * Single call (no fan-out); returns a flat array of per-prompt rows. Pagination is
-     * applied client-side by the controller (Semrush has no server-side paging).
+     * Returns a flat array of per-prompt rows. Pagination is applied client-side by the
+     * controller (Semrush has no server-side paging).
+     *
+     * Market scope: the element takes ONE top-level `project_id` per call (a `CBF_project`
+     * advanced filter is a no-op — verified live LLMO-6674). So when the caller selects
+     * markets, this fans out one call per project id (bounded concurrency, mirroring
+     * owned-urls) and UNIONS the results, deduped by prompt text — the same prompt cited in
+     * two markets is one row. No `projectIds` → one unscoped call across the whole
+     * sub-workspace (unchanged behavior). Category is a `CBF_tags` filter applied on every
+     * per-project call.
+     *
+     * On dedupe the first occurrence wins for scalar fields, `brands` are unioned, and the
+     * latest `closestDate` is kept — so the SR dialog's Brands mentioned / Last cited
+     * columns reflect all selected markets, not just the first.
      *
      * @param {string} workspaceId - Semrush sub-workspace UUID (projects/prompts live here).
-     * @param {object} params - Query params (url, model/platform, startDate, endDate).
+     * @param {object} params - Query params (url, model/platform, startDate, endDate,
+     *   category, projectIds).
+     * @param {string[]} [params.projectIds] - Semrush project ids to scope to. Empty → one
+     *   unscoped (sub-workspace-wide) fetch.
      * @returns {Promise<Array<object>>} Per-prompt rows (see transformUrlPromptsResponse).
      */
     /* c8 ignore start -- LLMO-6620 POC endpoint; unit tests deferred (see url-prompts.js tests) */
-    async getUrlPrompts(workspaceId, params) {
-      const raw = await transport.fetchElement(
-        workspaceId,
-        ELEMENT_IDS.URL_PROMPTS,
-        buildUrlPromptsPayload(params),
+    async getUrlPrompts(workspaceId, {
+      url, model, platform, startDate, endDate, category, projectIds = [],
+    }) {
+      const ids = Array.isArray(projectIds)
+        ? [...new Set(projectIds.filter(hasText))]
+        : [];
+      // One top-level project_id per call; `undefined` = the unscoped aggregate.
+      const scopes = ids.length > 0 ? ids : [undefined];
+      // Bound the per-market fan-out (mirrors owned-urls) so a brand with many markets
+      // can't spawn unbounded parallel Semrush requests (429 / pool risk).
+      const URL_PROMPTS_PROJECT_CONCURRENCY = 8;
+      const perProject = await mapWithConcurrency(
+        scopes,
+        URL_PROMPTS_PROJECT_CONCURRENCY,
+        async (projectId) => {
+          const raw = await transport.fetchElement(
+            workspaceId,
+            ELEMENT_IDS.URL_PROMPTS,
+            buildUrlPromptsPayload({
+              url, model, platform, startDate, endDate, category, projectId,
+            }),
+          );
+          return transformUrlPromptsResponse(raw);
+        },
       );
-      return transformUrlPromptsResponse(raw);
+
+      // Single scope → nothing to merge; return as-is.
+      if (scopes.length === 1) {
+        return perProject[0];
+      }
+
+      // Union across markets, deduped by prompt text.
+      const byPrompt = new Map();
+      for (const row of perProject.flat()) {
+        const existing = byPrompt.get(row.prompt);
+        if (!existing) {
+          byPrompt.set(row.prompt, { ...row, brands: [...row.brands] });
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        // Union brands (dedupe), keep the latest closestDate.
+        existing.brands = [...new Set([...existing.brands, ...row.brands])];
+        if (row.closestDate && (!existing.closestDate || row.closestDate > existing.closestDate)) {
+          existing.closestDate = row.closestDate;
+        }
+      }
+      return [...byPrompt.values()];
     },
     /* c8 ignore stop */
 

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -48,6 +48,7 @@ import {
   transformDomainUrlsResponse,
   buildUrlPromptsPayload,
   transformUrlPromptsResponse,
+  mergeUrlPromptsResponses,
   buildMarketMentionsTrendPayload,
   buildMarketCitationsTrendPayload,
   transformMarketTrackingTrends,
@@ -350,14 +351,10 @@ export function createElementsService(transport, log) {
      * Market scope: the element takes ONE top-level `project_id` per call (a `CBF_project`
      * advanced filter is a no-op — verified live LLMO-6674). So when the caller selects
      * markets, this fans out one call per project id (bounded concurrency, mirroring
-     * owned-urls) and UNIONS the results, deduped by prompt text — the same prompt cited in
-     * two markets is one row. No `projectIds` → one unscoped call across the whole
-     * sub-workspace (unchanged behavior). Category is a `CBF_tags` filter applied on every
-     * per-project call.
-     *
-     * On dedupe the first occurrence wins for scalar fields, `brands` are unioned, and the
-     * latest `closestDate` is kept — so the SR dialog's Brands mentioned / Last cited
-     * columns reflect all selected markets, not just the first.
+     * owned-urls) and UNIONS the results, deduped by prompt text via
+     * {@link mergeUrlPromptsResponses} (which documents the dedupe/collision rules). No
+     * `projectIds` → one unscoped call across the whole sub-workspace (unchanged behavior).
+     * Category is a `CBF_tags` filter applied on every per-project call.
      *
      * @param {string} workspaceId - Semrush sub-workspace UUID (projects/prompts live here).
      * @param {object} params - Query params (url, model/platform, startDate, endDate,
@@ -393,27 +390,12 @@ export function createElementsService(transport, log) {
         },
       );
 
-      // Single scope → nothing to merge; return as-is.
+      // Single scope → nothing to merge; return the transformed rows as-is.
       if (scopes.length === 1) {
         return perProject[0];
       }
-
-      // Union across markets, deduped by prompt text.
-      const byPrompt = new Map();
-      for (const row of perProject.flat()) {
-        const existing = byPrompt.get(row.prompt);
-        if (!existing) {
-          byPrompt.set(row.prompt, { ...row, brands: [...row.brands] });
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        // Union brands (dedupe), keep the latest closestDate.
-        existing.brands = [...new Set([...existing.brands, ...row.brands])];
-        if (row.closestDate && (!existing.closestDate || row.closestDate > existing.closestDate)) {
-          existing.closestDate = row.closestDate;
-        }
-      }
-      return [...byPrompt.values()];
+      // Multi-market: union + dedupe by prompt text (see mergeUrlPromptsResponses).
+      return mergeUrlPromptsResponses(perProject);
     },
     /* c8 ignore stop */
 

--- a/test/support/elements/definitions/url-prompts.test.js
+++ b/test/support/elements/definitions/url-prompts.test.js
@@ -69,6 +69,36 @@ describe('url-prompts definitions', () => {
       expect(payload.filters.simple).to.not.have.property('CBF_brand');
       expect(advancedVal(payload, 'CBF_brand')).to.be.undefined;
     });
+
+    it('scopes the market via a TOP-LEVEL project_id when projectId is given', () => {
+      const payload = buildUrlPromptsPayload({ url: URL, projectId: 'US-en' });
+      expect(payload.project_id).to.equal('US-en');
+    });
+
+    it('omits project_id when no projectId is given (aggregate across the sub-workspace)', () => {
+      expect(buildUrlPromptsPayload({ url: URL })).to.not.have.property('project_id');
+    });
+
+    it('never scopes the market via a CBF_project advanced filter (verified no-op)', () => {
+      const payload = buildUrlPromptsPayload({ url: URL, projectId: 'US-en' });
+      expect(advancedVal(payload, 'CBF_project')).to.be.undefined;
+    });
+
+    it('scopes the category via CBF_tags (eq) in advanced, sent as-is', () => {
+      const payload = buildUrlPromptsPayload({ url: URL, category: 'category__Brand' });
+      const tagFilter = payload.filters.advanced.filters.find((f) => f.col === 'CBF_tags');
+      expect(tagFilter).to.deep.equal({ op: 'eq', val: 'category__Brand', col: 'CBF_tags' });
+    });
+
+    it('never puts CBF_tags in the simple block (verified no-op)', () => {
+      const payload = buildUrlPromptsPayload({ url: URL, category: 'category__Brand' });
+      expect(payload.filters.simple).to.not.have.property('CBF_tags');
+    });
+
+    it('omits CBF_tags when no category is given', () => {
+      const payload = buildUrlPromptsPayload({ url: URL });
+      expect(advancedVal(payload, 'CBF_tags')).to.be.undefined;
+    });
   });
 
   describe('transformUrlPromptsResponse', () => {

--- a/test/support/elements/definitions/url-prompts.test.js
+++ b/test/support/elements/definitions/url-prompts.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import {
   buildUrlPromptsPayload,
   transformUrlPromptsResponse,
+  mergeUrlPromptsResponses,
 } from '../../../../src/support/elements/definitions/url-prompts.js';
 import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
 
@@ -151,6 +152,74 @@ describe('url-prompts definitions', () => {
       expect(row.sourceTitle).to.equal('');
       expect(row.brandMentioned).to.equal('');
       expect(row.closestDate).to.equal(null);
+    });
+  });
+
+  describe('mergeUrlPromptsResponses', () => {
+    // Minimal transformed-row factory (the shape transformUrlPromptsResponse emits).
+    const row = (prompt, over = {}) => ({
+      prompt,
+      category: '',
+      region: '',
+      topics: '',
+      citations: 0,
+      sourceTitle: '',
+      brandMentioned: '',
+      brands: [],
+      closestDate: null,
+      ...over,
+    });
+
+    it('returns an empty array for empty / non-array input', () => {
+      expect(mergeUrlPromptsResponses()).to.deep.equal([]);
+      expect(mergeUrlPromptsResponses([])).to.deep.equal([]);
+      expect(mergeUrlPromptsResponses([null, undefined])).to.deep.equal([]);
+    });
+
+    it('unions distinct prompts across markets in first-seen order', () => {
+      const merged = mergeUrlPromptsResponses([[row('a')], [row('b')], [row('a')]]);
+      expect(merged.map((r) => r.prompt)).to.deep.equal(['a', 'b']);
+    });
+
+    it('dedupes the same prompt across markets: unions brands, keeps latest closestDate', () => {
+      const merged = mergeUrlPromptsResponses([
+        [row('p', { brands: ['Lovesac'], closestDate: '2026-07-01T00:00:00Z' })],
+        [row('p', { brands: ['Lovesac', 'Figma'], closestDate: '2026-07-26T00:00:00Z' })],
+      ]);
+      expect(merged).to.have.length(1);
+      expect(merged[0].brands).to.deep.equal(['Lovesac', 'Figma']);
+      expect(merged[0].closestDate).to.equal('2026-07-26T00:00:00Z');
+    });
+
+    it('keeps the EARLIER closestDate when a later market has an older one', () => {
+      const merged = mergeUrlPromptsResponses([
+        [row('p', { closestDate: '2026-07-26T00:00:00Z' })],
+        [row('p', { closestDate: '2026-07-01T00:00:00Z' })],
+      ]);
+      expect(merged[0].closestDate).to.equal('2026-07-26T00:00:00Z');
+    });
+
+    it('first occurrence wins for scalar fields (sourceTitle/brandMentioned)', () => {
+      const merged = mergeUrlPromptsResponses([
+        [row('p', { sourceTitle: 'first', brandMentioned: 'mentioned' })],
+        [row('p', { sourceTitle: 'second', brandMentioned: 'not_mentioned' })],
+      ]);
+      expect(merged[0].sourceTitle).to.equal('first');
+      expect(merged[0].brandMentioned).to.equal('mentioned');
+    });
+
+    it('drops malformed blank-prompt rows instead of collapsing them into one entry', () => {
+      const merged = mergeUrlPromptsResponses([
+        [row(''), row('real')],
+        [row('')],
+      ]);
+      expect(merged.map((r) => r.prompt)).to.deep.equal(['real']);
+    });
+
+    it('does not mutate the input rows (brands array is copied)', () => {
+      const input = [[row('p', { brands: ['A'] })], [row('p', { brands: ['B'] })]];
+      mergeUrlPromptsResponses(input);
+      expect(input[0][0].brands).to.deep.equal(['A']);
     });
   });
 });


### PR DESCRIPTION
## Related Issues
- [LLMO-6674](https://jira.corp.adobe.com/browse/LLMO-6674)

## Summary
The Serenity URL Inspector `url-prompts` endpoint (added in LLMO-6620) ignored the dashboard's market and category filters, so a URL's prompt list showed prompts across all markets and categories. This scopes the endpoint by both, matching its sibling url-inspector panels (owned-urls, cited-domains). A companion frontend PR in project-elmo-ui forwards the `category` param (market was already forwarded).

## Changes
- `buildUrlPromptsPayload`: scope market via the element's top-level `project_id` (not `CBF_project`, a verified no-op) and category via `CBF_tags` (op eq) in the `advanced` block (not `simple`), value = the full `category__<label>` tag.
- `getUrlPrompts` (service): the element takes one `project_id` per call, so fan out one call per selected market (bounded concurrency, mirroring owned-urls) and union the results, deduped by prompt text. On collision, `brands` are unioned and the latest `closestDate` is kept. No market selected → one unscoped call (unchanged).
- `listUrlPrompts` (controller): run the project-ownership guard (`extractProjectIds` + `fetchBrandSemrushProjects` + `checkProjectIdsOwnership`, mirroring `listOwnedUrls`) and pass `projectIds` + `category` to the service. `authorizeBrandSubWorkspace` now also returns `brandUuid` for the ownership lookup (additive; other callers unaffected).
- No new route or spec change: the url-prompts route (like its owned-urls/domain-urls siblings) is not in the OpenAPI spec, and no route or param was added.

## Multi-market decision
Fan out per selected market and union/dedupe by prompt text, rather than scoping only when exactly one market is selected. The SR market filter is multi-select, so the single-market-only option would leave the common multi-select case unfiltered.

## Verified live (2026-07-30, prod Lovesac ws 3cbb3c36, /sactionals, 4-week window)
- Market via top-level `project_id`: baseline 508 rows; US-es=18, US-en=490 (clean partition); bogus id → HTTP 422.
- Category via `CBF_tags` eq in `advanced`: `category__Brand` → 451; bogus tag → 0. (`CBF_project` and `CBF_tags` in `simple` are no-ops.)

## Test plan
- [x] `test/support/elements/definitions/url-prompts.test.js` — 7 new payload cases assert top-level `project_id` (plus the CBF_project no-op guard), `CBF_tags` eq in `advanced` (plus the simple-block no-op guard), and the absent-filter cases. 18 pass.
- [x] `npx mocha 'test/support/elements/**/*.test.js'` — 390 pass.
- [x] `npm run lint` and `npm run type-check` — clean.
- Note: `getUrlPrompts` (service) and `listUrlPrompts` (controller) are c8-ignored POC code per the sibling convention, so the fan-out/dedupe path is not unit-tested — consistent with owned-urls/domain-urls.