### PR TITLE
fix(feature-flags): resolve the organization's own flag row independent of the unique key

### DIFF
--- a/src/support/feature-flags-storage.js
+++ b/src/support/feature-flags-storage.js
@@ -40,7 +40,26 @@ export function isValidFeatureFlagName(flagName) {
 }
 
 /**
- * Upserts a boolean feature flag row (org + product + flag_name unique).
+ * The organization's own row, not a brand's override of it. `brand_id` is absent
+ * from every row before the brand-scope migration and NULL on the organization's
+ * row after it, so this selects correctly under both schemas.
+ *
+ * @param {object} row - Raw PostgREST `feature_flags` row.
+ * @returns {boolean} `true` for the organization-level row.
+ */
+const isOrgRow = (row) => (row.brand_id ?? null) === null;
+
+/**
+ * Writes an organization's boolean feature flag, creating the row when it does
+ * not exist yet and updating it in place when it does. A brand's override of the
+ * same flag is left untouched.
+ *
+ * Keyed on the row's primary key rather than a composite `ON CONFLICT` target,
+ * so it does not depend on the shape of the table's unique key. That costs
+ * atomicity: two concurrent creates of the *same* flag leave one hitting the
+ * unique constraint as a retryable duplicate-key error. The write callers are
+ * the admin endpoint, onboarding and mode remediation, which carry essentially
+ * no concurrency.
  *
  * @param {object} params
  * @param {string} params.organizationId - SpaceCat org id (matches mysticat organizations.id)
@@ -63,19 +82,36 @@ export async function upsertFeatureFlag({
     throw new Error('PostgREST client is required for feature flags');
   }
 
-  const row = {
-    organization_id: organizationId,
-    product,
-    flag_name: flagName,
-    flag_value: value,
-    updated_by: updatedBy,
-  };
-
-  const { data, error } = await postgrestClient
+  const { data: existing, error: readError } = await postgrestClient
     .from('feature_flags')
-    .upsert(row, { onConflict: 'organization_id,product,flag_name' })
-    .select()
-    .single();
+    .select('*')
+    .eq('organization_id', organizationId)
+    .eq('product', product)
+    .eq('flag_name', flagName);
+
+  if (readError) {
+    throw new Error(`Failed to upsert feature flag: ${readError.message}`);
+  }
+
+  const current = (existing ?? []).find(isOrgRow);
+  const { data, error } = current
+    ? await postgrestClient
+      .from('feature_flags')
+      .update({ flag_value: value, updated_by: updatedBy })
+      .eq('id', current.id)
+      .select()
+      .single()
+    : await postgrestClient
+      .from('feature_flags')
+      .insert({
+        organization_id: organizationId,
+        product,
+        flag_name: flagName,
+        flag_value: value,
+        updated_by: updatedBy,
+      })
+      .select()
+      .single();
 
   if (error) {
     throw new Error(`Failed to upsert feature flag: ${error.message}`);
@@ -85,7 +121,8 @@ export async function upsertFeatureFlag({
 }
 
 /**
- * Reads a single feature flag value by org, product, and flag name.
+ * Reads an organization's own value for a feature flag, ignoring any brand's
+ * override of it.
  *
  * @param {object} params
  * @param {string} params.organizationId
@@ -106,20 +143,23 @@ export async function readFeatureFlag({
 
   const { data, error } = await postgrestClient
     .from('feature_flags')
-    .select('flag_value')
+    .select('*')
     .eq('organization_id', organizationId)
     .eq('product', product)
-    .eq('flag_name', flagName)
-    .maybeSingle();
+    .eq('flag_name', flagName);
 
   if (error) {
     throw new Error(`Failed to read feature flag ${flagName}: ${error.message}`);
   }
 
-  return typeof data?.flag_value === 'boolean' ? data.flag_value : null;
+  const row = (data ?? []).find(isOrgRow);
+  return typeof row?.flag_value === 'boolean' ? row.flag_value : null;
 }
 
 /**
+ * Lists an organization's own enabled flags for a product. Brand overrides are
+ * excluded, so the endpoint built on this describes the organization's state.
+ *
  * @param {object} params
  * @param {string} params.organizationId
  * @param {'ASO'|'LLMO'} params.product
@@ -147,5 +187,5 @@ export async function listFeatureFlagsByOrgAndProduct({
     throw new Error(`Failed to list feature flags: ${error.message}`);
   }
 
-  return data ?? [];
+  return (data ?? []).filter(isOrgRow);
 }

--- a/src/support/feature-flags-storage.js
+++ b/src/support/feature-flags-storage.js
@@ -44,6 +44,12 @@ export function isValidFeatureFlagName(flagName) {
  * from every row before the brand-scope migration and NULL on the organization's
  * row after it, so this selects correctly under both schemas.
  *
+ * Every query feeding this predicate selects the full row, and must keep doing
+ * so. Naming `brand_id` in a projection fails against the current schema, where
+ * the column does not exist yet; omitting it once it does exist makes every
+ * override row arrive with `brand_id: undefined` and read as the organization's
+ * own. A wildcard projection is the only shape that is correct under both.
+ *
  * @param {object} row - Raw PostgREST `feature_flags` row.
  * @returns {boolean} `true` for the organization-level row.
  */
@@ -82,6 +88,7 @@ export async function upsertFeatureFlag({
     throw new Error('PostgREST client is required for feature flags');
   }
 
+  // Wildcard projection is required — see `isOrgRow`.
   const { data: existing, error: readError } = await postgrestClient
     .from('feature_flags')
     .select('*')
@@ -141,6 +148,7 @@ export async function readFeatureFlag({
     throw new Error('PostgREST client is required for feature flags');
   }
 
+  // Wildcard projection is required — see `isOrgRow`.
   const { data, error } = await postgrestClient
     .from('feature_flags')
     .select('*')
@@ -175,6 +183,7 @@ export async function listFeatureFlagsByOrgAndProduct({
     throw new Error('PostgREST client is required for feature flags');
   }
 
+  // Wildcard projection is required — see `isOrgRow`.
   const { data, error } = await postgrestClient
     .from('feature_flags')
     .select('*')

--- a/test/controllers/feature-flags.test.js
+++ b/test/controllers/feature-flags.test.js
@@ -33,6 +33,24 @@ describe('FeatureFlagsController', () => {
   let mockHasAdmin;
   let baseCtx;
 
+  /**
+   * Wires `postgrestClient.from` for a flag write: the org-row lookup finds
+   * nothing, so the write lands as an insert that resolves to `row`.
+   *
+   * @param {object} row - The row the write returns.
+   * @returns {object} The `insert` stub, for asserting the written payload.
+   */
+  function stubFlagWrite(row) {
+    const eq3 = sandbox.stub().resolves({ data: [], error: null });
+    const eq2 = sandbox.stub().returns({ eq: eq3 });
+    const eq1 = sandbox.stub().returns({ eq: eq2 });
+    const select = sandbox.stub().returns({ eq: eq1 });
+    const single = sandbox.stub().resolves({ data: row, error: null });
+    const insert = sandbox.stub().returns({ select: sandbox.stub().returns({ single }) });
+    mockDataAccess.services.postgrestClient.from = sandbox.stub().returns({ select, insert });
+    return insert;
+  }
+
   beforeEach(() => {
     sandbox.restore();
 
@@ -281,10 +299,7 @@ describe('FeatureFlagsController', () => {
         updated_at: 'u',
         updated_by: 'user-1',
       };
-      const singleStub = sandbox.stub().resolves({ data: cleanRow, error: null });
-      const selectStub = sandbox.stub().returns({ single: singleStub });
-      const upsertStub = sandbox.stub().returns({ select: selectStub });
-      mockDataAccess.services.postgrestClient.from = sandbox.stub().returns({ upsert: upsertStub });
+      const insertStub = stubFlagWrite(cleanRow);
 
       const res = await controller.putByOrganizationProductAndName({
         ...baseCtx,
@@ -294,7 +309,7 @@ describe('FeatureFlagsController', () => {
       expect(res.status).to.equal(200);
       const body = await res.json();
       expect(body.flagValue).to.equal(true);
-      expect(upsertStub.firstCall.args[0]).to.deep.include({
+      expect(insertStub.firstCall.args[0]).to.deep.include({
         flag_name: 'beta',
         flag_value: true,
         updated_by: 'user-1',
@@ -331,17 +346,14 @@ describe('FeatureFlagsController', () => {
         updated_at: 'u',
         updated_by: 'sub-9',
       };
-      const singleStub = sandbox.stub().resolves({ data: cleanRow, error: null });
-      const selectStub = sandbox.stub().returns({ single: singleStub });
-      const upsertStub = sandbox.stub().returns({ select: selectStub });
-      mockDataAccess.services.postgrestClient.from = sandbox.stub().returns({ upsert: upsertStub });
+      const insertStub = stubFlagWrite(cleanRow);
       mockDataAccess.Organization.findById = sandbox.stub().resolves(mockOrganization);
 
       await controller.putByOrganizationProductAndName({
         ...baseCtx,
         params: { organizationId, product: 'LLMO', flagName: 'gamma' },
       });
-      expect(upsertStub.firstCall.args[0].updated_by).to.equal('sub-9');
+      expect(insertStub.firstCall.args[0].updated_by).to.equal('sub-9');
     });
 
     it('reads profile from authInfo.profile when getProfile is absent', async () => {
@@ -371,17 +383,14 @@ describe('FeatureFlagsController', () => {
         updated_at: 'u',
         updated_by: 'plain-profile',
       };
-      const singleStub = sandbox.stub().resolves({ data: cleanRow, error: null });
-      const selectStub = sandbox.stub().returns({ single: singleStub });
-      const upsertStub = sandbox.stub().returns({ select: selectStub });
-      mockDataAccess.services.postgrestClient.from = sandbox.stub().returns({ upsert: upsertStub });
+      const insertStub = stubFlagWrite(cleanRow);
       mockDataAccess.Organization.findById = sandbox.stub().resolves(mockOrganization);
 
       await controller.putByOrganizationProductAndName({
         ...baseCtx,
         params: { organizationId, product: 'LLMO', flagName: 'eta' },
       });
-      expect(upsertStub.firstCall.args[0].updated_by).to.equal('plain-profile');
+      expect(insertStub.firstCall.args[0].updated_by).to.equal('plain-profile');
     });
 
     it('uses service fallback for updatedBy when profile has no ids', async () => {
@@ -414,17 +423,14 @@ describe('FeatureFlagsController', () => {
         updated_at: 'u',
         updated_by: 'spacecat-api-service',
       };
-      const singleStub = sandbox.stub().resolves({ data: cleanRow, error: null });
-      const selectStub = sandbox.stub().returns({ single: singleStub });
-      const upsertStub = sandbox.stub().returns({ select: selectStub });
-      mockDataAccess.services.postgrestClient.from = sandbox.stub().returns({ upsert: upsertStub });
+      const insertStub = stubFlagWrite(cleanRow);
       mockDataAccess.Organization.findById = sandbox.stub().resolves(mockOrganization);
 
       await controller.putByOrganizationProductAndName({
         ...baseCtx,
         params: { organizationId, product: 'LLMO', flagName: 'delta' },
       });
-      expect(upsertStub.firstCall.args[0].updated_by).to.equal('spacecat-api-service');
+      expect(insertStub.firstCall.args[0].updated_by).to.equal('spacecat-api-service');
     });
 
     it('returns 500 when upsert throws', async () => {
@@ -458,10 +464,7 @@ describe('FeatureFlagsController', () => {
         updated_at: 'u',
         updated_by: 'user-1',
       };
-      const singleStub = sandbox.stub().resolves({ data: cleanRow, error: null });
-      const selectStub = sandbox.stub().returns({ single: singleStub });
-      const upsertStub = sandbox.stub().returns({ select: selectStub });
-      mockDataAccess.services.postgrestClient.from = sandbox.stub().returns({ upsert: upsertStub });
+      const insertStub = stubFlagWrite(cleanRow);
 
       const res = await controller.deleteByOrganizationProductAndName({
         ...baseCtx,
@@ -471,7 +474,7 @@ describe('FeatureFlagsController', () => {
       expect(res.status).to.equal(200);
       const body = await res.json();
       expect(body.flagValue).to.equal(false);
-      expect(upsertStub.firstCall.args[0].flag_value).to.equal(false);
+      expect(insertStub.firstCall.args[0].flag_value).to.equal(false);
     });
 
     it('returns 500 when upsert throws', async () => {

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -58,17 +58,20 @@ describe('LLMO Onboarding Functions', () => {
 
     // Default feature_flags stub so all v2-path tests get a working postgrestClient.
     // Individual tests can override with .withArgs('feature_flags') for specific assertions.
-    const defaultUpsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
-    const defaultUpsertSelect = sinon.stub().returns({ single: defaultUpsertSingle });
-    const defaultUpsert = sinon.stub().returns({ select: defaultUpsertSelect });
-    const defaultMaybeSingle = sinon.stub().resolves({ data: null, error: null });
-    const defaultEq3 = sinon.stub().returns({ maybeSingle: defaultMaybeSingle });
+    const defaultWriteSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+    const defaultWriteSelect = sinon.stub().returns({ single: defaultWriteSingle });
+    const defaultInsert = sinon.stub().returns({ select: defaultWriteSelect });
+    const defaultUpdate = sinon.stub().returns({
+      eq: sinon.stub().returns({ select: defaultWriteSelect }),
+    });
+    const defaultEq3 = sinon.stub().resolves({ data: [], error: null });
     const defaultEq2 = sinon.stub().returns({ eq: defaultEq3 });
     const defaultEq1 = sinon.stub().returns({ eq: defaultEq2 });
     const defaultSelect = sinon.stub().returns({ eq: defaultEq1 });
     mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
       select: defaultSelect,
-      upsert: defaultUpsert,
+      insert: defaultInsert,
+      update: defaultUpdate,
     });
 
     // Default brands lookup (LLMO-5556 collision check) — no existing brand,
@@ -1558,8 +1561,7 @@ describe('LLMO Onboarding Functions', () => {
       mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
 
       // feature_flags: read (mode resolution) + upsert (brandalf enable) tracking
-      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const selectRead = sinon.stub().returns({ eq: eqOrg });
@@ -1568,7 +1570,7 @@ describe('LLMO Onboarding Functions', () => {
       const upsertStub = sinon.stub().returns({ select: upsertSelect });
       mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
         select: selectRead,
-        upsert: upsertStub,
+        insert: upsertStub,
       });
 
       const mockConfig = createMockConfig();
@@ -1875,8 +1877,7 @@ describe('LLMO Onboarding Functions', () => {
 
       // Stub postgrestClient for feature flag read (resolveLlmoOnboardingMode)
       // and upsert (enabling brandalf during v2 onboarding)
-      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const selectRead = sinon.stub().returns({ eq: eqOrg });
@@ -1890,7 +1891,7 @@ describe('LLMO Onboarding Functions', () => {
       const upsertStub = sinon.stub().returns({ select: upsertSelect });
       mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
         select: selectRead,
-        upsert: upsertStub,
+        insert: upsertStub,
       });
 
       // Use helper functions for common mocks
@@ -2107,8 +2108,7 @@ describe('LLMO Onboarding Functions', () => {
       mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
 
       // Feature flag postgrest mock
-      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const selectRead = sinon.stub().returns({ eq: eqOrg });
@@ -2117,7 +2117,7 @@ describe('LLMO Onboarding Functions', () => {
       const upsertStub = sinon.stub().returns({ select: upsertSelect });
       mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
         select: selectRead,
-        upsert: upsertStub,
+        insert: upsertStub,
       });
 
       // upsertBrand throws — should not block onboarding
@@ -2213,8 +2213,7 @@ describe('LLMO Onboarding Functions', () => {
       mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
 
       // Feature flag postgrest mock
-      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const selectRead = sinon.stub().returns({ eq: eqOrg });
@@ -2223,7 +2222,7 @@ describe('LLMO Onboarding Functions', () => {
       const upsertStub = sinon.stub().returns({ select: upsertSelect });
       mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
         select: selectRead,
-        upsert: upsertStub,
+        insert: upsertStub,
       });
 
       // Existing brand with the same name already points at a DIFFERENT site.
@@ -2320,8 +2319,7 @@ describe('LLMO Onboarding Functions', () => {
       mockDataAccess.Site.create.resolves(mockSite);
       mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
 
-      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const selectRead = sinon.stub().returns({ eq: eqOrg });
@@ -2330,7 +2328,7 @@ describe('LLMO Onboarding Functions', () => {
       const upsertStub = sinon.stub().returns({ select: upsertSelect });
       mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
         select: selectRead,
-        upsert: upsertStub,
+        insert: upsertStub,
       });
 
       // Brand lookup returns a PostgREST error (does not throw).
@@ -2425,8 +2423,7 @@ describe('LLMO Onboarding Functions', () => {
       mockDataAccess.Site.create.resolves(mockSite);
       mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
 
-      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const selectRead = sinon.stub().returns({ eq: eqOrg });
@@ -2435,7 +2432,7 @@ describe('LLMO Onboarding Functions', () => {
       const upsertStub = sinon.stub().returns({ select: upsertSelect });
       mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
         select: selectRead,
-        upsert: upsertStub,
+        insert: upsertStub,
       });
 
       // Existing brand exists by name but has no primary site (site_id null) —
@@ -2529,8 +2526,7 @@ describe('LLMO Onboarding Functions', () => {
       mockDataAccess.Site.create.resolves(mockSite);
       mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
 
-      const maybeSingle = sinon.stub().resolves({ data: null, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const selectRead = sinon.stub().returns({ eq: eqOrg });
@@ -2539,7 +2535,7 @@ describe('LLMO Onboarding Functions', () => {
       const upsertStub = sinon.stub().returns({ select: upsertSelect });
       mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
         select: selectRead,
-        upsert: upsertStub,
+        insert: upsertStub,
       });
 
       // Existing brand already points at THIS site (same-site re-onboard) — no
@@ -2630,15 +2626,23 @@ describe('LLMO Onboarding Functions', () => {
         getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
       };
 
-      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      // The org already carries the brandalf row, so the flag write updates it.
+      const eqFlag = sinon.stub().resolves({
+        data: [{ id: 'flag-row-1', flag_value: true }],
+        error: null,
+      });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const select = sinon.stub().returns({ eq: eqOrg });
       const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
       const upsertSelect = sinon.stub().returns({ single: upsertSingle });
-      const upsertStub = sinon.stub().returns({ select: upsertSelect });
-      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({ select, upsert: upsertStub });
+      const upsertStub = sinon.stub().returns({
+        eq: sinon.stub().returns({ select: upsertSelect }),
+      });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select,
+        update: upsertStub,
+      });
 
       mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
       mockDataAccess.Site.findByBaseURL.resolves(null);
@@ -2721,15 +2725,23 @@ describe('LLMO Onboarding Functions', () => {
         getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
       };
 
-      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      // The org already carries the brandalf row, so the flag write updates it.
+      const eqFlag = sinon.stub().resolves({
+        data: [{ id: 'flag-row-1', flag_value: true }],
+        error: null,
+      });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const select = sinon.stub().returns({ eq: eqOrg });
       const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
       const upsertSelect = sinon.stub().returns({ single: upsertSingle });
-      const upsertStub = sinon.stub().returns({ select: upsertSelect });
-      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({ select, upsert: upsertStub });
+      const upsertStub = sinon.stub().returns({
+        eq: sinon.stub().returns({ select: upsertSelect }),
+      });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select,
+        update: upsertStub,
+      });
 
       mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
       mockDataAccess.Site.findByBaseURL.resolves(null);
@@ -2811,15 +2823,23 @@ describe('LLMO Onboarding Functions', () => {
         getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
       };
 
-      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
-      const eqFlag = sinon.stub().returns({ maybeSingle });
+      // The org already carries the brandalf row, so the flag write updates it.
+      const eqFlag = sinon.stub().resolves({
+        data: [{ id: 'flag-row-1', flag_value: true }],
+        error: null,
+      });
       const eqProduct = sinon.stub().returns({ eq: eqFlag });
       const eqOrg = sinon.stub().returns({ eq: eqProduct });
       const select = sinon.stub().returns({ eq: eqOrg });
       const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
       const upsertSelect = sinon.stub().returns({ single: upsertSingle });
-      const upsertStub = sinon.stub().returns({ select: upsertSelect });
-      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({ select, upsert: upsertStub });
+      const upsertStub = sinon.stub().returns({
+        eq: sinon.stub().returns({ select: upsertSelect }),
+      });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select,
+        update: upsertStub,
+      });
 
       mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
       mockDataAccess.Site.findByBaseURL.resolves(null);

--- a/test/it/shared/tests/brand-for-org-site.js
+++ b/test/it/shared/tests/brand-for-org-site.js
@@ -23,6 +23,7 @@ import {
   NON_EXISTENT_ORG_ID,
   NON_EXISTENT_SITE_ID,
 } from '../seed-ids.js';
+import { upsertFeatureFlag } from '../../../../src/support/feature-flags-storage.js';
 
 /**
  * Integration tests for the LLMO-4716 (org, site) → brand resolver endpoint.
@@ -49,24 +50,23 @@ import {
 export default function brandForOrgSiteTests(getHttpClient, resetData, getPostgrestClient) {
   describe('GET /v2/orgs/:spaceCatId/sites/:siteId/brand (LLMO-4716)', () => {
     /**
-     * Sets a feature flag for the given org. Used to set brandalf=true (the
-     * primary gate) and brandalf_migration=true (the dual-publish window
-     * Adobe is in today).
+     * Sets an org-level feature flag for the given org. Used to set
+     * brandalf=true (the primary gate) and brandalf_migration=true (the
+     * dual-publish window Adobe is in today).
+     *
+     * Goes through the production storage helper rather than its own PostgREST
+     * write, so the setup path stays valid under whatever shape the table's
+     * unique key has.
      */
     async function setFlag(orgId, flagName, value) {
-      const pg = getPostgrestClient();
-      const { error } = await pg
-        .from('feature_flags')
-        .upsert({
-          organization_id: orgId,
-          product: 'LLMO',
-          flag_name: flagName,
-          flag_value: value,
-          updated_by: 'it-setup',
-        }, { onConflict: 'organization_id,product,flag_name' });
-      if (error) {
-        throw new Error(`Failed to set ${flagName} flag: ${error.message}`);
-      }
+      await upsertFeatureFlag({
+        organizationId: orgId,
+        product: 'LLMO',
+        flagName,
+        value,
+        updatedBy: 'it-setup',
+        postgrestClient: getPostgrestClient(),
+      });
     }
 
     const setBrandalfTrue = (orgId) => setFlag(orgId, 'brandalf', true);

--- a/test/support/feature-flags-storage.test.js
+++ b/test/support/feature-flags-storage.test.js
@@ -28,6 +28,21 @@ use(sinonChai);
 describe('feature-flags-storage', () => {
   const sandbox = sinon.createSandbox();
   const ORG = '123e4567-e89b-42d3-a456-426614174000';
+  const BRAND = '223e4567-e89b-42d3-a456-426614174001';
+
+  /**
+   * Builds a `from('feature_flags').select().eq().eq().eq()` chain that resolves
+   * to the given PostgREST result — the shape every org-row lookup uses.
+   */
+  function makeSelectChain(result) {
+    const eq3 = sandbox.stub().resolves(result);
+    const eq2 = sandbox.stub().returns({ eq: eq3 });
+    const eq1 = sandbox.stub().returns({ eq: eq2 });
+    const select = sandbox.stub().returns({ eq: eq1 });
+    return {
+      select, eq1, eq2, eq3,
+    };
+  }
 
   afterEach(() => sandbox.restore());
 
@@ -64,6 +79,40 @@ describe('feature-flags-storage', () => {
   });
 
   describe('upsertFeatureFlag', () => {
+    const WRITTEN_ROW = {
+      id: 'id-1',
+      organization_id: ORG,
+      product: 'LLMO',
+      flag_name: 'beta',
+      flag_value: true,
+      created_at: 't0',
+      updated_at: 't1',
+      updated_by: 'admin',
+    };
+
+    /**
+     * Wires the read-then-write chain: the org-row lookup resolves to
+     * `existingRows`, and whichever write branch runs resolves to `WRITTEN_ROW`.
+     */
+    function makeClient(existingRows, { readError = null, writeError = null } = {}) {
+      const read = makeSelectChain({
+        data: readError ? null : existingRows,
+        error: readError,
+      });
+      const single = sandbox.stub().resolves({
+        data: writeError ? null : WRITTEN_ROW,
+        error: writeError,
+      });
+      const writeSelect = sandbox.stub().returns({ single });
+      const updateEq = sandbox.stub().returns({ select: writeSelect });
+      const update = sandbox.stub().returns({ eq: updateEq });
+      const insert = sandbox.stub().returns({ select: writeSelect });
+      const from = sandbox.stub().returns({ select: read.select, update, insert });
+      return {
+        client: { from }, from, read, update, updateEq, insert,
+      };
+    }
+
     it('throws when postgrest client missing', async () => {
       await expect(
         upsertFeatureFlag({
@@ -77,21 +126,10 @@ describe('feature-flags-storage', () => {
       ).to.be.rejectedWith('PostgREST client is required');
     });
 
-    it('upserts and returns row', async () => {
-      const row = {
-        id: 'id-1',
-        organization_id: ORG,
-        product: 'LLMO',
-        flag_name: 'beta',
-        flag_value: true,
-        created_at: 't0',
-        updated_at: 't1',
-        updated_by: 'admin',
-      };
-      const singleStub = sandbox.stub().resolves({ data: row, error: null });
-      const selectStub = sandbox.stub().returns({ single: singleStub });
-      const upsertStub = sandbox.stub().returns({ select: selectStub });
-      const fromStub = sandbox.stub().returns({ upsert: upsertStub });
+    it('inserts and returns the row when the org has no row yet', async () => {
+      const {
+        client, from, read, insert, update,
+      } = makeClient([]);
 
       const out = await upsertFeatureFlag({
         organizationId: ORG,
@@ -99,28 +137,118 @@ describe('feature-flags-storage', () => {
         flagName: 'beta',
         value: true,
         updatedBy: 'admin',
-        postgrestClient: { from: fromStub },
+        postgrestClient: client,
       });
 
-      expect(fromStub).to.have.been.calledWith('feature_flags');
-      expect(upsertStub.firstCall.args[0]).to.deep.include({
+      expect(from).to.have.been.calledWith('feature_flags');
+      expect(read.select).to.have.been.calledWith('*');
+      expect(read.eq1).to.have.been.calledWith('organization_id', ORG);
+      expect(read.eq2).to.have.been.calledWith('product', 'LLMO');
+      expect(read.eq3).to.have.been.calledWith('flag_name', 'beta');
+      expect(insert.firstCall.args[0]).to.deep.equal({
         organization_id: ORG,
         product: 'LLMO',
         flag_name: 'beta',
         flag_value: true,
         updated_by: 'admin',
       });
-      expect(upsertStub.firstCall.args[1]).to.deep.equal({
-        onConflict: 'organization_id,product,flag_name',
+      expect(update).to.not.have.been.called;
+      expect(out).to.deep.equal(WRITTEN_ROW);
+    });
+
+    it('treats a null read payload as no existing row', async () => {
+      const { client, insert } = makeClient(null);
+
+      await upsertFeatureFlag({
+        organizationId: ORG,
+        product: 'LLMO',
+        flagName: 'beta',
+        value: true,
+        updatedBy: 'admin',
+        postgrestClient: client,
       });
-      expect(out).to.deep.equal(row);
+
+      expect(insert).to.have.been.calledOnce;
+    });
+
+    it('updates the existing org row in place, keyed on its id', async () => {
+      const {
+        client, update, updateEq, insert,
+      } = makeClient([{ id: 'row-org', flag_value: false }]);
+
+      const out = await upsertFeatureFlag({
+        organizationId: ORG,
+        product: 'LLMO',
+        flagName: 'beta',
+        value: true,
+        updatedBy: 'admin',
+        postgrestClient: client,
+      });
+
+      expect(update).to.have.been.calledOnceWith({
+        flag_value: true,
+        updated_by: 'admin',
+      });
+      expect(updateEq).to.have.been.calledOnceWith('id', 'row-org');
+      expect(insert).to.not.have.been.called;
+      expect(out).to.deep.equal(WRITTEN_ROW);
+    });
+
+    // A brand's override is a separate row for the same (org, product,
+    // flag_name). Writing the org's value must never retarget it.
+    it('inserts the org row when only a brand override exists', async () => {
+      const { client, insert, update } = makeClient([
+        { id: 'row-brand', brand_id: BRAND, flag_value: true },
+      ]);
+
+      await upsertFeatureFlag({
+        organizationId: ORG,
+        product: 'LLMO',
+        flagName: 'beta',
+        value: true,
+        updatedBy: 'admin',
+        postgrestClient: client,
+      });
+
+      expect(insert).to.have.been.calledOnce;
+      expect(update).to.not.have.been.called;
+    });
+
+    it('updates the org row and not the brand override when both exist', async () => {
+      const { client, updateEq } = makeClient([
+        { id: 'row-brand', brand_id: BRAND, flag_value: true },
+        { id: 'row-org', brand_id: null, flag_value: false },
+      ]);
+
+      await upsertFeatureFlag({
+        organizationId: ORG,
+        product: 'LLMO',
+        flagName: 'beta',
+        value: true,
+        updatedBy: 'admin',
+        postgrestClient: client,
+      });
+
+      expect(updateEq).to.have.been.calledOnceWith('id', 'row-org');
+    });
+
+    it('throws when the org-row lookup fails', async () => {
+      const { client } = makeClient([], { readError: { message: 'read boom' } });
+
+      await expect(
+        upsertFeatureFlag({
+          organizationId: ORG,
+          product: 'LLMO',
+          flagName: 'beta',
+          value: true,
+          updatedBy: 'admin',
+          postgrestClient: client,
+        }),
+      ).to.be.rejectedWith('Failed to upsert feature flag: read boom');
     });
 
     it('throws on postgrest error', async () => {
-      const singleStub = sandbox.stub().resolves({ data: null, error: { message: 'nope' } });
-      const selectStub = sandbox.stub().returns({ single: singleStub });
-      const upsertStub = sandbox.stub().returns({ select: selectStub });
-      const fromStub = sandbox.stub().returns({ upsert: upsertStub });
+      const { client } = makeClient([], { writeError: { message: 'nope' } });
 
       await expect(
         upsertFeatureFlag({
@@ -129,116 +257,92 @@ describe('feature-flags-storage', () => {
           flagName: 'beta',
           value: false,
           updatedBy: 'admin',
-          postgrestClient: { from: fromStub },
+          postgrestClient: client,
         }),
-      ).to.be.rejectedWith('Failed to upsert feature flag');
+      ).to.be.rejectedWith('Failed to upsert feature flag: nope');
     });
   });
 
   describe('readFeatureFlag', () => {
+    /**
+     * @param {object} result - PostgREST result the org-row lookup resolves to.
+     * @returns {object} `{ client, read }` for assertions on the query chain.
+     */
+    function makeClient(result) {
+      const read = makeSelectChain(result);
+      const from = sandbox.stub().returns({ select: read.select });
+      return { client: { from }, from, read };
+    }
+
+    const read = (postgrestClient) => readFeatureFlag({
+      organizationId: ORG,
+      product: 'LLMO',
+      flagName: 'brandalf',
+      postgrestClient,
+    });
+
     it('throws when client missing', async () => {
-      await expect(
-        readFeatureFlag({
-          organizationId: ORG,
-          product: 'LLMO',
-          flagName: 'brandalf',
-          postgrestClient: null,
-        }),
-      ).to.be.rejectedWith('PostgREST client is required');
+      await expect(read(null)).to.be.rejectedWith('PostgREST client is required');
     });
 
     it('returns boolean true when flag is true', async () => {
-      const maybeSingle = sandbox.stub().resolves({ data: { flag_value: true }, error: null });
-      const eq3 = sandbox.stub().returns({ maybeSingle });
-      const eq2 = sandbox.stub().returns({ eq: eq3 });
-      const eq1 = sandbox.stub().returns({ eq: eq2 });
-      const selectStub = sandbox.stub().returns({ eq: eq1 });
-      const fromStub = sandbox.stub().returns({ select: selectStub });
-
-      const result = await readFeatureFlag({
-        organizationId: ORG,
-        product: 'LLMO',
-        flagName: 'brandalf',
-        postgrestClient: { from: fromStub },
+      const { client, from, read: chain } = makeClient({
+        data: [{ flag_value: true }],
+        error: null,
       });
 
-      expect(result).to.equal(true);
-      expect(fromStub).to.have.been.calledWith('feature_flags');
-      expect(eq1).to.have.been.calledWith('organization_id', ORG);
-      expect(eq2).to.have.been.calledWith('product', 'LLMO');
-      expect(eq3).to.have.been.calledWith('flag_name', 'brandalf');
+      expect(await read(client)).to.equal(true);
+      expect(from).to.have.been.calledWith('feature_flags');
+      expect(chain.select).to.have.been.calledWith('*');
+      expect(chain.eq1).to.have.been.calledWith('organization_id', ORG);
+      expect(chain.eq2).to.have.been.calledWith('product', 'LLMO');
+      expect(chain.eq3).to.have.been.calledWith('flag_name', 'brandalf');
     });
 
     it('returns boolean false when flag is false', async () => {
-      const maybeSingle = sandbox.stub().resolves({ data: { flag_value: false }, error: null });
-      const eq3 = sandbox.stub().returns({ maybeSingle });
-      const eq2 = sandbox.stub().returns({ eq: eq3 });
-      const eq1 = sandbox.stub().returns({ eq: eq2 });
-      const selectStub = sandbox.stub().returns({ eq: eq1 });
-      const fromStub = sandbox.stub().returns({ select: selectStub });
-
-      const result = await readFeatureFlag({
-        organizationId: ORG,
-        product: 'LLMO',
-        flagName: 'brandalf',
-        postgrestClient: { from: fromStub },
-      });
-
-      expect(result).to.equal(false);
+      const { client } = makeClient({ data: [{ flag_value: false }], error: null });
+      expect(await read(client)).to.equal(false);
     });
 
     it('returns null when no row found', async () => {
-      const maybeSingle = sandbox.stub().resolves({ data: null, error: null });
-      const eq3 = sandbox.stub().returns({ maybeSingle });
-      const eq2 = sandbox.stub().returns({ eq: eq3 });
-      const eq1 = sandbox.stub().returns({ eq: eq2 });
-      const selectStub = sandbox.stub().returns({ eq: eq1 });
-      const fromStub = sandbox.stub().returns({ select: selectStub });
+      const { client } = makeClient({ data: [], error: null });
+      expect(await read(client)).to.be.null;
+    });
 
-      const result = await readFeatureFlag({
-        organizationId: ORG,
-        product: 'LLMO',
-        flagName: 'brandalf',
-        postgrestClient: { from: fromStub },
-      });
-
-      expect(result).to.be.null;
+    it('returns null when the payload is null', async () => {
+      const { client } = makeClient({ data: null, error: null });
+      expect(await read(client)).to.be.null;
     });
 
     it('returns null when flag value is not a boolean', async () => {
-      const maybeSingle = sandbox.stub().resolves({ data: { flag_value: 'true' }, error: null });
-      const eq3 = sandbox.stub().returns({ maybeSingle });
-      const eq2 = sandbox.stub().returns({ eq: eq3 });
-      const eq1 = sandbox.stub().returns({ eq: eq2 });
-      const selectStub = sandbox.stub().returns({ eq: eq1 });
-      const fromStub = sandbox.stub().returns({ select: selectStub });
+      const { client } = makeClient({ data: [{ flag_value: 'true' }], error: null });
+      expect(await read(client)).to.be.null;
+    });
 
-      const result = await readFeatureFlag({
-        organizationId: ORG,
-        product: 'LLMO',
-        flagName: 'brandalf',
-        postgrestClient: { from: fromStub },
+    // The org's value is the row with no brand, whichever order PostgREST
+    // returns the rows in; a brand's override must not answer for the org.
+    it('returns the org row and ignores a brand override', async () => {
+      const { client } = makeClient({
+        data: [
+          { flag_value: true, brand_id: BRAND },
+          { flag_value: false, brand_id: null },
+        ],
+        error: null,
       });
+      expect(await read(client)).to.equal(false);
+    });
 
-      expect(result).to.be.null;
+    it('returns null when only a brand override exists', async () => {
+      const { client } = makeClient({
+        data: [{ flag_value: true, brand_id: BRAND }],
+        error: null,
+      });
+      expect(await read(client)).to.be.null;
     });
 
     it('throws on postgrest error', async () => {
-      const maybeSingle = sandbox.stub().resolves({ data: null, error: { message: 'boom' } });
-      const eq3 = sandbox.stub().returns({ maybeSingle });
-      const eq2 = sandbox.stub().returns({ eq: eq3 });
-      const eq1 = sandbox.stub().returns({ eq: eq2 });
-      const selectStub = sandbox.stub().returns({ eq: eq1 });
-      const fromStub = sandbox.stub().returns({ select: selectStub });
-
-      await expect(
-        readFeatureFlag({
-          organizationId: ORG,
-          product: 'LLMO',
-          flagName: 'brandalf',
-          postgrestClient: { from: fromStub },
-        }),
-      ).to.be.rejectedWith('Failed to read feature flag brandalf: boom');
+      const { client } = makeClient({ data: null, error: { message: 'boom' } });
+      await expect(read(client)).to.be.rejectedWith('Failed to read feature flag brandalf: boom');
     });
   });
 
@@ -290,6 +394,29 @@ describe('feature-flags-storage', () => {
       expect(eq3).to.have.been.calledWith('flag_value', true);
       expect(orderStub).to.have.been.calledWith('flag_name', { ascending: true });
       expect(out).to.deep.equal(rows);
+    });
+
+    // The endpoint built on this describes the ORGANIZATION's flags, so a
+    // brand's override must not surface as an extra entry for the same flag.
+    it('omits brand overrides', async () => {
+      const orgRow = { id: '1', flag_name: 'serenity', brand_id: null };
+      const orderStub = sandbox.stub().resolves({
+        data: [orgRow, { id: '2', flag_name: 'serenity', brand_id: BRAND }],
+        error: null,
+      });
+      const eq3 = sandbox.stub().returns({ order: orderStub });
+      const eq2 = sandbox.stub().returns({ eq: eq3 });
+      const eq1 = sandbox.stub().returns({ eq: eq2 });
+      const selectStub = sandbox.stub().returns({ eq: eq1 });
+      const fromStub = sandbox.stub().returns({ select: selectStub });
+
+      const out = await listFeatureFlagsByOrgAndProduct({
+        organizationId: ORG,
+        product: 'LLMO',
+        postgrestClient: { from: fromStub },
+      });
+
+      expect(out).to.deep.equal([orgRow]);
     });
 
     it('throws on postgrest error', async () => {

--- a/test/support/llmo-onboarding-mode.test.js
+++ b/test/support/llmo-onboarding-mode.test.js
@@ -40,40 +40,48 @@ function makeSite(createdAt, id = 'site-id') {
 /**
  * Builds a postgrestClient stub whose feature_flags read returns the given value.
  * Pass `null` to simulate a missing row, `'throw'` to simulate a DB error.
- * Also supports the upsert chain used by `upsertFeatureFlag`.
+ * Also supports the write chain used by `upsertFeatureFlag`.
  */
 function makePostgrestClient(brandalfValue) {
   if (brandalfValue === undefined) {
     return undefined;
   }
-  const maybeSingle = brandalfValue === 'throw'
-    ? sinon.stub().resolves({ data: null, error: { message: 'boom' } })
-    : sinon.stub().resolves({
-      data: brandalfValue === null ? null : { flag_value: brandalfValue },
+  // Org-row lookup: from().select().eq().eq().eq() resolves to the matching rows.
+  const flagRows = brandalfValue === 'throw'
+    ? { data: null, error: { message: 'boom' } }
+    : {
+      data: brandalfValue === null ? [] : [{ id: 'flag-row-1', flag_value: brandalfValue }],
       error: null,
-    });
-
-  // Upsert chain: from().upsert().select().single()
-  const upsertSingle = sinon.stub().resolves({ data: { flag_value: false }, error: null });
-  const upsertSelect = sinon.stub().returns({ single: upsertSingle });
-  const upsert = sinon.stub().returns({ select: upsertSelect });
-
-  // Read chain: from().select().eq().eq().eq().maybeSingle()
+    };
   const readSelect = sinon.stub().returns({
     eq: sinon.stub().returns({
       eq: sinon.stub().returns({
-        eq: sinon.stub().returns({ maybeSingle }),
+        eq: sinon.stub().resolves(flagRows),
       }),
     }),
   });
 
+  // Write branches: from().update().eq().select().single() when the org already
+  // has a row, from().insert().select().single() when it does not.
+  const writeSingle = sinon.stub().resolves({ data: { flag_value: false }, error: null });
+  const writeSelect = sinon.stub().returns({ single: writeSingle });
+  const update = sinon.stub().returns({ eq: sinon.stub().returns({ select: writeSelect }) });
+  const insert = sinon.stub().returns({ select: writeSelect });
+
   const client = {
     from: sinon.stub().returns({
       select: readSelect,
-      upsert,
+      update,
+      insert,
     }),
   };
-  client.getUpsertStub = () => upsert;
+  // The remediation path only ever runs on an org whose brandalf row exists, so
+  // the flag write is always the update branch.
+  client.getUpsertStub = () => update;
+  client.failWrite = () => writeSingle.resolves({
+    data: null,
+    error: { message: 'upsert failed' },
+  });
   return client;
 }
 
@@ -105,13 +113,12 @@ describe('llmo-onboarding-mode', () => {
 
   describe('readBrandalfFlagOverride', () => {
     it('reads the brandalf flag from feature_flags', async () => {
-      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
       const postgrestClient = {
         from: sinon.stub().returns({
           select: sinon.stub().returns({
             eq: sinon.stub().returns({
               eq: sinon.stub().returns({
-                eq: sinon.stub().returns({ maybeSingle }),
+                eq: sinon.stub().resolves({ data: [{ flag_value: true }], error: null }),
               }),
             }),
           }),
@@ -132,13 +139,12 @@ describe('llmo-onboarding-mode', () => {
     });
 
     it('returns null when flag_value is not a boolean', async () => {
-      const maybeSingle = sinon.stub().resolves({ data: { flag_value: 'true' }, error: null });
       const postgrestClient = {
         from: sinon.stub().returns({
           select: sinon.stub().returns({
             eq: sinon.stub().returns({
               eq: sinon.stub().returns({
-                eq: sinon.stub().returns({ maybeSingle }),
+                eq: sinon.stub().resolves({ data: [{ flag_value: 'true' }], error: null }),
               }),
             }),
           }),
@@ -149,13 +155,12 @@ describe('llmo-onboarding-mode', () => {
     });
 
     it('throws when the DB returns an error', async () => {
-      const maybeSingle = sinon.stub().resolves({ data: null, error: { message: 'boom' } });
       const postgrestClient = {
         from: sinon.stub().returns({
           select: sinon.stub().returns({
             eq: sinon.stub().returns({
               eq: sinon.stub().returns({
-                eq: sinon.stub().returns({ maybeSingle }),
+                eq: sinon.stub().resolves({ data: null, error: { message: 'boom' } }),
               }),
             }),
           }),
@@ -171,9 +176,7 @@ describe('llmo-onboarding-mode', () => {
 
   describe('readBrandalfMigrationFlagOverride', () => {
     it('reads the brandalf_migration flag from feature_flags', async () => {
-      const eqStub3 = sinon.stub();
-      const maybeSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
-      eqStub3.returns({ maybeSingle });
+      const eqStub3 = sinon.stub().resolves({ data: [{ flag_value: true }], error: null });
       const eqStub2 = sinon.stub().returns({ eq: eqStub3 });
       const eqStub1 = sinon.stub().returns({ eq: eqStub2 });
       const postgrestClient = {
@@ -345,12 +348,8 @@ describe('llmo-onboarding-mode', () => {
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
           brandalfValue: true,
         });
-        // Make upsert fail
-        ctx.dataAccess.services.postgrestClient.getUpsertStub().returns({
-          select: sinon.stub().returns({
-            single: sinon.stub().resolves({ data: null, error: { message: 'upsert failed' } }),
-          }),
-        });
+        // Make the flag write fail
+        ctx.dataAccess.services.postgrestClient.failWrite();
         const mode = await resolveLlmoOnboardingMode('org-1', ctx);
         expect(mode).to.equal('v1');
         expect(ctx.log.error).to.have.been.calledWithMatch(/Failed to revert brandalf flag.*Flag may still be true/);
@@ -572,17 +571,12 @@ describe('llmo-onboarding-mode', () => {
      * brandalf and brandalf_migration independently.
      */
     function makeMultiFlagContext(flags, sites = []) {
-      const maybeSingle = sinon.stub();
       const flagNameEq = sinon.stub().callsFake((field, flagName) => {
-        if (field === 'flag_name' && flagName in flags) {
-          maybeSingle.onCall(maybeSingle.callCount).resolves({
-            data: flags[flagName] === null ? null : { flag_value: flags[flagName] },
-            error: null,
-          });
-        } else {
-          maybeSingle.onCall(maybeSingle.callCount).resolves({ data: null, error: null });
-        }
-        return { maybeSingle };
+        const value = field === 'flag_name' ? flags[flagName] : undefined;
+        return Promise.resolve({
+          data: value === null || value === undefined ? [] : [{ flag_value: value }],
+          error: null,
+        });
       });
       const productEq = sinon.stub().returns({ eq: flagNameEq });
       const orgEq = sinon.stub().returns({ eq: productEq });
@@ -646,12 +640,11 @@ describe('llmo-onboarding-mode', () => {
       });
 
       it('warns and falls through when brandalf_migration read throws', async () => {
-        const maybeSingle = sinon.stub();
-        // First call: brandalf read returns null
-        maybeSingle.onFirstCall().resolves({ data: null, error: null });
+        const flagNameEq = sinon.stub();
+        // First call: brandalf read finds no row
+        flagNameEq.onFirstCall().resolves({ data: [], error: null });
         // Second call: brandalf_migration read returns a DB error
-        maybeSingle.onSecondCall().resolves({ data: null, error: { message: 'boom' } });
-        const flagNameEq = sinon.stub().returns({ maybeSingle });
+        flagNameEq.onSecondCall().resolves({ data: null, error: { message: 'boom' } });
         const productEq = sinon.stub().returns({ eq: flagNameEq });
         const orgEq = sinon.stub().returns({ eq: productEq });
         const select = sinon.stub().returns({ eq: orgEq });

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -124,20 +124,30 @@ describe('onboard-llmo-modal', () => {
     sendMessage: sinonSandbox.stub(),
   });
 
-  const createDefaultMockPostgrestClient = (sinonSandbox) => ({
-    from: sinonSandbox.stub().callsFake(() => ({
+  const createDefaultMockPostgrestClient = (sinonSandbox) => {
+    // One chain link that is both further-chainable and awaitable, so a single
+    // fake serves the brands lookup (which ends in `.maybeSingle()`) and the
+    // feature-flags org-row lookup (three `.eq()`s, awaited directly). Both
+    // resolve to "no row", so the flag write lands as an insert.
+    const link = {
+      eq: sinonSandbox.stub().callsFake(() => link),
+      maybeSingle: sinonSandbox.stub().resolves({ data: null, error: null }),
+      then: (onFulfilled) => Promise.resolve({ data: [], error: null }).then(onFulfilled),
+    };
+    const writeResult = () => sinonSandbox.stub().returns({
       select: sinonSandbox.stub().returns({
-        eq: sinonSandbox.stub().returns({
-          maybeSingle: sinonSandbox.stub().resolves({ data: null, error: null }),
-        }),
+        single: sinonSandbox.stub().resolves({ data: { flag_value: true }, error: null }),
       }),
-      upsert: sinonSandbox.stub().returns({
-        select: sinonSandbox.stub().returns({
-          single: sinonSandbox.stub().resolves({ data: { flag_value: true }, error: null }),
-        }),
-      }),
-    })),
-  });
+    });
+    return {
+      from: sinonSandbox.stub().callsFake(() => ({
+        select: sinonSandbox.stub().returns(link),
+        // `upsert` is the brand write (upsertBrand); `insert` is the flag write.
+        upsert: writeResult(),
+        insert: writeResult(),
+      })),
+    };
+  };
 
   const createDefaultMockLambdaCtx = (sinonSandbox, overrides = {}) => {
     const mockSite = overrides.mockSite || createDefaultMockSite(sinonSandbox);


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
The three `feature_flags` storage helpers in `src/support/feature-flags-storage.js` now resolve an organization's own flag row by predicate rather than through the table's unique key, so they are correct both against today's schema and against the schema that adds an optional `feature_flags.brand_id`.

## 2. Reasoning
Serenity activation is becoming a per-brand decision so that an organization migrates to Semrush in waves rather than as one irreversible cutover — Adobe Corp carries 16 active brands and 91,671 active prompts behind a single flag today. The gate for that is an optional `feature_flags.brand_id`: a row with `brand_id` NULL is the organization's value, and a row naming a brand overrides it for that brand alone.

Carrying two brands' overrides of one flag means the table's unique key has to widen to `UNIQUE NULLS NOT DISTINCT (organization_id, product, flag_name, brand_id)`, which drops `feature_flags_org_product_flag_name_key`. Any consumer that names that constraint as an `ON CONFLICT` target then fails with *"there is no unique or exclusion constraint matching the ON CONFLICT specification"* the moment the migration deploys, independent of whether a single override row exists. A partial unique index is not an escape: PostgreSQL only infers one for `ON CONFLICT` when the statement repeats its predicate, which a PostgREST upsert never emits.

This change is therefore a precondition for that migration, and it deliberately takes on no dependency in return, so the two can land in either order with no deploy coordination.

## 3. High-level overview of the changes
The helpers select the organization's row with a predicate that holds under both schemas — `brand_id` is absent from every row before the migration and NULL on the organization's row after it — so none of them names the new column. That is what lets this ship ahead of it.

- `upsertFeatureFlag` previously targeted the three-column key with `ON CONFLICT`. It now reads the matching rows, picks the organization's, and either updates that row keyed on its primary key or inserts a new one. This trades `ON CONFLICT`'s atomicity for a read-then-write: two concurrent creates of the *same* flag now leave one hitting the unique constraint as a retryable duplicate-key error rather than silently merging. Its callers are the admin endpoint, LLMO onboarding, and onboarding-mode remediation, which carry essentially no concurrency. Once the column exists this can move back to a four-column `ON CONFLICT` if the atomicity is wanted.
- `readFeatureFlag` resolved its row through `.maybeSingle()`, which rejects a multi-row result. As soon as any brand overrides a flag, that read would start throwing for the organization. It now selects the whole row set and picks the organization's row.
- `listFeatureFlagsByOrgAndProduct` returned every matching row unfiltered, so overrides would have surfaced as extra entries in `GET /organizations/:id/feature-flags/llmo`. It now returns the organization's rows only.

Nothing user-visible changes. `FeatureFlagDto` does not expose `brand_id`, so the endpoint's response shape, its security tiers, and the enable/disable semantics are all untouched, and project-elmo-ui and the DRS runner (which consume that endpoint rather than the table) need nothing.

For an organization with no brand override rows — every customer today — all three helpers return exactly what they returned before. This is behaviour-preserving on its own; the first observable change comes when a wave writes its first override.

An integration-test helper carried a second copy of the same `ON CONFLICT` upsert and now goes through the production helper, so the test setup path stays valid under whichever shape the unique key has.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/3020
- Implementation plan: https://github.com/adobe/serenity-docs/issues/317
- Other: https://github.com/adobe/mysticat-data-service/pull/856 (the migration CLI that executes each wave) , https://jira.corp.adobe.com/browse/LLMO-6623 (the Semrush-scoped IMS promise-token pair, which bounds the calendar every wave runs against)

## 5. Affected / used mysticat-workspace projects
- **mysticat-data-service** — contract, and a blocking prerequisite of its own. It owns `feature_flags` and the pending `brand_id` migration. It also carries two consumers that name the dropped constraint and must be fixed before that migration deploys: `scripts/serenity_migration/persist.py` (lines 238 and 285, the wave-execution CLI, run against prod) and `scripts/seed-semrush-mock.sql` (lines 125 and 176, consumed by the local stack). Several of its reads additionally resolve a flag as `rows[0]` / `fetchone()` over an unordered result, and its two rollback `UPDATE`s carry no brand filter — correct until the first override row exists, wrong afterwards. `docs/feature-flags-schema.md` still documents the three-column key.
- **mystique** — contract only, no code here. `app/services/control/feature_flags.py` (line 552) has the same `ON CONFLICT`, but its write gate needs an opt-in that is off by default in every environment and refuses Prod/Stage regardless, so the path is unreachable in production; only the dev operator console is affected.
- **spacecat-audit-worker** — consumed, no change needed. `isBrandalfEnabled` reads the table with `.maybeSingle()`, which is safe while `brandalf` carries no brand overrides.
- **llmo-data-retrieval-service** — consumed, no change needed. It reads this service's feature-flags endpoint rather than the table, so it is covered by the `listFeatureFlagsByOrgAndProduct` filter here.
- **project-elmo-ui** — contract only, no change needed. Same endpoint, unchanged response shape.

## 6. Additional information outside the code
The premise this change was specified against was checked against the live systems rather than taken from the plan:

- **The set of consumers that break was audited across every workspace repo, and it is larger than the issue states.** The issue asserts that `src/support/feature-flags-storage.js` is the only place depending on the three-column key. Five sites name it; the two outside this repo listed in section 5 are prod-relevant. Anyone re-checking this should read the files rather than sweep for a pattern: in `persist.py` the table name sits three to four lines above the `ON CONFLICT` clause inside a multi-line Python string, so a windowed grep for the two together finds nothing and reads as a clean bill of health.
- **Live prod schema and version confirmed** by querying the prod mysticat database: `feature_flags` carries `feature_flags_org_product_flag_name_key UNIQUE (organization_id, product, flag_name)` plus a primary key on `id`, and no `brand_id` column. The primary key is what the new read-then-write targets, which is why it is valid under both schemas. Prod runs PostgreSQL 16.11 and the integration-test image is `postgres:16-alpine`, so the `NULLS NOT DISTINCT` key the migration needs (PostgreSQL 15+) is available in both.
- The migration `20260810090000_feature_flags_brand_scope.sql` does not yet exist on `main` or on the CLI branch of mysticat-data-service, checked through the contents API on both refs. Part 2 of the issue — the per-brand predicate and the four gates — is consequently not in this PR; it cannot function until that column lands.

## 7. Test plan
Locally, beyond the unit suite, the new write path was exercised against real PostgreSQL and PostgREST through the integration harness rather than against fakes, which is the part that matters here: a read-then-write is exactly the kind of change that passes against stubs and fails on the wire.

- `test/it/postgres/feature-flags.test.js` drives both new branches end to end. `PUT /organizations/:id/feature-flags/llmo/brandalf` takes the insert branch against the seeded organization, and the subsequent `DELETE` takes the update branch on the row that PUT created. It also re-reads each write back through `readFeatureFlag`, so the endpoint and the storage helper are shown to agree on the same row.
- `test/it/postgres/brand-for-org-site.test.js` covers the integration helper that was rewritten to use the production helper.
- `test/it/postgres/serenity.test.js` and `test/it/postgres/activate-brand-for-org.test.js` exercise `readFeatureFlag` through `isSerenityActiveForOrg` against a seeded `LLMO/serenity=true` row, confirming the rewritten read resolves the same value the `.maybeSingle()` version did.

Run them with:

    npx mocha --require test/it/postgres/harness.js --timeout 60000 test/it/postgres/feature-flags.test.js test/it/postgres/brand-for-org-site.test.js
    npx mocha --require test/it/postgres/harness.js --timeout 60000 test/it/postgres/serenity.test.js test/it/postgres/activate-brand-for-org.test.js

On **dev**, after deploy:

1. `PUT /organizations/:orgId/feature-flags/llmo/<flag>` on an organization with no such flag, then `GET /organizations/:orgId/feature-flags?product=LLMO` — the flag appears with `flagValue: true`. This is the insert branch.
2. `DELETE` the same flag, then `GET` again — `flagValue: false` and the row is the same `id` as before, not a new one. This is the update branch, and the stable `id` is what shows the read-then-write found the existing row rather than creating a second.
3. `PUT` the same flag a second time — still one row, still the same `id`, `flagValue` back to `true`. Repeating a write must stay idempotent now that `ON CONFLICT` is no longer doing that work.
4. Confirm an organization already carrying `LLMO/serenity=true` still reads as serenity-active on the `/serenity/*` surface, and that a brand edit touching URLs / competitors / aliases still fans out — those paths read the flag through the rewritten helper.

On **prod**, this is behaviour-preserving with no override rows in existence, so the check is negative: after deploy, confirm the admin feature-flag endpoints still write (the operation most likely to regress, since it changed shape), and that no new `Failed to upsert feature flag` or `Failed to read feature flag` appears in the service logs.

## 8. Deployment & merge order
This PR is independently deployable and has no prerequisite. It is, however, the first step of a sequence whose later steps depend on it:

- https://github.com/adobe/mysticat-data-service/pull/856 — related. It carries the wave-execution CLI whose `persist.py` names the dropped constraint; that CLI must be corrected before the migration deploys, independently of this PR.
- The `feature_flags.brand_id` migration in mysticat-data-service — depends on this PR being deployed, and equally on the mysticat-data-service consumer fixes described in sections 5 and 6. It is not yet written.
- Part 2 of https://github.com/adobe/spacecat-api-service/issues/3020 (the per-brand predicate and the `/serenity/*`, brand create/edit, and brand-presence gates) — depends on the migration.

Ordered sequence: this PR → the mysticat-data-service consumer fixes (`persist.py`, `seed-semrush-mock.sql`, the unordered reads, the rollback `UPDATE`s, `docs/feature-flags-schema.md`) → the `brand_id` migration → Part 2 in this repo → the per-brand UI in project-elmo-ui → wave 1 execution. Merging this PR alone is safe at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Igor Grubic", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```