### PR TITLE
feat: allow insightsLocation in the geo-experiment PATCH endpoint

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -2521,6 +2521,7 @@ function SuggestionsController(ctx, sqs, env) {
       { key: 'suggestionIds', setter: 'setSuggestionIds' },
       { key: 'promptsCount', setter: 'setPromptsCount' },
       { key: 'promptsLocation', setter: 'setPromptsLocation' },
+      { key: 'insightsLocation', setter: 'setInsightsLocation' },
       { key: 'startTime', setter: 'setStartTime' },
       { key: 'endTime', setter: 'setEndTime' },
       { key: 'metadata', setter: 'setMetadata' },

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -10546,6 +10546,7 @@ describe('Suggestions Controller', () => {
         setSuggestionIds: sandbox.stub(),
         setPromptsCount: sandbox.stub(),
         setPromptsLocation: sandbox.stub(),
+        setInsightsLocation: sandbox.stub(),
         setStartTime: sandbox.stub(),
         setEndTime: sandbox.stub(),
         setMetadata: sandbox.stub(),
@@ -10671,6 +10672,18 @@ describe('Suggestions Controller', () => {
       expect(mockGeoExperiment.save.calledOnce).to.be.true;
     });
 
+    it('patches insightsLocation and saves', async () => {
+      const insightsLocation = `geo-experiments/${GEO_EXP_ID}/insights.json`;
+      const response = await suggestionsController.patchGeoExperiment({
+        ...context,
+        params: { siteId: SITE_ID, geoExperimentId: GEO_EXP_ID },
+        data: { insightsLocation },
+      });
+      expect(response.status).to.equal(200);
+      expect(mockGeoExperiment.setInsightsLocation.calledWith(insightsLocation)).to.be.true;
+      expect(mockGeoExperiment.save.calledOnce).to.be.true;
+    });
+
     it('patches all optional geo experiment fields in one request', async () => {
       const suggestionIds = [SUGGESTION_IDS[0]];
       const errorPayload = { code: 'E_TEST' };
@@ -10685,6 +10698,7 @@ describe('Suggestions Controller', () => {
           suggestionIds,
           promptsCount: 7,
           promptsLocation: 'geo-experiments/bucket/key.json',
+          insightsLocation: 'geo-experiments/bucket/insights.json',
           startTime: '2026-01-01T00:00:00.000Z',
           endTime: '2026-06-01T00:00:00.000Z',
           error: errorPayload,
@@ -10698,6 +10712,7 @@ describe('Suggestions Controller', () => {
       expect(mockGeoExperiment.setSuggestionIds.calledWith(suggestionIds)).to.be.true;
       expect(mockGeoExperiment.setPromptsCount.calledWith(7)).to.be.true;
       expect(mockGeoExperiment.setPromptsLocation.calledWith('geo-experiments/bucket/key.json')).to.be.true;
+      expect(mockGeoExperiment.setInsightsLocation.calledWith('geo-experiments/bucket/insights.json')).to.be.true;
       expect(mockGeoExperiment.setStartTime.calledWith('2026-01-01T00:00:00.000Z')).to.be.true;
       expect(mockGeoExperiment.setEndTime.calledWith('2026-06-01T00:00:00.000Z')).to.be.true;
       expect(mockGeoExperiment.setError.calledWith(errorPayload)).to.be.true;


### PR DESCRIPTION
## What
Adds `insightsLocation` to the `PATCHABLE_FIELDS` allow-list of `PATCH /sites/:siteId/geo-experiments/:geoExperimentId` (`patchGeoExperiment`).

## Why
The DTO already exposes `insightsLocation` on read, and the `GeoExperiment` model has `setInsightsLocation`, but the PATCH allow-list omitted it — so it could never be set via the API. A PATCH that included `insightsLocation` returned `200` while silently dropping the field (and `400 "No valid fields to update"` if it was the only field).

This is the field the llmo-experimentation-engine writes at the end of the impact-measurement lifecycle (the `geo-experiments/{id}/insights.json` pointer). Allowing it here gives an authenticated, access-controlled way to set/correct it manually — direct PostgREST writes to `geo_experiments` are service-role-only, so the API is the only user-facing write path.

## Changes
- `src/controllers/suggestions.js` — one entry added to `PATCHABLE_FIELDS`: `{ key: 'insightsLocation', setter: 'setInsightsLocation' }`.
- `test/controllers/suggestions.test.js` — added `setInsightsLocation` to the mock, a dedicated `patches insightsLocation and saves` test, and extended the all-fields test to cover it.

## Test plan
- [x] `npx eslint` on both files — clean
- [x] `patchGeoExperiment` suite passes (16 passing, incl. the new cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```