### PR TITLE
fix(serenity): surface renamed origin__ authorship root in filter dimensions (LLMO-7000)

### DIFF
--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -11,7 +11,12 @@
  */
 
 import { resolveElementModel, SEP } from '../constants.js';
-import { INTENT_ROOT_NAME, LEGACY_INTENT_ROOT_NAME } from '../../serenity/prompt-tags.js';
+import {
+  INTENT_ROOT_NAME,
+  LEGACY_INTENT_ROOT_NAME,
+  ORIGIN_ROOT_NAME,
+  LEGACY_ORIGIN_ROOT_NAME,
+} from '../../serenity/prompt-tags.js';
 
 /**
  * Builds the payload for the Topics (Tags) filter-dimensions element (row 3).
@@ -160,34 +165,61 @@ export function transformIntentsToFilterDimensions(raw) {
 }
 
 /**
- * Extracts only "source__"-prefixed entries → `{ id: original tag, label }`,
- * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
- * hierarchy.
+ * The origin (authorship) dimension's root names, and therefore its Elements tag
+ * prefixes — the current `origin` and the pre-rename `source`. The Elements tag
+ * encoding is the `__`-joined tag PATH, so a dimension's prefix is literally its
+ * root's name, and the rename (LLMO-7000, mirroring the intent rename of
+ * LLMO-6984) changes what these tags look like on the wire. The rename runs
+ * project by project, so both shapes are read; a project's authorship carries one
+ * or the other.
+ *
+ * `source__` is deliberately kept, not just for un-reshaped projects: it is the
+ * pre-rename authorship spelling AND the new producing-system dimension's prefix,
+ * and the two cannot be told apart here (see LEGACY_ORIGIN_ROOT_NAME). Producing-
+ * system values therefore ride along under `origins` on reshaped projects until a
+ * dedicated source dimension claims them; the tolerance drops to `origin__` alone
+ * once no live project carries the pre-rename authorship spelling.
+ */
+const ORIGIN_ROOT_NAMES = [ORIGIN_ROOT_NAME, LEGACY_ORIGIN_ROOT_NAME];
+
+/**
+ * Extracts the origin-prefixed entries → `{ id: original tag, label }`, plus
+ * `parent_id`/`parent_label` when the tag encodes a "Parent__Child" hierarchy.
+ *
+ * `id` stays the original tag value, which is what a caller passes back as a
+ * `tags` filter, so it carries whichever prefix that project actually uses. The
+ * `label` is the bare value either way — the rename touches only the root.
+ *
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformOriginsToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'source')
-    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'source__') }));
+  return ORIGIN_ROOT_NAMES.flatMap((root) => {
+    const marker = `${root}${SEP}`;
+    return extractByPrefix(raw, root)
+      .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, marker) }));
+  });
 }
 
 const KNOWN_TAG_PREFIXES = [
   'topic__',
   'category__',
   ...INTENT_ROOT_NAMES.map((root) => `${root}${SEP}`),
-  'source__',
+  ...ORIGIN_ROOT_NAMES.map((root) => `${root}${SEP}`),
 ];
 
 /**
  * Extracts every tag NOT already covered by {@link KNOWN_TAG_PREFIXES} —
- * `topic__`, `category__`, `source__` and both intent spellings — so
+ * `topic__`, `category__`, and both the intent and origin spellings
+ * (`$abv_tags$intent__`/`intent__`, `origin__`/`source__`) — so
  * newly-introduced Semrush tag types (e.g. `type__branded`) surface in the
  * response without a code change per prefix.
  *
- * Both intent spellings are covered, so a renamed project's tags are claimed by
- * `page_intents` rather than resurfacing here as a dynamic `$abv_tags$intent`
- * group — this catch-all is where an unrecognised dimension would otherwise leak
- * into the filter payload under its raw upstream name.
+ * Both intent and both origin spellings are covered, so a renamed project's tags
+ * are claimed by `page_intents`/`origins` rather than resurfacing here as a
+ * dynamic `$abv_tags$intent`/`origin` group — this catch-all is where an
+ * unrecognised dimension would otherwise leak into the filter payload under its
+ * raw upstream name.
  *
  * - `prefix__value` tags are grouped by their prefix into a dynamic key
  *   (e.g. `{ type: [{ id: 'type__branded', label: 'branded' }, ...] }`), unless

--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -99,6 +99,33 @@ export const INTENT_ROOT_NAME = '$abv_tags$intent';
 export const LEGACY_INTENT_ROOT_NAME = DIMENSION.INTENT;
 
 /**
+ * The origin (authorship) dimension root name — who authored the prompt. Named
+ * after its dimension key, like the other roots.
+ */
+export const ORIGIN_ROOT_NAME = DIMENSION.ORIGIN;
+
+/**
+ * The pre-rename origin root name. Authorship shipped under a root literally
+ * named `source` before the rename to `origin` (LLMO-6270 §46,
+ * origin-dimension.md). The rename runs project by project from the migration
+ * CLI, so a project can carry either spelling until the sweep completes, and the
+ * Elements read path tolerates both.
+ *
+ * COLLISION — pinned to the literal `source`, NOT to {@link DIMENSION.SOURCE},
+ * even though the two coincide today: this is the *historical* wire spelling of
+ * authorship and must not drift if the producing-system dimension is ever
+ * renamed. The producing-system `source` dimension (LLMO-6270 §47) also emits
+ * `source__` tags, so a `source__` value is ambiguous — pre-rename authorship on
+ * an un-reshaped project, or a producing-system value on a reshaped one — and the
+ * two cannot be told apart at this prefix. The origins read tolerates `source__`
+ * for the un-reshaped case and accepts that producing-system values ride along on
+ * reshaped projects until a dedicated source dimension claims them. Unlike
+ * LLMO-6986's intent tolerance, this one is not cleanly observable from the read
+ * surface (producing-system `source__` masks it), so there is no transition log.
+ */
+export const LEGACY_ORIGIN_ROOT_NAME = 'source';
+
+/**
  * Every name reserved at the root level: the four roots named after their
  * dimension, plus BOTH intent spellings — the upstream `$abv_tags$intent` and
  * the pre-rename `intent`, which stays reserved while any project still carries

--- a/test/support/elements/definitions/topics.test.js
+++ b/test/support/elements/definitions/topics.test.js
@@ -20,7 +20,12 @@ import {
   transformOtherTagsForFilterDimensions,
 } from '../../../../src/support/elements/definitions/topics.js';
 import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
-import { INTENT_ROOT_NAME, LEGACY_INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
+import {
+  INTENT_ROOT_NAME,
+  LEGACY_INTENT_ROOT_NAME,
+  ORIGIN_ROOT_NAME,
+  LEGACY_ORIGIN_ROOT_NAME,
+} from '../../../../src/support/serenity/prompt-tags.js';
 
 // Mirrors the fixed keys elements-service.js's `getUrlInspectorFilterDimensions`
 // builds `result` with, plus the JS-unsafe names it also guards against.
@@ -394,11 +399,72 @@ describe('topics definitions', () => {
       expect(item.label).to.equal('direct');
     });
 
-    it('excludes non-source entries', () => {
+    it('excludes entries under no origin root', () => {
       const raw = { blocks: { value: [{ value: 'topic__SEO' }, { value: 'source__organic' }] } };
       const result = transformOriginsToFilterDimensions(raw);
       expect(result).to.have.length(1);
       expect(result[0].id).to.equal('source__organic');
+    });
+
+    // Both spellings read the same way; parent_id is rebuilt from whichever
+    // prefix matched. The tolerance drops to `origin__` alone once no live
+    // project carries the pre-rename `source__` authorship spelling.
+    [LEGACY_ORIGIN_ROOT_NAME, ORIGIN_ROOT_NAME].forEach((root) => {
+      it(`adds parent_id/parent_label under the \`${root}\` root`, () => {
+        const raw = { blocks: { value: [{ value: `${root}__Team__ai` }] } };
+        const [item] = transformOriginsToFilterDimensions(raw);
+        expect(item).to.deep.equal({
+          id: `${root}__Team__ai`,
+          label: 'ai',
+          parent_id: `${root}__Team`,
+          parent_label: 'Team',
+        });
+      });
+    });
+
+    // LLMO-7000: the authorship root was renamed `source` -> `origin`, so real
+    // authorship values now arrive as `origin__ai` / `origin__human`. They must
+    // land in `origins`, not leak through the catch-all as a stray `origin` group
+    // (see transformOtherTagsForFilterDimensions).
+    it('reads the renamed `origin` root, keeping the prefix in id and stripping it from label', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: `${ORIGIN_ROOT_NAME}__ai` },
+            { value: `${ORIGIN_ROOT_NAME}__human` },
+          ],
+        },
+      };
+      expect(transformOriginsToFilterDimensions(raw)).to.deep.equal([
+        { id: `${ORIGIN_ROOT_NAME}__ai`, label: 'ai' },
+        { id: `${ORIGIN_ROOT_NAME}__human`, label: 'human' },
+      ]);
+    });
+
+    // A reshaped project carries authorship under `origin__` and producing-system
+    // values under `source__`; both surface here while the `source__` tolerance
+    // stands — they cannot be told apart at the prefix. `origin__` is read first,
+    // matching the ORIGIN_ROOT_NAMES order.
+    it('reads renamed authorship and pre-rename/producing-system source together', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: `${ORIGIN_ROOT_NAME}__ai` },
+            { value: `${ORIGIN_ROOT_NAME}__human` },
+            { value: 'source__config' },
+          ],
+        },
+      };
+      expect(transformOriginsToFilterDimensions(raw)).to.deep.equal([
+        { id: `${ORIGIN_ROOT_NAME}__ai`, label: 'ai' },
+        { id: `${ORIGIN_ROOT_NAME}__human`, label: 'human' },
+        { id: 'source__config', label: 'config' },
+      ]);
+    });
+
+    it('does not double-count: the legacy prefix does not also match a renamed tag', () => {
+      const raw = { blocks: { value: [{ value: `${ORIGIN_ROOT_NAME}__ai` }] } };
+      expect(transformOriginsToFilterDimensions(raw)).to.have.length(1);
     });
   });
 
@@ -407,11 +473,12 @@ describe('topics definitions', () => {
       expect(transformOtherTagsForFilterDimensions(null)).to.deep.equal({ tags: [] });
     });
 
-    it('excludes known-prefixed entries (topic/category/intent/source)', () => {
+    it('excludes known-prefixed entries (topic/category/intent/origin/source)', () => {
       const result = transformOtherTagsForFilterDimensions(RAW_MIXED);
       expect(result).to.not.have.property('topic');
       expect(result).to.not.have.property('category');
       expect(result).to.not.have.property('intent');
+      expect(result).to.not.have.property('origin');
       expect(result).to.not.have.property('source');
       expect(result.tags).to.deep.equal([]);
     });
@@ -434,6 +501,26 @@ describe('topics definitions', () => {
       expect(result).to.not.have.property(INTENT_ROOT_NAME);
       expect(result.tags).to.deep.equal([]);
       // An genuinely unknown prefix still surfaces — the catch-all keeps working.
+      expect(result.type).to.deep.equal([{ id: 'type__branded', label: 'branded' }]);
+    });
+
+    // LLMO-7000: the renamed origin prefix must be claimed by `origins`, not
+    // grouped under its raw `origin` name in the catch-all — the customer-visible
+    // half of the defect (real authorship options vanishing from the Origin
+    // dropdown, resurfacing as a stray dynamic group).
+    it('claims the renamed origin prefix rather than grouping it under its raw name', () => {
+      const raw = {
+        blocks: {
+          value: [
+            { value: `${ORIGIN_ROOT_NAME}__ai` },
+            { value: ORIGIN_ROOT_NAME },
+            { value: 'type__branded' },
+          ],
+        },
+      };
+      const result = transformOtherTagsForFilterDimensions(raw);
+      expect(result).to.not.have.property(ORIGIN_ROOT_NAME);
+      expect(result.tags).to.deep.equal([]);
       expect(result.type).to.deep.equal([{ id: 'type__branded', label: 'branded' }]);
     });
 


### PR DESCRIPTION
## LLMO-7000

The Origin filter on the Brand Presence / URL Inspector surface offered producing-system values as if they were authorship values, and lost the real authorship values on any project the dimension-root reshape had reached.

### Root cause
`transformOriginsToFilterDimensions` only read the pre-rename `source__` prefix, and `KNOWN_TAG_PREFIXES` omitted `origin__`. After the `source` → `origin` authorship rename:
- real authorship tags (`origin__ai` / `origin__human`) were never surfaced under `origins`, and
- they leaked through the catch-all (`transformOtherTagsForFilterDimensions`) as a stray dynamic `origin` group.

So on a reshaped project the `ai` / `human` options disappeared from the Origin dropdown, while producing-system `source__config` etc. rendered there instead.

### Fix
Mirrors the LLMO-6984 intent-rename fix — both parts required:
1. `transformOriginsToFilterDimensions` dual-reads both roots (`origin` + legacy `source`), preserving the matched prefix when reconstructing `parent_id`.
2. `origin__` added to `KNOWN_TAG_PREFIXES`, so a reshaped project's authorship tags stop resurfacing through the catch-all.

New root-name constants (`ORIGIN_ROOT_NAME`, `LEGACY_ORIGIN_ROOT_NAME`) live in `prompt-tags.js` alongside the intent equivalents.

### Deviation from the ticket: no transition log
The ticket suggested a transition log line "as LLMO-6984 does for intent." Intentionally omitted: the legacy origin spelling `source__` is now **shared** with the new producing-system `source` dimension, so a `source__`-presence log would fire permanently across the entire migrated fleet and never signal when the tolerance can drop — the opposite of intent's clean, self-quieting signal. Documented in the code comments so the follow-up (dropping the `source__` tolerance) is discoverable.

No `project-elmo-ui` change needed — it already carries the tolerant read as `LEGACY_ORIGIN_DIMENSION`. The gap was server-side only.

### Testing
- `topics.test.js` — added dual-root `parent_id`, renamed-root read, mixed authorship+producing-system, no-double-count, and catch-all-claims-`origin` cases
- Full elements sweep (597 tests), `type-check` (base + strict), and `eslint` all pass

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```