### PR TITLE
feat(llmo): add caller + host to O@E onboarding logs and log the journey start

### DIFF
--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -21,6 +21,7 @@ import AkamaiClient, {
 } from '@adobe/spacecat-shared-akamai-client';
 import TokowakaClient from '@adobe/spacecat-shared-tokowaka-client';
 import AccessControlUtil from '../../support/access-control-util.js';
+import { auditHostname } from './llmo-utils.js';
 import {
   buildRuleConfig, mergeIntoTree, managedRuleNames, redactSecrets,
 } from './llmo-akamai-utils.js';
@@ -221,7 +222,9 @@ function LlmoAkamaiController(ctx) {
    */
   const papiErrorResponse = (error, action, context, fields = {}) => {
     const message = error?.message || String(error);
-    log.error(auditLine(context, 'papi-call', 'error', { op: action, ...fields, error: message }));
+    log.error(auditLine(context, 'papi-call', 'error', {
+      severity: 'error', op: action, ...fields, error: message,
+    }));
     // Read the status from the "-> <status>:" token the client emits right after the path, not by
     // scanning the whole string: the response body (up to 1000 chars) can itself contain a
     // "-> 404" and mis-map a genuine 5xx. Take the FIRST such token, which is the real status.
@@ -363,7 +366,9 @@ function LlmoAkamaiController(ctx) {
       apiKey = await getLlmoApiKey(site, context);
     } catch (e) {
       log.error(auditLine(context, 'resolve-config', 'metaconfig-failed', {
-        siteId: site.getId(), error: e.message,
+        severity: 'error',
+        siteId: site.getId(),
+        error: e.message,
       }));
       return { error: createResponse({ message: 'Failed to fetch site metaconfig' }, 502) };
     }
@@ -553,8 +558,9 @@ function LlmoAkamaiController(ctx) {
         validated = false;
         warnings = ruleTree.warnings || [];
         log.warn(auditLine(context, 'plan', 'dry-run-failed', {
+          severity: 'error',
           siteId: site.getId(),
-          host: siteHostname(site),
+          host: auditHostname(site),
           propertyId,
           version,
           error: dryRunError.message,
@@ -563,7 +569,7 @@ function LlmoAkamaiController(ctx) {
 
       log.info(auditLine(context, 'plan', 'ok', {
         siteId: site.getId(),
-        host: siteHostname(site),
+        host: auditHostname(site),
         propertyId,
         version,
         validated,
@@ -651,7 +657,7 @@ function LlmoAkamaiController(ctx) {
     }
 
     log.info(auditLine(context, 'deploy', 'started', {
-      siteId, host: siteHostname(site), propertyId,
+      siteId, host: auditHostname(site), propertyId,
     }));
 
     // Hoisted so the catch can report it: createVersion may succeed before a later call throws.
@@ -698,8 +704,9 @@ function LlmoAkamaiController(ctx) {
       const warnings = putResult?.warnings || [];
       if (papiErrors.length > 0) {
         log.error(auditLine(context, 'deploy', 'papi-rejected', {
+          severity: 'error',
           siteId,
-          host: siteHostname(site),
+          host: auditHostname(site),
           propertyId,
           newVersion,
           errorCount: papiErrors.length,
@@ -714,7 +721,7 @@ function LlmoAkamaiController(ctx) {
 
       log.info(auditLine(context, 'deploy', 'deployed', {
         siteId,
-        host: siteHostname(site),
+        host: auditHostname(site),
         propertyId,
         baseVersion,
         newVersion,
@@ -782,7 +789,7 @@ function LlmoAkamaiController(ctx) {
     // an IMS user GUID) — never accepted from the client.
     const notifyEmail = getCallerEmail(context);
     if (!notifyEmail) {
-      log.error(auditLine(context, 'activate', 'no-notify-email', { siteId, propertyId }));
+      log.error(auditLine(context, 'activate', 'no-notify-email', { severity: 'error', siteId, propertyId }));
       return forbidden('Unable to derive a notification email from the authenticated user');
     }
 
@@ -815,13 +822,17 @@ function LlmoAkamaiController(ctx) {
         // PAPI accepted the activation but returned no usable link — surface it rather than
         // reporting success with an empty activationId the UI cannot poll.
         log.error(auditLine(context, 'activate', 'no-activation-link', {
-          siteId, propertyId, version, network,
+          severity: 'error',
+          siteId,
+          propertyId,
+          version,
+          network,
         }));
         return createResponse({ message: 'Akamai returned no activation link' }, 502);
       }
       log.info(auditLine(context, 'activate', 'submitted', {
         siteId,
-        host: siteHostname(site),
+        host: auditHostname(site),
         propertyId,
         version,
         network,
@@ -878,7 +889,12 @@ function LlmoAkamaiController(ctx) {
           // Double failure (activate POST AND the recovery probe both failed) — log at error level
           // for alerting visibility; the caller still gets the sanitized activation error below.
           log.error(auditLine(context, 'activate', 'recover-failed', {
-            siteId, propertyId, version, network, error: recoverErr?.message,
+            severity: 'error',
+            siteId,
+            propertyId,
+            version,
+            network,
+            error: recoverErr?.message,
           }));
         }
       }

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -456,6 +456,12 @@ function LlmoAkamaiController(ctx) {
       // on an empty domain (guarded above), so the catch below is defensive against future client
       // versions. Mutating flows (deploy/activate) disambiguate this via an authenticated probe.
       const properties = await client.findPropertiesByDomain(host);
+      // First call made with the customer's own EdgeGrid credentials, so this is the earliest
+      // server-side evidence that an Akamai onboarding is under way. Everything before it is
+      // client-side only. Alerting keys off this; `plan` is several steps later.
+      log.info(auditLine(context, 'list-properties', 'ok', {
+        siteId: site.getId(), host, count: properties.length,
+      }));
       return ok({ domain: host, properties });
     } catch (e) {
       return papiErrorResponse(e, 'property listing', context, { siteId: site.getId(), host });
@@ -547,12 +553,21 @@ function LlmoAkamaiController(ctx) {
         validated = false;
         warnings = ruleTree.warnings || [];
         log.warn(auditLine(context, 'plan', 'dry-run-failed', {
-          siteId: site.getId(), propertyId, version, error: dryRunError.message,
+          siteId: site.getId(),
+          host: siteHostname(site),
+          propertyId,
+          version,
+          error: dryRunError.message,
         }));
       }
 
       log.info(auditLine(context, 'plan', 'ok', {
-        siteId: site.getId(), propertyId, version, validated, errorCount: errors.length,
+        siteId: site.getId(),
+        host: siteHostname(site),
+        propertyId,
+        version,
+        validated,
+        errorCount: errors.length,
       }));
       return ok({
         propertyId,
@@ -635,7 +650,9 @@ function LlmoAkamaiController(ctx) {
       return cfgError;
     }
 
-    log.info(auditLine(context, 'deploy', 'started', { siteId, propertyId }));
+    log.info(auditLine(context, 'deploy', 'started', {
+      siteId, host: siteHostname(site), propertyId,
+    }));
 
     // Hoisted so the catch can report it: createVersion may succeed before a later call throws.
     let newVersion;
@@ -681,7 +698,11 @@ function LlmoAkamaiController(ctx) {
       const warnings = putResult?.warnings || [];
       if (papiErrors.length > 0) {
         log.error(auditLine(context, 'deploy', 'papi-rejected', {
-          siteId, propertyId, newVersion, errorCount: papiErrors.length,
+          siteId,
+          host: siteHostname(site),
+          propertyId,
+          newVersion,
+          errorCount: papiErrors.length,
         }));
         return createResponse({
           message: 'Akamai rejected the rule tree',
@@ -692,7 +713,12 @@ function LlmoAkamaiController(ctx) {
       }
 
       log.info(auditLine(context, 'deploy', 'deployed', {
-        siteId, propertyId, baseVersion, newVersion, warningCount: warnings.length,
+        siteId,
+        host: siteHostname(site),
+        propertyId,
+        baseVersion,
+        newVersion,
+        warningCount: warnings.length,
       }));
       return ok({
         propertyId,
@@ -794,7 +820,12 @@ function LlmoAkamaiController(ctx) {
         return createResponse({ message: 'Akamai returned no activation link' }, 502);
       }
       log.info(auditLine(context, 'activate', 'submitted', {
-        siteId, propertyId, version, network, activationId,
+        siteId,
+        host: siteHostname(site),
+        propertyId,
+        version,
+        network,
+        activationId,
       }));
       return ok({
         propertyId, version, network, activationId, activationLink,

--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -17,6 +17,7 @@ import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 import TokowakaClient from '@adobe/spacecat-shared-tokowaka-client';
 import CloudflareClient from '@adobe/spacecat-shared-cloudflare-client';
 import AccessControlUtil from '../../support/access-control-util.js';
+import { auditHostname } from './llmo-utils.js';
 import {
   deriveWorkerName, hostInSiteDomain, registrableDomain, routePatternHost, routePatternHostGlob,
   routePatternsOverlap,
@@ -73,18 +74,6 @@ const toWorkerTag = (value) => {
   // Replacement preserves length (every char maps to itself or '_'), so a non-empty input always
   // yields a non-empty tag — no empty-result case to guard here.
   return value.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, CF_TAG_MAX_LEN);
-};
-
-/**
- * Best-effort hostname for audit lines. Returns undefined for a malformed base URL so auditLine
- * simply drops the field — a log line must never be able to fail the request it describes.
- */
-const siteHostname = (site) => {
-  try {
-    return new URL(site.getBaseURL()).hostname;
-  } catch {
-    return undefined;
-  }
 };
 
 /**
@@ -171,7 +160,9 @@ function LlmoCloudflareController(ctx) {
    */
   const cfErrorResponse = (error, action, context, fields = {}) => {
     const message = error?.message || String(error);
-    log.error(auditLine(context, 'cf-call', 'error', { op: action, ...fields, error: message }));
+    log.error(auditLine(context, 'cf-call', 'error', {
+      severity: 'error', op: action, ...fields, error: message,
+    }));
     if (/returned 401\b/.test(message)) {
       return unauthorized('Cloudflare authentication failed');
     }
@@ -249,7 +240,7 @@ function LlmoCloudflareController(ctx) {
       // client-side only and `deploy-worker` is the last step. Onboarding alerts key off this.
       log.info(auditLine(context, auditAction, 'ok', {
         siteId: site.getId(),
-        host: siteHostname(site),
+        host: auditHostname(site),
         count: Array.isArray(listed) ? listed.length : undefined,
       }));
       return ok(listed);
@@ -318,7 +309,7 @@ function LlmoCloudflareController(ctx) {
       // most common Cloudflare onboarding dead end, and invisible without this line.
       log.info(auditLine(context, 'list-zones', 'ok', {
         siteId: site.getId(),
-        host: siteHostname(site),
+        host: auditHostname(site),
         accountId,
         listed: (zones || []).length,
         matched: matching.length,
@@ -399,12 +390,18 @@ function LlmoCloudflareController(ctx) {
       llmoApiKey = await getLlmoApiKey(site, context);
     } catch (e) {
       log.error(auditLine(context, 'deploy-worker', 'metaconfig-failed', {
-        siteId, accountId, scriptName, error: e.message,
+        severity: 'error',
+        siteId,
+        accountId,
+        scriptName,
+        error: e.message,
       }));
       return createResponse({ message: 'Failed to fetch site metaconfig' }, 502);
     }
     if (!hasText(llmoApiKey)) {
-      log.error(auditLine(context, 'deploy-worker', 'no-api-key', { siteId, accountId, scriptName }));
+      log.error(auditLine(context, 'deploy-worker', 'no-api-key', {
+        severity: 'error', siteId, accountId, scriptName,
+      }));
       return internalServerError('LLMO API key not configured for this site');
     }
 
@@ -466,6 +463,7 @@ function LlmoCloudflareController(ctx) {
       // log the partial state explicitly and return a structured response the caller can
       // act on (re-deploy to set the secret).
       log.error(auditLine(context, 'deploy-worker', 'secret-failed', {
+        severity: 'error',
         siteId,
         accountId,
         scriptName,

--- a/src/controllers/llmo/llmo-cloudflare.js
+++ b/src/controllers/llmo/llmo-cloudflare.js
@@ -76,6 +76,18 @@ const toWorkerTag = (value) => {
 };
 
 /**
+ * Best-effort hostname for audit lines. Returns undefined for a malformed base URL so auditLine
+ * simply drops the field — a log line must never be able to fail the request it describes.
+ */
+const siteHostname = (site) => {
+  try {
+    return new URL(site.getBaseURL()).hostname;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * Builds a single greppable audit line for the Cloudflare onboarding operations. Every line
  * carries action, outcome, caller, and requestId so a deploy/route attempt can be correlated
  * end-to-end in Splunk; `fields` adds operation-specific identifiers (siteId, accountId, ...).
@@ -220,17 +232,27 @@ function LlmoCloudflareController(ctx) {
    * Builds a handler for a parameter-less Cloudflare list call (accounts, zones, ...): runs
    * access control + token resolution, invokes `cfClient[method]()`, and maps failures.
    */
-  const cfListProxy = (method, action) => async (context) => {
+  const cfListProxy = (method, action, auditAction) => async (context) => {
     const result = await getSiteAndCheckAccess(context);
     if (result.status) {
       return result;
     }
+    const { site } = result;
     const { client, error } = requireCfClient(context);
     if (error) {
       return error;
     }
     try {
-      return ok(await client[method]());
+      const listed = await client[method]();
+      // Runs with the customer's own Cloudflare API token, so this is the earliest server-side
+      // evidence that a Cloudflare onboarding is under way — every preceding wizard step is
+      // client-side only and `deploy-worker` is the last step. Onboarding alerts key off this.
+      log.info(auditLine(context, auditAction, 'ok', {
+        siteId: site.getId(),
+        host: siteHostname(site),
+        count: Array.isArray(listed) ? listed.length : undefined,
+      }));
+      return ok(listed);
     } catch (e) {
       return cfErrorResponse(e, action, context, { siteId: context.params?.siteId });
     }
@@ -255,7 +277,7 @@ function LlmoCloudflareController(ctx) {
   };
 
   // GET /sites/:siteId/llmo/cdn-onboard/cloudflare/accounts
-  const listAccounts = cfListProxy('listAccounts', 'account listing');
+  const listAccounts = cfListProxy('listAccounts', 'account listing', 'list-accounts');
 
   /**
    * GET /sites/:siteId/llmo/cdn-onboard/cloudflare/zones?accountId=<id>
@@ -292,6 +314,15 @@ function LlmoCloudflareController(ctx) {
       const matching = (zones || []).filter(
         (zone) => hasText(zone?.name) && !!siteApex && registrableDomain(zone.name) === siteApex,
       );
+      // matched=0 with listed>0 means the token works but no zone is on the site's apex — the
+      // most common Cloudflare onboarding dead end, and invisible without this line.
+      log.info(auditLine(context, 'list-zones', 'ok', {
+        siteId: site.getId(),
+        host: siteHostname(site),
+        accountId,
+        listed: (zones || []).length,
+        matched: matching.length,
+      }));
       return ok(matching);
     } catch (e) {
       return cfErrorResponse(e, 'zone listing', context, {

--- a/src/controllers/llmo/llmo-cloudfront.js
+++ b/src/controllers/llmo/llmo-cloudfront.js
@@ -54,6 +54,41 @@ const TARGETED_PATHS_MAX_ENTRY_LENGTH = 256;
 function LlmoCloudFrontController(ctx) {
   const accessControlUtil = AccessControlUtil.fromContext(ctx);
 
+  // Caller identity for audit lines; defaults so the field is always present (mirrors Cloudflare).
+  const getCallerId = (context) => context?.attributes?.authInfo?.getProfile?.()?.email || 'unknown';
+
+  // Best-effort site hostname for audit lines. Never throws: a log line must not be able to fail
+  // the request it describes, and calculateForwardedHost rejects malformed base URLs.
+  const siteHost = (site, log) => {
+    try {
+      return calculateForwardedHost(site?.getBaseURL?.(), log) || undefined;
+    } catch (e) {
+      log?.debug?.(`[cdn-onboard-cloudfront] could not derive host for audit line: ${e.message}`);
+      return undefined;
+    }
+  };
+
+  // Greppable key=value audit line per mutation (started/done/error), correlated by requestId —
+  // same shape as the Cloudflare onboarding controller. Null/empty fields are dropped.
+  const auditLine = (context, action, outcome, fields = {}) => {
+    const entries = {
+      action,
+      outcome,
+      caller: getCallerId(context),
+      requestId: context?.invocation?.id || 'unknown',
+      ...fields,
+    };
+    const fmt = (v) => {
+      const s = String(v);
+      return /\s/.test(s) ? `"${s.replace(/"/g, "'")}"` : s;
+    };
+    const kv = Object.entries(entries)
+      .filter(([, v]) => v !== undefined && v !== null && v !== '')
+      .map(([k, v]) => `${k}=${fmt(v)}`)
+      .join(' ');
+    return `[cdn-onboard-cloudfront] ${kv}`;
+  };
+
   /**
    * POST /sites/{siteId}/llmo/cdn-onboard/cloudfront/bootstrap-url
    * Builds a one-click CloudFormation quick-create URL (with a server-side
@@ -147,7 +182,11 @@ function LlmoCloudFrontController(ctx) {
       Object.entries(params).forEach(([k, v]) => qs.set(`param_${k}`, v));
       const quickCreateUrl = `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/quickcreate?${qs.toString()}`;
 
-      log.info(`[cdn-onboard-cloudfront] Generated bootstrap URL for site ${siteId}, account ${accountId}`);
+      // First step of the CloudFront wizard the customer can reach, so this doubles as the
+      // "onboarding started" signal for alerting — hence caller + host, not just ids.
+      log.info(auditLine(context, 'bootstrap-url', 'generated', {
+        siteId, accountId, host: siteHost(site, log),
+      }));
 
       return ok({
         externalId,
@@ -217,30 +256,6 @@ function LlmoCloudFrontController(ctx) {
       ...assumed,
       cloudFrontClient: new CloudFrontEdgeClient({ credentials: assumed.credentials }),
     };
-  };
-
-  // Caller identity for audit lines; defaults so the field is always present (mirrors Cloudflare).
-  const getCallerId = (context) => context?.attributes?.authInfo?.getProfile?.()?.email || 'unknown';
-
-  // Greppable key=value audit line per mutation (started/done/error), correlated by requestId —
-  // same shape as the Cloudflare onboarding controller. Null/empty fields are dropped.
-  const auditLine = (context, action, outcome, fields = {}) => {
-    const entries = {
-      action,
-      outcome,
-      caller: getCallerId(context),
-      requestId: context?.invocation?.id || 'unknown',
-      ...fields,
-    };
-    const fmt = (v) => {
-      const s = String(v);
-      return /\s/.test(s) ? `"${s.replace(/"/g, "'")}"` : s;
-    };
-    const kv = Object.entries(entries)
-      .filter(([, v]) => v !== undefined && v !== null && v !== '')
-      .map(([k, v]) => `${k}=${fmt(v)}`)
-      .join(' ');
-    return `[cdn-onboard-cloudfront] ${kv}`;
   };
 
   // Surface actionable AWS failures (permissions, preconditions, throttling) as 4xx instead of a
@@ -314,19 +329,24 @@ function LlmoCloudFrontController(ctx) {
     }
 
     try {
-      const { error, externalId } = await gateEdgeOptimizeWizard(siteId, Site, 'connect the CloudFront connector role');
+      const { error, site, externalId } = await gateEdgeOptimizeWizard(siteId, Site, 'connect the CloudFront connector role');
       if (error) {
         return error;
       }
 
       try {
         const { roleArn } = await assumeConnectorRole({ accountId, externalId, roleName });
-        log.info(`[cdn-onboard-cloudfront] Connected site ${siteId} to account ${accountId}`);
+        log.info(auditLine(context, 'connect', 'done', {
+          siteId, accountId, host: siteHost(site, log),
+        }));
         return ok({ connected: true, accountId, roleArn });
       } catch (assumeError) {
         // The role may not exist yet (customer still creating it) or the external ID may not
         // match — surface as not-connected so the wizard can keep polling rather than erroring.
-        log.info(`[cdn-onboard-cloudfront] Role not yet assumable for site ${siteId}: ${assumeError.message}`);
+        // Emitted once per poll, so dedupe by siteId before alerting on it.
+        log.info(auditLine(context, 'connect', 'role-not-assumable', {
+          siteId, accountId, error: assumeError.message,
+        }));
         return ok({ connected: false, reason: cleanupHeaderValue(assumeError.message) });
       }
     } catch (error) {
@@ -901,7 +921,9 @@ function LlmoCloudFrontController(ctx) {
 
       const url = /^https?:\/\//.test(domain) ? domain : `https://${domain}/`;
       const result = await verifyAwsRouting(url);
-      log.info(`[cdn-onboard-cloudfront] Verified routing for site ${siteId}: passed=${result.passed}`);
+      log.info(auditLine(context, 'verify', result.passed ? 'passed' : 'failed', {
+        siteId, accountId, distributionId, host: domain,
+      }));
       return ok(result);
     } catch (error) {
       log.error(`Failed to verify CloudFront routing for site ${siteId}:`, error);
@@ -1072,8 +1094,12 @@ function LlmoCloudFrontController(ctx) {
         accountId: resolvedAccountId,
       });
 
-      log.info(`[cdn-onboard-cloudfront] site ${siteId}: canProceed=${result.canProceed},`
-        + ` steps=${result.steps.map((s) => `${s.key}:${s.action}`).join(',')}`);
+      log.info(auditLine(context, 'plan', result.canProceed ? 'ok' : 'blocked', {
+        siteId,
+        distributionId,
+        host: forwardedHost,
+        steps: result.steps.map((s) => `${s.key}:${s.action}`).join(','),
+      }));
       // targetDomain lets the FE display exactly the host the BE will route to for this site.
       // Loosely coupled: the FE also knows it locally, so this is purely informational.
       return ok({ ...result, targetDomain: forwardedHost });
@@ -1140,7 +1166,7 @@ function LlmoCloudFrontController(ctx) {
         })),
       };
 
-      log.info(`[cdn-onboard-cloudfront] Returned permissions for site ${siteId}`);
+      log.info(auditLine(context, 'permissions', 'returned', { siteId }));
       return ok({ adobeAccount, manifest });
     } catch (error) {
       log.error(`Failed to read the CloudFront connector permissions for site ${siteId}:`, error);

--- a/src/controllers/llmo/llmo-cloudfront.js
+++ b/src/controllers/llmo/llmo-cloudfront.js
@@ -23,6 +23,7 @@ import TokowakaClient, {
   CloudFrontEdgeClient,
 } from '@adobe/spacecat-shared-tokowaka-client';
 import AccessControlUtil from '../../support/access-control-util.js';
+import { auditHostname } from './llmo-utils.js';
 
 // CloudFormation templates use intrinsic-function tags (!Ref/!Sub/!GetAtt/...) that plain YAML
 // rejects. This schema tolerates them (constructing each to its raw value) so the permissions
@@ -56,17 +57,6 @@ function LlmoCloudFrontController(ctx) {
 
   // Caller identity for audit lines; defaults so the field is always present (mirrors Cloudflare).
   const getCallerId = (context) => context?.attributes?.authInfo?.getProfile?.()?.email || 'unknown';
-
-  // Best-effort site hostname for audit lines. Never throws: a log line must not be able to fail
-  // the request it describes, and calculateForwardedHost rejects malformed base URLs.
-  const siteHost = (site, log) => {
-    try {
-      return calculateForwardedHost(site?.getBaseURL?.(), log) || undefined;
-    } catch (e) {
-      log?.debug?.(`[cdn-onboard-cloudfront] could not derive host for audit line: ${e.message}`);
-      return undefined;
-    }
-  };
 
   // Greppable key=value audit line per mutation (started/done/error), correlated by requestId —
   // same shape as the Cloudflare onboarding controller. Null/empty fields are dropped.
@@ -185,7 +175,7 @@ function LlmoCloudFrontController(ctx) {
       // First step of the CloudFront wizard the customer can reach, so this doubles as the
       // "onboarding started" signal for alerting — hence caller + host, not just ids.
       log.info(auditLine(context, 'bootstrap-url', 'generated', {
-        siteId, accountId, host: siteHost(site, log),
+        siteId, accountId, host: auditHostname(site),
       }));
 
       return ok({
@@ -337,7 +327,7 @@ function LlmoCloudFrontController(ctx) {
       try {
         const { roleArn } = await assumeConnectorRole({ accountId, externalId, roleName });
         log.info(auditLine(context, 'connect', 'done', {
-          siteId, accountId, host: siteHost(site, log),
+          siteId, accountId, host: auditHostname(site),
         }));
         return ok({ connected: true, accountId, roleArn });
       } catch (assumeError) {
@@ -590,7 +580,11 @@ function LlmoCloudFrontController(ctx) {
       return ok(result);
     } catch (error) {
       log.error(auditLine(context, 'create-origin', 'error', {
-        siteId, accountId, distributionId, error: error.message,
+        severity: 'error',
+        siteId,
+        accountId,
+        distributionId,
+        error: error.message,
       }));
       return mutationErrorResponse(error, 'Failed to create the Edge Optimize origin, please try again');
     }
@@ -667,7 +661,11 @@ function LlmoCloudFrontController(ctx) {
       return ok(result);
     } catch (error) {
       log.error(auditLine(context, 'create-function', 'error', {
-        siteId, accountId, distributionId, error: error.message,
+        severity: 'error',
+        siteId,
+        accountId,
+        distributionId,
+        error: error.message,
       }));
       return mutationErrorResponse(error, 'Failed to create the CloudFront routing function, please try again');
     }
@@ -718,7 +716,12 @@ function LlmoCloudFrontController(ctx) {
       return ok(result);
     } catch (error) {
       log.error(auditLine(context, 'apply-cache', 'error', {
-        siteId, accountId, distributionId, behavior: pathPattern, error: error.message,
+        severity: 'error',
+        siteId,
+        accountId,
+        distributionId,
+        behavior: pathPattern,
+        error: error.message,
       }));
       return mutationErrorResponse(error, 'Failed to apply CloudFront cache headers, please try again');
     }
@@ -770,7 +773,11 @@ function LlmoCloudFrontController(ctx) {
       return ok(result);
     } catch (error) {
       log.error(auditLine(context, 'create-lambda', 'error', {
-        siteId, accountId, distributionId, error: error.message,
+        severity: 'error',
+        siteId,
+        accountId,
+        distributionId,
+        error: error.message,
       }));
       return mutationErrorResponse(error, 'Failed to create the CloudFront Lambda@Edge function, please try again');
     }
@@ -868,7 +875,12 @@ function LlmoCloudFrontController(ctx) {
       return ok(result);
     } catch (error) {
       log.error(auditLine(context, 'associate', 'error', {
-        siteId, accountId, distributionId, behavior: pathPattern, error: error.message,
+        severity: 'error',
+        siteId,
+        accountId,
+        distributionId,
+        behavior: pathPattern,
+        error: error.message,
       }));
       return mutationErrorResponse(error, 'Failed to associate CloudFront routing, please try again');
     }
@@ -921,8 +933,15 @@ function LlmoCloudFrontController(ctx) {
 
       const url = /^https?:\/\//.test(domain) ? domain : `https://${domain}/`;
       const result = await verifyAwsRouting(url);
+      // `host` is always the site (comparable across providers); `probedHost` is what was actually
+      // hit, which may be a caller override or the distribution's *.cloudfront.net fallback.
       log.info(auditLine(context, 'verify', result.passed ? 'passed' : 'failed', {
-        siteId, accountId, distributionId, host: domain,
+        siteId,
+        accountId,
+        distributionId,
+        host: auditHostname(site),
+        probedHost: domain,
+        severity: result.passed ? undefined : 'error',
       }));
       return ok(result);
     } catch (error) {
@@ -1016,7 +1035,12 @@ function LlmoCloudFrontController(ctx) {
       return ok(result);
     } catch (error) {
       log.error(auditLine(context, 'deploy', 'error', {
-        siteId, accountId, distributionId, behavior, error: error.message,
+        severity: 'error',
+        siteId,
+        accountId,
+        distributionId,
+        behavior,
+        error: error.message,
       }));
       return mutationErrorResponse(error, 'Failed to deploy CloudFront routing, please try again');
     }
@@ -1097,7 +1121,8 @@ function LlmoCloudFrontController(ctx) {
       log.info(auditLine(context, 'plan', result.canProceed ? 'ok' : 'blocked', {
         siteId,
         distributionId,
-        host: forwardedHost,
+        host: auditHostname(site),
+        forwardedHost,
         steps: result.steps.map((s) => `${s.key}:${s.action}`).join(','),
       }));
       // targetDomain lets the FE display exactly the host the BE will route to for this site.

--- a/src/controllers/llmo/llmo-utils.js
+++ b/src/controllers/llmo/llmo-utils.js
@@ -13,6 +13,31 @@
 // LLMO constants
 export const LLMO_SHEETDATA_SOURCE_URL = 'https://main--project-elmo-ui-data--adobe.aem.live';
 
+/**
+ * Canonical site hostname for CDN-onboarding audit lines: a bare, lowercase host with no scheme,
+ * port or trailing dot. Matches the akamai-client `normalizeDomain` semantics.
+ *
+ * Every cdn-onboard controller MUST log `host=` through this, so that one Splunk query matches all
+ * three providers. In particular, do not use `calculateForwardedHost()` for an audit `host`: it
+ * describes the ORIGIN forwarding host and deliberately rewrites a bare apex
+ * (`example.com` -> `www.example.com`), which silently excludes those events from a
+ * `host=example.com` search. Log that value under a distinct key when it is genuinely needed.
+ *
+ * Best-effort: returns undefined for a malformed base URL so the audit line simply drops the
+ * field — a log line must never be able to fail the request it describes.
+ *
+ * @param {object} site - Site entity
+ * @returns {string|undefined} bare lowercase hostname, or undefined when it cannot be derived
+ */
+export const auditHostname = (site) => {
+  try {
+    const { hostname } = new URL(site?.getBaseURL?.());
+    return hostname.toLowerCase().replace(/\.$/, '') || undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 // Supported CDN types. Aligned with auth-service (cdn-logs-infrastructure/common.js).
 export const CDN_TYPES = {
   BYOCDN_FASTLY: 'byocdn-fastly',

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -191,6 +191,14 @@ describe('LlmoAkamaiController', () => {
       expect(mockAkamaiClient.findPropertiesByDomain).to.have.been.calledWith('www.example.com');
     });
 
+    it('emits a list-properties audit line carrying caller and host (onboarding-started signal)', async () => {
+      await controller.listProperties(mockContext);
+      const logged = mockContext.log.info.getCalls().map((c) => c.args[0]).join('\n');
+      expect(logged).to.contain('[llmo-akamai] action=list-properties outcome=ok');
+      expect(logged).to.contain('host=www.example.com');
+      expect(logged).to.contain('caller=');
+    });
+
     it('returns 200 with an empty list when the client finds nothing (it swallows search errors)', async () => {
       // The real findPropertiesByDomain returns [] on bad creds/no match rather than rejecting.
       mockAkamaiClient.findPropertiesByDomain.resolves([]);

--- a/test/controllers/llmo/llmo-cloudflare.test.js
+++ b/test/controllers/llmo/llmo-cloudflare.test.js
@@ -178,6 +178,16 @@ describe('LlmoCloudflareController', () => {
       expect(body).to.deep.equal(accounts);
     });
 
+    it('emits a list-accounts audit line carrying caller and host (onboarding-started signal)', async () => {
+      mockCfClient.listAccounts.resolves([{ id: ACCOUNT_ID, name: 'Test Account' }]);
+
+      await controller.listAccounts(mockContext);
+      const logged = mockContext.log.info.getCalls().map((c) => c.args[0]).join('\n');
+      expect(logged).to.contain('[llmo-cf] action=list-accounts outcome=ok');
+      expect(logged).to.contain('count=1');
+      expect(logged).to.contain('caller=');
+    });
+
     it('returns 400 when CF token is missing', async () => {
       mockContext.pathInfo.headers = {};
       const res = await controller.listAccounts(mockContext);

--- a/test/controllers/llmo/llmo-cloudfront.test.js
+++ b/test/controllers/llmo/llmo-cloudfront.test.js
@@ -344,6 +344,20 @@ describe('LlmoCloudFrontController', () => {
       expect(logged).to.contain('[cdn-onboard-cloudfront] action=bootstrap-url outcome=generated');
       expect(logged).to.contain('accountId=682033462621');
       expect(logged).to.contain('caller=');
+      // host must be the SITE hostname, identical to what the Akamai/Cloudflare controllers log,
+      // so a single `host=` query matches all three. calculateForwardedHost is NOT usable here:
+      // it rewrites a bare apex (example.com -> www.example.com) and would silently exclude
+      // CloudFront rows from that query.
+      expect(logged).to.contain('host=www.example.com');
+    });
+
+    it('logs the site host, not the forwarded host, for a bare apex site', async () => {
+      mockSite.getBaseURL.returns('https://example.com');
+
+      await controller.createBootstrapUrl(bootstrapContext);
+      const logged = bootstrapContext.log.info.getCalls().map((c) => c.args[0]).join('\n');
+      expect(logged).to.contain('host=example.com');
+      expect(logged).to.not.contain('host=www.example.com');
     });
 
     it('returns 400 for an invalid account id', async () => {

--- a/test/controllers/llmo/llmo-cloudfront.test.js
+++ b/test/controllers/llmo/llmo-cloudfront.test.js
@@ -338,6 +338,14 @@ describe('LlmoCloudFrontController', () => {
       expect(getSignedUrlStub.calledOnce).to.equal(true);
     });
 
+    it('emits a bootstrap-url audit line carrying caller and host (onboarding-started signal)', async () => {
+      await controller.createBootstrapUrl(bootstrapContext);
+      const logged = bootstrapContext.log.info.getCalls().map((c) => c.args[0]).join('\n');
+      expect(logged).to.contain('[cdn-onboard-cloudfront] action=bootstrap-url outcome=generated');
+      expect(logged).to.contain('accountId=682033462621');
+      expect(logged).to.contain('caller=');
+    });
+
     it('returns 400 for an invalid account id', async () => {
       const result = await controller.createBootstrapUrl({ ...bootstrapContext, data: { accountId: '123' } });
 


### PR DESCRIPTION
## Why

Onboarding alerting for the CloudFront / Akamai / Cloudflare wizards can't currently answer two basic questions:

1. **Who started this, and for which domain?** The CloudFront lines are free text carrying only ids — no `caller`, no host. The Akamai audit lines have `caller` but no host.
2. **Did anyone start at all?** Every wizard step before Akamai's `plan` and Cloudflare's `deploy-worker` is read-only and logs nothing, so a customer who enters credentials and abandons is completely invisible server-side.

## What

**1. CloudFront free-text logs → `auditLine`**

`bootstrap-url`, `connect`, `verify`, `plan`, `permissions` now use the same greppable `key=value` audit line as the other two controllers, which injects `caller` + `requestId` for free, plus `host`. `getCallerId`/`auditLine` are hoisted above the handlers (`no-use-before-define`).

**2. `host` added to the Akamai audit lines** (`plan`, `deploy`, `activate`). `siteHostname()` already existed; the lines just never carried it.

**3. Earliest-possible "onboarding started" signal for Akamai and Cloudflare**

`listProperties` (Akamai) and `listAccounts` / `listZones` (Cloudflare) are the first calls made with the *customer's own* credentials, so they now emit audit lines. This moves Akamai from "Review step" and Cloudflare from "Deploy step" to the moment credentials are submitted — putting all three providers at comparable depth, which is what makes a cross-provider "started" metric meaningful.

`list-zones` also reports `listed` vs `matched`, surfacing the most common Cloudflare dead end: a valid token with no zone on the site's apex.

### Audit actions added / changed

| Controller | Prefix | Actions |
|---|---|---|
| CloudFront | `[cdn-onboard-cloudfront]` | `bootstrap-url`, `connect`, `verify`, `plan`, `permissions` |
| Akamai | `[llmo-akamai]` | `list-properties` |
| Cloudflare | `[llmo-cf]` | `list-accounts`, `list-zones` |

## ⚠️ Breaking for log consumers

The five CloudFront lines changed shape. Any Splunk search using the old free text must be updated:

```diff
- "[cdn-onboard-cloudfront] Generated bootstrap URL"
+ "[cdn-onboard-cloudfront] action=bootstrap-url"
```

A `[Prod] OAE Cloudfront CDN Onboarding started` alert already exists in `TA-aem_skyline` matching the old string — it needs updating when this deploys, or it goes silent.

## Risk

Logging only — no behaviour or response-shape change. Host derivation is best-effort and never throws, so it cannot fail the request it describes. `connect` now destructures `site` from an existing `gateEdgeOptimizeWizard` return value.

Note `caller` is an IMS user GUID (`GUID@hexOrgId.e`), not an RFC-5322 address — see the comment in `llmo-cloudflare.js`.

## Validation

- `npx eslint src/controllers/llmo/ test/controllers/llmo/llmo-{cloudfront,akamai,cloudflare}.test.js` — clean
- `mocha test/controllers/llmo/*.test.js` — **2139 passing**
- 3 new tests assert each provider's onboarding-started line carries `caller` + `host`/`count`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Piyush Jindal", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```