### PR TITLE
feat(llmo-6844): Make hostname param optional

### DIFF
--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -409,7 +409,7 @@ Only `domain_type='Owned'` rows are kept (client-side — the element has no ser
 
 **`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls`**
 
-Phase 2 of the URL Inspector **"Cited Third Party URLs"** expandable tree: expand a cited domain (from [Cited Domains](#4-list-cited-domains)) → the URLs within it. **Drop-in compatible with the legacy `url-inspector/domain-urls` contract.** Same Semrush element as [Owned URLs](#5-list-owned-urls) (`STATS_PER_URL` 9af5ed83) **minus** the trend element and the Postgres traffic hybrid, filtered to a single domain (required `hostname`) instead of `domain_type='Owned'`.
+Phase 2 of the URL Inspector **"Cited Third Party URLs"** expandable tree: expand a cited domain (from [Cited Domains](#4-list-cited-domains)) → the URLs within it. **Drop-in compatible with the legacy `url-inspector/domain-urls` contract.** Same Semrush element as [Owned URLs](#5-list-owned-urls) (`STATS_PER_URL` 9af5ed83) **minus** the trend element and the Postgres traffic hybrid. When `hostname` is present, results are filtered to that domain after the Semrush response is fetched; when omitted, the endpoint returns all source hosts for the requested page.
 
 ### Parameters
 
@@ -417,7 +417,7 @@ Phase 2 of the URL Inspector **"Cited Third Party URLs"** expandable tree: expan
 |---|---|---|---|
 | `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
 | `brandId` | path | ✅ | SpaceCat brand UUID. Selects the brand's Semrush **sub-workspace** (flat-mode falls back to the org parent). LLMO ReBAC `brand` resource (FACS `llmo/can_view`); requires `brand:read`. `404` if not in the org |
-| `hostname` / `domain` | query | ✅ | The (registered) domain to drill into, as returned by Cited Domains. `400` if missing. Matched host-or-subdomain (see below) |
+| `hostname` / `domain` | query | ❌ | Optional registered domain to drill into, as returned by Cited Domains. Matched host-or-subdomain (see below). When omitted, all source hosts are returned before pagination. |
 | `model` / `platform` | query | ❌ | AI model filter (`model` wins). Default `search-gpt` |
 | `startDate` / `start_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing, malformed, or after `endDate` |
 | `endDate` / `end_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing or malformed |
@@ -437,7 +437,7 @@ Scoped by top-level `project_id` + date + `CBF_model`. The endpoint fans out **p
 
 ### What it returns
 
-The element has **no server-side domain filter** (verified live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq` + `contains`, all return the full project table), so `hostname` is applied **client-side** — the same pattern Owned URLs uses for `domain_type='Owned'`. Cited Domains reports the **registered domain** (e.g. `openai.com`), but `source` hosts are often subdomains (`help.openai.com`), so a row matches when its host **equals `hostname` or is a subdomain of it** (`host === hostname || host.endsWith('.'+hostname)`, `www.`-stripped, lowercased). Exact-host matching would miss most URLs — e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`. An optional `channel` (content-type) filter is then applied client-side on `contentType`. URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full post-filter count. Field mapping:
+The element has **no server-side domain filter** (verified live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq` + `contains`, all return the full project table), so `hostname` is applied **client-side** — the same pattern Owned URLs uses for `domain_type='Owned'`. Cited Domains reports the **registered domain** (e.g. `openai.com`), but `source` hosts are often subdomains (`help.openai.com`), so a row matches when its host **equals `hostname` or is a subdomain of it** (`host === hostname || host.endsWith('.'+hostname)`, `www.`-stripped, lowercased). Exact-host matching would miss most URLs — e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`. When `hostname` is omitted, all source hosts are retained before applying `channel`, sorting, and pagination. An optional `channel` (content-type) filter is then applied client-side on `contentType`. URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full post-filter count. Field mapping:
 
 - **`url`** ← `source`; **`citations`** ← `citations`; **`promptsCited`** ← `prompts_with_citation`
 - **`contentType`** ← `domain_type`

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -4794,7 +4794,9 @@ url-inspector-domain-urls:
     description: |
       Returns paginated URLs within a specific domain. Used as a Phase 2 drilldown
       from the cited-domains view. The underlying RPC does not accept brand, category,
-      or region filters — domain-level drilldown is already scoped by hostname.
+      or region filters — domain-level drilldown is already scoped by hostname when
+      provided. `hostname` is optional: when omitted, URLs across all source hosts
+      for the requested page are returned instead of a single-domain drilldown.
     operationId: getUrlInspectorDomainUrls
     parameters:
       - name: siteId
@@ -4803,8 +4805,8 @@ url-inspector-domain-urls:
         schema: { type: string, format: uuid }
       - name: hostname
         in: query
-        required: true
-        description: Domain hostname to drill into
+        required: false
+        description: Domain hostname to drill into. When omitted, URLs across all source hosts are returned.
         schema:
           type: string
           example: 'competitor.com'

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -1236,10 +1236,10 @@ export default function ElementsController(context, log, env) {
   /**
    * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence
    *     /url-inspector/domain-urls
-   * Phase 2 of the Cited Third-Party tree: expand a cited domain → its URLs.
-   * Same Semrush element as owned-urls (Stats-per-URL 9af5ed83) minus the trend
-   * element and the Postgres traffic hybrid, filtered to a single domain
-   * (required `hostname`) client-side instead of `domain_type='Owned'`.
+    * Phase 2 of the Cited Third-Party tree: expand a cited domain → its URLs.
+    * Same Semrush element as owned-urls (Stats-per-URL 9af5ed83) minus the trend
+    * element and the Postgres traffic hybrid, optionally filtered to a single
+    * domain (`hostname`) client-side instead of `domain_type='Owned'`.
    */
   /* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
   const listDomainUrls = async (ctx) => {
@@ -1273,13 +1273,6 @@ export default function ElementsController(context, log, env) {
         return badRequest(`Date range must not exceed ${MAX_RANGE_DAYS} days`);
       }
 
-      // hostname (aka domain) is the domain to drill into — required (the UI only
-      // calls this after a domain row is expanded).
-      const hostname = query.hostname || query.domain;
-      if (!hasText(hostname)) {
-        return badRequest('hostname is required for domain URL drilldown');
-      }
-
       const service = await buildService(ctx);
 
       const { BrandSemrushProject } = ctx?.dataAccess ?? {};
@@ -1301,9 +1294,11 @@ export default function ElementsController(context, log, env) {
       } else {
         projects = await service.getOwnedUrlProjects(workspaceId, { brandSemrushProjects });
       }
+      const hostname = query.hostname || query.domain;
 
-      // The transform host-filters, sorts by citations desc, and slices client-side
-      // (Semrush has no server-side pagination); totalCount is the full post-filter count.
+      // The transform optionally host-filters, sorts by citations desc, and slices
+      // client-side (Semrush has no server-side pagination); totalCount is the full
+      // post-filter count.
       const result = await service.getDomainUrls(workspaceId, {
         projects,
         hostname,

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -1236,12 +1236,11 @@ export default function ElementsController(context, log, env) {
   /**
    * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence
    *     /url-inspector/domain-urls
-    * Phase 2 of the Cited Third-Party tree: expand a cited domain → its URLs.
-    * Same Semrush element as owned-urls (Stats-per-URL 9af5ed83) minus the trend
-    * element and the Postgres traffic hybrid, optionally filtered to a single
-    * domain (`hostname`) client-side instead of `domain_type='Owned'`.
+   * Phase 2 of the Cited Third-Party tree: expand a cited domain → its URLs.
+   * Same Semrush element as owned-urls (Stats-per-URL 9af5ed83) minus the trend
+   * element and the Postgres traffic hybrid, optionally filtered to a single
+   * domain (`hostname`) client-side instead of `domain_type='Owned'`.
    */
-  /* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
   const listDomainUrls = async (ctx) => {
     try {
       const auth = await authorizeOrg(ctx);
@@ -1294,7 +1293,9 @@ export default function ElementsController(context, log, env) {
       } else {
         projects = await service.getOwnedUrlProjects(workspaceId, { brandSemrushProjects });
       }
-      const hostname = query.hostname || query.domain;
+      // Normalize whitespace-only hostname to "no filter" explicitly at the API
+      // boundary, rather than relying on the transform's downstream `.trim()`.
+      const hostname = (query.hostname || query.domain || '').trim() || undefined;
 
       // The transform optionally host-filters, sorts by citations desc, and slices
       // client-side (Semrush has no server-side pagination); totalCount is the full
@@ -1316,7 +1317,6 @@ export default function ElementsController(context, log, env) {
       return mapError(e, log);
     }
   };
-  /* c8 ignore stop */
 
   /**
    * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/market-tracking-trends

--- a/src/support/elements/definitions/domain-urls.js
+++ b/src/support/elements/definitions/domain-urls.js
@@ -114,20 +114,22 @@ function parsePagination({ page, pageSize } = {}) {
  * `regions`/`categories` are STRINGS here (the legacy contract + the UI `DomainUrlRow`
  * type), NOT arrays like owned-urls.
  *
- * Only rows whose `source` host matches `hostname` (host-or-subdomain, see
- * {@link hostMatches}) are kept. An optional `channel` (content-type) filter is then
- * applied client-side on `contentType` (case-insensitive) — the element has no
- * server-side content-type filter, so this mirrors cited-domains + the legacy RPC's
- * `p_channel`. Semrush has no server-side pagination, so after filtering we sort by
- * citations desc and slice client-side; `totalCount` is the post-filter, pre-slice count.
+ * When `hostname` is supplied, only rows whose `source` host matches it
+ * (host-or-subdomain, see {@link hostMatches}) are kept. When omitted, all source
+ * hosts are kept. An optional `channel` (content-type) filter is then applied
+ * client-side on `contentType` (case-insensitive) — the element has no server-side
+ * content-type filter, so this mirrors cited-domains + the legacy RPC's `p_channel`.
+ * Semrush has no server-side pagination, so after filtering we sort by citations
+ * desc and slice client-side; `totalCount` is the post-filter, pre-slice count.
  *
  * @param {Array<{region?: string, stats: object}>} projectResults
- * @param {object} params - { hostname (required), channel, page, pageSize }.
+ * @param {object} params - { hostname, channel, page, pageSize }.
  * @returns {{ urls: Array<object>, totalCount: number }}
  */
 export function transformDomainUrlsResponse(projectResults = [], params = {}) {
   const { page, pageSize } = parsePagination(params);
-  const hostname = String(params.hostname ?? '').replace(/^www\./, '').toLowerCase();
+  const hostname = String(params.hostname ?? '').trim().replace(/^www\./, '').toLowerCase();
+  const filterByHostname = hostname !== '';
   const channel = typeof params.channel === 'string' ? params.channel.trim() : '';
   const byUrl = new Map();
 
@@ -138,7 +140,7 @@ export function transformDomainUrlsResponse(projectResults = [], params = {}) {
         continue;
       }
       const host = hostOf(row.source);
-      if (!host || !hostMatches(host, hostname)) {
+      if (!host || (filterByHostname && !hostMatches(host, hostname))) {
         // eslint-disable-next-line no-continue
         continue;
       }

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -1701,6 +1701,18 @@ describe('ElementsController', () => {
       const [, params] = serviceStub.getDomainUrls.firstCall.args;
       expect(params.hostname).to.equal('reddit.com');
     });
+
+    it('collapses a whitespace-only hostname to undefined (no filter)', async () => {
+      const ctx = fakeContext({
+        url: domainUrlsUrl('?startDate=2026-07-01&endDate=2026-07-14&hostname=%20%20'),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listDomainUrls(ctx);
+
+      expect(res.status).to.equal(200);
+      const [, params] = serviceStub.getDomainUrls.firstCall.args;
+      expect(params.hostname).to.be.undefined;
+    });
   });
 
   // The 4th URL Inspector KPI card, split out of getUrlInspectorStats — shares

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -220,6 +220,7 @@ describe('ElementsController', () => {
       getWeeks: sinon.stub().resolves(WEEKS_RESULT),
       getBrandPresenceStats: sinon.stub().resolves(STATS_RESULT),
       getUrlInspectorStats: sinon.stub().resolves(URL_INSPECTOR_STATS_RESULT),
+      getDomainUrls: sinon.stub().resolves({ urls: [], totalCount: 0 }),
       getOwnedUrlProjects: sinon.stub().resolves([{ region: 'US', projectId: 'proj-1' }]),
     };
     createElementsServiceStub = sinon.stub().returns(serviceStub);
@@ -1670,6 +1671,35 @@ describe('ElementsController', () => {
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       const res = await ctrl.getUrlInspectorStats(ctx);
       expect(res.status).to.equal(502);
+    });
+  });
+
+  describe('listDomainUrls', () => {
+    const domainUrlsUrl = (qs = '') => `https://api.example.com/v2/orgs/${ORG_ID}`
+      + `/brands/${BRAND_ID}/serenity/brand-presence/url-inspector/domain-urls${qs}`;
+
+    it('allows hostname to be omitted', async () => {
+      const ctx = fakeContext({
+        url: domainUrlsUrl('?startDate=2026-07-01&endDate=2026-07-14'),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listDomainUrls(ctx);
+
+      expect(res.status).to.equal(200);
+      const [, params] = serviceStub.getDomainUrls.firstCall.args;
+      expect(params.hostname).to.be.undefined;
+    });
+
+    it('keeps a single domain query param as a string', async () => {
+      const ctx = fakeContext({
+        url: domainUrlsUrl('?startDate=2026-07-01&endDate=2026-07-14&domain=reddit.com'),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listDomainUrls(ctx);
+
+      expect(res.status).to.equal(200);
+      const [, params] = serviceStub.getDomainUrls.firstCall.args;
+      expect(params.hostname).to.equal('reddit.com');
     });
   });
 

--- a/test/support/elements/definitions/domain-urls.test.js
+++ b/test/support/elements/definitions/domain-urls.test.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  buildDomainUrlsPayload,
+  transformDomainUrlsResponse,
+} from '../../../../src/support/elements/definitions/domain-urls.js';
+import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
+
+function modelFilter(payload) {
+  return payload.filters.advanced.filters.find((filter) => filter.filters?.[0]?.col === 'CBF_model');
+}
+
+describe('domain-urls definitions', () => {
+  describe('buildDomainUrlsPayload', () => {
+    it('defaults the model to DEFAULT_ELEMENT_MODEL when no platform is provided', () => {
+      const payload = buildDomainUrlsPayload();
+
+      expect(modelFilter(payload)).to.deep.equal({
+        op: 'or', filters: [{ op: 'eq', val: DEFAULT_ELEMENT_MODEL, col: 'CBF_model' }],
+      });
+    });
+
+    it('keeps the existing platform translation for non-all values', () => {
+      const payload = buildDomainUrlsPayload({ platform: 'openai' });
+
+      expect(modelFilter(payload).filters[0].val).to.equal('chatgpt-paid');
+    });
+  });
+
+  describe('transformDomainUrlsResponse', () => {
+    it('returns all hostnames sorted by citations when hostname is omitted', () => {
+      const result = transformDomainUrlsResponse([
+        {
+          region: 'US',
+          stats: {
+            blocks: {
+              data: [
+                {
+                  source: 'https://low.example.com/a', citations: 2, prompts_with_citation: 1, domain_type: 'Other',
+                },
+                {
+                  source: 'https://reddit.com/b', citations: 9, prompts_with_citation: 4, domain_type: 'Other',
+                },
+                {
+                  source: 'https://adobe.com/c', citations: 5, prompts_with_citation: 3, domain_type: 'Owned',
+                },
+              ],
+            },
+          },
+        },
+      ], { pageSize: 2 });
+
+      expect(result.totalCount).to.equal(3);
+      expect(result.urls.map((url) => url.url)).to.deep.equal([
+        'https://reddit.com/b',
+        'https://adobe.com/c',
+      ]);
+    });
+
+    it('filters by a single hostname while preserving subdomain matching', () => {
+      const result = transformDomainUrlsResponse([
+        {
+          region: 'US',
+          stats: {
+            blocks: {
+              data: [
+                {
+                  source: 'https://www.reddit.com/a',
+                  citations: 12,
+                  prompts_with_citation: 6,
+                  domain_type: 'Other',
+                },
+                {
+                  source: 'https://help.adobe.com/b',
+                  citations: 10,
+                  prompts_with_citation: 4,
+                  domain_type: 'Owned',
+                },
+                {
+                  source: 'https://example.com/c',
+                  citations: 99,
+                  prompts_with_citation: 8,
+                  domain_type: 'Other',
+                },
+              ],
+            },
+          },
+        },
+      ], { hostname: 'adobe.com' });
+
+      expect(result.totalCount).to.equal(1);
+      expect(result.urls.map((url) => url.url)).to.deep.equal([
+        'https://help.adobe.com/b',
+      ]);
+    });
+  });
+});

--- a/test/support/elements/definitions/domain-urls.test.js
+++ b/test/support/elements/definitions/domain-urls.test.js
@@ -104,5 +104,56 @@ describe('domain-urls definitions', () => {
         'https://help.adobe.com/b',
       ]);
     });
+
+    it('treats a whitespace-only hostname as no filter', () => {
+      const result = transformDomainUrlsResponse([
+        {
+          region: 'US',
+          stats: {
+            blocks: {
+              data: [
+                {
+                  source: 'https://reddit.com/a', citations: 9, prompts_with_citation: 4, domain_type: 'Other',
+                },
+                {
+                  source: 'https://adobe.com/b', citations: 5, prompts_with_citation: 3, domain_type: 'Owned',
+                },
+              ],
+            },
+          },
+        },
+      ], { hostname: '   ' });
+
+      expect(result.totalCount).to.equal(2);
+      expect(result.urls.map((url) => url.url)).to.deep.equal([
+        'https://reddit.com/a',
+        'https://adobe.com/b',
+      ]);
+    });
+
+    it('applies the channel filter on top of the hostname-omitted (all hosts) mode', () => {
+      const result = transformDomainUrlsResponse([
+        {
+          region: 'US',
+          stats: {
+            blocks: {
+              data: [
+                {
+                  source: 'https://reddit.com/a', citations: 9, prompts_with_citation: 4, domain_type: 'Other',
+                },
+                {
+                  source: 'https://adobe.com/b', citations: 5, prompts_with_citation: 3, domain_type: 'Owned',
+                },
+              ],
+            },
+          },
+        },
+      ], { channel: 'Owned' });
+
+      expect(result.totalCount).to.equal(1);
+      expect(result.urls.map((url) => url.url)).to.deep.equal([
+        'https://adobe.com/b',
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [x] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [x] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [x] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues

No related issue.

This PR updates the Serenity `domain-urls` endpoint so `hostname` / `domain` is optional. When it is omitted, the endpoint returns URLs across all source hosts for the requested page, preserving the existing citation-descending ordering and pagination behavior. When `hostname` is provided, the existing host-or-subdomain filtering behavior is unchanged.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Andrei Paraschiv", "Dominique Jäggi", "TB ADBE"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```