### PR TITLE
feat(sites): server-side filtering and sorting on GET /sites

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -846,12 +846,14 @@ SiteSearchResponse:
   type: object
   description: |
     Response for the filtered/sorted `GET /sites` mode, entered when any of
-    `baseUrlContains`, `deliveryType`, `isLive`, or `sort` is provided. Unlike
-    `SitePagedResponse`, this path is not cursor-iterable: `pagination` carries no
-    `cursor`, paginates by `offset`, and echoes back only the filters/sort that were
-    actually applied, so a client can confirm the request was honored (an older
-    deployment that ignores one of these params but honors `limit` would return this
-    same envelope shape with unfiltered/unsorted sites and no echo for that param).
+    `baseUrlContains`, `deliveryType`, `isLive`, `sort`, `tier`, or `productCode` is
+    provided. Unlike `SitePagedResponse`, this path is not cursor-iterable: `pagination`
+    carries no `cursor`, paginates by `offset`, and echoes back only the filters/sort
+    that were actually applied, so a client can confirm the request was honored (an
+    older deployment that ignores one of these params but honors `limit` would return
+    this same envelope shape with unfiltered/unsorted sites and no echo for that param).
+    `tier` and/or `productCode` route the query through the entitlement-enrollment join
+    instead of the plain site query; the other filters/sort still compose with them.
   properties:
     sites:
       type: array
@@ -898,6 +900,20 @@ SiteSearchResponse:
             only when `sort` was provided on the request.
           type: string
           example: "updatedAt:desc"
+        tier:
+          description: |
+            The entitlement tier filter that was applied. Present only when `tier` was
+            provided on the request.
+          type: string
+          enum: [FREE_TRIAL, PAID, PLG]
+          example: PAID
+        productCode:
+          description: |
+            The entitlement product code filter that was applied. Present only when
+            `productCode` was provided on the request.
+          type: string
+          enum: [LLMO, ASO, ACO]
+          example: LLMO
       required:
         - limit
         - offset

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -896,8 +896,10 @@ SiteSearchResponse:
           example: true
         sort:
           description: |
-            The `<field>:<direction>` sort that was applied, echoed verbatim. Present
-            only when `sort` was provided on the request.
+            The applied sort, echoed in canonical `<field>:<direction>` form (the
+            implicit `:asc` direction is added when omitted from the request, so
+            `sort=updatedAt` echoes `updatedAt:asc`). Present only when `sort` was
+            provided on the request.
           type: string
           example: "updatedAt:desc"
         tier:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -845,11 +845,13 @@ SitePagedResponse:
 SiteSearchResponse:
   type: object
   description: |
-    Response for the `baseUrlContains` substring search on `GET /sites`. Unlike
+    Response for the filtered/sorted `GET /sites` mode, entered when any of
+    `baseUrlContains`, `deliveryType`, `isLive`, or `sort` is provided. Unlike
     `SitePagedResponse`, this path is not cursor-iterable: `pagination` carries no
-    `cursor`, paginates by `offset`, and echoes the trimmed `baseUrlContains` query so a
-    client can confirm the search was actually applied (an older deployment that ignores
-    `baseUrlContains` but honors `limit` would return `SitePagedResponse` with no echo).
+    `cursor`, paginates by `offset`, and echoes back only the filters/sort that were
+    actually applied, so a client can confirm the request was honored (an older
+    deployment that ignores one of these params but honors `limit` would return this
+    same envelope shape with unfiltered/unsorted sites and no echo for that param).
   properties:
     sites:
       type: array
@@ -872,16 +874,34 @@ SiteSearchResponse:
           example: false
         baseUrlContains:
           description: |
-            The trimmed `baseUrlContains` query that was applied (3-256 chars). Echoed so
-            clients can confirm the search ran; absent on deployments that ignore the
-            param.
+            The trimmed `baseUrlContains` query that was applied (3-256 chars). Present
+            only when `baseUrlContains` was provided on the request; absent otherwise
+            (including on deployments that ignore the param).
           type: string
           example: "adobe"
+        deliveryType:
+          description: |
+            The `deliveryType` filter that was applied. Present only when
+            `deliveryType` was provided on the request.
+          type: string
+          enum: [aem_cs, aem_edge, aem_ams, aem_headless, other]
+          example: aem_edge
+        isLive:
+          description: |
+            The `isLive` filter that was applied, as a boolean. Present only when
+            `isLive` was provided on the request.
+          type: boolean
+          example: true
+        sort:
+          description: |
+            The `<field>:<direction>` sort that was applied, echoed verbatim. Present
+            only when `sort` was provided on the request.
+          type: string
+          example: "updatedAt:desc"
       required:
         - limit
         - offset
         - hasMore
-        - baseUrlContains
   required:
     - sites
     - pagination

--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -262,8 +262,9 @@ sites:
           `asc` when omitted). An unrecognized field or direction returns 400.
           When `sort` is omitted entirely, results default to `baseURL` ascending —
           the same default across every filter combination, including `tier` and
-          `productCode`. `pagination.sort` echoes the applied value verbatim (and is
-          absent when `sort` was omitted). Not combinable with `cursor` (400; use
+          `productCode`. `pagination.sort` echoes the applied sort in canonical
+          `<field>:<direction>` form — so `sort=updatedAt` echoes `updatedAt:asc` — and
+          is absent when `sort` was omitted. Not combinable with `cursor` (400; use
           `offset` instead).
         schema:
           type: string

--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -135,6 +135,16 @@ sites:
         branch paginates by `offset`). Defaults to a limit of 50 (clamped to 500) and an
         offset of 0. The search term must be at least 3 characters after trimming
         (otherwise 400).
+      - **Server-side filter/sort (with `deliveryType`, `isLive`, and/or `sort`, alone or
+        combined with `baseUrlContains`):** same non-cursor, offset-paginated envelope as
+        substring search — `{ sites, pagination }` where `pagination` is
+        `{ limit, offset, hasMore, baseUrlContains?, deliveryType?, isLive?, sort? }`
+        (only the filters/sort actually applied are echoed back). `deliveryType` filters
+        on an exact match; `isLive` filters by live status (`"true"`/`"false"`); `sort` is
+        `<field>:<direction>` (field ∈ `baseURL`, `updatedAt`, `createdAt`,
+        `deliveryType`, `isLive`; direction ∈ `asc`/`desc`, defaults to `asc`). Multiple
+        filters combine with AND. Defaults to a limit of 50 (clamped to 500) and an
+        offset of 0. Not combinable with `cursor` (400; use `offset` instead).
 
       Required capabilities: admin access or S2S `site:readAll`.
     operationId: getSites
@@ -188,30 +198,88 @@ sites:
         in: query
         required: false
         description: |
-          Zero-based offset into the `baseUrlContains` search results, used to page
+          Zero-based offset into the filtered/sorted search results, used to page
           through matches (e.g. `offset=2&limit=2` returns the second page of 2).
-          Only honored on the `baseUrlContains` search path. Defaults to 0. Negative
+          Only honored on the filtered/sorted search path (i.e. when `baseUrlContains`,
+          `deliveryType`, `isLive`, and/or `sort` is present). Defaults to 0. Negative
           or non-integer values return 400.
         schema:
           type: integer
           minimum: 0
           example: 0
+      - name: deliveryType
+        in: query
+        required: false
+        description: |
+          Server-side filter: only return sites whose `deliveryType` equals this value.
+          When provided — alone, or combined with `baseUrlContains`, `isLive`, and/or
+          `sort` — the response uses the non-cursor, offset-paginated envelope
+          (`{ sites, pagination: { limit, offset, hasMore, deliveryType, ... } }`),
+          where `pagination.deliveryType` echoes the applied value. An unrecognized
+          value returns 400. Not combinable with `cursor` (400; use `offset` instead).
+          The `limit` parameter (default 50, clamped to 500) bounds the page size and
+          `offset` (default 0) selects the page.
+        schema:
+          type: string
+          enum:
+            - aem_cs
+            - aem_edge
+            - aem_ams
+            - aem_headless
+            - other
+          example: aem_edge
+      - name: isLive
+        in: query
+        required: false
+        description: |
+          Server-side filter: only return sites whose `isLive` flag equals this value.
+          Accepts only the literal strings `"true"` or `"false"` (any other value
+          returns 400). When provided — alone, or combined with `baseUrlContains`,
+          `deliveryType`, and/or `sort` — the response uses the non-cursor,
+          offset-paginated envelope, where `pagination.isLive` echoes the applied
+          value as a boolean. Not combinable with `cursor` (400; use `offset` instead).
+        schema:
+          type: string
+          enum:
+            - 'true'
+            - 'false'
+          example: 'true'
+      - name: sort
+        in: query
+        required: false
+        description: |
+          Server-side sort for the filtered/offset-paginated `GET /sites` mode, in
+          `<field>:<direction>` form (e.g. `updatedAt:desc`). Providing `sort` alone,
+          with no other filter, is enough to enter the offset-paginated envelope.
+          `<field>` must be one of `baseURL`, `updatedAt`, `createdAt`, `deliveryType`,
+          `isLive`; `<direction>` is optional and must be `asc` or `desc` (defaults to
+          `asc` when omitted). An unrecognized field or direction returns 400.
+          `pagination.sort` echoes the applied value verbatim. Not combinable with
+          `cursor` (400; use `offset` instead).
+        schema:
+          type: string
+          example: "updatedAt:desc"
       - $ref: './parameters.yaml#/fields'
     responses:
       '200':
         description: |
-          A paginated list of sites. The `pagination` shape depends on whether
-          `baseUrlContains` was provided.
+          A paginated list of sites. The `pagination` shape depends on whether any of
+          `baseUrlContains`, `deliveryType`, `isLive`, or `sort` was provided.
         content:
           application/json:
             schema:
               description: |
                 Two response shapes are possible, selected by the request and
                 unambiguous by JSON shape, so no `discriminator` is used:
-                - When `baseUrlContains` is provided → **`SiteSearchResponse`**, a JSON
-                  object with `sites` and a non-cursor `pagination`
-                  (`{ limit, offset, hasMore, baseUrlContains }`). The `baseUrlContains`
-                  echo lets a client confirm the search ran on the deployment it hit.
+                - When any of `baseUrlContains`, `deliveryType`, `isLive`, or `sort` is
+                  provided → **`SiteSearchResponse`**, a JSON object with `sites` and a
+                  non-cursor `pagination`
+                  (`{ limit, offset, hasMore, baseUrlContains?, deliveryType?, isLive?,
+                  sort? }`). Only the filters/sort actually applied are echoed back, so
+                  a client can confirm what ran on the deployment it hit (e.g. an older
+                  deployment that ignores `deliveryType` but honors `limit` would
+                  return this envelope with unfiltered sites and no `deliveryType`
+                  echo).
                 - Otherwise (default first page, or with `limit`/`cursor`) →
                   **`SitePagedResponse`**, a JSON object with `sites` and a
                   cursor-based `pagination`.

--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -260,8 +260,11 @@ sites:
           `<field>` must be one of `baseURL`, `updatedAt`, `createdAt`, `deliveryType`,
           `isLive`; `<direction>` is optional and must be `asc` or `desc` (defaults to
           `asc` when omitted). An unrecognized field or direction returns 400.
-          `pagination.sort` echoes the applied value verbatim. Not combinable with
-          `cursor` (400; use `offset` instead).
+          When `sort` is omitted entirely, results default to `baseURL` ascending —
+          the same default across every filter combination, including `tier` and
+          `productCode`. `pagination.sort` echoes the applied value verbatim (and is
+          absent when `sort` was omitted). Not combinable with `cursor` (400; use
+          `offset` instead).
         schema:
           type: string
           example: "updatedAt:desc"

--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -145,11 +145,14 @@ sites:
         `<field>:<direction>` (field ∈ `baseURL`, `updatedAt`, `createdAt`,
         `deliveryType`, `isLive`; direction ∈ `asc`/`desc`, defaults to `asc`). `tier`
         restricts to sites enrolled at that entitlement tier; `productCode` (optionally
-        combined with `tier`) further restricts to that product's entitlement. Multiple
-        filters combine with AND. Defaults to a limit of 50 (clamped to 500) and an
-        offset of 0. Not combinable with `cursor` (400; use `offset` instead).
+        combined with `tier`) further restricts to that product's entitlement — both
+        require full admin access (see their parameter descriptions). Multiple filters
+        combine with AND. Defaults to a limit of 50 (clamped to 500) and an offset of 0.
+        Not combinable with `cursor` (400; use `offset` instead).
 
-      Required capabilities: admin access or S2S `site:readAll`.
+      Required capabilities: admin access or S2S `site:readAll`. `tier` and
+      `productCode` additionally require full admin (403 for read-only admins and S2S
+      `site:readAll` callers) — see the `tier`/`productCode` parameter descriptions.
     operationId: getSites
     parameters:
       - name: limit
@@ -267,13 +270,20 @@ sites:
         required: false
         description: |
           Server-side filter: only return sites enrolled at this entitlement tier.
-          When provided — alone, or combined with `baseUrlContains`, `deliveryType`,
-          `isLive`, `sort`, and/or `productCode` — the response uses the non-cursor,
-          offset-paginated envelope, calling the enrollment-aware data-access path
-          instead of the plain site query, where `pagination.tier` echoes the applied
-          value. An unrecognized value returns 400. Not combinable with `cursor` (400;
-          use `offset` instead). The `limit` parameter (default 50, clamped to 500)
-          bounds the page size and `offset` (default 0) selects the page.
+          **Requires full admin access** — unlike every other `GET /sites` filter,
+          this one is NOT available to S2S `site:readAll` callers or read-only admins
+          (403 `Filtering sites by tier or productCode requires admin access`), the
+          same restriction as the standalone `GET /sites/by-tier/{tier}` endpoint,
+          because it exposes entitlement/enrollment data. When provided — alone, or
+          combined with `baseUrlContains`, `deliveryType`, `isLive`, `sort`, and/or
+          `productCode` — the response uses the non-cursor, offset-paginated envelope,
+          calling the enrollment-aware data-access path instead of the plain site
+          query, where `pagination.tier` echoes the applied value. An unrecognized
+          value returns 400 (only for full admins; non-full-admins get 403 regardless
+          of whether the value is valid, so the two outcomes cannot be used to probe
+          valid tier values). Not combinable with `cursor` (400; use `offset`
+          instead). The `limit` parameter (default 50, clamped to 500) bounds the page
+          size and `offset` (default 0) selects the page.
         schema:
           type: string
           enum:
@@ -286,7 +296,9 @@ sites:
         required: false
         description: |
           Server-side filter: only return sites enrolled under this product's
-          entitlement. May be combined with `tier` to narrow to that product's
+          entitlement. **Requires full admin access** — same restriction as `tier`
+          above (not available to S2S `site:readAll` callers or read-only admins; see
+          `tier` for details). May be combined with `tier` to narrow to that product's
           entitlement at a specific tier, or provided alone to match the product across
           any tier. When provided — alone, or combined with `baseUrlContains`,
           `deliveryType`, `isLive`, `sort`, and/or `tier` — the response uses the

--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -135,14 +135,17 @@ sites:
         branch paginates by `offset`). Defaults to a limit of 50 (clamped to 500) and an
         offset of 0. The search term must be at least 3 characters after trimming
         (otherwise 400).
-      - **Server-side filter/sort (with `deliveryType`, `isLive`, and/or `sort`, alone or
-        combined with `baseUrlContains`):** same non-cursor, offset-paginated envelope as
-        substring search — `{ sites, pagination }` where `pagination` is
-        `{ limit, offset, hasMore, baseUrlContains?, deliveryType?, isLive?, sort? }`
-        (only the filters/sort actually applied are echoed back). `deliveryType` filters
-        on an exact match; `isLive` filters by live status (`"true"`/`"false"`); `sort` is
+      - **Server-side filter/sort (with `deliveryType`, `isLive`, `sort`, `tier`,
+        and/or `productCode`, alone or combined with `baseUrlContains`):** same
+        non-cursor, offset-paginated envelope as substring search — `{ sites, pagination
+        }` where `pagination` is `{ limit, offset, hasMore, baseUrlContains?,
+        deliveryType?, isLive?, sort?, tier?, productCode? }` (only the filters/sort
+        actually applied are echoed back). `deliveryType` filters on an exact match;
+        `isLive` filters by live status (`"true"`/`"false"`); `sort` is
         `<field>:<direction>` (field ∈ `baseURL`, `updatedAt`, `createdAt`,
-        `deliveryType`, `isLive`; direction ∈ `asc`/`desc`, defaults to `asc`). Multiple
+        `deliveryType`, `isLive`; direction ∈ `asc`/`desc`, defaults to `asc`). `tier`
+        restricts to sites enrolled at that entitlement tier; `productCode` (optionally
+        combined with `tier`) further restricts to that product's entitlement. Multiple
         filters combine with AND. Defaults to a limit of 50 (clamped to 500) and an
         offset of 0. Not combinable with `cursor` (400; use `offset` instead).
 
@@ -201,8 +204,8 @@ sites:
           Zero-based offset into the filtered/sorted search results, used to page
           through matches (e.g. `offset=2&limit=2` returns the second page of 2).
           Only honored on the filtered/sorted search path (i.e. when `baseUrlContains`,
-          `deliveryType`, `isLive`, and/or `sort` is present). Defaults to 0. Negative
-          or non-integer values return 400.
+          `deliveryType`, `isLive`, `sort`, `tier`, and/or `productCode` is present).
+          Defaults to 0. Negative or non-integer values return 400.
         schema:
           type: integer
           minimum: 0
@@ -259,27 +262,67 @@ sites:
         schema:
           type: string
           example: "updatedAt:desc"
+      - name: tier
+        in: query
+        required: false
+        description: |
+          Server-side filter: only return sites enrolled at this entitlement tier.
+          When provided — alone, or combined with `baseUrlContains`, `deliveryType`,
+          `isLive`, `sort`, and/or `productCode` — the response uses the non-cursor,
+          offset-paginated envelope, calling the enrollment-aware data-access path
+          instead of the plain site query, where `pagination.tier` echoes the applied
+          value. An unrecognized value returns 400. Not combinable with `cursor` (400;
+          use `offset` instead). The `limit` parameter (default 50, clamped to 500)
+          bounds the page size and `offset` (default 0) selects the page.
+        schema:
+          type: string
+          enum:
+            - FREE_TRIAL
+            - PAID
+            - PLG
+          example: PAID
+      - name: productCode
+        in: query
+        required: false
+        description: |
+          Server-side filter: only return sites enrolled under this product's
+          entitlement. May be combined with `tier` to narrow to that product's
+          entitlement at a specific tier, or provided alone to match the product across
+          any tier. When provided — alone, or combined with `baseUrlContains`,
+          `deliveryType`, `isLive`, `sort`, and/or `tier` — the response uses the
+          non-cursor, offset-paginated envelope, calling the enrollment-aware
+          data-access path instead of the plain site query, where
+          `pagination.productCode` echoes the applied value. An unrecognized value
+          returns 400. Not combinable with `cursor` (400; use `offset` instead).
+        schema:
+          type: string
+          enum:
+            - LLMO
+            - ASO
+            - ACO
+          example: LLMO
       - $ref: './parameters.yaml#/fields'
     responses:
       '200':
         description: |
           A paginated list of sites. The `pagination` shape depends on whether any of
-          `baseUrlContains`, `deliveryType`, `isLive`, or `sort` was provided.
+          `baseUrlContains`, `deliveryType`, `isLive`, `sort`, `tier`, or `productCode`
+          was provided.
         content:
           application/json:
             schema:
               description: |
                 Two response shapes are possible, selected by the request and
                 unambiguous by JSON shape, so no `discriminator` is used:
-                - When any of `baseUrlContains`, `deliveryType`, `isLive`, or `sort` is
-                  provided → **`SiteSearchResponse`**, a JSON object with `sites` and a
-                  non-cursor `pagination`
+                - When any of `baseUrlContains`, `deliveryType`, `isLive`, `sort`,
+                  `tier`, or `productCode` is provided → **`SiteSearchResponse`**, a
+                  JSON object with `sites` and a non-cursor `pagination`
                   (`{ limit, offset, hasMore, baseUrlContains?, deliveryType?, isLive?,
-                  sort? }`). Only the filters/sort actually applied are echoed back, so
-                  a client can confirm what ran on the deployment it hit (e.g. an older
-                  deployment that ignores `deliveryType` but honors `limit` would
-                  return this envelope with unfiltered sites and no `deliveryType`
-                  echo).
+                  sort?, tier?, productCode? }`). Only the filters/sort actually applied
+                  are echoed back, so a client can confirm what ran on the deployment it
+                  hit (e.g. an older deployment that ignores `deliveryType` but honors
+                  `limit` would return this envelope with unfiltered sites and no
+                  `deliveryType` echo).
                 - Otherwise (default first page, or with `limit`/`cursor`) →
                   **`SitePagedResponse`**, a JSON object with `sites` and a
                   cursor-based `pagination`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
         "@adobe/spacecat-shared-content-client": "1.10.0",
-        "@adobe/spacecat-shared-data-access": "4.16.1",
+        "@adobe/spacecat-shared-data-access": "4.21.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
         "@adobe/spacecat-shared-http-utils": "1.35.0",
@@ -3863,9 +3863,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.16.1.tgz",
-      "integrity": "sha512-NUBUxPEYFWSWi5wQQLIal/kNpbOe6NYFOBK4NpkK69irUO+skzIVoyU92ahYgaC4Rch2E+wz3tM2DBeGjqSeZA==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.21.0.tgz",
+      "integrity": "sha512-4nobD+tRfQnvxIXckdczvJvb/hER3f6c5VhYK1QTO1NmC44+fD14wAK4HjzIHLuAWGROLntQ3siExhyej8Ac8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
     "@adobe/spacecat-shared-content-client": "1.10.0",
-    "@adobe/spacecat-shared-data-access": "4.16.1",
+    "@adobe/spacecat-shared-data-access": "4.20.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
     "@adobe/spacecat-shared-http-utils": "1.35.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
     "@adobe/spacecat-shared-content-client": "1.10.0",
-    "@adobe/spacecat-shared-data-access": "4.20.0",
+    "@adobe/spacecat-shared-data-access": "4.21.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
     "@adobe/spacecat-shared-http-utils": "1.35.0",

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -176,6 +176,13 @@ const SEARCH_DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 500;
 // Allowlisted `sort` fields for the GET /sites filtered/sorted mode.
 const SORT_FIELDS = new Set(['baseURL', 'updatedAt', 'createdAt', 'deliveryType', 'isLive']);
+// Default order for the filtered/sorted mode when the caller sends no `sort`.
+// Applied EXPLICITLY (as an orderBy both branches honor) rather than left to each
+// data-access method's own default: Site.all's all-index default is baseURL asc,
+// but Site.allByEnrollmentFiltered defaults to updatedAt desc and ignores the
+// `order` option entirely — so an implicit default would order the tier/productCode
+// branch differently from the baseUrlContains/deliveryType/isLive branch.
+const DEFAULT_SORT = { attribute: 'baseURL', direction: 'asc' };
 
 /**
  * Filters Ahrefs top pages by site base URL
@@ -565,7 +572,7 @@ function SitesController(ctx, log, env) {
     if (hasText(deliveryType) && !Object.values(SiteModel.DELIVERY_TYPES).includes(deliveryType)) {
       return badRequest(`Invalid deliveryType: ${deliveryType}`);
     }
-    let orderBy;
+    let orderBy = DEFAULT_SORT;
     if (hasText(sortParam)) {
       const [sortField, sortDirection = 'asc'] = sortParam.split(':');
       if (!SORT_FIELDS.has(sortField)) {
@@ -644,12 +651,13 @@ function SitesController(ctx, log, env) {
       };
 
       // Fetch one extra row to detect whether more results exist beyond the limit.
-      const allOpts = { limit: effectiveLimit + 1, cursor: offsetCursor, order: 'asc' };
+      // orderBy is passed EXPLICITLY (never left to each method's implicit default)
+      // so the Site.all and Site.allByEnrollmentFiltered branches return the SAME
+      // order — see DEFAULT_SORT. allByEnrollmentFiltered ignores an `order` option,
+      // so a bare `order: 'asc'` here would silently not apply to the tier branch.
+      const allOpts = { limit: effectiveLimit + 1, cursor: offsetCursor, orderBy };
       if (hasWhereConditions) {
         allOpts.where = where;
-      }
-      if (orderBy) {
-        allOpts.orderBy = orderBy;
       }
 
       // tier/productCode compose with the SAME where/orderBy/limit/cursor built above —
@@ -715,7 +723,7 @@ function SitesController(ctx, log, env) {
           ...(trimmedQuery !== null && { baseUrlContains: trimmedQuery }),
           ...(hasText(deliveryType) && { deliveryType }),
           ...(isLiveBool !== undefined && { isLive: isLiveBool }),
-          ...(orderBy && { sort: sortParam }),
+          ...(hasText(sortParam) && { sort: sortParam }),
           ...(hasText(tier) && { tier }),
           ...(hasText(productCode) && { productCode }),
         },

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -492,18 +492,23 @@ function SitesController(ctx, log, env) {
    * explicit paginated request.
    *
    * Filtered/sorted mode: triggered when ANY of `baseUrlContains`, `deliveryType`,
-   * `isLive`, `sort` is present. Returns a non-cursor, offset-paginated response:
-   * `{ sites, pagination: { limit, offset, hasMore, baseUrlContains?, deliveryType?,
-   * isLive?, sort? } }` - only the filters/sort actually applied are echoed back, so a
-   * client can confirm what was applied even if it hits an older deployment that ignores
-   * some of the params. `baseUrlContains` (3-256 chars after trim) performs a
-   * case-insensitive substring search on `baseURL`; LIKE wildcards in the input are
-   * escaped so callers cannot inject their own wildcards. `deliveryType` and `isLive`
-   * are exact-match filters; when more than one filter is present they compose with AND.
-   * `sort` (`<field>:<asc|desc>`, field one of `baseURL`/`updatedAt`/`createdAt`/
-   * `deliveryType`/`isLive`) sets the result order. `cursor` is not supported together
-   * with any filter/sort (use `offset` instead) - accepting both would silently discard
-   * the cursor and mislead the client into thinking cursor pagination is active.
+   * `isLive`, `sort`, `tier`, `productCode` is present. Returns a non-cursor,
+   * offset-paginated response: `{ sites, pagination: { limit, offset, hasMore,
+   * baseUrlContains?, deliveryType?, isLive?, sort?, tier?, productCode? } }` - only the
+   * filters/sort actually applied are echoed back, so a client can confirm what was
+   * applied even if it hits an older deployment that ignores some of the params.
+   * `baseUrlContains` (3-256 chars after trim) performs a case-insensitive substring
+   * search on `baseURL`; LIKE wildcards in the input are escaped so callers cannot
+   * inject their own wildcards. `deliveryType` and `isLive` are exact-match filters;
+   * when more than one filter is present they compose with AND. `sort`
+   * (`<field>:<asc|desc>`, field one of `baseURL`/`updatedAt`/`createdAt`/
+   * `deliveryType`/`isLive`) sets the result order. `tier` (one of
+   * `CUSTOMER_VISIBLE_TIERS`) and `productCode` (one of `EntitlementModel.PRODUCT_CODES`)
+   * filter to sites enrolled at that entitlement tier/product; when either is present the
+   * SAME where/orderBy/limit/cursor built for the branch is passed to
+   * `Site.allByEnrollmentFiltered` instead of `Site.all`. `cursor` is not supported
+   * together with any filter/sort (use `offset` instead) - accepting both would silently
+   * discard the cursor and mislead the client into thinking cursor pagination is active.
    * @returns {Promise<Response>} Paginated sites response
    */
   const getAll = async (context) => {
@@ -523,12 +528,19 @@ function SitesController(ctx, log, env) {
     const cursor = context?.data?.cursor || null;
 
     // Optional filtered/sorted mode: triggered when ANY of baseUrlContains, deliveryType,
-    // isLive, sort is present. Runs after the authz check (so unauthorized callers still
-    // get 403) and before the cursor/legacy branches. Offset-paginated (not cursor-based).
+    // isLive, sort, tier, productCode is present. Runs after the authz check (so
+    // unauthorized callers still get 403) and before the cursor/legacy branches.
+    // Offset-paginated (not cursor-based).
     const baseUrlContains = context?.data?.baseUrlContains;
     const deliveryType = context?.data?.deliveryType;
     const isLiveParam = context?.data?.isLive;
     const sortParam = context?.data?.sort;
+    // AUTHZ NOTE (reviewer/security): tier/productCode intentionally run under getAll's
+    // EXISTING admin-read/S2S-readAll authz checked above — NOT the stricter full-admin
+    // gate used by the standalone GET /sites/by-tier endpoint (getAllByEnrollmentAndTier).
+    // No tier-specific gating is added here by design; flagging for review.
+    const tier = context?.data?.tier;
+    const productCode = context?.data?.productCode;
 
     // Validate facets/sort up front (after authz, before branching) so invalid input is
     // always rejected the same way, whether or not it's combined with other filters.
@@ -553,9 +565,16 @@ function SitesController(ctx, log, env) {
       }
       orderBy = { attribute: sortField, direction: sortDirection };
     }
+    if (hasText(tier) && !CUSTOMER_VISIBLE_TIERS.includes(tier)) {
+      return badRequest(`Invalid tier: ${tier}`);
+    }
+    const validProductCodes = Object.values(EntitlementModel.PRODUCT_CODES);
+    if (hasText(productCode) && !validProductCodes.includes(productCode)) {
+      return badRequest(`Invalid productCode: ${productCode}`);
+    }
 
     const hasFilters = hasText(baseUrlContains) || hasText(deliveryType)
-      || hasText(isLiveParam) || hasText(sortParam);
+      || hasText(isLiveParam) || hasText(sortParam) || hasText(tier) || hasText(productCode);
     if (hasFilters && hasText(cursor)) {
       // The public search path paginates via offset, not the client cursor;
       // accepting both would silently discard the cursor and mislead the client
@@ -622,9 +641,21 @@ function SitesController(ctx, log, env) {
         allOpts.orderBy = orderBy;
       }
 
+      // tier/productCode compose with the SAME where/orderBy/limit/cursor built above —
+      // they just swap which data-access method resolves the rows.
+      const useEnrollmentFilter = hasText(tier) || hasText(productCode);
+
       let rows;
       try {
-        rows = await Site.all({}, allOpts);
+        rows = useEnrollmentFilter
+          ? await Site.allByEnrollmentFiltered(
+            {
+              tier: hasText(tier) ? tier : undefined,
+              productCode: hasText(productCode) ? productCode : undefined,
+            },
+            allOpts,
+          )
+          : await Site.all({}, allOpts);
       } catch (e) {
         // Re-throw so the framework still returns a 500 — the point here is a
         // searchable, prefixed log line, not swallowing the error.
@@ -674,6 +705,8 @@ function SitesController(ctx, log, env) {
           ...(hasText(deliveryType) && { deliveryType }),
           ...(isLiveBool !== undefined && { isLive: isLiveBool }),
           ...(orderBy && { sort: sortParam }),
+          ...(hasText(tier) && { tier }),
+          ...(hasText(productCode) && { productCode }),
         },
       });
     }

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -597,15 +597,16 @@ function SitesController(ctx, log, env) {
       // The public search path paginates via offset, not the client cursor;
       // accepting both would silently discard the cursor and mislead the client
       // into thinking cursor pagination is active. Reject the combination explicitly.
-      return badRequest('cursor is not supported with baseUrlContains; use offset');
+      return badRequest('cursor is not supported with filters or sort; use offset');
     }
     if (hasFilters) {
-      if (hasText(baseUrlContains)) {
-        const q = baseUrlContains.trim();
-        if (q.length < 3) {
+      // Trim once and reuse for validation, escaping, echo, and logging.
+      const trimmedQuery = hasText(baseUrlContains) ? baseUrlContains.trim() : null;
+      if (trimmedQuery !== null) {
+        if (trimmedQuery.length < 3) {
           return badRequest('baseUrlContains must be at least 3 characters');
         }
-        if (q.length > 256) {
+        if (trimmedQuery.length > 256) {
           return badRequest('baseUrlContains exceeds maximum length');
         }
       }
@@ -623,7 +624,6 @@ function SitesController(ctx, log, env) {
       }
 
       // Escape LIKE special chars so user input cannot inject its own wildcards.
-      const trimmedQuery = hasText(baseUrlContains) ? baseUrlContains.trim() : null;
       const escaped = trimmedQuery !== null ? trimmedQuery.replace(/([\\%_])/g, '\\$1') : null;
 
       // The data-access layer paginates by an offset-encoded cursor (postgrest.utils
@@ -678,7 +678,7 @@ function SitesController(ctx, log, env) {
       } catch (e) {
         // Re-throw so the framework still returns a 500 — the point here is a
         // searchable, prefixed log line, not swallowing the error.
-        log.error(`[sites][baseUrlContains] query failed requestId=${requestId}`, e);
+        log.error(`[sites][filtered] query failed requestId=${requestId}`, e);
         throw e;
       }
       let list;
@@ -687,19 +687,19 @@ function SitesController(ctx, log, env) {
       } else if (Array.isArray(rows?.data)) {
         list = rows.data;
       } else {
-        log.warn(`[sites][baseUrlContains] unexpected Site.all shape; returning empty requestId=${requestId}`);
+        log.warn(`[sites][filtered] unexpected Site.all shape; returning empty requestId=${requestId}`);
         list = [];
       }
       const hasMore = list.length > effectiveLimit;
       const sites = list.slice(0, effectiveLimit).map((site) => SiteDto.toListJSON(site));
 
       if (s2sResult.allowed) {
-        log.info(`[s2s-readall] GET /sites (baseUrlContains) granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_SITE_READ_ALL} count=${sites.length} requestId=${requestId}`);
+        log.info(`[s2s-readall] GET /sites (filtered) granted clientId=${s2sResult.clientId} consumerId=${s2sResult.consumerId} capability=${CAP_SITE_READ_ALL} count=${sites.length} requestId=${requestId}`);
       }
 
       // Unconditional observability for both admin and S2S paths. Never log the raw
       // query value (URLs may be sensitive) — only its length and result counts.
-      log.info(`[sites][baseUrlContains] qlen=${trimmedQuery !== null ? trimmedQuery.length : 0} count=${sites.length} hasMore=${hasMore} requestId=${requestId}`);
+      log.info(`[sites][filtered] qlen=${trimmedQuery !== null ? trimmedQuery.length : 0} count=${sites.length} hasMore=${hasMore} requestId=${requestId}`);
 
       const { list: projectedSites, error: fieldsError } = applyFieldProjection(
         sites,

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -723,7 +723,7 @@ function SitesController(ctx, log, env) {
           ...(trimmedQuery !== null && { baseUrlContains: trimmedQuery }),
           ...(hasText(deliveryType) && { deliveryType }),
           ...(isLiveBool !== undefined && { isLive: isLiveBool }),
-          ...(hasText(sortParam) && { sort: sortParam }),
+          ...(hasText(sortParam) && { sort: `${orderBy.attribute}:${orderBy.direction}` }),
           ...(hasText(tier) && { tier }),
           ...(hasText(productCode) && { productCode }),
         },

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -574,7 +574,11 @@ function SitesController(ctx, log, env) {
     }
     let orderBy = DEFAULT_SORT;
     if (hasText(sortParam)) {
-      const [sortField, sortDirection = 'asc'] = sortParam.split(':');
+      const sortParts = sortParam.split(':');
+      if (sortParts.length > 2) {
+        return badRequest('Invalid sort: expected "<field>" or "<field>:<direction>"');
+      }
+      const [sortField, sortDirection = 'asc'] = sortParts;
       if (!SORT_FIELDS.has(sortField)) {
         return badRequest(`Invalid sort field: ${sortField}`);
       }

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -506,7 +506,12 @@ function SitesController(ctx, log, env) {
    * `CUSTOMER_VISIBLE_TIERS`) and `productCode` (one of `EntitlementModel.PRODUCT_CODES`)
    * filter to sites enrolled at that entitlement tier/product; when either is present the
    * SAME where/orderBy/limit/cursor built for the branch is passed to
-   * `Site.allByEnrollmentFiltered` instead of `Site.all`. `cursor` is not supported
+   * `Site.allByEnrollmentFiltered` instead of `Site.all`. Unlike every other filter here,
+   * `tier`/`productCode` require FULL admin (`accessControlUtil.hasAdminAccess()`) -
+   * the same gate as the standalone `GET /sites/by-tier` endpoint
+   * (`getAllByEnrollmentAndTier`) - so a read-only admin or an S2S `site:readAll`
+   * caller gets 403 for either param, checked before their enum validation so the 403
+   * vs 400 outcome can't be used to probe valid values. `cursor` is not supported
    * together with any filter/sort (use `offset` instead) - accepting both would silently
    * discard the cursor and mislead the client into thinking cursor pagination is active.
    * @returns {Promise<Response>} Paginated sites response
@@ -535,12 +540,18 @@ function SitesController(ctx, log, env) {
     const deliveryType = context?.data?.deliveryType;
     const isLiveParam = context?.data?.isLive;
     const sortParam = context?.data?.sort;
-    // AUTHZ NOTE (reviewer/security): tier/productCode intentionally run under getAll's
-    // EXISTING admin-read/S2S-readAll authz checked above — NOT the stricter full-admin
-    // gate used by the standalone GET /sites/by-tier endpoint (getAllByEnrollmentAndTier).
-    // No tier-specific gating is added here by design; flagging for review.
+    // AUTHZ NOTE: baseUrlContains/deliveryType/isLive/sort keep getAll's EXISTING
+    // broad authz (admin-read or S2S site:readAll, checked above). tier/productCode
+    // are more sensitive (entitlement/enrollment data) and require FULL admin — the
+    // SAME gate as the standalone GET /sites/by-tier endpoint
+    // (getAllByEnrollmentAndTier, ~:809) — enforced immediately below, before any
+    // tier/productCode validation, so a caller who fails this check can't use the
+    // enum 400 to probe which tier/productCode values are valid.
     const tier = context?.data?.tier;
     const productCode = context?.data?.productCode;
+    if ((hasText(tier) || hasText(productCode)) && !accessControlUtil.hasAdminAccess()) {
+      return forbidden('Filtering sites by tier or productCode requires admin access');
+    }
 
     // Validate facets/sort up front (after authz, before branching) so invalid input is
     // always rejected the same way, whether or not it's combined with other filters.

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -174,6 +174,8 @@ const BRAND_PROFILE_AGENT_ID = 'brand-profile';
 const DEFAULT_LIMIT = 100;
 const SEARCH_DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 500;
+// Allowlisted `sort` fields for the GET /sites filtered/sorted mode.
+const SORT_FIELDS = new Set(['baseURL', 'updatedAt', 'createdAt', 'deliveryType', 'isLive']);
 
 /**
  * Filters Ahrefs top pages by site base URL
@@ -489,12 +491,19 @@ function SitesController(ctx, log, env) {
    * 100, no cursor) as the `{ sites, pagination }` envelope - the same shape as an
    * explicit paginated request.
    *
-   * Optional `baseUrlContains` query param: when provided (3-256 chars after trim),
-   * performs a case-insensitive substring search on `baseURL` and returns a non-cursor
-   * `{ sites, pagination: { limit, offset, hasMore, baseUrlContains } }` response. The
-   * trimmed query is echoed back in `pagination.baseUrlContains` so a client can confirm
-   * its search was applied even if it hits an older deployment that ignores the param.
-   * LIKE wildcards in the input are escaped so callers cannot inject their own wildcards.
+   * Filtered/sorted mode: triggered when ANY of `baseUrlContains`, `deliveryType`,
+   * `isLive`, `sort` is present. Returns a non-cursor, offset-paginated response:
+   * `{ sites, pagination: { limit, offset, hasMore, baseUrlContains?, deliveryType?,
+   * isLive?, sort? } }` - only the filters/sort actually applied are echoed back, so a
+   * client can confirm what was applied even if it hits an older deployment that ignores
+   * some of the params. `baseUrlContains` (3-256 chars after trim) performs a
+   * case-insensitive substring search on `baseURL`; LIKE wildcards in the input are
+   * escaped so callers cannot inject their own wildcards. `deliveryType` and `isLive`
+   * are exact-match filters; when more than one filter is present they compose with AND.
+   * `sort` (`<field>:<asc|desc>`, field one of `baseURL`/`updatedAt`/`createdAt`/
+   * `deliveryType`/`isLive`) sets the result order. `cursor` is not supported together
+   * with any filter/sort (use `offset` instead) - accepting both would silently discard
+   * the cursor and mislead the client into thinking cursor pagination is active.
    * @returns {Promise<Response>} Paginated sites response
    */
   const getAll = async (context) => {
@@ -513,22 +522,55 @@ function SitesController(ctx, log, env) {
     const limitParam = context?.data?.limit;
     const cursor = context?.data?.cursor || null;
 
-    // Optional substring search by base URL. Runs after the authz check (so
-    // unauthorized callers still get 403) and before the cursor/legacy branches.
+    // Optional filtered/sorted mode: triggered when ANY of baseUrlContains, deliveryType,
+    // isLive, sort is present. Runs after the authz check (so unauthorized callers still
+    // get 403) and before the cursor/legacy branches. Offset-paginated (not cursor-based).
     const baseUrlContains = context?.data?.baseUrlContains;
-    if (hasText(baseUrlContains) && hasText(cursor)) {
+    const deliveryType = context?.data?.deliveryType;
+    const isLiveParam = context?.data?.isLive;
+    const sortParam = context?.data?.sort;
+
+    // Validate facets/sort up front (after authz, before branching) so invalid input is
+    // always rejected the same way, whether or not it's combined with other filters.
+    let isLiveBool;
+    if (hasText(isLiveParam)) {
+      if (isLiveParam !== 'true' && isLiveParam !== 'false') {
+        return badRequest('isLive must be "true" or "false"');
+      }
+      isLiveBool = isLiveParam === 'true';
+    }
+    if (hasText(deliveryType) && !Object.values(SiteModel.DELIVERY_TYPES).includes(deliveryType)) {
+      return badRequest(`Invalid deliveryType: ${deliveryType}`);
+    }
+    let orderBy;
+    if (hasText(sortParam)) {
+      const [sortField, sortDirection = 'asc'] = sortParam.split(':');
+      if (!SORT_FIELDS.has(sortField)) {
+        return badRequest(`Invalid sort field: ${sortField}`);
+      }
+      if (sortDirection !== 'asc' && sortDirection !== 'desc') {
+        return badRequest(`Invalid sort direction: ${sortDirection}`);
+      }
+      orderBy = { attribute: sortField, direction: sortDirection };
+    }
+
+    const hasFilters = hasText(baseUrlContains) || hasText(deliveryType)
+      || hasText(isLiveParam) || hasText(sortParam);
+    if (hasFilters && hasText(cursor)) {
       // The public search path paginates via offset, not the client cursor;
       // accepting both would silently discard the cursor and mislead the client
       // into thinking cursor pagination is active. Reject the combination explicitly.
       return badRequest('cursor is not supported with baseUrlContains; use offset');
     }
-    if (hasText(baseUrlContains)) {
-      const q = baseUrlContains.trim();
-      if (q.length < 3) {
-        return badRequest('baseUrlContains must be at least 3 characters');
-      }
-      if (q.length > 256) {
-        return badRequest('baseUrlContains exceeds maximum length');
+    if (hasFilters) {
+      if (hasText(baseUrlContains)) {
+        const q = baseUrlContains.trim();
+        if (q.length < 3) {
+          return badRequest('baseUrlContains must be at least 3 characters');
+        }
+        if (q.length > 256) {
+          return badRequest('baseUrlContains exceeds maximum length');
+        }
       }
 
       const parsedLimit = hasText(limitParam) ? parseInt(limitParam, 10) : SEARCH_DEFAULT_LIMIT;
@@ -544,24 +586,45 @@ function SitesController(ctx, log, env) {
       }
 
       // Escape LIKE special chars so user input cannot inject its own wildcards.
-      const escaped = q.replace(/([\\%_])/g, '\\$1');
+      const trimmedQuery = hasText(baseUrlContains) ? baseUrlContains.trim() : null;
+      const escaped = trimmedQuery !== null ? trimmedQuery.replace(/([\\%_])/g, '\\$1') : null;
 
       // The data-access layer paginates by an offset-encoded cursor (postgrest.utils
       // encodeCursor); it exposes no public `offset` option, so we build the same
       // shape here. If a direct offset option is ever added upstream, switch to it.
       const offsetCursor = Buffer.from(JSON.stringify({ offset }), 'utf-8').toString('base64');
 
+      // The data-access `where` builder passes (attrs, op): `attrs` maps model fields to
+      // DB columns, `op` carries the operators (NOT `s => s.ilike(...)`). Conditions
+      // compose with AND; a single condition is returned bare (not wrapped in `op.and`).
+      const hasWhereConditions = escaped !== null
+        || hasText(deliveryType) || isLiveBool !== undefined;
+      const where = (attr, op) => {
+        const conds = [];
+        if (escaped !== null) {
+          conds.push(op.ilike(attr.baseURL, `%${escaped}%`));
+        }
+        if (hasText(deliveryType)) {
+          conds.push(op.eq(attr.deliveryType, deliveryType));
+        }
+        if (isLiveBool !== undefined) {
+          conds.push(op.eq(attr.isLive, isLiveBool));
+        }
+        return conds.length === 1 ? conds[0] : op.and(...conds);
+      };
+
       // Fetch one extra row to detect whether more results exist beyond the limit.
-      // The data-access `where` builder passes (attrs, op): `attrs` maps model
-      // fields to DB columns, `op` carries the operators. (NOT `s => s.ilike(...)`.)
+      const allOpts = { limit: effectiveLimit + 1, cursor: offsetCursor, order: 'asc' };
+      if (hasWhereConditions) {
+        allOpts.where = where;
+      }
+      if (orderBy) {
+        allOpts.orderBy = orderBy;
+      }
+
       let rows;
       try {
-        rows = await Site.all({}, {
-          where: (attr, op) => op.ilike(attr.baseURL, `%${escaped}%`),
-          limit: effectiveLimit + 1,
-          cursor: offsetCursor,
-          order: 'asc',
-        });
+        rows = await Site.all({}, allOpts);
       } catch (e) {
         // Re-throw so the framework still returns a 500 — the point here is a
         // searchable, prefixed log line, not swallowing the error.
@@ -586,7 +649,7 @@ function SitesController(ctx, log, env) {
 
       // Unconditional observability for both admin and S2S paths. Never log the raw
       // query value (URLs may be sensitive) — only its length and result counts.
-      log.info(`[sites][baseUrlContains] qlen=${q.length} count=${sites.length} hasMore=${hasMore} requestId=${requestId}`);
+      log.info(`[sites][baseUrlContains] qlen=${trimmedQuery !== null ? trimmedQuery.length : 0} count=${sites.length} hasMore=${hasMore} requestId=${requestId}`);
 
       const { list: projectedSites, error: fieldsError } = applyFieldProjection(
         sites,
@@ -596,14 +659,21 @@ function SitesController(ctx, log, env) {
         return badRequest(fieldsError);
       }
 
-      // Echo the trimmed query in the pagination so a new client can confirm its
-      // search was actually applied. An older deployment that ignores `baseUrlContains`
-      // but still honors `limit` would return the cursor envelope with unfiltered
-      // sites and no `baseUrlContains` echo — letting clients detect the version skew.
+      // Echo only the filters/sort actually applied, so a client can confirm what was
+      // applied even if it hits an older deployment that ignores some of the params.
+      // An older deployment that ignores a param but still honors `limit` would return
+      // the offset envelope with unfiltered sites and no echo for that param — letting
+      // clients detect the version skew.
       return ok({
         sites: projectedSites,
         pagination: {
-          limit: effectiveLimit, offset, hasMore, baseUrlContains: q,
+          limit: effectiveLimit,
+          offset,
+          hasMore,
+          ...(trimmedQuery !== null && { baseUrlContains: trimmedQuery }),
+          ...(hasText(deliveryType) && { deliveryType }),
+          ...(isLiveBool !== undefined && { isLive: isLiveBool }),
+          ...(orderBy && { sort: sortParam }),
         },
       });
     }

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1557,6 +1557,19 @@ describe('Sites Controller', () => {
       expect(loggerStub.error).to.have.been.calledWithMatch(/\[sites\]\[filtered\] query failed/);
     });
 
+    it('logs a prefixed error and re-throws when the enrollment-filtered query rejects', async () => {
+      // Mirror of the Site.all error-path test for the tier/productCode branch —
+      // the try/catch wraps BOTH data-access calls with the same prefixed log.
+      const boom = new Error('boom');
+      mockDataAccess.Site.allByEnrollmentFiltered.rejects(boom);
+
+      await expect(
+        sitesController.getAll({ ...context, data: { tier: 'PAID' } }),
+      ).to.be.rejectedWith('boom');
+
+      expect(loggerStub.error).to.have.been.calledWithMatch(/\[sites\]\[filtered\] query failed/);
+    });
+
     it('filters by deliveryType alone using an eq where and the offset envelope', async () => {
       mockDataAccess.Site.all.resolves(sites);
       const res = await sitesController.getAll({ ...context, data: { deliveryType: 'aem_edge', limit: '10' } });
@@ -1650,6 +1663,7 @@ describe('Sites Controller', () => {
       for (const data of [
         { deliveryType: 'nope' }, { isLive: 'maybe' },
         { sort: 'bogus:desc' }, { sort: 'updatedAt:sideways' },
+        { sort: 'updatedAt:desc:extra' },
       ]) {
         // eslint-disable-next-line no-await-in-loop
         const res = await sitesController.getAll({ ...context, data });
@@ -1768,6 +1782,29 @@ describe('Sites Controller', () => {
         { type: 'ilike', field: 'base_url', value: '%sem%' },
         { type: 'eq', field: 'delivery_type', value: 'aem_edge' },
       ]);
+    });
+
+    it('composes isLive (boolean) with tier and passes it in the where to allByEnrollmentFiltered', async () => {
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'PAID', isLive: 'false' },
+      });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.pagination).to.include({ tier: 'PAID', isLive: false });
+
+      const [, opts] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
+      const op = {
+        eq: (f, v) => ({ type: 'eq', field: f, value: v }),
+        and: (...c) => ({ type: 'and', conditions: c }),
+      };
+      // isLive is the only site-table condition here → returned bare (not wrapped in
+      // op.and) and boolean-valued (false, not the string 'false').
+      const expr = opts.where({ isLive: 'is_live' }, op);
+      expect(expr).to.deep.equal({ type: 'eq', field: 'is_live', value: false });
     });
 
     it('productCode alone (no tier) calls Site.allByEnrollmentFiltered with tier undefined', async () => {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1528,7 +1528,7 @@ describe('Sites Controller', () => {
       const error = await result.json();
 
       expect(result.status).to.equal(400);
-      expect(error).to.have.property('message', 'cursor is not supported with baseUrlContains; use offset');
+      expect(error).to.have.property('message', 'cursor is not supported with filters or sort; use offset');
       expect(mockDataAccess.Site.all).to.not.have.been.called;
     });
 
@@ -1543,7 +1543,7 @@ describe('Sites Controller', () => {
       expect(body.pagination).to.deep.equal({
         limit: 50, offset: 0, hasMore: false, baseUrlContains: 'site',
       });
-      expect(loggerStub.warn).to.have.been.calledWithMatch(/\[sites\]\[baseUrlContains\] unexpected Site\.all shape/);
+      expect(loggerStub.warn).to.have.been.calledWithMatch(/\[sites\]\[filtered\] unexpected Site\.all shape/);
     });
 
     it('logs a prefixed error and re-throws when the Site.all search query rejects', async () => {
@@ -1554,7 +1554,7 @@ describe('Sites Controller', () => {
         sitesController.getAll({ ...context, data: { baseUrlContains: 'site' } }),
       ).to.be.rejectedWith('boom');
 
-      expect(loggerStub.error).to.have.been.calledWithMatch(/\[sites\]\[baseUrlContains\] query failed/);
+      expect(loggerStub.error).to.have.been.calledWithMatch(/\[sites\]\[filtered\] query failed/);
     });
 
     it('filters by deliveryType alone using an eq where and the offset envelope', async () => {
@@ -1613,10 +1613,9 @@ describe('Sites Controller', () => {
     });
 
     // ── tier / productCode (server-side enrollment filter) ──
-    // When present, the filtered branch calls Site.allByEnrollmentFiltered (a
-    // shared-data-access method not yet released — see spacecat-shared branch
-    // feat/sites-tier-join) instead of Site.all, passing the SAME
-    // where/orderBy/limit/cursor the branch already builds.
+    // When present, the filtered branch calls Site.allByEnrollmentFiltered
+    // (shipped in @adobe/spacecat-shared-data-access 4.21.0) instead of Site.all,
+    // passing the SAME where/orderBy/limit/cursor the branch already builds.
 
     it('tier alone calls Site.allByEnrollmentFiltered (not Site.all), with the same opts, and echoes tier', async () => {
       mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
@@ -1874,7 +1873,7 @@ describe('Sites Controller', () => {
       expect(body.pagination).to.include({ baseUrlContains: 'site' });
       expect(body.pagination).to.not.have.property('cursor');
       expect(loggerStub.info).to.have.been.calledWithMatch(
-        /\[s2s-readall\] GET \/sites \(baseUrlContains\) granted clientId=svc-1 consumerId=consumer-id-1 capability=site:readAll count=2 requestId=req-s2s-baseurlcontains-1/,
+        /\[s2s-readall\] GET \/sites \(filtered\) granted clientId=svc-1 consumerId=consumer-id-1 capability=site:readAll count=2 requestId=req-s2s-baseurlcontains-1/,
       );
     });
 

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1296,7 +1296,8 @@ describe('Sites Controller', () => {
       expect(mockDataAccess.Site.all).to.have.been.calledOnce;
       const [firstArg, opts] = mockDataAccess.Site.all.firstCall.args;
       expect(firstArg).to.deep.equal({});
-      expect(opts.order).to.equal('asc');
+      // No `sort` param → explicit default orderBy (baseURL asc), not left implicit.
+      expect(opts.orderBy).to.deep.equal({ attribute: 'baseURL', direction: 'asc' });
       expect(opts.limit).to.equal(11); // effectiveLimit (10) + 1
 
       // Invoke the captured `where` builder with the real (attrs, op) signature:
@@ -1635,9 +1636,29 @@ describe('Sites Controller', () => {
       expect(mockDataAccess.Site.allByEnrollmentFiltered).to.have.been.calledOnce;
       const [filter, opts] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
       expect(filter).to.deep.equal({ tier: 'PAID', productCode: undefined });
-      expect(opts.order).to.equal('asc');
+      // No `sort` param → same explicit default orderBy the non-enrollment Site.all
+      // branch gets (baseURL asc), so both branches return the SAME default order.
+      // allByEnrollmentFiltered ignores an `order` option, so this MUST be orderBy.
+      expect(opts.orderBy).to.deep.equal({ attribute: 'baseURL', direction: 'asc' });
       expect(opts.limit).to.equal(11); // effectiveLimit (10) + 1
       expect(opts.cursor).to.equal(Buffer.from(JSON.stringify({ offset: 0 })).toString('base64'));
+    });
+
+    it('with no sort, the enrollment and non-enrollment branches receive an IDENTICAL default orderBy', async () => {
+      // Regression: Site.all defaults (via its all-index) to baseURL asc, while
+      // Site.allByEnrollmentFiltered defaults to updatedAt desc and ignores `order`.
+      // The controller must pass the SAME explicit orderBy to both so the default
+      // page order does not silently change when a tier/productCode filter is added.
+      mockDataAccess.Site.all.resolves(sites);
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
+
+      await sitesController.getAll({ ...context, data: { deliveryType: 'aem_edge' } });
+      await sitesController.getAll({ ...context, data: { tier: 'PAID' } });
+
+      const [, nonEnrollmentOpts] = mockDataAccess.Site.all.firstCall.args;
+      const [, enrollmentOpts] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
+      expect(enrollmentOpts.orderBy).to.deep.equal(nonEnrollmentOpts.orderBy);
+      expect(enrollmentOpts.orderBy).to.deep.equal({ attribute: 'baseURL', direction: 'asc' });
     });
 
     it('tier + productCode calls Site.allByEnrollmentFiltered with both and echoes both', async () => {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1732,6 +1732,36 @@ describe('Sites Controller', () => {
       expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
     });
 
+    it('returns 403 when a read-only admin requests tier filtering (full admin required)', async () => {
+      context.attributes.authInfo.withProfile({ is_admin: false, is_read_only_admin: true });
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'PAID' },
+      });
+      const error = await result.json();
+
+      expect(result.status).to.equal(403);
+      expect(error).to.have.property('message', 'Filtering sites by tier or productCode requires admin access');
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
+    });
+
+    it('returns 403 when a read-only admin requests productCode filtering (full admin required)', async () => {
+      context.attributes.authInfo.withProfile({ is_admin: false, is_read_only_admin: true });
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { productCode: 'LLMO' },
+      });
+      const error = await result.json();
+
+      expect(result.status).to.equal(403);
+      expect(error).to.have.property('message', 'Filtering sites by tier or productCode requires admin access');
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
+    });
+
     it('uses Site.all (not allByEnrollmentFiltered) when neither tier nor productCode is present', async () => {
       mockDataAccess.Site.all.resolves(sites);
 
@@ -1825,6 +1855,24 @@ describe('Sites Controller', () => {
       expect(loggerStub.info).to.have.been.calledWithMatch(
         /\[s2s-readall\] GET \/sites \(baseUrlContains\) granted clientId=svc-1 consumerId=consumer-id-1 capability=site:readAll count=2 requestId=req-s2s-baseurlcontains-1/,
       );
+    });
+
+    it('denies S2S consumer with site:readAll when tier is requested (full admin required)', async () => {
+      context.s2sConsumer = makeS2SConsumer();
+      mockDataAccess.Consumer.findByClientIdAndImsOrgId
+        .resolves(makeFreshConsumer({ capabilities: ['site:readAll'] }));
+
+      const result = await sitesController.getAll({ ...context, data: { tier: 'PAID' } });
+      const body = await result.json();
+
+      // The S2S readAll check itself passes (proven by the Consumer lookup running) —
+      // it's the NEW admin-only guard for tier/productCode that denies here, not the
+      // base GET /sites authz.
+      expect(mockDataAccess.Consumer.findByClientIdAndImsOrgId).to.have.been.calledOnce;
+      expect(result.status).to.equal(403);
+      expect(body).to.have.property('message', 'Filtering sites by tier or productCode requires admin access');
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
     });
 
     it('denies S2S consumer with only site:read (no readAll)', async () => {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1586,6 +1586,30 @@ describe('Sites Controller', () => {
       ]);
     });
 
+    it('composes all three of baseUrlContains, deliveryType and isLive into one op.and', async () => {
+      mockDataAccess.Site.all.resolves(sites);
+      await sitesController.getAll({
+        ...context,
+        data: { baseUrlContains: 'sem', deliveryType: 'aem_edge', isLive: 'false' },
+      });
+      const [, opts] = mockDataAccess.Site.all.firstCall.args;
+      const op = {
+        ilike: (f, v) => ({ type: 'ilike', field: f, value: v }),
+        eq: (f, v) => ({ type: 'eq', field: f, value: v }),
+        and: (...c) => ({ type: 'and', conditions: c }),
+      };
+      const expr = opts.where(
+        { baseURL: 'base_url', deliveryType: 'delivery_type', isLive: 'is_live' },
+        op,
+      );
+      expect(expr.type).to.equal('and');
+      expect(expr.conditions).to.deep.equal([
+        { type: 'ilike', field: 'base_url', value: '%sem%' },
+        { type: 'eq', field: 'delivery_type', value: 'aem_edge' },
+        { type: 'eq', field: 'is_live', value: false },
+      ]);
+    });
+
     it('passes orderBy from a valid sort param and echoes it', async () => {
       mockDataAccess.Site.all.resolves(sites);
       const res = await sitesController.getAll({ ...context, data: { sort: 'updatedAt:desc' } });
@@ -1593,6 +1617,33 @@ describe('Sites Controller', () => {
       const [, opts] = mockDataAccess.Site.all.firstCall.args;
       expect(opts.orderBy).to.deep.equal({ attribute: 'updatedAt', direction: 'desc' });
       expect(body.pagination.sort).to.equal('updatedAt:desc');
+    });
+
+    it('defaults an omitted sort direction to asc and echoes the canonical <field>:<direction>', async () => {
+      mockDataAccess.Site.all.resolves(sites);
+      // `sort=baseURL` with no `:direction` → implicit asc.
+      const res = await sitesController.getAll({ ...context, data: { sort: 'baseURL' } });
+      const body = await res.json();
+      const [, opts] = mockDataAccess.Site.all.firstCall.args;
+      expect(opts.orderBy).to.deep.equal({ attribute: 'baseURL', direction: 'asc' });
+      // Echo is normalized to the canonical form, not the raw verbatim `baseURL`.
+      expect(body.pagination.sort).to.equal('baseURL:asc');
+    });
+
+    it('passes BOTH orderBy and where on the same call when sort combines with a filter', async () => {
+      mockDataAccess.Site.all.resolves(sites);
+      const res = await sitesController.getAll({
+        ...context,
+        data: { deliveryType: 'aem_edge', sort: 'updatedAt:desc' },
+      });
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.pagination).to.include({ deliveryType: 'aem_edge', sort: 'updatedAt:desc' });
+      const [, opts] = mockDataAccess.Site.all.firstCall.args;
+      expect(opts.orderBy).to.deep.equal({ attribute: 'updatedAt', direction: 'desc' });
+      const op = { eq: (f, v) => ({ type: 'eq', field: f, value: v }), and: (...c) => ({ type: 'and', conditions: c }) };
+      const expr = opts.where({ deliveryType: 'delivery_type' }, op);
+      expect(expr).to.deep.equal({ type: 'eq', field: 'delivery_type', value: 'aem_edge' });
     });
 
     it('rejects invalid deliveryType, isLive, sort field, and sort direction with 400', async () => {
@@ -1658,6 +1709,19 @@ describe('Sites Controller', () => {
       const [, enrollmentOpts] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
       expect(enrollmentOpts.orderBy).to.deep.equal(nonEnrollmentOpts.orderBy);
       expect(enrollmentOpts.orderBy).to.deep.equal({ attribute: 'baseURL', direction: 'asc' });
+    });
+
+    it('sets hasMore:true and trims the body to the limit when the enrollment branch returns N+1 rows', async () => {
+      // The N+1 hasMore detection is shared with Site.all: effectiveLimit = 1, so
+      // allByEnrollmentFiltered returning 2 rows means "more exists".
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites); // 2 rows
+      const res = await sitesController.getAll({ ...context, data: { tier: 'PAID', limit: '1' } });
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.sites).to.be.an('array').with.lengthOf(1); // trimmed to effectiveLimit
+      expect(body.pagination).to.deep.equal({
+        limit: 1, offset: 0, hasMore: true, tier: 'PAID',
+      });
     });
 
     it('tier + productCode calls Site.allByEnrollmentFiltered with both and echoes both', async () => {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1554,6 +1554,61 @@ describe('Sites Controller', () => {
 
       expect(loggerStub.error).to.have.been.calledWithMatch(/\[sites\]\[baseUrlContains\] query failed/);
     });
+
+    it('filters by deliveryType alone using an eq where and the offset envelope', async () => {
+      mockDataAccess.Site.all.resolves(sites);
+      const res = await sitesController.getAll({ ...context, data: { deliveryType: 'aem_edge', limit: '10' } });
+      const body = await res.json();
+      expect(res.status).to.equal(200);
+      expect(body.pagination).to.include({ limit: 10, offset: 0, deliveryType: 'aem_edge' });
+      const [, opts] = mockDataAccess.Site.all.firstCall.args;
+      const op = { eq: (f, v) => ({ type: 'eq', field: f, value: v }), and: (...c) => ({ type: 'and', conditions: c }) };
+      const expr = opts.where({ deliveryType: 'delivery_type' }, op);
+      expect(expr).to.deep.equal({ type: 'eq', field: 'delivery_type', value: 'aem_edge' });
+    });
+
+    it('composes baseUrlContains AND isLive via op.and', async () => {
+      mockDataAccess.Site.all.resolves(sites);
+      await sitesController.getAll({ ...context, data: { baseUrlContains: 'sem', isLive: 'true' } });
+      const [, opts] = mockDataAccess.Site.all.firstCall.args;
+      const op = {
+        ilike: (f, v) => ({ type: 'ilike', field: f, value: v }),
+        eq: (f, v) => ({ type: 'eq', field: f, value: v }),
+        and: (...c) => ({ type: 'and', conditions: c }),
+      };
+      const expr = opts.where({ baseURL: 'base_url', isLive: 'is_live' }, op);
+      expect(expr.type).to.equal('and');
+      expect(expr.conditions).to.deep.equal([
+        { type: 'ilike', field: 'base_url', value: '%sem%' },
+        { type: 'eq', field: 'is_live', value: true },
+      ]);
+    });
+
+    it('passes orderBy from a valid sort param and echoes it', async () => {
+      mockDataAccess.Site.all.resolves(sites);
+      const res = await sitesController.getAll({ ...context, data: { sort: 'updatedAt:desc' } });
+      const body = await res.json();
+      const [, opts] = mockDataAccess.Site.all.firstCall.args;
+      expect(opts.orderBy).to.deep.equal({ attribute: 'updatedAt', direction: 'desc' });
+      expect(body.pagination.sort).to.equal('updatedAt:desc');
+    });
+
+    it('rejects invalid deliveryType, isLive, sort field, and sort direction with 400', async () => {
+      for (const data of [
+        { deliveryType: 'nope' }, { isLive: 'maybe' },
+        { sort: 'bogus:desc' }, { sort: 'updatedAt:sideways' },
+      ]) {
+        // eslint-disable-next-line no-await-in-loop
+        const res = await sitesController.getAll({ ...context, data });
+        expect(res.status, JSON.stringify(data)).to.equal(400);
+      }
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+    });
+
+    it('returns 400 when cursor is combined with any filter/sort', async () => {
+      const res = await sitesController.getAll({ ...context, data: { cursor: 'c', deliveryType: 'aem_edge' } });
+      expect(res.status).to.equal(400);
+    });
   });
 
   describe('GET /sites - S2S readAll capability', () => {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -198,6 +198,7 @@ describe('Sites Controller', () => {
         all: sandbox.stub().resolves(sites),
         allByDeliveryType: sandbox.stub().resolves(sites),
         allByEnrollmentAndTier: sandbox.stub().resolves(sites),
+        allByEnrollmentFiltered: sandbox.stub().resolves(sites),
         allWithLatestAudit: sandbox.stub().resolves(sites),
         allByOrganizationId: sandbox.stub().resolves(sites),
         create: sandbox.stub().resolves(sites[0]),
@@ -1608,6 +1609,140 @@ describe('Sites Controller', () => {
     it('returns 400 when cursor is combined with any filter/sort', async () => {
       const res = await sitesController.getAll({ ...context, data: { cursor: 'c', deliveryType: 'aem_edge' } });
       expect(res.status).to.equal(400);
+    });
+
+    // ── tier / productCode (server-side enrollment filter) ──
+    // When present, the filtered branch calls Site.allByEnrollmentFiltered (a
+    // shared-data-access method not yet released — see spacecat-shared branch
+    // feat/sites-tier-join) instead of Site.all, passing the SAME
+    // where/orderBy/limit/cursor the branch already builds.
+
+    it('tier alone calls Site.allByEnrollmentFiltered (not Site.all), with the same opts, and echoes tier', async () => {
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'PAID', limit: '10' },
+      });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.pagination).to.deep.equal({
+        limit: 10, offset: 0, hasMore: false, tier: 'PAID',
+      });
+
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.have.been.calledOnce;
+      const [filter, opts] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
+      expect(filter).to.deep.equal({ tier: 'PAID', productCode: undefined });
+      expect(opts.order).to.equal('asc');
+      expect(opts.limit).to.equal(11); // effectiveLimit (10) + 1
+      expect(opts.cursor).to.equal(Buffer.from(JSON.stringify({ offset: 0 })).toString('base64'));
+    });
+
+    it('tier + productCode calls Site.allByEnrollmentFiltered with both and echoes both', async () => {
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'PAID', productCode: 'LLMO' },
+      });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.pagination).to.include({ tier: 'PAID', productCode: 'LLMO' });
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      const [filter] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
+      expect(filter).to.deep.equal({ tier: 'PAID', productCode: 'LLMO' });
+    });
+
+    it('tier + baseUrlContains + deliveryType compose into the same where passed to allByEnrollmentFiltered', async () => {
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'PAID', baseUrlContains: 'sem', deliveryType: 'aem_edge' },
+      });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.pagination).to.include({
+        tier: 'PAID', baseUrlContains: 'sem', deliveryType: 'aem_edge',
+      });
+
+      // Invoke the captured `where` builder with the real (attrs, op) signature, exactly
+      // like the baseUrlContains+isLive composition test above.
+      const [, opts] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
+      const op = {
+        ilike: (f, v) => ({ type: 'ilike', field: f, value: v }),
+        eq: (f, v) => ({ type: 'eq', field: f, value: v }),
+        and: (...c) => ({ type: 'and', conditions: c }),
+      };
+      const expr = opts.where({ baseURL: 'base_url', deliveryType: 'delivery_type' }, op);
+      expect(expr.type).to.equal('and');
+      expect(expr.conditions).to.deep.equal([
+        { type: 'ilike', field: 'base_url', value: '%sem%' },
+        { type: 'eq', field: 'delivery_type', value: 'aem_edge' },
+      ]);
+    });
+
+    it('productCode alone (no tier) calls Site.allByEnrollmentFiltered with tier undefined', async () => {
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { productCode: 'LLMO' },
+      });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.pagination).to.include({ productCode: 'LLMO' });
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.have.been.calledOnce;
+      const [filter] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
+      expect(filter).to.deep.equal({ tier: undefined, productCode: 'LLMO' });
+    });
+
+    it('returns 400 for an invalid tier and calls neither Site.all nor Site.allByEnrollmentFiltered', async () => {
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'BOGUS_TIER' },
+      });
+      expect(result.status).to.equal(400);
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
+    });
+
+    it('returns 400 for an invalid productCode and calls neither Site.all nor Site.allByEnrollmentFiltered', async () => {
+      const result = await sitesController.getAll({
+        ...context,
+        data: { productCode: 'BOGUS_PRODUCT' },
+      });
+      expect(result.status).to.equal(400);
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
+    });
+
+    it('returns 400 when cursor is combined with tier', async () => {
+      const result = await sitesController.getAll({
+        ...context,
+        data: { cursor: 'c', tier: 'PAID' },
+      });
+      expect(result.status).to.equal(400);
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
+    });
+
+    it('uses Site.all (not allByEnrollmentFiltered) when neither tier nor productCode is present', async () => {
+      mockDataAccess.Site.all.resolves(sites);
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { deliveryType: 'aem_edge' },
+      });
+
+      expect(result.status).to.equal(200);
+      expect(mockDataAccess.Site.all).to.have.been.calledOnce;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
     });
   });
 

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -77,6 +77,22 @@ function expectSiteListDto(site) {
 }
 
 /**
+ * Returns true if every element is <= the previous one (ties allowed) — used to
+ * assert `sort=<field>:desc` ordering without hardcoding the expected sequence.
+ */
+function isNonIncreasing(values) {
+  return values.every((v, i) => i === 0 || v <= values[i - 1]);
+}
+
+/**
+ * Returns true if every element is >= the previous one (ties allowed) — used to
+ * assert `sort=<field>:asc` ordering without hardcoding the expected sequence.
+ */
+function isNonDecreasing(values) {
+  return values.every((v, i) => i === 0 || v >= values[i - 1]);
+}
+
+/**
  * Shared Site endpoint tests.
  * Runs identically against both DynamoDB (v2) and PostgreSQL (v3).
  *
@@ -245,6 +261,104 @@ export default function siteTests(getHttpClient, resetData) {
       it('user: baseUrlContains still returns 403 (authz parity with the list endpoint)', async () => {
         const http = getHttpClient();
         const res = await http.user.get('/sites?baseUrlContains=semrush');
+        expect(res.status).to.equal(403);
+      });
+
+      // ── deliveryType / isLive / sort (server-side filter/sort mode) ──
+      // Like baseUrlContains, these enter the offset-paginated envelope and exercise
+      // the REAL PostgREST `eq`/`and`/`order` path end-to-end: exact-match facet
+      // filtering, AND-combination across facets, and real ORDER BY for sort —
+      // against actual seeded rows (not a stub).
+      it('admin: deliveryType filters to only matching sites and echoes the value', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?deliveryType=aem_edge');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object').that.has.all.keys('sites', 'pagination');
+        expect(res.body.pagination).to.include({ hasMore: false, deliveryType: 'aem_edge' });
+        // Seed has 5 aem_edge sites (SITE_1, SITE_3, SITE_4, and the two LLMO
+        // fixtures); the rest are aem_cs (1, site2) and other (1, the market mirror).
+        expect(res.body.sites).to.be.an('array').with.lengthOf(5);
+        res.body.sites.forEach((s) => expect(s.deliveryType).to.equal('aem_edge'));
+      });
+
+      it('admin: deliveryType + baseUrlContains combine with AND, not OR', async () => {
+        const http = getHttpClient();
+        const res = await http
+          .admin.get('/sites?deliveryType=aem_edge&baseUrlContains=example.com');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({
+          hasMore: false, deliveryType: 'aem_edge', baseUrlContains: 'example.com',
+        });
+        // All 5 aem_edge sites happen to be *.example.com, so AND yields the same 5
+        // as deliveryType alone; if the where-builder ever regressed to OR this would
+        // instead be 6 (also picking up the aem_cs site2.example.com).
+        expect(res.body.sites).to.be.an('array').with.lengthOf(5);
+        res.body.sites.forEach((s) => {
+          expect(s.deliveryType).to.equal('aem_edge');
+          expect(s.baseURL.toLowerCase()).to.include('example.com');
+        });
+      });
+
+      it('admin: isLive=true returns only live sites', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?isLive=true');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({ hasMore: false, isLive: true });
+        // 6 of the 7 seeded sites are live; only site2.example.com is not.
+        expect(res.body.sites).to.be.an('array').with.lengthOf(6);
+        res.body.sites.forEach((s) => expect(s.isLive).to.equal(true));
+      });
+
+      it('admin: isLive=false returns only non-live sites', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?isLive=false');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({ hasMore: false, isLive: false });
+        expect(res.body.sites).to.be.an('array').with.lengthOf(1);
+        res.body.sites.forEach((s) => expect(s.isLive).to.equal(false));
+      });
+
+      it('admin: sort=updatedAt:desc orders sites by non-increasing updatedAt', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?sort=updatedAt:desc');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({ hasMore: false, sort: 'updatedAt:desc' });
+        expect(res.body.sites).to.be.an('array').with.lengthOf(7);
+        const updatedAts = res.body.sites.map((s) => new Date(s.updatedAt).getTime());
+        expect(isNonIncreasing(updatedAts)).to.equal(true);
+      });
+
+      it('admin: sort=baseURL:asc orders sites by non-decreasing baseURL', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?sort=baseURL:asc');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({ hasMore: false, sort: 'baseURL:asc' });
+        expect(res.body.sites).to.be.an('array').with.lengthOf(7);
+        const baseUrls = res.body.sites.map((s) => s.baseURL);
+        expect(isNonDecreasing(baseUrls)).to.equal(true);
+      });
+
+      it('admin: deliveryType is rejected with 400 when not a recognized value', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?deliveryType=nope');
+        expect(res.status).to.equal(400);
+      });
+
+      it('admin: sort is rejected with 400 when the field is not recognized', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?sort=bogus:desc');
+        expect(res.status).to.equal(400);
+      });
+
+      it('admin: isLive is rejected with 400 when not "true" or "false"', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?isLive=maybe');
+        expect(res.status).to.equal(400);
+      });
+
+      it('user: deliveryType still returns 403 (authz parity with the list endpoint)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get('/sites?deliveryType=aem_edge');
         expect(res.status).to.equal(403);
       });
     });

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -361,6 +361,80 @@ export default function siteTests(getHttpClient, resetData) {
         const res = await http.user.get('/sites?deliveryType=aem_edge');
         expect(res.status).to.equal(403);
       });
+
+      // ── tier / productCode (server-side entitlement-enrollment filter) ──
+      // Exercises the REAL entitlement/enrollment join end-to-end (not a stub), via
+      // Site.allByEnrollmentFiltered, against actual seeded rows. Seed enrollments:
+      // ENTITLEMENT_1 (LLMO, FREE_TRIAL, ORG_1) -> SITE_ENROLLMENT_1 -> SITE_1 only;
+      // ENTITLEMENT_3 (LLMO, PAID, ORG_3) -> SITE_ENROLLMENT_2/3 -> SITE_1 and SITE_4;
+      // ENTITLEMENT_2 (ASO, PAID, ORG_1) has no site enrollment at all. `GET /sites`
+      // is already a cross-tenant admin/S2S-readAll view with no org-scoping (see the
+      // "no exclusion" test above, which returns sites from ORG_1/2/3 alike), so tier/
+      // productCode composing across orgs here does not widen that existing scope.
+      it('admin: tier=FREE_TRIAL returns only the site enrolled at that tier and echoes tier', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?tier=FREE_TRIAL');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object').that.has.all.keys('sites', 'pagination');
+        expect(res.body.pagination).to.include({ hasMore: false, tier: 'FREE_TRIAL' });
+        expect(res.body.sites).to.be.an('array').with.lengthOf(1);
+        expect(res.body.sites[0].id).to.equal(SITE_1_ID);
+        expectSiteListDto(res.body.sites[0]);
+      });
+
+      it('admin: tier=PAID returns every site enrolled at that tier across orgs and echoes tier', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?tier=PAID');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({ hasMore: false, tier: 'PAID' });
+        // ENTITLEMENT_3 (LLMO, PAID) is enrolled by SITE_1 (ORG_1) and SITE_4 (ORG_3);
+        // ENTITLEMENT_2 (ASO, PAID) has no enrollment and contributes nothing.
+        const ids = res.body.sites.map((s) => s.id);
+        expect(ids.sort()).to.deep.equal([SITE_1_ID, SITE_4_ID].sort());
+      });
+
+      it('admin: tier + baseUrlContains compose with AND, narrowing to the matching site', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?tier=PAID&baseUrlContains=delegate');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({
+          hasMore: false, tier: 'PAID', baseUrlContains: 'delegate',
+        });
+        // tier=PAID alone yields {SITE_1, SITE_4}; only SITE_4's baseURL
+        // (site4-delegate.example.com) contains "delegate" — if the where-builder ever
+        // regressed to OR this would instead return both sites.
+        expect(res.body.sites).to.be.an('array').with.lengthOf(1);
+        expect(res.body.sites[0].id).to.equal(SITE_4_ID);
+      });
+
+      it('admin: tier + productCode compose, narrowing to sites enrolled under that product', async () => {
+        const http = getHttpClient();
+        // ENTITLEMENT_2 (ASO, PAID) has no site enrollment, unlike ENTITLEMENT_3
+        // (LLMO, PAID) — proves productCode genuinely narrows the join rather than
+        // being ignored once tier is already present.
+        const res = await http.admin.get('/sites?tier=PAID&productCode=ASO');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({ hasMore: false, tier: 'PAID', productCode: 'ASO' });
+        expect(res.body.sites).to.be.an('array').that.is.empty;
+      });
+
+      it('admin: tier is rejected with 400 when not a recognized value', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?tier=BOGUS_TIER');
+        expect(res.status).to.equal(400);
+      });
+
+      it('admin: productCode is rejected with 400 when not a recognized value', async () => {
+        const http = getHttpClient();
+        const res = await http.admin.get('/sites?productCode=BOGUS_PRODUCT');
+        expect(res.status).to.equal(400);
+      });
+
+      it('user: tier still returns 403 (authz parity with the list endpoint)', async () => {
+        const http = getHttpClient();
+        const res = await http.user.get('/sites?tier=PAID');
+        expect(res.status).to.equal(403);
+      });
     });
 
     describe('GET /sites/:siteId', () => {


### PR DESCRIPTION
  ## Summary

  Extends `GET /sites` beyond the existing `baseUrlContains` substring search into a
  full server-side **filter + sort** contract, so clients (internal UI, S2S consumers)
  can narrow and order the site list in the database instead of fetching everything and
  filtering client-side.

  ## What's added

  New optional query params on `GET /sites`. They compose with AND, and any one of them
  switches the response to the offset-paginated envelope:

  - `deliveryType` — exact match (e.g. `aem_edge`, `aem_cs`)
  - `isLive` — `true` / `false`
  - `sort` — `<field>:<direction>`, where `<field>` is one of `baseURL`, `updatedAt`,
    `createdAt`, `deliveryType`, `isLive`, and `<direction>` is `asc` (default) or `desc`
  - `tier` — entitlement tier (e.g. `PAID`, `FREE_TRIAL`)
  - `productCode` — entitlement product (e.g. `LLMO`, `ASO`)

  Response uses the offset envelope: `{ sites, pagination: { limit, offset, hasMore, ...echoed filters } }`.
  Default `limit` is 50, max 500. `cursor` is rejected with 400 in this mode — use `offset`.

  ## Access control

  - `baseUrlContains` / `deliveryType` / `isLive` / `sort` keep the existing broad authz
    (admin-read or S2S `site:readAll`).
  - `tier` / `productCode` require **full admin** — they expose entitlement/enrollment
    data, so they use the same gate as `GET /sites/by-tier/{tier}` (403 otherwise,
    checked before enum validation so the 400 can't be used to probe valid values).

  ## Data access

  - `tier`/`productCode` route to `Site.allByEnrollmentFiltered` (enrollment join);
    everything else uses `Site.all`. Both honor the same where / orderBy / limit / offset.
  - Bumps `@adobe/spacecat-shared-data-access` to `4.21.0` (ships `allByEnrollmentFiltered`).
  - Default order is **baseURL ascending**, applied explicitly and identically across both
    branches, so adding a `tier` filter never silently re-orders the page.

  ## Testing

  - Unit (`test/controllers/sites.test.js`): validation, authz, where-composition, N+1
    `hasMore`, offset paging, per-facet echo, and default-order parity across both
    data-access branches.
  - Integration (`test/it/shared/tests/sites.js`): real PostgREST filter / sort / tier /
    productCode coverage end-to-end.

  ## API docs

  - `docs/openapi/sites-api.yaml` + `schemas.yaml` updated with all params, the offset
    envelope, and request/response examples. `npm run docs:lint` passes.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```