### PR TITLE
feat(ai-visibility): scope brand prompts and topics to subdomains

### DIFF
--- a/src/support/ai-visibility/grpc-utils.js
+++ b/src/support/ai-visibility/grpc-utils.js
@@ -17,7 +17,9 @@ import {
   LLM_ENUM,
   TOPIC_INTENT_ENUM,
 } from '@quazar/ai-seo-ts/common/types_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
 import { ConnectError, Code } from '@connectrpc/connect';
+import { parse as parseDomain } from 'tldts';
 
 export { COUNTRY_ENUM, LLM_ENUM, TOPIC_INTENT_ENUM };
 
@@ -183,6 +185,25 @@ export function num(v) {
 export function brandTarget(domain) {
   const d = domain.trim().toLowerCase();
   return { domain: d, name: d };
+}
+
+/**
+ * Resolve the Semrush `search_type` for a target domain. When the target carries a
+ * non-www subdomain (e.g. `quickbooks.intuit.com`) mentions/citations must be scoped
+ * to that subdomain; otherwise Semrush interprets the target as the registrable domain
+ * (`intuit.com`) and returns the parent-domain results. Apex domains and bare `www.`
+ * hosts resolve to DOMAIN. Uses tldts so multi-part TLDs (`.co.uk`, `.com.au`) are
+ * handled correctly. Unparseable input defaults to DOMAIN (preserving prior behaviour).
+ *
+ * @param {string|null|undefined} domain target domain/hostname (may include scheme or `www.`)
+ * @returns {number} SEARCH_TYPE_ENUM.SUBDOMAIN when a non-www subdomain is present, else DOMAIN
+ */
+export function resolveSearchType(domain) {
+  const parsed = parseDomain(String(domain ?? ''));
+  const subdomain = parsed?.subdomain || '';
+  return subdomain !== '' && subdomain !== 'www'
+    ? SEARCH_TYPE_ENUM.SUBDOMAIN
+    : SEARCH_TYPE_ENUM.DOMAIN;
 }
 
 export function parseLimitOffset(sp) {

--- a/src/support/ai-visibility/handlers/v1/prompt/brand-prompts-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt/brand-prompts-export.js
@@ -31,6 +31,7 @@ import {
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   responseFromGrpcError,
   PROTO_FROM_JSON,
@@ -41,6 +42,7 @@ import { buildBrandPromptsDimensionFilterQl } from './brand-prompts.js';
 /* c8 ignore start */
 export async function handleBrandPromptsExport(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.US;
   const sortBy = sp.get('sortBy') || PROMPTS_REQUEST_ORDER_BY_ENUM.MENTIONED_BRANDS_COUNT;
@@ -69,6 +71,7 @@ export async function handleBrandPromptsExport(sp, clients) {
         categories,
         dimension_filter_ql: buildBrandPromptsDimensionFilterQl(sp),
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/prompt/brand-prompts.js
+++ b/src/support/ai-visibility/handlers/v1/prompt/brand-prompts.js
@@ -29,6 +29,7 @@ import {
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   responseFromGrpcError,
   escapeQlString,
@@ -65,6 +66,7 @@ export function buildBrandPromptsDimensionFilterQl(sp) {
 /* c8 ignore start */
 export async function handleBrandPrompts(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.US;
   const sortBy = sp.get('sortBy') || PROMPTS_REQUEST_ORDER_BY_ENUM.MENTIONED_BRANDS_COUNT;
@@ -98,6 +100,7 @@ export async function handleBrandPrompts(sp, clients) {
         categories,
         dimension_filter_ql: dimensionFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );
@@ -111,6 +114,7 @@ export async function handleBrandPrompts(sp, clients) {
         categories,
         dimension_filter_ql: dimensionFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/topic/brand-topics-export.js
+++ b/src/support/ai-visibility/handlers/v1/topic/brand-topics-export.js
@@ -31,6 +31,7 @@ import {
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   responseFromGrpcError,
   PROTO_FROM_JSON,
@@ -44,6 +45,7 @@ import {
 /* c8 ignore start */
 export async function handleBrandTopicsExport(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const sortBy = sp.get('sortBy') || BRAND_TOPICS_ORDER_BY_ENUM.VISIBILITY;
@@ -80,6 +82,7 @@ export async function handleBrandTopicsExport(sp, clients) {
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/topic/brand-topics-totals.js
+++ b/src/support/ai-visibility/handlers/v1/topic/brand-topics-totals.js
@@ -24,6 +24,7 @@ import {
 } from '@quazar/ai-seo-ts/v2/topic/enums_pb.js';
 import {
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   responseFromGrpcError,
   PROTO_FROM_JSON,
@@ -37,6 +38,7 @@ import {
 /* c8 ignore start */
 export async function handleBrandTopicsTotals(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const date = sp.get('date');
@@ -65,6 +67,7 @@ export async function handleBrandTopicsTotals(sp, clients) {
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/topic/brand-topics.js
+++ b/src/support/ai-visibility/handlers/v1/topic/brand-topics.js
@@ -27,6 +27,7 @@ import {
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   responseFromGrpcError,
   buildRangeExpr,
@@ -90,6 +91,7 @@ export function buildBrandTopicsMetricFilterQl(sp) {
 
 export async function handleBrandTopics(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const sortBy = sp.get('sortBy') || BRAND_TOPICS_ORDER_BY_ENUM.VISIBILITY;
@@ -126,6 +128,7 @@ export async function handleBrandTopics(sp, clients) {
         dimension_filter_ql: dimensionFilterQl,
         metric_filter_ql: metricFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/test/support/ai-visibility/grpc-utils.test.js
+++ b/test/support/ai-visibility/grpc-utils.test.js
@@ -12,6 +12,7 @@
  */
 
 import { expect } from 'chai';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
 import {
   COUNTRY_ENUM,
   LLM_ENUM,
@@ -25,6 +26,7 @@ import {
   TOPIC_OPPORTUNITY_PROMPTS_MAX_PAGES,
   num,
   brandTarget,
+  resolveSearchType,
   parseLimitOffset,
   normalizeCountryForGrpc,
   resolveCountry,
@@ -239,6 +241,35 @@ describe('grpc-utils', () => {
   describe('brandTarget', () => {
     it('normalizes domain to lowercase trimmed', () => {
       expect(brandTarget(' Example.COM ')).to.deep.equal({ domain: 'example.com', name: 'example.com' });
+    });
+  });
+
+  describe('resolveSearchType', () => {
+    it('returns DOMAIN for an apex domain', () => {
+      expect(resolveSearchType('intuit.com')).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+    it('returns DOMAIN for a bare www host', () => {
+      expect(resolveSearchType('www.intuit.com')).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+    it('returns SUBDOMAIN for a non-www subdomain', () => {
+      expect(resolveSearchType('quickbooks.intuit.com')).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+    it('returns SUBDOMAIN for a deep subdomain', () => {
+      expect(resolveSearchType('a.b.intuit.com')).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+    it('handles multi-part TLDs: apex is DOMAIN', () => {
+      expect(resolveSearchType('example.co.uk')).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+    it('handles multi-part TLDs: subdomain is SUBDOMAIN', () => {
+      expect(resolveSearchType('blog.example.co.uk')).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+    it('ignores scheme and path when present', () => {
+      expect(resolveSearchType('https://quickbooks.intuit.com/foo')).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+    it('defaults to DOMAIN for empty or unparseable input', () => {
+      expect(resolveSearchType('')).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+      expect(resolveSearchType(null)).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+      expect(resolveSearchType(undefined)).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
     });
   });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Scope the AI Visibility "Performing Prompts" tab (topics and their prompts) to the selected subdomain instead of collapsing it to the registrable domain.

## 2. Reasoning
The tab does not support subdomains: loading it for `quickbooks.intuit.com` returns the same topics and prompts as `intuit.com`. The `brand-prompts` and `brand-topics` handlers build the Semrush gRPC request with `target={domain}` but never set `search_type`, so Semrush defaults to `DOMAIN` and reduces any subdomain to its registrable domain. Semrush now supports `search_type: SUBDOMAIN` (confirmed by Dima Gulkin's manual probe on the Intuit brands), and the vendored `@quazar/ai-seo-ts` SDK already exposes the field on both request families. There is customer interest (Intuit) in showing subdomain-level data as a quick win.

## 3. High-level overview of the changes
Backend only. No UI change is required — the UI already sends the full subdomain as the `domain` query param.

- New helper `resolveSearchType(domain)` in `src/support/ai-visibility/grpc-utils.js`. It uses `tldts` (the same approach as `llmo-onboarding.js` `hasNonWWWSubdomain`): a non-`www` subdomain resolves to `SEARCH_TYPE_ENUM.SUBDOMAIN`; an apex domain or a bare `www.` host resolves to `DOMAIN`; unparseable/empty input resolves to `DOMAIN`, preserving today's behaviour.
- The helper is wired into all six request bodies that back the tab: `brand-prompts` (list, totals, export) and `brand-topics` (list, totals, export).

Behaviour delta:
- Before: selecting `quickbooks.intuit.com` returned `intuit.com`'s topics and prompts.
- After: selecting a subdomain scopes both the topic list and each topic's prompts to that subdomain; selecting the apex domain is unchanged.

Scope is deliberately limited to the Performing Prompts tab (its two endpoint families). Other AI Visibility tabs stay domain-level for now.

## 4. Required information
- Jira / issue: [LLMO-6992](https://jira.corp.adobe.com/browse/LLMO-6992) (Epic [LLMO-6009](https://jira.corp.adobe.com/browse/LLMO-6009) — [Serenity] AI Visibility - Phase 2)
- Exemption: trivial, contract-neutral behavior fix grounded in LLMO-6992 — no spec required for this change.

## 6. Affected / used mysticat-workspace projects
- `project-elmo-ui` — consumes the `GET /llmo/ai-visibility/v1/topic/brand-topics` and `/v1/prompt/brand-prompts` endpoints for the Performing Prompts tab. The request/response contract is unchanged (same query params); it already sends the full subdomain, so no UI change is needed to benefit.

## 7. Additional information outside the code
- External evidence that the Semrush layer differentiates subdomains: Dima Gulkin's manual `brand prompts` probe on the Intuit brands returned distinct prompt sets for `quickbooks.intuit.com`, `turbotax.intuit.com`, and `intuit.com` when `search_type: SUBDOMAIN` was set (Slack thread). His test also noted `erp.intuit.com` has no mentions but ~538 cited prompts.
- Local backend end-to-end verification (subdomain vs apex through the two endpoints) is pending and will be run against a local backend before merge — see the test plan.

## 8. Test plan
(a) Local: run the backend locally and call the two endpoints for a subdomain and its apex, comparing results:
- `GET /llmo/ai-visibility/v1/topic/brand-topics?domain=quickbooks.intuit.com&country=US&date=2026-08-09`
- `GET /llmo/ai-visibility/v1/prompt/brand-prompts?domain=quickbooks.intuit.com&topicId=<id>&country=US&date=2026-08-09`
Confirm the topic list and prompts differ from the same calls with `domain=intuit.com`. Spot-check a citations-only subdomain (`erp.intuit.com`) returns citation-backed rows.

(b) Per environment:
- dev: hit the two endpoints with `domain=quickbooks.intuit.com` vs `intuit.com` and confirm the responses diverge.
- prod: in the ABV webapp, open AI Visibility → Performing Prompts, select a subdomain in the domain filter, and confirm the topics and expanded prompts are subdomain-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dima", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```