### PR TITLE
fix(serenity): decouple async prompt-classification routing from deferPublish (#33)

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12027,7 +12027,20 @@ SerenityCreatePromptsRequest:
         carries `published: false`). Used for chunked CSV imports, where the
         client posts several chunks and issues a single publish after the last
         one (serenity-docs#32). Omitted/false publishes once at the end of the
-        call as usual.
+        call as usual. This is a synchronous-path hint only and does NOT trigger
+        async processing — use `async` for that.
+    async:
+      type: boolean
+      default: false
+      description: >
+        When true (flat-mode brands only), the request is processed
+        ASYNCHRONOUSLY: instead of classifying + creating + publishing inline,
+        the whole write is enqueued to a background job and the endpoint returns
+        202 with a job id to poll via
+        `GET .../serenity/prompts/jobs/{jobId}` (serenity-docs#33). Deliberately
+        distinct from `deferPublish` (a synchronous publish-batching hint) so
+        that the synchronous CSV-chunking client is never routed to async
+        unexpectedly. Omitted/false processes synchronously as usual.
 
 SerenityCreatePromptsResponse:
   type: object

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -29,7 +29,7 @@ import {
   handleCreatePrompts,
   handleUpdatePrompt,
   handleBulkDeletePrompts,
-  validateDeferPublish,
+  validateAsync,
   BULK_PROMPTS_MAX_ITEMS,
   resolveCallerId,
 } from '../support/serenity/handlers/prompts.js';
@@ -530,16 +530,18 @@ function SerenityController(context, log, env) {
       if (auth.error) {
         return auth.error;
       }
-      // serenity-docs#33: CSV import is the ONLY bulk write path that routes to
-      // the async job runner — every other write path (single create, single
-      // edit, UI multi-add) stays synchronous. Routing is by SOURCE, not array
-      // length: `deferPublish` is the exact flag CSV-chunking already sets
-      // (see handleCreatePrompts' docstring) precisely because a UI multi-add
-      // never sets it, so a three-prompt UI add never pays queue+worker+publish
-      // latency. Flat-mode brands only for now — see this PR's report for why
-      // subworkspace-mode CSV import stays on the synchronous path.
+      // serenity-docs#33 + #2/#3: async routing is keyed off a DEDICATED
+      // `async: true` flag, NOT `deferPublish`. `deferPublish` is a publish-
+      // batching hint on the synchronous CSV-chunking path (set on every non-
+      // final chunk); conflating the two made that sync client silently receive
+      // 202s it never handled. Keying async off its own explicit opt-in keeps
+      // every existing write path — single create/edit, UI multi-add, and the
+      // sync CSV-chunking client — synchronous and untouched, and makes the
+      // async job runner strictly opt-in for callers that will poll the job.
+      // Flat-mode brands only for now — subworkspace-mode CSV import stays on
+      // the synchronous path (see the #33 report).
       const body = ctx.data || {};
-      if (auth.mode !== 'subworkspace' && validateDeferPublish(body)) {
+      if (auth.mode !== 'subworkspace' && validateAsync(body)) {
         const prompts = Array.isArray(body.prompts) ? body.prompts : [];
         if (prompts.length === 0) {
           return createResponse(

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -193,6 +193,30 @@ export function validateDeferPublish(body) {
 }
 
 /**
+ * Whether a bulk-create request opts into the ASYNC job runner (serenity-docs#33).
+ *
+ * This is a DEDICATED trigger, deliberately separate from `deferPublish`. The
+ * two are unrelated concerns and must not be conflated: `deferPublish` is a
+ * publish-batching hint on the synchronous path (defer the upstream publish
+ * until the last chunk), whereas `async` routes the whole write off the request
+ * path onto the SQS worker and returns 202 + a job id to poll. Overloading
+ * `deferPublish` for both meant the sync CSV-chunking client (which sets
+ * `deferPublish: true` on every non-final chunk) silently got 202s it did not
+ * expect. Keying async off its own explicit flag lets that client keep working
+ * synchronously untouched, and makes async strictly opt-in.
+ *
+ * @param {object} body - request body.
+ * @returns {boolean} true when `async === true`.
+ */
+export function validateAsync(body) {
+  const asyncFlag = body?.async;
+  if (asyncFlag !== undefined && typeof asyncFlag !== 'boolean') {
+    throw new ErrorWithStatusCode('async must be a boolean', 400);
+  }
+  return asyncFlag === true;
+}
+
+/**
  * Builds the prompt's tag list from the upstream item: one entry per tag,
  * carrying its id, bare name, parent id and root-first ancestry breadcrumb.
  *

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2771,18 +2771,19 @@ describe('SerenityController', () => {
       expect(handlers.handleCreatePromptsSubworkspace).not.to.have.been.called;
     });
 
-    // serenity-docs#33: CSV import routes to the async job runner instead of the
-    // synchronous classify/create/publish path. `deferPublish: true` is the exact
-    // flag CSV-chunking already sets (a UI multi-add never sets it), so routing
-    // is by source, not array length.
-    describe('CSV import async routing (serenity-docs#33)', () => {
-      it('enqueues a serenity-classify-prompts job and returns 202 when deferPublish is true (flat mode)', async () => {
+    // serenity-docs#33 (+#2/#3): bulk import routes to the async job runner via a
+    // DEDICATED `async: true` flag — NOT `deferPublish`. `deferPublish` stays a
+    // synchronous publish-batching hint; keying async off its own flag keeps the
+    // sync CSV-chunking client (which sets deferPublish on non-final chunks)
+    // working synchronously and untouched.
+    describe('async bulk routing (serenity-docs#33)', () => {
+      it('enqueues a serenity-classify-prompts job and returns 202 when async is true (flat mode)', async () => {
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const prompts = [{
           text: 'What is your return policy?', geoTargetId: 2840, languageCode: 'en', tagIds: ['tag-1'],
         }];
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts },
+          data: { async: true, prompts },
         }));
 
         expect(response.status).to.equal(202);
@@ -2800,7 +2801,21 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePrompts).to.not.have.been.called;
       });
 
-      it('stays synchronous (no enqueue) when deferPublish is absent, even for a large batch', async () => {
+      // Regression guard for the #2 collision: deferPublish alone MUST stay
+      // synchronous now that it no longer triggers async.
+      it('stays synchronous when deferPublish is true but async is absent (collision guard)', async () => {
+        handlers.handleCreatePrompts.resolves({ created: 1, failed: [] });
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const response = await controller.createPrompts(fakeContext({
+          data: { deferPublish: true, prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
+        }));
+
+        expect(response.status).to.equal(200);
+        expect(createAndEnqueueJobStub).to.not.have.been.called;
+        expect(handlers.handleCreatePrompts).to.have.been.calledOnce;
+      });
+
+      it('stays synchronous (no enqueue) when async is absent, even for a large batch', async () => {
         handlers.handleCreatePrompts.resolves({ created: 1, failed: [] });
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const response = await controller.createPrompts(fakeContext({
@@ -2812,14 +2827,24 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePrompts).to.have.been.calledOnce;
       });
 
-      it('stays synchronous for subworkspace-mode brands even when deferPublish is true', async () => {
+      it('400s when async is not a boolean', async () => {
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const response = await controller.createPrompts(fakeContext({
+          data: { async: 'yes', prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
+        }));
+
+        expect(response.status).to.equal(400);
+        expect(createAndEnqueueJobStub).to.not.have.been.called;
+      });
+
+      it('stays synchronous for subworkspace-mode brands even when async is true', async () => {
         resolveBrandWorkspaceStub.resolves({
           mode: 'subworkspace', workspaceId: SUBWS, parentWorkspaceId: WORKSPACE,
         });
         handlers.handleCreatePromptsSubworkspace.resolves({ created: 1, failed: [] });
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
+          data: { async: true, prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
         }));
 
         expect(response.status).to.equal(200);
@@ -2827,23 +2852,23 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePromptsSubworkspace).to.have.been.calledOnce;
       });
 
-      it('400s without enqueueing when deferPublish is true but prompts is empty', async () => {
+      it('400s without enqueueing when async is true but prompts is empty', async () => {
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts: [] },
+          data: { async: true, prompts: [] },
         }));
 
         expect(response.status).to.equal(400);
         expect(createAndEnqueueJobStub).to.not.have.been.called;
       });
 
-      it('400s without enqueueing when deferPublish is true and prompts exceeds the max item cap', async () => {
+      it('400s without enqueueing when async is true and prompts exceeds the max item cap', async () => {
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const tooMany = Array.from({ length: 501 }, (_, i) => ({
           text: `p${i}`, geoTargetId: 2840, languageCode: 'en',
         }));
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts: tooMany },
+          data: { async: true, prompts: tooMany },
         }));
 
         expect(response.status).to.equal(400);

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -25,6 +25,7 @@ import {
   normalizePromptInput,
   makeIntentInjector,
   validateDeferPublish,
+  validateAsync,
   reconcilePublishErrors,
   resolveCallerId,
   buildCreateMetadata,
@@ -2567,6 +2568,17 @@ describe('handlers/prompts.js — deferPublish (serenity-docs#32 CSV-chunking)',
     expect(validateDeferPublish({ deferPublish: true })).to.equal(true);
     expect(() => validateDeferPublish({ deferPublish: 'yes' }))
       .to.throw(ErrorWithStatusCode, /deferPublish must be a boolean/);
+  });
+
+  it('validateAsync resolves absent/false/true and rejects a non-boolean (serenity-docs#33)', () => {
+    expect(validateAsync({})).to.equal(false);
+    expect(validateAsync({ async: false })).to.equal(false);
+    expect(validateAsync({ async: true })).to.equal(true);
+    expect(() => validateAsync({ async: 'yes' }))
+      .to.throw(ErrorWithStatusCode, /async must be a boolean/);
+    // async and deferPublish are independent flags: neither implies the other.
+    expect(validateAsync({ deferPublish: true })).to.equal(false);
+    expect(validateDeferPublish({ async: true })).to.equal(false);
   });
 
   it('skips the trailing publish and reports published:false when deferPublish is true', async () => {


### PR DESCRIPTION
## Summary
Fixes a live routing collision in the async prompt-classification feature (serenity-docs#33). Async routing was keyed off `deferPublish: true` — but the **synchronous CSV-chunking client already sets `deferPublish: true` on every non-final chunk** for publish-batching. For a flat-mode brand, those chunks silently received a `202 {jobId}` job response the client never handles, breaking bulk import. (Latent today only because serenity brands are currently subworkspace-mode, which stays synchronous — it becomes a live bug the moment a flat-mode brand runs a CSV import.)

`deferPublish` and "go async" are unrelated concerns, so this **splits them**: async is now triggered by a **dedicated, explicit `async: true`** flag. `deferPublish` reverts to being purely a synchronous publish-batching hint. Result: every existing write path — single create/edit, UI multi-add, and the sync CSV-chunking client — stays synchronous and untouched, and the async runner is strictly opt-in for callers that will poll the job.

This is the api-service half of the #2/#3 fix. The elmo-ui half (rewrite CSV import to submit-once with `async:true` + poll the job-status endpoint) follows once the poll endpoint (**PR #3069**) lands.

## Changes
- `handlers/prompts.js`: new `validateAsync(body)` (mirrors `validateDeferPublish`).
- `controllers/serenity.js` `createPrompts`: routes on `validateAsync`; `validateDeferPublish` still governs the sync publish-batching path.
- OpenAPI: documents the new `async` request property, explicitly distinct from `deferPublish`.
- Tests: async-routing suite rekeyed to `async:true`; **added a regression guard that `deferPublish:true` alone stays synchronous** (the collision); `validateAsync` unit tests.

## Coordination with PR #3069
Minimal overlap, no code conflict (different functions/import lines). One doc nit: #3069's POST `202` response prose currently says the trigger is `deferPublish` — after this lands it should read `async`. Flagged to update in #3069.

## Test plan
- [x] `test/controllers/serenity.test.js` + `test/support/serenity/handlers/prompts.test.js` — 358 passing, 0 failing
- [x] eslint clean on all changed files
- [x] OpenAPI: my `async` schema addition introduces zero lint problems

🤖 Generated with [Claude Code](https://claude.com/claude-code)