### PR TITLE
feat(dev): mock POST /auth/login in the local dev server under SKIP_AUTH

### DIFF
--- a/test/dev/server.mjs
+++ b/test/dev/server.mjs
@@ -13,11 +13,63 @@ import { createRequire } from 'module';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
+import { Response } from '@adobe/fetch';
 import { DevelopmentServer } from '@adobe/helix-universal-devserver';
-import { main } from '../../src/index.js';
+import { main as apiMain } from '../../src/index.js';
 
 // Load .env file before starting server
 config();
+
+// --- Local-dev-only /auth/login mock (never bundled into the Lambda) ---------
+// The deployed api-service does NOT serve POST /auth/login — that route lives in
+// spacecat-auth-service. The ASO UI's AuthenticationProvider exchanges the IMS
+// token for a SpaceCat session token there on boot; when the exchange 404s it
+// renders "Service temporarily unavailable" and the app never mounts. Against
+// the local harness the UI points at this api-service (one base URL for auth and
+// data), so there is nothing to serve /auth/login and every local UI session
+// dead-ends. Under SKIP_AUTH (local dev only — the same escape hatch that injects
+// a mock admin identity) answer POST /auth/login with a mock session token so the
+// UI boots. This wrapper only intercepts that one route; everything else passes
+// through to the real handler unchanged. It cannot reach production: test/dev/**
+// is excluded from the Helix bundle (main = src/index.js).
+const AUTH_LOGIN_PATH = '/auth/login';
+
+// A well-formed but unsigned JWT. jwtDecode in the UI base64url-decodes the
+// payload and never verifies the signature; data calls authenticate server-side
+// via SKIP_AUTH, so this token is only ever read client-side for role/admin.
+// is_admin grants the admin break-glass that bypasses the UI capability guards.
+function mockSessionToken() {
+  const b64url = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const header = { alg: 'none', typ: 'JWT' };
+  const payload = {
+    sub: 'dev-local-mock-user',
+    is_admin: true,
+    facs_enabled: false,
+    tenants: [{ id: 'sitesinternal', name: 'Sites Internal', subServices: [] }],
+    iat: 1735689600, // 2025-01-01T00:00:00Z, fixed (dev servers avoid Date.now)
+    exp: 4102444800, // 2100-01-01T00:00:00Z
+  };
+  return `${b64url(header)}.${b64url(payload)}.dev-mock-not-a-real-signature`;
+}
+
+async function main(request, context) {
+  if (
+    process.env.SKIP_AUTH === 'true'
+    && request.method === 'POST'
+    && new URL(request.url).pathname === AUTH_LOGIN_PATH
+  ) {
+    const origin = request.headers.get('origin') || '*';
+    return new Response(JSON.stringify({ sessionToken: mockSessionToken() }), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'access-control-allow-origin': origin,
+        'access-control-allow-credentials': 'true',
+      },
+    });
+  }
+  return apiMain(request, context);
+}
 
 const require = createRequire(import.meta.url);
 const { version } = require('../../package.json');


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a local-dev-only mock of `POST /auth/login` to the SpaceCat API dev server (`test/dev/server.mjs`) so the ASO UI can complete its session-token exchange and boot when running against the local harness.

## 2. Reasoning
The deployed api-service does not serve `POST /auth/login` — that route lives in spacecat-auth-service. Since the global IMS bearer handler was removed, the ASO UI (`experience-success-studio-ui`) exchanges its IMS token for a SpaceCat session token via `POST /auth/login` on boot. Against the local harness the UI points at this api-service for both auth and data, so the exchange 404s, `AuthenticationProvider` renders "Service temporarily unavailable", and the app never mounts — blocking all local ASO UI development against the SpaceCat API.

## 3. High-level overview of the changes
- Before: a local UI session against the harness dead-ended on the missing `/auth/login` route, so no ASO screen could render.
- After: under `SKIP_AUTH`, the dev server answers `POST /auth/login` with a well-formed mock session token (plus CORS for the UI origin), so the UI completes its boot handshake and renders end-to-end.
- The wrapper intercepts only that one route; every other request passes through to the real handler unchanged.
- It cannot reach production: `test/dev/**` is excluded from the Helix Lambda bundle (`main = src/index.js`), and the mock is gated on `SKIP_AUTH === 'true'`, which is never set in a deployed environment — consistent with the existing local-dev mock-admin identity injection. The mock JWT is unsigned; the UI only base64url-decodes its payload client-side for role/admin, and data calls authenticate server-side via `SKIP_AUTH`.

## 4. Required information
- No linked issue or spec — this is a local dev-harness affordance, not a product or API change.

## 6. Affected / used mysticat-workspace projects
- `experience-success-studio-ui` — consumed at runtime (local dev only). Its `AuthenticationProvider` performs the `POST /auth/login` session-token exchange on boot; this mock is what lets it run against the local SpaceCat API harness. No change to that repo is required.

## 7. Additional information outside the code
Verified this session against the running local harness:
- The dev server boots with the wrapper in place; the `POST /auth/login` handshake returns a session token, the CORS preflight succeeds, and non-auth requests pass through to the real handler unchanged.
- End-to-end: the full ASO UI renders inside the local Experience Cloud shell — including the Opportunities view — which was previously blocked by the missing `/auth/login` route.

## 8. Test plan
- (a) Local e2e (done): ran the local harness with `SKIP_AUTH`, drove the ASO UI in the local Experience Cloud shell, and confirmed the app boots past the auth handshake and renders the Opportunities view; the `/auth/login` handshake and CORS preflight both succeed and non-auth traffic is unaffected.
- (b) Per-environment (eph/dev/stage/prod): none applicable. This file is local-dev-only and is never bundled or deployed (`test/dev/**` is excluded from the Lambda, and the mock is gated on `SKIP_AUTH`, which is unset in every deployed environment). There is nothing to verify on a deployed environment.