### PR TITLE
feat(serenity): accept strategy-chat as a Semrush prompt source | LLMO-6670

### DIFF
--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -196,6 +196,7 @@ export const SOURCE_VALUES = Object.freeze([
   'personalized',
   'agentic-traffic',
   'brand-concierge',
+  'strategy-chat',
 ]);
 
 /**

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -2885,6 +2885,12 @@ describe('handlers/prompts.js — per-item source override (LLMO-6556)', () => {
       expect(value.source).to.equal('semrush');
     });
 
+    it('accepts strategy-chat (chat-originated Track prompts)', () => {
+      const { value, reason } = normalizePromptInput({ ...base, source: 'strategy-chat' });
+      expect(reason).to.equal(null);
+      expect(value.source).to.equal('strategy-chat');
+    });
+
     it('rejects an unknown source (closed vocabulary — select, never invent)', () => {
       const { value, reason } = normalizePromptInput({ ...base, source: 'not-a-producer' });
       expect(value).to.equal(null);


### PR DESCRIPTION
## Summary

Adds `'strategy-chat'` to `SOURCE_VALUES` in `src/support/serenity/prompt-tags.js` so the Serenity → Semrush AIO prompt-create path (`POST /v2/orgs/:orgId/brands/:brandId/serenity/prompts`) accepts chat-originated prompts.

Previously, `source` on that path is validated against the closed `SOURCE_VALUES` list (`handlers/prompts.js`, `normalizePromptInput` → 400 on unknown). `strategy-chat` was already permitted on the **v2 Postgres** path (`prompt-sources.js` `TRACKED_PROMPT_SOURCES`) but was missing from the **Serenity** tag-dimension allowlist, so a chat prompt tracked to Semrush was 400-rejected. This aligns the two paths.

`SOURCE_LABEL` auto-derives from `SOURCE_VALUES`, so its exhaustiveness CI gate stays green with no manual label edit.

## Follow-ups (not in this PR)

- **UI wiring (required for any visible effect).** `project-elmo-ui`'s `toSerenityTrackSource()` allowlist (`src/utils/customerConfigurationTableUtils.ts`) still omits `strategy-chat`, so the client omits `source` and the server keeps its `config` default. Until that allowlist is flipped, nothing actually sends `strategy-chat` on the Semrush track path — this backend change unblocks it but is inert on its own.
- **Cross-repo mirror.** `SOURCE_VALUES` mirrors `mysticat-data-service` `scripts/serenity_migration/tags.py` `KNOWN_PROMPT_SOURCES`; that repo should get `strategy-chat` too (handled separately).

## Related issues
https://jira.corp.adobe.com/browse/LLMO-6670

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Char", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```