### PR TITLE
fix: read geo-experiment insights from the Mystique bucket (S3_MYSTIQUE_BUCKET)

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -2444,16 +2444,20 @@ function SuggestionsController(ctx, sqs, env) {
     // Fetch impact-measurement insights from S3 only when explicitly requested.
     // Insights exist once impact measurement completes; the S3 key is stored on the
     // experiment as insightsLocation (see spacecat-shared GeoExperiment model).
+    // The insights JSON (and the per-analysis detail blobs its rawDataUrls point at) are
+    // written by Mystique/the engine to the Mystique assets bucket (S3_MYSTIQUE_BUCKET),
+    // NOT the default services bucket — read it from there.
     let insights;
     const includeInsights = context.data?.includeInsights === 'true';
     if (includeInsights) {
       insights = null;
       const insightsS3Key = geoExperiment.getInsightsLocation?.();
-      if (insightsS3Key) {
+      const { S3_MYSTIQUE_BUCKET: mystiqueBucket } = context.env;
+      if (insightsS3Key && mystiqueBucket) {
         try {
-          const { s3Client, s3Bucket, GetObjectCommand } = context.s3;
+          const { s3Client, GetObjectCommand } = context.s3;
           const response = await s3Client.send(
-            new GetObjectCommand({ Bucket: s3Bucket, Key: insightsS3Key }),
+            new GetObjectCommand({ Bucket: mystiqueBucket, Key: insightsS3Key }),
           );
           const body = await response.Body.transformToString();
           insights = JSON.parse(body);

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -10170,6 +10170,8 @@ describe('Suggestions Controller', () => {
 
   describe('getGeoExperiment', () => {
     const GEO_EXP_ID = 'b1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    // Insights (and their detail blobs) live in the Mystique assets bucket, not the default one.
+    const MYSTIQUE_BUCKET = 'test-mystique-bucket';
 
     let mockGeoExperiment;
 
@@ -10185,6 +10187,7 @@ describe('Suggestions Controller', () => {
         GetObjectCommand: StubGetObjectCommand,
         getSignedUrl: sandbox.stub().resolves('https://presigned.example/blob'),
       };
+      context.env = { S3_MYSTIQUE_BUCKET: MYSTIQUE_BUCKET };
       sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
 
       mockGeoExperiment = {
@@ -10357,6 +10360,33 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(200);
       const body = await response.json();
       expect(body.insights).to.deep.equal(insightsPayload);
+      // Insights are read from the Mystique bucket; prompts from the default services bucket.
+      const insightsCall = context.s3.s3Client.send.getCalls()
+        .find((c) => c.args[0].Key === insightsKey);
+      expect(insightsCall.args[0].Bucket).to.equal(MYSTIQUE_BUCKET);
+      const promptsCall = context.s3.s3Client.send.getCalls()
+        .find((c) => c.args[0].Key.endsWith('-prompts.json'));
+      expect(promptsCall.args[0].Bucket).to.equal('test-bucket');
+    });
+
+    it('returns null insights when the Mystique bucket is not configured', async () => {
+      context.env = {};
+      mockGeoExperiment.getInsightsLocation = () => `geo-experiments/${SITE_ID}/${GEO_EXP_ID}-insights.json`;
+      context.s3.s3Client.send.resolves({
+        Body: { transformToString: sandbox.stub().resolves('[]') },
+      });
+      const response = await suggestionsController.getGeoExperiment({
+        ...context,
+        data: { includeInsights: 'true' },
+        params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
+      });
+      expect(response.status).to.equal(200);
+      const body = await response.json();
+      expect(body.insights).to.be.null;
+      // No insights GetObject attempted without a bucket (only the prompts fetch runs).
+      const insightsAttempted = context.s3.s3Client.send.getCalls()
+        .some((c) => c.args[0].Key.endsWith('-insights.json'));
+      expect(insightsAttempted).to.equal(false);
     });
 
     it('replaces each analysis rawDataUrl with a presigned URL when includeInsights=true', async () => {


### PR DESCRIPTION
## Problem

`GET /sites/{siteId}/geo-experiments/{id}?includeInsights=true` always returned `insights: null`, even when the insights blob existed in S3.

The insights `GetObject` used `context.s3.s3Bucket` (the **default services bucket**), but the impact-measurement artifacts — `insights.json` **and** the per-analysis detail blobs its `rawDataUrl`s point at — are written by Mystique/the engine to the **Mystique assets bucket** (`S3_MYSTIQUE_BUCKET`, e.g. `spacecat-dev-mystique-assets`). So the object was never in the bucket api-service looked in → `NoSuchKey`, swallowed and logged as "Could not fetch insights".

### Evidence (dev)
- `s3://spacecat-dev-mystique-assets/geo-experiments/4741ad90-…/insights.json` exists (LastModified `2026-07-31T07:59:10Z`).
- api-service Lambda log, **after** that write:
  `[geo-experiment] Could not fetch insights for 4741ad90-…: The specified key does not exist.`
- The prompts that *do* resolve (`geo-experiments/{siteId}/…-prompts.json`) are **404 in the Mystique bucket** — confirming api-service reads a different (default) bucket for them.

## Fix

Read the insights JSON from `context.env.S3_MYSTIQUE_BUCKET` instead of the default `s3Bucket`. Prompts stay on the default bucket (that's where they are), and the `rawDataUrl` presigning is unchanged — it already extracts the bucket from each `s3://…` URI.

`S3_MYSTIQUE_BUCKET` is an existing env var (already used by the reports controller; present in `.env.example`), so no new configuration is introduced.

## What does NOT change
- Prompts fetch (default `s3Bucket`).
- `presignInsightsRawData` (bucket parsed from each `rawDataUrl`).
- Response shape / the `includeInsights` gate.

## Test plan
- [x] `getGeoExperiment` suite green (18 tests), incl. new assertions that insights `GetObject` uses the Mystique bucket while prompts use the default bucket, and a "no `S3_MYSTIQUE_BUCKET` configured → insights null, no fetch attempted" case.
- [x] Full `suggestions.test.js` green (489 passing).
- [x] `eslint` clean.

Relates to LLMO-6042 (serve insights via geo-experiments API).