### PR TITLE
fix(serenity): stop benchmark alias writes from destroying what Semrush added

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -60,6 +60,7 @@ import {
   getBrandById,
   getBrandBySite,
   getBrandCompetitors,
+  getBrandAliases,
   readSerenityFlagScopes,
   withSerenityState,
 } from '../support/brands-storage.js';
@@ -1972,8 +1973,14 @@ function BrandsController(ctx, log, env) {
         ? await getBrandCompetitors(brandUuid, postgrestClient)
         : [];
       // Brand aliases (the extra names the brand is known by) re-sync to every
-      // market's project brand_names + own-brand benchmark on edit.
+      // market's project brand_names + own-brand benchmark on edit. Captured
+      // BEFORE the update for the same reason as the competitors above: the
+      // benchmark alias write removes only the aliases this edit dropped, so that
+      // the values Semrush's brand resolution added there survive it.
       const aliasesTouched = updates.brandAliases !== undefined;
+      const oldAliases = aliasesTouched
+        ? await getBrandAliases(brandUuid, postgrestClient)
+        : [];
 
       // Per-brand serenity rollout gate. An edit that changes URL sources /
       // competitors / aliases re-syncs onto the brand's Semrush projects (the
@@ -2270,6 +2277,7 @@ function BrandsController(ctx, log, env) {
               // of the brand's own properties.
               updated.urls,
               sharedProjects,
+              oldCompetitors,
             );
             rejectedAliases.push(...(competitorResult?.rejected ?? []));
           }
@@ -2281,6 +2289,7 @@ function BrandsController(ctx, log, env) {
               updated.semrushSubWorkspaceId,
               log,
               sharedProjects,
+              oldAliases,
             );
             rejectedAliases.push(...(aliasResult?.rejected ?? []));
           }

--- a/src/support/serenity/aliases.js
+++ b/src/support/serenity/aliases.js
@@ -165,6 +165,45 @@ export function mergeBenchmarkAliases(live, desired, removed = []) {
 }
 
 /**
+ * The alias keys other benchmarks in the same project already own — every OTHER
+ * benchmark's `brand_name` and `brand_aliases`, case-folded.
+ *
+ * Upstream enforces alias uniqueness across the union of every benchmark's name and
+ * aliases WITHIN A PROJECT, case-insensitively, and a duplicate is refused with a
+ * `409 duplicate brand name or alias` that fails the WHOLE write — for a batched
+ * create, every benchmark in the batch, including the ones that would have been
+ * fine (live-verified 2026-08-13). Sending an alias another benchmark owns is
+ * therefore not a small mistake; it takes unrelated work down with it.
+ *
+ * Callers subtract this from what they were going to send. The values are dropped
+ * silently rather than reported: they are ours to derive, so a customer cannot act
+ * on them, and the alternative is a failed edit.
+ *
+ * @param {Array<object>} benchmarks - `aio_benchmarks` from `listBenchmarks`.
+ * @param {string} [ownId] - the benchmark being written, excluded from the set.
+ * @returns {Set<string>} case-folded keys.
+ */
+export function aliasKeysOwnedByOthers(benchmarks, ownId) {
+  const owned = new Set();
+  for (const b of Array.isArray(benchmarks) ? benchmarks : []) {
+    if (ownId !== undefined && ownId !== null && String(b?.id) === String(ownId)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const values = [b?.brand_name, ...(Array.isArray(b?.brand_aliases) ? b.brand_aliases : [])];
+    for (const v of values) {
+      // Key on the trimmed value, not the raw one: `hasText` counts whitespace as
+      // text, so a blank name would otherwise add an empty key to the set.
+      const key = typeof v === 'string' ? v.trim().toLowerCase() : '';
+      if (hasText(key)) {
+        owned.add(key);
+      }
+    }
+  }
+  return owned;
+}
+
+/**
  * Whether two alias lists hold the same spellings (order ignored, casing
  * significant). The benchmark write decision uses this rather than
  * {@link sameAliasSet} so that a re-cased alias registers as a difference.

--- a/src/support/serenity/aliases.js
+++ b/src/support/serenity/aliases.js
@@ -51,8 +51,9 @@ export function dedupeAliases(list) {
 
 /**
  * Whether two alias lists denote the same set (order- and case-insensitive,
- * after trim/dedupe). Used to skip an in-place benchmark/project update when the
- * alias set has not actually changed.
+ * after trim/dedupe). Used to skip a project `brand_names` PATCH when the set has
+ * not actually changed. Benchmark `brand_aliases` use {@link sameAliasSetExact}
+ * instead — see the alias-identity note on {@link mergeBenchmarkAliases}.
  *
  * @param {Array<string>} [a]
  * @param {Array<string>} [b]
@@ -65,6 +66,129 @@ export function sameAliasSet(a, b) {
     return false;
   }
   return sa.every((v, i) => v === sb[i]);
+}
+
+/**
+ * The alias spellings to send for a benchmark, in the form Semrush's own brand
+ * resolution uses: all lowercase.
+ *
+ * Upstream identifies an alias by its case-folded value, so `Acme` and `acme` are
+ * ONE alias, not two — submitting both in a single list is rejected outright
+ * (`409 duplicate brand name or alias`, live-verified 2026-08-13). This returns one
+ * spelling per alias, lowercased, which is what Semrush stores when it creates an
+ * alias itself (benchmark `Apple` carries `apple`, `Ford` carries `ford`).
+ *
+ * The benchmark's own name is included, because a benchmark's `brand_aliases`
+ * normally repeats it and the same folding applies to that entry.
+ *
+ * Nothing is stored lowercase: `brand_aliases.alias` and `competitors.aliases`
+ * keep the casing the customer typed — that is what the UI renders, and our own
+ * matchers fold both sides already. The lowercasing happens HERE, on the way to
+ * the payload.
+ *
+ * These are PREFERENCES, not commands: {@link mergeBenchmarkAliases} only applies
+ * a spelling when it creates the alias, since upstream keeps the spelling an alias
+ * was first stored with (see there).
+ *
+ * @param {string} [brandName] - the benchmark's `brand_name`.
+ * @param {Array<string>} [aliases] - the aliases as stored on the brand.
+ * @returns {string[]}
+ */
+export function benchmarkAliases(brandName, aliases) {
+  const out = [];
+  const seen = new Set();
+  const add = (value) => {
+    const v = typeof value === 'string' ? value.trim().toLowerCase() : '';
+    if (!hasText(v) || seen.has(v)) {
+      return;
+    }
+    seen.add(v);
+    out.push(v);
+  };
+  dedupeAliases(aliases).forEach(add);
+  // hasText does not narrow string|undefined — check the value first (see the
+  // serenity type-checking notes).
+  if (brandName && hasText(brandName)) {
+    add(brandName);
+  }
+  return out;
+}
+
+/**
+ * The alias list to PUT on a benchmark: the live list, minus what this edit
+ * removed, plus any desired alias not already there.
+ *
+ * Three upstream behaviours shape this (all live-verified 2026-08-13):
+ *
+ * 1. An alias is identified by its CASE-FOLDED value, and the stored spelling is
+ *    the one it was created with. Re-submitting a different casing does not change
+ *    it — sending `Bark Phone` for a live `bark phone` leaves `bark phone`. So an
+ *    existing alias keeps its live spelling here, and `desired` only decides the
+ *    spelling of an alias being created. Re-casing an existing one takes a delete
+ *    and a re-add, which is a repair pass, not something an edit does.
+ * 2. A PUT replaces the whole list, so anything the caller does not send is gone.
+ *    Semrush's resolution adds values we cannot reproduce — benchmark
+ *    `General Motors` gains `gm`, `pixlr` gains the misspelling `pixlar` — and
+ *    those survive only by being carried forward from the live list.
+ * 3. Two spellings of one alias in a single list are rejected with a 409 that
+ *    fails the whole write, which folding by key here makes impossible to build.
+ *
+ * `removed` is subtracted before the merge, so an alias the customer deleted
+ * disappears while one that is both deleted and still desired survives.
+ *
+ * @param {Array<string>} [live] - the benchmark's current `brand_aliases`.
+ * @param {Array<string>} [desired] - preferred spellings, from {@link benchmarkAliases}.
+ * @param {Array<string>} [removed=[]] - aliases dropped from the brand in this edit.
+ * @returns {string[]}
+ */
+export function mergeBenchmarkAliases(live, desired, removed = []) {
+  const keyOf = (v) => (typeof v === 'string' ? v.trim().toLowerCase() : '');
+  const gone = new Set(
+    (Array.isArray(removed) ? removed : []).map(keyOf).filter((k) => hasText(k)),
+  );
+  // key → spelling to send. Live entries win their spelling; a desired alias only
+  // gets its own spelling when it is not already there.
+  const spellings = new Map();
+  for (const a of Array.isArray(live) ? live : []) {
+    const key = keyOf(a);
+    if (hasText(key) && !gone.has(key) && !spellings.has(key)) {
+      spellings.set(key, a.trim());
+    }
+  }
+  for (const a of Array.isArray(desired) ? desired : []) {
+    const key = keyOf(a);
+    if (hasText(key) && !spellings.has(key)) {
+      spellings.set(key, a.trim());
+    }
+  }
+  return [...spellings.values()];
+}
+
+/**
+ * Whether two alias lists hold the same spellings (order ignored, casing
+ * significant). The benchmark write decision uses this rather than
+ * {@link sameAliasSet} so that a re-cased alias registers as a difference.
+ *
+ * Because {@link mergeBenchmarkAliases} keeps every live spelling, comparing its
+ * result against the live list this way reports a difference only when an alias is
+ * genuinely added or removed — a spelling we would prefer but cannot apply does not
+ * cause a write, which is what keeps a steady-state re-sync silent.
+ *
+ * @param {Array<string>} [a]
+ * @param {Array<string>} [b]
+ * @returns {boolean}
+ */
+export function sameAliasSetExact(a, b) {
+  const trimmed = (list) => (Array.isArray(list) ? list : [])
+    .filter((v) => hasText(v))
+    .map((v) => v.trim());
+  const sa = [...new Set(trimmed(a))];
+  const sb = [...new Set(trimmed(b))];
+  if (sa.length !== sb.length) {
+    return false;
+  }
+  const set = new Set(sb);
+  return sa.every((v) => set.has(v));
 }
 
 /**

--- a/src/support/serenity/brand-aliases.js
+++ b/src/support/serenity/brand-aliases.js
@@ -187,9 +187,12 @@ export async function syncBrandAliasesAcrossMarkets(
         const withDerived = benchmarkAliases(benchmarkName, desiredBrandNames)
           .filter((a) => !ownedElsewhere.has(a.toLowerCase()));
         // Only the aliases this edit dropped from THIS market are removed; the rest
-        // of the live list (Semrush's enrichment) is carried forward.
+        // of the live list (Semrush's enrichment) is carried forward. Compared on the
+        // folded value, which is how upstream identifies an alias — a caller that
+        // re-spells an alias is editing it, not removing one and adding another.
+        const desiredKeys = new Set(desiredAliases.map((a) => a.toLowerCase()));
         const removedForMarket = collectAliasNames(previousAliases, market)
-          .filter((a) => !desiredAliases.includes(a));
+          .filter((a) => !desiredKeys.has(a.toLowerCase()));
         const nextAliases = mergeBenchmarkAliases(currentAliases, withDerived, removedForMarket);
         // Compared with casing significant, so a re-cased alias counts as a change.
         // The merge keeps every live spelling, so this is quiet in the steady state.

--- a/src/support/serenity/brand-aliases.js
+++ b/src/support/serenity/brand-aliases.js
@@ -20,7 +20,14 @@ import {
   marketOf,
   republishBestEffort,
 } from './brand-urls.js';
-import { dedupeAliases, sameAliasSet, rejectedAliasesFrom } from './aliases.js';
+import {
+  dedupeAliases,
+  sameAliasSet,
+  sameAliasSetExact,
+  benchmarkAliases,
+  mergeBenchmarkAliases,
+  rejectedAliasesFrom,
+} from './aliases.js';
 import { resolveProjects } from './resolve-projects.js';
 
 /** @typedef {import('./rest-transport.js').SerenityTransport} SerenityTransport */
@@ -78,6 +85,12 @@ export function collectAliasNames(aliases, market) {
  * @param {Array<object>|null} [prefetchedProjects=null] - a pre-fetched project listing
  *   to reuse (the brand-edit path lists once and shares it across the URL/competitor/alias
  *   syncs); null/undefined lists here. An explicit `[]` reuses the prefetch (no re-list).
+ * @param {Array<{name: string, regions?: string[]}>} [previousAliases=[]] - the brand's
+ *   aliases as they were BEFORE this edit, read by the caller ahead of the row write.
+ *   Region-filtered per market like the desired set, so the ones this edit dropped
+ *   from a given market are the only values removed from that market's benchmark;
+ *   everything else Semrush had added there is carried forward. An empty list makes
+ *   the benchmark write purely additive.
  * @returns {Promise<{markets: number, projectsUpdated: number,
  *   benchmarksUpdated: number, rejected: {projectId: string, market: string,
  *   domain: string|null, aliases: string[]}[]}>}
@@ -89,6 +102,7 @@ export async function syncBrandAliasesAcrossMarkets(
   workspaceId,
   log,
   prefetchedProjects = null,
+  previousAliases = [],
 ) {
   // Reuse a pre-fetched project listing when supplied (the brand-edit path lists
   // once and shares it across the URL/competitor/alias syncs), else list here.
@@ -142,8 +156,11 @@ export async function syncBrandAliasesAcrossMarkets(
       }
 
       // 2) Own-brand benchmark brand_aliases (PUT) — only when drifted.
+      // Read the DRAFT view: the PUT below acts on the draft, so diffing the
+      // published list would compare against a stale snapshot on any project that
+      // already has pending changes.
       // eslint-disable-next-line no-await-in-loop
-      const resp = await transport.listBenchmarks(workspaceId, projectId);
+      const resp = await transport.listBenchmarks(workspaceId, projectId, { draft: true });
       const benchmarks = Array.isArray(resp?.aio_benchmarks) ? resp.aio_benchmarks : [];
       const ownDomain = normalizeBenchmarkDomain(project?.domain);
       const own = benchmarks.find((b) => b?.main_brand === true && hasText(b?.id))
@@ -151,27 +168,51 @@ export async function syncBrandAliasesAcrossMarkets(
           && normalizeBenchmarkDomain(b?.domain) === ownDomain);
       if (own) {
         const currentAliases = Array.isArray(own.brand_aliases) ? own.brand_aliases : [];
-        if (!sameAliasSet(currentAliases, desiredAliases)) {
+        // Keep brand_name deterministic: own → display → project domain → ''
+        // (never undefined, which would make the PUT body non-deterministic).
+        const benchmarkName = hasText(own.brand_name)
+          ? own.brand_name
+          : (display || project?.domain || '');
+        // Preferred spellings come off the name upstream folds against — the
+        // benchmark's own brand_name, not the brand's display name.
+        const withDerived = benchmarkAliases(benchmarkName, desiredAliases);
+        // Only the aliases this edit dropped from THIS market are removed; the rest
+        // of the live list (Semrush's enrichment) is carried forward.
+        const removedForMarket = collectAliasNames(previousAliases, market)
+          .filter((a) => !desiredAliases.includes(a));
+        const nextAliases = mergeBenchmarkAliases(currentAliases, withDerived, removedForMarket);
+        // Compared with casing significant, so a re-cased alias counts as a change.
+        // The merge keeps every live spelling, so this is quiet in the steady state.
+        if (!sameAliasSetExact(currentAliases, nextAliases)) {
           // eslint-disable-next-line no-await-in-loop
           await transport.updateBenchmark(workspaceId, projectId, String(own.id), {
-            // Keep brand_name deterministic: own → display → project domain → ''
-            // (never undefined, which would make the PUT body non-deterministic).
-            brand_name: hasText(own.brand_name)
-              ? own.brand_name
-              : (display || project?.domain || ''),
+            brand_name: benchmarkName,
             domain: own.domain ?? project?.domain,
-            brand_aliases: desiredAliases,
+            brand_aliases: nextAliases,
           });
           benchmarksUpdated += 1;
           changed = true;
 
-          // Capture aliases Semrush rejected on the own-brand benchmark.
-          if (desiredAliases.length > 0) {
+          // Report the aliases the benchmark is not carrying, so the caller can warn
+          // the operator. Read the draft again — the write has not been published.
+          //
+          // `rejected_brand_aliases` is upstream's list of values this benchmark
+          // knows but does not currently apply, which includes the ones THIS edit
+          // just removed (live-verified 2026-08-13: dropping an alias moves it
+          // there). Reporting those back would flag the operator's own deletion as
+          // a problem, so they are filtered out and only the rest is surfaced.
+          if (nextAliases.length > 0) {
+            const removedKeys = new Set(removedForMarket.map((a) => a.toLowerCase()));
             // eslint-disable-next-line no-await-in-loop
-            const after = await transport.listBenchmarks(workspaceId, projectId);
+            const after = await transport.listBenchmarks(workspaceId, projectId, { draft: true });
             const list = Array.isArray(after?.aio_benchmarks) ? after.aio_benchmarks : [];
             rejected.push(
               ...rejectedAliasesFrom(list, (b) => String(b?.id) === String(own.id))
+                .map((r) => ({
+                  ...r,
+                  aliases: r.aliases.filter((a) => !removedKeys.has(String(a).toLowerCase())),
+                }))
+                .filter((r) => r.aliases.length > 0)
                 .map((r) => ({ projectId, market, ...r })),
             );
           }

--- a/src/support/serenity/brand-aliases.js
+++ b/src/support/serenity/brand-aliases.js
@@ -26,6 +26,7 @@ import {
   sameAliasSetExact,
   benchmarkAliases,
   mergeBenchmarkAliases,
+  aliasKeysOwnedByOthers,
   rejectedAliasesFrom,
 } from './aliases.js';
 import { resolveProjects } from './resolve-projects.js';
@@ -173,9 +174,18 @@ export async function syncBrandAliasesAcrossMarkets(
         const benchmarkName = hasText(own.brand_name)
           ? own.brand_name
           : (display || project?.domain || '');
-        // Preferred spellings come off the name upstream folds against — the
-        // benchmark's own brand_name, not the brand's display name.
-        const withDerived = benchmarkAliases(benchmarkName, desiredAliases);
+        // The own-brand benchmark carries the lowercase form of every name this
+        // project tracks — the display name and its region-applicable aliases, i.e.
+        // exactly the `brand_names` set PATCHed above — plus the benchmark's own
+        // name, which upstream folds against and which can differ from the display
+        // name. Keeping the two surfaces in step is the point: `brand_names`
+        // classifies branded prompts and the benchmark's aliases decide what counts
+        // as a mention of this brand, so a name known to one should be known to both.
+        // Never offer an alias another benchmark in this project already owns: the
+        // 409 that would follow fails the whole write, not just that alias.
+        const ownedElsewhere = aliasKeysOwnedByOthers(benchmarks, own.id);
+        const withDerived = benchmarkAliases(benchmarkName, desiredBrandNames)
+          .filter((a) => !ownedElsewhere.has(a.toLowerCase()));
         // Only the aliases this edit dropped from THIS market are removed; the rest
         // of the live list (Semrush's enrichment) is carried forward.
         const removedForMarket = collectAliasNames(previousAliases, market)

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -15,6 +15,7 @@
 import { hasText } from '@adobe/spacecat-shared-utils';
 
 import { isSemrushTransportError } from './errors.js';
+import { benchmarkAliases } from './aliases.js';
 import { resolveProjects } from './resolve-projects.js';
 
 /** @typedef {import('./rest-transport.js').SerenityTransport} SerenityTransport */
@@ -214,12 +215,14 @@ export async function ensureOwnBrandBenchmark(transport, workspaceId, projectId,
   if (!hasText(brand?.name) || ownDomain === null) {
     return null;
   }
+  // Create is the one point where we choose an alias's spelling: upstream keeps
+  // whatever an alias was created with, so a later PUT cannot re-case it. Use the
+  // lowercase form Semrush's own resolution would have stored.
+  const aliases = benchmarkAliases(brand.name, brand.aliases);
   const body = [{
     brand_name: brand.name,
     domain: brand.domain,
-    ...(Array.isArray(brand.aliases) && brand.aliases.length
-      ? { brand_aliases: brand.aliases }
-      : {}),
+    ...(aliases.length ? { brand_aliases: aliases } : {}),
   }];
   try {
     const created = await transport.createBenchmarks(workspaceId, projectId, body);

--- a/src/support/serenity/competitor-benchmarks.js
+++ b/src/support/serenity/competitor-benchmarks.js
@@ -272,8 +272,9 @@ export async function syncCompetitorBenchmarksForProject(
   for (const c of desired) {
     const existing = competitorByDomain.get(c.domain);
     if (existing) {
+      const keptKeys = new Set(c.aliases.map((a) => a.toLowerCase()));
       const removed = (previousByDomain.get(c.domain) || [])
-        .filter((a) => !c.aliases.includes(a));
+        .filter((a) => !keptKeys.has(a.toLowerCase()));
       plannedAliases.set(c.domain, mergeBenchmarkAliases(
         existing.aliases,
         allowed(benchmarkAliases(c.name, c.aliases), existing.id),
@@ -352,12 +353,15 @@ export async function syncCompetitorBenchmarksForProject(
         .map((c) => c.domain),
     ]);
     const removedKeysByDomain = new Map(
-      desired.map((c) => [
-        c.domain,
-        new Set((previousByDomain.get(c.domain) || [])
-          .filter((a) => !c.aliases.includes(a))
-          .map((a) => a.toLowerCase())),
-      ]),
+      desired.map((c) => {
+        const keptKeys = new Set(c.aliases.map((a) => a.toLowerCase()));
+        return [
+          c.domain,
+          new Set((previousByDomain.get(c.domain) || [])
+            .map((a) => a.toLowerCase())
+            .filter((a) => !keptKeys.has(a))),
+        ];
+      }),
     );
     // Draft again — the writes above are not published yet.
     const after = await transport.listBenchmarks(workspaceId, projectId, { draft: true });

--- a/src/support/serenity/competitor-benchmarks.js
+++ b/src/support/serenity/competitor-benchmarks.js
@@ -20,7 +20,13 @@ import {
   marketOf,
   republishBestEffort,
 } from './brand-urls.js';
-import { dedupeAliases, sameAliasSet, rejectedAliasesFrom } from './aliases.js';
+import {
+  dedupeAliases,
+  sameAliasSetExact,
+  benchmarkAliases,
+  mergeBenchmarkAliases,
+  rejectedAliasesFrom,
+} from './aliases.js';
 import { resolveProjects } from './resolve-projects.js';
 
 /** @typedef {import('./rest-transport.js').SerenityTransport} SerenityTransport */
@@ -141,16 +147,22 @@ export function removedCompetitorDomains(oldCompetitors, newCompetitors) {
   return [...removed];
 }
 
-// Builds the `{ brand_name, domain, brand_aliases? }` benchmark create/update
-// body from a collected competitor. `brand_aliases` is omitted when empty so the
-// upstream payload stays minimal (and an alias-less update clears nothing it
-// shouldn't — the PUT replaces the full benchmark, so we always send the
-// computed set, empty meaning "no aliases").
-function benchmarkBody(c) {
+// Builds the `{ brand_name, domain, brand_aliases }` benchmark create/update body
+// from a collected competitor.
+//
+// `brand_aliases` is ALWAYS sent, even when empty. Omitting the field does not
+// leave the stored list alone — it clears it (live-verified 2026-08-13: a PUT of
+// `{brand_name, domain}` over a benchmark holding two aliases emptied it). An
+// update that means to change only the name must therefore still carry the aliases
+// it wants to keep.
+//
+// `aliases` is the already-resolved list to send: on create the preferred spellings
+// for the competitor, on update those merged over the benchmark's live list.
+function benchmarkBody(c, aliases) {
   return {
     brand_name: c.name,
     domain: c.domain,
-    ...(c.aliases.length > 0 ? { brand_aliases: c.aliases } : {}),
+    brand_aliases: aliases,
   };
 }
 
@@ -176,6 +188,11 @@ function benchmarkBody(c) {
  * @param {object} [log] - optional logger ({ info? }).
  * @param {Set<string>} [reservedDomains=new Set()] - the brand's own normalized
  *   domains, excluded so a competitor can't be one of the brand's properties.
+ * @param {Array<{name?: string, url?: string, regions?: string[], aliases?: string[]}>}
+ *   [previousCompetitors=[]] - the competitors as they were BEFORE this edit. Run
+ *   through the same region filter, so per domain the aliases this edit dropped from
+ *   THIS market are the only values removed from that benchmark; the rest of its live
+ *   list (Semrush's enrichment) is carried forward.
  * @returns {Promise<{created: number, updated: number, deleted: number,
  *   changed: boolean, rejected: {domain: string, aliases: string[]}[]}>}
  */
@@ -188,6 +205,7 @@ export async function syncCompetitorBenchmarksForProject(
   market,
   log,
   reservedDomains = new Set(),
+  previousCompetitors = [],
 ) {
   const desired = collectCompetitorBenchmarks(competitors, market, reservedDomains);
   const removedSet = new Set(
@@ -202,10 +220,13 @@ export async function syncCompetitorBenchmarksForProject(
     };
   }
 
-  const resp = await transport.listBenchmarks(workspaceId, projectId);
+  // Read the DRAFT view: the writes below act on the draft, so diffing the
+  // published list would compare against a stale snapshot on any project that
+  // already has pending changes.
+  const resp = await transport.listBenchmarks(workspaceId, projectId, { draft: true });
   const benchmarks = Array.isArray(resp?.aio_benchmarks) ? resp.aio_benchmarks : [];
 
-  // Domain → competitor (non-main) benchmark { id, aliases }, for update/delete.
+  // Domain → competitor (non-main) benchmark { id, name, aliases }, for update/delete.
   const competitorByDomain = new Map();
   const presentDomains = new Set();
   for (const b of benchmarks) {
@@ -224,7 +245,30 @@ export async function syncCompetitorBenchmarksForProject(
     }
   }
 
+  // The aliases this edit dropped per domain, on this market's region filter.
+  const previousByDomain = new Map(
+    collectCompetitorBenchmarks(previousCompetitors, market, reservedDomains)
+      .map((c) => [c.domain, c.aliases]),
+  );
+
   const toCreate = desired.filter((c) => !presentDomains.has(c.domain));
+  // Domain → the alias list to PUT, for the competitors that already have a
+  // benchmark: the derived set merged over what is live there, minus the aliases
+  // this edit dropped. Computed once and reused by the drift check and the write.
+  const plannedAliases = new Map();
+  for (const c of desired) {
+    const existing = competitorByDomain.get(c.domain);
+    if (existing) {
+      const removed = (previousByDomain.get(c.domain) || [])
+        .filter((a) => !c.aliases.includes(a));
+      plannedAliases.set(c.domain, mergeBenchmarkAliases(
+        existing.aliases,
+        benchmarkAliases(c.name, c.aliases),
+        removed,
+      ));
+    }
+  }
+
   // Update an existing competitor benchmark when its display name OR its alias
   // set drifted. The benchmark is keyed by domain, so a rename that keeps the
   // same URL (e.g. "test1234" → "test12345" on test1234.de) would otherwise
@@ -238,7 +282,9 @@ export async function syncCompetitorBenchmarksForProject(
     // the desired one (a genuine rename). An absent upstream name is left alone
     // rather than backfilled, so a benchmark we did not name is never touched.
     const nameDrifted = existing.name !== '' && existing.name !== c.name;
-    return nameDrifted || !sameAliasSet(existing.aliases, c.aliases);
+    // Compared with casing significant; the merge keeps live spellings, so this is
+    // quiet in the steady state.
+    return nameDrifted || !sameAliasSetExact(existing.aliases, plannedAliases.get(c.domain));
   });
   const toDelete = [...removedSet]
     .map((d) => competitorByDomain.get(d)?.id)
@@ -247,14 +293,29 @@ export async function syncCompetitorBenchmarksForProject(
   let created = 0;
   let updated = 0;
   let deleted = 0;
+  // A created benchmark has no live list to merge over, so it takes the preferred
+  // spellings as they are — the one moment we get to choose them, since upstream
+  // keeps whatever spelling an alias was created with.
+  const createdAliases = new Map(
+    toCreate.map((c) => [c.domain, benchmarkAliases(c.name, c.aliases)]),
+  );
   if (toCreate.length > 0) {
-    await transport.createBenchmarks(workspaceId, projectId, toCreate.map(benchmarkBody));
+    await transport.createBenchmarks(
+      workspaceId,
+      projectId,
+      toCreate.map((c) => benchmarkBody(c, createdAliases.get(c.domain))),
+    );
     created = toCreate.length;
   }
   for (const c of toUpdate) {
     const { id } = competitorByDomain.get(c.domain);
     // eslint-disable-next-line no-await-in-loop
-    await transport.updateBenchmark(workspaceId, projectId, id, benchmarkBody(c));
+    await transport.updateBenchmark(
+      workspaceId,
+      projectId,
+      id,
+      benchmarkBody(c, plannedAliases.get(c.domain)),
+    );
     updated += 1;
   }
   if (toDelete.length > 0) {
@@ -262,21 +323,42 @@ export async function syncCompetitorBenchmarksForProject(
     deleted = toDelete.length;
   }
 
-  // Capture aliases Semrush rejected on the benchmarks we just wrote with aliases.
-  // Only re-read when an alias-bearing create or any update happened (a plain
-  // create-without-aliases or a delete can't produce rejections).
+  // Report the aliases a benchmark we just wrote is not carrying, so the caller can
+  // warn the operator. Only re-read when an alias-bearing write happened.
+  //
+  // Values THIS sync removed also land in `rejected_brand_aliases` (live-verified
+  // 2026-08-13), so they are filtered out per domain — flagging the operator's own
+  // deletion back at them is noise, not a warning.
   let rejected = [];
-  const wroteAliases = toUpdate.length > 0 || toCreate.some((c) => c.aliases.length > 0);
+  const wroteAliases = toUpdate.length > 0
+    || toCreate.some((c) => (createdAliases.get(c.domain) || []).length > 0);
   if (wroteAliases) {
-    const desiredAliasDomains = new Set(
-      desired.filter((c) => c.aliases.length > 0).map((c) => c.domain),
+    const desiredAliasDomains = new Set([
+      ...toUpdate.map((c) => c.domain),
+      ...toCreate.filter((c) => (createdAliases.get(c.domain) || []).length > 0)
+        .map((c) => c.domain),
+    ]);
+    const removedKeysByDomain = new Map(
+      desired.map((c) => [
+        c.domain,
+        new Set((previousByDomain.get(c.domain) || [])
+          .filter((a) => !c.aliases.includes(a))
+          .map((a) => a.toLowerCase())),
+      ]),
     );
-    const after = await transport.listBenchmarks(workspaceId, projectId);
+    // Draft again — the writes above are not published yet.
+    const after = await transport.listBenchmarks(workspaceId, projectId, { draft: true });
     const list = Array.isArray(after?.aio_benchmarks) ? after.aio_benchmarks : [];
     rejected = rejectedAliasesFrom(list, (b) => {
       const d = normalizeBenchmarkDomain(b?.domain);
       return b?.main_brand !== true && d !== null && desiredAliasDomains.has(d);
-    });
+    })
+      .map((r) => {
+        const key = normalizeBenchmarkDomain(r.domain ?? '');
+        const dropped = (key !== null && removedKeysByDomain.get(key)) || new Set();
+        return { ...r, aliases: r.aliases.filter((a) => !dropped.has(String(a).toLowerCase())) };
+      })
+      .filter((r) => r.aliases.length > 0);
   }
 
   if (created > 0 || updated > 0 || deleted > 0) {
@@ -311,6 +393,10 @@ export async function syncCompetitorBenchmarksForProject(
  * @param {Array<object>|null} [prefetchedProjects=null] - a pre-fetched project listing
  *   to reuse (the brand-edit path lists once and shares it across the URL/competitor/alias
  *   syncs); null/undefined lists here. An explicit `[]` reuses the prefetch (no re-list).
+ * @param {Array<{name?: string, url?: string, regions?: string[], aliases?: string[]}>}
+ *   [previousCompetitors=[]] - the competitors as they were BEFORE this edit (the same
+ *   list `removedDomains` was computed from), so each benchmark's alias write removes
+ *   only what this edit dropped and carries Semrush's enrichment forward.
  * @returns {Promise<{markets: number, created: number, updated: number,
  *   deleted: number, rejected: {projectId: string, market: string,
  *   domain: string|null, aliases: string[]}[]}>}
@@ -323,6 +409,7 @@ export async function syncCompetitorBenchmarksAcrossMarkets(
   log,
   brandOwnUrls = [],
   prefetchedProjects = null,
+  previousCompetitors = [],
 ) {
   // Reuse a pre-fetched project listing when supplied (the brand-edit path lists
   // once and shares it across the URL/competitor/alias syncs), else list here.
@@ -361,6 +448,7 @@ export async function syncCompetitorBenchmarksAcrossMarkets(
         market,
         log,
         reservedDomains,
+        previousCompetitors,
       );
       created += result.created;
       updated += result.updated;

--- a/src/support/serenity/competitor-benchmarks.js
+++ b/src/support/serenity/competitor-benchmarks.js
@@ -25,6 +25,7 @@ import {
   sameAliasSetExact,
   benchmarkAliases,
   mergeBenchmarkAliases,
+  aliasKeysOwnedByOthers,
   rejectedAliasesFrom,
 } from './aliases.js';
 import { resolveProjects } from './resolve-projects.js';
@@ -255,6 +256,18 @@ export async function syncCompetitorBenchmarksForProject(
   // Domain → the alias list to PUT, for the competitors that already have a
   // benchmark: the derived set merged over what is live there, minus the aliases
   // this edit dropped. Computed once and reused by the drift check and the write.
+  // An alias another benchmark in this project already owns must never be offered:
+  // upstream refuses it with a 409 that fails the WHOLE write, so on a batched
+  // create it would take every other competitor in the batch with it. The aliases
+  // we derive make that reachable — a competitor's own lowercase name can collide
+  // with a sibling benchmark's name or alias — so they are filtered here, against
+  // the listing already in hand.
+  const ownedElsewhere = (ownId) => aliasKeysOwnedByOthers(benchmarks, ownId);
+  const allowed = (list, ownId) => {
+    const owned = ownedElsewhere(ownId);
+    return list.filter((a) => !owned.has(a.toLowerCase()));
+  };
+
   const plannedAliases = new Map();
   for (const c of desired) {
     const existing = competitorByDomain.get(c.domain);
@@ -263,7 +276,7 @@ export async function syncCompetitorBenchmarksForProject(
         .filter((a) => !c.aliases.includes(a));
       plannedAliases.set(c.domain, mergeBenchmarkAliases(
         existing.aliases,
-        benchmarkAliases(c.name, c.aliases),
+        allowed(benchmarkAliases(c.name, c.aliases), existing.id),
         removed,
       ));
     }
@@ -297,7 +310,7 @@ export async function syncCompetitorBenchmarksForProject(
   // spellings as they are — the one moment we get to choose them, since upstream
   // keeps whatever spelling an alias was created with.
   const createdAliases = new Map(
-    toCreate.map((c) => [c.domain, benchmarkAliases(c.name, c.aliases)]),
+    toCreate.map((c) => [c.domain, allowed(benchmarkAliases(c.name, c.aliases))]),
   );
   if (toCreate.length > 0) {
     await transport.createBenchmarks(

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -1236,12 +1236,27 @@ export function createSerenityTransport({ env, imsToken }) {
      * brand carries `main_brand: true`; its `id` is the `benchmark_id` the brand
      * URL endpoints require. Returns `{ aio_benchmarks: [...] }`.
      *
+     * The default is the PUBLISHED view, exactly as for the brand URLs below: a
+     * benchmark that has been created or updated but not yet published is INVISIBLE
+     * to it (live-verified 2026-08-13 — create → the benchmark is absent from the
+     * default list and present under `?draft=true`; the project publish then promotes
+     * it). Benchmark writes act on the DRAFT, so a diff meant to converge the draft
+     * must read the draft; reading the published view compares against a stale
+     * snapshot whenever the project has unpublished changes.
+     *
      * @param {string} workspaceId
      * @param {string} projectId
+     * @param {object} [opts]
+     * @param {boolean} [opts.draft=false] - read the draft (pending) view.
      */
-    async listBenchmarks(workspaceId, projectId) {
+    async listBenchmarks(workspaceId, projectId, { draft = false } = {}) {
       return projects.listBenchmarks(
-        { params: { path: { id: workspaceId, project_id: projectId } } },
+        {
+          params: {
+            path: { id: workspaceId, project_id: projectId },
+            ...(draft ? { query: { draft: true } } : {}),
+          },
+        },
       );
     },
 
@@ -1292,8 +1307,22 @@ export function createSerenityTransport({ env, imsToken }) {
      * benchmark's `brand_aliases` (own-brand or a competitor) when the alias set
      * changes but the domain does not — the create/delete pair cannot express an
      * in-place alias edit. Upstream PUT confirmed live on prod 2026-06-24
-     * (OPTIONS .../benchmarks/{bid} → 405 allow: PUT). Semrush may silently reject
-     * some aliases; read them back from `listBenchmarks` (`rejected_brand_aliases`).
+     * (OPTIONS .../benchmarks/{bid} → 405 allow: PUT); re-verified 2026-08-13, and
+     * it is the ONLY write on a benchmark — there is no PATCH and no alias
+     * sub-resource, unlike `brand_urls` and `products`.
+     *
+     * Three behaviours to hold in mind, all live-verified 2026-08-13:
+     * - A field left OUT of the body is cleared, not preserved: a PUT of
+     *   `{brand_name, domain}` empties `brand_aliases`. Always send the full list.
+     * - `domain` is required in practice (a body without it 400s on `primary_url`),
+     *   even though the generated request type marks nothing required.
+     * - An alias is identified case-insensitively and keeps the spelling it was
+     *   created with, so a PUT cannot re-case one, and two spellings of the same
+     *   alias in one list are refused with a 409 that fails the whole write.
+     *
+     * `rejected_brand_aliases` on the read model is the set of aliases the benchmark
+     * knows but does not currently apply — which includes ones a previous write
+     * removed, so it is NOT a list of values Semrush refused.
      *
      * @param {string} workspaceId
      * @param {string} projectId

--- a/test/it/postgres/serenity.test.js
+++ b/test/it/postgres/serenity.test.js
@@ -13,7 +13,7 @@
 import { ctx } from './harness.js';
 import { resetPostgres } from './seed.js';
 import {
-  resetSemrushMocks, setUmMockQuota, dumpUmMock, dumpPeMock,
+  resetSemrushMocks, setUmMockQuota, dumpUmMock, dumpPeMock, putPeBenchmark,
 } from './setup.js';
 import serenityTests from '../shared/tests/serenity.js';
 
@@ -25,4 +25,5 @@ serenityTests(() => ctx.httpClient, resetPostgres, resetSemrushMocks, {
   setUmMockQuota,
   dumpUmMock,
   dumpPeMock,
+  putPeBenchmark,
 });

--- a/test/it/postgres/setup.js
+++ b/test/it/postgres/setup.js
@@ -223,6 +223,38 @@ export const dumpUmMock = () => dumpMock(UM_MOCK_BASE, 'UM');
 export const dumpPeMock = () => dumpMock(PE_MOCK_BASE, 'PE');
 
 /**
+ * Replaces a benchmark on the Project Engine mock through the vendor's own update route, the way
+ * Semrush's brand resolution would have — the mock has no control route for this, and none should
+ * be added: the point is to leave the benchmark in a state only the vendor can produce.
+ *
+ * A benchmark carries alias values Semrush added itself (`gm` on General Motors, the misspelling
+ * `pixlar` on pixlr). We hold no row for those, so nothing in our own derivation can reconstruct
+ * one — which is exactly what makes them the test subject for a merge-over-live write. Seeding one
+ * here and asserting it is still present after an unrelated brand edit is the only way to prove the
+ * write merged rather than replaced.
+ *
+ * Full-replace semantics, mirroring the vendor: `brand_aliases` is the complete list, and `domain`
+ * is required.
+ *
+ * @param {string} workspaceId - the sub-workspace holding the project
+ * @param {string} projectId - the project holding the benchmark
+ * @param {string} benchmarkId - the benchmark to replace
+ * @param {{brand_name: string, domain: string, brand_aliases: string[]}} body - the new state
+ * @returns {Promise<void>}
+ */
+export async function putPeBenchmark(workspaceId, projectId, benchmarkId, body) {
+  const url = `${PE_MOCK_BASE}/v1/workspaces/${workspaceId}/projects/${projectId}/ai_models/benchmarks/${benchmarkId}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer it-seed' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`PE mock benchmark PUT failed (${res.status}) for ${benchmarkId}`);
+  }
+}
+
+/**
  * Creates the MinIO bucket used by IT tests if it does not already exist.
  * MinIO is S3-compatible so `NoSuchBucket` errors are replaced by `HeadBucket 404`.
  */

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -1354,4 +1354,138 @@ export default function serenityTests(
         .to.deep.equal([a, b, c]);
     });
   });
+
+  describe('Serenity API — benchmark brand aliases survive a brand edit (live mock)', () => {
+    const { dumpPeMock, putPeBenchmark } = mockControls;
+    const brandPath = `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}`;
+    const serenityBase = `${brandPath}/serenity`;
+    // An alias no row of ours can produce, standing in for what Semrush's own brand resolution
+    // adds (`gm` on General Motors). If it is still on the benchmark after an unrelated edit, the
+    // write merged over the live list; if it is gone, the write replaced it.
+    const VENDOR_ALIAS = 'vendor resolved name';
+
+    before(function skipWithoutMockControls() {
+      if (typeof dumpPeMock !== 'function' || typeof putPeBenchmark !== 'function') {
+        this.skip();
+      }
+    });
+
+    beforeEach(async () => {
+      await resetData();
+      await resetMocks();
+    });
+
+    // Setup, not subject. The market create provisions the project; the own-brand benchmark is
+    // materialised separately, by the URL sync (`ensureOwnBrandBenchmark`), so a market alone
+    // leaves nothing for an alias write to land on. Both statuses are checked here so a refused
+    // setup fails on its own line rather than as a confusing "no such benchmark" later.
+    const createUsMarketWithBenchmark = async () => {
+      const market = await getHttpClient().admin.post(`${serenityBase}/markets`, {
+        market: 'US', languageCode: 'en', brandDomain: 'example.com', brandNames: ['Test Brand'],
+      });
+      expect(market.status).to.equal(201);
+      const urls = await getHttpClient().admin.patch(brandPath, {
+        urls: ['https://example.com/about'],
+      });
+      expect(urls.status).to.equal(200);
+    };
+
+    // The mock keys benchmarks per project (`benchmarks:{workspaceId}:{projectId}`), and the baked
+    // mock seed already supplies one such project. Flattening EVERY benchmark collection — and
+    // carrying each row's workspace/project along — is what keeps the lookup on the project the
+    // market under test resolved to rather than whichever collection the dump happens to list
+    // first. Same reason `storedPrompts` above flattens instead of picking one.
+    const storedBenchmarks = async () => {
+      const dump = await dumpPeMock();
+      const collections = Object.entries(dump)
+        .filter(([collection]) => collection.startsWith('benchmarks:'));
+      expect(collections.length, 'expected the PE mock to hold a benchmarks collection')
+        .to.be.greaterThan(0);
+      return collections.flatMap(([collection, rows]) => {
+        const [, workspaceId, projectId] = collection.split(':');
+        return (Array.isArray(rows) ? rows : []).map((row) => ({ workspaceId, projectId, row }));
+      });
+    };
+
+    const benchmarkNamed = async (name) => {
+      const all = await storedBenchmarks();
+      const found = all.find(({ row }) => row.brand_name === name);
+      // Naming the benchmarks that ARE stored turns a drift in how the own-brand benchmark is
+      // titled into a one-line diagnosis, instead of "expected undefined to exist".
+      const held = all.map(({ row }) => `${row.brand_name}=${JSON.stringify(row.brand_aliases || [])}`).join(' | ');
+      expect(found, `expected a benchmark named ${name}; mock holds: ${held || '(none)'}`).to.exist;
+      return found;
+    };
+
+    const aliasesOf = (row) => (row.brand_aliases || []).map((a) => a.toLowerCase());
+
+    it('keeps a vendor-added alias when the brand aliases are edited', async () => {
+      await createUsMarketWithBenchmark();
+
+      // Put the vendor's alias on the own-brand benchmark, as resolution would have.
+      const { workspaceId, projectId, row } = await benchmarkNamed('Test Brand');
+      await putPeBenchmark(workspaceId, projectId, row.id, {
+        brand_name: row.brand_name,
+        domain: row.domain,
+        brand_aliases: [...(row.brand_aliases || []), VENDOR_ALIAS],
+      });
+
+      const res = await getHttpClient().admin.patch(brandPath, {
+        brandAliases: [{ name: 'Test Alias', regions: ['WW'] }],
+      });
+      expect(res.status).to.equal(200);
+
+      const after = (await benchmarkNamed('Test Brand')).row;
+      expect(aliasesOf(after)).to.include(VENDOR_ALIAS);
+      // The edit's own alias lands too, in the lowercase spelling upstream uses
+      // when it creates one.
+      expect(after.brand_aliases).to.include('test alias');
+    });
+
+    it('removes an alias the edit dropped without taking the vendor-added one with it', async () => {
+      await createUsMarketWithBenchmark();
+      const seeded = await benchmarkNamed('Test Brand');
+      await putPeBenchmark(seeded.workspaceId, seeded.projectId, seeded.row.id, {
+        brand_name: seeded.row.brand_name,
+        domain: seeded.row.domain,
+        brand_aliases: [...(seeded.row.brand_aliases || []), VENDOR_ALIAS],
+      });
+
+      await getHttpClient().admin.patch(brandPath, {
+        brandAliases: [{ name: 'Temporary Alias', regions: ['WW'] }],
+      });
+      expect(aliasesOf((await benchmarkNamed('Test Brand')).row)).to.include('temporary alias');
+
+      // Dropping it from the brand must drop it upstream — the merge is additive over what the
+      // vendor holds, not over what we previously sent.
+      const res = await getHttpClient().admin.patch(brandPath, { brandAliases: [] });
+      expect(res.status).to.equal(200);
+
+      const after = (await benchmarkNamed('Test Brand')).row;
+      expect(aliasesOf(after)).to.not.include('temporary alias');
+      expect(aliasesOf(after)).to.include(VENDOR_ALIAS);
+    });
+
+    it('keeps a competitor benchmark\'s aliases when only its name changes', async () => {
+      await createUsMarketWithBenchmark();
+
+      await getHttpClient().admin.patch(brandPath, {
+        competitors: [{
+          name: 'Rival One', url: 'https://rival-one.example', aliases: ['Rival Incorporated'], regions: ['WW'],
+        }],
+      });
+      expect(aliasesOf((await benchmarkNamed('Rival One')).row)).to.include('rival incorporated');
+
+      // A rename carries no alias change. The write must still send `brand_aliases`: omitting the
+      // field does not leave the stored list alone, it clears it.
+      const res = await getHttpClient().admin.patch(brandPath, {
+        competitors: [{
+          name: 'Rival Uno', url: 'https://rival-one.example', aliases: ['Rival Incorporated'], regions: ['WW'],
+        }],
+      });
+      expect(res.status).to.equal(200);
+
+      expect(aliasesOf((await benchmarkNamed('Rival Uno')).row)).to.include('rival incorporated');
+    });
+  });
 }

--- a/test/support/serenity/aliases.test.js
+++ b/test/support/serenity/aliases.test.js
@@ -18,6 +18,7 @@ import {
   sameAliasSetExact,
   benchmarkAliases,
   mergeBenchmarkAliases,
+  aliasKeysOwnedByOthers,
   rejectedAliasesFrom,
 } from '../../../src/support/serenity/aliases.js';
 
@@ -127,6 +128,31 @@ describe('serenity alias helpers', () => {
       expect(mergeBenchmarkAliases(null, null)).to.deep.equal([]);
       expect(mergeBenchmarkAliases(['A'], null, null)).to.deep.equal(['A']);
       expect(mergeBenchmarkAliases(['A'], ['A'], [''])).to.deep.equal(['A']);
+    });
+  });
+
+  describe('aliasKeysOwnedByOthers', () => {
+    const benchmarks = [
+      { id: 'a', brand_name: 'Rival One', brand_aliases: ['rival one', 'R1'] },
+      { id: 'b', brand_name: 'Rival Two', brand_aliases: ['rival two'] },
+      { id: 'c', brand_name: '', brand_aliases: null },
+    ];
+
+    it('collects every other benchmark\'s name and aliases, case-folded', () => {
+      expect([...aliasKeysOwnedByOthers(benchmarks, 'a')].sort())
+        .to.deep.equal(['rival two']);
+      expect([...aliasKeysOwnedByOthers(benchmarks, 'b')].sort())
+        .to.deep.equal(['r1', 'rival one']);
+    });
+
+    it('excludes nothing when no owner id is given', () => {
+      expect([...aliasKeysOwnedByOthers(benchmarks)].sort())
+        .to.deep.equal(['r1', 'rival one', 'rival two']);
+    });
+
+    it('tolerates a non-array listing and blank values', () => {
+      expect(aliasKeysOwnedByOthers(null, 'a').size).to.equal(0);
+      expect(aliasKeysOwnedByOthers([{ id: 'x', brand_name: '  ' }], 'y').size).to.equal(0);
     });
   });
 

--- a/test/support/serenity/aliases.test.js
+++ b/test/support/serenity/aliases.test.js
@@ -15,6 +15,9 @@ import { expect } from 'chai';
 import {
   dedupeAliases,
   sameAliasSet,
+  sameAliasSetExact,
+  benchmarkAliases,
+  mergeBenchmarkAliases,
   rejectedAliasesFrom,
 } from '../../../src/support/serenity/aliases.js';
 
@@ -47,6 +50,83 @@ describe('serenity alias helpers', () => {
       expect(sameAliasSet([], null)).to.equal(true);
       expect(sameAliasSet(undefined, [])).to.equal(true);
       expect(sameAliasSet(['A'], [])).to.equal(false);
+    });
+  });
+
+  describe('sameAliasSetExact', () => {
+    it('is order-insensitive but case-SENSITIVE', () => {
+      expect(sameAliasSetExact(['A', 'b'], ['b', 'A'])).to.equal(true);
+      expect(sameAliasSetExact([' A ', 'b'], ['A', 'b'])).to.equal(true);
+      expect(sameAliasSetExact(['A', 'b'], ['a', 'b'])).to.equal(false);
+    });
+
+    it('detects a genuine difference and treats empty / non-array as the empty set', () => {
+      expect(sameAliasSetExact(['A'], ['A', 'a'])).to.equal(false);
+      expect(sameAliasSetExact([], null)).to.equal(true);
+      expect(sameAliasSetExact(undefined, ['A'])).to.equal(false);
+      expect(sameAliasSetExact(['A', ''], ['A'])).to.equal(true);
+    });
+
+    it('does not call two same-size sets equal when their members differ', () => {
+      expect(sameAliasSetExact(['A', 'B'], ['A', 'C'])).to.equal(false);
+    });
+  });
+
+  describe('benchmarkAliases', () => {
+    it('returns one lowercase spelling per alias, plus the benchmark name', () => {
+      expect(benchmarkAliases('Ford', ['Ford Motor', 'FoMoCo']))
+        .to.deep.equal(['ford motor', 'fomoco', 'ford']);
+    });
+
+    it('yields just the name when the brand has no aliases', () => {
+      expect(benchmarkAliases('Bass Pro', [])).to.deep.equal(['bass pro']);
+      expect(benchmarkAliases('Bass Pro', null)).to.deep.equal(['bass pro']);
+    });
+
+    it('collapses two spellings of one alias, so a 409 pair cannot be built', () => {
+      // Upstream folds case to identify an alias and refuses a list holding both.
+      expect(benchmarkAliases('GMC', ['GMC', 'gmc'])).to.deep.equal(['gmc']);
+      expect(benchmarkAliases('Acme', ['ACME', 'acme'])).to.deep.equal(['acme']);
+    });
+
+    it('tolerates a missing name and empty entries', () => {
+      expect(benchmarkAliases('', ['Acme', '  '])).to.deep.equal(['acme']);
+      expect(benchmarkAliases(null, ['Acme'])).to.deep.equal(['acme']);
+      expect(benchmarkAliases('Acme', [])).to.deep.equal(['acme']);
+    });
+  });
+
+  describe('mergeBenchmarkAliases', () => {
+    it('carries forward live values the desired set does not know', () => {
+      // 'gm' is Semrush's own enrichment — a plain replace would drop it.
+      expect(mergeBenchmarkAliases(['gm', 'onstar'], ['onstar', 'guardian']))
+        .to.deep.equal(['gm', 'onstar', 'guardian']);
+    });
+
+    it('keeps the live spelling of an alias already there', () => {
+      // A PUT cannot re-case an alias upstream already stores.
+      expect(mergeBenchmarkAliases(['Bass Pro'], ['bass pro'])).to.deep.equal(['Bass Pro']);
+    });
+
+    it('applies the preferred spelling only to an alias it creates', () => {
+      expect(mergeBenchmarkAliases(['Bass Pro'], ['bass pro', 'outdoor world']))
+        .to.deep.equal(['Bass Pro', 'outdoor world']);
+    });
+
+    it('drops a removed alias whatever its casing', () => {
+      expect(mergeBenchmarkAliases(['Old', 'Keep'], ['keep'], ['old']))
+        .to.deep.equal(['Keep']);
+    });
+
+    it('keeps a removed value the desired set still asks for', () => {
+      expect(mergeBenchmarkAliases(['Acme'], ['acme'], ['Acme'])).to.deep.equal(['acme']);
+    });
+
+    it('trims, drops empties, and tolerates non-array inputs', () => {
+      expect(mergeBenchmarkAliases([' A ', '', null], [' b '])).to.deep.equal(['A', 'b']);
+      expect(mergeBenchmarkAliases(null, null)).to.deep.equal([]);
+      expect(mergeBenchmarkAliases(['A'], null, null)).to.deep.equal(['A']);
+      expect(mergeBenchmarkAliases(['A'], ['A'], [''])).to.deep.equal(['A']);
     });
   });
 

--- a/test/support/serenity/brand-aliases.test.js
+++ b/test/support/serenity/brand-aliases.test.js
@@ -91,11 +91,15 @@ describe('brand-aliases helpers', () => {
         brand_name_display: 'Brand',
         brand_names: ['Brand', 'Acme', 'Acme Inc'],
       });
+      // One spelling per alias, lowercase — the form Semrush stores itself, and the
+      // only spelling we get to choose (a later PUT cannot re-case an alias).
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Brand',
         domain: 'brand.com',
-        brand_aliases: ['Acme', 'Acme Inc'],
+        brand_aliases: ['acme', 'acme inc', 'brand'],
       });
+      // The benchmark diff reads the DRAFT view — writes act on the draft.
+      expect(transport.listBenchmarks).to.have.been.calledWith(WS, 'p-us', { draft: true });
       expect(transport.publishProject).to.have.been.calledOnceWith(WS, 'p-us');
       expect(result).to.deep.equal({
         markets: 1, projectsUpdated: 1, benchmarksUpdated: 1, rejected: [],
@@ -147,23 +151,29 @@ describe('brand-aliases helpers', () => {
 
       const result = await syncBrandAliasesAcrossMarkets(transport, aliases, 'Brand', WS, undefined);
 
-      // Desired US aliases is empty → brand_names already [Brand] → no PATCH/PUT.
+      // Desired US aliases is empty → brand_names already [Brand] → no PATCH. The
+      // benchmark still gets the lowercase form of its own name, and nothing else:
+      // the DE-only alias is clamped out of the US market.
       expect(transport.updateProject).to.not.have.been.called;
-      expect(transport.updateBenchmark).to.not.have.been.called;
+      expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
+        brand_name: 'Brand', domain: 'brand.com', brand_aliases: ['brand'],
+      });
       expect(result.projectsUpdated).to.equal(0);
-      expect(result.benchmarksUpdated).to.equal(0);
+      expect(result.benchmarksUpdated).to.equal(1);
     });
 
     it('is a no-op when neither brand_names nor benchmark aliases drift', async () => {
       const transport = makeTransport(
         [projectWith('p-us', 'us', { brandNames: ['Brand', 'Acme'] })],
         {
+          // Already carries every alias the sync wants (spelling is upstream's to
+          // keep), so there is nothing to add.
           'p-us': [{
-            id: 'own', main_brand: true, domain: 'brand.com', brand_aliases: ['Acme'],
+            id: 'own', main_brand: true, domain: 'brand.com', brand_aliases: ['Acme', 'brand'],
           }],
         },
       );
-      const aliases = [{ name: 'acme', regions: [] }]; // same set (case-insensitive)
+      const aliases = [{ name: 'Acme', regions: [] }];
 
       const result = await syncBrandAliasesAcrossMarkets(transport, aliases, 'Brand', WS, undefined);
 
@@ -242,24 +252,90 @@ describe('brand-aliases helpers', () => {
       });
     });
 
-    it('clears benchmark aliases (and skips the rejected re-read) when the desired set is empty', async () => {
+    it('removes the alias this edit dropped, and keeps the derived form, when the desired set is empty', async () => {
       const transport = makeTransport(
         [projectWith('p-us', 'us', { brandNames: ['Brand', 'Old'] })],
         {
           'p-us': [{
-            id: 'own', main_brand: true, domain: 'brand.com', brand_aliases: ['Old'],
+            id: 'own', main_brand: true, domain: 'brand.com', brand_aliases: ['Old', 'old'],
           }],
         },
       );
 
-      const result = await syncBrandAliasesAcrossMarkets(transport, [], 'Brand', WS, undefined);
+      // 'Old' was the brand's alias before this edit and is gone from it now, so it
+      // (and the lowercase form derived from it) leaves the benchmark too.
+      const result = await syncBrandAliasesAcrossMarkets(
+        transport,
+        [],
+        'Brand',
+        WS,
+        undefined,
+        null,
+        [{ name: 'Old', regions: [] }],
+      );
 
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
-        brand_name: 'Brand', domain: 'brand.com', brand_aliases: [],
+        brand_name: 'Brand', domain: 'brand.com', brand_aliases: ['brand'],
       });
-      // desired aliases empty → no rejected re-read (listBenchmarks called once).
-      expect(transport.listBenchmarks).to.have.been.calledOnce;
       expect(result.benchmarksUpdated).to.equal(1);
+    });
+
+    it('carries the values Semrush added forward instead of replacing them', async () => {
+      const transport = makeTransport(
+        [projectWith('p-us', 'us', { brandNames: ['Brand', 'Bass Pro'] })],
+        {
+          'p-us': [{
+            id: 'own',
+            main_brand: true,
+            domain: 'brand.com',
+            // 'bass pro shops' is Semrush's enrichment — a value we cannot derive.
+            brand_aliases: ['Bass Pro', 'brand', 'bass pro shops'],
+          }],
+        },
+      );
+
+      const result = await syncBrandAliasesAcrossMarkets(
+        transport,
+        [{ name: 'Bass Pro', regions: [] }, { name: 'Outdoor World', regions: [] }],
+        'Brand',
+        WS,
+        undefined,
+      );
+
+      expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
+        brand_name: 'Brand',
+        domain: 'brand.com',
+        brand_aliases: ['Bass Pro', 'brand', 'bass pro shops', 'outdoor world'],
+      });
+      expect(result.benchmarksUpdated).to.equal(1);
+    });
+
+    it('does not re-offer an alias Semrush has already rejected', async () => {
+      const transport = makeTransport(
+        [projectWith('p-us', 'us', { brandNames: ['Chevrolet Canada'] })],
+        {
+          'p-us': [{
+            id: 'own',
+            main_brand: true,
+            domain: 'brand.com',
+            brand_aliases: ['Chevrolet Canada'],
+            // Semrush refused the lowercase form; re-sending it every sync would
+            // rewrite and republish the project for nothing.
+            rejected_brand_aliases: ['chevrolet canada'],
+          }],
+        },
+      );
+
+      const result = await syncBrandAliasesAcrossMarkets(
+        transport,
+        [{ name: 'Chevrolet Canada', regions: [] }],
+        'Chevrolet Canada',
+        WS,
+        undefined,
+      );
+
+      expect(transport.updateBenchmark).to.not.have.been.called;
+      expect(result.benchmarksUpdated).to.equal(0);
     });
 
     it('keeps the benchmark own brand_name + domain when present', async () => {
@@ -274,10 +350,12 @@ describe('brand-aliases helpers', () => {
 
       await syncBrandAliasesAcrossMarkets(transport, [{ name: 'Acme', regions: [] }], 'Brand', WS, undefined);
 
+      // The name-derived spelling comes off the BENCHMARK's name, which is what
+      // upstream folds against — not the brand's display name.
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Existing Brand',
         domain: 'existing.com',
-        brand_aliases: ['Acme'],
+        brand_aliases: ['acme', 'existing brand'],
       });
     });
 
@@ -292,7 +370,7 @@ describe('brand-aliases helpers', () => {
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Brand',
         domain: 'brand.com',
-        brand_aliases: ['Acme'],
+        brand_aliases: ['acme', 'brand'],
       });
     });
 
@@ -358,7 +436,7 @@ describe('brand-aliases helpers', () => {
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Brand',
         domain: 'brand.com',
-        brand_aliases: ['Acme'],
+        brand_aliases: ['acme', 'brand'],
       });
       expect(transport.publishProject).to.have.been.calledOnceWith(WS, 'p-us');
       expect(result).to.deep.equal({
@@ -459,10 +537,11 @@ describe('brand-aliases helpers', () => {
         undefined,
       );
 
+      // brand_name is '' → no name spelling to add, so only the alias itself.
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: '',
         domain: undefined,
-        brand_aliases: ['Acme'],
+        brand_aliases: ['acme'],
       });
     });
 

--- a/test/support/serenity/brand-aliases.test.js
+++ b/test/support/serenity/brand-aliases.test.js
@@ -91,12 +91,13 @@ describe('brand-aliases helpers', () => {
         brand_name_display: 'Brand',
         brand_names: ['Brand', 'Acme', 'Acme Inc'],
       });
-      // One spelling per alias, lowercase — the form Semrush stores itself, and the
-      // only spelling we get to choose (a later PUT cannot re-case an alias).
+      // Every name the project tracks, lowercased — the same set as brand_names
+      // above. One spelling per alias, which is the only spelling we get to choose
+      // (a later PUT cannot re-case an alias upstream already stores).
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Brand',
         domain: 'brand.com',
-        brand_aliases: ['acme', 'acme inc', 'brand'],
+        brand_aliases: ['brand', 'acme', 'acme inc'],
       });
       // The benchmark diff reads the DRAFT view — writes act on the draft.
       expect(transport.listBenchmarks).to.have.been.calledWith(WS, 'p-us', { draft: true });
@@ -310,6 +311,38 @@ describe('brand-aliases helpers', () => {
       expect(result.benchmarksUpdated).to.equal(1);
     });
 
+    it('drops an alias a competitor benchmark in the same project already owns', async () => {
+      // Upstream enforces alias uniqueness across every benchmark in the project,
+      // case-insensitively, and refuses a duplicate with a 409 that fails the whole
+      // write. So an alias owned elsewhere is never offered.
+      const transport = makeTransport(
+        [projectWith('p-us', 'us', { brandNames: ['Brand', 'Acme'] })],
+        {
+          'p-us': [
+            {
+              id: 'own', main_brand: true, domain: 'brand.com', brand_aliases: ['brand'],
+            },
+            {
+              id: 'rival', main_brand: false, domain: 'rival.com', brand_name: 'ACME',
+            },
+          ],
+        },
+      );
+
+      const result = await syncBrandAliasesAcrossMarkets(
+        transport,
+        [{ name: 'Acme', regions: [] }],
+        'Brand',
+        WS,
+        undefined,
+      );
+
+      // 'acme' belongs to the rival benchmark's name, so it is left out and the
+      // benchmark needs no write at all.
+      expect(transport.updateBenchmark).to.not.have.been.called;
+      expect(result.benchmarksUpdated).to.equal(0);
+    });
+
     it('does not re-offer an alias Semrush has already rejected', async () => {
       const transport = makeTransport(
         [projectWith('p-us', 'us', { brandNames: ['Chevrolet Canada'] })],
@@ -350,12 +383,12 @@ describe('brand-aliases helpers', () => {
 
       await syncBrandAliasesAcrossMarkets(transport, [{ name: 'Acme', regions: [] }], 'Brand', WS, undefined);
 
-      // The name-derived spelling comes off the BENCHMARK's name, which is what
-      // upstream folds against — not the brand's display name.
+      // Both names are covered: the display name the project tracks, and the
+      // benchmark's own name, which upstream folds against and differs here.
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Existing Brand',
         domain: 'existing.com',
-        brand_aliases: ['acme', 'existing brand'],
+        brand_aliases: ['brand', 'acme', 'existing brand'],
       });
     });
 
@@ -370,7 +403,7 @@ describe('brand-aliases helpers', () => {
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Brand',
         domain: 'brand.com',
-        brand_aliases: ['acme', 'brand'],
+        brand_aliases: ['brand', 'acme'],
       });
     });
 
@@ -436,7 +469,7 @@ describe('brand-aliases helpers', () => {
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, 'p-us', 'own', {
         brand_name: 'Brand',
         domain: 'brand.com',
-        brand_aliases: ['acme', 'brand'],
+        brand_aliases: ['brand', 'acme'],
       });
       expect(transport.publishProject).to.have.been.calledOnceWith(WS, 'p-us');
       expect(result).to.deep.equal({

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -243,8 +243,9 @@ describe('brand-urls helpers', () => {
         createBenchmarks: sandbox.stub().resolves({ ids: ['new-1'], existing_count: 0 }),
       };
       expect(await ensureOwnBrandBenchmark(transport, WS, PID, BRAND, undefined)).to.equal('new-1');
+      // The create carries the lowercase forms Semrush's own resolution would add.
       expect(transport.createBenchmarks).to.have.been.calledOnceWith(WS, PID, [
-        { brand_name: 'Acme', domain: 'https://acme.com', brand_aliases: ['acme inc'] },
+        { brand_name: 'Acme', domain: 'https://acme.com', brand_aliases: ['acme inc', 'acme'] },
       ]);
     });
 

--- a/test/support/serenity/competitor-benchmarks.test.js
+++ b/test/support/serenity/competitor-benchmarks.test.js
@@ -168,6 +168,29 @@ describe('competitor-benchmarks helpers', () => {
       });
     });
 
+    it('drops a derived alias a sibling benchmark owns, so the batch cannot 409', async () => {
+      // Live-verified 2026-08-13: alias uniqueness is project-wide and case-folded,
+      // and the 409 fails the WHOLE create — in a batch, the innocent members too.
+      // A competitor's own lowercase name is exactly what can collide.
+      const transport = makeTransport([
+        { id: 'own', main_brand: true, domain: 'acme.com' },
+        {
+          id: 'held', main_brand: false, domain: 'held.com', brand_name: 'Duck',
+        },
+      ]);
+      const competitors = [
+        // 'duck' (its lowercase name) is held by the 'Duck' benchmark above.
+        { name: 'DUCK', url: 'https://duckduckgo.com', regions: ['us'] },
+        { name: 'Clean', url: 'https://clean.com', regions: ['us'] },
+      ];
+      const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
+      expect(transport.createBenchmarks).to.have.been.calledOnceWith(WS, PID, [
+        { brand_name: 'DUCK', domain: 'duckduckgo.com', brand_aliases: [] },
+        { brand_name: 'Clean', domain: 'clean.com', brand_aliases: ['clean'] },
+      ]);
+      expect(result.created).to.equal(2);
+    });
+
     it('deletes the benchmark of a removed competitor (never the main brand)', async () => {
       const transport = makeTransport([
         { id: 'own', main_brand: true, domain: 'acme.com' },

--- a/test/support/serenity/competitor-benchmarks.test.js
+++ b/test/support/serenity/competitor-benchmarks.test.js
@@ -154,12 +154,17 @@ describe('competitor-benchmarks helpers', () => {
         { name: 'Duck', url: 'https://duckduckgo.com', regions: ['us'] }, // new → create
       ];
       const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
+      // A competitor with no aliases still carries the lowercase form of its name.
       expect(transport.createBenchmarks).to.have.been.calledOnceWith(WS, PID, [
-        { brand_name: 'Duck', domain: 'duckduckgo.com' },
+        { brand_name: 'Duck', domain: 'duckduckgo.com', brand_aliases: ['duck'] },
       ]);
+      // The diff reads the DRAFT view — the writes below act on the draft.
+      expect(transport.listBenchmarks).to.have.been.calledWith(WS, PID, { draft: true });
       expect(transport.deleteBenchmarks).to.not.have.been.called;
+      // Bing's benchmark is already present but carries no aliases, so it is updated
+      // to add the lowercase form of its name.
       expect(result).to.deep.equal({
-        created: 1, updated: 0, deleted: 0, changed: true, rejected: [],
+        created: 1, updated: 1, deleted: 0, changed: true, rejected: [],
       });
     });
 
@@ -178,7 +183,8 @@ describe('competitor-benchmarks helpers', () => {
     });
 
     it('is a no-op (changed:false) when nothing to add or remove', async () => {
-      const transport = makeTransport([{ id: 'bing', domain: 'bing.com' }]);
+      // Already carries the lowercase form of its name, so there is nothing to add.
+      const transport = makeTransport([{ id: 'bing', domain: 'bing.com', brand_aliases: ['bing'] }]);
       const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, [{ name: 'Bing', url: 'https://bing.com' }], [], 'us', undefined);
       expect(transport.createBenchmarks).to.not.have.been.called;
       expect(transport.deleteBenchmarks).to.not.have.been.called;
@@ -200,7 +206,11 @@ describe('competitor-benchmarks helpers', () => {
       ];
       const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
       expect(transport.createBenchmarks).to.have.been.calledOnceWith(WS, PID, [
-        { brand_name: 'Duck', domain: 'duckduckgo.com', brand_aliases: ['DDG', 'Duck Duck Go'] },
+        {
+          brand_name: 'Duck',
+          domain: 'duckduckgo.com',
+          brand_aliases: ['ddg', 'duck duck go', 'duck'],
+        },
       ]);
       expect(result.created).to.equal(1);
     });
@@ -222,9 +232,28 @@ describe('competitor-benchmarks helpers', () => {
           name: 'Bing', url: 'https://bing.com', aliases: ['Microsoft Bing'], regions: ['us'],
         },
       ];
-      const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
+      // 'MSN' was this competitor's alias before the edit and is gone from it now,
+      // so it leaves the benchmark; everything else there is carried forward.
+      const previous = [
+        {
+          name: 'Bing', url: 'https://bing.com', aliases: ['MSN'], regions: ['us'],
+        },
+      ];
+      const result = await syncCompetitorBenchmarksForProject(
+        transport,
+        WS,
+        PID,
+        competitors,
+        [],
+        'us',
+        undefined,
+        new Set(),
+        previous,
+      );
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, PID, 'bing', {
-        brand_name: 'Bing', domain: 'bing.com', brand_aliases: ['Microsoft Bing'],
+        brand_name: 'Bing',
+        domain: 'bing.com',
+        brand_aliases: ['microsoft bing', 'bing'],
       });
       expect(transport.createBenchmarks).to.not.have.been.called;
       expect(result).to.deep.equal({
@@ -245,7 +274,7 @@ describe('competitor-benchmarks helpers', () => {
       ];
       const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
       expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, PID, 'rival', {
-        brand_name: 'test12345', domain: 'test1234.de',
+        brand_name: 'test12345', domain: 'test1234.de', brand_aliases: ['test12345'],
       });
       expect(transport.createBenchmarks).to.not.have.been.called;
       expect(result).to.deep.equal({
@@ -259,7 +288,12 @@ describe('competitor-benchmarks helpers', () => {
       // is not clobbered by a drifting desired name.
       const transport = makeTransport([
         {
-          id: 'rival', main_brand: false, domain: 'test1234.de', brand_name: '',
+          id: 'rival',
+          main_brand: false,
+          domain: 'test1234.de',
+          brand_name: '',
+          // Already carries the derived form, so the name is the only difference.
+          brand_aliases: ['test12345'],
         },
       ]);
       const competitors = [
@@ -275,7 +309,11 @@ describe('competitor-benchmarks helpers', () => {
     it('does NOT update when the name and alias set are unchanged', async () => {
       const transport = makeTransport([
         {
-          id: 'rival', main_brand: false, domain: 'test1234.de', brand_name: 'test1234',
+          id: 'rival',
+          main_brand: false,
+          domain: 'test1234.de',
+          brand_name: 'test1234',
+          brand_aliases: ['test1234'],
         },
       ]);
       const competitors = [
@@ -286,10 +324,17 @@ describe('competitor-benchmarks helpers', () => {
       expect(result.changed).to.equal(false);
     });
 
-    it('does NOT update when the alias set is unchanged (order/case-insensitive)', async () => {
+    it('does NOT update when only the SPELLING of a live alias differs', async () => {
+      // Upstream keeps the spelling an alias was created with, so a PUT cannot
+      // re-case one. Treating a case difference as drift would rewrite and republish
+      // the project on every single sync.
       const transport = makeTransport([
         {
-          id: 'bing', main_brand: false, domain: 'bing.com', brand_aliases: ['MSN', 'Microsoft Bing'],
+          id: 'bing',
+          main_brand: false,
+          domain: 'bing.com',
+          brand_name: 'Bing',
+          brand_aliases: ['MSN', 'Microsoft Bing', 'bing'],
         },
       ]);
       const competitors = [
@@ -300,6 +345,30 @@ describe('competitor-benchmarks helpers', () => {
       const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
       expect(transport.updateBenchmark).to.not.have.been.called;
       expect(result.changed).to.equal(false);
+    });
+
+    it('carries a competitor benchmark\'s vendor-added aliases through a rename', async () => {
+      // The rename path used to omit brand_aliases entirely, which CLEARS the list
+      // upstream — so renaming a competitor wiped whatever Semrush had added to it.
+      const transport = makeTransport([
+        {
+          id: 'gm',
+          main_brand: false,
+          domain: 'gm.com',
+          brand_name: 'General Motors',
+          brand_aliases: ['gm'],
+        },
+      ]);
+      const competitors = [
+        { name: 'GM Company', url: 'https://gm.com', regions: ['us'] },
+      ];
+      const result = await syncCompetitorBenchmarksForProject(transport, WS, PID, competitors, [], 'us', undefined);
+      expect(transport.updateBenchmark).to.have.been.calledOnceWith(WS, PID, 'gm', {
+        brand_name: 'GM Company',
+        domain: 'gm.com',
+        brand_aliases: ['gm', 'gm company'],
+      });
+      expect(result.updated).to.equal(1);
     });
 
     it('treats a non-array re-read after an alias write as no benchmarks (no rejections)', async () => {
@@ -374,10 +443,10 @@ describe('competitor-benchmarks helpers', () => {
         undefined,
       );
       expect(transport.createBenchmarks).to.have.been.calledWith(WS, 'p-us', [
-        { brand_name: 'US rival', domain: 'us-rival.com' },
+        { brand_name: 'US rival', domain: 'us-rival.com', brand_aliases: ['us rival'] },
       ]);
       expect(transport.createBenchmarks).to.have.been.calledWith(WS, 'p-de', [
-        { brand_name: 'DE rival', domain: 'de-rival.com' },
+        { brand_name: 'DE rival', domain: 'de-rival.com', brand_aliases: ['de rival'] },
       ]);
       expect(transport.publishProject).to.have.been.calledTwice;
       expect(result).to.deep.equal({
@@ -437,7 +506,7 @@ describe('competitor-benchmarks helpers', () => {
       // Only the real rival survives for p-us; the three self-references (own
       // primary brand.com, other-market brand.de, own website shop.brand.io) drop.
       expect(transport.createBenchmarks).to.have.been.calledOnceWith(WS, 'p-us', [
-        { brand_name: 'US rival', domain: 'rival.com' },
+        { brand_name: 'US rival', domain: 'rival.com', brand_aliases: ['us rival'] },
       ]);
       expect(result).to.deep.equal({
         markets: 2, created: 1, updated: 0, deleted: 0, rejected: [],
@@ -498,12 +567,17 @@ describe('competitor-benchmarks helpers', () => {
         listProjects: sandbox.stub().resolves({
           items: [projectWith('p-us', 'us'), { id: 'p-x', settings: { ai: {} } }],
         }),
-        listBenchmarks: sandbox.stub().resolves({ aio_benchmarks: [{ id: 'r', domain: 'rival.com' }] }),
+        // Carries the derived form already, so the benchmark needs no write.
+        listBenchmarks: sandbox.stub().resolves({
+          aio_benchmarks: [{ id: 'r', domain: 'rival.com', brand_aliases: ['rival'] }],
+        }),
         createBenchmarks: sandbox.stub().resolves({}),
+        updateBenchmark: sandbox.stub().resolves(null),
         deleteBenchmarks: sandbox.stub().resolves(null),
         publishProject: sandbox.stub().resolves({}),
       };
       const result = await syncCompetitorBenchmarksAcrossMarkets(transport, [{ name: 'Rival', url: 'https://rival.com' }], [], WS, undefined);
+      expect(transport.updateBenchmark).to.not.have.been.called;
       expect(transport.createBenchmarks).to.not.have.been.called;
       expect(transport.publishProject).to.not.have.been.called;
       expect(result).to.deep.equal({
@@ -608,10 +682,14 @@ describe('competitor-benchmarks helpers', () => {
         listBenchmarks: sandbox.stub().resolves({
           aio_benchmarks: [
             { id: 'bad', main_brand: false, domain: '' }, // null domain -> skip
-            { id: 'good', main_brand: false, domain: 'bing.com' },
+            // Carries the derived form, so being present is all this asserts.
+            {
+              id: 'good', main_brand: false, domain: 'bing.com', brand_aliases: ['bing'],
+            },
           ],
         }),
         createBenchmarks: sandbox.stub().resolves({ ids: ['x'], existing_count: 0 }),
+        updateBenchmark: sandbox.stub().resolves(null),
         deleteBenchmarks: sandbox.stub().resolves(null),
       };
       const result = await syncCompetitorBenchmarksForProject(
@@ -629,7 +707,7 @@ describe('competitor-benchmarks helpers', () => {
       // bing.com is in presentDomains -> not created. Duck -> created.
       expect(result.created).to.equal(1);
       expect(transport.createBenchmarks).to.have.been.calledOnceWith(WS, PID, [
-        { brand_name: 'Duck', domain: 'duckduckgo.com' },
+        { brand_name: 'Duck', domain: 'duckduckgo.com', brand_aliases: ['duck'] },
       ]);
     });
   });

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -566,9 +566,11 @@ describe('markets-subworkspace handlers', () => {
         null,
         { competitors },
       );
-      // Our us competitor becomes a benchmark; the de one is excluded.
+      // Our us competitor becomes a benchmark; the de one is excluded. The created
+      // benchmark carries the lowercase form of its name, which is the spelling
+      // upstream keeps for an alias created with it.
       expect(transport.createBenchmarks).to.have.been.calledWith(WS, 'new-proj', [
-        { brand_name: 'Rival', domain: 'rival.com' },
+        { brand_name: 'Rival', domain: 'rival.com', brand_aliases: ['rival'] },
       ]);
       expect(transport.createBenchmarks).to.have.been.calledBefore(transport.publishProject);
     });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Benchmark alias writes now merge over the list Semrush actually holds instead of replacing it, so the aliases its own brand resolution added survive a brand edit. Alias spellings follow upstream's identity model: one spelling per alias, folded by case.

## 2. Reasoning
A benchmark's `brand_aliases` carries names Semrush added itself, and they are not lowercase copies of anything we hold — benchmark `General Motors` carries `gm`, `Mercedes-Benz` carries `mercedes`, `pixlr` carries the misspelling `pixlar`, `Star Health Insurance` carries `star health & allied insurance`. The only write upstream offers on a benchmark is a PUT that replaces the whole alias list; there is no PATCH and no per-alias route. The sync sent its own values as that whole list, so every alias write dropped Semrush's, and resolution never re-runs to put them back.

Measured on the prod tenant on 2026-08-13 across 307 active brands, 470 projects and 2,738 benchmarks: 493 benchmarks hold 720 such values, and the next alias write to any of them takes them.

The competitor path was worse. A rename sent `{brand_name, domain}` with no `brand_aliases` at all, on the belief — stated in the code comment — that omitting the field left the stored list alone. It clears it. So renaming a competitor we hold no aliases for wiped whatever Semrush had put there.

## 3. High-level overview of the changes
Before: the own-brand and competitor syncs computed the alias list from the brand row and PUT it as the complete `brand_aliases`, diffing against the published view with a case-insensitive comparison. Anything upstream had added was silently replaced, and a name-only competitor rename omitted the field entirely and cleared the list.

After, the write is a merge over what is live:

- Every alias already on the benchmark is carried forward. Only the aliases this edit removed are subtracted, which needs the brand's previous aliases and competitors — read before the row is written and threaded into the two syncs.
- `brand_aliases` is always sent, even when empty, so an update that changes only a name can no longer clear the list.
- The alias diff reads the draft view (`?draft=true`). Writes act on the draft, so the published listing was a stale snapshot on any project with pending changes.
- Alias spellings are folded by case, one per alias. Upstream identifies an alias by its case-folded value and refuses a list holding two spellings of one alias with a 409 that fails the whole write, so that list can no longer be constructed. A newly created alias takes the lowercase spelling Semrush itself uses when it creates one; an alias already there keeps its stored spelling, because a PUT cannot re-case it.

Operationally visible: a steady-state re-sync now issues no benchmark write and no republish, where previously any alias-touching edit rewrote and republished. The aliases an edit itself removes are also filtered out of what is reported back to the caller as not-applied — upstream lists removed aliases in `rejected_brand_aliases`, so those were being surfaced to the operator as if they were a problem.

Not user-visible: the database keeps the customer's casing. `brand_aliases.alias` and `competitors.aliases` are unchanged, which is what the UI renders and what our own matchers fold anyway.

## 4. Required information
- Jira / issue: SITES-49840 — https://jira.corp.adobe.com/browse/SITES-49840
- Spec: serenity-docs `docs/provisioning/benchmark-brand-alias-casing.md` — https://github.com/adobe/serenity-docs/pull/342
- Other: re-casing the aliases already stored in the customer's casing is SITES-49841 — https://jira.corp.adobe.com/browse/SITES-49841

## 5. Affected / used mysticat-workspace projects
- `mysticat-data-service` — the `serenity_migration` CLI writes the same benchmarks and carries the matching half of this change (additive merge, folded comparison, lowercase spellings in the plan). Changed, on the same session branch.
- `project-elmo-ui` — consumes the brand aliases as stored and drives the edit through `PATCH /brands`. Contract unchanged: the database keeps the customer's casing, so the rendered alias list is unaffected.

## 6. Additional information outside the code
Everything below was run against the live Semrush tenant `https://adobe-hackathon.semrush.com` on 2026-08-13 with a user IMS bearer token, on dev-DB fixture brands. Both fixtures were restored to their original alias lists and republished afterwards.

- **Census** — read-only walk of `brands` (active, `semrush_sub_workspace_id` set) from the prod reader, then the projects and benchmarks per brand. 2,738 benchmark rows, no request errors. It is the source of the 493-benchmark / 720-value exposure, and of the finding that no benchmark anywhere holds two spellings of one alias (0 of 2,738).
- **Contract probe** — `Allow` headers read from the router plus method probes aimed at a nonexistent benchmark id, so nothing could be mutated. The item route answers `Allow: PUT`; v2 and v3 item routes return `404 page not found`; all six spellings of an alias sub-resource 404 while `…/brand_urls` returns 200. Confirms the full-replace PUT is the only write available.
- **Write probes** established the model the code now follows: two spellings of one alias in a single list → `409 duplicate brand name or alias`; a PUT cannot re-case an alias already stored; omitting `brand_aliases` empties the list; a body without `domain` fails with `400 primary_url is required`; and an alias listed in `rejected_brand_aliases` can be re-submitted and lands.
- **End-to-end run of this code** against the tenant, driving `syncBrandAliasesAcrossMarkets` on the "Bark" fixture: adding an alias PUT `["Bark","bark collar"]` — the live spelling kept, the new alias lowercase — an immediate re-run issued zero writes and zero publishes, and removing the alias again restored `["Bark"]` with the project `live`. The first version of this change failed that middle step, rewriting and republishing on every run.

## 7. Test plan
Locally, beyond unit tests: the end-to-end run described in section 6 — add, re-run, remove — against the live tenant on a dev-DB fixture, which is the only place the upstream identity and spelling rules can actually be exercised.

To verify on **dev**: edit a brand's aliases through `PATCH /brands` for a brand with a sub-workspace, then read the benchmark before and after with `GET /enterprise/projects/api/v1/workspaces/{ws}/projects/{pid}/ai_models/benchmarks?draft=true`. Expect the new alias present in lowercase, every previously present alias still there, and the project back at `publish_status: live`. Repeat the same edit with no change and expect no benchmark write in the logs. Rename a competitor and confirm its alias list is unchanged.

On **stage** and **prod**: same check on a brand whose benchmark carries vendor-added values (`gm` on General Motors is the clearest), confirming they are still present after an unrelated alias edit. Re-running the census script is the population-level acceptance check.

## 8. Deployment & merge order
- https://github.com/adobe/serenity-docs/pull/342 — related. The design of record. Worth merging first so it is on `main` before this lands, though nothing here depends on it mechanically.
- https://github.com/adobe/mysticat-data-service/pull/856 — related, and deliberately staying unmerged for now. It carries the same alias model for the migration CLI, so until it lands the CLI on `main` keeps replacing benchmark aliases rather than merging them. That is a separate service with separate operators and does not block this change.

This PR is self-contained: it merges and deploys on its own.

SITES-49841 (re-casing existing aliases) must not run until this is deployed, or the population it repairs keeps growing behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```