### PR TITLE
feat(serenity): read intent tags under the renamed `$abv_tags$intent` root | LLMO-6984

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -11859,7 +11859,10 @@ SerenityPrompt:
         upstream, so a prompt can carry two tags with the same bare name from
         different dimensions (a sub-category `human` and the `source` value
         `human`). Read a tag's dimension from `path[0].name`, never from its
-        own name.
+        own name — bearing in mind that `path[0].name` is the root's UPSTREAM
+        name, which for the intent dimension is `$abv_tags$intent`, or the
+        pre-rename `intent` on a project the rename has not reached. Match both
+        spellings when keying on that dimension.
     tagIds:
       type: array
       items: { type: string }
@@ -11907,7 +11910,10 @@ SerenityPromptTag:
     parentage. What varies is DEPTH, not endpoint: upstream omits `parent_id` and
     `path` on a dimension root and carries both on a descendant. This API
     normalizes that absence to `null`, so a tag whose `path` is `null` is a
-    dimension root and its own `name` is its dimension.
+    dimension root and its own `name` names its dimension upstream. Names are
+    passed through exactly as upstream holds them, so the intent root reads
+    `$abv_tags$intent` — or the pre-rename `intent` on a project the rename has
+    not reached. The dimension is `intent` either way.
   required: [id, name]
   properties:
     id:
@@ -12795,7 +12801,11 @@ SerenityUrlInspectorFilterDimensions:
       items: { $ref: '#/SerenityFilterDimensionItem' }
     page_intents:
       type: array
-      description: Distinct `intent__`-prefixed tags. `id` is the original `intent__`-prefixed tag value.
+      description: >-
+        Distinct intent-prefixed tags. The prefix is the intent root's name on that
+        project — `$abv_tags$intent__`, or `intent__` on a project the rename has not
+        reached yet — and `id` is the original tag value, carrying whichever prefix
+        that project uses.
       items: { $ref: '#/SerenityFilterDimensionItem' }
     origins:
       type: array

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -546,9 +546,9 @@ v2-serenity-tags:
                 description: |
                   A BARE value — no dimension prefix. Must not contain ':' and
                   must not be one of the reserved dimension root names
-                  (`category`, `intent`, `source`, `type`). For a closed
-                  dimension it must exactly match one of that dimension's fixed
-                  enum values.
+                  (`category`, `intent`, `origin`, `type`, `source`,
+                  `$abv_tags$intent`). For a closed dimension it must exactly
+                  match one of that dimension's fixed enum values.
               geoTargetId:
                 type: integer
                 minimum: 1
@@ -687,7 +687,8 @@ v2-serenity-tag-by-id:
                 description: |
                   The tag's new BARE name — no dimension prefix. Must not
                   contain ':' and must not be one of the reserved dimension root
-                  names (`category`, `intent`, `source`, `type`).
+                  names (`category`, `intent`, `origin`, `type`, `source`,
+                  `$abv_tags$intent`).
               parentId:
                 type: string
                 description: |
@@ -1095,7 +1096,10 @@ v2-serenity-url-inspector-filter-dimensions:
 
       `topics`/`categories`/`page_intents`/`origins` are derived from the same
       underlying Topics element response, split apart by their `topic__`/
-      `category__`/`intent__`/`source__` tag prefix. Any other tag prefix Semrush
+      `category__`/`$abv_tags$intent__`/`source__` tag prefix. A tag prefix is the
+      name of the dimension's root tag, so `page_intents` also claims the
+      pre-rename `intent__` prefix on a project the intent rename has not reached.
+      Any other tag prefix Semrush
       introduces later (e.g. `type__branded`) surfaces automatically as an extra
       array property keyed by that prefix. Bare prefix declarations with no
       value (e.g. a lone `category` row) are ignored. `content_types` is

--- a/src/support/elements/constants.js
+++ b/src/support/elements/constants.js
@@ -13,6 +13,19 @@
 export const DEFAULT_ELEMENT_MODEL = 'search-gpt';
 
 /**
+ * Semrush's Elements API tag encoding: `prefix__value`, with `__` also used for
+ * `parent__child` nesting within the value. A tag's wire form is its `__`-joined
+ * PATH, so the leading segment is the name of its ROOT tag — which is why renaming
+ * a dimension root renames every one of its tags on this surface.
+ *
+ * This replaced an earlier `prefix:value` encoding (colon-delimited, `Parent__Child`
+ * nesting only within the value). The cutover was a one-time, atomic migration on
+ * Semrush's side — all workspaces/customers moved to `__` together, so there is no
+ * dual-format transition period and nothing parses both encodings.
+ */
+export const SEP = '__';
+
+/**
  * Sentinel platform/model value meaning "all platforms" — no single-model filter.
  * Mirrors the UI's `PLATFORM_CODES.All` ('all'), the same "no filter" convention the
  * category/region dimensions already use. Elements that support it OMIT the `CBF_model`

--- a/src/support/elements/definitions/prompts.js
+++ b/src/support/elements/definitions/prompts.js
@@ -36,9 +36,11 @@ export const INTENT_ENRICH_CONCURRENCY = 5;
  *   the shape Semrush's own UI sends for this element.
  * - **tags** — each value becomes its own `tags contains <value>` clause; multiple
  *   tags are AND-ed (a prompt must carry all). Callers pass the FULL prefixed tag
- *   value — the element's tag taxonomy varies by workspace (`type__`, `category__`,
- *   `intent__`, `source__`, `topic__`), so no prefix is assumed here. e.g. pass
- *   `type__branded` for the branded count, `category__Brand` for a category filter.
+ *   value — the prefix is the tag's root name, which varies by workspace and, for
+ *   the intent dimension, by how far the `$abv_tags$intent` rename has reached
+ *   (`type__`, `category__`, `$abv_tags$intent__`, `source__`, `topic__`), so no
+ *   prefix is assumed here. e.g. pass `type__branded` for the branded count,
+ *   `category__Brand` for a category filter.
  * - **projectIds** — a `CBF_project` `or` group; omitted → all projects in the
  *   (sub-)workspace. The UI already surfaces these as `semrush_project_id` via the
  *   URL Inspector filter-dimensions `regions`.

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { resolveElementModel } from '../constants.js';
+import { resolveElementModel, SEP } from '../constants.js';
+import { INTENT_ROOT_NAME, LEGACY_INTENT_ROOT_NAME } from '../../serenity/prompt-tags.js';
 
 /**
  * Builds the payload for the Topics (Tags) filter-dimensions element (row 3).
@@ -44,14 +45,6 @@ export function buildTopicsPayload({
     filters: { advanced: { op: 'and', filters } },
   };
 }
-
-// Semrush's Elements API tag encoding: `prefix__value`, with `__` also used for
-// `parent__child` nesting within the value. This replaced an earlier `prefix:value`
-// encoding (colon-delimited, `Parent__Child` nesting only within the value). The
-// cutover is a one-time, atomic migration on Semrush's side — all workspaces/customers
-// were migrated to `__` together, so there is no dual-format transition period and no
-// need to parse both encodings here.
-const SEP = '__';
 
 /**
  * @typedef {object} FilterDimensionItem
@@ -135,15 +128,35 @@ export function transformCategoriesToFilterDimensions(raw) {
 }
 
 /**
- * Extracts only "intent__"-prefixed entries → `{ id: original tag, label }`,
- * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
- * hierarchy.
+ * The intent dimension's root names, and therefore its Elements tag prefixes —
+ * the current `$abv_tags$intent` and the pre-rename `intent`. The Elements tag
+ * encoding is the `__`-joined tag PATH, so a dimension's prefix is literally its
+ * root's name and the rename (LLMO-6984) changes what these tags look like on
+ * the wire. The rename runs project by project, so both shapes are read; a
+ * project carries one or the other, never a mix, and the two prefixes cannot
+ * match the same value (`intent__` does not prefix `$abv_tags$intent__…`).
+ *
+ * LLMO-6986 drops the legacy entry once no project carries it.
+ */
+const INTENT_ROOT_NAMES = [INTENT_ROOT_NAME, LEGACY_INTENT_ROOT_NAME];
+
+/**
+ * Extracts the intent-prefixed entries → `{ id: original tag, label }`, plus
+ * `parent_id`/`parent_label` when the tag encodes a "Parent__Child" hierarchy.
+ *
+ * `id` stays the original tag value, which is what a caller passes back as a
+ * `tags` filter, so it carries whichever prefix that project actually uses. The
+ * `label` is the bare value either way — the rename touches only the root.
+ *
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformIntentsToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'intent')
-    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'intent__') }));
+  return INTENT_ROOT_NAMES.flatMap((root) => {
+    const marker = `${root}${SEP}`;
+    return extractByPrefix(raw, root)
+      .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, marker) }));
+  });
 }
 
 /**
@@ -158,12 +171,23 @@ export function transformOriginsToFilterDimensions(raw) {
     .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'source__') }));
 }
 
-const KNOWN_TAG_PREFIXES = ['topic__', 'category__', 'intent__', 'source__'];
+const KNOWN_TAG_PREFIXES = [
+  'topic__',
+  'category__',
+  ...INTENT_ROOT_NAMES.map((root) => `${root}${SEP}`),
+  'source__',
+];
 
 /**
- * Extracts every tag NOT already covered by the known `topic__`/`category__`/
- * `intent__`/`source__` prefixes, so newly-introduced Semrush tag types (e.g.
- * `type__branded`) surface in the response without a code change per prefix.
+ * Extracts every tag NOT already covered by {@link KNOWN_TAG_PREFIXES} —
+ * `topic__`, `category__`, `source__` and both intent spellings — so
+ * newly-introduced Semrush tag types (e.g. `type__branded`) surface in the
+ * response without a code change per prefix.
+ *
+ * Both intent spellings are covered, so a renamed project's tags are claimed by
+ * `page_intents` rather than resurfacing here as a dynamic `$abv_tags$intent`
+ * group — this catch-all is where an unrecognised dimension would otherwise leak
+ * into the filter payload under its raw upstream name.
  *
  * - `prefix__value` tags are grouped by their prefix into a dynamic key
  *   (e.g. `{ type: [{ id: 'type__branded', label: 'branded' }, ...] }`), unless

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -136,7 +136,10 @@ export function createElementsService(transport, log) {
       // log. Report it too, so LLMO-6986 can be gated on all three going quiet rather
       // than on a judgement call about which projects the sweep reached.
       if (result.page_intents.some((i) => i.id.startsWith(`${LEGACY_INTENT_ROOT_NAME}${SEP}`))) {
-        log?.info?.('serenity filter dimensions: workspace still carries pre-rename `intent__` tags', { workspaceId });
+        log?.info?.(
+          'serenity filter dimensions: workspace still carries pre-rename `intent__` tags',
+          { event: 'intent-rename-legacy-tags-present', workspaceId },
+        );
       }
       // Merge any tag types not covered above (e.g. `type:branded`) under their own
       // prefix key, and plain prefix-less tags under `tags` — see
@@ -267,7 +270,10 @@ export function createElementsService(transport, log) {
         if (!unreached) {
           return current;
         }
-        log?.info?.('serenity userIntent enrichment: no rows under the renamed intent root, retrying the pre-rename one', { workspaceId });
+        log?.info?.(
+          'serenity userIntent enrichment: no rows under the renamed intent root, retrying the pre-rename one',
+          { event: 'intent-rename-legacy-retry', workspaceId },
+        );
         return fetchIntentRound(LEGACY_INTENT_ROOT_NAME);
       };
 

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -12,9 +12,14 @@
 
 import { hasText } from '@adobe/spacecat-shared-utils';
 import { ELEMENT_IDS } from './element-ids.js';
+import { SEP } from './constants.js';
 import { mapWithConcurrency } from './concurrency.js';
 import { splitDateRangeIntoWeeksBackward } from './week-utils.js';
-import { INTENT_VALUE } from '../serenity/prompt-tags.js';
+import {
+  INTENT_VALUE,
+  INTENT_ROOT_NAME,
+  LEGACY_INTENT_ROOT_NAME,
+} from '../serenity/prompt-tags.js';
 import {
   buildBrandsPayload,
   transformBrandsToFilterDimensions,
@@ -126,6 +131,13 @@ export function createElementsService(transport, log) {
         origins: transformOriginsToFilterDimensions(rawTopics),
         content_types: transformContentTypesToFilterDimensions(rawContentTypes),
       };
+      // The dual-prefix intent read is the one rename tolerance that would otherwise
+      // fire silently forever — the write-path alias and the `getPrompts` retry both
+      // log. Report it too, so LLMO-6986 can be gated on all three going quiet rather
+      // than on a judgement call about which projects the sweep reached.
+      if (result.page_intents.some((i) => i.id.startsWith(`${LEGACY_INTENT_ROOT_NAME}${SEP}`))) {
+        log?.info?.('serenity filter dimensions: workspace still carries pre-rename `intent__` tags', { workspaceId });
+      }
       // Merge any tag types not covered above (e.g. `type:branded`) under their own
       // prefix key, and plain prefix-less tags under `tags` — see
       // transformOtherTagsForFilterDimensions. The reserved-key list is derived
@@ -173,11 +185,24 @@ export function createElementsService(transport, log) {
      * When `params.enrichUserIntent` is set (and the query is scoped to exactly
      * one `projectId` — see below), each returned row also carries its OWN intent
      * (`userIntent`). The intent isn't a column on the PROMPTS element, so it's
-     * derived with one `intent__<value>`-filtered call per Semrush intent, run in
-     * parallel and joined back to the base rows.
+     * derived with one `<intentRoot>__<value>`-filtered call per Semrush intent, run
+     * in parallel and joined back to the base rows.
+     *
+     * The intent root is being renamed to `$abv_tags$intent` project by project
+     * (LLMO-6984), and an Elements tag filter is the `__`-joined tag PATH — so the
+     * root's name IS the prefix, and a filter carrying the wrong one matches nothing
+     * and answers 200 with an empty `userIntent` on every row. The current spelling
+     * is therefore tried first and the pre-rename `intent` only as a RETRY, fired
+     * when all five calls came back empty: that is the signature of a project the
+     * rename has not reached. A renamed project stays at five calls, and the retry
+     * stops firing on its own as the sweep progresses, so removing the legacy
+     * spelling (LLMO-6986) is a no-op rather than a behaviour change.
      *
      * Enrichment is non-fatal per intent value: each call catches its own failure
      * and contributes nothing, so one failing intent drops only that intent's rows.
+     * A failed call is NOT read as the empty-result signature, though — when any of
+     * the five failed, the legacy retry is skipped rather than doubling the call
+     * volume against a struggling upstream for an answer that would be a guess.
      * The base call still propagates on failure. Without the flag, response shape
      * and upstream call count are unchanged.
      *
@@ -208,9 +233,11 @@ export function createElementsService(transport, log) {
       // `(prompt, prompt_topic)` join key — unique within the single requested slice.
       const rowKey = (row) => `${row?.prompt ?? ''} ${row?.prompt_topic ?? ''}`;
 
-      // Base call + one intent-filtered call per intent value, in parallel
-      // (~one extra round-trip). Each intent call degrades independently.
-      const intentPromise = mapWithConcurrency(
+      // One intent-filtered call per intent value under one root spelling, in
+      // parallel (~one extra round-trip). Each call degrades independently and
+      // reports whether it failed, so an empty round can be told apart from a
+      // broken one.
+      const fetchIntentRound = (intentRoot) => mapWithConcurrency(
         Object.values(INTENT_VALUE),
         INTENT_ENRICH_CONCURRENCY,
         async (value) => {
@@ -219,17 +246,33 @@ export function createElementsService(transport, log) {
             const raw = await transport.fetchElement(
               workspaceId,
               ELEMENT_IDS.PROMPTS,
-              buildPromptsPayload({ ...promptParams, tags: [...(promptParams.tags ?? []), `intent__${value}`] }),
+              buildPromptsPayload({
+                ...promptParams,
+                tags: [...(promptParams.tags ?? []), `${intentRoot}${SEP}${value}`],
+              }),
             );
-            return { key, rows: transformPromptsResponse(raw).prompts };
+            return { key, rows: transformPromptsResponse(raw).prompts, failed: false };
           } catch (e) {
-            log?.warn?.(`serenity userIntent enrichment: intent-filtered PROMPTS call failed for '${value}'`, { workspaceId, error: e?.message });
-            return { key, rows: [] };
+            log?.warn?.(`serenity userIntent enrichment: intent-filtered PROMPTS call failed for '${value}' under '${intentRoot}'`, { workspaceId, error: e?.message });
+            return { key, rows: [], failed: true };
           }
         },
       );
 
-      const [base, intentResults] = await Promise.all([basePromise, intentPromise]);
+      // Current spelling first; the pre-rename one only when all five answered
+      // successfully AND empty (see the doc above).
+      const resolveIntentRows = async () => {
+        const current = await fetchIntentRound(INTENT_ROOT_NAME);
+        const unreached = current.every(({ rows, failed }) => rows.length === 0 && !failed);
+        if (!unreached) {
+          return current;
+        }
+        log?.info?.('serenity userIntent enrichment: no rows under the renamed intent root, retrying the pre-rename one', { workspaceId });
+        return fetchIntentRound(LEGACY_INTENT_ROOT_NAME);
+      };
+
+      // Base call runs alongside the intent rounds rather than after them.
+      const [base, intentResults] = await Promise.all([basePromise, resolveIntentRows()]);
 
       // (prompt, prompt_topic) → own intent. A prompt carries exactly one intent
       // tag, so within a single slice it appears in at most one filtered result.

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -207,7 +207,15 @@ export function validateDeferPublish(body) {
  * `GET /aio/tags` — and the two objects compare equal for the same id (verified
  * live 2026-07-10). What varies is DEPTH, not endpoint: a ROOT tag omits
  * `parent_id` and `path` entirely, while a descendant carries both. So a tag
- * with no `path` is a root, and its own name is its dimension.
+ * with no `path` is a root, and its own name names its dimension.
+ *
+ * Names are passed through as upstream holds them, root breadcrumb included, so
+ * a root's name is not always the bare dimension key: the intent root is named
+ * `$abv_tags$intent` on a project the rename (LLMO-6984) has reached, and
+ * `intent` on one it has not. Folding either spelling to the dimension key here
+ * would put a name in `path[]` beside an id that upstream does not hold under
+ * it, so this stays a faithful mirror and a consumer that keys on the intent
+ * dimension matches both spellings.
  *
  * String-form tags (a defensive upstream fallback) carry a name but no id, and
  * are surfaced with an empty id rather than dropped.

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -21,7 +21,7 @@ import {
 } from '../validation.js';
 import { resolveProject } from '../subworkspace-projects.js';
 import {
-  ALL_DIMENSIONS, SERVER_OWNED_DIMENSIONS,
+  ALL_DIMENSIONS, SERVER_OWNED_DIMENSIONS, RESERVED_ROOT_NAMES,
   isClosedDimension, isServerOwnedDimension, closedValuesOf, isDimensionRootName,
   MAX_TAG_NAME_LEN,
 } from '../prompt-tags.js';
@@ -204,12 +204,12 @@ function parseCreateTagBody(body) {
   if (rawName.includes(':')) {
     throw new ErrorWithStatusCode('name must not contain ":"', 400);
   }
-  // The root level holds exactly the four dimension roots. A value may not
+  // The root level holds exactly the five dimension roots. A value may not
   // shadow one of their names, or the tree would have two tags a reader cannot
   // tell apart by name at the level that matters.
   if (isDimensionRootName(rawName)) {
     throw new ErrorWithStatusCode(
-      `name must not be a reserved dimension root name (${ALL_DIMENSIONS.join(', ')})`,
+      `name must not be a reserved dimension root name (${RESERVED_ROOT_NAMES.join(', ')})`,
       400,
     );
   }
@@ -592,7 +592,7 @@ function parseUpdateTagBody(body) {
   }
   if (isDimensionRootName(value)) {
     throw new ErrorWithStatusCode(
-      `name must not be a reserved dimension root name (${ALL_DIMENSIONS.join(', ')})`,
+      `name must not be a reserved dimension root name (${RESERVED_ROOT_NAMES.join(', ')})`,
       400,
     );
   }

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -21,7 +21,7 @@ import {
 } from '../validation.js';
 import { resolveProject } from '../subworkspace-projects.js';
 import {
-  ALL_DIMENSIONS, SERVER_OWNED_DIMENSIONS, RESERVED_ROOT_NAMES,
+  ALL_DIMENSIONS, SERVER_OWNED_DIMENSIONS,
   isClosedDimension, isServerOwnedDimension, closedValuesOf, isDimensionRootName,
   MAX_TAG_NAME_LEN,
 } from '../prompt-tags.js';
@@ -206,10 +206,13 @@ function parseCreateTagBody(body) {
   }
   // The root level holds exactly the five dimension roots. A value may not
   // shadow one of their names, or the tree would have two tags a reader cannot
-  // tell apart by name at the level that matters.
+  // tell apart by name at the level that matters. The CHECK covers every reserved
+  // name (both intent spellings); the MESSAGE names only the dimensions, so the
+  // `$abv_tags$` marker — a Semrush-internal detail that means nothing to a
+  // customer — stays out of a customer-facing 400.
   if (isDimensionRootName(rawName)) {
     throw new ErrorWithStatusCode(
-      `name must not be a reserved dimension root name (${RESERVED_ROOT_NAMES.join(', ')})`,
+      `name must not be a reserved dimension root name (${ALL_DIMENSIONS.join(', ')})`,
       400,
     );
   }
@@ -592,7 +595,7 @@ function parseUpdateTagBody(body) {
   }
   if (isDimensionRootName(value)) {
     throw new ErrorWithStatusCode(
-      `name must not be a reserved dimension root name (${RESERVED_ROOT_NAMES.join(', ')})`,
+      `name must not be a reserved dimension root name (${ALL_DIMENSIONS.join(', ')})`,
       400,
     );
   }

--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -59,13 +59,48 @@ export const DIMENSION = Object.freeze({
  * {@link canonicalizeSource} refuses a derived value longer than it.
  */
 export const MAX_TAG_NAME_LEN = 100;
-/** Root names, in the order they are provisioned on a project. */
-export const DIMENSION_ROOT_NAMES = Object.freeze([
+/** The five dimensions, in the order their roots are provisioned on a project. */
+export const DIMENSION_PROVISION_ORDER = Object.freeze([
   DIMENSION.CATEGORY,
   DIMENSION.INTENT,
   DIMENSION.ORIGIN,
   DIMENSION.TYPE,
   DIMENSION.SOURCE,
+]);
+
+/**
+ * The upstream ROOT NAME of the `intent` dimension.
+ *
+ * Semrush hides a tag tree entry whose name starts with the agreed `$abv_tags$`
+ * marker from the customer-facing Brand Presence tag filter, so the intent root
+ * is named `$abv_tags$intent` upstream. `intent` remains the DIMENSION KEY
+ * everywhere else — the `type` a client names on the tag endpoints, the key of
+ * the closed vocabularies, the value elmo reads — and only the root's upstream
+ * name carries the marker. The five intent VALUES stay bare-named
+ * (`Informational`, `Commercial`, …); the rename does not touch them.
+ */
+export const INTENT_ROOT_NAME = '$abv_tags$intent';
+
+/**
+ * The pre-rename intent root name, identical to the dimension key.
+ *
+ * TEMPORARY — the rename runs project by project from the data-service migration
+ * CLI (LLMO-6985), so a project can carry either spelling until that sweep
+ * completes. Both the tag-tree resolver and the Elements read path tolerate this
+ * one; LLMO-6986 removes the tolerance once no live project carries it.
+ */
+export const LEGACY_INTENT_ROOT_NAME = DIMENSION.INTENT;
+
+/**
+ * Every name reserved at the root level: the four roots named after their
+ * dimension, plus BOTH intent spellings — the upstream `$abv_tags$intent` and
+ * the pre-rename `intent`, which stays reserved while any project still carries
+ * it. A customer value may shadow neither, or the tree would hold two tags a
+ * reader cannot tell apart at the level that decides a tag's dimension.
+ */
+export const RESERVED_ROOT_NAMES = Object.freeze([
+  ...DIMENSION_PROVISION_ORDER,
+  INTENT_ROOT_NAME,
 ]);
 
 /** `origin` values — who authored the prompt. */
@@ -164,7 +199,7 @@ export const SERVER_OWNED_DIMENSIONS = Object.freeze([
 /**
  * Every dimension a caller may address on the create-tag endpoint. This is a
  * MEMBERSHIP set (used only for `.includes` validation), so its order is
- * irrelevant and INTENTIONALLY differs from {@link DIMENSION_ROOT_NAMES} — that
+ * irrelevant and INTENTIONALLY differs from {@link DIMENSION_PROVISION_ORDER} — that
  * list is provisioning ORDER (`category, intent, origin, type, source`), whereas
  * this is grouped open-then-closed (`category, source, intent, origin, type`).
  * Do not assume the two share an order.
@@ -253,15 +288,42 @@ export const STANDARD_PROMPT_TAG_VALUES = Object.freeze([
 ]);
 
 /**
- * True when `name` is a reserved dimension-root name. Root names are reserved:
- * a customer category may not be called `category`, and a closed value may not
- * be minted at the root level.
+ * True when `name` is a reserved dimension-root name ({@link RESERVED_ROOT_NAMES}).
+ * Root names are reserved: a customer category may not be called `category`, and
+ * a closed value may not be minted at the root level.
  *
  * @param {string} name - a bare tag name.
  * @returns {boolean}
  */
 export function isDimensionRootName(name) {
-  return (/** @type {readonly string[]} */ (DIMENSION_ROOT_NAMES)).includes(name);
+  return (/** @type {readonly string[]} */ (RESERVED_ROOT_NAMES)).includes(name);
+}
+
+/**
+ * The upstream root NAME a dimension's root is provisioned and resolved by — the
+ * dimension key itself for four of the five, {@link INTENT_ROOT_NAME} for
+ * `intent`. Anything outside the taxonomy maps to itself, so a caller gets the
+ * name it asked for rather than `undefined` flowing into a create.
+ *
+ * @param {string} dimension - a dimension key.
+ * @returns {string} the upstream root name.
+ */
+export function rootNameOfDimension(dimension) {
+  return dimension === DIMENSION.INTENT ? INTENT_ROOT_NAME : dimension;
+}
+
+/**
+ * The DIMENSION KEY a root name denotes — the inverse of
+ * {@link rootNameOfDimension}, and the fold that keeps `$abv_tags$intent` from
+ * leaking out of the tag-tree walk into everything that reasons about dimensions
+ * by key. Identity for every other name, the pre-rename `intent` included (it IS
+ * the key), so a mid-rename project and a renamed one answer the same thing.
+ *
+ * @param {string} rootName - a tag's root-ancestor name, as upstream spells it.
+ * @returns {string} the dimension key.
+ */
+export function dimensionOfRootName(rootName) {
+  return rootName === INTENT_ROOT_NAME ? DIMENSION.INTENT : rootName;
 }
 
 /**

--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -88,6 +88,13 @@ export const INTENT_ROOT_NAME = '$abv_tags$intent';
  * CLI (LLMO-6985), so a project can carry either spelling until that sweep
  * completes. Both the tag-tree resolver and the Elements read path tolerate this
  * one; LLMO-6986 removes the tolerance once no live project carries it.
+ *
+ * Each of the three tolerances logs when it fires, under its own `event` key, so
+ * "has the sweep finished?" is a query rather than a judgement call:
+ * `intent-rename-legacy-root-adopted` (tag-tree resolved the pre-rename root),
+ * `intent-rename-legacy-retry` (the Elements enrichment fell back), and
+ * `intent-rename-legacy-tags-present` (filter dimensions still saw `intent__`
+ * tags). LLMO-6986 is safe once all three have gone quiet.
  */
 export const LEGACY_INTENT_ROOT_NAME = DIMENSION.INTENT;
 

--- a/src/support/serenity/tag-tree.js
+++ b/src/support/serenity/tag-tree.js
@@ -48,9 +48,13 @@ import { ErrorWithStatusCode } from '../utils.js';
 import { listProjectTagTree } from './handlers/markets.js';
 import {
   DIMENSION,
-  DIMENSION_ROOT_NAMES,
+  DIMENSION_PROVISION_ORDER,
   CLOSED_DIMENSION_VALUES,
   CLOSED_DIMENSIONS,
+  INTENT_ROOT_NAME,
+  LEGACY_INTENT_ROOT_NAME,
+  rootNameOfDimension,
+  dimensionOfRootName,
 } from './prompt-tags.js';
 
 /** @typedef {import('./rest-transport.js').SerenityTransport} SerenityTransport */
@@ -61,8 +65,10 @@ import {
  * @typedef {object} TagPosition
  * @property {'root' | 'descendant' | 'unknown'} kind
  * @property {string | null} parentId
- * @property {string | null} rootName - the tag's dimension: its own name when it
- *   IS a root, else `path[0]`.
+ * @property {string | null} rootName - the tag's DIMENSION: its own name when it
+ *   IS a root, else `path[0]`, in both cases folded to the dimension key
+ *   ({@link dimensionOfRootName}) so a caller compares it against `DIMENSION.*`
+ *   without knowing how upstream spells that root on this project.
  * @property {string[]} ancestorIds - ids of the tag's ancestors, root FIRST and
  *   the tag itself excluded. Empty for a root and for an unknown id.
  */
@@ -111,6 +117,45 @@ export async function indexLevelByName(transport, semrushWorkspaceId, projectId,
 }
 
 /**
+ * Folds ALIAS resolutions into a level index, in place, and reports what is left
+ * to create.
+ *
+ * A wanted name that is absent while one of its aliases is present adopts that
+ * alias's id under the WANTED name, so a caller reads the level by the name it
+ * asked for whichever spelling the project actually carries. An alias is never
+ * created — only a name with no alias present is reported missing.
+ *
+ * Every level index {@link ensureChildren} may hand back goes through this,
+ * including the ones re-read on its recovery paths: a map that skipped the fold
+ * would be missing the wanted name entirely, and the `undefined` root id that
+ * follows degrades the next create to a ROOT-LEVEL one (see
+ * {@link requireServerOwnedRootId}).
+ *
+ * @param {Map<string, string>} level - a level index, mutated in place.
+ * @param {readonly string[]} wanted - the names the caller asked for.
+ * @param {Record<string, readonly string[]>} [aliases] - wanted name → older
+ *   spellings that count as already present.
+ * @returns {{ missing: string[], adopted: string[] }} `missing` is what still
+ *   has to be created; `adopted` names the wanted names an alias resolved.
+ */
+function adoptAliases(level, wanted, aliases) {
+  const missing = [];
+  const adopted = [];
+  for (const name of wanted) {
+    if (!level.has(name)) {
+      const alias = (aliases?.[name] ?? []).find((a) => level.has(a));
+      if (alias) {
+        level.set(name, /** @type {string} */ (level.get(alias)));
+        adopted.push(name);
+      } else {
+        missing.push(name);
+      }
+    }
+  }
+  return { missing, adopted };
+}
+
+/**
  * Creates the missing names under one parent and returns their ids, merged with
  * the ones that already existed. A single upstream call carries every name for
  * one parent, so the batch never straddles two parents (the wire has exactly one
@@ -130,8 +175,19 @@ export async function indexLevelByName(transport, semrushWorkspaceId, projectId,
  * @param {string} parentId - '' to create at the root level.
  * @param {readonly string[]} wanted - bare names that must exist under `parentId`.
  * @param {object} [log] - logger.
- * @returns {Promise<{ byName: Map<string, string>, createdNames: string[] }>}
- *   `byName` maps every wanted name to its tag id.
+ * @param {Record<string, readonly string[]>} [aliases] - older spellings of a
+ *   wanted name that count as ALREADY PRESENT. When the wanted name is absent
+ *   but one of its aliases resolves, that tag's id is adopted under the wanted
+ *   name and nothing is created — which is what keeps a name that upstream data
+ *   is still being renamed to from being minted a second time beside the
+ *   populated tag it renames (`$abv_tags$intent` vs `intent`, LLMO-6984). An
+ *   alias is never created: only the wanted name is. See {@link adoptAliases}.
+ * @returns {Promise<{ byName: Map<string, string>, createdNames: string[],
+ *   adoptedNames: string[] }>} `byName` maps every wanted name to its tag id.
+ *   `adoptedNames` names the wanted names an ALIAS resolved rather than the name
+ *   itself — reported rather than left to be inferred from the map, which also
+ *   carries the alias's own key and would make the inference an accident of
+ *   `indexLevelByName` returning the whole level.
  */
 export async function ensureChildren(
   transport,
@@ -140,11 +196,12 @@ export async function ensureChildren(
   parentId,
   wanted,
   log,
+  aliases,
 ) {
   const existing = await indexLevelByName(transport, semrushWorkspaceId, projectId, parentId, log);
-  const missing = wanted.filter((name) => !existing.has(name));
+  const { missing, adopted } = adoptAliases(existing, wanted, aliases);
   if (missing.length === 0) {
-    return { byName: existing, createdNames: [] };
+    return { byName: existing, createdNames: [], adoptedNames: adopted };
   }
 
   let echoed;
@@ -162,13 +219,14 @@ export async function ensureChildren(
     // before deciding this is a failure. The batch is all-or-nothing upstream,
     // so one collision also fails the names we were not racing on.
     const reread = await indexLevelByName(transport, semrushWorkspaceId, projectId, parentId, log);
+    const { adopted: rereadAdopted } = adoptAliases(reread, wanted, aliases);
     if (!missing.every((name) => reread.has(name))) {
       throw e;
     }
     log?.info?.('ensureChildren: lost a create race; resolved the names a concurrent writer minted', {
       semrushWorkspaceId, projectId, parentId, resolved: missing,
     });
-    return { byName: reread, createdNames: [] };
+    return { byName: reread, createdNames: [], adoptedNames: rereadAdopted };
   }
 
   // createProjectTags resolves to a LIST of the created nodes, in request order.
@@ -179,7 +237,7 @@ export async function ensureChildren(
     }
   }
   if (missing.every((name) => existing.has(name))) {
-    return { byName: existing, createdNames: missing };
+    return { byName: existing, createdNames: missing, adoptedNames: adopted };
   }
 
   // A node the upstream did not echo back leaves a hole. Re-read rather than hand
@@ -191,6 +249,7 @@ export async function ensureChildren(
     unechoed: missing.filter((name) => !existing.has(name)),
   });
   const byName = await indexLevelByName(transport, semrushWorkspaceId, projectId, parentId, log);
+  const { adopted: rereadAdopted } = adoptAliases(byName, wanted, aliases);
   const unresolved = missing.filter((name) => !byName.has(name));
   if (unresolved.length > 0) {
     // The create answered 2xx and the draft-layer re-read still does not see the
@@ -209,7 +268,11 @@ export async function ensureChildren(
   }
   // Only the names the create echoed are ours to claim. A name that reappeared on
   // the re-read was resolved, not minted here — another writer may have won it.
-  return { byName, createdNames: missing.filter((name) => existing.has(name)) };
+  return {
+    byName,
+    createdNames: missing.filter((name) => existing.has(name)),
+    adoptedNames: rereadAdopted,
+  };
 }
 
 /**
@@ -231,33 +294,58 @@ const LEGACY_SOURCE_ROOT_NAME = 'source';
  * Older projects predate this taxonomy entirely, so this is the seam that brings
  * them forward on first touch.
  *
- * Every root — `origin` included — is resolved-or-created by bare name. The
- * `source` → `origin` authorship rename is complete (origin-dimension.md): there is
- * no fallback for the pre-rename `source` name. A project that still carries a legacy
- * `source` authorship root gets a fresh `origin` root created here, and the stale
+ * Each root is resolved-or-created by its UPSTREAM NAME ({@link rootNameOfDimension}),
+ * which is the dimension key for four of the five and `$abv_tags$intent` for `intent`.
+ * The returned map is keyed by DIMENSION, so a caller asks for the dimension it means
+ * and never has to know which spelling a given project carries.
+ *
+ * The intent rename runs project by project from the migration CLI (LLMO-6985), so a
+ * project may still name that root `intent`. That name is passed as an ALIAS rather
+ * than resolved on its own: a project the rename has not reached keeps its populated
+ * root and gets no second one, while a project that has no intent root at all is
+ * provisioned under the new name. Minting `$abv_tags$intent` beside a populated
+ * `intent` would split the dimension across two roots and strand every prompt already
+ * tagged under the old one.
+ *
+ * The `source` → `origin` authorship rename, by contrast, is complete (origin-dimension.md):
+ * there is no fallback for the pre-rename `source` name. A project that still carries a
+ * legacy `source` authorship root gets a fresh `origin` root created here, and the stale
  * `source` root is left untouched for the data reshape to retire.
  *
- * Deploy ordering is the invariant, and it is enforced OUTSIDE this code (the reshape
- * lands before this resolver ships). If that ordering is violated and a project is
- * still authorship-on-`source` when this runs, the fresh `origin` root is minted EMPTY
- * and the populated `source` root's `ai`/`human` values are orphaned. This seam does
- * not detect or fail on that — the deploy gate owns it.
+ * Deploy ordering is the invariant for THAT rename, and it is enforced OUTSIDE this code
+ * (the reshape lands before this resolver ships). If that ordering is violated and a
+ * project is still authorship-on-`source` when this runs, the fresh `origin` root is
+ * minted EMPTY and the populated `source` root's `ai`/`human` values are orphaned. This
+ * seam does not detect or fail on that — the deploy gate owns it.
  *
  * @param {SerenityTransport} transport
  * @param {string} semrushWorkspaceId
  * @param {string} projectId
  * @param {object} [log] - logger.
- * @returns {Promise<Map<string, string>>} root name → tag id, in root order.
+ * @returns {Promise<Map<string, string>>} dimension → tag id, in provisioning order.
  */
 export async function ensureDimensionRoots(transport, semrushWorkspaceId, projectId, log) {
-  const { byName, createdNames } = await ensureChildren(
+  const { byName, createdNames, adoptedNames } = await ensureChildren(
     transport,
     semrushWorkspaceId,
     projectId,
     '',
-    DIMENSION_ROOT_NAMES,
+    DIMENSION_PROVISION_ORDER.map(rootNameOfDimension),
     log,
+    { [INTENT_ROOT_NAME]: [LEGACY_INTENT_ROOT_NAME] },
   );
+
+  // Report the projects the rename has not reached: adoption is invisible in the
+  // returned map (that is its point), and this is the write path's only signal of
+  // the sweep's progress — the one LLMO-6986 waits to go quiet before dropping the
+  // tolerance.
+  if (adoptedNames.includes(INTENT_ROOT_NAME)) {
+    log?.info?.(
+      'ensureDimensionRoots: resolved the pre-rename `intent` root — the '
+      + '`$abv_tags$intent` rename has not reached this project',
+      { semrushWorkspaceId, projectId },
+    );
+  }
 
   // Observability guardrail (no tolerance, no behavior change): freshly minting `origin`
   // while a legacy `source` root still sits at this level means the data reshape may have
@@ -277,10 +365,10 @@ export async function ensureDimensionRoots(transport, semrushWorkspaceId, projec
     }
   }
 
-  // Return the roots in canonical order.
+  // Return the roots keyed by DIMENSION, in canonical order.
   const roots = new Map();
-  for (const name of DIMENSION_ROOT_NAMES) {
-    roots.set(name, byName.get(name));
+  for (const dimension of DIMENSION_PROVISION_ORDER) {
+    roots.set(dimension, byName.get(rootNameOfDimension(dimension)));
   }
   return roots;
 }
@@ -293,7 +381,7 @@ export async function ensureDimensionRoots(transport, semrushWorkspaceId, projec
  * and `category`); the `source` root can be `undefined` on a mid-rename project,
  * so callers that need it read `roots.get(DIMENSION.SOURCE)` directly instead.
  *
- * @param {Map<string, string | undefined>} roots - the resolved root name → id map.
+ * @param {Map<string, string | undefined>} roots - the resolved dimension → id map.
  * @param {string} dimension - one of the always-resolved dimension root names.
  * @returns {string}
  */
@@ -314,7 +402,7 @@ function rootIdOf(roots, dimension) {
  * production, but a gate bypass must fail visibly, not corrupt the tree — so refuse
  * rather than proceed. A no-op for the always-provisioned dimensions.
  *
- * @param {Map<string, string | undefined>} roots - the resolved root name → id map.
+ * @param {Map<string, string | undefined>} roots - the resolved dimension → id map.
  * @param {string} dimension - a server-owned dimension root name.
  * @returns {string}
  */
@@ -363,7 +451,7 @@ export async function findTagsInTree(transport, semrushWorkspaceId, projectId, t
   for (const root of roots.items) {
     if (wanted.has(root.id)) {
       found.set(root.id, {
-        kind: 'root', parentId: null, rootName: root.name, ancestorIds: [],
+        kind: 'root', parentId: null, rootName: dimensionOfRootName(root.name), ancestorIds: [],
       });
     }
   }
@@ -371,7 +459,7 @@ export async function findTagsInTree(transport, semrushWorkspaceId, projectId, t
   let reads = 1;
   let frontier = roots.items
     .filter((r) => r.childrenCount > 0)
-    .map((r) => ({ node: r, rootName: r.name, ancestorIds: [r.id] }));
+    .map((r) => ({ node: r, rootName: dimensionOfRootName(r.name), ancestorIds: [r.id] }));
   while (frontier.length > 0 && found.size < wanted.size) {
     const next = [];
     for (const { node, rootName, ancestorIds } of frontier) {
@@ -396,7 +484,7 @@ export async function findTagsInTree(transport, semrushWorkspaceId, projectId, t
             found.set(child.id, {
               kind: 'descendant',
               parentId: child.parentId ?? node.id,
-              rootName: child.path?.[0]?.name ?? rootName,
+              rootName: dimensionOfRootName(child.path?.[0]?.name ?? rootName),
               ancestorIds,
             });
           }
@@ -432,7 +520,8 @@ export async function findTagsInTree(transport, semrushWorkspaceId, projectId, t
  * @param {string} tagId - the upstream id to locate.
  * @param {object} [log] - logger.
  * @returns {Promise<TagPosition>} `rootName` is the tag's dimension: its own name
- *   when it IS a root, else `path[0]`.
+ *   when it IS a root, else `path[0]`, folded to the dimension key either way
+ *   ({@link dimensionOfRootName}).
  */
 async function findTagInTree(transport, semrushWorkspaceId, projectId, tagId, log) {
   const found = await findTagsInTree(transport, semrushWorkspaceId, projectId, [tagId], log);
@@ -519,8 +608,8 @@ export async function assertParentWithinDimension(
  * @returns {Promise<{
  *   roots: Map<string, string | undefined>,
  *   values: Map<string, Map<string, string>>,
- * }>} `roots` maps a root name to its id (the `source` key is `undefined` on a
- *   mid-rename project — see {@link ensureDimensionRoots}); `values` maps a closed
+ * }>} `roots` maps a dimension to its root's id (the `source` key is `undefined` on
+ *   a mid-rename project — see {@link ensureDimensionRoots}); `values` maps a closed
  *   dimension name to that dimension's bare value → id map.
  */
 export async function provisionDimensionTree(transport, semrushWorkspaceId, projectId, log) {

--- a/src/support/serenity/tag-tree.js
+++ b/src/support/serenity/tag-tree.js
@@ -343,7 +343,7 @@ export async function ensureDimensionRoots(transport, semrushWorkspaceId, projec
     log?.info?.(
       'ensureDimensionRoots: resolved the pre-rename `intent` root — the '
       + '`$abv_tags$intent` rename has not reached this project',
-      { semrushWorkspaceId, projectId },
+      { event: 'intent-rename-legacy-root-adopted', semrushWorkspaceId, projectId },
     );
   }
 

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import {
   ORG_1_ID, BRAND_1_ID, SITE_1_ID,
 } from '../seed-ids.js';
+import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
 
 /**
  * End-to-end tests for the /serenity/* surface (LLMO-5190), driven against the
@@ -351,8 +352,12 @@ export default function serenityTests(
         `${base}/tags?geoTargetId=${US_GEO}&languageCode=en&parentId=`,
       );
       expect(roots.status).to.equal(200);
+      // The intent root is provisioned under its upstream name: Semrush hides a
+      // `$abv_tags$`-marked entry from the customer-facing Brand Presence tag
+      // filter, and a project provisioned here must not need the rename sweep
+      // (LLMO-6985) to come back for it.
       expect(roots.body.items.map((t) => t.name))
-        .to.have.members(['category', 'intent', 'origin', 'type', 'source']);
+        .to.have.members(['category', INTENT_ROOT_NAME, 'origin', 'type', 'source']);
       const categoryRoot = roots.body.items.find((t) => t.name === 'category');
       expect(res.body.parentId).to.equal(categoryRoot.id);
     });
@@ -426,7 +431,7 @@ export default function serenityTests(
       const roots = await getHttpClient().admin.get(
         `${base}/tags?geoTargetId=${US_GEO}&languageCode=en&parentId=`,
       );
-      const intentRoot = roots.body.items.find((t) => t.name === 'intent');
+      const intentRoot = roots.body.items.find((t) => t.name === INTENT_ROOT_NAME);
       expect(intentRoot, 'the intent root should be provisioned').to.exist;
 
       const res = await createTag('ai', intentRoot.id);

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -20,6 +20,7 @@ import {
   transformOtherTagsForFilterDimensions,
 } from '../../../../src/support/elements/definitions/topics.js';
 import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
+import { INTENT_ROOT_NAME, LEGACY_INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
 
 // Mirrors the fixed keys elements-service.js's `getUrlInspectorFilterDimensions`
 // builds `result` with, plus the JS-unsafe names it also guards against.
@@ -334,15 +335,42 @@ describe('topics definitions', () => {
       expect(result[0].label).to.equal('Buy');
     });
 
-    it('adds parent_id/parent_label when the value contains a double underscore', () => {
-      const raw = { blocks: { value: [{ value: 'intent__Commercial__Buy' }] } };
-      const [item] = transformIntentsToFilterDimensions(raw);
-      expect(item).to.deep.equal({
-        id: 'intent__Commercial__Buy',
-        label: 'Buy',
-        parent_id: 'intent__Commercial',
-        parent_label: 'Commercial',
+    // Both spellings read the same way; parent_id is rebuilt from whichever
+    // prefix matched. LLMO-6986 drops the legacy row from this table.
+    [LEGACY_INTENT_ROOT_NAME, INTENT_ROOT_NAME].forEach((root) => {
+      it(`adds parent_id/parent_label under the \`${root}\` root`, () => {
+        const raw = { blocks: { value: [{ value: `${root}__Commercial__Buy` }] } };
+        const [item] = transformIntentsToFilterDimensions(raw);
+        expect(item).to.deep.equal({
+          id: `${root}__Commercial__Buy`,
+          label: 'Buy',
+          parent_id: `${root}__Commercial`,
+          parent_label: 'Commercial',
+        });
       });
+    });
+
+    // LLMO-6984: an Elements tag prefix is the `__`-joined tag PATH, so renaming
+    // the intent root renames the prefix. Both spellings are read while the rename
+    // sweeps projects one at a time.
+    it('reads the renamed root, keeping the prefix in id and stripping it from label', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: `${INTENT_ROOT_NAME}__Informational` },
+            { value: `${INTENT_ROOT_NAME}__Transactional` },
+          ],
+        },
+      };
+      expect(transformIntentsToFilterDimensions(raw)).to.deep.equal([
+        { id: `${INTENT_ROOT_NAME}__Informational`, label: 'Informational' },
+        { id: `${INTENT_ROOT_NAME}__Transactional`, label: 'Transactional' },
+      ]);
+    });
+
+    it('does not double-count: the legacy prefix does not also match a renamed tag', () => {
+      const raw = { blocks: { value: [{ value: `${INTENT_ROOT_NAME}__Commercial` }] } };
+      expect(transformIntentsToFilterDimensions(raw)).to.have.length(1);
     });
   });
 
@@ -386,6 +414,27 @@ describe('topics definitions', () => {
       expect(result).to.not.have.property('intent');
       expect(result).to.not.have.property('source');
       expect(result.tags).to.deep.equal([]);
+    });
+
+    // The catch-all is what would otherwise expose the rename to customers: an
+    // unrecognised prefix becomes a dynamic group keyed by its raw upstream name,
+    // so a renamed project would grow a `$abv_tags$intent` group in the filter
+    // payload beside an empty `page_intents`.
+    it('claims the renamed intent prefix rather than grouping it under its raw name', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: `${INTENT_ROOT_NAME}__Commercial` },
+            { value: INTENT_ROOT_NAME },
+            { value: 'type__branded' },
+          ],
+        },
+      };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result).to.not.have.property(INTENT_ROOT_NAME);
+      expect(result.tags).to.deep.equal([]);
+      // An genuinely unknown prefix still surfaces — the catch-all keeps working.
+      expect(result.type).to.deep.equal([{ id: 'type__branded', label: 'branded' }]);
     });
 
     it('groups unknown prefix__value tags by their prefix', () => {

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -17,7 +17,11 @@ import sinonChai from 'sinon-chai';
 import { hasText } from '@adobe/spacecat-shared-utils';
 import { createElementsService } from '../../../src/support/elements/elements-service.js';
 import { ELEMENT_IDS } from '../../../src/support/elements/element-ids.js';
-import { INTENT_VALUE } from '../../../src/support/serenity/prompt-tags.js';
+import {
+  INTENT_VALUE,
+  INTENT_ROOT_NAME,
+  LEGACY_INTENT_ROOT_NAME,
+} from '../../../src/support/serenity/prompt-tags.js';
 
 const INTENT_VALUES = Object.values(INTENT_VALUE);
 
@@ -128,6 +132,54 @@ describe('createElementsService', () => {
     it('groups unknown prefix__value tags under their own prefix key', async () => {
       const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
       expect(result.type).to.deep.equal([{ id: 'type__branded', label: 'branded' }]);
+    });
+
+    it('populates page_intents from the renamed intent root without leaking it as a group', async () => {
+      // The whole point of the rename is that the intent dimension stops showing up
+      // in the customer-facing tag filter. Reaching this payload as a dynamic
+      // `$abv_tags$intent` group beside an empty `page_intents` would put it back —
+      // under its internal name, no less.
+      transport.fetchElement
+        .withArgs('ws-1', ELEMENT_IDS.TOPICS, sinon.match.any)
+        .resolves({
+          blocks: {
+            value: [
+              { value: 'topic__SEO' },
+              { value: `${INTENT_ROOT_NAME}__Informational` },
+              { value: INTENT_ROOT_NAME },
+            ],
+          },
+        });
+      const result = await service.getUrlInspectorFilterDimensions('ws-1', {});
+      expect(result.page_intents).to.deep.equal([
+        { id: `${INTENT_ROOT_NAME}__Informational`, label: 'Informational' },
+      ]);
+      expect(result).to.not.have.property(INTENT_ROOT_NAME);
+      expect(result.tags).to.deep.equal([]);
+    });
+
+    it('populates page_intents on a project the rename has not reached, and says so', async () => {
+      // The read tolerance is otherwise silent, so this log is what tells LLMO-6986
+      // the sweep is not finished. RAW_TOPICS carries the pre-rename prefix.
+      const log = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+      const result = await createElementsService(transport, log)
+        .getUrlInspectorFilterDimensions('ws-1', {});
+      expect(result.page_intents).to.deep.equal([
+        { id: 'intent__Informational', label: 'Informational' },
+      ]);
+      expect(log.info).to.have.been.calledWithMatch(
+        sinon.match(/pre-rename `intent__` tags/),
+        sinon.match({ workspaceId: 'ws-1' }),
+      );
+    });
+
+    it('stays quiet when every intent tag already carries the renamed root', async () => {
+      const log = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+      transport.fetchElement
+        .withArgs('ws-1', ELEMENT_IDS.TOPICS, sinon.match.any)
+        .resolves({ blocks: { value: [{ value: `${INTENT_ROOT_NAME}__Informational` }] } });
+      await createElementsService(transport, log).getUrlInspectorFilterDimensions('ws-1', {});
+      expect(log.info).to.not.have.been.called;
     });
 
     it('ignores plain, separator-less tags (bare prefix declarations)', async () => {
@@ -264,26 +316,44 @@ describe('createElementsService', () => {
         primary_intent: 'informational', prompt: 'p-comm', prompt_topic: 'T1', volume: 10,
       },
     ]);
-    // Matches a PROMPTS payload carrying a specific `intent__X` tag clause.
+    // Matches a PROMPTS payload carrying a specific `<intentRoot>__X` tag clause.
     const withTag = (val) => sinon.match((payload) => Boolean(
       payload?.filters?.advanced?.filters?.some((f) => f.col === 'tags' && f.val === val),
     ));
-    // Matches the base call (no `intent__` tag clause).
+    // Matches the base call — no intent tag clause under EITHER root spelling.
     const noIntentTag = sinon.match((payload) => !payload?.filters?.advanced?.filters
-      ?.some((f) => f.col === 'tags' && String(f.val).startsWith('intent__')));
-
-    beforeEach(() => {
-      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, noIntentTag).resolves(RAW_BASE);
-      // All intent-filtered calls return empty except Commercial, which claims p-comm.
+      ?.some((f) => f.col === 'tags' && String(f.val).includes('intent__')));
+    // The intent tag as Elements encodes it: the `__`-joined path, so the root's
+    // own name is the prefix.
+    const intentTag = (root, value) => `${root}__${value}`;
+    const promptCallsWith = (root) => transport.fetchElement.getCalls().filter(
+      (c) => c.args[1] === ELEMENT_IDS.PROMPTS
+        && c.args[2]?.filters?.advanced?.filters?.some(
+          (f) => f.col === 'tags' && String(f.val).startsWith(`${root}__`),
+        ),
+    );
+    const P_COMM_ROW = {
+      primary_intent: 'informational', prompt: 'p-comm', prompt_topic: 'T1', volume: 10,
+    };
+    /**
+     * Stubs the five intent-filtered calls under one root spelling: every value
+     * empty except Commercial, which claims p-comm. A project carries exactly one
+     * spelling, so the other root's calls stay unstubbed and answer empty.
+     */
+    const stubIntentRound = (root) => {
       INTENT_VALUES
         .filter((v) => v !== 'Commercial')
         .forEach((v) => transport.fetchElement
-          .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag(`intent__${v}`)).resolves(rawWith([])));
+          .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag(intentTag(root, v))).resolves(rawWith([])));
       transport.fetchElement
-        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag('intent__Commercial'))
-        .resolves(rawWith([{
-          primary_intent: 'informational', prompt: 'p-comm', prompt_topic: 'T1', volume: 10,
-        }]));
+        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag(intentTag(root, 'Commercial')))
+        .resolves(rawWith([P_COMM_ROW]));
+    };
+
+    beforeEach(() => {
+      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, noIntentTag).resolves(RAW_BASE);
+      // The common case: a project the intent rename has reached.
+      stubIntentRound(INTENT_ROOT_NAME);
     });
 
     // Enrichment requires exactly one projectId (single slice).
@@ -297,6 +367,35 @@ describe('createElementsService', () => {
       const promptCalls = transport.fetchElement.getCalls()
         .filter((c) => c.args[1] === ELEMENT_IDS.PROMPTS);
       expect(promptCalls).to.have.length(1 + INTENT_VALUES.length);
+    });
+
+    it('costs five intent calls on a renamed project — no legacy retry once rows come back', async () => {
+      await service.getPrompts('ws-1', ENRICH);
+      expect(promptCallsWith(INTENT_ROOT_NAME)).to.have.length(INTENT_VALUES.length);
+      expect(promptCallsWith(LEGACY_INTENT_ROOT_NAME)).to.have.length(0);
+    });
+
+    it('retries under the pre-rename root when all five renamed-root calls come back empty', async () => {
+      // A project the rename has not reached: it answers only the legacy prefix.
+      transport.fetchElement.reset();
+      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, noIntentTag).resolves(RAW_BASE);
+      stubIntentRound(LEGACY_INTENT_ROOT_NAME);
+      const result = await service.getPrompts('ws-1', ENRICH);
+      const byPrompt = Object.fromEntries(result.prompts.map((p) => [p.prompt, p.userIntent]));
+      expect(byPrompt['p-comm']).to.equal('commercial');
+      expect(byPrompt['p-info']).to.equal('');
+      expect(promptCallsWith(INTENT_ROOT_NAME)).to.have.length(INTENT_VALUES.length);
+      expect(promptCallsWith(LEGACY_INTENT_ROOT_NAME)).to.have.length(INTENT_VALUES.length);
+    });
+
+    it('leaves userIntent blank without a second round when a project has no intent tags at all', async () => {
+      transport.fetchElement.reset();
+      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, noIntentTag).resolves(RAW_BASE);
+      const result = await service.getPrompts('ws-1', ENRICH);
+      result.prompts.forEach((p) => expect(p.userIntent).to.equal(''));
+      // The bounded cost of the transition: an intent-less project pays a second
+      // round that also comes back empty.
+      expect(promptCallsWith(LEGACY_INTENT_ROOT_NAME)).to.have.length(INTENT_VALUES.length);
     });
 
     it('does not enrich or make extra calls without the flag', async () => {
@@ -327,11 +426,13 @@ describe('createElementsService', () => {
           primary_intent: 'informational', prompt: 'best sofa', prompt_topic: 'Recliners', volume: 5,
         },
       ]));
-      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag('intent__Commercial'))
+      transport.fetchElement
+        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag(intentTag(INTENT_ROOT_NAME, 'Commercial')))
         .resolves(rawWith([{
           primary_intent: 'informational', prompt: 'best sofa', prompt_topic: 'Sofas', volume: 5,
         }]));
-      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag('intent__Navigational'))
+      transport.fetchElement
+        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag(intentTag(INTENT_ROOT_NAME, 'Navigational')))
         .resolves(rawWith([{
           primary_intent: 'informational', prompt: 'best sofa', prompt_topic: 'Recliners', volume: 5,
         }]));
@@ -343,11 +444,25 @@ describe('createElementsService', () => {
 
     it('is non-fatal: a failing intent call degrades to blank userIntent', async () => {
       transport.fetchElement
-        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag('intent__Commercial'))
+        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag(intentTag(INTENT_ROOT_NAME, 'Commercial')))
         .rejects(new Error('intent call failed'));
       const result = await service.getPrompts('ws-1', ENRICH);
       expect(result.count).to.equal(2);
       result.prompts.forEach((p) => expect(p.userIntent).to.equal(''));
+    });
+
+    it('does not read an all-empty round as un-renamed when one of its calls failed', async () => {
+      // Every renamed-root call answers empty, but one of them because it FAILED —
+      // which is not the empty-result signature, so the legacy round must not fire
+      // and double the load on an upstream that is already struggling.
+      transport.fetchElement.reset();
+      transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, noIntentTag).resolves(RAW_BASE);
+      transport.fetchElement
+        .withArgs('ws-1', ELEMENT_IDS.PROMPTS, withTag(intentTag(INTENT_ROOT_NAME, 'Commercial')))
+        .rejects(new Error('intent call failed'));
+      const result = await service.getPrompts('ws-1', ENRICH);
+      result.prompts.forEach((p) => expect(p.userIntent).to.equal(''));
+      expect(promptCallsWith(LEGACY_INTENT_ROOT_NAME)).to.have.length(0);
     });
   });
 

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -320,12 +320,16 @@ describe('createElementsService', () => {
     const withTag = (val) => sinon.match((payload) => Boolean(
       payload?.filters?.advanced?.filters?.some((f) => f.col === 'tags' && f.val === val),
     ));
+    // The intent tag as Elements encodes it: the `__`-joined path, so the root's
+    // own name is the PREFIX — which is why the matchers below test startsWith,
+    // matching production rather than a looser substring search that a tag merely
+    // containing `intent__` further in would also satisfy.
+    const intentTag = (root, value) => `${root}__${value}`;
+    const isIntentTag = (val) => [INTENT_ROOT_NAME, LEGACY_INTENT_ROOT_NAME]
+      .some((root) => String(val).startsWith(`${root}__`));
     // Matches the base call — no intent tag clause under EITHER root spelling.
     const noIntentTag = sinon.match((payload) => !payload?.filters?.advanced?.filters
-      ?.some((f) => f.col === 'tags' && String(f.val).includes('intent__')));
-    // The intent tag as Elements encodes it: the `__`-joined path, so the root's
-    // own name is the prefix.
-    const intentTag = (root, value) => `${root}__${value}`;
+      ?.some((f) => f.col === 'tags' && isIntentTag(f.val)));
     const promptCallsWith = (root) => transport.fetchElement.getCalls().filter(
       (c) => c.args[1] === ELEMENT_IDS.PROMPTS
         && c.args[2]?.filters?.advanced?.filters?.some(
@@ -380,7 +384,14 @@ describe('createElementsService', () => {
       transport.fetchElement.reset();
       transport.fetchElement.withArgs('ws-1', ELEMENT_IDS.PROMPTS, noIntentTag).resolves(RAW_BASE);
       stubIntentRound(LEGACY_INTENT_ROOT_NAME);
-      const result = await service.getPrompts('ws-1', ENRICH);
+      const log = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+      const result = await createElementsService(transport, log).getPrompts('ws-1', ENRICH);
+      // The fallback is one of the three signals LLMO-6986 waits to go quiet, so
+      // the event key is part of the contract, not incidental logging.
+      expect(log.info).to.have.been.calledWithMatch(
+        sinon.match(/retrying the pre-rename one/),
+        sinon.match({ event: 'intent-rename-legacy-retry', workspaceId: 'ws-1' }),
+      );
       const byPrompt = Object.fromEntries(result.prompts.map((p) => [p.prompt, p.userIntent]));
       expect(byPrompt['p-comm']).to.equal('commercial');
       expect(byPrompt['p-info']).to.equal('');

--- a/test/support/serenity/fixtures/tag-tree.js
+++ b/test/support/serenity/fixtures/tag-tree.js
@@ -13,8 +13,10 @@
 import sinon from 'sinon';
 
 import {
-  DIMENSION_ROOT_NAMES,
+  DIMENSION_PROVISION_ORDER,
   CLOSED_DIMENSION_VALUES,
+  LEGACY_INTENT_ROOT_NAME,
+  rootNameOfDimension,
 } from '../../../../src/support/serenity/prompt-tags.js';
 
 /**
@@ -103,13 +105,25 @@ const CATEGORY_CRUMB = [{ id: TAG_IDS.categoryRoot, name: 'category' }];
  * Builds the level map: `parentId` → the tags directly beneath it. `''` is the
  * root level. Callers may add or replace levels via `extraLevels`.
  *
+ * The intent root is named as upstream names it — `$abv_tags$intent` by default,
+ * or the pre-rename `intent` when `legacyIntentRoot` is set, which is what a
+ * project the rename (LLMO-6984) has not reached still carries. Everything below
+ * that root is identical in both shapes: the rename touches only the root's name.
+ *
  * @param {Record<string, object[]>} [extraLevels]
+ * @param {object} [options]
+ * @param {boolean} [options.legacyIntentRoot] - name the intent root `intent`.
  * @returns {Record<string, object[]>}
  */
-export function dimensionTreeLevels(extraLevels = {}) {
-  const roots = DIMENSION_ROOT_NAMES.map((name) => upstreamTag({
+export function dimensionTreeLevels(extraLevels = {}, { legacyIntentRoot = false } = {}) {
+  const rootNameOf = (dimension) => (
+    legacyIntentRoot && dimension === 'intent'
+      ? LEGACY_INTENT_ROOT_NAME
+      : rootNameOfDimension(dimension)
+  );
+  const roots = DIMENSION_PROVISION_ORDER.map((name) => upstreamTag({
     id: ROOT_IDS[name],
-    name,
+    name: rootNameOf(name),
     // `category` carries one seeded sub-tree; the closed dimensions carry their
     // enum. The open `source` root reports `children_count: 0` so tree WALKS
     // (findTagsInTree) do not descend it, yet its level below still serves one
@@ -125,7 +139,7 @@ export function dimensionTreeLevels(extraLevels = {}) {
         id: CLOSED_VALUE_IDS[dimension][value],
         name: value,
         parentId: ROOT_IDS[dimension],
-        path: [{ id: ROOT_IDS[dimension], name: dimension }],
+        path: [{ id: ROOT_IDS[dimension], name: rootNameOf(dimension) }],
       })
     ));
   }

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -40,6 +40,7 @@ import {
   makeListProjectTagsStub,
   makeProvisioningTransportStubs,
 } from '../fixtures/tag-tree.js';
+import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -2295,7 +2296,7 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
       // `config` beneath the `source` root — the create path stamps the derived
       // origin AND source as well as the computed type.
       expect(createProjectTags.firstCall.args[2]).to.deep.equal([
-        'category', 'intent', 'origin', 'type', 'source',
+        'category', INTENT_ROOT_NAME, 'origin', 'type', 'source',
       ]);
       expect(createProjectTags.firstCall.args[3]).to.deep.equal({});
       expect(createProjectTags.secondCall.args[2]).to.deep.equal(['branded']);
@@ -2309,10 +2310,11 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
       expect(createProjectTags.getCall(3).args[2]).to.deep.equal(['config']);
       expect(createProjectTags.getCall(3).args[3]).to.deep.equal({ parentId: 'created::source' });
       expect(createProjectTags.getCall(4).args[2]).to.deep.equal(['Informational']);
-      expect(createProjectTags.getCall(4).args[3]).to.deep.equal({ parentId: 'created::intent' });
+      expect(createProjectTags.getCall(4).args[3])
+        .to.deep.equal({ parentId: `created::${INTENT_ROOT_NAME}` });
       expect(result.created[0].tagIds).to.deep.equal([
         'tag-cat-1', 'created:created::type:branded', 'created:created::origin:human',
-        'created:created::source:config', 'created:created::intent:Informational',
+        'created:created::source:config', `created:created::${INTENT_ROOT_NAME}:Informational`,
       ]);
     });
   });

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -17,6 +17,7 @@ import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
 
 import { TAG_IDS, dimensionTreeLevels, makeListProjectTagsStub } from '../fixtures/tag-tree.js';
+import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
 import { SerenityTransportError } from '../../../../src/support/serenity/rest-transport.js';
 
 use(chaiAsPromised);
@@ -166,7 +167,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       const createProjectTags = sinon.stub();
       createProjectTags.onFirstCall().resolves([
         { id: 'r-category', name: 'category' },
-        { id: 'r-intent', name: 'intent' },
+        { id: 'r-intent', name: INTENT_ROOT_NAME },
         { id: 'r-origin', name: 'origin' },
         { id: 'r-type', name: 'type' },
         { id: 'r-source', name: 'source' },
@@ -187,7 +188,8 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       );
 
       expect(res.status).to.equal(201);
-      expect(createProjectTags.firstCall.args[2]).to.deep.equal(['category', 'intent', 'origin', 'type', 'source']);
+      expect(createProjectTags.firstCall.args[2])
+        .to.deep.equal(['category', INTENT_ROOT_NAME, 'origin', 'type', 'source']);
       expect(createProjectTags.secondCall.args[2]).to.deep.equal(['Footwear']);
       expect(createProjectTags.secondCall.args[3]).to.deep.equal({ parentId: 'r-category' });
       expect(res.body).to.include({ id: 'new-cat', parentId: 'r-category' });
@@ -215,7 +217,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       // The roots were attempted; the category itself never was.
       expect(transport.createProjectTags).to.have.been.calledOnce;
       expect(transport.createProjectTags.firstCall.args[2])
-        .to.deep.equal(['category', 'intent', 'origin', 'type', 'source']);
+        .to.deep.equal(['category', INTENT_ROOT_NAME, 'origin', 'type', 'source']);
     });
 
     it('502s when the upstream create response carries no usable id', async () => {
@@ -1239,6 +1241,35 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(err.status).to.equal(400);
       expect(err.message).to.match(/server-owned "origin" dimension cannot be renamed or re-parented/);
       expect(transport.updateProjectTag).to.not.have.been.called;
+    });
+
+    // LLMO-6984 regression. The guard reads the target's DIMENSION, so it must keep
+    // holding whichever name the project's intent root carries. Were the raw upstream
+    // name to reach it, `$abv_tags$intent` would not be in SERVER_OWNED_DIMENSIONS and
+    // the guard would fail OPEN on exactly the projects the rename has reached — the
+    // client could then rename `Informational`, and the next server write would mint a
+    // second one beside it.
+    [
+      { label: 'renamed', levels: dimensionTreeLevels() },
+      { label: 'pre-rename', levels: dimensionTreeLevels({}, { legacyIntentRoot: true }) },
+    ].forEach(({ label, levels }) => {
+      it(`400s a rename of an intent value on a ${label} project`, async () => {
+        const transport = makeTransport({ listProjectTags: makeListProjectTagsStub(levels) });
+        const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+        const err = await handler.handleUpdateTag(
+          transport,
+          dataAccess,
+          BRAND,
+          WORKSPACE,
+          TAG_IDS.intentCommercial,
+          { name: 'Shopping', geoTargetId: 2840, languageCode: 'en' },
+          fakeLog(),
+        ).then(() => null, (e) => e);
+
+        expect(err.status).to.equal(400);
+        expect(err.message).to.match(/server-owned "intent" dimension cannot be renamed or re-parented/);
+        expect(transport.updateProjectTag).to.not.have.been.called;
+      });
     });
 
     // LLMO-6665 regression. `source` is server-owned but OPEN, so it is

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -255,7 +255,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
     it('400s a name that shadows a reserved dimension root', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
-      for (const name of ['category', 'intent', 'origin', 'type']) {
+      for (const name of ['category', 'intent', 'origin', 'type', INTENT_ROOT_NAME]) {
         // eslint-disable-next-line no-await-in-loop
         await expect(handler.handleCreateTag(
           transport,
@@ -978,7 +978,7 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
     it('400s on a rename to a reserved dimension root name', async () => {
       const transport = makeTransport();
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
-      for (const name of ['category', 'intent', 'origin', 'type']) {
+      for (const name of ['category', 'intent', 'origin', 'type', INTENT_ROOT_NAME]) {
         // eslint-disable-next-line no-await-in-loop
         await expect(handler.handleUpdateTag(
           transport,

--- a/test/support/serenity/prompt-tags.test.js
+++ b/test/support/serenity/prompt-tags.test.js
@@ -14,7 +14,12 @@ import { expect } from 'chai';
 
 import {
   DIMENSION,
-  DIMENSION_ROOT_NAMES,
+  DIMENSION_PROVISION_ORDER,
+  RESERVED_ROOT_NAMES,
+  INTENT_ROOT_NAME,
+  LEGACY_INTENT_ROOT_NAME,
+  rootNameOfDimension,
+  dimensionOfRootName,
   ORIGIN_VALUE,
   INTENT_VALUE,
   TYPE_VALUE,
@@ -39,16 +44,16 @@ describe('serenity prompt-tags taxonomy', () => {
     it('includes the five roots, all bare-named (membership, never a count)', () => {
       // Membership, not set-equality — a further open root is contemplated
       // (source-dimension.md header), so nothing may key on the root count.
-      expect([...DIMENSION_ROOT_NAMES]).to.include.members([
+      expect([...DIMENSION_PROVISION_ORDER]).to.include.members([
         'category', 'intent', 'origin', 'type', 'source',
       ]);
-      DIMENSION_ROOT_NAMES.forEach((n) => expect(n).to.not.include(':'));
+      DIMENSION_PROVISION_ORDER.forEach((n) => expect(n).to.not.include(':'));
     });
 
     it('splits the roots into open (category, source) and closed (intent, origin, type)', () => {
       expect([...OPEN_DIMENSIONS]).to.deep.equal([DIMENSION.CATEGORY, DIMENSION.SOURCE]);
       expect([...CLOSED_DIMENSIONS]).to.deep.equal(['intent', 'origin', 'type']);
-      expect([...ALL_DIMENSIONS].sort()).to.deep.equal([...DIMENSION_ROOT_NAMES].sort());
+      expect([...ALL_DIMENSIONS].sort()).to.deep.equal([...DIMENSION_PROVISION_ORDER].sort());
     });
 
     it('is server-owned for everything except category (write-guard / create-semantics axis)', () => {
@@ -67,9 +72,34 @@ describe('serenity prompt-tags taxonomy', () => {
       expect(isDimensionRootName('Running Shoes')).to.equal(false);
     });
 
+    it('reserves BOTH intent spellings, so neither can be shadowed mid-rename', () => {
+      expect(isDimensionRootName(INTENT_ROOT_NAME)).to.equal(true);
+      expect(isDimensionRootName(LEGACY_INTENT_ROOT_NAME)).to.equal(true);
+      expect([...RESERVED_ROOT_NAMES]).to.include(INTENT_ROOT_NAME);
+    });
+
+    it('maps a dimension to its upstream root name, and back', () => {
+      // Only `intent` differs from its key: Semrush hides a `$abv_tags$`-marked
+      // entry from the customer-facing Brand Presence tag filter.
+      expect(rootNameOfDimension(DIMENSION.INTENT)).to.equal(INTENT_ROOT_NAME);
+      expect(dimensionOfRootName(INTENT_ROOT_NAME)).to.equal(DIMENSION.INTENT);
+      // The pre-rename name IS the key, so the fold is identity for it and a
+      // mid-rename project answers the same dimension as a renamed one.
+      expect(dimensionOfRootName(LEGACY_INTENT_ROOT_NAME)).to.equal(DIMENSION.INTENT);
+      DIMENSION_PROVISION_ORDER
+        .filter((d) => d !== DIMENSION.INTENT)
+        .forEach((d) => {
+          expect(rootNameOfDimension(d)).to.equal(d);
+          expect(dimensionOfRootName(d)).to.equal(d);
+        });
+      // Nothing outside the taxonomy is rewritten in either direction.
+      expect(rootNameOfDimension('Running Shoes')).to.equal('Running Shoes');
+      expect(dimensionOfRootName('Running Shoes')).to.equal('Running Shoes');
+    });
+
     it('is frozen (immutable single source of truth)', () => {
       expect(Object.isFrozen(DIMENSION)).to.equal(true);
-      expect(Object.isFrozen(DIMENSION_ROOT_NAMES)).to.equal(true);
+      expect(Object.isFrozen(DIMENSION_PROVISION_ORDER)).to.equal(true);
       expect(Object.isFrozen(CLOSED_DIMENSION_VALUES)).to.equal(true);
     });
   });

--- a/test/support/serenity/tag-tree.test.js
+++ b/test/support/serenity/tag-tree.test.js
@@ -27,7 +27,11 @@ import {
   findTagsInTree,
   assertParentWithinDimension,
 } from '../../../src/support/serenity/tag-tree.js';
-import { DIMENSION } from '../../../src/support/serenity/prompt-tags.js';
+import {
+  DIMENSION,
+  INTENT_ROOT_NAME,
+  LEGACY_INTENT_ROOT_NAME,
+} from '../../../src/support/serenity/prompt-tags.js';
 import {
   TAG_IDS,
   dimensionTreeLevels,
@@ -279,14 +283,91 @@ describe('serenity tag-tree', () => {
       const log = fakeLog();
       const roots = await ensureDimensionRoots(transport, WS, PROJECT, log);
       expect(createProjectTags).to.have.been.calledOnce;
+      // Provisioned under the UPSTREAM root names, so a fresh project starts out
+      // with the renamed intent root rather than one the migration must revisit.
       expect(createProjectTags.firstCall.args[2])
-        .to.deep.equal(['category', 'intent', 'origin', 'type', 'source']);
+        .to.deep.equal(['category', INTENT_ROOT_NAME, 'origin', 'type', 'source']);
+      // …and the map a caller reads is keyed by DIMENSION, not by that name.
+      expect(roots.get('intent')).to.equal(`created::${INTENT_ROOT_NAME}`);
       expect(roots.get('type')).to.equal('created::type');
       // A fresh project mints the producing-system `source` root outright.
       expect(roots.get('source')).to.equal('created::source');
       // Complement of the reshape-missed guardrail: `origin` is minted, but no legacy
       // `source` root is present, so the guardrail must NOT warn on the fresh path.
       expect(log.warn).to.not.have.been.called;
+    });
+
+    it('adopts the pre-rename `intent` root rather than minting a second one beside it', async () => {
+      // A project the intent rename has not reached. Minting `$abv_tags$intent` here
+      // would split the dimension: the new root is empty, every already-tagged prompt
+      // stays under the old one, and no read sees both.
+      const transport = {
+        listProjectTags: makeListProjectTagsStub(
+          dimensionTreeLevels({}, { legacyIntentRoot: true }),
+        ),
+        createProjectTags: sinon.stub(),
+      };
+      const log = fakeLog();
+      const roots = await ensureDimensionRoots(transport, WS, PROJECT, log);
+      expect(transport.createProjectTags).to.not.have.been.called;
+      // Keyed by dimension, so the caller never learns which spelling this project has…
+      expect(roots.get('intent')).to.equal(TAG_IDS.intentRoot);
+      // …but the sweep's progress stays observable.
+      expect(log.info).to.have.been.calledWithMatch(
+        sinon.match(/has not reached this project/),
+        sinon.match({ projectId: PROJECT }),
+      );
+    });
+
+    it('keeps the adopted legacy root when a concurrent writer wins the create race', async () => {
+      // The race-recovery path answers from a FRESH level index, so the alias
+      // adoption has to be applied to that one too. Without it the intent root
+      // drops out of the returned map, and the `undefined` root id that follows
+      // makes the next create mint the intent VALUES as bogus root-level tags.
+      const rootLevel = (extra = []) => ([
+        { id: 'r-category', name: 'category', children_count: 0 },
+        { id: 'r-intent-legacy', name: LEGACY_INTENT_ROOT_NAME, children_count: 5 },
+        { id: 'r-origin', name: 'origin', children_count: 2 },
+        { id: 'r-type', name: 'type', children_count: 2 },
+        ...extra,
+      ]);
+      const listProjectTags = sinon.stub();
+      // The re-read sees `source`, minted by a concurrent writer between our read
+      // and our create — which is what makes the create's rejection survivable.
+      listProjectTags.resolves({
+        items: rootLevel([{ id: 'r-source-other', name: 'source', children_count: 0 }]),
+      });
+      listProjectTags.onFirstCall().resolves({ items: rootLevel() });
+      const transport = {
+        listProjectTags,
+        createProjectTags: sinon.stub().rejects(new Error('duplicate (parent, name)')),
+      };
+      const roots = await ensureDimensionRoots(transport, WS, PROJECT, fakeLog());
+      expect(roots.get(DIMENSION.INTENT)).to.equal('r-intent-legacy');
+      expect(roots.get('source')).to.equal('r-source-other');
+    });
+
+    it('prefers the renamed root over a leftover `intent` root when a project carries both', async () => {
+      // Two distinct roots is not the mid-rename shape — the rename is done here and a
+      // stale empty `intent` root simply survived it.
+      const levels = dimensionTreeLevels();
+      const transport = {
+        listProjectTags: makeListProjectTagsStub({
+          ...levels,
+          '': [
+            ...levels[''],
+            {
+              id: 'stale-intent', name: LEGACY_INTENT_ROOT_NAME, parent_id: null, children_count: 0,
+            },
+          ],
+        }),
+        createProjectTags: sinon.stub(),
+      };
+      const log = fakeLog();
+      const roots = await ensureDimensionRoots(transport, WS, PROJECT, log);
+      expect(roots.get('intent')).to.equal(TAG_IDS.intentRoot);
+      expect(transport.createProjectTags).to.not.have.been.called;
+      expect(log.info).to.not.have.been.called;
     });
 
     it('creates a fresh `origin` root, leaving a legacy `source` root untouched', async () => {
@@ -387,7 +468,7 @@ describe('serenity tag-tree', () => {
       expect(createProjectTags).to.have.callCount(4);
       expect(values.get('origin').get('ai')).to.equal('created:created::origin:ai');
       expect(values.get('intent').get('Navigational'))
-        .to.equal('created:created::intent:Navigational');
+        .to.equal(`created:created::${INTENT_ROOT_NAME}:Navigational`);
     });
 
     it('502s rather than return a values map missing a dimension', async () => {
@@ -629,8 +710,8 @@ describe('serenity tag-tree', () => {
       const { listProjectTags, createProjectTags } = makeProvisioningTransportStubs();
       const transport = { listProjectTags, createProjectTags };
       const res = await resolveIntentValueInjection(transport, WS, PROJECT, 'Task', fakeLog());
-      expect(res.computedId).to.equal('created:created::intent:Task');
-      expect(res.intentTagIds).to.deep.equal(['created:created::intent:Task']);
+      expect(res.computedId).to.equal(`created:created::${INTENT_ROOT_NAME}:Task`);
+      expect(res.intentTagIds).to.deep.equal([`created:created::${INTENT_ROOT_NAME}:Task`]);
     });
 
     it('502s rather than skip injection when the intent root cannot be resolved', async () => {
@@ -740,12 +821,30 @@ describe('serenity tag-tree', () => {
   });
 
   describe('findTagsInTree — single-id placement', () => {
-    it('reports a dimension root as a root, with its own name as the dimension', async () => {
+    it('reports a dimension root as a root, folding its upstream name to the dimension', async () => {
       const transport = { listProjectTags: makeListProjectTagsStub() };
       const placed = await findTagsInTree(transport, WS, PROJECT, [TAG_IDS.intentRoot], fakeLog());
       const found = placed.get(TAG_IDS.intentRoot);
+      // Upstream names this root `$abv_tags$intent`; a caller reasons in dimensions.
       expect(found).to.deep.equal({
         kind: 'root', parentId: null, rootName: 'intent', ancestorIds: [],
+      });
+    });
+
+    // The descendant branch reads `path[0]`, which upstream fills with the root's
+    // real name — so this is where an unfolded `$abv_tags$intent` would leak out and
+    // silently disarm every guard that compares against `DIMENSION.*`. Both spellings
+    // must answer the same dimension; LLMO-6986 drops the legacy row.
+    [
+      { label: 'renamed', levels: dimensionTreeLevels() },
+      { label: 'pre-rename', levels: dimensionTreeLevels({}, { legacyIntentRoot: true }) },
+    ].forEach(({ label, levels }) => {
+      it(`reports a value under the ${label} intent root as the \`intent\` dimension`, async () => {
+        const transport = { listProjectTags: makeListProjectTagsStub(levels) };
+        const id = TAG_IDS.intentCommercial;
+        const found = (await findTagsInTree(transport, WS, PROJECT, [id], fakeLog())).get(id);
+        expect(found.kind).to.equal('descendant');
+        expect(found.rootName).to.equal(DIMENSION.INTENT);
       });
     });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

The Semrush `intent` dimension root is being renamed in place to `$abv_tags$intent`, project by project. This makes the API service resolve intent tags under either spelling, on both the Elements read path and the tag-tree write path.

## 2. Reasoning

Semrush hides a tag-tree entry whose name starts with the agreed `$abv_tags$` marker from the customer-facing Brand Presence tag filter. Renaming the intent root is how the prompt-intent dimension gets out of that filter — the same substring-hiding mechanism the dimension-root program already documents. The five values stay bare-named (`Informational`, `Commercial`, `Navigational`, `Transactional`, `Task`); only the root's name changes.

The rename runs from the data-service migration CLI against Semrush, one project at a time, so at any moment some projects carry the new name and some the old. Without this change the failure is silent rather than loud: an Elements tag filter is the `__`-joined tag PATH, so a dimension's prefix is literally its root's name. A filter built from the wrong spelling matches nothing and the endpoint answers HTTP 200 with an empty `userIntent` on every row — which renders the elmo Topic Intent Alignment tile as total misalignment rather than as an error.

## 3. High-level overview of the changes

**Read path — per-prompt `userIntent`.** The enrichment fires its five intent-filtered calls under `$abv_tags$intent` and retries once under `intent` only when all five succeeded and returned no rows. That empty result is the signature of a project the rename has not reached; a *failed* call is not, so an upstream having a bad day does not get a second round of calls for an answer that would be a guess. A renamed project therefore stays at five calls, not ten, and the retry stops firing by itself as the migration progresses — which is what makes removing the legacy spelling later a no-op rather than a behaviour change. The bounded waste is a project with genuinely no intent-tagged prompts, which pays a second round that also comes back empty.

**Read path — filter dimensions.** `page_intents` is populated from either prefix, and both are registered as known prefixes. That second half matters as much as the first: the unknown-prefix catch-all would otherwise have claimed a renamed project's tags and surfaced them in the URL-inspector filter payload as a dynamic group keyed `$abv_tags$intent` — putting the dimension back in front of customers under its internal name, beside an empty `page_intents`.

**Write path.** `intent` stays the dimension KEY everywhere it is a contract — the `type` a client names on the tag endpoints, the key of the closed vocabularies, the value elmo reads — and is mapped to the upstream root NAME only at the seam that talks to Semrush. Concretely:

- Root resolution provisions the renamed root on a project that has no intent root, and ADOPTS an existing pre-rename root rather than minting a second one beside it. Minting would split the dimension: the new root empty, every already-tagged prompt still under the old one, and no read seeing both.
- The resolved map is now keyed by dimension, so no caller has to know which spelling a given project carries.
- The tree walk folds a tag's raw root name to its dimension key. Two guards depend on this and would otherwise have failed OPEN on exactly the projects the rename reached: the one that refuses a client rename or re-parent of a server-owned value (a customer could have renamed `Informational`, and the next server write would mint a second one beside it), and the parent-placement check. Both spellings also stay reserved at the root level, so a customer value cannot shadow either.

**Observability.** Each of the three tolerances logs when it fires, under its own event key — `intent-rename-legacy-root-adopted` (the write path resolved a pre-rename root), `intent-rename-legacy-retry` (the read enrichment fell back) and `intent-rename-legacy-tags-present` (filter dimensions still saw `intent__` tags). So the follow-up that removes the legacy half is gated on three queries going quiet rather than on a judgement call about which projects the sweep reached.

## 4. Required information

- Jira / issue: LLMO-6984 — https://jira.corp.adobe.com/browse/LLMO-6984
- Spec: dimension-root tag model — https://github.com/adobe/serenity-docs/blob/main/docs/prompt-management/dimension-root-tag-model.md and the substring-hiding mechanism recorded in https://github.com/adobe/serenity-docs/blob/main/docs/prompt-management/origin-dimension.md
- Other: LLMO-6985 (the rename script + migration CLI support) — https://jira.corp.adobe.com/browse/LLMO-6985 ; LLMO-6986 (removes the legacy `intent__` fallback) — https://jira.corp.adobe.com/browse/LLMO-6986

## 5. Affected / used mysticat-workspace projects

- **mysticat-data-service** — contract. Performs the actual rename against Semrush from the migration CLI (LLMO-6985). This PR is what makes that rename safe to run project by project instead of as a coordinated cutover.
- **project-elmo-ui** — consumed, no change needed. Verified rather than assumed: `intent__` appears nowhere in that repo; `INTENT_DIMENSION` is declared but reaches only a type union, with no helper keying a prompt tag on the intent dimension. The Topic Intent Alignment tile consumes the server-derived `userIntent` string, and the intent filter compares the bare lowercased child values, which the rename does not touch. Its only use of the tag-tree root level is a lookup of the `category` root by name, so the renamed root passes through it unread. A duplicate ticket should not be opened for elmo.

## 6. Additional information outside the code

Run against live Semrush (`adobe-hackathon.semrush.com`) with a user IMS bearer, driving the real Elements read path — CI cannot produce this.

**Renamed project** — LLMO-Dev-2 Brand-A CH-de (`997e17c3-1566-47d4-a84f-3db00870bdf7`), whose intent root is already `$abv_tags$intent`: 909 prompts returned, `userIntent` resolved on all 909 (informational 235, commercial 370, task 303, transactional 1), in exactly six Elements calls — one base plus five intent-filtered. No legacy retry fired.

**Un-renamed project with real data** — Adobe Helpx US-en (`cd713e77-e714-4ad5-86b4-6f0a8650977c`), an Adobe-owned brand on prod: 9,690 prompts, `userIntent` resolved on all 9,690, in eleven calls — the five new-prefix calls came back empty, the retry fired and the five legacy calls carried the rows. The dev reference project named in the ticket for this case (Brand-A US-en) turns out to have no prompt executions under any model, so it could not demonstrate it; this prod project could.

**Filter dimensions** — the LLMO-Dev-2 workspace currently holds BOTH shapes at once, which exercises the mixed case directly: `page_intents` came back carrying entries from each prefix with bare labels, no `$abv_tags$intent` group appeared in the payload, and the ungrouped `tags` array stayed empty.

**Unrelated observation, not addressed here.** The same live payload shows the `origins` dimension has the analogous problem from the earlier `source` → `origin` authorship rename: `transformOriginsToFilterDimensions` still extracts `source__` only, so `origins` returns producing-system values mixed with authorship ones (`source__config` beside `source__ai` / `source__human`) while a renamed project's `origin__human` falls through to the catch-all as a stray dynamic `origin` group. Reproduced on both the dev and the prod workspace above. Out of scope for this ticket — flagging it rather than widening the change.

## 7. Test plan

Beyond unit and integration coverage of both tag shapes, the end-to-end verification is the live run recorded in section 6: both root spellings resolved `userIntent` against real Semrush data, the renamed project cost five intent calls and the un-renamed one ten, and the filter-dimension payload was inspected on a workspace holding both shapes.

The write path's no-duplicate-root behaviour is covered against the Semrush vendor mock in the integration suite (a project provisioned through the API now gets `$abv_tags$intent`, so the migration does not have to come back for projects created after this ships). It was deliberately NOT exercised against live Semrush, since that would mutate a real project's tag tree.

To verify on dev after deploy: call the URL-inspector prompts endpoint with `userIntent` enrichment for a project on each side of the rename and confirm the field is populated in both cases; then read the URL-inspector filter dimensions for a workspace holding a renamed project and confirm `page_intents` is populated and no `$abv_tags$intent` key is present. The three transition events (`intent-rename-legacy-root-adopted`, `intent-rename-legacy-retry`, `intent-rename-legacy-tags-present`) are the signal for how far the sweep has got.

## 8. Deployment & merge order

Related to LLMO-6985 (the rename run) but deliberately NOT ordered against it — removing that ordering constraint is the point of the dual-spelling read. This can merge and deploy before or after any project is renamed, and the rename can then roll project by project. LLMO-6986 is the cleanup that follows once the three transition log lines have gone quiet everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```