### PR TITLE
fix(plg): auto-correct OTHER delivery type instead of alerting on mis…

### DIFF
--- a/src/controllers/plg/plg-onboarding/onboarding-flow.js
+++ b/src/controllers/plg/plg-onboarding/onboarding-flow.js
@@ -750,22 +750,29 @@ export async function performAsoPlgOnboarding({
         && detectedDeliveryType !== SiteModel.DELIVERY_TYPES.OTHER
         && detectedDeliveryType !== currentDeliveryType
       ) {
-        log.warn(`Delivery type mismatch for site ${site.getId()} (${baseURL}): stored=${currentDeliveryType} detected=${detectedDeliveryType}`);
-        const channelId = env.SLACK_PLG_ONBOARDING_CHANNEL_ID;
-        const token = env.SLACK_BOT_TOKEN;
-        /* c8 ignore next */
-        if (channelId && token) {
-          const message = ':warning: *PLG Onboarding — Delivery Type Mismatch*\n\n'
-            + `• *Site ID:* \`${site.getId()}\`\n`
-            + `• *Domain:* \`${baseURL}\`\n`
-            + `• *Org ID:* \`${organizationId}\`\n`
-            + `• *Org:* ${organization.getName()} (\`${imsOrgId}\`)\n`
-            + `• *Stored delivery type:* \`${currentDeliveryType}\`\n`
-            + `• *Detected delivery type:* \`${detectedDeliveryType}\``;
-          try {
-            await context.postSlackMessage(channelId, message, token);
-          } catch (err) {
-            log.error(`Failed to post delivery type mismatch alert: ${err.message}`);
+        if (currentDeliveryType === SiteModel.DELIVERY_TYPES.OTHER) {
+          // Stored type was a placeholder ("other") and detection found a confident
+          // signal — safe to auto-correct without a human review step.
+          log.info(`Auto-correcting delivery type for site ${site.getId()} (${baseURL}): stored=${currentDeliveryType} detected=${detectedDeliveryType}`);
+          site.setDeliveryType(detectedDeliveryType);
+        } else {
+          log.warn(`Delivery type mismatch for site ${site.getId()} (${baseURL}): stored=${currentDeliveryType} detected=${detectedDeliveryType}`);
+          const channelId = env.SLACK_PLG_ONBOARDING_CHANNEL_ID;
+          const token = env.SLACK_BOT_TOKEN;
+          /* c8 ignore next */
+          if (channelId && token) {
+            const message = ':warning: *PLG Onboarding — Delivery Type Mismatch*\n\n'
+              + `• *Site ID:* \`${site.getId()}\`\n`
+              + `• *Domain:* \`${baseURL}\`\n`
+              + `• *Org ID:* \`${organizationId}\`\n`
+              + `• *Org:* ${organization.getName()} (\`${imsOrgId}\`)\n`
+              + `• *Stored delivery type:* \`${currentDeliveryType}\`\n`
+              + `• *Detected delivery type:* \`${detectedDeliveryType}\``;
+            try {
+              await context.postSlackMessage(channelId, message, token);
+            } catch (err) {
+              log.error(`Failed to post delivery type mismatch alert: ${err.message}`);
+            }
           }
         }
       }

--- a/test/controllers/plg/plg-onboarding/site-setup.test.js
+++ b/test/controllers/plg/plg-onboarding/site-setup.test.js
@@ -532,6 +532,67 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
       });
     });
 
+    it('auto-corrects stored OTHER delivery type without alerting when detected is non-AMS', async () => {
+      const postSlackMessageStub = sandbox.stub().resolves();
+      const AutoCorrectControllerFactory = await createPlgEsmock(stubs, {
+        hasAdminAccess: false,
+        postSlackMessageStub,
+      });
+
+      rumRetrieveDomainkeyStub.rejects(new Error('No RUM data'));
+      findDeliveryTypeStub.resetHistory();
+      findDeliveryTypeStub.resolves('aem_edge');
+      const existingSite = createMockSite({ deliveryType: 'other', orgId: TEST_ORG_ID });
+      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
+
+      const autoCorrectController = AutoCorrectControllerFactory({ log: mockLog });
+      const context = buildContext({ domain: TEST_DOMAIN });
+      context.env = {
+        ...context.env,
+        SLACK_PLG_ONBOARDING_CHANNEL_ID: 'C_ALERT',
+        SLACK_BOT_TOKEN: 'xoxb-test',
+      };
+
+      const res = await autoCorrectController.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(mockOnboarding.setStatus).to.have.been.calledWith('ONBOARDED');
+      expect(existingSite.setDeliveryType).to.have.been.calledWith('aem_edge');
+      expect(mockLog.info).to.have.been.calledWithMatch(/Auto-correcting delivery type/);
+      expect(mockLog.warn).to.not.have.been.calledWithMatch(/Delivery type mismatch/);
+      expect(postSlackMessageStub).to.not.have.been.called;
+    });
+
+    it('auto-corrects stored OTHER delivery type without alerting when detected is AEM_AMS', async () => {
+      const postSlackMessageStub = sandbox.stub().resolves();
+      const AutoCorrectAmsControllerFactory = await createPlgEsmock(stubs, {
+        hasAdminAccess: false,
+        postSlackMessageStub,
+      });
+
+      rumRetrieveDomainkeyStub.rejects(new Error('No RUM data'));
+      findDeliveryTypeStub.resetHistory();
+      findDeliveryTypeStub.resolves('aem_ams');
+      const existingSite = createMockSite({ deliveryType: 'other', orgId: TEST_ORG_ID });
+      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
+
+      const autoCorrectController = AutoCorrectAmsControllerFactory({ log: mockLog });
+      const context = buildContext({ domain: TEST_DOMAIN });
+      context.env = {
+        ...context.env,
+        SLACK_PLG_ONBOARDING_CHANNEL_ID: 'C_ALERT',
+        SLACK_BOT_TOKEN: 'xoxb-test',
+      };
+
+      const res = await autoCorrectController.onboard(context);
+
+      expect(res.status).to.equal(200);
+      expect(existingSite.setDeliveryType).to.have.been.calledWith('aem_ams');
+      expect(mockLog.info).to.have.been.calledWithMatch(/Auto-correcting delivery type/);
+      expect(mockLog.warn).to.not.have.been.calledWithMatch(/Delivery type mismatch/);
+      expect(postSlackMessageStub).to.not.have.been.called;
+    });
+
     it('does not alert when detected delivery type matches existing', async () => {
       findDeliveryTypeStub.resetHistory();
       findDeliveryTypeStub.resolves('aem_edge');


### PR DESCRIPTION
## Summary
- During PLG onboarding, when a site's stored delivery type is a placeholder value (`other`) and a subsequent scan detects a real delivery type, the flow now auto-corrects the site's delivery type instead of just posting a Slack mismatch alert.
- The Slack "Delivery Type Mismatch" notification is now only sent when the *stored* delivery type is a confirmed, non-`other` value that disagrees with detection — i.e. a case that actually warrants human review.

## Why
Example real-world case (Hugo Boss AG, site `f5a28dcb-9e08-49a2-add3-92521f4c2825`, `hugoboss.com`):
- Stored delivery type: `other`
- Detected delivery type: `aem_ams`

`other` isn't a confirmed value — it's a placeholder set when we couldn't yet tell what the site was. Alerting on every "other → detected X" case was generating noise for something safe to auto-fix.

## Changes
- `src/controllers/plg/plg-onboarding/onboarding-flow.js`: in Step 5f (post-detection delivery-type comparison), when `currentDeliveryType === SiteModel.DELIVERY_TYPES.OTHER`, call `site.setDeliveryType(detectedDeliveryType)` directly and skip the Slack notification path. All other mismatches (stored is a real type but disagrees with detection) still alert as before.
- `test/controllers/plg/plg-onboarding/site-setup.test.js`: added coverage for auto-correction (non-AMS and AMS detected values) confirming `setDeliveryType` is called and no Slack message is sent, alongside existing mismatch-alert tests (unchanged, still passing).

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```