### PR TITLE
test(serenity): assert by_tags authorship-read ordering (LLMO-6667)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@adobe/spacecat-shared-http-utils": "1.34.0",
         "@adobe/spacecat-shared-ims-client": "1.12.7",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-        "@adobe/spacecat-shared-project-engine-client": "1.17.0",
+        "@adobe/spacecat-shared-project-engine-client": "1.18.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
         "@adobe/spacecat-shared-scrape-client": "2.6.3",
         "@adobe/spacecat-shared-slack-client": "1.6.7",
@@ -6586,9 +6586,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.17.0.tgz",
-      "integrity": "sha512-CyjDeXi8u1ULj5RfJzviHF9T87Bzi4m77Xkf1orwm4u5a74Kfnbn4YXS+Yr0KouA19KCfEk+2lEOnUGo+8+mXQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.18.0.tgz",
+      "integrity": "sha512-zc8b2cD6hoEOt2vyr4f6RjO9WqW8JzxEhifskZ0UOIT7BfDqp52R6hVwMcscAKGYBR3NZHt64KyFeHK5MEmcfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@adobe/spacecat-shared-http-utils": "1.34.0",
     "@adobe/spacecat-shared-ims-client": "1.12.7",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
-    "@adobe/spacecat-shared-project-engine-client": "1.17.0",
+    "@adobe/spacecat-shared-project-engine-client": "1.18.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",
     "@adobe/spacecat-shared-scrape-client": "2.6.3",
     "@adobe/spacecat-shared-slack-client": "1.6.7",

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -1394,7 +1394,7 @@ export default function serenityTests(
 
       // Descending is the regression guard — the reverse of insertion/store order, so it fails if
       // the keys are ignored. Ascending equals insertion order, so it only CONFIRMS the direction
-      // (the pre-#1859 no-op would have passed asc by accident); the pair is what makes it decisive.
+      // (the pre-#1859 no-op would have passed asc by accident); the pair is what makes it firm.
       expect(await orderedMineIds('&sort=metadata.created_at&order=asc', mine))
         .to.deep.equal([first, second, third]);
       expect(await orderedMineIds('&sort=metadata.created_at&order=desc', mine))

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -1275,10 +1275,12 @@ export default function serenityTests(
       return res.body.created[0].semrushPromptId;
     };
 
-    // A few ms between two stamped writes so their `created_at` / `updated_at` don't tie at the
-    // millisecond precision of `new Date().toISOString()` — otherwise an ordering assertion would
-    // rest on two writes happening to land in different milliseconds.
-    const STAMP_GAP_MS = 5;
+    // A gap between two stamped writes so their `created_at` / `updated_at` can't tie at the
+    // millisecond precision of `new Date().toISOString()`. Server stamps are already spaced by the
+    // IT round-trip; this adds margin so a loaded CI runner can't collapse two writes into one ms.
+    // Sleeps are the only lever — create/edit stamp `now()` server-side, so the test cannot inject
+    // controlled timestamps; 20ms keeps ties impossible at negligible cost.
+    const STAMP_GAP_MS = 20;
     const sleep = (ms) => new Promise((resolve) => {
       setTimeout(resolve, ms);
     });
@@ -1390,7 +1392,9 @@ export default function serenityTests(
       const third = await createPrompt('admin', 'created-order three?', [tagId]);
       const mine = [first, second, third];
 
-      // Ascending = insertion order; descending = its reverse, which DIFFERS from store order.
+      // Descending is the regression guard — the reverse of insertion/store order, so it fails if
+      // the keys are ignored. Ascending equals insertion order, so it only CONFIRMS the direction
+      // (the pre-#1859 no-op would have passed asc by accident); the pair is what makes it decisive.
       expect(await orderedMineIds('&sort=metadata.created_at&order=asc', mine))
         .to.deep.equal([first, second, third]);
       expect(await orderedMineIds('&sort=metadata.created_at&order=desc', mine))

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -1275,6 +1275,30 @@ export default function serenityTests(
       return res.body.created[0].semrushPromptId;
     };
 
+    // A few ms between two stamped writes so their `created_at` / `updated_at` don't tie at the
+    // millisecond precision of `new Date().toISOString()` — otherwise an ordering assertion would
+    // rest on two writes happening to land in different milliseconds.
+    const STAMP_GAP_MS = 5;
+    const sleep = (ms) => new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+
+    // An in-place text edit — bumps `updated_*` without touching `created_*` (spec §8).
+    const editPromptText = async (persona, promptId, text, tagIds) => {
+      const res = await getHttpClient()[persona].patch(`${base}/prompts/${promptId}`, {
+        text, tagIds, geoTargetId: US_GEO, languageCode: 'en',
+      });
+      expect(res.status).to.equal(200);
+    };
+
+    // The server-side order of just the prompts THIS test created. `resetData` is per-`describe`,
+    // not per-`it`, so a sorted list also carries prior tests' prompts; filtering to `mine` keeps
+    // their relative order within the global sort, which is exactly `mine` sorted by the key.
+    const orderedMineIds = async (extraQuery, mine) => {
+      const items = await listPrompts(extraQuery);
+      return items.map((p) => p.semrushPromptId).filter((id) => mine.includes(id));
+    };
+
     it('GET /serenity/prompts returns the four authorship fields for a stamped prompt', async () => {
       await createUsMarket();
       const tagId = await createCategory('Running');
@@ -1322,16 +1346,16 @@ export default function serenityTests(
     // brand's slice resolves to a project created fresh per run, so no unstamped row is ever
     // visible on the slice this endpoint reads. Reaching it would mean injecting one through the
     // mock's `__seed` control route into the resolved project — harness work beyond this change.
-    // `buildPromptDto`'s `metadata?.x ?? null` mapping carries that path at the unit level.
+    // `buildPromptDto`'s `metadata?.x ?? null` mapping carries that path at the unit level, and the
+    // absent-metadata SORT position (NULLS-LAST in both directions) is asserted where it is
+    // reachable — the project-engine-client mock e2e (spacecat-shared#1859, LLMO-6666).
 
     // The metadata opt-in travels on the QUERY string while the sort keys travel in the BODY, so a
-    // sorted read exercises both at once. This guards the interaction: a regression that moved the
-    // opt-in into the body alongside the sort keys would strip the authorship fields here while
+    // sorted read exercises both at once. These two guard that INTERACTION: a regression that moved
+    // the opt-in into the body alongside the sort keys would strip the authorship fields while
     // leaving the unsorted read above green. One case per sortable field, so a regression that
-    // reaches only one of them is reported on its own rather than hidden behind the other.
-    //
-    // Ordering itself is deliberately NOT asserted — the mock implements no sort logic, so any
-    // order assertion would pass regardless of which keys were sent and prove nothing.
+    // reaches only one of them is reported on its own. (The ORDER itself is asserted separately
+    // below.)
     it('still returns the authorship fields on a read sorted by created_at', async () => {
       await createUsMarket();
       const tagId = await createCategory('Cameras');
@@ -1350,6 +1374,56 @@ export default function serenityTests(
       const item = await readPromptById(promptId, '&sort=metadata.updated_at&order=desc');
       expect(item.createdBy).to.equal('test-admin@adobe.com');
       expect(item.updatedAt).to.be.a('string');
+    });
+
+    // Ordering, now that the mock honours the wire sort keys (spacecat-shared#1859, client 1.18.0 —
+    // LLMO-6666/6667). The descending case is the regression catcher: the pre-#1859 no-op returned
+    // store (insertion) order regardless of keys, so a reversed expectation fails if the keys ever
+    // regress to being ignored (or are sent under the wrong names).
+    it('orders the list by metadata.created_at, ascending and descending', async () => {
+      await createUsMarket();
+      const tagId = await createCategory('Tripods');
+      const first = await createPrompt('admin', 'created-order one?', [tagId]);
+      await sleep(STAMP_GAP_MS);
+      const second = await createPrompt('admin', 'created-order two?', [tagId]);
+      await sleep(STAMP_GAP_MS);
+      const third = await createPrompt('admin', 'created-order three?', [tagId]);
+      const mine = [first, second, third];
+
+      // Ascending = insertion order; descending = its reverse, which DIFFERS from store order.
+      expect(await orderedMineIds('&sort=metadata.created_at&order=asc', mine))
+        .to.deep.equal([first, second, third]);
+      expect(await orderedMineIds('&sort=metadata.created_at&order=desc', mine))
+        .to.deep.equal([third, second, first]);
+    });
+
+    it('orders the list by metadata.updated_at, independent of created order', async () => {
+      await createUsMarket();
+      const tagId = await createCategory('Gimbals');
+      const a = await createPrompt('admin', 'update-order A?', [tagId]);
+      await sleep(STAMP_GAP_MS);
+      const b = await createPrompt('admin', 'update-order B?', [tagId]);
+      await sleep(STAMP_GAP_MS);
+      const c = await createPrompt('admin', 'update-order C?', [tagId]);
+      const mine = [a, b, c];
+
+      // Re-touch in a DIFFERENT order than creation (b, then c, then a) so `updated_at` order
+      // (b < c < a) diverges from both `created_at` order (a < b < c) and store order — proving the
+      // wire sort key selects the right field, not just any monotonic default.
+      await editPromptText('admin', b, 'update-order B edited?', [tagId]);
+      await sleep(STAMP_GAP_MS);
+      await editPromptText('admin', c, 'update-order C edited?', [tagId]);
+      await sleep(STAMP_GAP_MS);
+      await editPromptText('admin', a, 'update-order A edited?', [tagId]);
+
+      expect(await orderedMineIds('&sort=metadata.updated_at&order=asc', mine))
+        .to.deep.equal([b, c, a]);
+      expect(await orderedMineIds('&sort=metadata.updated_at&order=desc', mine))
+        .to.deep.equal([a, c, b]);
+      // The edits left `created_at` untouched, so its order is still insertion order — the two keys
+      // sort independently.
+      expect(await orderedMineIds('&sort=metadata.created_at&order=asc', mine))
+        .to.deep.equal([a, b, c]);
     });
   });
 }

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -1285,8 +1285,10 @@ export default function serenityTests(
       setTimeout(resolve, ms);
     });
 
-    // An in-place text edit — bumps `updated_*` without touching `created_*` (spec §8).
-    const editPromptText = async (persona, promptId, text, tagIds) => {
+    // An in-place edit — replaces text AND tags (the PATCH body carries both), bumping `updated_*`
+    // without touching `created_*` (spec §8). The ordering tests pass the prompt's existing tag, so
+    // only the text (and the stamp) actually change.
+    const editPrompt = async (persona, promptId, text, tagIds) => {
       const res = await getHttpClient()[persona].patch(`${base}/prompts/${promptId}`, {
         text, tagIds, geoTargetId: US_GEO, languageCode: 'en',
       });
@@ -1414,11 +1416,11 @@ export default function serenityTests(
       // Re-touch in a DIFFERENT order than creation (b, then c, then a) so `updated_at` order
       // (b < c < a) diverges from both `created_at` order (a < b < c) and store order — proving the
       // wire sort key selects the right field, not just any monotonic default.
-      await editPromptText('admin', b, 'update-order B edited?', [tagId]);
+      await editPrompt('admin', b, 'update-order B edited?', [tagId]);
       await sleep(STAMP_GAP_MS);
-      await editPromptText('admin', c, 'update-order C edited?', [tagId]);
+      await editPrompt('admin', c, 'update-order C edited?', [tagId]);
       await sleep(STAMP_GAP_MS);
-      await editPromptText('admin', a, 'update-order A edited?', [tagId]);
+      await editPrompt('admin', a, 'update-order A edited?', [tagId]);
 
       expect(await orderedMineIds('&sort=metadata.updated_at&order=asc', mine))
         .to.deep.equal([b, c, a]);


### PR DESCRIPTION
## Summary

The last piece of the authorship-metadata read path: assert the sorted `/serenity/prompts` list actually comes back sorted. This was blocked until the Project Engine mock could sort — that shipped in [spacecat-shared#1859](https://github.com/adobe/spacecat-shared/pull/1859) (LLMO-6666), released as `@adobe/spacecat-shared-project-engine-client@1.18.0`.

## Changes

- **Bump `@adobe/spacecat-shared-project-engine-client` 1.17.0 → 1.18.0.** The IT harness pins the mock image tag to the installed client version, so the bump is what brings the sorting mock into the suite. Kept in the **same change** as the assertions so the suite is never green against a mock that cannot sort (the issue #2954 acceptance criterion).
- **Ordering assertions** in `test/it/shared/tests/serenity.js`:
  - `metadata.created_at` ascending + descending — descending differs from store order, so it fails if the wire keys regress to being ignored.
  - `metadata.updated_at` ascending + descending, with prompts re-touched in a **different order than creation**, so the `updated_at` order diverges from both `created_at` and store order — proving the wire key selects the right field, not just any monotonic default.
  - Small stamp gaps keep `created_at`/`updated_at` from tying at `toISOString()` ms precision; results are filtered to the ids each test created (`resetData` is per-`describe`).
- **Skip note replaced.** The absent-metadata sort position (NULLS-LAST in both directions, per LLMO-6666) is asserted where it is reachable — the mock e2e in #1859 — and remains unreachable through this api-service surface (documented).

## Notes

- **No src change** — the api-service already sends the correct `sort_field` / `sort_dir` keys (shipped in #2957); this is IT coverage + the client bump only.
- The mock image `1.18.0` is published (spacecat-shared release workflow succeeded), so CI's postgres IT will pull the sorting mock.
- **Carried-forward caveat:** the missing-key position and default sort direction are mock-*defined*, not live-*verified* (noted on LLMO-6666) — worth confirming against live Semrush before treating this as a prod-faithfulness guarantee.