### PR TITLE
fix(suggestions): reject illegal per-item status transitions in bulk PATCH (SITES-49063)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
         "@adobe/spacecat-shared-content-client": "1.8.24",
-        "@adobe/spacecat-shared-data-access": "4.16.0",
+        "@adobe/spacecat-shared-data-access": "4.16.1",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.6.23",
         "@adobe/spacecat-shared-http-utils": "1.34.0",
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.16.0.tgz",
-      "integrity": "sha512-EhyKObdqxkcyK+2b2OJVmPXd7xAS4ZQUSGsmUYsfumPY0e5Z62DrZAjxS4Ez41XJPaRHjWKXC3t+sXZbyLIjHA==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.16.1.tgz",
+      "integrity": "sha512-NUBUxPEYFWSWi5wQQLIal/kNpbOe6NYFOBK4NpkK69irUO+skzIVoyU92ahYgaC4Rch2E+wz3tM2DBeGjqSeZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.2.1",
     "@adobe/spacecat-shared-content-client": "1.8.24",
-    "@adobe/spacecat-shared-data-access": "4.16.0",
+    "@adobe/spacecat-shared-data-access": "4.16.1",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.6.23",
     "@adobe/spacecat-shared-http-utils": "1.34.0",

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1126,16 +1126,13 @@ function SuggestionsController(ctx, sqs, env) {
             }
           }
 
-          // Reject per-item transitions the suggestion lifecycle does not allow
-          // (SITES-49063): the bulk endpoint applies a caller-supplied status across a
-          // whole batch, which previously flipped OUTDATED -> FIXED (an OUTDATED
-          // suggestion's issue is no longer detected, so it must not become FIXED).
-          // The shared transition table (SITES-47091) is the single source of truth;
-          // this also gates a safe flip of STATUS_TRANSITION_ENFORCEMENT=enforce (SITES-47286).
-          // NOTE: the REJECTED hard-rule above (REJECTED only from PENDING_VALIDATION) is a
-          // stricter subset of this same invariant kept for its specific message/ACL; it
-          // fires first, so keep it ahead of this general gate.
+          // Per-item transition-legality gate (SITES-49063; part of the SITES-47286
+          // warn->enforce rollout). NOTE: the REJECTED hard-rule above is a stricter
+          // subset of this and fires first — keep it ahead of this general gate.
           if (!isAllowedSuggestionTransition(currentStatus, status)) {
+            // logged so unexpected 400s can be triaged from Splunk when
+            // STATUS_TRANSITION_ENFORCEMENT is flipped to enforce (SITES-47286).
+            context.log.info(`[patchSuggestionsStatus] rejected illegal status transition suggestionId=${id} ${currentStatus} -> ${status}`);
             return {
               index,
               uuid: id,

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -39,6 +39,7 @@ import {
   FEEDBACK_TIERS,
   verdictToSignal,
   toReviewView,
+  isAllowedSuggestionTransition,
 } from '@adobe/spacecat-shared-data-access';
 import TokowakaClient from '@adobe/spacecat-shared-tokowaka-client';
 import { SuggestionDto, SUGGESTION_VIEWS, SUGGESTION_SKIP_REASONS } from '../dto/suggestion.js';
@@ -1123,6 +1124,24 @@ function SuggestionsController(ctx, sqs, env) {
                 statusCode: 400,
               };
             }
+          }
+
+          // Reject per-item transitions the suggestion lifecycle does not allow
+          // (SITES-49063): the bulk endpoint applies a caller-supplied status across a
+          // whole batch, which previously flipped OUTDATED -> FIXED (an OUTDATED
+          // suggestion's issue is no longer detected, so it must not become FIXED).
+          // The shared transition table (SITES-47091) is the single source of truth;
+          // this also gates a safe flip of STATUS_TRANSITION_ENFORCEMENT=enforce (SITES-47286).
+          // NOTE: the REJECTED hard-rule above (REJECTED only from PENDING_VALIDATION) is a
+          // stricter subset of this same invariant kept for its specific message/ACL; it
+          // fires first, so keep it ahead of this general gate.
+          if (!isAllowedSuggestionTransition(currentStatus, status)) {
+            return {
+              index,
+              uuid: id,
+              message: `Illegal status transition: ${currentStatus} -> ${status}`,
+              statusCode: 400,
+            };
           }
 
           suggestion.setStatus(status);

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -77,7 +77,7 @@ describe('Suggestions Controller', () => {
       return suggData.status;
     },
     setStatus(value) {
-      if (value === 'throw-error') {
+      if (value === 'throw-error' || suggData.throwOnSetStatus) {
         throw new ValidationError('Validation error');
       }
       suggData.status = value;
@@ -3353,7 +3353,7 @@ describe('Suggestions Controller', () => {
         siteId: SITE_ID,
         opportunityId: OPPORTUNITY_ID,
       },
-      data: [{ id: SUGGESTION_IDS[0], status: 'NEW-updated' }, { id: SUGGESTION_IDS[1], status: 'APPROVED-updated' }],
+      data: [{ id: SUGGESTION_IDS[0], status: 'IN_PROGRESS' }, { id: SUGGESTION_IDS[1], status: 'FIXED' }],
       ...context,
     });
 
@@ -3371,8 +3371,8 @@ describe('Suggestions Controller', () => {
     expect(bulkPatchResponse.suggestions[1]).to.have.property('statusCode', 200);
     expect(bulkPatchResponse.suggestions[0].suggestion).to.exist;
     expect(bulkPatchResponse.suggestions[1].suggestion).to.exist;
-    expect(bulkPatchResponse.suggestions[0].suggestion).to.have.property('status', 'NEW-updated');
-    expect(bulkPatchResponse.suggestions[1].suggestion).to.have.property('status', 'APPROVED-updated');
+    expect(bulkPatchResponse.suggestions[0].suggestion).to.have.property('status', 'IN_PROGRESS');
+    expect(bulkPatchResponse.suggestions[1].suggestion).to.have.property('status', 'FIXED');
   });
 
   it('bulk patches suggestion status sets updatedBy to caller profile email on status change', async () => {
@@ -3381,7 +3381,7 @@ describe('Suggestions Controller', () => {
         siteId: SITE_ID,
         opportunityId: OPPORTUNITY_ID,
       },
-      data: [{ id: SUGGESTION_IDS[0], status: 'NEW-updated' }],
+      data: [{ id: SUGGESTION_IDS[0], status: 'IN_PROGRESS' }],
       ...context,
     });
 
@@ -3527,7 +3527,7 @@ describe('Suggestions Controller', () => {
         siteId: SITE_ID,
         opportunityId: OPPORTUNITY_ID,
       },
-      data: [{ id: SUGGESTION_IDS[1], status: 'NEW-APPROVED' }, { status: 'NEW-APPROVED' }],
+      data: [{ id: SUGGESTION_IDS[1], status: 'FIXED' }, { status: 'FIXED' }],
       ...context,
     });
     expect(response.status).to.equal(207);
@@ -3581,7 +3581,7 @@ describe('Suggestions Controller', () => {
         siteId: SITE_ID,
         opportunityId: OPPORTUNITY_ID,
       },
-      data: [{ id: SUGGESTION_IDS[1], status: 'NEW-APPROVED' }, { id: SUGGESTION_IDS[0] }],
+      data: [{ id: SUGGESTION_IDS[1], status: 'FIXED' }, { id: SUGGESTION_IDS[0] }],
       ...context,
     });
     expect(response.status).to.equal(207);
@@ -3608,7 +3608,7 @@ describe('Suggestions Controller', () => {
         siteId: SITE_ID,
         opportunityId: OPPORTUNITY_ID,
       },
-      data: [{ id: 'wrong-sugg-id', status: 'NEW-NEW' }, { id: SUGGESTION_IDS[0], status: 'NEW-APPROVED' }],
+      data: [{ id: 'wrong-sugg-id', status: 'APPROVED' }, { id: SUGGESTION_IDS[0], status: 'APPROVED' }],
       ...context,
     });
     expect(response.status).to.equal(207);
@@ -3700,14 +3700,14 @@ describe('Suggestions Controller', () => {
         opportunityId: OPPORTUNITY_ID,
       },
       data: [
-        { id: SUGGESTION_IDS[0], status: 'APPROVED' },
+        { id: SUGGESTION_IDS[0], status: 'NEW' },
       ],
       ...context,
     });
     expect(response.status).to.equal(207);
     const bulkPatchResponse = await response.json();
     expect(bulkPatchResponse.metadata.success).to.equal(1);
-    expect(suggs[0].status).to.equal('APPROVED');
+    expect(suggs[0].status).to.equal('NEW');
     expect(suggs[0].skipReason).to.be.null;
     expect(suggs[0].skipDetail).to.be.null;
   });
@@ -3735,7 +3735,7 @@ describe('Suggestions Controller', () => {
     expect(suggs[0].skipDetail).to.be.null;
   });
 
-  it('bulk patches suggestion status changes from SKIPPED to APPROVED without setSkipReason on model', async () => {
+  it('bulk patches suggestion status changes from SKIPPED to NEW without setSkipReason on model', async () => {
     suggs[0].status = 'SKIPPED';
     const entity = mockSuggestionEntity(suggs[0]);
     delete entity.setSkipReason;
@@ -3752,14 +3752,14 @@ describe('Suggestions Controller', () => {
         opportunityId: OPPORTUNITY_ID,
       },
       data: [
-        { id: SUGGESTION_IDS[0], status: 'APPROVED' },
+        { id: SUGGESTION_IDS[0], status: 'NEW' },
       ],
       ...context,
     });
     expect(response.status).to.equal(207);
     const bulkPatchResponse = await response.json();
     expect(bulkPatchResponse.metadata.success).to.equal(1);
-    expect(suggs[0].status).to.equal('APPROVED');
+    expect(suggs[0].status).to.equal('NEW');
     // Restore
     mockSuggestion.findById.callsFake((id) => {
       const s = suggs.find((sg) => sg.id === id);
@@ -3954,12 +3954,16 @@ describe('Suggestions Controller', () => {
   });
 
   it('bulk patches suggestion status fails if validation error in set status', async () => {
+    // A legal transition (NEW -> IN_PROGRESS) that still throws inside setStatus,
+    // to exercise the setStatus ValidationError -> 400 path after the transition gate.
+    suggs[0].throwOnSetStatus = true;
+    suggs[1].throwOnSetStatus = true;
     const response = await suggestionsController.patchSuggestionsStatus({
       params: {
         siteId: SITE_ID,
         opportunityId: OPPORTUNITY_ID,
       },
-      data: [{ id: SUGGESTION_IDS[0], status: 'throw-error' }, { id: SUGGESTION_IDS[1], status: 'throw-error' }],
+      data: [{ id: SUGGESTION_IDS[0], status: 'IN_PROGRESS' }, { id: SUGGESTION_IDS[1], status: 'IN_PROGRESS' }],
       ...context,
     });
     expect(response.status).to.equal(207);
@@ -3988,7 +3992,9 @@ describe('Suggestions Controller', () => {
         siteId: SITE_ID,
         opportunityId: OPPORTUNITY_ID,
       },
-      data: [{ id: SUGGESTION_IDS[0], status: 'NEW updated' }, { id: SUGGESTION_IDS[1], status: 'APPROVED updated' }],
+      // Legal transitions (NEW->IN_PROGRESS, APPROVED->FIXED) so the request reaches
+      // save(), where the mock throws.
+      data: [{ id: SUGGESTION_IDS[0], status: 'IN_PROGRESS' }, { id: SUGGESTION_IDS[1], status: 'FIXED' }],
       ...context,
     });
     expect(response.status).to.equal(207);
@@ -4254,6 +4260,62 @@ describe('Suggestions Controller', () => {
       expect(bulkPatchResponse.suggestions[0]).to.have.property('message', 'auth service unavailable');
       expect(bulkPatchResponse.metadata).to.have.property('failed', 1);
       expect(context.log.error).to.have.been.calledWithMatch(/\[patchSuggestionsStatus\] unexpected error/);
+    });
+  });
+
+  describe('status transition legality (SITES-49063)', () => {
+    const patchToStatus = async (currentStatus, targetStatus) => {
+      const suggestionEntity = mockSuggestionEntity({
+        id: SUGGESTION_IDS[0],
+        opportunityId: OPPORTUNITY_ID,
+        type: 'CODE_CHANGE',
+        status: currentStatus,
+        rank: 1,
+        data: { info: 'sample data' },
+      }, removeStub);
+      const saveSpy = sandbox.spy(suggestionEntity, 'save');
+
+      mockSuggestion.findById.withArgs(SUGGESTION_IDS[0]).resolves(suggestionEntity);
+      mockOpportunity.findById.withArgs(OPPORTUNITY_ID).resolves(opportunity);
+      mockSite.findById.withArgs(SITE_ID).resolves(site);
+
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({ allowed: false, reason: 'not-s2s' });
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+
+      const response = await suggestionsController.patchSuggestionsStatus({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: [{ id: SUGGESTION_IDS[0], status: targetStatus }],
+        ...context,
+      });
+      return { response, saveSpy };
+    };
+
+    it('rejects OUTDATED -> FIXED with a 400 and does not save', async () => {
+      const { response, saveSpy } = await patchToStatus('OUTDATED', 'FIXED');
+
+      expect(response.status).to.equal(207);
+      const body = await response.json();
+      expect(body.suggestions[0]).to.have.property('statusCode', 400);
+      expect(body.suggestions[0]).to.have.property('uuid', SUGGESTION_IDS[0]);
+      expect(body.suggestions[0]).to.have.property('message', 'Illegal status transition: OUTDATED -> FIXED');
+      expect(body.suggestions[0].suggestion).to.not.exist;
+      expect(body.metadata).to.have.property('failed', 1);
+      expect(body.metadata).to.have.property('success', 0);
+      // the exact invariant SITES-49063 is about: an illegal transition must not write
+      expect(saveSpy).to.not.have.been.called;
+    });
+
+    it('allows a legal transition (IN_PROGRESS -> FIXED)', async () => {
+      const { response, saveSpy } = await patchToStatus('IN_PROGRESS', 'FIXED');
+
+      expect(saveSpy).to.have.been.calledOnce;
+      expect(response.status).to.equal(207);
+      const body = await response.json();
+      expect(body.suggestions[0]).to.have.property('statusCode', 200);
+      expect(body.suggestions[0].suggestion).to.have.property('status', 'FIXED');
+      expect(body.metadata).to.have.property('success', 1);
+      expect(body.metadata).to.have.property('failed', 0);
     });
   });
 

--- a/test/it/shared/tests/suggestions.js
+++ b/test/it/shared/tests/suggestions.js
@@ -401,6 +401,38 @@ export default function suggestionTests(getHttpClient, resetData) {
         expect(updated.skipDetail).to.equal('Fix was applied manually');
       });
 
+      it('user: rejects an illegal transition (OUTDATED -> FIXED) with 400 and keeps the stored status (SITES-49063)', async () => {
+        const http = getHttpClient();
+        // fresh suggestion (created as NEW) so this case is isolated from testSuggId
+        const created = await http.user.post(BASE, [
+          { type: 'CODE_CHANGE', rank: 61, data: { title: 'Illegal transition test' } },
+        ]);
+        expect(created.status).to.equal(207);
+        const { id } = created.body.suggestions[0].suggestion;
+
+        // NEW -> OUTDATED is a legal transition
+        const toOutdated = await http.user.patch(`${BASE}/status`, [
+          { id, status: 'OUTDATED' },
+        ]);
+        expectBatch207(toOutdated, 1, 'suggestions');
+        expect(toOutdated.body.suggestions[0].statusCode).to.equal(200);
+
+        // OUTDATED -> FIXED is illegal: per-item 400 inside a 207 batch, no write
+        const toFixed = await http.user.patch(`${BASE}/status`, [
+          { id, status: 'FIXED' },
+        ]);
+        expectBatch207(toFixed, 1, 'suggestions');
+        expect(toFixed.body.metadata.success).to.equal(0);
+        expect(toFixed.body.metadata.failed).to.equal(1);
+        expect(toFixed.body.suggestions[0].statusCode).to.equal(400);
+        expect(toFixed.body.suggestions[0].message).to.equal('Illegal status transition: OUTDATED -> FIXED');
+
+        // the stored row must retain OUTDATED (the guard prevented the write end-to-end)
+        const check = await http.user.get(`${BASE}/${id}`);
+        expect(check.status).to.equal(200);
+        expect(check.body.status).to.equal('OUTDATED');
+      });
+
       it('user: returns 403 for denied site', async () => {
         const http = getHttpClient();
         const res = await http.user.patch(`${DENIED_BASE}/status`, [


### PR DESCRIPTION
## What

The bulk `PATCH /sites/{siteId}/opportunities/{oppId}/suggestions/status` handler (`patchSuggestionsStatus`) applied a caller-supplied target status across the whole batch **without checking per-item legality**, so it silently promoted **OUTDATED → FIXED**. An OUTDATED suggestion's issue is no longer detected, so it must not become FIXED.

This adds a per-item transition-legality gate using `isAllowedSuggestionTransition(currentStatus, status)` from the shared status-transition table (SITES-47091), returning `400 Illegal status transition: <from> -> <to>` **before** `setStatus`. Same-status writes, the SKIPPED skip-field-clearing path, and `updatedBy` stamping are unaffected (the gate sits inside the existing `currentStatus !== status` branch). The pre-existing REJECTED hard-rule (REJECTED only from PENDING_VALIDATION) is a stricter subset kept ahead for its specific message/ACL.

Also bumps `@adobe/spacecat-shared-data-access` **4.16.0 → 4.16.1** (the reconciled transition table from adobe/spacecat-shared#1860).

## Why

Surfaced by the SITES-47091 guard running in **warn** mode: **159 `OUTDATED → FIXED` violations** over 25 days in prod, all from this endpoint. This is the **last caller-side item** gating a safe flip of `STATUS_TRANSITION_ENFORCEMENT=warn → enforce` (SITES-47286) — once the endpoint stops doing this, `OUTDATED → FIXED` stays correctly disallowed in the shared table and `enforce` won't throw on legitimate traffic.

## Rollout-risk check

The shared table was reconciled from 25 days of warn-mode logs, which surfaced exactly **4** violation types: `OUTDATED→FIXED`, `REJECTED→OUTDATED`, `FAILED→ROLLED_BACK`, `NEW→REJECTED`. `SKIPPED→APPROVED` (a plausible "unskip & approve" one-hop) was **not** observed — since the guard wraps `setStatus`, it would have logged a violation had it occurred — so no legitimate current traffic is newly rejected by this gate.

## Tests

- New `status transition legality (SITES-49063)` block: `OUTDATED→FIXED` rejected with an explicit **save-not-called** assertion; `IN_PROGRESS→FIXED` allowed (saves once).
- Adjusted 9 pre-existing bulk-patch tests that had used synthetic placeholder statuses to use real legal transitions (added a `throwOnSetStatus` mock flag to preserve the setStatus-error path).
- **492 passing**, lint clean.

## Tickets
- Fixes SITES-49063
- Part of SITES-47286 (guard warn → enforce rollout) / SITES-47076 (lifecycle parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```