### PR TITLE
refactor(serenity): stop populating brands.pending_semrush_provisioning (SITES-49448)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1682,46 +1682,16 @@ function BrandsController(ctx, log, env) {
           return badRequest('market and languageCode are required when generatePrompts is true');
         }
         if (isPendingBrand) {
-          // Defer provisioning: persist the chosen (market, languageCode) AND
-          // the primary URL (if the user entered one before saving as pending)
-          // on the brand, so activation can provision the real sub-workspace +
-          // project later (stored in brands.pending_semrush_provisioning). The primary
-          // URL otherwise lives only on the Semrush side, so a site-less draft
-          // would have nowhere to keep it. The row lands as 'pending' because it
-          // has no anchor (no site_id, no semrush_sub_workspace_id) — see
+          // A pending (draft) brand defers ALL Semrush provisioning — no
+          // sub-workspace, no project. Its markets are added later from the Markets
+          // tab, and pending→active activation is sub-workspace-only (LLMO-6405), so
+          // nothing needs to be stashed at create time. The row lands as 'pending'
+          // because it has no anchor (no site_id, no semrush_sub_workspace_id) — see
           // upsertBrand's anchor check.
-          const primaryUrl = (Array.isArray(brandData.urls) ? brandData.urls : [])
-            .map((u) => (typeof u === 'string' ? u : u?.value))
-            .find(hasText) || null;
-          // AI models (LLMs) the wizard collected. Unlike the direct-provision
-          // path they are NOT required here — a draft can be saved before the
-          // user picks any, and they can be edited per-market later from the
-          // Markets tab. Seed the initial market's modelIds with them when
-          // present so activation applies them; omit the key entirely when none
-          // were chosen (mirrors normalizePendingSemrushProvisioning).
-          const seedModelIds = Array.isArray(brandData.semrushModelIds)
-            ? brandData.semrushModelIds.filter(hasText)
-            : [];
-          // A no-prompt draft may carry NO market at all (location/language are
-          // optional then) — stash only the market actually picked. The activate
-          // flow already handles 0..N stashed markets: an empty list + a primary
-          // URL provisions a single US/EN fallback project, and an empty list +
-          // no URL provisions a sub-workspace-only brand.
-          // TODO: the wizard creates at most one market today; if multi-market
-          // draft creation is added, build this array from all selected markets.
-          const markets = [];
-          if (hasSemrushMarket) {
-            const initialMarket = { market, languageCode };
-            if (seedModelIds.length > 0) {
-              initialMarket.modelIds = seedModelIds;
-            }
-            markets.push(initialMarket);
-          }
-          brandData.pendingSemrushProvisioning = {
-            primaryUrl,
-            markets,
-            generatePrompts,
-          };
+          //
+          // SITES-49448: brands.pending_semrush_provisioning is being retired — this
+          // was its last create-time writer. The staging blob no longer serves any
+          // activation path, so the draft is saved without one.
         } else if (hasSemrushMarket) {
           const brandDomain = brandDomainFromPayload(brandData);
           if (!brandDomain || !hasText(brandDomain)) {
@@ -1942,28 +1912,11 @@ function BrandsController(ctx, log, env) {
       // baseUrl is read-only (resolved from baseSiteId) — strip from updates.
       delete updates.baseUrl;
 
-      // pendingSemrushProvisioning is the deferred-provisioning staging blob for
-      // a *pending* (draft) brand. The draft UI mutates it via PATCH — the
-      // Markets tab appends a market / edits a market's LLMs before activation.
-      // Permit that ONLY while the brand is (and stays) pending: an active brand
-      // keeps its markets on the Semrush side, so a PATCH must never inject a
-      // primaryUrl/markets onto a live brand that activation would later trust.
-      // When the target isn't pending (or the same PATCH is flipping it to
-      // active — activation is the serenity endpoint's job, not PATCH's), strip
-      // it. Only pay for the status read when the field is actually present.
-      if (updates.pendingSemrushProvisioning !== undefined) {
-        const { data: currentBrand } = await postgrestClient
-          .from('brands')
-          .select('status')
-          .eq('organization_id', spaceCatId)
-          .eq('id', brandUuid)
-          .maybeSingle();
-        const isPending = currentBrand?.status === 'pending'
-          && (updates.status === undefined || updates.status === 'pending');
-        if (!isPending) {
-          delete updates.pendingSemrushProvisioning;
-        }
-      }
+      // pendingSemrushProvisioning was the deferred-provisioning staging blob for a
+      // *pending* (draft) brand, mutated by the draft Markets-tab UI via PATCH. That
+      // UI is gone and the blob is being retired (SITES-49448): never accept a
+      // client-supplied value, so no PATCH can (re)populate the column on any brand.
+      delete updates.pendingSemrushProvisioning;
 
       // Capture the competitor list BEFORE the update so the Semrush re-sync can
       // compute which competitors were removed (old − new) — the only ones it

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -2461,6 +2461,13 @@ function BrandsController(ctx, log, env) {
       // usually baseUrl); a pending brand resolves from its stashed Semrush primary URL.
       // We deliberately do NOT fall back to urls[] — that's the brand's listed URLs,
       // not a declared activation anchor, so guessing one would be wrong.
+      //
+      // SITES-49448: pendingSemrushProvisioning is no longer written at create, so this
+      // stash-primaryUrl fallback now serves ONLY legacy pending rows during drain. A new
+      // pending brand anchors via baseSiteId (the caller's site selection) or activates
+      // through /serenity/activate (sub-workspace-anchored, needs no site) — neither path
+      // reaches this branch. The fallback is removed with the read-path cleanup once no
+      // live row carries a non-empty blob.
       let { baseSiteId, baseUrl } = brand;
       if (!hasText(baseSiteId)) {
         const primaryUrl = brand.pendingSemrushProvisioning?.primaryUrl;

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -5620,7 +5620,7 @@ describe('Brands Controller', () => {
         expect(upsertStub.firstCall.args[0].semrushSubWorkspaceId).to.equal(null);
       });
 
-      it('saves a pending draft WITHOUT a primary URL: no provisioning, market stashed (201)', async () => {
+      it('saves a pending draft: defers provisioning, writes no stash, no anchor (201)', async () => {
         const provisionStub = sinon.stub().resolves({ semrushSubWorkspaceId: 'ws-1' });
         const upsertStub = sinon.stub().resolves({ id: 'draft-id', name: 'New Brand', status: 'pending' });
         const controller = await buildController({
@@ -5645,109 +5645,12 @@ describe('Brands Controller', () => {
         expect(response.status).to.equal(201);
         // Provisioning is deferred for a draft.
         expect(provisionStub.called).to.equal(false);
-        // The market is stashed for activation; no primary URL yet.
+        // SITES-49448: a pending draft no longer stashes a deferred-provisioning blob.
         const upsertArgs = upsertStub.firstCall.args[0];
-        expect(upsertArgs.brand.pendingSemrushProvisioning).to.deep.equal({
-          primaryUrl: null,
-          markets: [{ market: 'us', languageCode: 'en' }],
-          generatePrompts: false,
-        });
+        expect(upsertArgs.brand.pendingSemrushProvisioning).to.equal(undefined);
         // A draft is never bound to a workspace at create time.
         expect(upsertArgs.semrushSubWorkspaceId).to.equal(null);
         expect(upsertArgs.forceBrandId).to.equal(null);
-      });
-
-      it('stashes the primary URL on a pending draft when one was entered (still no provisioning)', async () => {
-        const provisionStub = sinon.stub().resolves({ semrushSubWorkspaceId: 'ws-1' });
-        const upsertStub = sinon.stub().resolves({ id: 'draft-id', name: 'New Brand', status: 'pending' });
-        const controller = await buildController({
-          provisionBrandSubworkspace: provisionStub, upsertBrand: upsertStub,
-        });
-
-        const response = await controller.createBrandForOrg({
-          ...context,
-          params: { spaceCatId: ORGANIZATION_ID },
-          data: {
-            name: 'New Brand',
-            status: 'pending',
-            urls: [{ value: 'https://acme.com/path' }],
-            semrushMarket: { market: 'us', languageCode: 'en' },
-          },
-          dataAccess: mockDataAccess,
-          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
-        });
-
-        expect(response.status).to.equal(201);
-        expect(provisionStub.called).to.equal(false);
-        expect(upsertStub.firstCall.args[0].brand.pendingSemrushProvisioning).to.deep.equal({
-          primaryUrl: 'https://acme.com/path',
-          markets: [{ market: 'us', languageCode: 'en' }],
-          generatePrompts: false,
-        });
-      });
-
-      it('stashes the primary URL from a bare STRING url entry on a pending draft', async () => {
-        // The wizard may send `urls` as plain strings rather than { value }
-        // objects; the pending primaryUrl resolution must accept either shape.
-        const provisionStub = sinon.stub().resolves({ semrushSubWorkspaceId: 'ws-1' });
-        const upsertStub = sinon.stub().resolves({ id: 'draft-id', name: 'New Brand', status: 'pending' });
-        const controller = await buildController({
-          provisionBrandSubworkspace: provisionStub, upsertBrand: upsertStub,
-        });
-
-        const response = await controller.createBrandForOrg({
-          ...context,
-          params: { spaceCatId: ORGANIZATION_ID },
-          data: {
-            name: 'New Brand',
-            status: 'pending',
-            // Plain strings, not { value } objects.
-            urls: ['https://acme.com/path'],
-            semrushMarket: { market: 'us', languageCode: 'en' },
-          },
-          dataAccess: mockDataAccess,
-          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
-        });
-
-        expect(response.status).to.equal(201);
-        expect(provisionStub.called).to.equal(false);
-        expect(upsertStub.firstCall.args[0].brand.pendingSemrushProvisioning).to.deep.equal({
-          primaryUrl: 'https://acme.com/path',
-          markets: [{ market: 'us', languageCode: 'en' }],
-          generatePrompts: false,
-        });
-      });
-
-      it('seeds the initial market modelIds from semrushModelIds on a pending draft (no provisioning)', async () => {
-        const provisionStub = sinon.stub().resolves({ semrushSubWorkspaceId: 'ws-1' });
-        const upsertStub = sinon.stub().resolves({ id: 'draft-id', name: 'New Brand', status: 'pending' });
-        const controller = await buildController({
-          provisionBrandSubworkspace: provisionStub, upsertBrand: upsertStub,
-        });
-
-        const response = await controller.createBrandForOrg({
-          ...context,
-          params: { spaceCatId: ORGANIZATION_ID },
-          data: {
-            name: 'New Brand',
-            status: 'pending',
-            urls: [{ value: 'https://acme.com' }],
-            semrushMarket: { market: 'us', languageCode: 'en' },
-            // The wizard's model picks: unlike the direct path they are optional
-            // for a draft, but when present they seed the initial market.
-            semrushModelIds: ['chatgpt', 'perplexity'],
-          },
-          dataAccess: mockDataAccess,
-          attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
-        });
-
-        expect(response.status).to.equal(201);
-        expect(provisionStub.called).to.equal(false);
-        expect(upsertStub.firstCall.args[0].brand.pendingSemrushProvisioning).to.deep.equal({
-          primaryUrl: 'https://acme.com',
-          markets: [{ market: 'us', languageCode: 'en', modelIds: ['chatgpt', 'perplexity'] }],
-          generatePrompts: false,
-        });
       });
 
       it('still requires market and languageCode even for a pending draft', async () => {
@@ -6079,10 +5982,10 @@ describe('Brands Controller', () => {
         expect(upsertStub.called).to.equal(false);
       });
 
-      it('stashes deferred provisioning for a PENDING serenity-active create (generatePrompts:false, no market)', async () => {
+      it('does not stash for a PENDING serenity-active create (generatePrompts:false, no market)', async () => {
         // In a serenity-active org a pending create is a Semrush create (the org flag
-        // decides mode, not the generatePrompts flag): it provisions nothing yet and
-        // stashes the deferred-provisioning blob for activation.
+        // decides mode, not the generatePrompts flag): it provisions nothing yet.
+        // SITES-49448: it no longer stashes a deferred-provisioning blob either.
         const upsertStub = sinon.stub().resolves({ id: 'draft-id', name: 'Draft', status: 'pending' });
         const provisionStub = sinon.stub().resolves({ semrushSubWorkspaceId: 'ws-x' });
         const controller = await buildCreateController({
@@ -6104,12 +6007,8 @@ describe('Brands Controller', () => {
 
         expect(response.status).to.equal(201);
         expect(provisionStub.called).to.equal(false);
-        // Treated as Semrush mode → deferred-provisioning stash written.
-        expect(upsertStub.firstCall.firstArg.brand.pendingSemrushProvisioning).to.deep.equal({
-          primaryUrl: null,
-          markets: [],
-          generatePrompts: false,
-        });
+        // Treated as Semrush mode, but SITES-49448: no deferred-provisioning stash.
+        expect(upsertStub.firstCall.firstArg.brand.pendingSemrushProvisioning).to.equal(undefined);
       });
     });
   });
@@ -6460,8 +6359,8 @@ describe('Brands Controller', () => {
     });
 
     it('strips pendingSemrushProvisioning from a PATCH when the brand is NOT pending (no runtime injection)', async () => {
-      // The describe-level postgrest mock resolves the brand with status:'active',
-      // so the pending-only guard strips the stash an attacker tried to inject.
+      // SITES-49448: the field is retired and never accepted from a client, so a
+      // stash an attacker tried to inject is stripped regardless of brand status.
       const updateBrandStub = sinon.stub()
         .resolves({ id: BRAND_UUID, semrushSubWorkspaceId: null });
       const controller = await buildUpdateController({
@@ -6492,9 +6391,10 @@ describe('Brands Controller', () => {
       expect(updates).to.not.have.property('pendingSemrushProvisioning');
     });
 
-    it('keeps pendingSemrushProvisioning on a PATCH when the brand IS pending (draft Markets-tab edit)', async () => {
-      // The draft Markets tab appends a market (with its LLMs) by PATCHing the
-      // stash; the pending-only guard must let it through for a pending brand.
+    it('strips pendingSemrushProvisioning on a PATCH even when the brand IS pending (SITES-49448: field retired)', async () => {
+      // The draft Markets-tab edit flow that mutated the stash is gone (elmo) and
+      // the blob is being retired, so a client-supplied value is stripped for a
+      // pending brand too — no PATCH can (re)populate the column on any brand.
       mockDataAccess.services.postgrestClient.from = sandbox.stub().callsFake(() => ({
         select: sandbox.stub().returnsThis(),
         eq: sandbox.stub().returnsThis(),
@@ -6524,7 +6424,7 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(200);
       expect(updateBrandStub).to.have.been.calledOnce;
       const { updates } = updateBrandStub.firstCall.args[0];
-      expect(updates.pendingSemrushProvisioning).to.deep.equal(stash);
+      expect(updates).to.not.have.property('pendingSemrushProvisioning');
     });
 
     it('strips pendingSemrushProvisioning when a PATCH would flip a pending brand to active', async () => {


### PR DESCRIPTION
## SITES-49448 — step 1 of a sequenced removal

Retires the `brands.pending_semrush_provisioning` "Save as pending" staging blob, starting with the two api-service write paths.

### Why this is safe now
- **No activation path uses it.** `pending → active` is sub-workspace-only (LLMO-6405) and *ignores* the stashed `primaryUrl`/`markets`; it only reads-then-clears the blob.
- **elmo is already clean.** The draft Markets-tab UI that read/mutated the blob (`PendingMarketsView` / `PendingEditModelsDialog`) is gone from `project-elmo-ui` main — no reference to `pendingSemrushProvisioning` anywhere in its source. api-service *constructs* the blob internally from normal create fields; elmo never POSTs or reads it.
- **Prod is effectively drained.** Live check (2026-08-07): 48 rows carry the blob (10 pending / 14 active / 24 deleted); no row outside `deleted` has a non-empty `markets` array — the survivors are a `{primaryUrl, generatePrompts, markets: []}` shell.

### What this PR changes (api-service only)
- `createBrandForOrg` no longer stashes the blob for a pending draft — it was the last create-time writer. The draft is still saved with no anchor (lands `pending`), exactly as before.
- `updateBrandForOrg` now strips a client-supplied `pendingSemrushProvisioning` **unconditionally** (was pending-only), so no PATCH can (re)populate the column on any brand.

### Deliberately backward-compatible
The activate **read/clear**, the DTO field, and the spacecat-shared attribute are left in place, so the ~24 legacy prod rows drain to `null` as they activate. Nothing here depends on merge ordering with other repos.

### Follow-ups (tracked, not in this PR)
1. api-service: remove the activate read + DTO field once prod shows no live row carries a non-empty blob.
2. spacecat-shared: drop the `pendingSemrushProvisioning` attribute (after #1).
3. mysticat-data-service: drop the `pending_semrush_provisioning` column + CHECK (last).

### Testing
- `brands.test.js` — create/update assertions flipped to the no-stash behavior; dropped 3 tests that only exercised deleted stash-construction internals (primaryURL resolution, modelIds seeding). 431 pass.
- `serenity.test.js` (438) + `brands-storage.test.js` — unchanged read/storage paths still green.
- `type-check` (base + strict) and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)