### PR TITLE
fix(sites): expose config.llmo.showWww in slim sites-list DTO | LLMO-6673

### DIFF
--- a/src/dto/config.js
+++ b/src/dto/config.js
@@ -40,7 +40,7 @@ const toListJSON = (config) => {
   if (isNonEmptyObject(json.llmo)) {
     result.llmo = {};
     const {
-      dataFolder, brand, tags, customerIntent, detectedCdn,
+      dataFolder, brand, tags, customerIntent, detectedCdn, showWww,
     } = json.llmo;
     if (dataFolder) {
       result.llmo.dataFolder = dataFolder;
@@ -56,6 +56,13 @@ const toListJSON = (config) => {
     }
     if (detectedCdn) {
       result.llmo.detectedCdn = detectedCdn;
+    }
+    // Whether to display the site's own domain with a leading "www." (LLMO-6673).
+    // A UI-relevant display flag, so it must ride along in the slim list response —
+    // without it the UI reads `showWww: undefined` from list-sourced sites and the
+    // www transform silently no-ops (e.g. the admin cross-org site list).
+    if (showWww) {
+      result.llmo.showWww = showWww;
     }
   }
   if (isNonEmptyObject(json.edgeOptimizeConfig)) {

--- a/test/dto/config.test.js
+++ b/test/dto/config.test.js
@@ -69,6 +69,7 @@ describe('ConfigDto', () => {
           tags: ['tag1'],
           customerIntent: [{ key: 'intent1' }],
           detectedCdn: 'aem-cs-fastly',
+          showWww: true,
           someInternalField: 'should-be-excluded',
         },
         edgeOptimizeConfig: { enabled: true, opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
@@ -90,6 +91,7 @@ describe('ConfigDto', () => {
           tags: ['tag1'],
           customerIntent: [{ key: 'intent1' }],
           detectedCdn: 'aem-cs-fastly',
+          showWww: true,
         },
         edgeOptimizeConfig: { enabled: true, opted: 1, stagingDomains: [{ domain: 'stage.example.com', id: 'abc' }] },
         slack: { channel: '#test', workspace: 'T123' },
@@ -124,6 +126,28 @@ describe('ConfigDto', () => {
       const result = ConfigDto.toListJSON({ some: 'config' });
       expect(result).to.deep.equal({
         llmo: { dataFolder: '/data', brand: 'Test', detectedCdn: 'other' },
+      });
+    });
+
+    it('includes showWww in toListJSON (LLMO-6673)', () => {
+      sinon.stub(Config, 'toDynamoItem').returns({
+        llmo: { dataFolder: '/data', brand: 'Test', showWww: true },
+      });
+
+      const result = ConfigDto.toListJSON({ some: 'config' });
+      expect(result).to.deep.equal({
+        llmo: { dataFolder: '/data', brand: 'Test', showWww: true },
+      });
+    });
+
+    it('omits showWww from toListJSON when falsy', () => {
+      sinon.stub(Config, 'toDynamoItem').returns({
+        llmo: { dataFolder: '/data', brand: 'Test', showWww: false },
+      });
+
+      const result = ConfigDto.toListJSON({ some: 'config' });
+      expect(result).to.deep.equal({
+        llmo: { dataFolder: '/data', brand: 'Test' },
       });
     });
 


### PR DESCRIPTION
## Problem

Sites can opt into displaying their own domain with a leading `www.` via the manually-set `config.llmo.showWww` flag (some customers — e.g. kent.edu, Lumen — were onboarded with `www.` stripped from `baseURL` but need it shown). The elmo-ui side of this is [adobe/project-elmo-ui#2637](https://github.com/adobe/project-elmo-ui/pull/2637), which centralizes the `www`/non-`www` display decision behind one helper keyed on `showWww`.

That helper reads `showWww` off the site objects the UI already has in memory (`availableSites` / `getSiteById`). Those are populated from **list** endpoints — and the slim list serializer drops the flag:

- `ConfigDto.toListJSON` (`src/dto/config.js`) rebuilds `config.llmo` from a **fixed whitelist** (`dataFolder, brand, tags, customerIntent, detectedCdn`) that did **not** include `showWww`.
- So `GET /sites` (the admin cross-org list, via `SiteDto.toListJSON`) returned sites **without** `showWww`, and the UI's `www` transform silently no-ops on those surfaces (site switchers, GSC connections picker, etc.).

`GET /sites/{id}` (`SiteDto.toJSON` → `ConfigDto.toJSON`) and `GET /organizations/{id}/sites` (also full `SiteDto.toJSON`) already return `showWww`, so **customer/org-scoped paths were unaffected** — the gap was specifically the admin cross-org site list.

## Change

Add `showWww` to the `toListJSON` `llmo` whitelist so the slim list representation carries it, matching the by-id / org-sites responses. `showWww` is a small display flag; it belongs in the UI-relevant list projection.

## Tests

- Extended the "returns only UI-relevant config keys" case to include `showWww`.
- Added `includes showWww in toListJSON (LLMO-6673)` and `omits showWww from toListJSON when falsy`.
- `npm run lint`, `npm run type-check`, and the config/site DTO + sites/organizations controller suites pass (539 passing).

## Companion

UI: [adobe/project-elmo-ui#2637](https://github.com/adobe/project-elmo-ui/pull/2637) — centralizes the `www` display; this PR ensures the flag actually reaches the UI on the admin list path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)