### PR TITLE
fix(serenity): guard PATCH on the server-owned source dimension (LLMO-6665)

### DIFF
--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -162,7 +162,7 @@ function parseUpdateParentId(body) {
  * The two flags answer two independent questions. `isClosed`
  * ({@link isClosedDimension}) drives VOCABULARY validation: a closed value's
  * `name` must be one of that dimension's fixed values ({@link closedValuesOf}).
- * `isServerOwned` ({@link SERVER_OWNED_DIMENSIONS}) drives the WRITE GUARD and
+ * `isServerOwned` ({@link isServerOwnedDimension}) drives the WRITE GUARD and
  * CREATE SEMANTICS: it forbids a `parentId` (server-owned values hang directly off
  * their root) and routes the create through resolve-or-create. `source` is
  * server-owned yet open — a `parentId` is refused and the value is resolved-or-
@@ -659,15 +659,14 @@ async function resolveUpdateTargets(
  * Three targets are refused. A DIMENSION ROOT is not editable — the root level is
  * reserved for the registered dimension roots ({@link ALL_DIMENSIONS}), and
  * renaming or moving one would leave its whole subtree without a dimension. A
- * SERVER-OWNED dimension's value ({@link SERVER_OWNED_DIMENSIONS}: `intent`,
- * `origin`, `type`, `source`) is not editable either: its vocabulary is authored by
- * the server, and since every resolve-or-create keys on the bare name under the
- * root, renaming a value — a closed `branded`, or a `source` value such as `gsc` —
- * would not move it, it would hide it, so the next server write mints a second value
+ * SERVER-OWNED dimension's value ({@link SERVER_OWNED_DIMENSIONS}) is not editable
+ * either: its vocabulary is authored by the server, and since every
+ * resolve-or-create keys on the bare name under the root, renaming a value would
+ * not move it, it would hide it — the next server write then mints a second value
  * under the same root and every prompt still carrying the first splits across two
- * ids for one dimension value. This is why the guard keys on the OWNERSHIP axis
- * ({@link isServerOwnedDimension}), not the closed/open vocabulary axis — `source`
- * is open yet server-owned, and was reachable here once its root seeded live
+ * ids for one dimension value. The guard therefore keys on the OWNERSHIP axis
+ * ({@link isServerOwnedDimension}), not the open/closed vocabulary axis: `source`
+ * is open yet server-owned, and became reachable here once its root seeded live
  * projects (LLMO-6665). An UNRESOLVABLE id is refused rather than forwarded: without
  * the target's current parent there is no body that preserves it, and guessing would
  * promote the tag.

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -21,7 +21,7 @@ import {
 } from '../validation.js';
 import { resolveProject } from '../subworkspace-projects.js';
 import {
-  ALL_DIMENSIONS, CLOSED_DIMENSIONS, SERVER_OWNED_DIMENSIONS,
+  ALL_DIMENSIONS, SERVER_OWNED_DIMENSIONS,
   isClosedDimension, isServerOwnedDimension, closedValuesOf, isDimensionRootName,
   MAX_TAG_NAME_LEN,
 } from '../prompt-tags.js';
@@ -160,7 +160,7 @@ function parseUpdateParentId(body) {
  * direct children of its root.
  *
  * The two flags answer two independent questions. `isClosed`
- * ({@link CLOSED_DIMENSIONS}) drives VOCABULARY validation: a closed value's
+ * ({@link isClosedDimension}) drives VOCABULARY validation: a closed value's
  * `name` must be one of that dimension's fixed values ({@link closedValuesOf}).
  * `isServerOwned` ({@link SERVER_OWNED_DIMENSIONS}) drives the WRITE GUARD and
  * CREATE SEMANTICS: it forbids a `parentId` (server-owned values hang directly off
@@ -657,13 +657,20 @@ async function resolveUpdateTargets(
  * requested one.
  *
  * Three targets are refused. A DIMENSION ROOT is not editable — the root level is
- * reserved for the four roots, and renaming or moving one would leave its whole
- * subtree without a dimension. A CLOSED dimension's value is not editable either:
- * the vocabulary is fixed, and since every resolve-or-create keys on the bare name
- * under the root, renaming `branded` would make the next prompt write mint a
- * second `branded` and silently orphan every prompt still carrying the first. An
- * UNRESOLVABLE id is refused rather than forwarded: without the target's current
- * parent there is no body that preserves it, and guessing would promote the tag.
+ * reserved for the registered dimension roots ({@link ALL_DIMENSIONS}), and
+ * renaming or moving one would leave its whole subtree without a dimension. A
+ * SERVER-OWNED dimension's value ({@link SERVER_OWNED_DIMENSIONS}: `intent`,
+ * `origin`, `type`, `source`) is not editable either: its vocabulary is authored by
+ * the server, and since every resolve-or-create keys on the bare name under the
+ * root, renaming a value — a closed `branded`, or a `source` value such as `gsc` —
+ * would not move it, it would hide it, so the next server write mints a second value
+ * under the same root and every prompt still carrying the first splits across two
+ * ids for one dimension value. This is why the guard keys on the OWNERSHIP axis
+ * ({@link isServerOwnedDimension}), not the closed/open vocabulary axis — `source`
+ * is open yet server-owned, and was reachable here once its root seeded live
+ * projects (LLMO-6665). An UNRESOLVABLE id is refused rather than forwarded: without
+ * the target's current parent there is no body that preserves it, and guessing would
+ * promote the tag.
  *
  * @param {{ value: string, parentId: string | undefined }} parsed
  * @param {{ kind: 'root' | 'descendant' | 'unknown', parentId: string | null,
@@ -684,11 +691,9 @@ function buildUpdatePayload(parsed, target, tagId) {
     err.code = ERROR_CODES.TAG_NOT_FOUND;
     throw err;
   }
-  if ((/** @type {readonly string[]} */ (CLOSED_DIMENSIONS)).includes(
-    /** @type {string} */ (target.rootName),
-  )) {
+  if (isServerOwnedDimension(/** @type {string} */ (target.rootName))) {
     throw new ErrorWithStatusCode(
-      `a value of the closed "${target.rootName}" dimension cannot be renamed or re-parented`,
+      `a value of the server-owned "${target.rootName}" dimension cannot be renamed or re-parented`,
       400,
     );
   }

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -1652,6 +1652,30 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(transport.updateProjectTag).to.not.have.been.called;
     });
 
+    // Completes the flat/subworkspace symmetry for LLMO-6665: the server-owned
+    // guard fires before the placement check in buildUpdatePayload, so a source
+    // RE-PARENT is refused on the subworkspace route too, same as flat mode.
+    it('400s a re-parent of a source value — shared server-owned guard (LLMO-6665)', async () => {
+      const handler = await loadHandler(sinon.stub().resolves({ id: 'proj-sub-1' }));
+      const transport = makeSourceDescendableTransport();
+      const err = await handler.handleUpdateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        TAG_IDS.sourceConfig,
+        {
+          name: 'config',
+          parentId: TAG_IDS.sourceSemrush,
+          geoTargetId: 2840,
+          languageCode: 'en',
+        },
+        fakeLog(),
+      ).then(() => null, (e) => e);
+
+      expect(err.status).to.equal(400);
+      expect(err.message).to.match(/server-owned "source" dimension cannot be renamed or re-parented/);
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
     it('404s (marketNotFound) when the slice has no live project', async () => {
       const handler = await loadHandler(sinon.stub().resolves(null));
       const transport = makeTransport();

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -57,6 +57,27 @@ function makeEmptyTreeTransport(overrides = {}) {
   });
 }
 
+// A transport whose `source` root is DESCENDABLE. The default fixture reports
+// children_count:0 on the `source` root so tree walks (findTagsInTree) skip it;
+// this bumps it so the walk descends and resolves a `source` value — the state
+// reachable after WP-S5 / the reconciles seed the root on live projects, and the
+// only state in which the LLMO-6665 guard is exercised. Shared by the flat-mode
+// and subworkspace update describes.
+function makeSourceDescendableTransport(overrides = {}) {
+  const levels = dimensionTreeLevels();
+  // Derive the count from the fixture's own source level rather than hardcoding a
+  // literal, so it can't drift if the fixture gains/loses a seeded `source` value
+  // (mysticatbot suggestion).
+  const sourceChildCount = (levels[TAG_IDS.sourceRoot] ?? []).length;
+  levels[''] = levels[''].map(
+    (r) => (r.name === 'source' ? { ...r, children_count: sourceChildCount } : r),
+  );
+  return makeTransport({
+    listProjectTags: makeListProjectTagsStub(levels),
+    ...overrides,
+  });
+}
+
 function makeDataAccess(findBySliceResult) {
   return {
     BrandSemrushProject: {
@@ -1226,22 +1247,8 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
     // a client can rename/re-parent a server-owned `source` value once its root
     // is seeded on live projects. Renaming `config` would hide it, not move it,
     // and the next server write would mint a SECOND `config` under the same root,
-    // splitting prompts across two ids for one producing system.
-    //
-    // The default fixture reports children_count:0 on the `source` root so tree
-    // walks skip it; bump it so findTagsInTree descends and resolves the value —
-    // the reachable state after WP-S5 / the reconciles seed the root live.
-    function makeSourceDescendableTransport(overrides = {}) {
-      const levels = dimensionTreeLevels();
-      levels[''] = levels[''].map(
-        (r) => (r.name === 'source' ? { ...r, children_count: 2 } : r),
-      );
-      return makeTransport({
-        listProjectTags: makeListProjectTagsStub(levels),
-        ...overrides,
-      });
-    }
-
+    // splitting prompts across two ids for one producing system. The descendable
+    // `source` root comes from the shared makeSourceDescendableTransport helper.
     it('400s a rename of a source value — server-owned though OPEN (LLMO-6665)', async () => {
       const transport = makeSourceDescendableTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
@@ -1623,6 +1630,25 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
 
       expect(err.status).to.equal(400);
       expect(err.message).to.match(/must not be a descendant of the tag/);
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    // Defense-in-depth for LLMO-6665: the source guard lives in the shared
+    // buildUpdatePayload, so it must refuse a server-owned `source` rename on the
+    // subworkspace route too, not only in flat mode (self-review should-fix).
+    it('400s a rename of a source value — shared server-owned guard (LLMO-6665)', async () => {
+      const handler = await loadHandler(sinon.stub().resolves({ id: 'proj-sub-1' }));
+      const transport = makeSourceDescendableTransport();
+      const err = await handler.handleUpdateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        TAG_IDS.sourceConfig,
+        { name: 'config-renamed', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      ).then(() => null, (e) => e);
+
+      expect(err.status).to.equal(400);
+      expect(err.message).to.match(/server-owned "source" dimension cannot be renamed or re-parented/);
       expect(transport.updateProjectTag).to.not.have.been.called;
     });
 

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -1196,12 +1196,13 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       );
     });
 
-    // A closed-dimension value is a descendant too, so it is renameable through
-    // the same path — the dimension root above it is what is protected.
-    // The vocabulary is fixed. Every resolve-or-create keys on the bare name under
-    // the root, so renaming `human` would make the next write mint a SECOND `human`
-    // and silently orphan every prompt still carrying the first.
-    it('400s a rename of a closed-dimension value', async () => {
+    // A server-owned value is a descendant too, so it is renameable through
+    // the same path — the dimension root above it is what is protected. The
+    // vocabulary is authored by the server. Every resolve-or-create keys on the
+    // bare name under the root, so renaming `human` would make the next write
+    // mint a SECOND `human` and silently orphan every prompt still carrying the
+    // first.
+    it('400s a rename of a closed server-owned value (origin)', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
       const err = await handler.handleUpdateTag(
@@ -1215,7 +1216,70 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       ).then(() => null, (e) => e);
 
       expect(err.status).to.equal(400);
-      expect(err.message).to.match(/closed "origin" dimension cannot be renamed or re-parented/);
+      expect(err.message).to.match(/server-owned "origin" dimension cannot be renamed or re-parented/);
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    // LLMO-6665 regression. `source` is server-owned but OPEN, so it is
+    // deliberately absent from CLOSED_DIMENSIONS — the guard must key on the
+    // OWNERSHIP axis (isServerOwnedDimension), not the closed-vocabulary one, or
+    // a client can rename/re-parent a server-owned `source` value once its root
+    // is seeded on live projects. Renaming `config` would hide it, not move it,
+    // and the next server write would mint a SECOND `config` under the same root,
+    // splitting prompts across two ids for one producing system.
+    //
+    // The default fixture reports children_count:0 on the `source` root so tree
+    // walks skip it; bump it so findTagsInTree descends and resolves the value —
+    // the reachable state after WP-S5 / the reconciles seed the root live.
+    function makeSourceDescendableTransport(overrides = {}) {
+      const levels = dimensionTreeLevels();
+      levels[''] = levels[''].map(
+        (r) => (r.name === 'source' ? { ...r, children_count: 2 } : r),
+      );
+      return makeTransport({
+        listProjectTags: makeListProjectTagsStub(levels),
+        ...overrides,
+      });
+    }
+
+    it('400s a rename of a source value — server-owned though OPEN (LLMO-6665)', async () => {
+      const transport = makeSourceDescendableTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const err = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        TAG_IDS.sourceConfig,
+        { name: 'config-renamed', geoTargetId: 2840, languageCode: 'en' },
+        fakeLog(),
+      ).then(() => null, (e) => e);
+
+      expect(err.status).to.equal(400);
+      expect(err.message).to.match(/server-owned "source" dimension cannot be renamed or re-parented/);
+      expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    it('400s a re-parent of a source value (LLMO-6665)', async () => {
+      const transport = makeSourceDescendableTransport();
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const err = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        TAG_IDS.sourceConfig,
+        {
+          name: 'config',
+          parentId: TAG_IDS.sourceSemrush,
+          geoTargetId: 2840,
+          languageCode: 'en',
+        },
+        fakeLog(),
+      ).then(() => null, (e) => e);
+
+      expect(err.status).to.equal(400);
+      expect(err.message).to.match(/server-owned "source" dimension cannot be renamed or re-parented/);
       expect(transport.updateProjectTag).to.not.have.been.called;
     });
 


### PR DESCRIPTION
## What

The tag `PATCH` write guard (`buildUpdatePayload`, `src/support/serenity/handlers/tags.js`) keyed on the **closed-vocabulary** axis (`CLOSED_DIMENSIONS`: `intent`, `origin`, `type`) instead of the **ownership** axis, so it did not cover the `source` dimension introduced by spec 47. `source` is registered in `SERVER_OWNED_DIMENSIONS` but, deliberately, **not** in `CLOSED_DIMENSIONS` — its vocabulary is the open set of producing systems, not a frozen enum.

## Why it matters

A `PATCH` on any descendant of the `source` root passed every guard, so a client could **rename or re-parent a server-owned `source` value** even though the server writes it entirely. Every server write resolves a value by its bare name under the dimension root, so renaming `gsc` does not move it — it hides it, and the next prompt write resolve-or-creates a *second* `gsc` under the same root. Prompts then split across two ids for one producing system (the same reasoning the code already gives for refusing a rename of a closed value like `branded`).

Reachability: latent while no live project carried a `source` root; **reachable the moment the migration seeds the root on live projects** (WP-S5 / the LLMO-6802 reconciles) — which is exactly the state the WP-S6 source backfill ([LLMO-6286](https://jira.corp.adobe.com/browse/LLMO-6286)) depends on. This is a pre-backfill safety gate.

## Change

- `buildUpdatePayload`: refuse the edit when `isServerOwnedDimension(target.rootName)` holds (covers `intent`, `origin`, `type`, `source`); message `closed` → `server-owned`.
- The create path (`handleCreateTag`) already used the correct `isServerOwnedDimension` predicate — this brings the update path into line.
- Removed the now-unused `CLOSED_DIMENSIONS` import; repointed its `{@link}`s; rewrote the `buildUpdatePayload` doc-comment (the stale "four roots" / "A CLOSED dimension's value" language flagged in the ticket).
- Tests: updated the origin assertion to the new message; added 2 regression tests — a source-value **rename** and **re-parent**, both `400` with `server-owned "source" …` and the transport never called.

## Verification

- `npx mocha test/support/serenity/handlers/tags.test.js` — 76/76 pass (incl. the 2 new).
- `eslint` clean on both files.
- `npm run type-check` fails only on **pre-existing** `rest-transport.js` errors (spec-35 metadata swagger drift); identical with this change stashed — not introduced here.

Refs: [LLMO-6665](https://jira.corp.adobe.com/browse/LLMO-6665), epic [LLMO-6270](https://jira.corp.adobe.com/browse/LLMO-6270).

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```