### PR TITLE
fix(deps): bump @adobe/spacecat-shared-data-access to 4.15.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "4.15.2",
+        "@adobe/spacecat-shared-data-access": "4.15.3",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.2.tgz",
-      "integrity": "sha512-IbQBL6IpkvQMSkLhAwGWyxOGjVVPFLaQcEbeolV59xZU7WndAACVUeTOKJHUeFnqM3LhuT2DwJRDGctvAOGXlg==",
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.3.tgz",
+      "integrity": "sha512-dylxr3Q6JzvCxyc8tVSXLMP7Gq7C2QVBUP0siAwrRMaqp6/8dLApF5dru+nXdVwKZ8tSl4b3Xpp3H3tVzH3WuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "4.15.2",
+    "@adobe/spacecat-shared-data-access": "4.15.3",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",


### PR DESCRIPTION
## What
Bumps `@adobe/spacecat-shared-data-access` from `4.15.2` to `4.15.3` (exact pin, lockfile resynced). No other dependency changes.

## Testing
CI (unit + it-postgres + type-check).