### PR TITLE
fix: resolve updatedBy identity in audit-policy revisions API

### DIFF
--- a/docs/openapi/audit-policy-api.yaml
+++ b/docs/openapi/audit-policy-api.yaml
@@ -329,7 +329,7 @@ AuditPolicyRevision:
     manualUrls: { type: array, items: { type: string } }
     scopeConfig: { type: object }
     lifecycleOverrides: { type: object }
-    updatedBy: { type: [string, 'null'] }
+    updatedBy: { type: [string, 'null'], description: 'Human-readable identity of who made this revision (display name or email), resolved server-side. May be "system" for unauthenticated writes.' }
     reason: { type: [string, 'null'] }
     note: { type: [string, 'null'] }
     effectiveAt: { type: [string, 'null'], format: date-time }

--- a/src/controllers/audit-policy.js
+++ b/src/controllers/audit-policy.js
@@ -73,8 +73,15 @@ function encodeCursor(version) {
   return Buffer.from(String(version), 'utf8').toString('base64url');
 }
 
-function displayName({ first_name: firstName, last_name: lastName, email }) {
-  const name = [firstName, lastName].filter(hasText).join(' ').trim();
+// Guards against a fulfilled-but-nullish IMS profile (a not-found/deactivated user that resolves
+// empty rather than throwing). Without the guard, destructuring null throws inside the batch
+// forEach, escapes to the outer catch, and abandons every remaining batch on the page.
+function displayName(profile) {
+  if (!profile) {
+    return null;
+  }
+  const { first_name: firstName, last_name: lastName, email } = profile;
+  const name = [firstName, lastName].filter(hasText).join(' ');
   return name || email || null;
 }
 

--- a/src/controllers/audit-policy.js
+++ b/src/controllers/audit-policy.js
@@ -22,6 +22,14 @@ const POLICY_TABLE = 'audit_policy';
 const REVISION_TABLE = 'audit_policy_revision';
 const UPSERT_RPC = 'wrpc_upsert_audit_policy';
 
+// getAuthor() stamps updated_by with an IMS user GUID for most auth paths (profile.email is
+// overloaded to carry the GUID, not an RFC-5322 address - see access-control-util.js) rather
+// than a human-readable identity. This gate mirrors fixes.js's IMS_ID_RE: only strings shaped
+// like a GUID@realm value are sent to getImsAdminProfile, so a legacy plain email/name/'system'
+// value already stored in the column is left untouched and returned as-is.
+const IMS_ID_RE = /^[A-Za-z0-9]+@(AdobeID|AdobeOrg|Email|AdobeServices|[0-9a-fA-F]{16,40}(?:\.[a-z])?)$/;
+const IMS_ENRICH_BATCH_SIZE = 5;
+
 const MAX_EXCLUSION_GLOBS = 200;
 const MAX_MANUAL_URLS = 2000;
 const MAX_ELEMENT_LEN = 2048;
@@ -63,6 +71,46 @@ function decodeCursor(c) {
 
 function encodeCursor(version) {
   return Buffer.from(String(version), 'utf8').toString('base64url');
+}
+
+function displayName({ first_name: firstName, last_name: lastName, email }) {
+  const name = [firstName, lastName].filter(hasText).join(' ').trim();
+  return name || email || null;
+}
+
+// Resolves IMS-GUID updated_by values to a human-readable display name/email, batched to cap
+// IMS concurrency. Non-GUID values (legacy plain email/name/'system') pass through unresolved.
+// Fails silently per-lookup (and as a whole if imsClient is unavailable) so the caller always
+// gets a response even when IMS is unreachable.
+async function resolveUpdatedByIdentities(context, rows) {
+  const { imsClient, log } = context;
+  const map = new Map();
+  if (!imsClient) {
+    return map;
+  }
+  const userIds = [...new Set(
+    rows.map((row) => row.updated_by).filter((id) => id && IMS_ID_RE.test(id)),
+  )];
+  if (!userIds.length) {
+    return map;
+  }
+  try {
+    for (let i = 0; i < userIds.length; i += IMS_ENRICH_BATCH_SIZE) {
+      const batch = userIds.slice(i, i + IMS_ENRICH_BATCH_SIZE);
+      // eslint-disable-next-line no-await-in-loop
+      const results = await Promise.allSettled(batch.map((id) => imsClient.getImsAdminProfile(id)));
+      results.forEach((result, j) => {
+        if (result.status === 'fulfilled') {
+          map.set(batch[j], displayName(result.value));
+        } else {
+          log?.warn?.(`audit-policy revision: failed to resolve IMS profile for author: ${result.reason?.message}`);
+        }
+      });
+    }
+  } catch (e) {
+    log?.warn?.(`audit-policy revision: could not resolve author identities: ${e.message}`);
+  }
+  return map;
 }
 
 function getAuthor(context) {
@@ -290,7 +338,11 @@ export default function AuditPolicyController() {
       context.log?.error?.(`audit-policy listRevisions failed: ${error.code} ${error.message}`);
       return internalServerError('Failed to read audit policy revisions');
     }
-    const items = (data || []).map(AuditPolicyRevisionDto.toJSON);
+    const rows = data || [];
+    const identityMap = await resolveUpdatedByIdentities(context, rows);
+    const items = rows.map(
+      (row) => AuditPolicyRevisionDto.toJSON(row, identityMap.get(row.updated_by)),
+    );
     // A full page implies more rows may exist; if the last page happens to contain exactly
     // `limit` rows, the client makes one harmless extra request that returns an empty page.
     const nextCursor = items.length === limit

--- a/src/dto/audit-policy.js
+++ b/src/dto/audit-policy.js
@@ -62,7 +62,9 @@ export const AuditPolicyDto = {
 export const AuditPolicyRevisionDto = {
   // `resolvedUpdatedBy` is a human-readable display name/email resolved server-side (e.g. via
   // IMS) for the row's raw `updated_by` value; falls back to the raw value when it can't be
-  // resolved (already a plain email/name, or IMS lookup failed/unavailable).
+  // resolved (already a plain email/name, or IMS lookup failed/unavailable). The `typeof`
+  // guard below defends against `list.map(AuditPolicyRevisionDto.toJSON)` - the repo's dominant
+  // DTO idiom - which would otherwise pass the array index in as `resolvedUpdatedBy`.
   toJSON(row, resolvedUpdatedBy) {
     return {
       version: row.version,
@@ -72,7 +74,7 @@ export const AuditPolicyRevisionDto = {
       manualUrls: row.manual_urls,
       scopeConfig: row.scope_config,
       lifecycleOverrides: row.lifecycle_overrides,
-      updatedBy: resolvedUpdatedBy || row.updated_by,
+      updatedBy: (typeof resolvedUpdatedBy === 'string' ? resolvedUpdatedBy : null) || row.updated_by,
       reason: row.reason,
       note: row.note,
       effectiveAt: toISO(row.effective_at),

--- a/src/dto/audit-policy.js
+++ b/src/dto/audit-policy.js
@@ -60,7 +60,10 @@ export const AuditPolicyDto = {
 };
 
 export const AuditPolicyRevisionDto = {
-  toJSON(row) {
+  // `resolvedUpdatedBy` is a human-readable display name/email resolved server-side (e.g. via
+  // IMS) for the row's raw `updated_by` value; falls back to the raw value when it can't be
+  // resolved (already a plain email/name, or IMS lookup failed/unavailable).
+  toJSON(row, resolvedUpdatedBy) {
     return {
       version: row.version,
       budget: row.budget,
@@ -69,7 +72,7 @@ export const AuditPolicyRevisionDto = {
       manualUrls: row.manual_urls,
       scopeConfig: row.scope_config,
       lifecycleOverrides: row.lifecycle_overrides,
-      updatedBy: row.updated_by,
+      updatedBy: resolvedUpdatedBy || row.updated_by,
       reason: row.reason,
       note: row.note,
       effectiveAt: toISO(row.effective_at),

--- a/test/controllers/audit-policy.test.js
+++ b/test/controllers/audit-policy.test.js
@@ -844,6 +844,119 @@ describe('AuditPolicyController — E3 listRevisions', () => {
   });
 });
 
+describe('AuditPolicyController — listRevisions updatedBy identity resolution', () => {
+  afterEach(() => sinon.restore());
+
+  function rowsWith(updatedByValues) {
+    return updatedByValues.map((updatedBy, i) => ({
+      version: updatedByValues.length - i,
+      budget: 4000,
+      strategy_name: 'tiered',
+      exclusion_globs: [],
+      manual_urls: [],
+      scope_config: {},
+      lifecycle_overrides: {},
+      updated_by: updatedBy,
+      reason: 'r',
+      note: null,
+      effective_at: '2026-01-01T00:00:00Z',
+      superseded_at: null,
+    }));
+  }
+
+  function clientReturning(rows) {
+    const order = sinon.stub().returnsThis();
+    const limit = sinon.stub().resolves({ data: rows, error: null });
+    return {
+      from: () => ({ select: () => ({ eq: () => ({ order, limit }) }) }),
+      rpc: sinon.stub(),
+    };
+  }
+
+  it('resolves an IMS-GUID updated_by to a display name via getImsAdminProfile', async () => {
+    const rows = rowsWith(['A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg']);
+    const client = clientReturning(rows);
+    const imsClient = {
+      getImsAdminProfile: sinon.stub().resolves({ first_name: 'Jane', last_name: 'Doe', email: 'jane@x.com' }),
+    };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('Jane Doe');
+    expect(imsClient.getImsAdminProfile).to.have.been.calledOnceWith('A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg');
+  });
+
+  it('dedupes repeated updated_by values into a single IMS lookup', async () => {
+    const guid = 'A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg';
+    const rows = rowsWith([guid, guid, guid]);
+    const client = clientReturning(rows);
+    const imsClient = {
+      getImsAdminProfile: sinon.stub().resolves({ first_name: 'Jane', last_name: 'Doe', email: 'jane@x.com' }),
+    };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    expect(body.items.every((item) => item.updatedBy === 'Jane Doe')).to.equal(true);
+    expect(imsClient.getImsAdminProfile).to.have.been.calledOnce;
+  });
+
+  it('falls back to email when the IMS profile has no first/last name', async () => {
+    const rows = rowsWith(['A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg']);
+    const client = clientReturning(rows);
+    const imsClient = {
+      getImsAdminProfile: sinon.stub().resolves({ first_name: null, last_name: null, email: 'jane@x.com' }),
+    };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('jane@x.com');
+  });
+
+  it('leaves a non-GUID updated_by value (plain email/name/"system") untouched, without calling IMS', async () => {
+    const rows = rowsWith(['system']);
+    const client = clientReturning(rows);
+    const imsClient = { getImsAdminProfile: sinon.stub() };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('system');
+    expect(imsClient.getImsAdminProfile).to.not.have.been.called;
+  });
+
+  it('falls back to the raw GUID when the IMS lookup rejects, and logs a warning', async () => {
+    const rows = rowsWith(['A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg']);
+    const client = clientReturning(rows);
+    const imsClient = { getImsAdminProfile: sinon.stub().rejects(new Error('ims down')) };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg');
+    expect(ctx.log.warn).to.have.been.calledWith(sinon.match(/failed to resolve IMS profile/));
+  });
+
+  it('skips resolution entirely (no throw) when context.imsClient is not available', async () => {
+    const rows = rowsWith(['A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg']);
+    const client = clientReturning(rows);
+    const controller = loadController();
+    const res = await controller.listRevisions(buildContext({ client }));
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg');
+  });
+});
+
 describe('AuditPolicyController — E4-E6 scope-read 501 stubs', () => {
   afterEach(() => sinon.restore());
   for (const fn of ['getScopePages', 'getScopeSummary', 'getScopeSections']) {

--- a/test/controllers/audit-policy.test.js
+++ b/test/controllers/audit-policy.test.js
@@ -946,6 +946,22 @@ describe('AuditPolicyController — listRevisions updatedBy identity resolution'
     expect(ctx.log.warn).to.have.been.calledWith(sinon.match(/failed to resolve IMS profile/));
   });
 
+  it('falls back to raw updated_by and logs a warning when the resolution loop itself throws synchronously', async () => {
+    const rows = rowsWith(['A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg']);
+    const client = clientReturning(rows);
+    // Throws synchronously (not a rejected promise) so batch.map() throws inside the try block,
+    // before Promise.allSettled ever runs - exercises the outer catch, not the per-lookup one.
+    const imsClient = { getImsAdminProfile: sinon.stub().throws(new Error('boom')) };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg');
+    expect(ctx.log.warn).to.have.been.calledWith(sinon.match(/could not resolve author identities/));
+  });
+
   it('skips resolution entirely (no throw) when context.imsClient is not available', async () => {
     const rows = rowsWith(['A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg']);
     const client = clientReturning(rows);

--- a/test/controllers/audit-policy.test.js
+++ b/test/controllers/audit-policy.test.js
@@ -52,6 +52,9 @@ function buildClient({ row = null, rpcResult, revisions = [] } = {}) {
   };
 }
 
+// Deliberately omits `imsClient` so listRevisions' resolveUpdatedByIdentities() short-circuits
+// (returns an empty Map) - keeps the pre-existing listRevisions tests asserting raw updatedBy.
+// The identity-resolution suite attaches ctx.imsClient by hand after construction.
 function buildContext({
   client, params = {}, data = {}, profile = { email: 'u@x.com' },
 } = {}) {
@@ -903,6 +906,105 @@ describe('AuditPolicyController — listRevisions updatedBy identity resolution'
     const body = await res.json();
     expect(body.items.every((item) => item.updatedBy === 'Jane Doe')).to.equal(true);
     expect(imsClient.getImsAdminProfile).to.have.been.calledOnce;
+  });
+
+  it('maps two distinct GUIDs to their two distinct identities on the same page (per-row keying)', async () => {
+    const guidA = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@AdobeOrg';
+    const guidB = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB@AdobeOrg';
+    const rows = rowsWith([guidA, guidB]);
+    const client = clientReturning(rows);
+    const imsClient = { getImsAdminProfile: sinon.stub() };
+    imsClient.getImsAdminProfile.withArgs(guidA).resolves({ first_name: 'Ann', last_name: 'Alpha', email: 'ann@x.com' });
+    imsClient.getImsAdminProfile.withArgs(guidB).resolves({ first_name: 'Bob', last_name: 'Beta', email: 'bob@x.com' });
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    // rowsWith assigns version desc: items[0] is guidA (v2), items[1] is guidB (v1)
+    expect(body.items[0].updatedBy).to.equal('Ann Alpha');
+    expect(body.items[1].updatedBy).to.equal('Bob Beta');
+  });
+
+  it('resolves across the batch boundary (>IMS_ENRICH_BATCH_SIZE distinct GUIDs) keying each row correctly', async () => {
+    // 6 distinct GUIDs > batch size 5, so the batching loop runs twice.
+    const guids = Array.from({ length: 6 }, (_, i) => `${'C'.repeat(31)}${i}@AdobeOrg`);
+    const rows = rowsWith(guids);
+    const client = clientReturning(rows);
+    const imsClient = { getImsAdminProfile: sinon.stub() };
+    guids.forEach((g, i) => imsClient.getImsAdminProfile.withArgs(g).resolves({ first_name: `User${i}`, last_name: null, email: null }));
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    expect(imsClient.getImsAdminProfile.callCount).to.equal(6);
+    body.items.forEach((item, i) => expect(item.updatedBy).to.equal(`User${i}`));
+  });
+
+  it('a fulfilled-but-null IMS profile falls back to the raw GUID for that row without dropping sibling resolutions', async () => {
+    const guidA = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@AdobeOrg';
+    const guidNull = 'DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD0@AdobeOrg';
+    const rows = rowsWith([guidA, guidNull]);
+    const client = clientReturning(rows);
+    const imsClient = { getImsAdminProfile: sinon.stub() };
+    imsClient.getImsAdminProfile.withArgs(guidA).resolves({ first_name: 'Ann', last_name: 'Alpha', email: 'ann@x.com' });
+    imsClient.getImsAdminProfile.withArgs(guidNull).resolves(null);
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    expect(res.status).to.equal(200);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('Ann Alpha');
+    expect(body.items[1].updatedBy).to.equal(guidNull);
+  });
+
+  it('resolves GUIDs but passes non-GUID values through untouched on a mixed page', async () => {
+    const guid = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@AdobeOrg';
+    const rows = rowsWith([guid, 'system', 'jane@x.com']);
+    const client = clientReturning(rows);
+    const imsClient = {
+      getImsAdminProfile: sinon.stub().resolves({ first_name: 'Jane', last_name: 'Doe', email: 'jane@x.com' }),
+    };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('Jane Doe');
+    expect(body.items[1].updatedBy).to.equal('system');
+    expect(body.items[2].updatedBy).to.equal('jane@x.com');
+    expect(imsClient.getImsAdminProfile).to.have.been.calledOnce;
+  });
+
+  it('builds the display name from a partial (first-only) IMS profile', async () => {
+    const rows = rowsWith(['A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg']);
+    const client = clientReturning(rows);
+    const imsClient = {
+      getImsAdminProfile: sinon.stub().resolves({ first_name: 'Jane', last_name: null, email: 'jane@x.com' }),
+    };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal('Jane');
+  });
+
+  it('falls back to the raw GUID when the IMS profile has neither name nor email', async () => {
+    const guid = 'A1B2C3D4E5F60708A1B2C3D4E5F60708@AdobeOrg';
+    const rows = rowsWith([guid]);
+    const client = clientReturning(rows);
+    const imsClient = {
+      getImsAdminProfile: sinon.stub().resolves({ first_name: null, last_name: null, email: null }),
+    };
+    const controller = loadController();
+    const ctx = buildContext({ client });
+    ctx.imsClient = imsClient;
+    const res = await controller.listRevisions(ctx);
+    const body = await res.json();
+    expect(body.items[0].updatedBy).to.equal(guid);
   });
 
   it('falls back to email when the IMS profile has no first/last name', async () => {

--- a/test/dto/audit-policy.test.js
+++ b/test/dto/audit-policy.test.js
@@ -149,6 +149,26 @@ describe('AuditPolicyDto', () => {
     expect(dto.updatedBy).to.equal('Jane Doe');
   });
 
+  it('revision toJSON ignores a non-string 2nd arg (e.g. the array index from list.map) and keeps the raw column', () => {
+    const row = {
+      version: 4,
+      budget: 4000,
+      strategy_name: 'tiered',
+      exclusion_globs: [],
+      manual_urls: [],
+      scope_config: {},
+      lifecycle_overrides: {},
+      updated_by: 'u@x.com',
+      reason: 'r',
+      note: null,
+      effective_at: null,
+      superseded_at: null,
+    };
+    // Simulates [row].map(AuditPolicyRevisionDto.toJSON) passing (row, index).
+    const dto = AuditPolicyRevisionDto.toJSON(row, 3);
+    expect(dto.updatedBy).to.equal('u@x.com');
+  });
+
   it('revision toJSON falls back to the raw updated_by column when no resolution is supplied', () => {
     const row = {
       version: 4,

--- a/test/dto/audit-policy.test.js
+++ b/test/dto/audit-policy.test.js
@@ -130,6 +130,44 @@ describe('AuditPolicyDto', () => {
     });
   });
 
+  it('revision toJSON uses resolvedUpdatedBy over the raw column when supplied', () => {
+    const row = {
+      version: 4,
+      budget: 4000,
+      strategy_name: 'tiered',
+      exclusion_globs: [],
+      manual_urls: [],
+      scope_config: {},
+      lifecycle_overrides: {},
+      updated_by: 'A1B2C3D4E5F6@AdobeOrg',
+      reason: 'r',
+      note: null,
+      effective_at: null,
+      superseded_at: null,
+    };
+    const dto = AuditPolicyRevisionDto.toJSON(row, 'Jane Doe');
+    expect(dto.updatedBy).to.equal('Jane Doe');
+  });
+
+  it('revision toJSON falls back to the raw updated_by column when no resolution is supplied', () => {
+    const row = {
+      version: 4,
+      budget: 4000,
+      strategy_name: 'tiered',
+      exclusion_globs: [],
+      manual_urls: [],
+      scope_config: {},
+      lifecycle_overrides: {},
+      updated_by: 'u@x.com',
+      reason: 'r',
+      note: null,
+      effective_at: null,
+      superseded_at: null,
+    };
+    const dto = AuditPolicyRevisionDto.toJSON(row);
+    expect(dto.updatedBy).to.equal('u@x.com');
+  });
+
   it('revision toJSON normalizes raw Postgres timestamptz text to Z-suffixed ISO8601', () => {
     const row = {
       version: 4,


### PR DESCRIPTION
## Summary
- `updated_by` on `audit_policy_revision` rows is stamped with whatever `getAuthor()` captured at write time — for JWT/IMS auth this is often an IMS user GUID, not a human-readable value — and was returned to clients unresolved, forcing the History dialog (SITES-48394) to fall back to a raw value or "—".
- `listRevisions` now batch-resolves GUID-shaped `updated_by` values via `imsClient.getImsAdminProfile` (same pattern as `fixes.js`'s `#enrichFixesWithUserNames`), producing a display name (or email fallback). Non-GUID values (plain email/name/`system`) and failed/unavailable IMS lookups pass through unchanged.
- Updated the `AuditPolicyRevision` OpenAPI schema description for `updatedBy`.

Jira: [SITES-49158](https://jira.corp.adobe.com/browse/SITES-49158)

## Test plan
- [x] `npx mocha test/controllers/audit-policy.test.js test/dto/audit-policy.test.js` — added coverage for GUID resolution, dedupe/batching, name-less profile fallback, non-GUID passthrough, IMS failure fallback, and missing `imsClient`
- [x] `npm run lint`
- [x] `npm run docs:lint`
- [x] `npm run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```