### PR TITLE
fix(suggestions): include skip reason/detail, org name, and ASO link 

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -162,11 +162,27 @@ async function postPlgSuggestionSkipAlert(site, opportunity, suggestion, context
     const suggestionId = suggestion.getId?.() ?? 'unknown';
     const skipReason = suggestion.getSkipReason?.() ?? null;
     const skipDetail = suggestion.getSkipDetail?.() ?? null;
+    const organizationId = site.getOrganizationId?.() ?? null;
+
+    let orgName = null;
+    if (organizationId) {
+      try {
+        const org = await context.dataAccess.Organization.findById(organizationId);
+        orgName = org?.getName?.() || null;
+      } catch (orgLookupError) {
+        log.warn(`Failed to look up org name for PLG suggestion skip alert: ${orgLookupError.message}`);
+      }
+    }
 
     let message = ':no_entry_sign: *PLG Customer Skipped a Suggestion*\n\n'
       + `• *Site:* \`${siteBaseURL}\`\n`
-      + `• *Site ID:* \`${site.getId()}\`\n`
-      + `• *Opportunity Type:* \`${opportunityType}\`\n`
+      + `• *Site ID:* \`${site.getId()}\``;
+
+    if (orgName) {
+      message += `\n• *IMS Org Name:* ${orgName}`;
+    }
+
+    message += `\n• *Opportunity Type:* \`${opportunityType}\`\n`
       + `• *Opportunity ID:* \`${opportunityId}\`\n`
       + `• *Suggestion ID:* \`${suggestionId}\``;
 
@@ -175,6 +191,12 @@ async function postPlgSuggestionSkipAlert(site, opportunity, suggestion, context
     }
     if (skipDetail) {
       message += `\n• *Skip Detail:* \`${skipDetail}\``;
+    }
+
+    if (organizationId) {
+      const experienceUrl = env.EXPERIENCE_URL || 'https://experience.adobe.com';
+      const asoUrl = `${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${site.getId()}`;
+      message += `\n• *ASO Link:* ${asoUrl}`;
     }
 
     await postSlackMessage(channelId, message, token);

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -57,6 +57,7 @@ describe('Suggestions Controller', () => {
   const SITE_ID = 'f964a7f8-5402-4b01-bd5b-1ab499bcf797';
   const SITE_ID_NOT_FOUND = '3c677e57-9a6a-441c-a556-262eb8b4fc0e';
   const SITE_ID_NOT_ENABLED = '07efc218-79f6-48b5-970e-deb0f88ce01b';
+  const ORGANIZATION_ID = '6d69b6c5-4c1f-4d6a-92ad-b2c1fdb4ff54';
 
   const mockSuggestionEntity = (suggData, removeStub) => ({
     getId() {
@@ -3330,6 +3331,86 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(200);
       expect(postSlackMessageStub).to.have.been.calledOnce;
       expect(postSlackMessageStub.firstCall.args[1]).to.include('Already handled elsewhere');
+    });
+
+    it('includes an ASO link in the PLG skip alert message when the site has an organization', async () => {
+      const postSlackMessageStub = sandbox.stub().resolves();
+      const ControllerWithSlack = await esmock.p('../../src/controllers/suggestions.js', {
+        '../../src/utils/slack/base.js': { postSlackMessage: postSlackMessageStub },
+      });
+
+      const plgSite = { ...makePlgSite('PLG'), getOrganizationId: sandbox.stub().returns(ORGANIZATION_ID) };
+      const organization = { getName: sandbox.stub().returns('Acme Corp') };
+      const da = {
+        ...mockSuggestionDataAccess,
+        Site: { findById: sandbox.stub().resolves(plgSite) },
+        Organization: { findById: sandbox.stub().resolves(organization) },
+      };
+      const ctrl = ControllerWithSlack({
+        dataAccess: da, pathInfo: { headers: {} }, ...authContext,
+      }, mockSqs, {
+      AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+      LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+    });
+
+      const response = await ctrl.patchSuggestion({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
+        data: { status: 'SKIPPED', skipReason: 'TOO_RISKY' },
+        env: {
+          SLACK_PLG_SKIP_CHANNEL_ID: 'C_SKIP',
+          SLACK_BOT_TOKEN: 'xoxb-token',
+          EXPERIENCE_URL: 'https://experience.adobe.com',
+        },
+        ...context,
+        dataAccess: da,
+      });
+      await new Promise(setImmediate);
+
+      expect(response.status).to.equal(200);
+      expect(postSlackMessageStub).to.have.been.calledOnce;
+      expect(da.Organization.findById).to.have.been.calledWith(ORGANIZATION_ID);
+      expect(postSlackMessageStub.firstCall.args[1]).to.include('*IMS Org Name:* Acme Corp');
+      expect(postSlackMessageStub.firstCall.args[1]).to.include(
+        `https://experience.adobe.com/?organizationId=${ORGANIZATION_ID}#/sites-optimizer/sites/${SITE_ID}`,
+      );
+    });
+
+    it('omits IMS Org Name in the PLG skip alert message when the org lookup fails', async () => {
+      const postSlackMessageStub = sandbox.stub().resolves();
+      const ControllerWithSlack = await esmock.p('../../src/controllers/suggestions.js', {
+        '../../src/utils/slack/base.js': { postSlackMessage: postSlackMessageStub },
+      });
+
+      const plgSite = { ...makePlgSite('PLG'), getOrganizationId: sandbox.stub().returns(ORGANIZATION_ID) };
+      const da = {
+        ...mockSuggestionDataAccess,
+        Site: { findById: sandbox.stub().resolves(plgSite) },
+        Organization: { findById: sandbox.stub().rejects(new Error('org lookup failed')) },
+      };
+      const ctrl = ControllerWithSlack({
+        dataAccess: da, pathInfo: { headers: {} }, ...authContext,
+      }, mockSqs, {
+      AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+      LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+    });
+
+      const response = await ctrl.patchSuggestion({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
+        data: { status: 'SKIPPED', skipReason: 'TOO_RISKY' },
+        env: {
+          SLACK_PLG_SKIP_CHANNEL_ID: 'C_SKIP',
+          SLACK_BOT_TOKEN: 'xoxb-token',
+          EXPERIENCE_URL: 'https://experience.adobe.com',
+        },
+        ...context,
+        dataAccess: da,
+      });
+      await new Promise(setImmediate);
+
+      expect(response.status).to.equal(200);
+      expect(postSlackMessageStub).to.have.been.calledOnce;
+      expect(postSlackMessageStub.firstCall.args[1]).to.not.include('IMS Org Name');
+      expect(postSlackMessageStub.firstCall.args[1]).to.include('ASO Link');
     });
 
     it('sends PLG skip Slack alert for each newly-SKIPPED suggestion via patchSuggestionsStatus', async () => {


### PR DESCRIPTION
## Summary
- Add the site's IMS org name (via `Organization.findById`, mirroring the pattern used in `plg-onboarding/notifications.js`), shown right after Site ID. Lookup failures are logged and the line is simply omitted, never fails the alert.
- Add a direct ASO deep link (`{EXPERIENCE_URL}/?organizationId=...#/sites-optimizer/sites/...`) to the alert, same URL pattern as the PLG onboarding notification.

<img width="1155" height="320" alt="image" src="https://github.com/user-attachments/assets/15503544-96ec-4436-99ef-f0d3bfdc00ae" />


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```