### PR TITLE
fix(sites): deep-merge hlxConfig/deliveryConfig on PATCH to preserve content.source (SITES-49362)

### DIFF
--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -105,6 +105,8 @@ async function buildResolveData(org, site, context, asoEntitlement) {
  * - Omitted keys keep their existing value in `base`.
  * - A `null` value deletes the key.
  * - Plain objects are merged recursively; arrays and non-object values replace.
+ * - Dangerous keys (`__proto__`/`constructor`/`prototype`) are ignored to
+ *   prevent prototype pollution from an untrusted request body.
  *
  * @param {object} base - Existing value.
  * @param {object} patch - Incoming partial patch.
@@ -113,7 +115,9 @@ async function buildResolveData(org, site, context, asoEntitlement) {
 function deepMerge(base, patch) {
   const result = { ...(isObject(base) ? base : {}) };
   for (const [key, value] of Object.entries(patch)) {
-    if (value === null) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      // Ignore prototype-pollution vectors from the request body.
+    } else if (value === null) {
       delete result[key];
     } else if (isObject(value) && isObject(result[key])) {
       result[key] = deepMerge(result[key], value);

--- a/src/controllers/sites.js
+++ b/src/controllers/sites.js
@@ -99,6 +99,32 @@ async function buildResolveData(org, site, context, asoEntitlement) {
 }
 
 /**
+ * Recursively deep-merges `patch` into `base`, returning a new object.
+ *
+ * Merge semantics (used for PATCH of nested config like hlxConfig/deliveryConfig):
+ * - Omitted keys keep their existing value in `base`.
+ * - A `null` value deletes the key.
+ * - Plain objects are merged recursively; arrays and non-object values replace.
+ *
+ * @param {object} base - Existing value.
+ * @param {object} patch - Incoming partial patch.
+ * @returns {object} Merged result.
+ */
+function deepMerge(base, patch) {
+  const result = { ...(isObject(base) ? base : {}) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete result[key];
+    } else if (isObject(value) && isObject(result[key])) {
+      result[key] = deepMerge(result[key], value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
  * Resolves the org's per-product default site from config.defaults, validating it belongs
  * to the org and is enrolled. Returns the resolved data object or null to fall through
  * to getFirstEnrollment().
@@ -1331,12 +1357,15 @@ function SitesController(ctx, log, env) {
       ? requestBody.authoringType
       : site.getAuthoringType();
 
+    // Deep-merge `deliveryConfig`/`hlxConfig` so a partial patch (e.g. hlxConfig with only
+    // rso+code) preserves omitted sub-keys like hlxConfig.content.source. An explicit `null`
+    // for a sub-key deletes it; omitting the field entirely keeps the existing value.
     const nextDeliveryConfig = isObject(requestBody.deliveryConfig)
-      ? requestBody.deliveryConfig
+      ? deepMerge(site.getDeliveryConfig(), requestBody.deliveryConfig)
       : site.getDeliveryConfig();
 
     const nextHlxConfig = isObject(requestBody.hlxConfig)
-      ? requestBody.hlxConfig
+      ? deepMerge(site.getHlxConfig(), requestBody.hlxConfig)
       : site.getHlxConfig();
 
     const authoringTypeChanged = nextAuthoringType !== site.getAuthoringType();

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -770,6 +770,103 @@ describe('Sites Controller', () => {
     });
   });
 
+  it('deep-merges hlxConfig, preserving existing content.source on partial patch', async () => {
+    const site = sites[0];
+    site.setHlxConfig({
+      content: { source: { type: 'markup', url: 'https://content.example/' } },
+      code: { source: { type: 'github', url: 'https://github.com/old/repo' } },
+    });
+    site.save = sandbox.spy(site.save);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        hlxConfig: {
+          rso: { owner: 'newOwner', site: 'newSite' },
+          code: { source: { type: 'github', url: 'https://github.com/new/repo' } },
+        },
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(site.save).to.have.been.calledOnce;
+    expect(response.status).to.equal(200);
+    const updatedSite = await response.json();
+    expect(updatedSite.hlxConfig).to.deep.equal({
+      content: { source: { type: 'markup', url: 'https://content.example/' } },
+      code: { source: { type: 'github', url: 'https://github.com/new/repo' } },
+      rso: { owner: 'newOwner', site: 'newSite' },
+    });
+  });
+
+  it('deletes an hlxConfig sub-key when patched with null', async () => {
+    const site = sites[0];
+    site.setHlxConfig({
+      content: { source: { type: 'markup', url: 'https://content.example/' } },
+      rso: { owner: 'owner', site: 'site' },
+    });
+    site.save = sandbox.spy(site.save);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: { hlxConfig: { content: null } },
+      ...defaultAuthAttributes,
+    });
+
+    expect(site.save).to.have.been.calledOnce;
+    expect(response.status).to.equal(200);
+    const updatedSite = await response.json();
+    expect(updatedSite.hlxConfig).to.deep.equal({
+      rso: { owner: 'owner', site: 'site' },
+    });
+  });
+
+  it('leaves hlxConfig unchanged when the patch omits it', async () => {
+    const site = sites[0];
+    const existingHlxConfig = {
+      content: { source: { type: 'markup', url: 'https://content.example/' } },
+    };
+    site.setHlxConfig(existingHlxConfig);
+    site.save = sandbox.spy(site.save);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: { deliveryType: 'other' },
+      ...defaultAuthAttributes,
+    });
+
+    expect(site.save).to.have.been.calledOnce;
+    expect(response.status).to.equal(200);
+    const updatedSite = await response.json();
+    expect(updatedSite.hlxConfig).to.deep.equal(existingHlxConfig);
+  });
+
+  it('deep-merges deliveryConfig, preserving omitted sub-keys on partial patch', async () => {
+    const site = sites[0];
+    site.setDeliveryConfig({
+      programId: '12652',
+      environmentId: '16854',
+      authorURL: 'https://author-p12652-e16854-cmstg.adobeaemcloud.com/',
+    });
+    site.save = sandbox.spy(site.save);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: { deliveryConfig: { siteId: '1234' } },
+      ...defaultAuthAttributes,
+    });
+
+    expect(site.save).to.have.been.calledOnce;
+    expect(response.status).to.equal(200);
+    const updatedSite = await response.json();
+    expect(updatedSite.deliveryConfig).to.deep.equal({
+      programId: '12652',
+      environmentId: '16854',
+      authorURL: 'https://author-p12652-e16854-cmstg.adobeaemcloud.com/',
+      siteId: '1234',
+    });
+  });
+
   it('returns forbidden when trying to update organizationId', async () => {
     const site = sites[0];
     site.save = sandbox.spy(site.save);

--- a/test/controllers/sites.test.js
+++ b/test/controllers/sites.test.js
@@ -867,6 +867,26 @@ describe('Sites Controller', () => {
     });
   });
 
+  it('ignores __proto__ keys in a config patch to prevent prototype pollution', async () => {
+    const site = sites[0];
+    site.setHlxConfig({ rso: { owner: 'o' } });
+    site.save = sandbox.spy(site.save);
+
+    const response = await sitesController.updateSite({
+      params: { siteId: SITE_IDS[0] },
+      data: {
+        hlxConfig: JSON.parse('{"__proto__": {"polluted": true}, "rso": {"site": "s"}}'),
+      },
+      ...defaultAuthAttributes,
+    });
+
+    expect(response.status).to.equal(200);
+    // Object.prototype must not have been polluted.
+    expect({}.polluted).to.equal(undefined);
+    const updatedSite = await response.json();
+    expect(updatedSite.hlxConfig).to.deep.equal({ rso: { owner: 'o', site: 's' } });
+  });
+
   it('returns forbidden when trying to update organizationId', async () => {
     const site = sites[0];
     site.save = sandbox.spy(site.save);

--- a/test/it/shared/tests/sites.js
+++ b/test/it/shared/tests/sites.js
@@ -942,6 +942,36 @@ export default function siteTests(getHttpClient, resetData) {
         expect(after.status).to.equal(200);
         expect(after.body.baseURL).to.equal(SITE_1_BASE_URL);
       });
+
+      it('deep-merges hlxConfig on a partial patch, preserving content.source (SITES-49362)', async () => {
+        const http = getHttpClient();
+        // Seed a crosswalk-shaped hlxConfig (content.source.type=markup).
+        const seed = await http.user.patch(`/sites/${testSiteId}`, {
+          hlxConfig: {
+            content: { source: { type: 'markup', url: 'https://author.example/bin/franklin.delivery/o/s/main' } },
+            rso: {
+              owner: 'o', site: 's', ref: 'main', tld: 'aem.live',
+            },
+          },
+        });
+        expect(seed.status).to.equal(200);
+        expect(seed.body.hlxConfig.content.source.type).to.equal('markup');
+
+        // A partial patch touching only rso must NOT drop the sibling content.source.
+        const res = await http.user.patch(`/sites/${testSiteId}`, {
+          hlxConfig: {
+            rso: {
+              owner: 'o', site: 's2', ref: 'main', tld: 'aem.live',
+            },
+          },
+        });
+        expect(res.status).to.equal(200);
+        expect(res.body.hlxConfig.content.source).to.deep.equal({
+          type: 'markup',
+          url: 'https://author.example/bin/franklin.delivery/o/s/main',
+        });
+        expect(res.body.hlxConfig.rso.site).to.equal('s2');
+      });
     });
 
     describe('PATCH /sites/:siteId/config/scraper', () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill: repo has its own pull_request_template.md; raw PR intentional -->

## Summary

`PATCH /sites/:siteId` (`updateSite`) replaced `hlxConfig` and `deliveryConfig` **wholesale** from the request body, so a partial patch (e.g. `hlxConfig` with only `rso`/`code`) silently dropped sibling sub-keys — notably crosswalk `hlxConfig.content.source.type: "markup"`. This deep-merges both against the existing value instead:

- omitted keys keep their existing value
- an explicit `null` deletes a key
- nested objects merge recursively; arrays and scalars replace

`authoringType` stays scalar.

This is the durable **API-level backstop** behind the ASO "Connect to AEM Sites" dialog guard (SITES-49236 / `experience-success-studio-ui#2168`): it stops **any** caller — the dialog, Slack commands, scripts, or other services — from wiping crosswalk config on a partial update, not just the dialog. Relevant now that product is investing in crosswalk (World Bank, auth0, …).

Supersedes draft #3012 — re-applied on current `main` so it doesn't regress features that landed since that branch was cut; the `deepMerge` helper and tests are Miriam's (co-authored).

## Testing

- 4 controller unit tests: partial `hlxConfig` patch preserves `content.source`; `null` deletes a sub-key; omitted `hlxConfig` unchanged; `deliveryConfig` merges. `npx mocha test/controllers/sites.test.js` — green.
- 1 integration test (`test/it/shared/tests/sites.js` → `PATCH /sites/:siteId`): partial patch preserves `content.source`. Not run locally (needs Docker + ECR); CI validates.
- `lint` + `type-check` clean via the pre-commit hook.

No API schema change (fields unchanged; behavior-only), so no OpenAPI/example updates needed.

---

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes. <!-- N/A: no schema change; PATCH merge-semantics fix only -->

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues

- SITES-49362

Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Miriam Mchome", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```