### PR TITLE
fix(brand-claims): select latest Monday sheet for daily cadence

### DIFF
--- a/src/support/slack/commands/run-brand-claims.js
+++ b/src/support/slack/commands/run-brand-claims.js
@@ -57,9 +57,32 @@ export function sanitizePathComponent(component) {
 }
 
 /**
+ * True if the S3 date partition (`YYYY`/`MM`/`DD`) falls on a Monday (UTC).
+ *
+ * Claims runs on a WEEKLY cadence keyed to Monday's sheet: the Brand Claims
+ * consumer's cadence gate drops a daily sheet whose `sheet_date` isn't a Monday.
+ * So a daily sheet is only eligible as "latest" on a Monday partition.
+ *
+ * @param {string} yyyy - 4-digit year.
+ * @param {string} mm - 2-digit month.
+ * @param {string} dd - 2-digit day.
+ * @returns {boolean} True when the date is a Monday.
+ */
+function isMondayPartition(yyyy, mm, dd) {
+  const date = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
+  return date.getUTCDay() === 1;
+}
+
+/**
  * Finds the same "latest" object under `prefix` the Brand Claims consumer's
  * freshness guard would independently pick: max by (S3 date partition,
  * LastModified) — mirrors `brand_presence_s3.discover_latest_bp_object`.
+ *
+ * For DAILY sheets (6-digit run suffix) only Monday partitions are eligible, so
+ * the selection agrees with the consumer's daily→Monday cadence gate; a
+ * mid-week daily sheet would otherwise be published and then dropped as
+ * `non_monday_dropped`. Weekly sheets (no suffix) are always eligible.
+ * (LLMO-6877)
  *
  * @param {object} s3Client - AWS SDK S3 client.
  * @param {string} prefix - `{siteId}/{brandSlug}/analytics/{platform}/`.
@@ -86,14 +109,19 @@ async function findLatestSheet(s3Client, prefix, bucket) {
       const dateMatch = key.match(KEY_DATE_RE);
 
       if (filenameMatch && dateMatch) {
+        const [, week, year, dailySuffix] = filenameMatch;
         const [, yyyy, mm, dd] = dateMatch;
         const partitionDate = `${yyyy}-${mm}-${dd}`;
         const lastModified = object.LastModified ? new Date(object.LastModified).getTime() : 0;
 
-        if (!best
-          || partitionDate > best.partitionDate
-          || (partitionDate === best.partitionDate && lastModified > best.lastModified)) {
-          const [, week, year, dailySuffix] = filenameMatch;
+        // Claims runs weekly on Monday's sheet; a daily sheet is eligible as
+        // "latest" only on a Monday partition (weekly sheets always eligible).
+        const eligible = !dailySuffix || isMondayPartition(yyyy, mm, dd);
+
+        if (eligible
+          && (!best
+            || partitionDate > best.partitionDate
+            || (partitionDate === best.partitionDate && lastModified > best.lastModified))) {
           best = {
             key,
             partitionDate,

--- a/test/support/slack/commands/run-brand-claims.test.js
+++ b/test/support/slack/commands/run-brand-claims.test.js
@@ -152,6 +152,27 @@ describe('RunBrandClaimsCommand', () => {
       expect(event.cadence).to.equal('daily');
     });
 
+    it('skips a mid-week daily sheet and picks the latest Monday daily sheet', async () => {
+      getBrandBySiteStub.resolves({ id: BRAND_ID, name: 'Acme', brandClaimsEnabled: true });
+      // Daily-cadence site with a Monday (2026-08-10) and a newer Tuesday
+      // (2026-08-11) sheet. The consumer only runs daily sheets on a Monday, so
+      // the newer Tuesday sheet must be skipped for Monday's. (LLMO-6877)
+      s3SendStub.resolves(s3Page([
+        `${SITE_ID}/acme/analytics/chatgpt_free/2026/08/10/brandpresence-chatgpt-w33-2026-100826.xlsx`,
+        `${SITE_ID}/acme/analytics/chatgpt_free/2026/08/11/brandpresence-chatgpt-w33-2026-110826.xlsx`,
+      ]));
+
+      const command = RunBrandClaimsCommand(context);
+      await command.handleExecution(['https://example.com'], slackContext);
+
+      const [, event] = sqsSendMessageStub.firstCall.args;
+      expect(event.cadence).to.equal('daily');
+      expect(event.sheet_date).to.equal('2026-08-10');
+      expect(event.s3_key).to.equal(
+        `${SITE_ID}/acme/analytics/chatgpt_free/2026/08/10/brandpresence-chatgpt-w33-2026-100826.xlsx`,
+      );
+    });
+
     it('picks the newest key across paginated S3 listings', async () => {
       getBrandBySiteStub.resolves({ id: BRAND_ID, name: 'Acme', brandClaimsEnabled: true });
       s3SendStub.onFirstCall().resolves(s3Page(


### PR DESCRIPTION
## What
`run-brand-claims` picked the absolute-latest Brand Presence sheet. For **daily-cadence** sites the mystique consumer only runs **Monday** sheets (cadence gate drops any other `sheet_date` as `non_monday_dropped`), so a mid-week daily sheet was published and then silently dropped — no daily site could run.

## Change
`findLatestSheet` now gates **daily** sheets (6-digit run suffix `…-w{WW}-{YYYY}-{NNNNNN}.xlsx`) on a **Monday** partition; weekly sheets (no suffix) are unchanged. Same signal the existing `cadence` field already derives from the filename.

## Tests
`test/support/slack/commands/run-brand-claims.test.js` — added a case proving a newer Tuesday daily sheet is skipped in favour of Monday's. 22 pass, lint clean.

## Context
Part of the 3-repo fix (this must agree with mystique's freshness guard + the audit-worker scheduled trigger). Ticket: LLMO-6939 (epic LLMO-5741 Brand Claims GA).

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```