### PR TITLE
feat(sites): accept all entitlement tiers for the full-admin tier filter on GET /sites

### DIFF
--- a/docs/openapi/sites-api.yaml
+++ b/docs/openapi/sites-api.yaml
@@ -274,6 +274,11 @@ sites:
         required: false
         description: |
           Server-side filter: only return sites enrolled at this entitlement tier.
+          Accepts any entitlement tier, including `PRE_ONBOARD` (internal-only, not
+          customer-visible) — not just the customer-visible subset — because this
+          filter is already full-admin-gated below, the same as the standalone
+          `GET /sites/by-tier/{tier}` endpoint, for which `PRE_ONBOARD` is a
+          legitimate admin query (e.g. to find sites still awaiting onboarding).
           **Requires full admin access** — unlike every other `GET /sites` filter,
           this one is NOT available to S2S `site:readAll` callers or read-only admins
           (403 `Filtering sites by tier or productCode requires admin access`), the
@@ -294,6 +299,7 @@ sites:
             - FREE_TRIAL
             - PAID
             - PLG
+            - PRE_ONBOARD
           example: PAID
       - name: productCode
         in: query

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -510,7 +510,8 @@ function SitesController(ctx, log, env) {
    * when more than one filter is present they compose with AND. `sort`
    * (`<field>:<asc|desc>`, field one of `baseURL`/`updatedAt`/`createdAt`/
    * `deliveryType`/`isLive`) sets the result order. `tier` (one of
-   * `CUSTOMER_VISIBLE_TIERS`) and `productCode` (one of `EntitlementModel.PRODUCT_CODES`)
+   * `EntitlementModel.TIERS`, incl. `PRE_ONBOARD` - not just `CUSTOMER_VISIBLE_TIERS`)
+   * and `productCode` (one of `EntitlementModel.PRODUCT_CODES`)
    * filter to sites enrolled at that entitlement tier/product; when either is present the
    * SAME where/orderBy/limit/cursor built for the branch is passed to
    * `Site.allByEnrollmentFiltered` instead of `Site.all`. Unlike every other filter here,
@@ -518,7 +519,10 @@ function SitesController(ctx, log, env) {
    * the same gate as the standalone `GET /sites/by-tier` endpoint
    * (`getAllByEnrollmentAndTier`) - so a read-only admin or an S2S `site:readAll`
    * caller gets 403 for either param, checked before their enum validation so the 403
-   * vs 400 outcome can't be used to probe valid values. `cursor` is not supported
+   * vs 400 outcome can't be used to probe valid values; the tier accepted-value set
+   * intentionally mirrors that sibling admin-only endpoint (both accept the full
+   * `EntitlementModel.TIERS`, since PRE_ONBOARD is a legitimate admin query here too).
+   * `cursor` is not supported
    * together with any filter/sort (use `offset` instead) - accepting both would silently
    * discard the cursor and mislead the client into thinking cursor pagination is active.
    * @returns {Promise<Response>} Paginated sites response
@@ -587,8 +591,9 @@ function SitesController(ctx, log, env) {
       }
       orderBy = { attribute: sortField, direction: sortDirection };
     }
-    if (hasText(tier) && !CUSTOMER_VISIBLE_TIERS.includes(tier)) {
-      return badRequest(`Invalid tier: ${tier}`);
+    const validTiers = Object.values(EntitlementModel.TIERS);
+    if (hasText(tier) && !validTiers.includes(tier)) {
+      return badRequest(`Tier must be one of: ${validTiers.join(', ')}`);
     }
     const validProductCodes = Object.values(EntitlementModel.PRODUCT_CODES);
     if (hasText(productCode) && !validProductCodes.includes(productCode)) {

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -1708,6 +1708,27 @@ describe('Sites Controller', () => {
       expect(opts.cursor).to.equal(Buffer.from(JSON.stringify({ offset: 0 })).toString('base64'));
     });
 
+    it('accepts tier=PRE_ONBOARD for a full admin (not just CUSTOMER_VISIBLE_TIERS) and calls Site.allByEnrollmentFiltered', async () => {
+      // This filter path is already full-admin-gated (see the 403 tests below), so it
+      // accepts the full Entitlement.TIERS set - same as the sibling admin-only
+      // GET /sites/by-tier endpoint (getAllByEnrollmentAndTier) - not just the
+      // customer-visible subset.
+      mockDataAccess.Site.allByEnrollmentFiltered.resolves(sites);
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'PRE_ONBOARD' },
+      });
+      const body = await result.json();
+
+      expect(result.status).to.equal(200);
+      expect(body.pagination).to.include({ tier: 'PRE_ONBOARD' });
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.have.been.calledOnce;
+      const [filter] = mockDataAccess.Site.allByEnrollmentFiltered.firstCall.args;
+      expect(filter).to.deep.equal({ tier: 'PRE_ONBOARD', productCode: undefined });
+    });
+
     it('with no sort, the enrollment and non-enrollment branches receive an IDENTICAL default orderBy', async () => {
       // Regression: Site.all defaults (via its all-index) to baseURL asc, while
       // Site.allByEnrollmentFiltered defaults to updatedAt desc and ignores `order`.
@@ -1829,7 +1850,10 @@ describe('Sites Controller', () => {
         ...context,
         data: { tier: 'BOGUS_TIER' },
       });
+      const error = await result.json();
       expect(result.status).to.equal(400);
+      // Mirrors the sibling GET /sites/by-tier wording (getAllByEnrollmentAndTier).
+      expect(error.message).to.match(/^Tier must be one of:/);
       expect(mockDataAccess.Site.all).to.not.have.been.called;
       expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
     });
@@ -1859,6 +1883,21 @@ describe('Sites Controller', () => {
       const result = await sitesController.getAll({
         ...context,
         data: { tier: 'PAID' },
+      });
+      const error = await result.json();
+
+      expect(result.status).to.equal(403);
+      expect(error).to.have.property('message', 'Filtering sites by tier or productCode requires admin access');
+      expect(mockDataAccess.Site.all).to.not.have.been.called;
+      expect(mockDataAccess.Site.allByEnrollmentFiltered).to.not.have.been.called;
+    });
+
+    it('returns 403 (not 400 or 200) when a read-only admin requests tier=PRE_ONBOARD - the admin-access guard runs before tier enum validation', async () => {
+      context.attributes.authInfo.withProfile({ is_admin: false, is_read_only_admin: true });
+
+      const result = await sitesController.getAll({
+        ...context,
+        data: { tier: 'PRE_ONBOARD' },
       });
       const error = await result.json();
 

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -418,6 +418,18 @@ export default function siteTests(getHttpClient, resetData) {
         expect(res.body.sites).to.be.an('array').that.is.empty;
       });
 
+      it('admin: tier=PRE_ONBOARD is accepted (internal-only, not customer-visible) since this filter is already admin-gated', async () => {
+        const http = getHttpClient();
+        // Mirrors the sibling GET /sites/by-tier/PRE_ONBOARD IT test: no PRE_ONBOARD
+        // entitlement is seeded above, so this only asserts the value is ACCEPTED
+        // (200, echoed in pagination) rather than rejected with 400, not that any
+        // specific site is returned.
+        const res = await http.admin.get('/sites?tier=PRE_ONBOARD');
+        expect(res.status).to.equal(200);
+        expect(res.body.pagination).to.include({ hasMore: false, tier: 'PRE_ONBOARD' });
+        expect(res.body.sites).to.be.an('array');
+      });
+
       it('admin: tier is rejected with 400 when not a recognized value', async () => {
         const http = getHttpClient();
         const res = await http.admin.get('/sites?tier=BOGUS_TIER');


### PR DESCRIPTION
  Description:
  ## What
  `GET /sites`'s `tier` filter now accepts **all** `Entitlement.TIERS` values
  (`FREE_TRIAL`, `PAID`, `PLG`, `PRE_ONBOARD`) instead of only the customer-visible
  subset (`FREE_TRIAL`, `PAID`, `PLG`).
  
  - `getAll` tier validation switched from `CUSTOMER_VISIBLE_TIERS` to
    `Object.values(EntitlementModel.TIERS)`, mirroring the sibling
    `GET /sites/by-tier/:tier` (`getAllByEnrollmentAndTier`).
  - Invalid-tier error message aligned with the sibling
    (`Tier must be one of: …`); a genuinely unknown tier still returns 400.
  - OpenAPI `tier` enum updated to include `PRE_ONBOARD`.
  
  ## Why
  The `tier`/`productCode` filter on `GET /sites` is already **full-admin gated**
  (added in #3046), so it should accept the same tier set as the other full-admin
  tier endpoint (`/sites/by-tier`), which deliberately accepts every tier —
  including `PRE_ONBOARD` — to let admins find sites still awaiting onboarding.
  The back-office sites dashboard offers `PRE_ONBOARD` in its tier dropdown;
  without this change, selecting it returns a 400.
  
  ## Changes
  - `src/controllers/sites.js` — tier validation + message
  - `docs/openapi/sites-api.yaml` — `tier` enum
  - `test/controllers/sites.test.js` — PRE_ONBOARD accepted (full admin); bogus tier → 400; non-full-admin + tier → 403 (guard runs before enum validation)
  - `test/it/shared/tests/sites.js` — integration coverage for the tier filter
  
  ## Testing
  - Unit: `test/controllers/sites.test.js` green (node 24).
  - The full-admin authz guard is unchanged and verified to still run **before**
    tier enum validation (unauthorized callers get 403, not a 400 they could use
    to probe valid tier values).
  - Integration tests run in CI (`it-postgres`).
  
  ## Notes
  - Builds on #3046 (server-side sites filter/sort).
  - No behavior change to the broad gate for `baseURL`/`deliveryType`/`isLive`/`sort`.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```