### PR TITLE
feat(sites): allow PRE_ONBOARD tier on GET /sites/by-tier/:tier

### DIFF
--- a/docs/openapi/parameters.yaml
+++ b/docs/openapi/parameters.yaml
@@ -35,7 +35,9 @@ deliveryType:
     $ref: './schemas.yaml#/DeliveryType'
 tier:
   name: tier
-  description: Entitlement tier to filter by
+  description: >-
+    Entitlement tier to filter by. Includes PRE_ONBOARD (internal-only, not
+    customer-visible) since GET /sites/by-tier/{tier} is admin-only.
   in: path
   required: true
   schema:
@@ -44,6 +46,7 @@ tier:
       - PAID
       - FREE_TRIAL
       - PLG
+      - PRE_ONBOARD
 productCodeQuery:
   name: productCode
   description: Optional product code to further filter the result (e.g. LLMO)

--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -265,7 +265,7 @@ sites-by-tier:
     summary: Retrieve all sites enrolled at a given entitlement tier
     description: |
       Returns sites whose organization has an entitlement at the requested tier
-      (PAID, FREE_TRIAL, or PLG) and that are enrolled into that entitlement.
+      (PAID, FREE_TRIAL, PLG, or PRE_ONBOARD) and that are enrolled into that entitlement.
       Optionally restrict to a single product via the `productCode` query
       parameter (e.g. LLMO). Results are ordered by site ID. Not paginated -
       admin-only, bounded use case. Supports the `fields` query parameter to

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -688,8 +688,13 @@ function SitesController(ctx, log, env) {
 
   /**
    * Gets all sites enrolled at a given entitlement tier (e.g. 'PAID',
-   * 'FREE_TRIAL', 'PLG'). Optionally narrows the result to a single product
-   * code via the `productCode` query parameter (e.g. 'LLMO').
+   * 'FREE_TRIAL', 'PLG', 'PRE_ONBOARD'). Optionally narrows the result to a
+   * single product code via the `productCode` query parameter (e.g. 'LLMO').
+   *
+   * Accepts any Entitlement.TIERS value, not just CUSTOMER_VISIBLE_TIERS -
+   * this endpoint is already admin-gated below, so PRE_ONBOARD (internal-only,
+   * not customer-visible) is a legitimate admin query, e.g. to find sites
+   * still awaiting onboarding.
    *
    * Returns the full result set (no pagination) - acceptable for a
    * bounded admin-only use case. Sites are ordered by ID. Supports the
@@ -708,8 +713,9 @@ function SitesController(ctx, log, env) {
     if (!hasText(tier)) {
       return badRequest('Tier required');
     }
-    if (!CUSTOMER_VISIBLE_TIERS.includes(tier)) {
-      return badRequest(`Tier must be one of: ${CUSTOMER_VISIBLE_TIERS.join(', ')}`);
+    const validTiers = Object.values(EntitlementModel.TIERS);
+    if (!validTiers.includes(tier)) {
+      return badRequest(`Tier must be one of: ${validTiers.join(', ')}`);
     }
     const validProductCodes = Object.values(EntitlementModel.PRODUCT_CODES);
     if (productCode !== undefined && !validProductCodes.includes(productCode)) {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1902,14 +1902,28 @@ describe('Sites Controller', () => {
     expect(error).to.have.property('message', 'Tier required');
   });
 
-  it('returns bad request when tier is not customer-visible on getAllByEnrollmentAndTier', async () => {
+  it('returns bad request when tier is not a known Entitlement tier on getAllByEnrollmentAndTier', async () => {
     const result = await sitesController.getAllByEnrollmentAndTier({
-      params: { tier: 'PRE_ONBOARD' },
+      params: { tier: 'NOT_A_TIER' },
     });
     const error = await result.json();
 
     expect(result.status).to.equal(400);
     expect(error.message).to.match(/^Tier must be one of:/);
+  });
+
+  it('allows PRE_ONBOARD (internal-only, not customer-visible) since this endpoint is admin-gated', async () => {
+    mockDataAccess.Site.allByEnrollmentAndTier.resolves(sites);
+
+    const result = await sitesController.getAllByEnrollmentAndTier({
+      params: { tier: 'PRE_ONBOARD' },
+    });
+    const body = await result.json();
+
+    expect(result.status).to.equal(200);
+    expect(mockDataAccess.Site.allByEnrollmentAndTier)
+      .to.have.been.calledOnceWithExactly('PRE_ONBOARD', undefined);
+    expect(body.sites).to.be.an('array').with.lengthOf(2);
   });
 
   it('returns bad request when productCode is invalid on getAllByEnrollmentAndTier', async () => {

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -527,8 +527,15 @@ export default function siteTests(getHttpClient, resetData) {
 
       it('admin: returns 400 for an invalid tier', async () => {
         const http = getHttpClient();
-        const res = await http.admin.get('/sites/by-tier/PRE_ONBOARD?productCode=LLMO');
+        const res = await http.admin.get('/sites/by-tier/NOT_A_TIER?productCode=LLMO');
         expect(res.status).to.equal(400);
+      });
+
+      it('admin: accepts PRE_ONBOARD (internal-only tier, not customer-visible)', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites/by-tier/PRE_ONBOARD?productCode=LLMO');
+        expect(res.status).to.equal(200);
+        expect(res.body.sites).to.be.an('array');
       });
 
       it('user: returns 403', async () => {


### PR DESCRIPTION
## Summary
- `getAllByEnrollmentAndTier` (`GET /sites/by-tier/:tier`) validated `:tier` against `CUSTOMER_VISIBLE_TIERS` (`FREE_TRIAL`, `PAID`, `PLG`), rejecting `PRE_ONBOARD` with 400.
- This endpoint is already admin-gated (`accessControlUtil.hasAdminAccess()`), so restricting it to customer-visible tiers was blocking a legitimate admin use case — finding sites still awaiting onboarding.
- Now validates against all of `Entitlement.TIERS` instead. `CUSTOMER_VISIBLE_TIERS` itself is untouched everywhere else it's used (it still governs actual customer-facing visibility, e.g. in `access-control-util.js`).
- OpenAPI spec (`parameters.yaml`, `sites-api.yaml`) updated to document `PRE_ONBOARD` as a valid `tier` value.

Follow-up to #3017, in support of SITES-49512 (backoffice UI now lets admins filter sites by tier, including PRE_ONBOARD).

## Test plan
- [x] Unit tests: `PRE_ONBOARD` now returns 200 and forwards to `Site.allByEnrollmentAndTier`; a genuinely unknown tier string still returns 400
- [x] Integration test: `GET /sites/by-tier/PRE_ONBOARD` returns 200; `GET /sites/by-tier/NOT_A_TIER` returns 400
- [x] `npx mocha test/controllers/sites.test.js` — 439/440 passing (1 pre-existing unrelated flaky timeout, confirmed present on `main` too)
- [x] `npx eslint` clean on changed files
- [x] `npm run docs:lint` — spec still valid, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```