### PR TITLE
feat(sites): support field projection on GET /sites/by-tier/:tier

### DIFF
--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -258,6 +258,7 @@ sites-by-tier:
   parameters:
     - $ref: './parameters.yaml#/tier'
     - $ref: './parameters.yaml#/productCodeQuery'
+    - $ref: './parameters.yaml#/fields'
   get:
     tags:
       - site
@@ -267,7 +268,8 @@ sites-by-tier:
       (PAID, FREE_TRIAL, or PLG) and that are enrolled into that entitlement.
       Optionally restrict to a single product via the `productCode` query
       parameter (e.g. LLMO). Results are ordered by site ID. Not paginated -
-      admin-only, bounded use case. Admin-only.
+      admin-only, bounded use case. Supports the `fields` query parameter to
+      project a subset of fields per site. Admin-only.
     operationId: getSitesByEnrollmentAndTier
     responses:
       '200':

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -692,7 +692,8 @@ function SitesController(ctx, log, env) {
    * code via the `productCode` query parameter (e.g. 'LLMO').
    *
    * Returns the full result set (no pagination) - acceptable for a
-   * bounded admin-only use case. Sites are ordered by ID.
+   * bounded admin-only use case. Sites are ordered by ID. Supports the
+   * `fields` query parameter to project a subset of fields per site.
    *
    * @param {object} context - Context of the request.
    * @returns {Promise<Response>} Sites response.
@@ -718,8 +719,14 @@ function SitesController(ctx, log, env) {
     const all = (await Site.allByEnrollmentAndTier(tier, productCode))
       .sort((a, b) => a.getId().localeCompare(b.getId()));
 
+    const sites = all.map((site) => SiteDto.toJSON(site));
+    const { list, error } = applyFieldProjection(sites, context.data?.fields);
+    if (error) {
+      return badRequest(error);
+    }
+
     return ok({
-      sites: all.map((site) => SiteDto.toJSON(site)),
+      sites: list,
     });
   };
 

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1924,6 +1924,32 @@ describe('Sites Controller', () => {
     expect(mockDataAccess.Site.allByEnrollmentAndTier).to.have.not.been.called;
   });
 
+  it('projects sites by enrollment tier when ?fields= is passed', async () => {
+    mockDataAccess.Site.allByEnrollmentAndTier.resolves(sites);
+
+    const result = await sitesController.getAllByEnrollmentAndTier({
+      params: { tier: 'PAID' },
+      data: { fields: 'baseURL' },
+    });
+    const body = await result.json();
+
+    expect(result.status).to.equal(200);
+    expect(Object.keys(body.sites[0]).sort()).to.deep.equal(['baseURL', 'id']);
+  });
+
+  it('returns 400 when ?fields= matches no known field on getAllByEnrollmentAndTier', async () => {
+    mockDataAccess.Site.allByEnrollmentAndTier.resolves(sites);
+
+    const result = await sitesController.getAllByEnrollmentAndTier({
+      params: { tier: 'PAID' },
+      data: { fields: 'nope' },
+    });
+    const error = await result.json();
+
+    expect(result.status).to.equal(400);
+    expect(error).to.have.property('message', 'Invalid fields: nope');
+  });
+
   it('returns bad request if audit type is not provided', async () => {
     const result = await sitesController.getAllWithLatestAudit({ params: {} });
     const error = await result.json();

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -536,6 +536,19 @@ export default function siteTests(getHttpClient, resetData) {
         const res = await http.user.get('/sites/by-tier/PAID?productCode=LLMO');
         expect(res.status).to.equal(403);
       });
+
+      it('admin: projects sites to the requested fields', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites/by-tier/PAID?productCode=LLMO&fields=baseURL');
+        expect(res.status).to.equal(200);
+        expect(Object.keys(res.body.sites[0]).sort()).to.deep.equal(['baseURL', 'id']);
+      });
+
+      it('admin: returns 400 when fields matches no known field', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites/by-tier/PAID?productCode=LLMO&fields=nope');
+        expect(res.status).to.equal(400);
+      });
     });
 
     // ── Write operations ──


### PR DESCRIPTION
## Summary
- Adds `?fields=` sparse-fieldset support to `getAllByEnrollmentAndTier` (`GET /sites/by-tier/:tier`), matching the pattern already used by the other sites list endpoints (`getAllByDeliveryType`, `getAllWithLatestAudit`, baseUrlContains search).
- Updates the OpenAPI spec for the endpoint to document the `fields` param.

## Test plan
- [x] Unit tests added: projects fields correctly, 400 on unknown field (`test/controllers/sites.test.js`)
- [x] Integration tests added covering the same cases (`test/it/shared/tests/sites.js`)
- [x] `npx mocha test/controllers/sites.test.js` — 436 passing (1 pre-existing unrelated flaky timeout)
- [x] `npx eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```