### PR TITLE
feat(ai-visibility): flag-gated per-brand Semrush auth seam skeleton (inert)

### DIFF
--- a/src/support/ai-visibility/grpc-transport.js
+++ b/src/support/ai-visibility/grpc-transport.js
@@ -23,6 +23,10 @@ import {
 } from '@quazar/ai-seo-ts/ai-cr/service_pb.js';
 import { Sources as VoSources } from '@quazar/ai-seo-ts/ai-vo/service_pb.js';
 import { Relations } from '@quazar/ai-seo-ts/ai-pr/service_pb.js';
+import {
+  resolveSemrushCredential,
+  getCachedToken,
+} from './semrush-credential-resolver.js';
 
 const DEFAULT_SCOPES = 'ai-seo.meta ai-seo.topics ai-seo.prompts ai-seo.sources ai-seo.brand-metrics ai-seo.relations ai-seo.competitors-metrics ai-seo.competitor';
 
@@ -75,24 +79,49 @@ function createAuthInterceptor(env) {
   };
 }
 
-let cachedClients = null;
+/**
+ * Feature flag: resolve the Semrush credential per brand instead of using the single
+ * process-wide shared client_credentials machine credential. DEFAULT OFF -- when off,
+ * behavior is byte-identical to the historical shared-singleton path.
+ */
+const PER_BRAND_AUTH_FLAG = 'AI_VISIBILITY_PER_BRAND_AUTH_ENABLED';
+
+function isPerBrandAuthEnabled(env) {
+  const v = env?.[PER_BRAND_AUTH_FLAG];
+  return v === true || v === 'true' || v === '1';
+}
 
 /**
- * Lazy-init gRPC transport + all service clients.
- * Reuses a singleton per process so multiple requests share the same HTTP/2 connection pool.
+ * Cache key for the shared (resolver-returned-null) credential under flag-on.
+ * Resolved credential keys are namespaced ({@link credentialPoolKey}) so a
+ * provider-supplied key can never collide with this sentinel.
  */
-export function getGrpcClients(env) {
-  if (cachedClients) {
-    return cachedClients;
-  }
+const SHARED_CREDENTIAL_KEY = '__shared__';
 
+/** Namespace a resolved credential key so it can't collide with the shared sentinel. */
+function credentialPoolKey(credentialKey) {
+  return `credential:${credentialKey}`;
+}
+
+/** Default upper bound on distinct per-credential transports held at once. */
+const DEFAULT_MAX_CLIENTS_CACHE_SIZE = 100;
+
+/** Mutable so tests can exercise eviction without building 100 transports. */
+let maxClientsCacheSize = DEFAULT_MAX_CLIENTS_CACHE_SIZE;
+
+/**
+ * Build the gRPC transport + all service clients around a single auth interceptor.
+ * The transport options are identical across the shared and per-credential paths;
+ * only the interceptor differs.
+ */
+function buildClients(interceptor) {
   const transport = createGrpcTransport({
     baseUrl: GRPC_BASE_URL,
     httpVersion: '2',
-    interceptors: [createAuthInterceptor(env)],
+    interceptors: [interceptor],
   });
 
-  cachedClients = {
+  return {
     brandClient: createClient(BrandService, transport),
     topicClient: createClient(TopicService, transport),
     promptClient: createClient(PromptService, transport),
@@ -103,13 +132,89 @@ export function getGrpcClients(env) {
     voSourcesClient: createClient(VoSources, transport),
     prRelationsClient: createClient(Relations, transport),
   };
+}
 
-  return cachedClients;
+/**
+ * Auth interceptor for the per-credential path. When a credential descriptor is
+ * resolved, tokens are minted through its `getAuthToken` and cached per credential
+ * key with a TTL. When no credential is resolved (`credential == null`) it falls back
+ * to the shared client_credentials token -- identical to {@link createAuthInterceptor}.
+ */
+function createCredentialInterceptor(env, credential) {
+  return (next) => async (req) => {
+    const token = credential
+      ? await getCachedToken(credential.key, () => credential.getAuthToken(env))
+      : await getAccessToken(env);
+    req.header.set('authorization', `Bearer ${token}`);
+    return next(req);
+  };
+}
+
+let cachedClients = null;
+
+/** key -> clients, used only on the per-brand (flag-on) path. */
+const perCredentialClients = new Map();
+
+/**
+ * Lazy-init gRPC transport + all service clients.
+ *
+ * Flag OFF (default): reuses a singleton per process so multiple requests share the
+ * same HTTP/2 connection pool, authenticating with the shared client_credentials
+ * machine credential via {@link createAuthInterceptor}.
+ *
+ * Flag ON: resolves the credential for `brand` via the auth seam and keys a bounded
+ * pool of transports per credential. Because no provider is configured by default,
+ * the resolver returns `null` and this still falls back to the shared credential --
+ * i.e. flag-on is inert until PR-3b injects a real provider.
+ *
+ * @param {object} env - request environment (secrets, config, feature flags).
+ * @param {unknown} [brand] - brand/org scope (only consulted when the flag is on).
+ */
+export function getGrpcClients(env, brand) {
+  if (!isPerBrandAuthEnabled(env)) {
+    if (cachedClients) {
+      return cachedClients;
+    }
+    cachedClients = buildClients(createAuthInterceptor(env));
+    return cachedClients;
+  }
+
+  const credential = resolveSemrushCredential(brand, env);
+  const key = credential
+    ? credentialPoolKey(credential.key)
+    : SHARED_CREDENTIAL_KEY;
+
+  const existing = perCredentialClients.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  // Bound the pool: evict the oldest (FIFO by build time) transport when at capacity.
+  while (perCredentialClients.size >= maxClientsCacheSize) {
+    const oldestKey = perCredentialClients.keys().next().value;
+    perCredentialClients.delete(oldestKey);
+  }
+
+  const clients = buildClients(createCredentialInterceptor(env, credential));
+  perCredentialClients.set(key, clients);
+  return clients;
 }
 
 /** @visibleForTesting */
 export function resetGrpcClients() {
   cachedClients = null;
+  perCredentialClients.clear();
+  maxClientsCacheSize = DEFAULT_MAX_CLIENTS_CACHE_SIZE;
+}
+
+/** @visibleForTesting */
+export function setClientPoolMaxSize(n) {
+  maxClientsCacheSize = n;
+}
+
+/** @visibleForTesting */
+export function getClientPoolSize() {
+  return perCredentialClients.size;
 }
 
 export { getAccessToken, createAuthInterceptor };

--- a/src/support/ai-visibility/semrush-credential-resolver.js
+++ b/src/support/ai-visibility/semrush-credential-resolver.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Auth seam for the Spacecat -> Semrush AI Visibility gRPC backend (LLMO-6836, PR-3a).
+ *
+ * This module is the provider-agnostic *skeleton* for resolving the Semrush
+ * credential per brand so an unattended server-side run can be authorized. It is
+ * inert by default: no provider is configured, so {@link resolveSemrushCredential}
+ * returns `null` and callers fall back to the existing shared client_credentials
+ * path in `grpc-transport.js`.
+ *
+ * A future PR (3b) installs a real provider via {@link setSemrushCredentialProvider}.
+ * The provider may mint a per-org OAuth2 client_credentials token OR a future IMS
+ * technical-account token -- this module does not care which. It only understands a
+ * credential *descriptor*:
+ *
+ *   { key: string, getAuthToken: (env) => Promise<string> }
+ *
+ * where `key` is a stable cache key for the credential scope (e.g. the brand/org id)
+ * and `getAuthToken` yields the raw token string (NO "Bearer " prefix).
+ */
+
+/**
+ * @typedef {object} SemrushCredential
+ * @property {string} key - stable cache key for the credential scope (brand/org id).
+ * @property {(env: object) => Promise<string>} getAuthToken - yields the raw token.
+ */
+
+/**
+ * @typedef {(brand: unknown, env: object) => (SemrushCredential | null)} SemrushCredentialProvider
+ */
+
+/**
+ * @typedef {string | { token: string, expiresInMs?: number, expiresAtMs?: number }} MintResult
+ */
+
+/** Conservative fallback token lifetime when the mint result carries no expiry. */
+const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
+
+/** Default upper bound on distinct credential scopes cached at once. */
+const DEFAULT_MAX_TOKEN_CACHE_SIZE = 1000;
+
+/**
+ * Pluggable credential provider. `null` = no provider configured (default),
+ * which makes {@link resolveSemrushCredential} return `null`.
+ * @type {SemrushCredentialProvider | null}
+ */
+let credentialProvider = null;
+
+/** Per-credential token cache: key -> { token, expiresAtMs }. */
+const tokenCache = new Map();
+
+/** Mutable so tests can exercise eviction without minting thousands of tokens. */
+let maxTokenCacheSize = DEFAULT_MAX_TOKEN_CACHE_SIZE;
+
+/**
+ * Install (or clear) the credential provider. Passing a non-function (e.g. `null`)
+ * disables per-brand resolution and restores the default fall-back behavior.
+ * @param {SemrushCredentialProvider | null} fn
+ */
+export function setSemrushCredentialProvider(fn) {
+  credentialProvider = typeof fn === 'function' ? fn : null;
+}
+
+/**
+ * Resolve the Semrush credential descriptor for a brand.
+ *
+ * @param {unknown} brand - brand/org scope the caller wants a credential for.
+ * @param {object} env - request environment (secrets, config).
+ * @returns {SemrushCredential | null} `null` when no provider is configured (caller
+ *   falls back to the shared client_credentials path), otherwise the descriptor.
+ */
+export function resolveSemrushCredential(brand, env) {
+  if (!credentialProvider) {
+    return null;
+  }
+  return credentialProvider(brand, env) || null;
+}
+
+/**
+ * TTL token cache generalizing today's mint-every-request behavior. Reuses a cached
+ * token for `key` until it expires, then re-mints via `mintFn`. `now` is injected so
+ * tests can drive expiry deterministically.
+ *
+ * `mintFn` may resolve to either the raw token string, or an object
+ * `{ token, expiresInMs }` / `{ token, expiresAtMs }` so a provider can pass through
+ * the credential's real lifetime. When no expiry is supplied a conservative default
+ * TTL is used.
+ *
+ * @param {string} key - stable cache key for the credential scope.
+ * @param {() => Promise<MintResult>} mintFn - MUST resolve a non-empty token string
+ *   or an object with a string `token`; anything else throws and caches nothing.
+ * @param {number} [nowMs=Date.now()] - current time in ms (injectable for tests).
+ * @returns {Promise<string>} the raw token string.
+ * @throws {Error} when `mintFn` violates the contract above.
+ */
+export async function getCachedToken(key, mintFn, nowMs = Date.now()) {
+  const existing = tokenCache.get(key);
+  if (existing && nowMs < existing.expiresAtMs) {
+    return existing.token;
+  }
+
+  const minted = await mintFn();
+
+  let token;
+  let expiresAtMs;
+  if (typeof minted === 'string') {
+    token = minted;
+    expiresAtMs = nowMs + DEFAULT_TOKEN_TTL_MS;
+  } else if (minted && typeof minted.token === 'string') {
+    token = minted.token;
+    if (typeof minted.expiresAtMs === 'number') {
+      expiresAtMs = minted.expiresAtMs;
+    } else if (typeof minted.expiresInMs === 'number') {
+      expiresAtMs = nowMs + minted.expiresInMs;
+    } else {
+      expiresAtMs = nowMs + DEFAULT_TOKEN_TTL_MS;
+    }
+  } else {
+    // Enforce the mint contract: nothing is cached when it is violated, so the
+    // caller sees a clear error instead of a `Bearer undefined` header downstream.
+    throw new Error(
+      'getCachedToken: mintFn must resolve a token string or { token: string, ... }',
+    );
+  }
+
+  // FIFO by mint time: a re-mint deletes then re-inserts the key so it sorts last,
+  // but a cache HIT (returned above) does NOT refresh recency -- this is not LRU.
+  tokenCache.delete(key);
+  // Bound the cache: evict oldest entries when at capacity. Brand count can grow.
+  while (tokenCache.size >= maxTokenCacheSize) {
+    const oldestKey = tokenCache.keys().next().value;
+    tokenCache.delete(oldestKey);
+  }
+  tokenCache.set(key, { token, expiresAtMs });
+  return token;
+}
+
+/** @visibleForTesting */
+export function resetSemrushCredentialCache() {
+  tokenCache.clear();
+  maxTokenCacheSize = DEFAULT_MAX_TOKEN_CACHE_SIZE;
+}
+
+/** @visibleForTesting */
+export function setTokenCacheMaxSize(n) {
+  maxTokenCacheSize = n;
+}
+
+/** @visibleForTesting */
+export function getTokenCacheSize() {
+  return tokenCache.size;
+}

--- a/test/support/ai-visibility/grpc-transport-per-brand.test.js
+++ b/test/support/ai-visibility/grpc-transport-per-brand.test.js
@@ -1,0 +1,285 @@
+/* eslint-disable header/header */
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+
+use(chaiAsPromised);
+
+/** Snapshot at load time so we can reset after other suites stub `globalThis.fetch`. */
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function restoreGlobalFetchIfStubbed() {
+  const f = globalThis.fetch;
+  if (f && typeof f.restore === 'function') {
+    f.restore();
+  }
+  if (typeof ORIGINAL_FETCH === 'function') {
+    globalThis.fetch = ORIGINAL_FETCH;
+  }
+}
+
+const FLAG = 'AI_VISIBILITY_PER_BRAND_AUTH_ENABLED';
+
+describe('grpc-transport per-brand auth seam', () => {
+  let sandbox;
+  let getGrpcClients;
+  let resetGrpcClients;
+  let setClientPoolMaxSize;
+  let getClientPoolSize;
+  let mockCreateClient;
+  let mockCreateGrpcTransport;
+  let mockResolve;
+  let mockGetCachedToken;
+
+  beforeEach(async () => {
+    restoreGlobalFetchIfStubbed();
+    sandbox = sinon.createSandbox();
+    // Each createClient call returns a distinct object so we can assert per-key pools.
+    mockCreateClient = sandbox.stub().callsFake(() => ({}));
+    mockCreateGrpcTransport = sandbox.stub().callsFake(() => ({}));
+    mockResolve = sandbox.stub();
+    mockGetCachedToken = sandbox.stub();
+
+    const mod = await esmock(
+      '../../../src/support/ai-visibility/grpc-transport.js',
+      {
+        '@connectrpc/connect': { createClient: mockCreateClient },
+        '@connectrpc/connect-node': {
+          createGrpcTransport: mockCreateGrpcTransport,
+        },
+        '../../../third-party/ai-seo-ts/v2/brand/service_pb.js': {
+          BrandService: {},
+        },
+        '../../../third-party/ai-seo-ts/v2/topic/service_pb.js': {
+          TopicService: {},
+        },
+        '../../../third-party/ai-seo-ts/v2/prompt/service_pb.js': {
+          PromptService: {},
+        },
+        '../../../third-party/ai-seo-ts/v2/source/service_pb.js': {
+          SourceService: {},
+        },
+        '../../../third-party/ai-seo-ts/v2/competitor/service_pb.js': {
+          CompetitorService: {},
+        },
+        '../../../third-party/ai-seo-ts/ai-cr/service_pb.js': {
+          CompetitorsMetrics: {},
+          Meta: {},
+        },
+        '../../../third-party/ai-seo-ts/ai-vo/service_pb.js': { Sources: {} },
+        '../../../third-party/ai-seo-ts/ai-pr/service_pb.js': { Relations: {} },
+        '../../../src/support/ai-visibility/semrush-credential-resolver.js': {
+          resolveSemrushCredential: mockResolve,
+          getCachedToken: mockGetCachedToken,
+        },
+      },
+    );
+    ({
+      getGrpcClients,
+      resetGrpcClients,
+      setClientPoolMaxSize,
+      getClientPoolSize,
+    } = mod);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    restoreGlobalFetchIfStubbed();
+    if (resetGrpcClients) {
+      resetGrpcClients();
+    }
+  });
+
+  /** Grab the single interceptor handed to the (stubbed) transport factory. */
+  function interceptorFromCall(callIndex = 0) {
+    return mockCreateGrpcTransport.getCall(callIndex).args[0].interceptors[0];
+  }
+
+  /** Drive an interceptor exactly as connect would, returning the mutated request. */
+  async function runInterceptor(interceptor) {
+    const next = sandbox.stub().resolves('response');
+    const req = { header: { set: sandbox.stub() } };
+    const result = await interceptor(next)(req);
+    return { next, req, result };
+  }
+
+  function stubSharedTokenFetch(token = 'shared-tok') {
+    restoreGlobalFetchIfStubbed();
+    return sandbox.stub(globalThis, 'fetch').resolves({
+      status: 200,
+      json: () => Promise.resolve({ access_token: token }),
+    });
+  }
+
+  describe('flag OFF (default)', () => {
+    it('never consults the credential seam and reuses the singleton', () => {
+      const env = { SEO_CLIENT_ID: 'id', SEO_CLIENT_SECRET: 'sec' };
+      const first = getGrpcClients(env);
+      const second = getGrpcClients(env, 'brand-1');
+
+      expect(first).to.equal(second);
+      expect(mockCreateGrpcTransport.calledOnce).to.be.true;
+      expect(mockResolve.notCalled).to.be.true;
+      expect(mockGetCachedToken.notCalled).to.be.true;
+    });
+
+    it('treats FLAG="false" as off', () => {
+      getGrpcClients({ [FLAG]: 'false' }, 'brand-1');
+      expect(mockResolve.notCalled).to.be.true;
+    });
+
+    it('treats an unrecognized FLAG value as off', () => {
+      getGrpcClients({ [FLAG]: 'yes' }, 'brand-1');
+      expect(mockResolve.notCalled).to.be.true;
+    });
+
+    it('uses the shared client_credentials interceptor (getAccessToken via fetch)', async () => {
+      const fetchStub = stubSharedTokenFetch('off-tok');
+      const env = { SEO_CLIENT_ID: 'id', SEO_CLIENT_SECRET: 'sec' };
+
+      getGrpcClients(env);
+      const { req, next } = await runInterceptor(interceptorFromCall());
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(mockGetCachedToken.notCalled).to.be.true;
+      expect(req.header.set.firstCall.args).to.deep.equal([
+        'authorization',
+        'Bearer off-tok',
+      ]);
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe('flag ON', () => {
+    const onEnv = () => ({
+      [FLAG]: 'true',
+      SEO_CLIENT_ID: 'id',
+      SEO_CLIENT_SECRET: 'sec',
+    });
+
+    it('resolver returns null -> falls back to the shared credential path', async () => {
+      mockResolve.returns(null);
+      const fetchStub = stubSharedTokenFetch('fallback-tok');
+      const env = onEnv();
+
+      getGrpcClients(env, 'brand-1');
+
+      expect(mockResolve.calledOnceWithExactly('brand-1', env)).to.be.true;
+      expect(mockCreateGrpcTransport.calledOnce).to.be.true;
+
+      const { req } = await runInterceptor(interceptorFromCall());
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(mockGetCachedToken.notCalled).to.be.true;
+      expect(req.header.set.firstCall.args).to.deep.equal([
+        'authorization',
+        'Bearer fallback-tok',
+      ]);
+    });
+
+    it('resolver returns a descriptor -> uses its key + token via the TTL cache', async () => {
+      const getAuthToken = sandbox.stub().resolves('brand-raw-token');
+      mockResolve.returns({ key: 'org-42', getAuthToken });
+      mockGetCachedToken.resolves('brand-cached-token');
+      const env = onEnv();
+
+      getGrpcClients(env, 'brand-1');
+      const { req } = await runInterceptor(interceptorFromCall());
+
+      // Header carries the token from the credential cache, not the shared path.
+      expect(req.header.set.firstCall.args).to.deep.equal([
+        'authorization',
+        'Bearer brand-cached-token',
+      ]);
+      // Cache was keyed by the descriptor key; getAuthToken was NOT called directly
+      // (only through the mint fn the cache owns).
+      expect(mockGetCachedToken.calledOnce).to.be.true;
+      expect(mockGetCachedToken.firstCall.args[0]).to.equal('org-42');
+      expect(getAuthToken.notCalled).to.be.true;
+    });
+
+    it('the mint fn passed to the cache mints the raw token via getAuthToken(env)', async () => {
+      const getAuthToken = sandbox.stub().resolves('brand-raw-token');
+      mockResolve.returns({ key: 'org-42', getAuthToken });
+      // Execute the mint fn the interceptor hands to the cache.
+      mockGetCachedToken.callsFake((key, mintFn) => mintFn());
+      const env = onEnv();
+
+      getGrpcClients(env, 'brand-1');
+      const { req } = await runInterceptor(interceptorFromCall());
+
+      expect(getAuthToken.calledOnceWithExactly(env)).to.be.true;
+      expect(req.header.set.firstCall.args).to.deep.equal([
+        'authorization',
+        'Bearer brand-raw-token',
+      ]);
+    });
+
+    it('keys the transport pool per credential (distinct brands -> distinct clients)', () => {
+      mockResolve.withArgs('brand-a').returns({ key: 'org-a', getAuthToken: async () => 'a' });
+      mockResolve.withArgs('brand-b').returns({ key: 'org-b', getAuthToken: async () => 'b' });
+      const env = onEnv();
+
+      const a1 = getGrpcClients(env, 'brand-a');
+      const a2 = getGrpcClients(env, 'brand-a');
+      const b1 = getGrpcClients(env, 'brand-b');
+
+      expect(a1).to.equal(a2); // same key -> cached
+      expect(a1).to.not.equal(b1); // different key -> distinct pool
+      expect(mockCreateGrpcTransport.calledTwice).to.be.true; // one per key
+    });
+
+    it('resetGrpcClients clears the per-credential pool', () => {
+      mockResolve.returns({ key: 'org-42', getAuthToken: async () => 't' });
+      const env = onEnv();
+
+      const first = getGrpcClients(env, 'brand-1');
+      resetGrpcClients();
+      const second = getGrpcClients(env, 'brand-1');
+
+      expect(first).to.not.equal(second);
+      expect(mockCreateGrpcTransport.calledTwice).to.be.true;
+    });
+
+    it('bounds the client pool and rebuilds an evicted key', () => {
+      setClientPoolMaxSize(2);
+      mockResolve.withArgs('brand-a').returns({ key: 'org-a', getAuthToken: async () => 'a' });
+      mockResolve.withArgs('brand-b').returns({ key: 'org-b', getAuthToken: async () => 'b' });
+      mockResolve.withArgs('brand-c').returns({ key: 'org-c', getAuthToken: async () => 'c' });
+      const env = onEnv();
+
+      const a1 = getGrpcClients(env, 'brand-a');
+      getGrpcClients(env, 'brand-b');
+      getGrpcClients(env, 'brand-c'); // evicts org-a (oldest)
+
+      expect(getClientPoolSize()).to.equal(2); // never exceeds the bound
+      expect(mockCreateGrpcTransport.callCount).to.equal(3);
+
+      // org-a was evicted -> re-resolving builds a NEW clients object (transport recreated).
+      const a2 = getGrpcClients(env, 'brand-a');
+      expect(a2).to.not.equal(a1);
+      expect(getClientPoolSize()).to.equal(2);
+      expect(mockCreateGrpcTransport.callCount).to.equal(4);
+    });
+
+    it('enables the per-brand path for boolean true and string "1"', () => {
+      getGrpcClients({ [FLAG]: true, SEO_CLIENT_ID: 'id', SEO_CLIENT_SECRET: 'sec' }, 'brand-1');
+      getGrpcClients({ [FLAG]: '1', SEO_CLIENT_ID: 'id', SEO_CLIENT_SECRET: 'sec' }, 'brand-2');
+
+      expect(mockResolve.calledWith('brand-1')).to.be.true;
+      expect(mockResolve.calledWith('brand-2')).to.be.true;
+    });
+  });
+});

--- a/test/support/ai-visibility/semrush-credential-resolver.test.js
+++ b/test/support/ai-visibility/semrush-credential-resolver.test.js
@@ -1,0 +1,189 @@
+/* eslint-disable header/header */
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import chaiAsPromised from 'chai-as-promised';
+
+import {
+  resolveSemrushCredential,
+  setSemrushCredentialProvider,
+  getCachedToken,
+  resetSemrushCredentialCache,
+  setTokenCacheMaxSize,
+  getTokenCacheSize,
+} from '../../../src/support/ai-visibility/semrush-credential-resolver.js';
+
+use(chaiAsPromised);
+
+describe('semrush-credential-resolver', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    // Restore module state to its default (inert) shape between tests.
+    setSemrushCredentialProvider(null);
+    resetSemrushCredentialCache();
+  });
+
+  describe('resolveSemrushCredential', () => {
+    it('returns null when no provider is configured (default)', () => {
+      expect(resolveSemrushCredential('brand-1', {})).to.equal(null);
+    });
+
+    it('returns the descriptor from an installed provider with the correct key', () => {
+      const getAuthToken = sandbox.stub().resolves('raw-token');
+      const provider = sandbox.stub().returns({ key: 'org-42', getAuthToken });
+      setSemrushCredentialProvider(provider);
+
+      const env = { SOME: 'env' };
+      const descriptor = resolveSemrushCredential('brand-1', env);
+
+      expect(descriptor).to.not.equal(null);
+      expect(descriptor.key).to.equal('org-42');
+      expect(descriptor.getAuthToken).to.equal(getAuthToken);
+      expect(provider.calledOnceWithExactly('brand-1', env)).to.be.true;
+    });
+
+    it('returns null when the provider yields a falsy value', () => {
+      setSemrushCredentialProvider(() => null);
+      expect(resolveSemrushCredential('brand-1', {})).to.equal(null);
+    });
+
+    it('treats a non-function provider as no provider (restores fallback)', () => {
+      setSemrushCredentialProvider(() => ({ key: 'k', getAuthToken: async () => 't' }));
+      setSemrushCredentialProvider(null);
+      expect(resolveSemrushCredential('brand-1', {})).to.equal(null);
+    });
+  });
+
+  describe('getCachedToken', () => {
+    it('mints once and reuses the cached token within the default TTL', async () => {
+      const mint = sandbox.stub().resolves('tok-1');
+
+      const first = await getCachedToken('k1', mint, 0);
+      const second = await getCachedToken('k1', mint, 1000);
+
+      expect(first).to.equal('tok-1');
+      expect(second).to.equal('tok-1');
+      expect(mint.calledOnce).to.be.true;
+    });
+
+    it('re-mints after expiry (default TTL, injected now)', async () => {
+      let n = 0;
+      const mint = sandbox.stub().callsFake(() => {
+        n += 1;
+        return Promise.resolve(`tok-${n}`);
+      });
+
+      const ttl = 5 * 60 * 1000;
+      const first = await getCachedToken('k1', mint, 0);
+      // Still within TTL: cached.
+      const cached = await getCachedToken('k1', mint, ttl - 1);
+      // At/after TTL boundary: re-mint.
+      const reminted = await getCachedToken('k1', mint, ttl);
+
+      expect(first).to.equal('tok-1');
+      expect(cached).to.equal('tok-1');
+      expect(reminted).to.equal('tok-2');
+      expect(mint.calledTwice).to.be.true;
+    });
+
+    it('honors expiresInMs from the mint result', async () => {
+      const mint = sandbox.stub();
+      mint.onFirstCall().resolves({ token: 'a', expiresInMs: 100 });
+      mint.onSecondCall().resolves({ token: 'b', expiresInMs: 100 });
+
+      const first = await getCachedToken('k1', mint, 0);
+      const stillCached = await getCachedToken('k1', mint, 99);
+      const reminted = await getCachedToken('k1', mint, 100);
+
+      expect(first).to.equal('a');
+      expect(stillCached).to.equal('a');
+      expect(reminted).to.equal('b');
+      expect(mint.calledTwice).to.be.true;
+    });
+
+    it('honors an absolute expiresAtMs from the mint result', async () => {
+      const mint = sandbox.stub();
+      mint.onFirstCall().resolves({ token: 'a', expiresAtMs: 500 });
+      mint.onSecondCall().resolves({ token: 'b', expiresAtMs: 5000 });
+
+      const first = await getCachedToken('k1', mint, 100);
+      const stillCached = await getCachedToken('k1', mint, 499);
+      const reminted = await getCachedToken('k1', mint, 500);
+
+      expect(first).to.equal('a');
+      expect(stillCached).to.equal('a');
+      expect(reminted).to.equal('b');
+    });
+
+    it('caches distinct keys independently', async () => {
+      const mintA = sandbox.stub().resolves('a');
+      const mintB = sandbox.stub().resolves('b');
+
+      const a = await getCachedToken('k-a', mintA, 0);
+      const b = await getCachedToken('k-b', mintB, 0);
+
+      expect(a).to.equal('a');
+      expect(b).to.equal('b');
+      expect(getTokenCacheSize()).to.equal(2);
+    });
+
+    it('throws on a malformed mint result and caches nothing', async () => {
+      const mint = sandbox.stub().resolves({ notToken: 'oops' });
+
+      await expect(getCachedToken('k1', mint, 0)).to.be.rejectedWith(
+        /mintFn must resolve a token string/,
+      );
+      expect(getTokenCacheSize()).to.equal(0);
+
+      // A subsequent well-formed mint still works (nothing poisoned the cache).
+      const good = sandbox.stub().resolves('tok-ok');
+      expect(await getCachedToken('k1', good, 0)).to.equal('tok-ok');
+      expect(good.calledOnce).to.be.true;
+    });
+
+    it('propagates a mintFn rejection and caches nothing', async () => {
+      const boom = new Error('mint failed');
+      const mint = sandbox.stub().rejects(boom);
+
+      await expect(getCachedToken('k1', mint, 0)).to.be.rejectedWith('mint failed');
+      expect(getTokenCacheSize()).to.equal(0);
+    });
+
+    it('evicts the oldest entry when the cache is at capacity', async () => {
+      setTokenCacheMaxSize(2);
+
+      const mint = sandbox.stub();
+      mint.resolves('t');
+
+      await getCachedToken('a', mint, 0);
+      await getCachedToken('b', mint, 0);
+      await getCachedToken('c', mint, 0); // evicts 'a'
+
+      expect(getTokenCacheSize()).to.equal(2);
+      expect(mint.callCount).to.equal(3);
+
+      // 'a' was evicted -> re-request mints again; 'b'/'c' remain cached.
+      await getCachedToken('a', mint, 0);
+      expect(mint.callCount).to.equal(4);
+      await getCachedToken('c', mint, 0);
+      expect(mint.callCount).to.equal(4);
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a flag-gated, provider-agnostic auth-seam skeleton for resolving the Spacecat → Semrush AI Visibility credential per brand. Inert by default — no behavior change until a later PR injects a real provider.

## 2. Reasoning
Brand Claims and other server-side consumers need to read a customer's Semrush AI Visibility data unattended (no IMS user token), but Semrush authorizes by workspace membership and has no S2S path today — an unattended service token is rejected (LLMO-6836). The eventual fix routes a per-brand technical-account credential, but the exact shape (single shared vs per-org technical account; `workspaceId` vs `ims_org_id` mapping) is still being negotiated. This PR lands the decision-independent seam now, so the contested choice becomes a small provider swap later rather than transport surgery.

## 3. High-level overview of the changes
- New `semrush-credential-resolver.js`: `resolveSemrushCredential(brand, env)` (returns a credential descriptor or `null`), a pluggable `setSemrushCredentialProvider` (default: none), and `getCachedToken`, a per-credential TTL token cache (bounded, FIFO by mint time, injectable clock).
- `grpc-transport.js` wiring behind `AI_VISIBILITY_PER_BRAND_AUTH_ENABLED` (default **off**):
  - **Flag off (default):** unchanged — the process-wide singleton transport, authenticating with the shared `client_credentials` machine credential minted per request. Byte-identical to today.
  - **Flag on:** resolves the credential per request and keys a bounded per-credential transport pool; when the resolver returns `null` it falls back to the shared credential. Resolved keys are namespaced so a provider key can never collide with the shared sentinel.
- `getGrpcClients` gains an optional `brand` argument (additive; no caller changes).

Behavior delta: **none** in any current environment. The seam is double-gated — no provider is configured, so even with the flag on the resolver returns `null` and the shared credential is still used. Turning the flag on alone is a no-op; PR-3b injects the real provider and threads `brand`.

## 4. Required information
- Jira / issue: [LLMO-7028](https://jira.corp.adobe.com/browse/LLMO-7028) (sub-task of [LLMO-6585](https://jira.corp.adobe.com/browse/LLMO-6585); blocker [LLMO-6836](https://jira.corp.adobe.com/browse/LLMO-6836))
- Spec: adobe/mysticat-architecture#248 — `products/llmo/spec-brand-claims-semrush-ingestion-feed.md` §6.2

## 7. Test plan
(a) Local: unit tests exercise the flag on/off wiring, the null-provider fallback to the shared credential, per-credential token-cache reuse within TTL and re-mint after expiry, the malformed-mint guard, the bounded client-pool eviction + transport rebuild, and confirm the existing `grpc-transport` suite is unchanged. Confirmed flag-off produces the same transport options and client set as before, and never touches the resolver or token cache.

(b) Per environment: nothing to verify — the flag defaults off everywhere and the change is behavior-preserving. The existing `GET /llmo/ai-visibility/*` responses are unchanged. When PR-3b is ready, enabling `AI_VISIBILITY_PER_BRAND_AUTH_ENABLED` in dev (with a provider installed) is the first live check; until then the flag is inert.

## 8. Deployment & merge order
- adobe/mysticat-architecture#248 — related (design of record, §6.2); docs-only, no deploy coupling.
- LLMO-7029 (PR-3b, live provider wiring) stacks on this and is gated on the contested technical-account decision. This PR must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Rachel Dong", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```