### PR TITLE
feat: allow tracking user activities for paying customers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
         "@adobe/spacecat-shared-content-client": "1.10.0",
-        "@adobe/spacecat-shared-data-access": "4.16.1",
+        "@adobe/spacecat-shared-data-access": "4.19.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
         "@adobe/spacecat-shared-http-utils": "1.35.0",
@@ -546,6 +546,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.2.tgz",
       "integrity": "sha512-LIF6K7YQ78/Wxw2OQY+f5HxdIsoZnsJCcNWm9fnBQBRGHBIh3hQq+krD1yRWe/pkBVxAm7o4FJs8SmJkJjU0LQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -3863,9 +3864,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.16.1.tgz",
-      "integrity": "sha512-NUBUxPEYFWSWi5wQQLIal/kNpbOe6NYFOBK4NpkK69irUO+skzIVoyU92ahYgaC4Rch2E+wz3tM2DBeGjqSeZA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.19.0.tgz",
+      "integrity": "sha512-e9MiStlAkPX4P5c14qneurhr9luExA3IhHBuYUgPQ7XGo4Mstpo2pmMwbJ+COxA0rQarHdtG2TG04/LsUIiKDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -10898,7 +10899,6 @@
       "version": "3.973.13",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -12554,7 +12554,6 @@
       "version": "3.973.21",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.21",
         "@smithy/core": "^3.24.6",
@@ -12569,7 +12568,6 @@
       "version": "3.972.8",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -12625,7 +12623,6 @@
       "version": "3.972.19",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
         "@aws-sdk/types": "^3.973.13",
@@ -12641,7 +12638,6 @@
       "version": "3.973.13",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -13219,7 +13215,8 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.7.0",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -13237,6 +13234,7 @@
     "node_modules/@connectrpc/connect": {
       "version": "2.1.1",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -14120,6 +14118,7 @@
     "node_modules/@langchain/core": {
       "version": "0.3.80",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -14369,6 +14368,7 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -14543,6 +14543,7 @@
       "version": "1.9.0",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -14687,6 +14688,7 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -16421,6 +16423,7 @@
     "node_modules/@types/express": {
       "version": "5.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -16611,6 +16614,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16649,6 +16653,7 @@
       "version": "8.20.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17029,6 +17034,7 @@
     "node_modules/aws-xray-sdk-core": {
       "version": "3.12.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -17211,6 +17217,7 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -17800,6 +17807,7 @@
       "version": "6.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19692,6 +19700,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -23364,6 +23373,7 @@
       "version": "4.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -24296,7 +24306,6 @@
       "version": "0.38.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -24305,6 +24314,7 @@
       "version": "6.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -26764,6 +26774,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -27179,8 +27190,7 @@
     "node_modules/obliterator": {
       "version": "1.6.1",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -27224,6 +27234,7 @@
     "node_modules/openai": {
       "version": "5.12.2",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -28217,6 +28228,7 @@
       "version": "19.2.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28225,6 +28237,7 @@
       "version": "19.2.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -28865,6 +28878,7 @@
       "version": "25.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -30023,6 +30037,7 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -30797,6 +30812,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -30900,6 +30916,7 @@
     "node_modules/unified": {
       "version": "11.0.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -31568,6 +31585,7 @@
     "node_modules/ws": {
       "version": "8.18.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -31812,6 +31830,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -31819,6 +31838,7 @@
     "node_modules/zod-to-json-schema": {
       "version": "3.25.0",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
     "@adobe/spacecat-shared-content-client": "1.10.0",
-    "@adobe/spacecat-shared-data-access": "4.16.1",
+    "@adobe/spacecat-shared-data-access": "4.19.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
     "@adobe/spacecat-shared-http-utils": "1.35.0",

--- a/src/support/access-control-util.js
+++ b/src/support/access-control-util.js
@@ -385,30 +385,40 @@ export default class AccessControlUtil {
           lastSeenAt: new Date().toISOString(),
         });
       }
-    // Lazy one-time backfill of externalUserId for PAID-tier (Brandalf) users onboarded via
-    // invitation. These users are created without externalUserId; we record it here on the
-    // first authenticated request so the userDetails lookup can resolve their display name.
-    // NOTE: profile.email is an IMS user GUID (e.g. GUID@hexOrgId.e), not an RFC-5322 address.
-    // profile.trial_email is the human-readable email used as the DB row selector.
-    // Both claims refer to the same identity and are attested by IMS on the same token.
-    // findByEmailId runs on every non-FREE_TRIAL request (same as the FREE_TRIAL branch above),
-    // so this adds no new per-request overhead relative to existing behaviour.
+    // lastSeenAt refresh (plus a lazy one-time externalUserId backfill) for PAID/PLG-tier
+    // (Brandalf) trial users. Paying-customer trial users are looked up by externalUserId —
+    // unlike FREE_TRIAL users, email is not stored for them (@adobe/spacecat-shared-data-access
+    // 4.19.0 added the findByExternalUserId index for this). We fall back to the legacy
+    // emailId lookup (and backfill externalUserId from it) for PAID/PLG trial users created
+    // via the older email-invite flow, before that support existed.
+    // NOTE: profile.email is an IMS user GUID (e.g. GUID@hexOrgId.e), not an RFC-5322 address,
+    // and doubles as externalUserId. profile.trial_email is the human-readable email used as
+    // the legacy DB row selector. Both claims refer to the same identity and are attested by
+    // IMS on the same token.
     } else if (!this.authInfo?.isS2SConsumer?.()) {
       const profile = this.authInfo.getProfile?.();
-      if (profile?.email && profile?.trial_email) {
+      if (profile?.email) {
         try {
-          const trialUser = await this.TrialUser.findByEmailId(profile.trial_email);
-          if (trialUser && !trialUser.getExternalUserId()) {
-            trialUser.setExternalUserId(profile.email);
+          let trialUser = await this.TrialUser.findByExternalUserId(profile.email);
+
+          if (!trialUser && profile?.trial_email) {
+            trialUser = await this.TrialUser.findByEmailId(profile.trial_email);
+            if (trialUser && !trialUser.getExternalUserId()) {
+              trialUser.setExternalUserId(profile.email);
+              this.log?.info('[AccessControl] Backfilled externalUserId for PAID-tier user', {
+                trialEmail: profile.trial_email,
+                organizationId: org.getId(),
+              });
+            }
+          }
+
+          if (trialUser) {
+            trialUser.setLastSeenAt(new Date().toISOString());
             await trialUser.save();
-            this.log?.info('[AccessControl] Backfilled externalUserId for PAID-tier user', {
-              trialEmail: profile.trial_email,
-              organizationId: org.getId(),
-            });
           }
         } catch (err) {
-          this.log?.warn('[AccessControl] externalUserId backfill failed; continuing', {
-            trialEmail: profile.trial_email,
+          this.log?.warn('[AccessControl] trial user update failed; continuing', {
+            externalUserId: profile.email,
             error: err.message,
           });
         }

--- a/src/support/access-control-util.js
+++ b/src/support/access-control-util.js
@@ -401,7 +401,7 @@ export default class AccessControlUtil {
         try {
           let trialUser = await this.TrialUser.findByExternalUserId(profile.email);
 
-          if (!trialUser && profile?.trial_email) {
+          if (!trialUser && profile.trial_email) {
             trialUser = await this.TrialUser.findByEmailId(profile.trial_email);
             if (trialUser && !trialUser.getExternalUserId()) {
               trialUser.setExternalUserId(profile.email);
@@ -419,6 +419,7 @@ export default class AccessControlUtil {
         } catch (err) {
           this.log?.warn('[AccessControl] trial user update failed; continuing', {
             externalUserId: profile.email,
+            ...(profile.trial_email && { trialEmail: profile.trial_email }),
             error: err.message,
           });
         }

--- a/test/support/access-control-util.test.js
+++ b/test/support/access-control-util.test.js
@@ -1366,7 +1366,7 @@ describe('Access Control Util', () => {
       expect(mockTrialUser.findByExternalUserId).to.have.been.calledWith(TEST_IMS_GUID);
       expect(mockTrialUser.findByEmailId).to.not.have.been.called;
       expect(existingUser.setExternalUserId).to.not.have.been.called;
-      expect(existingUser.setLastSeenAt).to.have.been.calledOnce;
+      expect(existingUser.setLastSeenAt).to.have.been.calledOnceWith(sinon.match.string);
       expect(existingUser.save).to.have.been.calledOnce;
     });
 
@@ -1396,7 +1396,7 @@ describe('Access Control Util', () => {
 
       expect(mockTrialUser.findByEmailId).to.have.been.calledWith('trial@example.com');
       expect(existingUser.setExternalUserId).to.have.been.calledWith(TEST_IMS_GUID);
-      expect(existingUser.setLastSeenAt).to.have.been.calledOnce;
+      expect(existingUser.setLastSeenAt).to.have.been.calledOnceWith(sinon.match.string);
       expect(existingUser.save).to.have.been.calledOnce;
     });
 
@@ -1425,7 +1425,7 @@ describe('Access Control Util', () => {
       await util.validateEntitlement(mockOrg, null, 'llmo');
 
       expect(existingUser.setExternalUserId).to.not.have.been.called;
-      expect(existingUser.setLastSeenAt).to.have.been.calledOnce;
+      expect(existingUser.setLastSeenAt).to.have.been.calledOnceWith(sinon.match.string);
       expect(existingUser.save).to.have.been.calledOnce;
     });
 

--- a/test/support/access-control-util.test.js
+++ b/test/support/access-control-util.test.js
@@ -780,6 +780,7 @@ describe('Access Control Util', () => {
 
       mockTrialUser = {
         findByEmailId: sinon.stub(),
+        findByExternalUserId: sinon.stub(),
         create: sinon.stub(),
       };
 
@@ -1340,7 +1341,37 @@ describe('Access Control Util', () => {
     const TEST_IMS_GUID = '145D1F646365E9C70A495FC8@17481f256365e20f495cc2.e';
     const EXISTING_IMS_GUID = '1BB32091680634E20A495CA8@17481f256365e20f495cc2.e';
 
-    it('should backfill externalUserId for PAID-tier trial user that is missing it', async () => {
+    it('should find PAID-tier trial user by externalUserId and refresh lastSeenAt', async () => {
+      const entitlement = {
+        getId: () => 'entitlement-paid',
+        getProductCode: () => 'llmo',
+        getTier: () => 'PAID',
+      };
+      mockTierClient.checkValidEntitlement.resolves({ entitlement });
+      mockAuthInfo.getProfile.returns({
+        email: TEST_IMS_GUID,
+        // no trial_email — paying-customer trial users don't store email
+      });
+
+      const existingUser = {
+        getExternalUserId: sinon.stub().returns(TEST_IMS_GUID),
+        setExternalUserId: sinon.stub(),
+        setLastSeenAt: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      mockTrialUser.findByExternalUserId.resolves(existingUser);
+
+      await util.validateEntitlement(mockOrg, null, 'llmo');
+
+      expect(mockTrialUser.findByExternalUserId).to.have.been.calledWith(TEST_IMS_GUID);
+      expect(mockTrialUser.findByEmailId).to.not.have.been.called;
+      expect(existingUser.setExternalUserId).to.not.have.been.called;
+      expect(existingUser.setLastSeenAt).to.have.been.calledOnce;
+      expect(existingUser.save).to.have.been.calledOnce;
+    });
+
+    it('should fall back to legacy emailId lookup and backfill externalUserId when '
+      + 'PAID-tier trial user is not found by externalUserId', async () => {
       const entitlement = {
         getId: () => 'entitlement-paid',
         getProductCode: () => 'llmo',
@@ -1351,31 +1382,42 @@ describe('Access Control Util', () => {
         trial_email: 'trial@example.com',
         email: TEST_IMS_GUID,
       });
+      mockTrialUser.findByExternalUserId.resolves(null);
 
       const existingUser = {
         getExternalUserId: sinon.stub().returns(null),
         setExternalUserId: sinon.stub(),
+        setLastSeenAt: sinon.stub(),
         save: sinon.stub().resolves(),
       };
       mockTrialUser.findByEmailId.resolves(existingUser);
 
       await util.validateEntitlement(mockOrg, null, 'llmo');
 
+      expect(mockTrialUser.findByEmailId).to.have.been.calledWith('trial@example.com');
       expect(existingUser.setExternalUserId).to.have.been.calledWith(TEST_IMS_GUID);
+      expect(existingUser.setLastSeenAt).to.have.been.calledOnce;
       expect(existingUser.save).to.have.been.calledOnce;
     });
 
-    it('should not overwrite externalUserId for PAID-tier user that already has it set', async () => {
+    it('should not overwrite externalUserId for a legacy PAID-tier user that already has it '
+      + 'set, but still refreshes lastSeenAt', async () => {
       const entitlement = {
         getId: () => 'entitlement-paid',
         getProductCode: () => 'llmo',
         getTier: () => 'PAID',
       };
       mockTierClient.checkValidEntitlement.resolves({ entitlement });
+      mockAuthInfo.getProfile.returns({
+        trial_email: 'trial@example.com',
+        email: TEST_IMS_GUID,
+      });
+      mockTrialUser.findByExternalUserId.resolves(null);
 
       const existingUser = {
         getExternalUserId: sinon.stub().returns(EXISTING_IMS_GUID),
         setExternalUserId: sinon.stub(),
+        setLastSeenAt: sinon.stub(),
         save: sinon.stub().resolves(),
       };
       mockTrialUser.findByEmailId.resolves(existingUser);
@@ -1383,10 +1425,11 @@ describe('Access Control Util', () => {
       await util.validateEntitlement(mockOrg, null, 'llmo');
 
       expect(existingUser.setExternalUserId).to.not.have.been.called;
-      expect(existingUser.save).to.not.have.been.called;
+      expect(existingUser.setLastSeenAt).to.have.been.calledOnce;
+      expect(existingUser.save).to.have.been.calledOnce;
     });
 
-    it('should skip externalUserId backfill for PAID-tier when profile has no email', async () => {
+    it('should skip trial user lookup for PAID-tier when profile has no email', async () => {
       const entitlement = {
         getId: () => 'entitlement-paid',
         getProductCode: () => 'llmo',
@@ -1394,32 +1437,30 @@ describe('Access Control Util', () => {
       };
       mockTierClient.checkValidEntitlement.resolves({ entitlement });
 
-      const existingUser = {
-        getExternalUserId: sinon.stub().returns(null),
-        setExternalUserId: sinon.stub(),
-        save: sinon.stub().resolves(),
-      };
-      mockTrialUser.findByEmailId.resolves(existingUser);
-
       mockAuthInfo.getProfile.returns({
         trial_email: 'trial@example.com',
-        // no email field — findByEmailId should not be called
+        // no email field — neither lookup should be called
       });
 
       await util.validateEntitlement(mockOrg, null, 'llmo');
 
+      expect(mockTrialUser.findByExternalUserId).to.not.have.been.called;
       expect(mockTrialUser.findByEmailId).to.not.have.been.called;
-      expect(existingUser.setExternalUserId).to.not.have.been.called;
-      expect(existingUser.save).to.not.have.been.called;
     });
 
-    it('should skip externalUserId backfill for PAID-tier when findByEmailId returns null', async () => {
+    it('should do nothing for PAID-tier when neither externalUserId nor legacy emailId '
+      + 'lookup finds a trial user', async () => {
       const entitlement = {
         getId: () => 'entitlement-paid',
         getProductCode: () => 'llmo',
         getTier: () => 'PAID',
       };
       mockTierClient.checkValidEntitlement.resolves({ entitlement });
+      mockAuthInfo.getProfile.returns({
+        trial_email: 'trial@example.com',
+        email: TEST_IMS_GUID,
+      });
+      mockTrialUser.findByExternalUserId.resolves(null);
       mockTrialUser.findByEmailId.resolves(null);
 
       await util.validateEntitlement(mockOrg, null, 'llmo');
@@ -1427,7 +1468,7 @@ describe('Access Control Util', () => {
       expect(mockTrialUser.create).to.not.have.been.called;
     });
 
-    it('should not backfill externalUserId for PAID-tier when caller is S2S consumer', async () => {
+    it('should not look up a trial user for PAID-tier when caller is S2S consumer', async () => {
       const entitlement = {
         getId: () => 'entitlement-paid',
         getProductCode: () => 'llmo',
@@ -1443,31 +1484,38 @@ describe('Access Control Util', () => {
       const existingUser = {
         getExternalUserId: sinon.stub().returns(null),
         setExternalUserId: sinon.stub(),
+        setLastSeenAt: sinon.stub(),
         save: sinon.stub().resolves(),
       };
+      mockTrialUser.findByExternalUserId.resolves(existingUser);
       mockTrialUser.findByEmailId.resolves(existingUser);
 
       await util.validateEntitlement(mockOrg, null, 'llmo');
 
+      expect(mockTrialUser.findByExternalUserId).to.not.have.been.called;
       expect(mockTrialUser.findByEmailId).to.not.have.been.called;
       expect(existingUser.setExternalUserId).to.not.have.been.called;
       expect(existingUser.save).to.not.have.been.called;
     });
 
-    it('should not throw when PAID-tier backfill save fails', async () => {
+    it('should not throw when PAID-tier lastSeenAt save fails', async () => {
       const entitlement = {
         getId: () => 'entitlement-paid',
         getProductCode: () => 'llmo',
         getTier: () => 'PAID',
       };
       mockTierClient.checkValidEntitlement.resolves({ entitlement });
+      mockAuthInfo.getProfile.returns({
+        email: TEST_IMS_GUID,
+      });
 
       const existingUser = {
-        getExternalUserId: sinon.stub().returns(null),
+        getExternalUserId: sinon.stub().returns(TEST_IMS_GUID),
         setExternalUserId: sinon.stub(),
+        setLastSeenAt: sinon.stub(),
         save: sinon.stub().rejects(new Error('DDB throttle')),
       };
-      mockTrialUser.findByEmailId.resolves(existingUser);
+      mockTrialUser.findByExternalUserId.resolves(existingUser);
 
       await expect(util.validateEntitlement(mockOrg, null, 'llmo')).to.not.be.rejected;
     });


### PR DESCRIPTION
## Summary

- Extends trial-user "last seen" tracking to paying customers (PAID/PLG-tier entitlements),
  which previously only refreshed `lastSeenAt` for FREE_TRIAL-tier trial users.
- Fixes the trial-user lookup for paying customers: their `TrialUser` rows don't store an
  email, so the old email-based lookup could never find them. Switches to looking them up by
  `externalUserId` (the IMS user GUID), using the new `TrialUser.findByExternalUserId` index
  added in `@adobe/spacecat-shared-data-access@4.19.0`.
- Falls back to the legacy email-based lookup (with the existing one-time `externalUserId`
  backfill) for older PAID/PLG trial users created via the email-invite flow, so nothing
  already in production breaks.

## Changes

### `src/support/access-control-util.js` — `AccessControlUtil.validateEntitlement()`
- The non-`FREE_TRIAL` branch (entered for `PAID`/`PLG`-tier entitlements) now:
  1. Looks up the trial user via `TrialUser.findByExternalUserId(profile.email)` first.
  2. Falls back to `TrialUser.findByEmailId(profile.trial_email)` if not found, backfilling
     `externalUserId` on that record the first time it's found this way (unchanged legacy
     behavior).
  3. Refreshes `lastSeenAt` and saves whenever a trial user is found by either path — this is
     new; previously this branch only ever backfilled `externalUserId`, never touched
     `lastSeenAt`.
- Error handling/logging updated to reflect the externalUserId-first lookup.

### `package.json` / `package-lock.json`
- Bumped `@adobe/spacecat-share`4.19.0` (adds
  `TrialUser.findByExternalUserId`).

### `test/support/access-control-util.test.js`
- Added `findByExternalUserId` ` fixture.
- Replaced the old "PAID-tier backfill" test group with cases covering:
  - found via `externalUserId`
  - not found via `externalUserId`, falls back to legacy email lookup + backfill
  - legacy fallback where `exte (no backfill, `lastSeenAt`still
    refreshed)
  - no email on profile → both lookups skipped
  - neither lookup finds a user
  - S2S consumer → both lookups skipped
  - save failure → swallowed, d

## Known limitations (not addresed in this PR)
- `POST /sites/:siteId/user-activities` (`user-activities.js`) still looks up the trial
user
  only by `trial_email` — no `externalUserId` fallback. Paying customers hitting that
endpoint
  without a `trial_email` claim will still get "Trial user not found."
- The `PAID`/`PLG` branch has n's simply "not `FREE_TRIAL`," so `PLG`
  entitlements get the same `la as `PAID`. This predates thisPR.
- `TrialUser.lastSeenAt` is not field shared acrossLLMO/ASO/ACO, so
  it can't tell you *which* pro last seen on. Per-productactivity is
  only available via `TrialUsertCode` field).

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```