### PR TITLE
fix(autofix): require LLMO capability for LLMO auto-fix

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1345,6 +1345,19 @@ function SuggestionsController(ctx, sqs, env) {
       return forbidden('User does not belong to the organization or does not have sufficient permissions');
     }
 
+    // LLMO auto-fix: enforce the finer-grained LLMO capability for this site.
+    // LLMO logins never carry the ASO `auto_fix` scope, so the access check above
+    // only confirmed org membership; require the LLMO capability too. S2S callers
+    // were already authorized via CAP_FIX_ENTITY_CREATE and are not FACS subjects,
+    // so they are exempt.
+    if (
+      xProduct === 'LLMO'
+      && !s2sResult.allowed
+      && !await accessControlUtil.hasLlmoCapabilityForSite(site)
+    ) {
+      return forbidden(accessControlUtil.llmoForbiddenMessage('Only LLMO administrators can trigger auto-fix'));
+    }
+
     const opportunity = await Opportunity.findById(opportunityId);
     if (!opportunity || opportunity.getSiteId() !== siteId) {
       return notFound('Opportunity not found');

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -4452,6 +4452,44 @@ describe('Suggestions Controller', () => {
       expect(hasAccessStub).to.have.been.calledWithExactly(sinon.match.any, 'auto_fix');
     });
 
+    it('returns 403 for the LLMO product when the caller lacks the LLMO capability for the site', async () => {
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+      const capabilityStub = sandbox.stub(AccessControlUtil.prototype, 'hasLlmoCapabilityForSite').resolves(false);
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+        pathInfo: { headers: { 'x-product': 'LLMO' } },
+      });
+
+      expect(response.status).to.equal(403);
+      expect(capabilityStub).to.have.been.calledOnce;
+    });
+
+    it('proceeds with LLMO autofix when the caller has the LLMO capability for the site', async () => {
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+      const capabilityStub = sandbox.stub(AccessControlUtil.prototype, 'hasLlmoCapabilityForSite').resolves(true);
+      opportunity.getType = sandbox.stub().returns('meta-tags');
+      mockSuggestionGrant.splitSuggestionsByGrantStatus.resolves({
+        grantedIds: [SUGGESTION_IDS[0]],
+        notGrantedIds: [],
+        grantIds: [`grant-${SUGGESTION_IDS[0]}`],
+      });
+      mockSuggestion.allByOpportunityId.resolves([mockSuggestionEntity(suggs[0])]);
+      mockSuggestion.bulkUpdateStatus.resolves(
+        [mockSuggestionEntity({ ...suggs[0], status: 'IN_PROGRESS' })],
+      );
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+        pathInfo: { headers: { 'x-product': 'LLMO' } },
+      });
+
+      expect(response.status).to.equal(207);
+      expect(capabilityStub).to.have.been.calledOnce;
+    });
+
     it('proceeds with autofix when summit-plg is enabled and all suggestions are granted', async () => {
       opportunity.getType = sandbox.stub().returns('meta-tags');
       mockSuggestionGrant.splitSuggestionsByGrantStatus.resolves({


### PR DESCRIPTION
## What

Adds an early exit to `autofixSuggestions` (`PATCH /sites/{siteId}/opportunities/{opportunityId}/suggestions/auto-fixes`): when the request is for the **LLMO** product (`x-product: LLMO`) and the caller does not hold `hasLlmoCapabilityForSite`, the request is rejected with `403`.

## Why

LLMO logins never carry the ASO `auto_fix` scope (`dx_aem_perf_auto_fix`), so for LLMO requests the existing access check intentionally falls back to plain org-membership (LLMO-6553). That left LLMO auto-fix gated only on org membership, not on the finer-grained LLMO capability that other LLMO routes already enforce. This closes that gap.

## How

- After the existing S2S / `hasAccess` gate, require `accessControlUtil.hasLlmoCapabilityForSite(site)` when `xProduct === 'LLMO'`.
- Reuses the standard `hasLlmoCapabilityForSite` / `llmoForbiddenMessage` pair, same as the LLMO edge-optimize routes in `llmo.js`.
- **S2S callers are exempt**: they are already authorized via `CAP_FIX_ENTITY_CREATE` and are not FACS subjects, so the gate is skipped when `s2sResult.allowed` — this avoids regressing the LLMO-6553 S2S path.

## Tests

- LLMO product **without** the capability → `403`.
- LLMO product **with** the capability → proceeds (`207`).
- Full `auto-fix suggestions` suite (70 tests) and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```