### PR TITLE
fix: migrate Adobe Post Office auth to Bearer + x-api-key (LLMO-7021)

### DIFF
--- a/src/controllers/trial-users.js
+++ b/src/controllers/trial-users.js
@@ -149,11 +149,18 @@ function TrialUsersController(ctx) {
       if (!env.EMAIL_IMS_CLIENT_ID) {
         return internalServerError('EMAIL_IMS_CLIENT_ID is not configured');
       }
-      env.IMS_CLIENT_ID = env.EMAIL_IMS_CLIENT_ID;
-      env.IMS_CLIENT_SECRET = env.EMAIL_IMS_CLIENT_SECRET;
-      env.IMS_CLIENT_CODE = env.EMAIL_IMS_CLIENT_CODE;
-      env.IMS_SCOPE = env.EMAIL_IMS_SCOPE;
-      const imsClient = ImsClient.createFrom(context);
+      // Use a local env copy for the email-specific IMS credentials.
+      // Do NOT mutate context.env: it is reused across warm Lambda invocations,
+      // so writing IMS_CLIENT_ID here would leak the email client's credentials
+      // into later requests that expect the default client.
+      const emailEnv = {
+        ...env,
+        IMS_CLIENT_ID: env.EMAIL_IMS_CLIENT_ID,
+        IMS_CLIENT_SECRET: env.EMAIL_IMS_CLIENT_SECRET,
+        IMS_CLIENT_CODE: env.EMAIL_IMS_CLIENT_CODE,
+        IMS_SCOPE: env.EMAIL_IMS_SCOPE,
+      };
+      const imsClient = ImsClient.createFrom({ ...context, env: emailEnv });
       const imsTokenPayload = await imsClient.getServiceAccessToken();
       const postOfficeEndpoint = env.ADOBE_POSTOFFICE_ENDPOINT;
       const emailTemplateName = env.EMAIL_LLMO_TEMPLATE;

--- a/src/controllers/trial-users.js
+++ b/src/controllers/trial-users.js
@@ -146,6 +146,9 @@ function TrialUsersController(ctx) {
         return createResponse({ message: `Trial user with this email already exists ${existingTrialUser.getId()}` }, 409);
       }
 
+      if (!env.EMAIL_IMS_CLIENT_ID) {
+        return internalServerError('EMAIL_IMS_CLIENT_ID is not configured');
+      }
       env.IMS_CLIENT_ID = env.EMAIL_IMS_CLIENT_ID;
       env.IMS_CLIENT_SECRET = env.EMAIL_IMS_CLIENT_SECRET;
       env.IMS_CLIENT_CODE = env.EMAIL_IMS_CLIENT_CODE;

--- a/src/controllers/trial-users.js
+++ b/src/controllers/trial-users.js
@@ -160,7 +160,8 @@ function TrialUsersController(ctx) {
         method: 'POST',
         headers: {
           Accept: 'application/xml',
-          Authorization: `IMS ${imsTokenPayload.access_token}`,
+          Authorization: `Bearer ${imsTokenPayload.access_token}`,
+          'x-api-key': env.EMAIL_IMS_CLIENT_ID,
           'Content-Type': 'application/xml',
         },
         body: emailPayload,

--- a/src/support/email-service.js
+++ b/src/support/email-service.js
@@ -33,6 +33,9 @@ export async function getEmailServiceToken(context) {
 
   try {
     const tokenPayload = await imsClient.getServiceAccessToken();
+    if (!tokenPayload?.access_token) {
+      throw new Error('IMS returned no access token');
+    }
     return tokenPayload.access_token;
   } catch (error) {
     context.log.error('[email-service] Failed to acquire IMS token', { error: error.message });

--- a/src/support/email-service.js
+++ b/src/support/email-service.js
@@ -74,6 +74,11 @@ export async function sendEmail(context, {
       return result;
     }
 
+    if (!env.LLMO_EMAIL_IMS_CLIENT_ID) {
+      result.error = 'LLMO_EMAIL_IMS_CLIENT_ID is not configured';
+      return result;
+    }
+
     const accessToken = providedToken ?? await getEmailServiceToken(context);
     const postOfficeEndpoint = env.ADOBE_POSTOFFICE_ENDPOINT;
 

--- a/src/support/email-service.js
+++ b/src/support/email-service.js
@@ -99,7 +99,8 @@ export async function sendEmail(context, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
-        Authorization: `IMS ${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
+        'x-api-key': env.LLMO_EMAIL_IMS_CLIENT_ID,
         'Content-Type': 'application/json',
       },
       body,

--- a/test/controllers/trial-users.test.js
+++ b/test/controllers/trial-users.test.js
@@ -485,6 +485,34 @@ describe('Trial User Controller', () => {
       expect(body).to.have.property('emailId', 'newuser@example.com');
     });
 
+    it('should return internal server error when EMAIL_IMS_CLIENT_ID is not configured', async () => {
+      const context = {
+        params: { organizationId },
+        data: { emailId: 'newuser@example.com' },
+        dataAccess: mockDataAccess,
+        log: mockLogger,
+        env: {
+          EMAIL_IMS_CLIENT_SECRET: 'test-client-secret',
+          EMAIL_IMS_CLIENT_CODE: 'test-client-code',
+          EMAIL_IMS_SCOPE: 'test-scope',
+          ADOBE_POSTOFFICE_ENDPOINT: 'https://test-postoffice.adobe.com/po-server/message',
+          EMAIL_LLMO_TEMPLATE: 'expdev_xwalk_trial_confirm',
+        },
+        attributes: {
+          authInfo: new AuthInfo()
+            .withType('jwt')
+            .withProfile({ is_admin: true })
+            .withAuthenticated(true),
+        },
+      };
+
+      const result = await trialUserController.createTrialUserForEmailInvite(context);
+
+      expect(result.status).to.equal(500);
+      const body = await result.json();
+      expect(body.message).to.equal('EMAIL_IMS_CLIENT_ID is not configured');
+    });
+
     it('should return bad request for invalid organization ID', async () => {
       const context = {
         params: { organizationId: 'invalid-uuid' },
@@ -759,7 +787,7 @@ describe('Trial User Controller', () => {
         data: { emailId: 'existing@example.com' },
         dataAccess: mockDataAccess,
         log: mockLogger,
-        env: {},
+        env: { EMAIL_IMS_CLIENT_ID: 'test-client-id' },
         attributes: {
           authInfo: new AuthInfo()
             .withType('jwt')
@@ -784,7 +812,7 @@ describe('Trial User Controller', () => {
         data: { emailId: 'newuser@example.com' },
         dataAccess: mockDataAccess,
         log: mockLogger,
-        env: {},
+        env: { EMAIL_IMS_CLIENT_ID: 'test-client-id' },
         attributes: {
           authInfo: new AuthInfo()
             .withType('jwt')

--- a/test/support/email-service.test.js
+++ b/test/support/email-service.test.js
@@ -99,7 +99,8 @@ describe('email-service', () => {
       expect(url).to.include('templateName=test-template');
       expect(url).to.include('locale=en_US');
       expect(options.method).to.equal('POST');
-      expect(options.headers.Authorization).to.equal('IMS test-token');
+      expect(options.headers.Authorization).to.equal('Bearer test-token');
+      expect(options.headers['x-api-key']).to.equal('client-id');
       expect(options.headers['Content-Type']).to.equal('application/json');
       expect(options.headers.Accept).to.equal('application/json');
       const body = JSON.parse(options.body);
@@ -161,7 +162,7 @@ describe('email-service', () => {
       expect(result.success).to.be.true;
       expect(ImsClientStub.createFrom).to.not.have.been.called;
       const [, options] = fetchStub.firstCall.args;
-      expect(options.headers.Authorization).to.equal('IMS provided-token');
+      expect(options.headers.Authorization).to.equal('Bearer provided-token');
     });
 
     it('should return error when ADOBE_POSTOFFICE_ENDPOINT is not configured', async () => {

--- a/test/support/email-service.test.js
+++ b/test/support/email-service.test.js
@@ -177,6 +177,19 @@ describe('email-service', () => {
       expect(result.error).to.equal('ADOBE_POSTOFFICE_ENDPOINT is not configured');
     });
 
+    it('should return error when LLMO_EMAIL_IMS_CLIENT_ID is not configured', async () => {
+      delete mockContext.env.LLMO_EMAIL_IMS_CLIENT_ID;
+
+      const result = await sendEmail(mockContext, {
+        recipients: ['test@example.com'],
+        templateName: 'test-template',
+      });
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal('LLMO_EMAIL_IMS_CLIENT_ID is not configured');
+      expect(fetchStub).to.not.have.been.called;
+    });
+
     it('should return error when ADOBE_POSTOFFICE_ENDPOINT uses HTTP instead of HTTPS', async () => {
       mockContext.env.ADOBE_POSTOFFICE_ENDPOINT = 'http://postoffice.example.com';
 

--- a/test/support/email-service.test.js
+++ b/test/support/email-service.test.js
@@ -261,6 +261,19 @@ describe('email-service', () => {
       expect(result.error).to.equal('IMS unavailable');
     });
 
+    it('should return error when IMS returns no access token', async () => {
+      imsClientInstance.getServiceAccessToken.resolves({});
+
+      const result = await sendEmail(mockContext, {
+        recipients: ['test@example.com'],
+        templateName: 'test-template',
+      });
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal('IMS returned no access token');
+      expect(fetchStub).to.not.have.been.called;
+    });
+
     it('should use custom locale when provided', async () => {
       fetchStub.resolves({ status: 200, text: async () => 'OK' });
 


### PR DESCRIPTION
## What

Migrates the Adobe Post Office (APO) email integration to the new API contract ahead of APO's domain move.

Per the APO team, the contract change is **auth header + endpoint**:
- `Authorization: IMS <token>` → `Authorization: Bearer <token>`
- New required header `x-api-key: <ims-client-id>`

The endpoint URL itself (`ADOBE_POSTOFFICE_ENDPOINT` → `https://apo-prod.adobe.io` / `https://apo-stage.adobe.io`) is a **Vault** change, not code — it is not modified here.

## Changes

- `src/support/email-service.js` — `Bearer` auth + `x-api-key: env.LLMO_EMAIL_IMS_CLIENT_ID`
- `src/controllers/trial-users.js` (trial/welcome email) — `Bearer` auth + `x-api-key: env.EMAIL_IMS_CLIENT_ID`
- `test/support/email-service.test.js` — updated header assertions + `x-api-key` coverage

## Testing

`npx mocha test/support/email-service.test.js test/controllers/trial-users.test.js` — 59 passing.

## Notes

- Coordinated with the APO team (reference: `OneAdobe/aem-xwalk-trial#107`); migration guide: PostOffice Migration wiki (FDT space).
- Companion change in `spacecat-reporting-worker` (weekly digest) is a separate PR.
- Deploy + Vault URL flip must land together per environment, else sends break.

Ref: LLMO-7021
