### PR TITLE
feat(serenity): job-status endpoint for async prompt classification (#33)

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -156,6 +156,8 @@ paths:
     $ref: './prompts-v2-api.yaml#/v2-prompts-by-brand-bulk-delete'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/prompts:
     $ref: './serenity-api.yaml#/v2-serenity-prompts'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/prompts/jobs/{jobId}:
+    $ref: './serenity-api.yaml#/v2-serenity-prompts-job'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/prompts/{semrushPromptId}:
     $ref: './serenity-api.yaml#/v2-serenity-prompt-by-id'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/prompts/bulk-delete:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -14077,3 +14077,60 @@ OnboardingNotificationResponse:
         Present only when notified is false. Explains why no notification was
         sent (e.g. a duplicate request arrived within the per-org cooldown window).
       example: "recently notified"
+
+SerenityPromptClassificationJobAccepted:
+  type: object
+  required: [jobId, status]
+  description: >-
+    202 response from the bulk prompt-create path (serenity-docs#33): the import
+    was enqueued as an async classification job. Poll the job via
+    `GET .../serenity/prompts/jobs/{jobId}`.
+  properties:
+    jobId:
+      type: string
+      format: uuid
+      description: Id of the enqueued classification job.
+    status:
+      type: string
+      description: Job status at enqueue time (always IN_PROGRESS).
+      enum: [IN_PROGRESS]
+  example:
+    jobId: '99999999-8888-7777-6666-555555555555'
+    status: IN_PROGRESS
+
+SerenityPromptClassificationJob:
+  type: object
+  required: [jobId, status]
+  description: Status of an async Serenity prompt-classification job (serenity-docs#33).
+  properties:
+    jobId:
+      type: string
+      format: uuid
+    status:
+      type: string
+      enum: [IN_PROGRESS, COMPLETED, FAILED, CANCELLED]
+    result:
+      description: >-
+        Present on COMPLETED. Mirrors the synchronous create response's
+        per-prompt outcome (created / skipped / failed).
+      allOf:
+        - $ref: '#/SerenityCreatePromptsResponse'
+    error:
+      type: object
+      description: Present on FAILED.
+      properties:
+        code: { type: [string, 'null'] }
+        message: { type: [string, 'null'] }
+    needsReauth:
+      type: boolean
+      description: >-
+        Present and true only when the job failed because the promise token can
+        no longer be exchanged (code NEEDS_REAUTH); the caller must
+        re-authenticate and resubmit.
+  example:
+    jobId: '99999999-8888-7777-6666-555555555555'
+    status: FAILED
+    error:
+      code: NEEDS_REAUTH
+      message: promise token exchange requires re-authentication
+    needsReauth: true

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -14113,8 +14113,7 @@ SerenityPromptClassificationJob:
       description: >-
         Present on COMPLETED. Mirrors the synchronous create response's
         per-prompt outcome (created / skipped / failed).
-      allOf:
-        - $ref: '#/SerenityCreatePromptsResponse'
+      $ref: '#/SerenityCreatePromptsResponse'
     error:
       type: object
       description: Present on FAILED.

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -143,7 +143,7 @@ v2-serenity-prompts:
       '202':
         description: |
           Accepted for asynchronous processing (serenity-docs#33). Returned for
-          bulk/CSV imports (flat-mode brands with `deferPublish: true`): the
+          bulk/CSV imports (flat-mode brands with `async: true`): the
           request is enqueued as a classification job and the response carries a
           `jobId` to poll via `GET .../serenity/prompts/jobs/{jobId}`.
         content:

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -140,6 +140,15 @@ v2-serenity-prompts:
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityCreatePromptsResponse' }
+      '202':
+        description: |
+          Accepted for asynchronous processing (serenity-docs#33). Returned for
+          bulk/CSV imports (flat-mode brands with `deferPublish: true`): the
+          request is enqueued as a classification job and the response carries a
+          `jobId` to poll via `GET .../serenity/prompts/jobs/{jobId}`.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityPromptClassificationJobAccepted' }
       '400': { $ref: './responses.yaml#/400' }
       '404':
         description: Organization, brand, or workspace not found, or serenity is not active for the organization.
@@ -148,6 +157,53 @@ v2-serenity-prompts:
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
+v2-serenity-prompts-job:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+    - name: jobId
+      in: path
+      required: true
+      description: Async classification job id returned by the 202 create response.
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Poll an async prompt-classification job
+    description: |
+      Returns the status of a bulk prompt-classification job (serenity-docs#33)
+      enqueued by the `202` path of the create endpoint. Poll until `status` is
+      terminal (`COMPLETED`, `FAILED`, or `CANCELLED`). On `COMPLETED` the
+      per-prompt `result` mirrors the synchronous create response. On `FAILED`
+      with a dead promise token, `needsReauth: true` is set so the caller can
+      prompt a re-authentication and resubmit.
+    operationId: getSerenityPromptClassificationJobStatus
+    security:
+      - session_token: []
+    responses:
+      '200':
+        description: Job status retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityPromptClassificationJob' }
+      '400': { $ref: './responses.yaml#/400' }
+      '404':
+        description: Job not found for this brand, or serenity is not active for the brand.
       '500': { $ref: './responses.yaml#/500' }
 
 v2-serenity-prompt-by-id:

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -657,7 +657,10 @@ function SerenityController(context, log, env) {
       if (!job
         || metadata.jobType !== CLASSIFY_PROMPTS_JOB_TYPE
         || metadata.brandId !== auth.brandUuid) {
-        return notFound(`Job not found: ${jobId}`);
+        // Static body — do not echo the caller-supplied id back. Log it
+        // server-side so the mismatch stays diagnosable.
+        log.info(`serenity: classification job not found or not accessible: ${jobId}`);
+        return notFound('Job not found');
       }
 
       const status = job.getStatus();

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -33,7 +33,7 @@ import {
   BULK_PROMPTS_MAX_ITEMS,
   resolveCallerId,
 } from '../support/serenity/handlers/prompts.js';
-import { createAndEnqueueJob } from '../support/serenity/async-job-runner.js';
+import { createAndEnqueueJob, NEEDS_REAUTH_ERROR_CODE } from '../support/serenity/async-job-runner.js';
 import { CLASSIFY_PROMPTS_JOB_TYPE } from '../support/serenity/handlers/classify-prompts-job.js';
 import {
   handleListMarkets,
@@ -608,6 +608,70 @@ function SerenityController(context, log, env) {
           { orgId: ctx?.params?.spaceCatId },
         );
       return createResponse(result, 200);
+    } catch (e) {
+      return mapError(e, log);
+    }
+  };
+
+  /**
+   * Poll the status of an async prompt-classification job enqueued by
+   * `createPrompts` (serenity-docs#33). The enqueue path returns `202 {jobId}`;
+   * this is what the caller polls until the job reaches a terminal state.
+   *
+   * Auth mirrors the write path: the same `authorize(ctx)` brand-access +
+   * serenity-active gate, plus a defence-in-depth ownership check that the job's
+   * stored `metadata.brandId` matches the resolved brand — so a caller with
+   * access to brand A cannot read brand B's job by guessing its id — and a
+   * job-type guard so this endpoint only ever serves serenity classify jobs.
+   *
+   * Response:
+   *   - always: `{ jobId, status }` (status is the `AsyncJob` status:
+   *     IN_PROGRESS | COMPLETED | FAILED | CANCELLED).
+   *   - COMPLETED: `result` — the classify job's `{ created, skipped, failed }`.
+   *   - FAILED: `error` (`{ code, message }`), plus `needsReauth: true` when the
+   *     failure was a dead promise token (`code === NEEDS_REAUTH`), so the UI can
+   *     prompt a re-auth + resubmit rather than surfacing a generic failure.
+   */
+  const getPromptClassificationJobStatus = async (ctx) => {
+    try {
+      const auth = await authorize(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { jobId } = ctx?.params || {};
+      if (!isValidUUID(jobId)) {
+        return createResponse(
+          { error: 'invalidRequest', message: 'jobId must be a UUID' },
+          400,
+        );
+      }
+      const AsyncJob = ctx?.dataAccess?.AsyncJob;
+      if (!AsyncJob || typeof AsyncJob.findById !== 'function') {
+        return internalServerError('AsyncJob data-access not available');
+      }
+      const job = await AsyncJob.findById(jobId);
+      const metadata = job?.getMetadata?.() || {};
+      // A wrong job type or a brand mismatch is reported as 404, not 403 — the
+      // same "no such job here" contract, revealing nothing about jobs the
+      // caller can't see.
+      if (!job
+        || metadata.jobType !== CLASSIFY_PROMPTS_JOB_TYPE
+        || metadata.brandId !== auth.brandUuid) {
+        return notFound(`Job not found: ${jobId}`);
+      }
+
+      const status = job.getStatus();
+      const body = { jobId: job.getId(), status };
+      if (status === 'COMPLETED') {
+        body.result = job.getResult() ?? null;
+      } else if (status === 'FAILED') {
+        const error = job.getError() || {};
+        body.error = { code: error.code ?? null, message: error.message ?? null };
+        if (error.code === NEEDS_REAUTH_ERROR_CODE) {
+          body.needsReauth = true;
+        }
+      }
+      return createResponse(body, 200);
     } catch (e) {
       return mapError(e, log);
     }
@@ -1766,6 +1830,7 @@ function SerenityController(context, log, env) {
   return {
     listPrompts,
     createPrompts,
+    getPromptClassificationJobStatus,
     updatePrompt,
     bulkDeletePrompts,
     listMarkets,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -865,6 +865,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId': 'llmo/can_view',
       // Serenity proxy (Semrush AIO replacement) — reads under brand
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -239,6 +239,7 @@ export default function getRouteHandlers(
     'POST /v2/orgs/:spaceCatId/brands/:brandId/activate': brandsController.activateBrandForOrg,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': serenityController.listPrompts,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': serenityController.createPrompts,
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId': serenityController.getPromptClassificationJobStatus,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-delete': serenityController.bulkDeletePrompts,
     'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:semrushPromptId': serenityController.updatePrompt,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets': serenityController.listMarkets,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -304,6 +304,7 @@ const routeRequiredCapabilities = {
   'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/delete': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/check': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'organization:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId': 'organization:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'organization:write',
   'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:semrushPromptId': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-delete': 'organization:write',

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2757,6 +2757,128 @@ describe('SerenityController', () => {
     });
   });
 
+  describe('getPromptClassificationJobStatus (serenity-docs#33)', () => {
+    const JOB_ID = '99999999-8888-7777-6666-555555555555';
+
+    // Build a fake AsyncJob and attach it to the context's data-access layer
+    // (fakeContext does not provide AsyncJob by default).
+    function ctxWithJob(job, { jobId = JOB_ID, params = {} } = {}) {
+      const ctx = fakeContext({ params: { jobId, ...params } });
+      ctx.dataAccess.AsyncJob = {
+        findById: sinon.stub().resolves(job),
+      };
+      return ctx;
+    }
+
+    function makeJob({
+      status = 'IN_PROGRESS', result, error, metadata = {},
+    } = {}) {
+      return {
+        getId: () => JOB_ID,
+        getStatus: () => status,
+        getResult: () => result,
+        getError: () => error,
+        getMetadata: () => ({
+          jobType: 'serenity-classify-prompts', brandId: BRAND, ...metadata,
+        }),
+      };
+    }
+
+    it('returns 200 + status for an in-progress job', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob({ status: 'IN_PROGRESS' })),
+      );
+      expect(response.status).to.equal(200);
+      expect(await readBody(response)).to.deep.equal({ jobId: JOB_ID, status: 'IN_PROGRESS' });
+    });
+
+    it('returns the classify result on COMPLETED', async () => {
+      const result = { created: [{ text: 'x' }], skipped: [], failed: [] };
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob({ status: 'COMPLETED', result })),
+      );
+      expect(response.status).to.equal(200);
+      expect(await readBody(response)).to.deep.equal({ jobId: JOB_ID, status: 'COMPLETED', result });
+    });
+
+    it('surfaces needsReauth:true on FAILED with a NEEDS_REAUTH error code', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob({
+          status: 'FAILED',
+          error: { code: 'NEEDS_REAUTH', message: 'promise token dead' },
+        })),
+      );
+      expect(response.status).to.equal(200);
+      expect(await readBody(response)).to.deep.equal({
+        jobId: JOB_ID,
+        status: 'FAILED',
+        error: { code: 'NEEDS_REAUTH', message: 'promise token dead' },
+        needsReauth: true,
+      });
+    });
+
+    it('does not set needsReauth on FAILED with a non-reauth error code', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob({
+          status: 'FAILED',
+          error: { code: 'JOB_FAILED', message: 'boom' },
+        })),
+      );
+      expect(response.status).to.equal(200);
+      const body = await readBody(response);
+      expect(body).to.deep.equal({
+        jobId: JOB_ID,
+        status: 'FAILED',
+        error: { code: 'JOB_FAILED', message: 'boom' },
+      });
+      expect(body).to.not.have.property('needsReauth');
+    });
+
+    it('400s when jobId is not a UUID', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob(), { jobId: 'not-a-uuid' }),
+      );
+      expect(response.status).to.equal(400);
+    });
+
+    it('404s when the job does not exist', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(ctxWithJob(null));
+      expect(response.status).to.equal(404);
+    });
+
+    it('404s when the job belongs to a different brand (ownership guard)', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob({ metadata: { brandId: 'some-other-brand' } })),
+      );
+      expect(response.status).to.equal(404);
+    });
+
+    it('404s when the job is not a serenity classify job (jobType guard)', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob({ metadata: { jobType: 'some-other-job' } })),
+      );
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns the authorize() error (403) when the caller lacks org access', async () => {
+      accessControlHasAccessStub.resolves(false);
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const ctx = ctxWithJob(makeJob());
+      const response = await controller.getPromptClassificationJobStatus(ctx);
+      expect(response.status).to.equal(403);
+      // never reaches the job lookup
+      expect(ctx.dataAccess.AsyncJob.findById).to.not.have.been.called;
+    });
+  });
+
   describe('defensive branch coverage', () => {
     // Line 365-372: createPrompts flat-mode dispatch. The default
     // resolveBrandWorkspaceStub returns flat mode, so this reaches handleCreatePrompts.

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2868,6 +2868,37 @@ describe('SerenityController', () => {
       expect(response.status).to.equal(404);
     });
 
+    it('returns the bare {jobId, status} shape on CANCELLED (no result/error)', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.getPromptClassificationJobStatus(
+        ctxWithJob(makeJob({ status: 'CANCELLED' })),
+      );
+      expect(response.status).to.equal(200);
+      const body = await readBody(response);
+      expect(body).to.deep.equal({ jobId: JOB_ID, status: 'CANCELLED' });
+      expect(body).to.not.have.property('result');
+      expect(body).to.not.have.property('error');
+    });
+
+    it('500s when AsyncJob data-access is unavailable', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const ctx = fakeContext({ params: { jobId: JOB_ID } });
+      // No AsyncJob on dataAccess → the guard returns 500 before any lookup.
+      delete ctx.dataAccess.AsyncJob;
+      const response = await controller.getPromptClassificationJobStatus(ctx);
+      expect(response.status).to.equal(500);
+    });
+
+    it('maps an unexpected error (findById throws) via mapError', async () => {
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const ctx = fakeContext({ params: { jobId: JOB_ID } });
+      ctx.dataAccess.AsyncJob = {
+        findById: sinon.stub().rejects(new Error('dynamo exploded')),
+      };
+      const response = await controller.getPromptClassificationJobStatus(ctx);
+      expect(response.status).to.equal(500);
+    });
+
     it('returns the authorize() error (403) when the caller lacks org access', async () => {
       accessControlHasAccessStub.resolves(false);
       const controller = SerenityController({ env: {} }, fakeLog(), {});

--- a/test/it/postgres/seed-data/async-jobs.js
+++ b/test/it/postgres/seed-data/async-jobs.js
@@ -10,10 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
+import {
+  BRAND_1_ID,
+  SERENITY_CLASSIFY_JOB_1_ID,
+  SERENITY_CLASSIFY_JOB_OTHER_BRAND_ID,
+} from '../../shared/seed-ids.js';
+
 /**
  * Immutable baseline async jobs for IT tests.
  *
  * JOB_1: A completed preflight job referencing SITE_1.
+ *
+ * Serenity classify jobs (serenity-docs#33): a COMPLETED job owned by BRAND_1
+ * (happy path for the poll endpoint) and one carrying a foreign brandId (the
+ * endpoint's ownership guard 404s it even though its jobType matches).
  *
  * Note: AsyncJob only exists in v3 (PostgreSQL) — no DynamoDB equivalent.
  *
@@ -46,5 +56,35 @@ export const asyncJobs = [
     },
     started_at: '2025-01-20T10:00:00.000Z',
     ended_at: '2025-01-20T10:05:00.000Z',
+  },
+  {
+    id: SERENITY_CLASSIFY_JOB_1_ID,
+    status: 'COMPLETED',
+    result: {
+      created: [], skipped: [], failed: [], published: true,
+    },
+    metadata: {
+      jobType: 'serenity-classify-prompts',
+      brandId: BRAND_1_ID,
+      tags: ['serenity-classify-prompts'],
+    },
+    started_at: '2025-01-21T10:00:00.000Z',
+    ended_at: '2025-01-21T10:00:30.000Z',
+  },
+  {
+    id: SERENITY_CLASSIFY_JOB_OTHER_BRAND_ID,
+    status: 'COMPLETED',
+    result: {
+      created: [], skipped: [], failed: [], published: true,
+    },
+    metadata: {
+      jobType: 'serenity-classify-prompts',
+      // A brand other than BRAND_1 — the poll endpoint's ownership guard must
+      // 404 this for a BRAND_1 caller rather than leak another brand's job.
+      brandId: 'ffffffff-ffff-4fff-bfff-ffffffffffff',
+      tags: ['serenity-classify-prompts'],
+    },
+    started_at: '2025-01-21T11:00:00.000Z',
+    ended_at: '2025-01-21T11:00:30.000Z',
   },
 ];

--- a/test/it/shared/seed-ids.js
+++ b/test/it/shared/seed-ids.js
@@ -197,6 +197,15 @@ export const ASYNC_JOB_1_ID = 'eeee1111-1111-4111-b111-111111111111'; // COMPLET
 export const ASYNC_JOB_2_ID = 'eeee2222-2222-4222-a222-222222222222'; // IN_PROGRESS site-detection job
 export const NON_EXISTENT_JOB_ID = 'eeee9999-9999-4999-b999-999999999999';
 
+// Serenity async prompt-classification jobs (serenity-docs#33). Both are
+// jobType 'serenity-classify-prompts'; ownership is carried in metadata.brandId.
+// SERENITY_CLASSIFY_JOB_1 belongs to BRAND_1 (happy path); the OTHER_BRAND job
+// carries a foreign brandId so the endpoint's ownership guard 404s it even
+// though its jobType matches. ASYNC_JOB_1 (a preflight job) covers the
+// wrong-jobType 404 for the same brand.
+export const SERENITY_CLASSIFY_JOB_1_ID = 'eeee3333-3333-4333-b333-333333333333';
+export const SERENITY_CLASSIFY_JOB_OTHER_BRAND_ID = 'eeee4444-4444-4444-a444-444444444444';
+
 // ── Consumers (S2S) ──
 
 export const CONSUMER_1_ID = '11111111-1111-4111-b112-111111111111';

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -12,7 +12,7 @@
 
 import { expect } from 'chai';
 import {
-  ORG_1_ID, BRAND_1_ID, SITE_1_ID,
+  ORG_1_ID, ORG_3_ID, BRAND_1_ID, SITE_1_ID,
   ASYNC_JOB_1_ID, NON_EXISTENT_JOB_ID,
   SERENITY_CLASSIFY_JOB_1_ID, SERENITY_CLASSIFY_JOB_OTHER_BRAND_ID,
 } from '../seed-ids.js';
@@ -1528,7 +1528,12 @@ export default function serenityTests(
     });
 
     it('403s a caller without access to the organization', async () => {
-      const res = await getHttpClient().user.get(jobPath(SERENITY_CLASSIFY_JOB_1_ID));
+      // The `user` persona is a member of ORG_1 (it drives the write tests above),
+      // so a genuine no-access 403 needs an org it does NOT belong to. ORG_3 is
+      // such an org — hasAccess() fails in authorize() before any job lookup.
+      const res = await getHttpClient().user.get(
+        `/v2/orgs/${ORG_3_ID}/brands/${BRAND_1_ID}/serenity/prompts/jobs/${SERENITY_CLASSIFY_JOB_1_ID}`,
+      );
       expect(res.status).to.equal(403);
     });
   });

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -13,6 +13,8 @@
 import { expect } from 'chai';
 import {
   ORG_1_ID, BRAND_1_ID, SITE_1_ID,
+  ASYNC_JOB_1_ID, NON_EXISTENT_JOB_ID,
+  SERENITY_CLASSIFY_JOB_1_ID, SERENITY_CLASSIFY_JOB_OTHER_BRAND_ID,
 } from '../seed-ids.js';
 import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
 
@@ -1486,6 +1488,48 @@ export default function serenityTests(
       expect(res.status).to.equal(200);
 
       expect(aliasesOf((await benchmarkNamed('Rival Uno')).row)).to.include('rival incorporated');
+    });
+  });
+
+  describe('Serenity API — async prompt-classification job status (serenity-docs#33)', () => {
+    const base = `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/serenity`;
+    const jobPath = (jobId) => `${base}/prompts/jobs/${jobId}`;
+
+    it('GET /serenity/prompts/jobs/:jobId returns 200 + the terminal status and result', async () => {
+      const res = await getHttpClient().admin.get(jobPath(SERENITY_CLASSIFY_JOB_1_ID));
+      expect(res.status).to.equal(200);
+      expect(res.body.jobId).to.equal(SERENITY_CLASSIFY_JOB_1_ID);
+      expect(res.body.status).to.equal('COMPLETED');
+      // COMPLETED surfaces the create-shaped result (created / skipped / failed).
+      expect(res.body.result).to.deep.equal({
+        created: [], skipped: [], failed: [], published: true,
+      });
+    });
+
+    it('404s a job owned by a different brand (ownership guard, no cross-brand leak)', async () => {
+      const res = await getHttpClient().admin.get(jobPath(SERENITY_CLASSIFY_JOB_OTHER_BRAND_ID));
+      expect(res.status).to.equal(404);
+    });
+
+    it('404s a job of a different type (jobType guard)', async () => {
+      // ASYNC_JOB_1 is a preflight job, not a serenity classify job.
+      const res = await getHttpClient().admin.get(jobPath(ASYNC_JOB_1_ID));
+      expect(res.status).to.equal(404);
+    });
+
+    it('404s an unknown job id', async () => {
+      const res = await getHttpClient().admin.get(jobPath(NON_EXISTENT_JOB_ID));
+      expect(res.status).to.equal(404);
+    });
+
+    it('400s a non-UUID job id', async () => {
+      const res = await getHttpClient().admin.get(jobPath('not-a-uuid'));
+      expect(res.status).to.equal(400);
+    });
+
+    it('403s a caller without access to the organization', async () => {
+      const res = await getHttpClient().user.get(jobPath(SERENITY_CLASSIFY_JOB_1_ID));
+      expect(res.status).to.equal(403);
     });
   });
 }

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -38,7 +38,9 @@ function fakeLog() {
   };
 }
 
-function fakeContext({ params = {}, data = undefined, query = {} } = {}) {
+function fakeContext({
+  params = {}, data = undefined, query = {}, asyncJob = undefined,
+} = {}) {
   // Build a request.url from `query` so handlers that read params via extractQuery
   // (the ElementsController endpoints) see them. Handlers that read ctx.query
   // directly are unaffected (both are populated).
@@ -73,6 +75,9 @@ function fakeContext({ params = {}, data = undefined, query = {} } = {}) {
           getLanguageCode: () => 'en',
         }]),
       },
+      // Only consumed by getSerenityPromptClassificationJobStatus, whose fixture
+      // supplies a stub job via `asyncJob`.
+      ...(asyncJob ? { AsyncJob: asyncJob } : {}),
     },
     params: { spaceCatId: ORG, brandId: BRAND, ...params },
     data,
@@ -614,6 +619,33 @@ const FIXTURES = {
       closestDate: '2026-07-26T00:00:00Z',
     }],
   },
+  // Served by the controller directly off ctx.dataAccess.AsyncJob (no serenity
+  // handler), so it has no handlerName/serviceMethod. The stub job resolves as a
+  // COMPLETED classify job owned by BRAND, so the documented COMPLETED shape
+  // (bare {jobId, status} plus the SerenityCreatePromptsResponse `result`) is
+  // exercised against the schema.
+  getSerenityPromptClassificationJobStatus: {
+    expectedStatus: 200,
+    controllerMethod: 'getPromptClassificationJobStatus',
+    params: { jobId: '99999999-8888-7777-6666-555555555555' },
+    asyncJob: {
+      findById: () => Promise.resolve({
+        getId: () => '99999999-8888-7777-6666-555555555555',
+        getStatus: () => 'COMPLETED',
+        getMetadata: () => ({
+          jobType: 'serenity-classify-prompts',
+          brandId: BRAND,
+        }),
+        getResult: () => ({
+          created: [],
+          skipped: [],
+          failed: [],
+          published: true,
+        }),
+        getError: () => null,
+      }),
+    },
+  },
 };
 
 function makeAjv() {
@@ -753,7 +785,12 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
         listGlobalModelCatalog: sinon.stub(),
         listLanguageCatalog: sinon.stub(),
       };
-      handlerStubs[fx.handlerName].resolves(fx.handlerResult);
+      // getSerenityPromptClassificationJobStatus reads ctx.dataAccess.AsyncJob
+      // directly rather than delegating to a serenity handler, so it has no
+      // handlerName to stub.
+      if (fx.handlerName) {
+        handlerStubs[fx.handlerName].resolves(fx.handlerResult);
+      }
 
       const SerenityController = (await esmock(
         '../../src/controllers/serenity.js',
@@ -855,6 +892,7 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
         params: fx.params || {},
         data: fx.data,
         query: fx.query || {},
+        asyncJob: fx.asyncJob,
       });
       const controller = SerenityController(ctx, fakeLog());
       const response = await controller[fx.controllerMethod](ctx);

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1002,6 +1002,7 @@ describe('getRouteHandlers', () => {
       'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/check',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-delete',
       'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:semrushPromptId',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets',


### PR DESCRIPTION
## Summary
The async prompt-classification enqueue path (serenity-docs#33) returns `202 {jobId, status}`, but there was **no endpoint to poll that job** — the id was inert, and the worker's `NEEDS_REAUTH` terminal state was never surfaced to any caller. This adds the poll endpoint.

`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId`:
- Reuses the same `authorize()` brand-access + serenity-active gate as the write path, plus a **defence-in-depth ownership check** (`AsyncJob` `metadata.brandId` must match the resolved brand) and a **job-type guard**, so a caller with access to brand A can't read brand B's job by guessing its id (both report `404`, not `403`).
- Response: `{ jobId, status }` always; `result` (the `{created, skipped, failed}` classify outcome) on `COMPLETED`; `error` on `FAILED`, with **`needsReauth: true`** when the failure was a dead promise token (`code === NEEDS_REAUTH`) so the UI can prompt a re-auth + resubmit rather than showing a generic error.
- Wired into `required-capabilities` (`organization:read`) and the llmo FACS map (`llmo/can_view`). `jobId` was already in `FACS_NON_RESOURCE_PARAMS`.

Also documents the **previously-undocumented `202`** response on the bulk-create path and adds the OpenAPI path + `SerenityPromptClassificationJob` / `SerenityPromptClassificationJobAccepted` schemas.

## Context
Closes the top "still open, blocking" gap from the #33 audit — the classification consumer, runner, and infra are already merged; this makes the returned `jobId` actually usable end-to-end. The `needsReauth`-boolean-only contract (no server-built reauth URL) was chosen deliberately so the API doesn't presume the not-yet-built UI's auth flow.

## Not in this PR (tracked follow-ups)
- **`deferPublish` routing collision** — async routing keys off `deferPublish:true`, which elmo-ui also sets on non-final CSV chunks; needs reconciliation before the UI relies on this path.
- UI 202/poll + re-auth surface (Phase 7).
- Async-path observability/metrics.

## Test plan
- [x] `test/controllers/serenity.test.js` — 9 new cases (in-progress / completed+result / failed+needsReauth / failed-non-reauth / 400 bad jobId / 404 not-found / 404 brand-mismatch / 404 wrong-job-type / 403 no-access)
- [x] `test/routes/index.test.js`, `test/routes/facs-capabilities.test.js`, `test/routes/required-capabilities.test.js` — green (route + capability classification)
- [x] `eslint` clean on all changed files
- [x] OpenAPI: my additions produce zero lint problems (2 pre-existing baseline errors are unrelated)
- Note: local `tsc` shows errors only in the untouched `rest-transport.js`, an artifact of stale symlinked `node_modules` (1.15.0 vs the 1.18.1 both this branch and main pin); CI installs 1.18.1 fresh. My files type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)