### PR TITLE
refactor(ai-visibility): extract shared prompt-response derivation helpers

### DIFF
--- a/src/support/ai-visibility/grpc-utils.js
+++ b/src/support/ai-visibility/grpc-utils.js
@@ -78,6 +78,77 @@ export function settledFulfilledMap(settled, mapFn, fallback) {
   return settled.status === 'fulfilled' ? mapFn(settled.value) : fallback;
 }
 
+/**
+ * Normalizes a relation `date` into an ISO `YYYY-MM-DD` string. The gRPC relation
+ * value carries `date` as a protobuf Date message (`{ year, month, day }`, plus a
+ * `$typeName` tag), not a scalar — emitting it verbatim leaks that struct to callers.
+ * Passes an already-formatted string through unchanged; returns `null` when the date
+ * is absent or incomplete.
+ *
+ * @param {object|string|null|undefined} d
+ * @returns {string|null}
+ */
+export function toIsoDate(d) {
+  if (!d) { return null; }
+  if (typeof d === 'string') { return d; }
+  const { year, month, day } = d;
+  if (!year || !month || !day) { return null; }
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${year}-${pad(month)}-${pad(day)}`;
+}
+
+/**
+ * Single identity predicate, reused by both the relation-call guard and
+ * `attempted[i]`, so the two cannot drift. `attempted[i]` records whether we
+ * actually issued the per-prompt relation call: without it a skipped prompt
+ * (missing identity → Promise.resolve(null)) is indistinguishable from a
+ * relation call that fulfilled with a null value, which hides why a row has no
+ * full response.
+ *
+ * @param {object} p prompt proto
+ * @returns {boolean}
+ */
+export function hasRelationIdentity(p) {
+  return Boolean(p.promptHash && String(p.serpId ?? '') && p.topicId);
+}
+
+/**
+ * Per-item relation status so callers (e.g. claims_extraction) can tell a real
+ * full response from a degraded one. `error` was previously swallowed silently.
+ *
+ * @param {{ attempted: boolean, settled: { status: 'fulfilled'|'rejected' } }} params
+ * @returns {'skipped'|'error'|'ok'}
+ */
+export function relationStatusFor({ attempted, settled }) {
+  if (!attempted) { return 'skipped'; }
+  if (settled.status === 'rejected') { return 'error'; }
+  return 'ok';
+}
+
+/**
+ * Response provenance. Preserves the exact legacy `response` value (nullish-coalesce
+ * chain) while exposing whether it came from the full relation response or the
+ * brief excerpt. LLMO-6585: claims must never be extracted from an excerpt that is
+ * mistaken for the full answer, so the excerpt fallback is now explicit, not silent.
+ *
+ * @param {object|null|undefined} rel relation value (`relations[i]`), may be null
+ * @param {string|null|undefined} briefResponse the prompt's brief excerpt
+ * @returns {{ response: string, responseSource: 'full'|'excerpt'|'none', responseComplete: boolean }}
+ */
+export function deriveResponse(rel, briefResponse) {
+  const relResponse = rel?.response;
+  const excerpt = briefResponse ?? '';
+  const usedFullResponse = relResponse != null; // relation supplied a `response` field
+  const response = usedFullResponse ? relResponse : excerpt;
+  let responseSource;
+  if (usedFullResponse) { responseSource = 'full'; } else if (excerpt !== '') { responseSource = 'excerpt'; } else { responseSource = 'none'; }
+  return {
+    response,
+    responseSource,
+    responseComplete: responseSource === 'full' && response.length > 0,
+  };
+}
+
 export const GAP_SOURCE_DOMAINS_MAX_RANGE_LIMIT = 100;
 /** Max topicIds query values combined into Semrush dimensionFilterQl (injection-safe numeric ids only). */
 export const MAX_TOPIC_IDS_DIMENSION_FILTER = 50;

--- a/src/support/ai-visibility/handlers/prompts.js
+++ b/src/support/ai-visibility/handlers/prompts.js
@@ -16,27 +16,9 @@ import { PROMPTS_REQUEST_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/prompt/enums
 import {
   num, brandTarget, parseLimitOffset, resolveCountryForFts, requiredLlmFromQuery,
   llmToEngine, promptMatchesResponsesQuery, mentionedBrandRestLabel,
-  PROMPTS_RESPONSES_PROMPTS_SCAN_LIMIT,
+  PROMPTS_RESPONSES_PROMPTS_SCAN_LIMIT, toIsoDate, hasRelationIdentity,
+  relationStatusFor, deriveResponse,
 } from '../grpc-utils.js';
-
-/**
- * Normalizes a relation `date` into an ISO `YYYY-MM-DD` string. The gRPC relation
- * value carries `date` as a protobuf Date message (`{ year, month, day }`, plus a
- * `$typeName` tag), not a scalar — emitting it verbatim leaks that struct to callers.
- * Passes an already-formatted string through unchanged; returns `null` when the date
- * is absent or incomplete.
- *
- * @param {object|string|null|undefined} d
- * @returns {string|null}
- */
-function toIsoDate(d) {
-  if (!d) { return null; }
-  if (typeof d === 'string') { return d; }
-  const { year, month, day } = d;
-  if (!year || !month || !day) { return null; }
-  const pad = (n) => String(n).padStart(2, '0');
-  return `${year}-${pad(month)}-${pad(day)}`;
-}
 
 export async function handlePromptsResponses(sp, clients) {
   const domain = sp.get('domain')?.trim();
@@ -64,7 +46,6 @@ export async function handlePromptsResponses(sp, clients) {
   // (missing identity → Promise.resolve(null)) is indistinguishable from a
   // relation call that fulfilled with a null value, which hides why a row has no
   // full response.
-  const hasRelationIdentity = (p) => Boolean(p.promptHash && String(p.serpId ?? '') && p.topicId);
   const attempted = page.map(hasRelationIdentity);
   const settled = await Promise.allSettled(
     page.map((p) => {
@@ -81,18 +62,12 @@ export async function handlePromptsResponses(sp, clients) {
     const rel = relations[i]?.value ?? null;
     // Per-item relation status so callers (e.g. claims_extraction) can tell a real
     // full response from a degraded one. `error` was previously swallowed silently.
-    let relationStatus;
-    if (!attempted[i]) { relationStatus = 'skipped'; } else if (settled[i].status === 'rejected') { relationStatus = 'error'; } else { relationStatus = 'ok'; }
+    const relationStatus = relationStatusFor({ attempted: attempted[i], settled: settled[i] });
     // Response provenance. Preserves the exact legacy `response` value (nullish-coalesce
     // chain) while exposing whether it came from the full relation response or the
     // brief excerpt. LLMO-6585: claims must never be extracted from an excerpt that is
     // mistaken for the full answer, so the excerpt fallback is now explicit, not silent.
-    const relResponse = rel?.response;
-    const excerpt = p.briefResponse ?? '';
-    const usedFullResponse = relResponse != null; // relation supplied a `response` field
-    const response = usedFullResponse ? relResponse : excerpt;
-    let responseSource;
-    if (usedFullResponse) { responseSource = 'full'; } else if (excerpt !== '') { responseSource = 'excerpt'; } else { responseSource = 'none'; }
+    const { response, responseSource, responseComplete } = deriveResponse(rel, p.briefResponse);
     return {
       prompt: p.prompt,
       promptHash: String(p.promptHash ?? ''),
@@ -103,7 +78,7 @@ export async function handlePromptsResponses(sp, clients) {
       response,
       responseExcerpt: p.briefResponse ?? '',
       responseSource,
-      responseComplete: responseSource === 'full' && response.length > 0,
+      responseComplete,
       relationStatus,
       date: toIsoDate(rel?.date),
       citedPages: Array.isArray(rel?.sources) ? rel.sources : [],

--- a/test/support/ai-visibility/grpc-utils.test.js
+++ b/test/support/ai-visibility/grpc-utils.test.js
@@ -68,6 +68,10 @@ import {
   settledValueOrElse,
   settledFulfilledMap,
   buildTextFilterQl,
+  toIsoDate,
+  hasRelationIdentity,
+  relationStatusFor,
+  deriveResponse,
 } from '../../../src/support/ai-visibility/grpc-utils.js';
 
 function sp(query) {
@@ -106,6 +110,122 @@ describe('grpc-utils', () => {
     });
     it('settledFulfilledMap returns fallback when rejected', () => {
       expect(settledFulfilledMap({ status: 'rejected', reason: new Error('x') }, () => 1, null)).to.equal(null);
+    });
+  });
+
+  describe('toIsoDate', () => {
+    it('formats a protobuf Date struct into YYYY-MM-DD', () => {
+      expect(toIsoDate({
+        $typeName: 'semrush...Date', year: 2026, month: 7, day: 3,
+      })).to.equal('2026-07-03');
+    });
+
+    it('pads single-digit month and day', () => {
+      expect(toIsoDate({ year: 2024, month: 1, day: 9 })).to.equal('2024-01-09');
+    });
+
+    it('passes an already-formatted string through unchanged', () => {
+      expect(toIsoDate('2026-08-01')).to.equal('2026-08-01');
+    });
+
+    it('returns null for null', () => {
+      expect(toIsoDate(null)).to.be.null;
+    });
+
+    it('returns null for undefined', () => {
+      expect(toIsoDate(undefined)).to.be.null;
+    });
+
+    it('returns null when year/month/day is partial', () => {
+      expect(toIsoDate({ year: 2024, month: 6 })).to.be.null;
+      expect(toIsoDate({ year: 2024, day: 6 })).to.be.null;
+      expect(toIsoDate({ month: 6, day: 6 })).to.be.null;
+    });
+  });
+
+  describe('hasRelationIdentity', () => {
+    it('returns true when promptHash, serpId, and topicId are all present', () => {
+      expect(hasRelationIdentity({ promptHash: 'h', serpId: 's', topicId: 't' })).to.be.true;
+    });
+
+    it('returns true when serpId is numeric 0 (string-coerced, non-empty)', () => {
+      expect(hasRelationIdentity({ promptHash: 'h', serpId: 0, topicId: 't' })).to.be.true;
+    });
+
+    it('returns false when promptHash is missing', () => {
+      expect(hasRelationIdentity({ serpId: 's', topicId: 't' })).to.be.false;
+    });
+
+    it('returns false when topicId is missing', () => {
+      expect(hasRelationIdentity({ promptHash: 'h', serpId: 's' })).to.be.false;
+    });
+
+    it('returns false when serpId is missing/undefined', () => {
+      expect(hasRelationIdentity({ promptHash: 'h', topicId: 't' })).to.be.false;
+    });
+
+    it('returns false when serpId is empty string', () => {
+      expect(hasRelationIdentity({ promptHash: 'h', serpId: '', topicId: 't' })).to.be.false;
+    });
+  });
+
+  describe('relationStatusFor', () => {
+    it('returns skipped when not attempted', () => {
+      expect(relationStatusFor({ attempted: false, settled: { status: 'fulfilled' } })).to.equal('skipped');
+    });
+
+    it('returns error when attempted and settled rejected', () => {
+      expect(relationStatusFor({ attempted: true, settled: { status: 'rejected' } })).to.equal('error');
+    });
+
+    it('returns ok when attempted and settled fulfilled', () => {
+      expect(relationStatusFor({ attempted: true, settled: { status: 'fulfilled' } })).to.equal('ok');
+    });
+  });
+
+  describe('deriveResponse', () => {
+    it('uses the full relation response when present', () => {
+      const result = deriveResponse({ response: 'Full answer' }, 'excerpt');
+      expect(result).to.deep.equal({
+        response: 'Full answer',
+        responseSource: 'full',
+        responseComplete: true,
+      });
+    });
+
+    it('falls back to the excerpt when the relation is null', () => {
+      const result = deriveResponse(null, 'brief text');
+      expect(result).to.deep.equal({
+        response: 'brief text',
+        responseSource: 'excerpt',
+        responseComplete: false,
+      });
+    });
+
+    it('falls back to the excerpt when rel.response is null', () => {
+      const result = deriveResponse({ response: null }, 'brief text');
+      expect(result).to.deep.equal({
+        response: 'brief text',
+        responseSource: 'excerpt',
+        responseComplete: false,
+      });
+    });
+
+    it('reports responseSource=none when neither a full response nor an excerpt exists', () => {
+      const result = deriveResponse(null, undefined);
+      expect(result).to.deep.equal({
+        response: '',
+        responseSource: 'none',
+        responseComplete: false,
+      });
+    });
+
+    it('reports responseComplete=false when the full response is an empty string', () => {
+      const result = deriveResponse({ response: '' }, 'excerpt');
+      // relResponse === '' is != null, so it still counts as "full", just incomplete
+      expect(result.responseSource).to.equal('full');
+      expect(result.response).to.equal('');
+      expect(result.responseComplete).to.equal(false);
     });
   });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Extracts the per-row prompt-response derivation logic out of `handlePromptsResponses` into four reusable helpers in `src/support/ai-visibility/grpc-utils.js`. Pure refactor — no API or response-shape change.

## 2. Reasoning
The Brand Claims × Semrush ingestion feed (LLMO-6585) adds two new AI Visibility endpoints — a batch hydration `POST` and a whole-brand traversal `GET` — that must derive `response` / `responseSource` / `responseComplete` / `relationStatus` / ISO `date` from a gRPC relation exactly the way the existing `prompts/responses` endpoint does (shipped in #3053). Rather than copy that logic a third time across the new handlers, this PR lifts it into shared, individually-tested helpers first, so the feed PRs consume one canonical implementation. Spec: mysticat-architecture#248.

## 3. High-level overview of the changes
Behaviour is unchanged; this is a move, not a rewrite. Four helpers are extracted verbatim from `handlePromptsResponses` and re-exported from `grpc-utils.js`:

- `toIsoDate(d)` — normalize a protobuf `Date` message (`{year, month, day}`) to ISO `YYYY-MM-DD`, pass a formatted string through, return `null` when incomplete. Prevents leaking the raw protobuf struct to callers (the leak #3053 fixed).
- `hasRelationIdentity(p)` — the single `{promptHash, serpId, topicId}` identity predicate, now the one source of truth for both the relation-call guard and the `attempted[]` flags so the two cannot drift.
- `relationStatusFor({attempted, settled})` — returns `skipped | error | ok`.
- `deriveResponse(rel, briefResponse)` — returns `response` plus `responseSource` (`full | excerpt | none`) and `responseComplete`, preserving the exact legacy nullish-coalesce chain and the `!= null` / `!== ''` checks.

`handlePromptsResponses` and `handlePromptsResponsesLatest` now call the helpers instead of holding the logic inline. No endpoint, request, or response shape changes; the wire output is identical.

## 4. Required information
- Jira / issue: [LLMO-6585](https://jira.corp.adobe.com/browse/LLMO-6585)
- Spec: adobe/mysticat-architecture#248 (`products/llmo/spec-brand-claims-semrush-ingestion-feed.md`, status: proposed)

## 7. Test plan
(a) Local, beyond unit tests: ran `npx mocha` on the prompts handler suite and the grpc-utils suite in the worktree. The prompts handler suite passes byte-for-byte unchanged (same assertions and expected values for `responseSource`, `responseComplete`, `relationStatus`, `date`, and the excerpt-fallback edge cases), confirming the extraction is behaviour-preserving. New unit tests exercise every branch of each of the four helpers (full/excerpt/none, ok/error/skipped, empty-string-full-response edge, incomplete/absent date). Two pre-existing unrelated failures (`normalizeCountryForGrpc` / `restCountryFromGrpcRequestCountry` on `COUNTRY_ENUM.NZ`) were confirmed present on unmodified `main` and are not touched by this change.

(b) Per environment: no behavioural change to verify — this is an internal refactor with identical wire output. Standard CI on the PR covers it; the existing `GET /llmo/ai-visibility/prompts/responses` and `.../responses/latest` responses are unchanged on any environment.

## 8. Deployment & merge order
- adobe/mysticat-architecture#248 — related (the spec this refactor is groundwork for); docs-only, no deploy coupling.
- Upcoming feed endpoint PRs (batch, whole-brand) — this PR blocks them; they will import these helpers. Merge this first, then the feed PRs stack on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
