### PR TITLE
feat(slack): show org name alongside imsOrgId in get-site output

### DIFF
--- a/src/utils/slack/format.js
+++ b/src/utils/slack/format.js
@@ -78,16 +78,17 @@ const printSiteDetails = async (site, isAuditEnabled = true, psiStrategy = 'mobi
 
   const auditDisabledText = !isAuditEnabled ? ':warning: LHS audits have been disabled for site or strategy! This is usually done when PSI audits experience errors due to the target having issues (e.g. DNS or 404).\n' : '';
 
-  // Fetch organization to get IMS Org ID
+  // Fetch organization to get IMS Org ID and name
   const organization = await site.getOrganization();
   const imsOrgId = organization?.getImsOrgId();
+  const orgName = organization?.getName();
 
   return `${auditDisabledText}
       :identification_card: ${site.getId()}
       :cat-egory-white: ${site.getDeliveryType()}
       :github-4173: ${site.getGitHubURL() || '_not set_'}
       :space-cat: ${site.getOrganizationId() || '_not set_'}
-      :ims: ${imsOrgId || '_not set_'}
+      :ims: ${imsOrgId ? `${imsOrgId}${orgName ? ` (${orgName})` : ''}` : '_not set_'}
       ${site.getIsLive() ? `:rocket: Is live (${formatDate(site.getIsLiveToggledAt())})` : ':submarine: Is not live'}
       :lighthouse: ${viewPSILink}${runPSILink}
     `;

--- a/test/support/slack/commands/add-repo.test.js
+++ b/test/support/slack/commands/add-repo.test.js
@@ -47,6 +47,7 @@ describe('AddRepoCommand', () => {
       getOrganizationId: sinon.stub().returns('org-123'),
       getOrganization: sinon.stub().resolves({
         getImsOrgId: () => 'ims-org-456',
+        getName: () => 'Test Org',
       }),
       getIsLive: sinon.stub(),
       updateGitHubURL: sinon.stub(),
@@ -169,7 +170,7 @@ describe('AddRepoCommand', () => {
         + '      :cat-egory-white: aem_edge\n'
         + '      :github-4173: _not set_\n'
         + '      :space-cat: org-123\n'
-        + '      :ims: ims-org-456\n'
+        + '      :ims: ims-org-456 (Test Org)\n'
         + '      :submarine: Is not live\n'
         + '      :lighthouse: <https://psi.experiencecloud.live?url=undefined&strategy=mobile|Run PSI Check>\n'
         + '    \n'

--- a/test/support/slack/commands/get-site.test.js
+++ b/test/support/slack/commands/get-site.test.js
@@ -78,6 +78,7 @@ describe('GetSiteCommand', () => {
       getOrganizationId: () => 'org-123',
       getOrganization: sinon.stub().resolves({
         getImsOrgId: () => 'ims-org-456',
+        getName: () => 'Test Org',
       }),
       getIsLive: () => true,
       getIsLiveToggledAt: () => '2011-10-05T14:48:00.000Z',
@@ -190,6 +191,7 @@ describe('GetSiteCommand', () => {
 
       expect(responseText).to.include('org-123');
       expect(responseText).to.include('ims-org-456');
+      expect(responseText).to.include('Test Org');
     });
 
     it('handles missing organization ID and IMS org gracefully', async () => {

--- a/test/support/slack/commands/get-site.test.js
+++ b/test/support/slack/commands/get-site.test.js
@@ -194,6 +194,26 @@ describe('GetSiteCommand', () => {
       expect(responseText).to.include('Test Org');
     });
 
+    it('shows only imsOrgId when org name is not available', async () => {
+      site.getOrganization = sinon.stub().resolves({
+        getImsOrgId: () => 'ims-org-456',
+        getName: () => null,
+      });
+      site.getAuditsByAuditType.resolves(generateMockAudits(1));
+
+      const args = ['example.com', 'mobile'];
+      const command = GetSiteCommand(context);
+
+      await command.handleExecution(args, slackContext);
+
+      expect(slackContext.say.called).to.be.true;
+      const callArgs = slackContext.say.firstCall.args;
+      const responseText = JSON.stringify(callArgs);
+
+      expect(responseText).to.include('ims-org-456');
+      expect(responseText).to.not.include('(null)');
+    });
+
     it('handles missing organization ID and IMS org gracefully', async () => {
       site.getOrganizationId = () => null;
       site.getOrganization = sinon.stub().resolves(null);

--- a/test/utils/slack/format.test.js
+++ b/test/utils/slack/format.test.js
@@ -94,6 +94,7 @@ describe('Utility Functions', () => {
         getOrganizationId: sinon.stub().returns('org-123'),
         getOrganization: sinon.stub().resolves({
           getImsOrgId: () => 'ims-org-456',
+          getName: () => 'Test Org',
         }),
         getIsLive: sinon.stub(),
         getIsLiveToggledAt: sinon.stub().returns('2011-10-05T14:48:00.000Z'),
@@ -114,7 +115,7 @@ describe('Utility Functions', () => {
       :cat-egory-white: aem_edge
       :github-4173: https://github.com/example/repo
       :space-cat: org-123
-      :ims: ims-org-456
+      :ims: ims-org-456 (Test Org)
       :rocket: Is live (2011-10-05 14:48:00)
       :lighthouse: <https://psi.experiencecloud.live?url=https://example.com&strategy=mobile|Run PSI Check>
     `;
@@ -131,7 +132,7 @@ describe('Utility Functions', () => {
       :cat-egory-white: aem_edge
       :github-4173: _not set_
       :space-cat: org-123
-      :ims: ims-org-456
+      :ims: ims-org-456 (Test Org)
       :submarine: Is not live
       :lighthouse: <https://psi.experiencecloud.live?url=https://example.com&strategy=mobile|Run PSI Check>
     `;
@@ -154,7 +155,7 @@ describe('Utility Functions', () => {
       :cat-egory-white: aem_edge
       :github-4173: https://github.com/example/repo
       :space-cat: org-123
-      :ims: ims-org-456
+      :ims: ims-org-456 (Test Org)
       :rocket: Is live (2011-10-05 14:48:00)
       :lighthouse: :warning: <https://googlechrome.github.io/lighthouse/viewer/?jsonurl=https://psi-result/1|View Latest Audit> or <https://psi.experiencecloud.live?url=https://example.com&strategy=mobile|Run PSI Check>
     `;
@@ -177,7 +178,7 @@ describe('Utility Functions', () => {
       :cat-egory-white: aem_edge
       :github-4173: https://github.com/example/repo
       :space-cat: org-123
-      :ims: ims-org-456
+      :ims: ims-org-456 (Test Org)
       :rocket: Is live (2011-10-05 14:48:00)
       :lighthouse: <https://googlechrome.github.io/lighthouse/viewer/?jsonurl=https://psi-result/1|View Latest Audit> or <https://psi.experiencecloud.live?url=https://example.com&strategy=mobile|Run PSI Check>
     `;
@@ -195,7 +196,7 @@ describe('Utility Functions', () => {
       :cat-egory-white: aem_edge
       :github-4173: _not set_
       :space-cat: org-123
-      :ims: ims-org-456
+      :ims: ims-org-456 (Test Org)
       :submarine: Is not live
       :lighthouse: <https://psi.experiencecloud.live?url=https://example.com&strategy=mobile|Run PSI Check>
     `;


### PR DESCRIPTION
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

The `@spacecat get site <url>` Slack command showed only the raw IMS org ID in its output. When operators see an unfamiliar UUID-style org ID they have to manually look it up to know which org it belongs to.

## Changes

- `src/utils/slack/format.js`: fetch `organization.getName()` alongside `getImsOrgId()` and render as `:ims: <imsOrgId> (<orgName>)`. Falls back to just the ID if name is unavailable, and `_not set_` if both are missing.
- `test/support/slack/commands/get-site.test.js`: add `getName` to the org mock and assert org name appears in the response.

Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi", "Tej Kotthakota"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```