### PR TITLE
fix: Rename brands to '{name}_deleted' on delete to free the name for reuse | LLMO-6978

### DIFF
--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -33,6 +33,13 @@ const BRAND_SELECT = [
   'brand_urls(url)',
 ].join(', ');
 
+// LLMO-6978: on delete a brand is renamed to `{name}_deleted` to free its
+// original name for reuse (see deleteBrand). A same-named deleted brand already
+// present bumps the suffix to `_deleted2`, `_deleted3`, ... Each colliding
+// rename costs one round-trip, so this caps a pathological loop (a customer
+// deleting the same name hundreds of times) rather than any expected volume.
+const MAX_DELETED_NAME_ATTEMPTS = 100;
+
 // Re-landed from Igor Grubic's #2504 (LLMO-5183): map the data-layer
 // chk_active_brand_has_site_id CheckViolation to a typed 400 (covers the race
 // where site_id is cleared between our SELECT and this write).
@@ -1578,31 +1585,104 @@ export async function updateBrand({
 }
 
 /**
- * Soft-deletes a brand by setting status to 'deleted'.
+ * Soft-deletes a brand, renaming it to `{name}_deleted` so its original name is
+ * freed for reuse (LLMO-6978).
+ *
+ * The `brands` table has a per-org unique constraint on `name`
+ * (`uq_brand_name_per_org`) that spans deleted rows, so a soft-deleted brand
+ * that kept its original name would keep that name "taken" and block a customer
+ * from recreating a brand with the same name. To avoid that, the delete renames
+ * the brand to `{name}_deleted` in the same UPDATE that flips its status to
+ * `deleted`. If a same-named deleted brand already exists in the org (e.g. the
+ * customer created + deleted "Acme" more than once), an incrementing index is
+ * appended (`{name}_deleted2`, `{name}_deleted3`, ...) until the name is free —
+ * the only re-collision case is a customer literally naming a brand `..._deleted`.
+ *
+ * A brand that is already `deleted` is left untouched (returns false → 404) so
+ * a repeated delete never double-suffixes an already-renamed brand
+ * (`Acme_deleted` → `Acme_deleted_deleted`). Any other status — including a NULL
+ * status, which the rest of the code treats as a live brand — is renamed as
+ * normal; the guard is a JS `status === 'deleted'` check rather than a SQL
+ * `status != 'deleted'` filter precisely because the latter would also exclude
+ * NULL-status rows (`NULL <> 'deleted'` is NULL) and leave them undeletable.
+ *
+ * A colliding rename surfaces as a `23505` unique violation (`name` is the only
+ * unique column this UPDATE touches), which we resolve by advancing the index
+ * and retrying — race-safe against concurrent deletes of same-named brands
+ * (the rename is keyed by brand id, so a re-run recomputes the same target and
+ * is idempotent).
+ *
+ * Backfilling brands deleted before this change (which kept their original
+ * names) is a separate one-off data migration and is intentionally out of scope
+ * here — this governs only the forward-looking delete path.
  *
  * @param {string} organizationId - SpaceCat organization UUID
  * @param {string} brandId - Brand UUID
  * @param {object} postgrestClient - PostgREST client
  * @param {string} [updatedBy] - User performing the operation
- * @returns {Promise<boolean>} True if deleted, false if not found
+ * @returns {Promise<boolean>} True if the brand is deleted (freshly soft-deleted,
+ *   or already deleted — DELETE stays idempotent), false if no such brand exists
  */
 export async function deleteBrand(organizationId, brandId, postgrestClient, updatedBy = 'system') {
   if (!postgrestClient?.from) {
     throw new Error('PostgREST client is required');
   }
 
-  const { data, error } = await postgrestClient
+  // Read the brand's current name (and status) so we can rename it on delete.
+  const { data: brand, error: readError } = await postgrestClient
     .from('brands')
-    .update({ status: 'deleted', updated_by: updatedBy })
+    .select('name, status')
     .eq('organization_id', organizationId)
     .eq('id', brandId)
-    .select('id')
     .maybeSingle();
 
-  if (error) {
-    throw new Error(`Failed to delete brand: ${error.message}`);
+  if (readError) {
+    throw new Error(`Failed to delete brand: ${readError.message}`);
   }
-  return !!data;
+  // Genuinely not found → false (404).
+  if (!brand) {
+    return false;
+  }
+  // Already soft-deleted → succeed idempotently (matches the pre-LLMO-6978
+  // behavior where a repeat delete returned 204) WITHOUT re-renaming, so an
+  // already-renamed name is never re-suffixed (`Acme_deleted_deleted`).
+  if (brand.status === 'deleted') {
+    return true;
+  }
+
+  // Try `{name}_deleted`, then `{name}_deleted2`, `{name}_deleted3`, ... until a
+  // free name lands. A collision rejects the UPDATE with a 23505 (a same-named
+  // brand was already deleted, or two deletes race) — advance the index and
+  // retry rather than surfacing a 500. The UPDATE is keyed by brand id, so a
+  // concurrent re-run recomputes the same target name and stays idempotent.
+  for (let index = 1; index <= MAX_DELETED_NAME_ATTEMPTS; index += 1) {
+    const deletedName = index === 1
+      ? `${brand.name}_deleted`
+      : `${brand.name}_deleted${index}`;
+
+    // eslint-disable-next-line no-await-in-loop -- sequential retry on name collision
+    const { data, error } = await postgrestClient
+      .from('brands')
+      .update({ status: 'deleted', name: deletedName, updated_by: updatedBy })
+      .eq('organization_id', organizationId)
+      .eq('id', brandId)
+      .select('id')
+      .maybeSingle();
+
+    if (!error) {
+      return !!data;
+    }
+    // Not a name collision → a real failure; surface it.
+    if (error.code !== '23505') {
+      throw new Error(`Failed to delete brand: ${error.message}`);
+    }
+    // else: `{name}_deletedN` is taken — fall through and try the next index.
+  }
+
+  throw new Error(
+    `Failed to delete brand: could not free the name "${brand.name}" after `
+    + `${MAX_DELETED_NAME_ATTEMPTS} attempts`,
+  );
 }
 
 /**

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -1598,19 +1598,25 @@ export async function updateBrand({
  * appended (`{name}_deleted2`, `{name}_deleted3`, ...) until the name is free —
  * the only re-collision case is a customer literally naming a brand `..._deleted`.
  *
- * A brand that is already `deleted` is left untouched (returns false → 404) so
- * a repeated delete never double-suffixes an already-renamed brand
- * (`Acme_deleted` → `Acme_deleted_deleted`). Any other status — including a NULL
- * status, which the rest of the code treats as a live brand — is renamed as
- * normal; the guard is a JS `status === 'deleted'` check rather than a SQL
- * `status != 'deleted'` filter precisely because the latter would also exclude
- * NULL-status rows (`NULL <> 'deleted'` is NULL) and leave them undeletable.
+ * A brand that is already `deleted` short-circuits (returns true → idempotent
+ * 204) WITHOUT re-renaming, so a repeated delete never double-suffixes an
+ * already-renamed brand (`Acme_deleted` → `Acme_deleted_deleted`). Any other
+ * status — including a NULL status, which the rest of the code treats as a live
+ * brand — is renamed as normal. This early check is a JS `status === 'deleted'`
+ * guard rather than a SQL `status != 'deleted'` filter, which would also
+ * exclude NULL-status rows (`NULL <> 'deleted'` is NULL) and leave them
+ * undeletable. To also close the read-then-write race, the UPDATE itself is
+ * filtered with PostgREST `.not('status', 'eq', 'deleted')` — which DOES match
+ * NULL-status rows — so a concurrent delete that already renamed the row turns
+ * our UPDATE into a zero-row no-op (reported as success) instead of
+ * re-suffixing it.
  *
- * A colliding rename surfaces as a `23505` unique violation (`name` is the only
- * unique column this UPDATE touches), which we resolve by advancing the index
- * and retrying — race-safe against concurrent deletes of same-named brands
- * (the rename is keyed by brand id, so a re-run recomputes the same target and
- * is idempotent).
+ * A colliding rename surfaces as a `23505` on the per-org name constraint
+ * (`uq_brand_name_per_org`, the only unique column this UPDATE touches), which
+ * we resolve by advancing the index and retrying; any other 23505 is surfaced
+ * rather than retried. Race-safe against concurrent deletes of same-named
+ * brands (the rename is keyed by brand id, so a re-run recomputes the same
+ * target and is idempotent).
  *
  * Backfilling brands deleted before this change (which kept their original
  * names) is a separate one-off data migration and is intentionally out of scope
@@ -1661,19 +1667,33 @@ export async function deleteBrand(organizationId, brandId, postgrestClient, upda
       : `${brand.name}_deleted${index}`;
 
     // eslint-disable-next-line no-await-in-loop -- sequential retry on name collision
-    const { data, error } = await postgrestClient
+    const { error } = await postgrestClient
       .from('brands')
       .update({ status: 'deleted', name: deletedName, updated_by: updatedBy })
       .eq('organization_id', organizationId)
       .eq('id', brandId)
+      // Make the write itself the concurrency guard: only a still-live row is
+      // renamed. If a concurrent deleteBrand already flipped this row to
+      // `deleted` between our SELECT above and this UPDATE, we match zero rows
+      // instead of re-suffixing an already-renamed brand (`Acme_deleted` →
+      // `Acme_deleted2`). PostgREST `.not(...eq...)` still matches NULL-status
+      // rows (unlike a bare `status != 'deleted'`), so NULL-status live brands
+      // stay deletable.
+      .not('status', 'eq', 'deleted')
       .select('id')
       .maybeSingle();
 
     if (!error) {
-      return !!data;
+      // Either we renamed + soft-deleted the row, OR a racing caller already
+      // soft-deleted it so our status-guarded UPDATE matched zero rows — either
+      // way the brand is now deleted, so report success idempotently.
+      return true;
     }
-    // Not a name collision → a real failure; surface it.
-    if (error.code !== '23505') {
+    // A 23505 on our per-org name constraint means `{name}_deletedN` is taken —
+    // advance the index and retry. Any other 23505 (a different unique
+    // constraint) can't be resolved by renaming, so surface it immediately
+    // rather than burning the whole retry budget on an unresolvable violation.
+    if (error.code !== '23505' || !error.message?.includes('uq_brand_name_per_org')) {
       throw new Error(`Failed to delete brand: ${error.message}`);
     }
     // else: `{name}_deletedN` is taken — fall through and try the next index.

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -9059,6 +9059,7 @@ describe('Brands Controller', () => {
           select: sandbox.stub().returnsThis(),
           eq: sandbox.stub().returnsThis(),
           neq: sandbox.stub().returnsThis(),
+          not: sandbox.stub().returnsThis(),
           order: sandbox.stub().returnsThis(),
           update: sandbox.stub().returnsThis(),
           ilike: sandbox.stub().returnsThis(),

--- a/test/it/shared/tests/brands.js
+++ b/test/it/shared/tests/brands.js
@@ -236,4 +236,64 @@ export default function brandsTests(getHttpClient, resetData) {
       expect(reuse.body.baseSiteId).to.equal(SITE_2_ID);
     });
   });
+
+  describe('Brands v2 delete frees the name for reuse (LLMO-6978)', () => {
+    before(() => resetData());
+
+    it('renames a deleted brand to {name}_deleted so the name can be recreated, indexing repeats', async () => {
+      const http = getHttpClient();
+      const NAME = 'Reusable Name Brand';
+
+      // 1. Create a brand, then soft-delete it. Deleting must free the name by
+      //    renaming the row to `${NAME}_deleted` (uq_brand_name_per_org spans
+      //    deleted rows, so keeping the original name would block recreation).
+      const createA = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
+        name: NAME, region: ['US'],
+      });
+      expect(createA.status).to.equal(201);
+      const brandAId = createA.body.id;
+
+      const deleteA = await http.admin.delete(`/v2/orgs/${ORG_1_ID}/brands/${brandAId}`);
+      expect(deleteA.status).to.equal(204);
+
+      // 2. Recreating a brand with the ORIGINAL name now succeeds (previously
+      //    rejected by uq_brand_name_per_org) and yields a NEW brand id.
+      const createB = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
+        name: NAME, region: ['US'],
+      });
+      expect(createB.status).to.equal(201);
+      expect(createB.body.id).to.not.equal(brandAId);
+      const brandBId = createB.body.id;
+
+      // 3. Deleting the second same-named brand collides with the first deleted
+      //    `${NAME}_deleted`, so it must take the `_deleted2` index (exercises the
+      //    23505 retry path against the real per-org unique constraint).
+      const deleteB = await http.admin.delete(`/v2/orgs/${ORG_1_ID}/brands/${brandBId}`);
+      expect(deleteB.status).to.equal(204);
+
+      // 4. The name is still free — a third create with the same name succeeds.
+      const createC = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
+        name: NAME, region: ['US'],
+      });
+      expect(createC.status).to.equal(201);
+      expect(createC.body.id).to.not.equal(brandAId);
+      expect(createC.body.id).to.not.equal(brandBId);
+
+      // 5. The two deleted rows carry the indexed `_deleted` names; the live list
+      //    (which excludes deleted brands) shows exactly one brand with the name.
+      const deletedList = await http.admin.get(`/v2/orgs/${ORG_1_ID}/brands?status=deleted`);
+      expect(deletedList.status).to.equal(200);
+      const deletedNames = deletedList.body.brands
+        .filter((b) => b.name === `${NAME}_deleted` || b.name === `${NAME}_deleted2`)
+        .map((b) => b.name)
+        .sort();
+      expect(deletedNames).to.deep.equal([`${NAME}_deleted`, `${NAME}_deleted2`]);
+
+      const liveList = await http.admin.get(`/v2/orgs/${ORG_1_ID}/brands`);
+      expect(liveList.status).to.equal(200);
+      const liveWithName = liveList.body.brands.filter((b) => b.name === NAME);
+      expect(liveWithName).to.have.lengthOf(1);
+      expect(liveWithName[0].id).to.equal(createC.body.id);
+    });
+  });
 }

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -3244,7 +3244,7 @@ describe('brands-storage', () => {
     it('appends an incrementing index when {name}_deleted already exists (LLMO-6978)', async () => {
       const client = createCapturingClient({
         brands: [
-          { data: { name: 'Acme' }, error: null }, // read current name
+          { data: { name: 'Acme', status: 'active' }, error: null }, // read name + status
           // first rename collides with an existing deleted "Acme_deleted"
           { data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"' } },
           { data: { id: BRAND_ID }, error: null }, // retry with _deleted2 succeeds
@@ -3294,14 +3294,49 @@ describe('brands-storage', () => {
     it('throws after exhausting the collision-retry budget', async () => {
       const client = createTableMockClient({
         brands: [
-          { data: { name: 'Acme' }, error: null }, // read current name
-          // every rename attempt collides (clamped: reused for all updates)
-          { data: null, error: { code: '23505', message: 'duplicate key' } },
+          { data: { name: 'Acme', status: 'active' }, error: null }, // read name + status
+          // every rename attempt collides on the per-org name constraint
+          // (clamped: reused for all updates), so the loop keeps retrying.
+          { data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"' } },
         ],
       });
 
       await expect(deleteBrand(ORG_ID, BRAND_ID, client))
         .to.be.rejectedWith('could not free the name "Acme" after 100 attempts');
+    });
+
+    it('reports success when a concurrent delete already soft-deleted the row (guarded zero-row UPDATE)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { name: 'Acme', status: 'active' }, error: null }, // read: still live
+          // Our guarded UPDATE (.not status eq deleted) matches zero rows because a
+          // racing deleteBrand already flipped this row to deleted between the read
+          // and the write — so we neither 404 nor re-suffix the already-renamed brand.
+          { data: null, error: null },
+        ],
+      });
+
+      const result = await deleteBrand(ORG_ID, BRAND_ID, client, 'user@test.com');
+
+      // Idempotent success: the racing caller completed the delete for us.
+      expect(result).to.be.true;
+      // Exactly one UPDATE, no extra retries — the write itself is the guard.
+      expect(client.capturedCalls.update).to.have.lengthOf(1);
+      expect(client.capturedCalls.update[0].row.name).to.equal('Acme_deleted');
+    });
+
+    it('surfaces a 23505 from a different unique constraint immediately instead of retrying', async () => {
+      const client = createTableMockClient({
+        brands: [
+          { data: { name: 'Acme', status: 'active' }, error: null }, // read name + status
+          // A 23505 that is NOT the per-org name collision — advancing the index
+          // can't resolve it, so it must surface right away, not burn 100 attempts.
+          { data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "brands_base_site_unique"' } },
+        ],
+      });
+
+      await expect(deleteBrand(ORG_ID, BRAND_ID, client))
+        .to.be.rejectedWith('Failed to delete brand: duplicate key value violates unique constraint "brands_base_site_unique"');
     });
   });
   describe('active->pending demotion guard (LLMO-5587)', () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -3193,27 +3193,115 @@ describe('brands-storage', () => {
       await expect(deleteBrand(ORG_ID, BRAND_ID, null)).to.be.rejectedWith('PostgREST client is required');
     });
 
-    it('returns true when brand is found and soft-deleted', async () => {
-      const query = createChainableQuery({ data: { id: BRAND_ID }, error: null });
-      const postgrestClient = { from: sinon.stub().returns(query) };
+    it('renames the brand to {name}_deleted and returns true (LLMO-6978)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { name: 'Acme', status: 'active' }, error: null }, // read name + status
+          { data: { id: BRAND_ID }, error: null }, // rename + soft-delete
+        ],
+      });
 
-      const result = await deleteBrand(ORG_ID, BRAND_ID, postgrestClient, 'user@test.com');
+      const result = await deleteBrand(ORG_ID, BRAND_ID, client, 'user@test.com');
+
       expect(result).to.be.true;
+      expect(client.capturedCalls.update).to.have.lengthOf(1);
+      expect(client.capturedCalls.update[0].row).to.deep.equal({
+        status: 'deleted',
+        name: 'Acme_deleted',
+        updated_by: 'user@test.com',
+      });
     });
 
-    it('returns false when brand not found', async () => {
-      const query = createChainableQuery({ data: null, error: null });
-      const postgrestClient = { from: sinon.stub().returns(query) };
+    it('renames a brand with a NULL status (treated as live) rather than 404ing it', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { name: 'Acme', status: null }, error: null }, // read name + status
+          { data: { id: BRAND_ID }, error: null }, // rename + soft-delete
+        ],
+      });
 
-      const result = await deleteBrand(ORG_ID, BRAND_ID, postgrestClient);
+      const result = await deleteBrand(ORG_ID, BRAND_ID, client, 'user@test.com');
+
+      expect(result).to.be.true;
+      expect(client.capturedCalls.update[0].row.name).to.equal('Acme_deleted');
+    });
+
+    it('succeeds idempotently without renaming when the brand is already deleted', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { name: 'Acme_deleted', status: 'deleted' }, error: null }, // read
+        ],
+      });
+
+      const result = await deleteBrand(ORG_ID, BRAND_ID, client);
+
+      // Idempotent DELETE (→ 204), but no second write — the already-renamed
+      // name is left untouched so it is never re-suffixed.
+      expect(result).to.be.true;
+      expect(client.capturedCalls.update).to.have.lengthOf(0);
+    });
+
+    it('appends an incrementing index when {name}_deleted already exists (LLMO-6978)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: { name: 'Acme' }, error: null }, // read current name
+          // first rename collides with an existing deleted "Acme_deleted"
+          { data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint "uq_brand_name_per_org"' } },
+          { data: { id: BRAND_ID }, error: null }, // retry with _deleted2 succeeds
+        ],
+      });
+
+      const result = await deleteBrand(ORG_ID, BRAND_ID, client, 'user@test.com');
+
+      expect(result).to.be.true;
+      expect(client.capturedCalls.update.map((u) => u.row.name)).to.deep.equal([
+        'Acme_deleted',
+        'Acme_deleted2',
+      ]);
+    });
+
+    it('returns false when no live brand is found (already deleted / not found)', async () => {
+      const client = createTableMockClient({
+        brands: [{ data: null, error: null }], // read finds no non-deleted row
+      });
+
+      const result = await deleteBrand(ORG_ID, BRAND_ID, client);
+
       expect(result).to.be.false;
     });
 
-    it('throws on database error', async () => {
-      const query = createChainableQuery({ data: null, error: { message: 'delete failed' } });
-      const postgrestClient = { from: sinon.stub().returns(query) };
+    it('throws when the current-name read fails', async () => {
+      const client = createTableMockClient({
+        brands: [{ data: null, error: { message: 'read failed' } }],
+      });
 
-      await expect(deleteBrand(ORG_ID, BRAND_ID, postgrestClient)).to.be.rejectedWith('Failed to delete brand: delete failed');
+      await expect(deleteBrand(ORG_ID, BRAND_ID, client))
+        .to.be.rejectedWith('Failed to delete brand: read failed');
+    });
+
+    it('throws on a non-collision database error during the rename', async () => {
+      const client = createTableMockClient({
+        brands: [
+          { data: { name: 'Acme' }, error: null }, // read current name
+          { data: null, error: { message: 'delete failed' } }, // rename fails hard
+        ],
+      });
+
+      await expect(deleteBrand(ORG_ID, BRAND_ID, client))
+        .to.be.rejectedWith('Failed to delete brand: delete failed');
+    });
+
+    it('throws after exhausting the collision-retry budget', async () => {
+      const client = createTableMockClient({
+        brands: [
+          { data: { name: 'Acme' }, error: null }, // read current name
+          // every rename attempt collides (clamped: reused for all updates)
+          { data: null, error: { code: '23505', message: 'duplicate key' } },
+        ],
+      });
+
+      await expect(deleteBrand(ORG_ID, BRAND_ID, client))
+        .to.be.rejectedWith('could not free the name "Acme" after 100 attempts');
     });
   });
   describe('active->pending demotion guard (LLMO-5587)', () => {


### PR DESCRIPTION
## What & why

Soft-deleting a brand kept its original name, so the per-org unique constraint `uq_brand_name_per_org` (which spans deleted rows) kept the name "taken" and blocked recreating a brand with that name.

This rewrites `deleteBrand()` in `src/support/brands-storage.js` to read the brand's name + status and rename any non-deleted brand to `{name}_deleted` in the same UPDATE that sets `status='deleted'`, appending an incrementing index (`_deleted2`, `_deleted3`, …) on a `23505` name collision (retried, race-safe). An already-deleted brand short-circuits to an idempotent 204 without re-renaming (no double-suffix); a NULL status is treated as live via a JS check rather than a SQL filter (which would exclude NULL rows).

The change is contained to `spacecat-api-service`; the shared Brand model is a read/patch surface not in the delete path, so no `spacecat-shared` change was needed. Backfilling pre-existing deleted brands is a separate workstream and out of scope.

## Tests

- Unit (`test/support/brands-storage.test.js`): rename, NULL-status, already-deleted idempotency, `_deleted2` collision index, not-found, read error, non-collision error, retry-exhaustion.
- Integration (`test/it/shared/tests/brands.js`): create → delete → recreate-same-name → delete-again (`_deleted2`) → recreate, asserting freed names against the real constraint. (Runs in CI — Postgres/Docker unavailable locally.)
- Local: eslint clean; `mocha test/support/brands-storage.test.js` (217 passing); `mocha test/controllers/brands.test.js -g deleteBrandForOrg` (10 passing); `npm run type-check` base+strict exit 0; c8 on `brands-storage.js` = 100% stmts/lines, 98.42% branches.

## Links

- Jira: https://jira.corp.adobe.com/browse/LLMO-6978
- Slack thread: https://cq-dev.slack.com/archives/C0BEJH1SNNL/p1786548369491819

---
🤖 Draft opened by the slack-pipeline. Auto-reviewed at implement time; CI + reviewer handled next.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```