### PR TITLE
feat: admin-gated backend create for state-layer access mappings

### DIFF
--- a/src/controllers/state-access-mappings.js
+++ b/src/controllers/state-access-mappings.js
@@ -572,6 +572,136 @@ function StateAccessMappingsController(context) {
   }
 
   /**
+   * Persists ONE subject↔resource binding and returns the HTTP response —
+   * shared by `createMapping` (customer manager flow) and `adminCreateMapping`
+   * (admin backend flow). The caller owns ALL authorization + validation before
+   * calling this; here we only insert (or, on an active duplicate,
+   * upsert-overwrite) and emit the audit event.
+   *
+   * Upsert semantics: an active duplicate (same subject + resource + org +
+   * product) has its `granted_capabilities` overwritten with `capabilitiesToStore`
+   * and returns `200`; a fresh insert returns `201`. A rare revoke race between
+   * the insert conflict and the overwrite surfaces as `409`.
+   *
+   * @param {object} ctx
+   * @param {object} args
+   * @param {string} args.imsOrgId               Canonical org id.
+   * @param {string} args.product                Uppercase product code.
+   * @param {'user'|'org'} args.subjectType
+   * @param {string} args.subjectId
+   * @param {string} args.resourceType
+   * @param {string} args.resourceId
+   * @param {string[]} args.capabilitiesToStore  Validated, deduped, can_view-baselined.
+   * @param {string|null} args.createdBy         Actor recorded as created_by / updated_by.
+   * @returns {Promise<Response>}
+   */
+  async function persistMappingBinding(ctx, {
+    imsOrgId,
+    product,
+    subjectType,
+    subjectId,
+    resourceType,
+    resourceId,
+    capabilitiesToStore,
+    createdBy,
+  }) {
+    try {
+      const { postgrestClient } = ctx.dataAccess.services;
+      const result = await createFacsAccessMappings(postgrestClient, {
+        imsOrgId,
+        product,
+        resourceType,
+        resourceId,
+        grantedCapabilities: capabilitiesToStore,
+        subjects: [{ type: subjectType, id: subjectId }],
+        createdBy,
+      });
+      if (result.created.length === 0 && result.skipped.length > 0) {
+        // Active duplicate already exists — upsert semantics: overwrite the
+        // existing binding's capabilities with the request's set rather than
+        // rejecting the call. Look the row up by its natural key, then replace
+        // its capabilities via the same capability-edit RPC PATCH uses.
+        const existing = await listFacsAccessMappings(postgrestClient, {
+          imsOrgId,
+          product,
+          subjectType,
+          subjectId,
+          resourceType,
+          resourceId,
+          limit: 1,
+        });
+        const conflictId = existing[0]?.id ?? null;
+        // Defensive: the active row vanished (revoked) between the insert
+        // conflict and this read. Nothing to update — surface the conflict.
+        if (!conflictId) {
+          return createResponse(
+            {
+              message: 'Active access mapping already exists for this subject and resource',
+              id: null,
+            },
+            409,
+          );
+        }
+        const updated = await updateFacsAccessMappingCapabilities(postgrestClient, {
+          id: conflictId,
+          imsOrgId,
+          product,
+          grantedCapabilities: capabilitiesToStore,
+          updatedBy: createdBy,
+        });
+        if (!updated) {
+          // Same race as above, observed one layer down (the RPC filters on
+          // `revoked_at IS NULL`). Surface the conflict rather than a 500.
+          return createResponse(
+            {
+              message: 'Active access mapping already exists for this subject and resource',
+              id: conflictId,
+            },
+            409,
+          );
+        }
+        await emitAuditEvent(ctx, {
+          imsOrgId,
+          product,
+          operation: 'update_capabilities',
+          outcome: 'allow',
+          statusCode: 200,
+          mappingId: updated.id,
+          bindingSubjectType: updated.subject_type,
+          bindingSubjectId: updated.subject_id,
+          resourceType: updated.resource_type,
+          resourceId: updated.resource_id,
+          grantedCapabilities: capabilitiesToStore,
+        });
+        return ok(toMappingDto(updated));
+      }
+      const createdRow = result.created[0];
+      await emitAuditEvent(ctx, {
+        imsOrgId,
+        product,
+        operation: 'create',
+        outcome: 'allow',
+        statusCode: 201,
+        mappingId: createdRow.id,
+        bindingSubjectType: subjectType,
+        bindingSubjectId: subjectId,
+        resourceType,
+        resourceId,
+        // Audit the capabilities actually persisted (incl. the auto-injected
+        // can_view baseline), not the raw request input.
+        grantedCapabilities: capabilitiesToStore,
+      });
+      return createResponse(toMappingDto(createdRow), 201);
+    } catch (error) {
+      log.error(
+        { tag: 'state-access-mappings', err: error.message },
+        'Failed to create state-layer access mapping',
+      );
+      return internalServerError('Failed to create access mapping');
+    }
+  }
+
+  /**
    * GET /state/access-mappings — list ACTIVE bindings. Requires at least one
    * of (subjectType + subjectId) or (resourceType + resourceId).
    */
@@ -759,100 +889,133 @@ function StateAccessMappingsController(context) {
       product,
     );
 
-    try {
-      const { postgrestClient } = ctx.dataAccess.services;
-      const result = await createFacsAccessMappings(postgrestClient, {
-        imsOrgId,
-        product,
-        resourceType,
-        resourceId,
-        grantedCapabilities: capabilitiesToStore,
-        subjects: [{ type: subjectType, id: subjectId }],
-        createdBy,
-      });
-      if (result.created.length === 0 && result.skipped.length > 0) {
-        // Active duplicate already exists — upsert semantics: overwrite the
-        // existing binding's capabilities with the request's set rather than
-        // rejecting the call. Look the row up by its natural key, then replace
-        // its capabilities via the same capability-edit RPC PATCH uses.
-        const existing = await listFacsAccessMappings(postgrestClient, {
-          imsOrgId,
-          product,
-          subjectType,
-          subjectId,
-          resourceType,
-          resourceId,
-          limit: 1,
-        });
-        const conflictId = existing[0]?.id ?? null;
-        // Defensive: the active row vanished (revoked) between the insert
-        // conflict and this read. Nothing to update — surface the conflict.
-        if (!conflictId) {
-          return createResponse(
-            {
-              message: 'Active access mapping already exists for this subject and resource',
-              id: null,
-            },
-            409,
-          );
-        }
-        const updated = await updateFacsAccessMappingCapabilities(postgrestClient, {
-          id: conflictId,
-          imsOrgId,
-          product,
-          grantedCapabilities: capabilitiesToStore,
-          updatedBy: createdBy,
-        });
-        if (!updated) {
-          // Same race as above, observed one layer down (the RPC filters on
-          // `revoked_at IS NULL`). Surface the conflict rather than a 500.
-          return createResponse(
-            {
-              message: 'Active access mapping already exists for this subject and resource',
-              id: conflictId,
-            },
-            409,
-          );
-        }
-        await emitAuditEvent(ctx, {
-          imsOrgId,
-          product,
-          operation: 'update_capabilities',
-          outcome: 'allow',
-          statusCode: 200,
-          mappingId: updated.id,
-          bindingSubjectType: updated.subject_type,
-          bindingSubjectId: updated.subject_id,
-          resourceType: updated.resource_type,
-          resourceId: updated.resource_id,
-          grantedCapabilities: capabilitiesToStore,
-        });
-        return ok(toMappingDto(updated));
-      }
-      const createdRow = result.created[0];
-      await emitAuditEvent(ctx, {
-        imsOrgId,
-        product,
-        operation: 'create',
-        outcome: 'allow',
-        statusCode: 201,
-        mappingId: createdRow.id,
-        bindingSubjectType: subjectType,
-        bindingSubjectId: subjectId,
-        resourceType,
-        resourceId,
-        // Audit the capabilities actually persisted (incl. the auto-injected
-        // can_view baseline), not the raw request input.
-        grantedCapabilities: capabilitiesToStore,
-      });
-      return createResponse(toMappingDto(createdRow), 201);
-    } catch (error) {
-      log.error(
-        { tag: 'state-access-mappings', err: error.message },
-        'Failed to create state-layer access mapping',
-      );
-      return internalServerError('Failed to create access mapping');
+    return persistMappingBinding(ctx, {
+      imsOrgId,
+      product,
+      subjectType,
+      subjectId,
+      resourceType,
+      resourceId,
+      capabilitiesToStore,
+      createdBy,
+    });
+  }
+
+  /**
+   * POST /state/access-mappings/admin — admin-only backend provisioning of a
+   * single binding. Unlike `createMapping`, EVERYTHING that scopes the binding
+   * is taken from the request body — `imsOrgId`, `product`, `subjectType`,
+   * `subjectId`, `resourceType`, `resourceId`, `grantedCapabilities`. Nothing is
+   * derived from `authInfo` except the actor id recorded in the audit trail.
+   *
+   * This is the backend path for provisioning a narrow, resource-scoped binding
+   * on behalf of a trial customer in THEIR org — a case the customer-facing
+   * `createMapping` cannot serve because it (a) derives the org from the caller's
+   * JWT tenant, (b) derives the product from the `x-product` header, (c) enforces
+   * the hybrid manager gate (`gateManager`), and (d) restricts internal admins to
+   * resources in their own org (`requireAdminResourceInOrg`). All four are
+   * intentionally bypassed here; the sole gate is `isAdmin()`.
+   *
+   * Body: { imsOrgId, product, subjectType, subjectId, resourceType, resourceId,
+   *         grantedCapabilities }. Capabilities are validated against the
+   *         product's catalog; the upsert + `can_view`-baseline semantics match
+   *         `createMapping`. An admin caller is trusted to grant any catalog
+   *         capability (including `can_manage_users`), so there is no
+   *         `requireFacsManageToGrant` gate here.
+   */
+  async function adminCreateMapping(ctx) {
+    // Sole authorization gate: internal admin. No FACS/manager evaluation and no
+    // org/product derivation — this is a trusted backend provisioning surface.
+    if (!ctx.attributes?.authInfo?.isAdmin?.()) {
+      return forbidden('Admin access required');
     }
+    const guard = requirePostgrestForFacsMappings(ctx);
+    if (guard) {
+      return guard;
+    }
+
+    const { data } = ctx;
+    if (!data || typeof data !== 'object') {
+      return badRequest('request body is required');
+    }
+    const {
+      imsOrgId: rawImsOrgId,
+      product: rawProduct,
+      subjectType,
+      subjectId,
+      resourceType,
+      resourceId,
+      grantedCapabilities,
+    } = data;
+
+    // Product comes from the body (NOT the x-product header). Must reference a
+    // known product so the capability-catalog + resource-type checks below have
+    // a valid basis.
+    if (!hasText(rawProduct)) {
+      return badRequest('product is required');
+    }
+    const product = rawProduct.toUpperCase();
+    if (!routeFacsCapabilities.PRODUCTS_ROUTES[product]) {
+      return badRequest('product must reference a known product');
+    }
+
+    // IMS org comes from the body. Normalize to the canonical `<ident>@<authSrc>`
+    // form so the stored row and the org-subject check below use the same shape
+    // as the rest of the table.
+    if (!hasText(rawImsOrgId)) {
+      return badRequest('imsOrgId is required');
+    }
+    const imsOrgId = normalizeImsOrgId(rawImsOrgId);
+
+    if (!ALLOWED_SUBJECT_TYPES.has(subjectType)) {
+      return badRequest("subjectType must be 'user' or 'org'");
+    }
+    if (!hasText(subjectId)) {
+      return badRequest('subjectId is required');
+    }
+    if (subjectType === 'user' && !subjectId.includes('@')) {
+      return badRequest("subjectId for type 'user' must be canonical '<ident>@<authSrc>'");
+    }
+    // An org subject binds the org to its OWN resources; the only legal org
+    // subjectId is the payload's imsOrgId. (createMapping compares against the
+    // caller's org; here both values come from the body.)
+    if (subjectType === 'org' && subjectId !== imsOrgId) {
+      return badRequest("subjectId for type 'org' must equal the payload imsOrgId");
+    }
+
+    const productResourceTypes = getProductResourceTypes(product);
+    if (!productResourceTypes.includes(resourceType)) {
+      return badRequest(
+        `resourceType must be one of [${productResourceTypes.join(', ')}] for product ${product}`,
+      );
+    }
+    if (!hasText(resourceId)) {
+      return badRequest('resourceId is required');
+    }
+
+    const capErr = validateGrantedCapabilities(grantedCapabilities, product);
+    if (capErr) {
+      return badRequest(capErr);
+    }
+    // De-duplicate, then guarantee the baseline `<product>/can_view` (see
+    // createMapping).
+    const capabilitiesToStore = ensureBaselineCanView(
+      [...new Set(grantedCapabilities)],
+      product,
+    );
+
+    return persistMappingBinding(ctx, {
+      imsOrgId,
+      product,
+      subjectType,
+      subjectId,
+      resourceType,
+      resourceId,
+      capabilitiesToStore,
+      // Audit trail only: record the real admin/service caller. No mapping
+      // access-scope data is derived from authInfo.
+      createdBy: resolveCallerUserIdent(ctx),
+    });
   }
 
   /**
@@ -1281,6 +1444,7 @@ function StateAccessMappingsController(context) {
     listMappings,
     listHistory,
     createMapping,
+    adminCreateMapping,
     patchMapping,
     deleteMapping,
     getProductCapabilities,

--- a/src/controllers/state-access-mappings.js
+++ b/src/controllers/state-access-mappings.js
@@ -977,9 +977,13 @@ function StateAccessMappingsController(context) {
       return badRequest("subjectId for type 'user' must be canonical '<ident>@<authSrc>'");
     }
     // An org subject binds the org to its OWN resources; the only legal org
-    // subjectId is the payload's imsOrgId. (createMapping compares against the
-    // caller's org; here both values come from the body.)
-    if (subjectType === 'org' && subjectId !== imsOrgId) {
+    // subjectId is the payload's imsOrgId. Normalize it the same way as imsOrgId
+    // so a caller may send both bare (e.g. 'FOO' / 'FOO') or both canonical — the
+    // canonical form is what gets compared and persisted.
+    const normalizedSubjectId = subjectType === 'org'
+      ? normalizeImsOrgId(subjectId)
+      : subjectId;
+    if (subjectType === 'org' && normalizedSubjectId !== imsOrgId) {
       return badRequest("subjectId for type 'org' must equal the payload imsOrgId");
     }
 
@@ -992,7 +996,17 @@ function StateAccessMappingsController(context) {
     if (!hasText(resourceId)) {
       return badRequest('resourceId is required');
     }
+    // The only ReBAC resource types (brand, site) are UUID-keyed. Unlike
+    // createMapping, this endpoint performs no DB-backed resource check
+    // (canActOnResource / requireAdminResourceInOrg are bypassed), so validate
+    // the format here to avoid writing a dangling reference into the table.
+    if (!isValidUUID(resourceId)) {
+      return badRequest('resourceId must be a valid UUID');
+    }
 
+    // No requireFacsManageToGrant gate: unlike the customer flow, an internal
+    // admin is trusted to grant any capability in the product catalog (incl.
+    // can_manage_users). Catalog membership is still enforced below.
     const capErr = validateGrantedCapabilities(grantedCapabilities, product);
     if (capErr) {
       return badRequest(capErr);
@@ -1008,7 +1022,7 @@ function StateAccessMappingsController(context) {
       imsOrgId,
       product,
       subjectType,
-      subjectId,
+      subjectId: normalizedSubjectId,
       resourceType,
       resourceId,
       capabilitiesToStore,

--- a/src/controllers/state-access-mappings.js
+++ b/src/controllers/state-access-mappings.js
@@ -693,8 +693,11 @@ function StateAccessMappingsController(context) {
       });
       return createResponse(toMappingDto(createdRow), 201);
     } catch (error) {
+      // Log the full error (stack + any nested cause), not just the message:
+      // this shared helper fails for several reasons (PostgREST drop, constraint
+      // violation, unexpected null) and the stack is what pins the call site.
       log.error(
-        { tag: 'state-access-mappings', err: error.message },
+        { tag: 'state-access-mappings', err: error },
         'Failed to create state-layer access mapping',
       );
       return internalServerError('Failed to create access mapping');

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -178,6 +178,11 @@ const routeFacsCapabilities = {
     'POST /sites/:siteId/llmo/cdn-onboard/akamai/activate',
     'GET /sites/:siteId/llmo/cdn-onboard/akamai/activation-status',
     // Admin-only writes
+    // State-layer backend provisioning — admin-only (isAdmin() in the
+    // state-access-mappings controller). Full payload (imsOrgId, product,
+    // subject, resource, capabilities); nothing derived from authInfo. Not a
+    // customer FACS surface, so it bypasses facsWrapper entirely.
+    'POST /state/access-mappings/admin', // hasAdminAccess (adminCreateMapping)
     'POST /sites', // hasAdminAccess
     'DELETE /sites/:siteId', // restricted (always 403)
     'PATCH /sites/:siteId/:auditType', // hasAdminAccess (sites-audits-toggle)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -504,6 +504,11 @@ export default function getRouteHandlers(
     'GET /state/access-mappings': stateAccessMappingsController.listMappings,
     'GET /state/access-mappings/history': stateAccessMappingsController.listHistory,
     'POST /state/access-mappings': stateAccessMappingsController.createMapping,
+    // Admin-only backend provisioning: the entire binding (imsOrgId, product,
+    // subject, resource, capabilities) comes from the body — nothing from
+    // authInfo. Gated by isAdmin() in the controller; see INTERNAL_ROUTES in
+    // facs-capabilities.js (bypasses facsWrapper).
+    'POST /state/access-mappings/admin': stateAccessMappingsController.adminCreateMapping,
     'PATCH /state/access-mappings/:id': stateAccessMappingsController.patchMapping,
     'DELETE /state/access-mappings/:id': stateAccessMappingsController.deleteMapping,
     'GET /product/capabilities': stateAccessMappingsController.getProductCapabilities,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -203,6 +203,9 @@ export const INTERNAL_ROUTES = [
   'GET /state/access-mappings',
   'GET /state/access-mappings/history',
   'POST /state/access-mappings',
+  // Admin-only backend provisioning (full payload; nothing from authInfo).
+  // Internal-only, self-gated by isAdmin() in the controller — never S2S.
+  'POST /state/access-mappings/admin',
   'PATCH /state/access-mappings/:id',
   'DELETE /state/access-mappings/:id',
   'GET /organizations/:organizationId/permission/audit-logs',

--- a/test/controllers/state-access-mappings.test.js
+++ b/test/controllers/state-access-mappings.test.js
@@ -809,6 +809,27 @@ describe('StateAccessMappingsController', () => {
       expect(res.status).to.equal(201);
     });
 
+    it("normalizes a bare 'org' subjectId so a bare imsOrgId + bare subjectId match (201)", async () => {
+      const createStub = sinon.stub().resolves({
+        created: [makeRow({ subject_type: 'org', subject_id: 'BARE-ORG@AdobeOrg', ims_org_id: 'BARE-ORG@AdobeOrg' })],
+        skipped: [],
+      });
+      const { Controller } = await loadController({ createFacsAccessMappings: createStub });
+      const ctx = makeContext({
+        isAdmin: true,
+        body: {
+          ...adminBody, imsOrgId: 'BARE-ORG', subjectType: 'org', subjectId: 'BARE-ORG',
+        },
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(201);
+      // Both values are normalized to the canonical form before compare + persist.
+      expect(createStub.firstCall.args[1].imsOrgId).to.equal('BARE-ORG@AdobeOrg');
+      expect(createStub.firstCall.args[1].subjects).to.deep.equal([
+        { type: 'org', id: 'BARE-ORG@AdobeOrg' },
+      ]);
+    });
+
     it('returns 400 for a resourceType not valid for the product', async () => {
       const { Controller } = await loadController();
       const ctx = makeContext({ isAdmin: true, body: { ...adminBody, resourceType: 'site' } });
@@ -821,6 +842,15 @@ describe('StateAccessMappingsController', () => {
       const ctx = makeContext({ isAdmin: true, body: { ...adminBody, resourceId: '' } });
       const res = await Controller(ctx).adminCreateMapping(ctx);
       expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when resourceId is not a valid UUID', async () => {
+      const { Controller, stubs } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, resourceId: 'not-a-uuid' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+      // Denied before any write — no dangling reference is persisted.
+      expect(stubs.createFacsAccessMappings.called).to.be.false;
     });
 
     it('returns 400 when grantedCapabilities is empty', async () => {

--- a/test/controllers/state-access-mappings.test.js
+++ b/test/controllers/state-access-mappings.test.js
@@ -703,6 +703,245 @@ describe('StateAccessMappingsController', () => {
     });
   });
 
+  describe('POST /state/access-mappings/admin (adminCreateMapping)', () => {
+    // A trial customer's org — deliberately DIFFERENT from the caller's tenant
+    // (CALLER_ORG_BARE) so tests prove the org is taken from the payload, not
+    // from authInfo.
+    const TRIAL_ORG = 'TRIAL-ORG-777@AdobeOrg';
+    const adminBody = {
+      imsOrgId: TRIAL_ORG,
+      product: 'LLMO',
+      subjectType: 'user',
+      subjectId: 'trial-user@AdobeID',
+      resourceType: 'brand',
+      resourceId: VALID_UUID_RES,
+      grantedCapabilities: ['llmo/can_view'],
+    };
+    // Row the create helper returns — stamped with the payload org/product.
+    const adminRow = () => makeRow({
+      subject_id: 'trial-user@AdobeID', ims_org_id: TRIAL_ORG,
+    });
+
+    it('returns 403 when the caller is not an admin', async () => {
+      const { Controller, stubs } = await loadController();
+      const ctx = makeContext({ isAdmin: false, body: adminBody });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(403);
+      // Denied before any DB work.
+      expect(stubs.createFacsAccessMappings.called).to.be.false;
+    });
+
+    it('returns 503 when postgrest is unavailable', async () => {
+      const { Controller } = await loadController({
+        requirePostgrestForFacsMappings: () => ({ status: 503 }),
+      });
+      const ctx = makeContext({ isAdmin: true, body: adminBody });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(503);
+    });
+
+    it('returns 400 when body is missing', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: null });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when product is missing', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, product: undefined } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when product is unknown', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, product: 'BOGUS' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when imsOrgId is missing', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, imsOrgId: '' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 for invalid subjectType', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, subjectType: 'group' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when user subjectId is not canonical', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, subjectId: 'noatsign' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it("returns 400 when an 'org' subjectId differs from the payload imsOrgId", async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({
+        isAdmin: true,
+        body: {
+          ...adminBody, subjectType: 'org', subjectId: 'OTHER@AdobeOrg',
+        },
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it("accepts an 'org' subjectId equal to the payload imsOrgId (201)", async () => {
+      const row = makeRow({ subject_type: 'org', subject_id: TRIAL_ORG, ims_org_id: TRIAL_ORG });
+      const { Controller } = await loadController({
+        createFacsAccessMappings: sinon.stub().resolves({ created: [row], skipped: [] }),
+      });
+      const ctx = makeContext({
+        isAdmin: true,
+        body: {
+          ...adminBody, subjectType: 'org', subjectId: TRIAL_ORG,
+        },
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(201);
+    });
+
+    it('returns 400 for a resourceType not valid for the product', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, resourceType: 'site' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when resourceId is empty', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, resourceId: '' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when grantedCapabilities is empty', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, grantedCapabilities: [] } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when a granted capability is outside the payload product catalog', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({
+        isAdmin: true, body: { ...adminBody, grantedCapabilities: ['aso/can_view'] },
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('creates the binding from the PAYLOAD org + product, not from authInfo/x-product', async () => {
+      const createStub = sinon.stub().resolves({ created: [adminRow()], skipped: [] });
+      const { Controller, stubs } = await loadController({ createFacsAccessMappings: createStub });
+      // Caller tenant is CALLER_ORG_BARE and the x-product header says ASO —
+      // both MUST be ignored in favour of the payload's TRIAL_ORG / LLMO.
+      const ctx = makeContext({
+        isAdmin: true,
+        product: 'ASO',
+        imsOrgId: CALLER_ORG_BARE,
+        body: adminBody,
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(201);
+      const args = createStub.firstCall.args[1];
+      expect(args.imsOrgId).to.equal(TRIAL_ORG);
+      expect(args.product).to.equal('LLMO');
+      // No manager/authority evaluation and no admin same-org resource check.
+      expect(stubs.listFacsAccessMappings.called).to.be.false;
+      expect(stubs.getResourceImsOrgId.called).to.be.false;
+    });
+
+    it('normalizes a bare payload imsOrgId to the canonical form', async () => {
+      const createStub = sinon.stub().resolves({ created: [adminRow()], skipped: [] });
+      const { Controller } = await loadController({ createFacsAccessMappings: createStub });
+      const ctx = makeContext({
+        isAdmin: true, body: { ...adminBody, imsOrgId: 'BARE-TRIAL-ORG' },
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(201);
+      expect(createStub.firstCall.args[1].imsOrgId).to.equal('BARE-TRIAL-ORG@AdobeOrg');
+    });
+
+    it('injects the baseline can_view when the request omits it', async () => {
+      const createStub = sinon.stub().resolves({ created: [adminRow()], skipped: [] });
+      const { Controller } = await loadController({ createFacsAccessMappings: createStub });
+      const ctx = makeContext({
+        isAdmin: true, body: { ...adminBody, grantedCapabilities: ['llmo/can_configure'] },
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(201);
+      expect(createStub.firstCall.args[1].grantedCapabilities)
+        .to.have.members(['llmo/can_configure', 'llmo/can_view']);
+    });
+
+    it('lets an admin grant can_manage_users (no FACS-layer gate on this surface)', async () => {
+      const createStub = sinon.stub().resolves({ created: [adminRow()], skipped: [] });
+      const { Controller } = await loadController({ createFacsAccessMappings: createStub });
+      const ctx = makeContext({
+        isAdmin: true,
+        facsPermissions: [],
+        body: { ...adminBody, grantedCapabilities: ['llmo/can_manage_users'] },
+      });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(201);
+      expect(createStub.firstCall.args[1].grantedCapabilities)
+        .to.include('llmo/can_manage_users');
+    });
+
+    it('emits a create audit event stamped with the payload org + caller actor', async () => {
+      const { Controller, stubs } = await loadController({
+        createFacsAccessMappings: sinon.stub().resolves({ created: [adminRow()], skipped: [] }),
+      });
+      const ctx = makeContext({ isAdmin: true, body: adminBody });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(201);
+      const event = stubs.insertFacsAccessMappingAuditEvent.firstCall.args[1];
+      expect(event).to.include({
+        imsOrgId: TRIAL_ORG,
+        product: 'LLMO',
+        operation: 'create',
+        outcome: 'allow',
+      });
+      // Actor is the real admin caller (audit trail only).
+      expect(event.actorId).to.equal(CALLER_USER);
+    });
+
+    it('upserts on an active duplicate: overwrites capabilities and returns 200', async () => {
+      const existing = makeRow({ id: 'pre-existing-id', ims_org_id: TRIAL_ORG });
+      const updateStub = sinon.stub().resolves(existing);
+      const { Controller } = await loadController({
+        createFacsAccessMappings: sinon.stub().resolves({
+          created: [],
+          skipped: [{ subject: { type: 'user', id: 'trial-user@AdobeID' }, reason: 'duplicate' }],
+        }),
+        listFacsAccessMappings: sinon.stub().resolves([existing]),
+        updateFacsAccessMappingCapabilities: updateStub,
+      });
+      const ctx = makeContext({ isAdmin: true, body: adminBody });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(200);
+      expect(updateStub.firstCall.args[1].imsOrgId).to.equal(TRIAL_ORG);
+    });
+
+    it('returns 500 when the helper throws', async () => {
+      const { Controller } = await loadController({
+        createFacsAccessMappings: sinon.stub().rejects(new Error('boom')),
+      });
+      const ctx = makeContext({ isAdmin: true, body: adminBody });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(500);
+    });
+  });
+
   describe('PATCH /state/access-mappings/:id (patchMapping)', () => {
     it('returns 400 when id is not a UUID', async () => {
       const { Controller } = await loadController();

--- a/test/controllers/state-access-mappings.test.js
+++ b/test/controllers/state-access-mappings.test.js
@@ -775,6 +775,13 @@ describe('StateAccessMappingsController', () => {
       expect(res.status).to.equal(400);
     });
 
+    it('returns 400 when subjectId is missing', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, body: { ...adminBody, subjectId: '' } });
+      const res = await Controller(ctx).adminCreateMapping(ctx);
+      expect(res.status).to.equal(400);
+    });
+
     it('returns 400 when user subjectId is not canonical', async () => {
       const { Controller } = await loadController();
       const ctx = makeContext({ isAdmin: true, body: { ...adminBody, subjectId: 'noatsign' } });

--- a/test/it/shared/tests/state-access-mappings.js
+++ b/test/it/shared/tests/state-access-mappings.js
@@ -38,7 +38,15 @@ function expectIsoTimestamp(value, label = 'timestamp') {
 // Literal UUIDs below identify the ReBAC resources being granted.
 const BRAND_RESOURCE_ID = 'b1111111-1111-4111-8111-111111111111';
 const BRAND_RESOURCE_ID_2 = 'b2222222-2222-4222-8222-222222222222';
+const BRAND_RESOURCE_ID_3 = 'b3333333-3333-4333-8333-333333333333';
 const SITE_RESOURCE_ID = '5a5a5a5a-5a5a-4a5a-8a5a-5a5a5a5a5a5a';
+
+// A trial customer's org, deliberately DIFFERENT from any test persona's tenant
+// so the admin-backend-create tests prove the org is taken from the payload
+// (not from the caller's JWT). `ims_org_id` is a plain text column with no FK,
+// so an org that owns no seeded resource is a valid target.
+const TRIAL_CUSTOMER_ORG = 'TRIAL-CUST-IT-ORG@AdobeOrg';
+const ADMIN_BASE = '/state/access-mappings/admin';
 
 // Canonical IMS user idents (subject_id for subject_type='user').
 const USER_SUBJECT = 'grantee123@AdobeID';
@@ -395,6 +403,92 @@ export default function stateAccessMappingsTests(getHttpClient, resetData) {
           grantedCapabilities: ['llmo/can_view'],
         });
         expect(res.status).to.equal(404);
+      });
+    });
+
+    describe('admin backend create (full payload, cross-org)', () => {
+      before(() => resetData());
+
+      it('403s for a non-admin caller (even a FACS manager)', async () => {
+        const http = getHttpClient();
+        const res = await http.facsManager.post(ADMIN_BASE, {
+          imsOrgId: TRIAL_CUSTOMER_ORG,
+          product: 'LLMO',
+          subjectType: 'user',
+          subjectId: USER_SUBJECT,
+          resourceType: 'brand',
+          resourceId: BRAND_RESOURCE_ID_3,
+          grantedCapabilities: ['llmo/can_view'],
+        });
+        expect(res.status).to.equal(403);
+      });
+
+      it('creates a binding scoped to the PAYLOAD org + product (201)', async () => {
+        const http = getHttpClient();
+        // The admin persona's tenant is ORG_1's IMS org and the default
+        // x-product for this route is ASO — both are ignored; the row is stamped
+        // with the payload's TRIAL_CUSTOMER_ORG / LLMO.
+        const res = await http.admin.post(ADMIN_BASE, {
+          imsOrgId: TRIAL_CUSTOMER_ORG,
+          product: 'LLMO',
+          subjectType: 'user',
+          subjectId: USER_SUBJECT,
+          resourceType: 'brand',
+          resourceId: BRAND_RESOURCE_ID_3,
+          grantedCapabilities: ['llmo/can_configure'],
+        });
+        expect(res.status).to.equal(201);
+        expectMappingDto(res.body);
+        expect(res.body.imsOrgId).to.equal(TRIAL_CUSTOMER_ORG);
+        expect(res.body.product).to.equal('LLMO');
+        expect(res.body.subjectId).to.equal(USER_SUBJECT);
+        expect(res.body.resourceId).to.equal(BRAND_RESOURCE_ID_3);
+        // can_view baseline is auto-injected alongside the requested capability.
+        expect(res.body.grantedCapabilities)
+          .to.have.members(['llmo/can_configure', 'llmo/can_view']);
+      });
+
+      it('upserts a duplicate for the same payload org/subject/resource (200)', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.post(ADMIN_BASE, {
+          imsOrgId: TRIAL_CUSTOMER_ORG,
+          product: 'LLMO',
+          subjectType: 'user',
+          subjectId: USER_SUBJECT,
+          resourceType: 'brand',
+          resourceId: BRAND_RESOURCE_ID_3,
+          grantedCapabilities: ['llmo/can_deploy'],
+        });
+        expect(res.status).to.equal(200);
+        expect(res.body.imsOrgId).to.equal(TRIAL_CUSTOMER_ORG);
+        expect(res.body.grantedCapabilities)
+          .to.have.members(['llmo/can_deploy', 'llmo/can_view']);
+      });
+
+      it('400s when the payload is missing product', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.post(ADMIN_BASE, {
+          imsOrgId: TRIAL_CUSTOMER_ORG,
+          subjectType: 'user',
+          subjectId: USER_SUBJECT,
+          resourceType: 'brand',
+          resourceId: BRAND_RESOURCE_ID_3,
+          grantedCapabilities: ['llmo/can_view'],
+        });
+        expect(res.status).to.equal(400);
+      });
+
+      it('400s when the payload is missing imsOrgId', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.post(ADMIN_BASE, {
+          product: 'LLMO',
+          subjectType: 'user',
+          subjectId: USER_SUBJECT,
+          resourceType: 'brand',
+          resourceId: BRAND_RESOURCE_ID_3,
+          grantedCapabilities: ['llmo/can_view'],
+        });
+        expect(res.status).to.equal(400);
       });
     });
 

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -742,6 +742,7 @@ describe('getRouteHandlers', () => {
       'GET /state/access-mappings',
       'GET /state/access-mappings/history',
       'POST /state/access-mappings',
+      'POST /state/access-mappings/admin',
       'GET /product/capabilities',
       'POST /tools/import/jobs',
       'POST /tools/scrape/jobs',


### PR DESCRIPTION
## What

Adds `POST /state/access-mappings/admin` — an **admin-only** handler on the state-access-mappings controller that creates a `facs_access_mappings` binding **entirely from the request body**: `imsOrgId`, `product`, `subjectType`, `subjectId`, `resourceType`, `resourceId`, `grantedCapabilities`.

## Why

We need a backend path to provision a **narrow, resource-scoped** binding on behalf of a **trial customer in their own org** — a case the customer-facing `POST /state/access-mappings` (`createMapping`) can't serve because it scopes everything to the *caller*.

## How it differs from `createMapping`

Unlike `createMapping`, this handler derives **nothing** from `authInfo` except the actor recorded in the audit trail, and takes the product from the payload (not the `x-product` header). It intentionally bypasses:

- JWT-tenant org derivation → `imsOrgId` comes from the body (bare idents normalized to `@AdobeOrg`)
- `x-product` derivation → `product` comes from the body (validated against known products)
- the hybrid manager gate (`gateManager`)
- the internal-admin same-org restriction (`requireAdminResourceInOrg`)

**Sole gate:** `authInfo.isAdmin()` → `403` otherwise. An admin is trusted to grant any capability in the product catalog (including `can_manage_users`) for user or org subjects. Capability-catalog validation, `can_view` baseline injection, and the upsert / `409` semantics are shared with `createMapping` via an extracted `persistMappingBinding` helper, so the two paths can't drift.

## Changes

- **controller** (`src/controllers/state-access-mappings.js`): `adminCreateMapping` + shared `persistMappingBinding` helper
- **routes** (`src/routes/index.js`): wire `POST /state/access-mappings/admin`
- **FACS** (`src/routes/facs-capabilities.js`): classify as `INTERNAL_ROUTES` (admin-only, bypasses `facsWrapper`)
- **tests**: 19 controller unit cases; IT block (cross-org create, upsert, `403` non-admin, `400`s); route-surface lock entry

## Testing

- Unit + route + FACS-invariant + utils suites pass locally on the affected files
- ESLint clean on all changed files
- IT additions are wired via the shared factory (run in CI — Docker wasn't available locally)

## Notes

- **No OpenAPI docs** in this PR — API docs were deemed not required for this internal/backend surface. There is no route↔docs parity test, so the build is unaffected.
- **E2E**: per the repo's triage guidance, unit + IT fully cover this admin backend path; no new e2e scenario added.
- The local `type-check` pre-commit gate currently fails on pre-existing `src/support/serenity/*` errors (a stale local `@adobe/spacecat-shared-project-engine-client`), unrelated to this diff — none of the changed files appear in those errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```