### PR TITLE
feat(brand-claims): toggle brand-claims audit with enable/disable command

### DIFF
--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -960,15 +960,16 @@ export async function getBrandBySite(organizationId, siteId, postgrestClient, lo
 /**
  * Sets the brand-scoped `brand_claims_enabled` scheduling gate (LLMO-5741),
  * keyed on the brand UUID (the PK), so operators can enable/disable Brand Claims
- * for a brand directly. Returns the updated `{ id, name }` or null when no brand
- * matches the id.
+ * for a brand directly. Returns the updated `{ id, name, site_id }` or null when
+ * no brand matches the id. `site_id` (the brand's primary site) lets callers keep
+ * the per-site `brand-claims` audit toggle in lock-step with this flag.
  *
  * @param {Object} params
  * @param {string} params.brandId - Brand UUID.
  * @param {boolean} params.enabled - Target flag value.
  * @param {Object} params.postgrestClient - PostgREST client.
  * @param {string} [params.updatedBy] - Audit actor.
- * @returns {Promise<{id: string, name: string}|null>}
+ * @returns {Promise<{id: string, name: string, site_id: string|null}|null>}
  */
 export async function setBrandClaimsEnabled({
   brandId,
@@ -993,7 +994,7 @@ export async function setBrandClaimsEnabled({
     // Do not flip the flag on a soft-deleted brand (matches the .neq guard used
     // across brands-storage); a deleted brand returns no row -> null.
     .neq('status', 'deleted')
-    .select('id, name')
+    .select('id, name, site_id')
     .maybeSingle();
 
   if (error) {

--- a/src/support/slack/commands/toggle-brand-claims.js
+++ b/src/support/slack/commands/toggle-brand-claims.js
@@ -111,16 +111,9 @@ function BrandClaimsCommand(context) {
 
       log.info(`brand-claims: ${enabled ? 'enabled' : 'disabled'} for brand ${brand.id} ("${brand.name}") by ${actor}`);
 
-      // Keep the per-site `brand-claims` audit handler in lock-step with the
-      // brand flag: enabling opts the brand's primary site into the scheduled
-      // audit, disabling opts it back out. The URL branch already has the site;
-      // otherwise resolve the brand's primary site from the returned `site_id`.
-      //
-      // The brand flag is already committed to Postgres at this point, so the
-      // audit toggle runs in its own try/catch: a failure here leaves the two
-      // halves out of sync (flag flipped, audit not), so we surface that partial
-      // state to the operator rather than a generic error that hides which half
-      // succeeded.
+      // Toggle the per-site audit in lock-step with the (already-committed) brand
+      // flag; own try/catch so a failure reports the partial state, not a generic
+      // error that hides which half succeeded.
       const verb = enabled ? 'enabled' : 'disabled';
       let auditToggled = false;
       let auditError = null;
@@ -139,8 +132,7 @@ function BrandClaimsCommand(context) {
           auditToggled = true;
           log.info(`brand-claims: ${verb} '${BRAND_CLAIMS_AUDIT_TYPE}' audit for site ${site.getId()} (${site.getBaseURL()})`);
         } else if (brand.site_id) {
-          // site_id points at a site that no longer resolves (soft-deleted /
-          // unreachable) — distinct from a brand that never had a primary site.
+          // site_id set but the site no longer resolves (soft-deleted/unreachable).
           log.warn(`brand-claims: brand ${brand.id} primary site ${brand.site_id} not found; '${BRAND_CLAIMS_AUDIT_TYPE}' audit not ${verb}`);
         } else {
           log.warn(`brand-claims: brand ${brand.id} has no primary site; '${BRAND_CLAIMS_AUDIT_TYPE}' audit not ${verb}`);

--- a/src/support/slack/commands/toggle-brand-claims.js
+++ b/src/support/slack/commands/toggle-brand-claims.js
@@ -17,12 +17,15 @@ import { extractURLFromSlackInput, postErrorMessage } from '../../../utils/slack
 
 const ENABLE_PHRASE = 'enable-brand-claims';
 const DISABLE_PHRASE = 'disable-brand-claims';
+const BRAND_CLAIMS_AUDIT_TYPE = 'brand-claims';
 
 /**
  * One command, two explicit keywords: `enable-brand-claims {brandId|baseURL}` and
  * `disable-brand-claims {brandId|baseURL}`. Flips the brand-scoped
  * `brand_claims_enabled` scheduling gate the mystique Brand Claims consumer reads
- * back (LLMO-5741). The verb is derived from which keyword was used — no on/off
+ * back (LLMO-5741) AND the per-site `brand-claims` audit handler in lock-step, so
+ * enabling opts the brand's primary site into the scheduled audit and disabling
+ * opts it back out. The verb is derived from which keyword was used — no on/off
  * argument to get wrong. The target may be a brand UUID (as before) or a site base
  * URL, which is resolved to its active brand — so operators can target a site
  * without a separate brand-id lookup.
@@ -40,7 +43,7 @@ function BrandClaimsCommand(context) {
   });
 
   const { dataAccess, log } = context;
-  const { Site } = dataAccess;
+  const { Site, Configuration } = dataAccess;
 
   const execute = async (message, slackContext) => {
     const { say, user } = slackContext;
@@ -66,6 +69,7 @@ function BrandClaimsCommand(context) {
       // parsed as a site base URL and resolved to that site's active brand
       // (no brand-id lookup).
       let brandId;
+      let site = null;
       if (isValidUUID(target)) {
         brandId = target;
       } else {
@@ -74,7 +78,7 @@ function BrandClaimsCommand(context) {
           await say(`:warning: '${target}' is not a valid brand ID (UUID) or site URL. ${baseCommand.usage()}`);
           return;
         }
-        const site = await Site.findByBaseURL(baseUrl);
+        site = await Site.findByBaseURL(baseUrl);
         if (!site) {
           await say(`:x: Site not found: \`${target}\``);
           return;
@@ -106,7 +110,33 @@ function BrandClaimsCommand(context) {
       }
 
       log.info(`brand-claims: ${enabled ? 'enabled' : 'disabled'} for brand ${brand.id} ("${brand.name}") by ${actor}`);
-      await say(`:white_check_mark: Brand claims *${enabled ? 'enabled' : 'disabled'}* for brand "${brand.name}" (${brand.id}).`);
+
+      // Keep the per-site `brand-claims` audit handler in lock-step with the
+      // brand flag: enabling opts the brand's primary site into the scheduled
+      // audit, disabling opts it back out. The URL branch already has the site;
+      // otherwise resolve the brand's primary site from the returned `site_id`.
+      let auditToggled = false;
+      if (!site && brand.site_id) {
+        site = await Site.findById(brand.site_id);
+      }
+      if (site) {
+        const configuration = await Configuration.findLatest();
+        if (enabled) {
+          configuration.enableHandlerForSite(BRAND_CLAIMS_AUDIT_TYPE, site);
+        } else {
+          configuration.disableHandlerForSite(BRAND_CLAIMS_AUDIT_TYPE, site);
+        }
+        await configuration.save();
+        auditToggled = true;
+        log.info(`brand-claims: ${enabled ? 'enabled' : 'disabled'} '${BRAND_CLAIMS_AUDIT_TYPE}' audit for site ${site.getId()} (${site.getBaseURL()})`);
+      } else {
+        log.warn(`brand-claims: brand ${brand.id} has no resolvable primary site; '${BRAND_CLAIMS_AUDIT_TYPE}' audit not ${enabled ? 'enabled' : 'disabled'}`);
+      }
+
+      const auditNote = auditToggled
+        ? ` The \`${BRAND_CLAIMS_AUDIT_TYPE}\` audit was ${enabled ? 'enabled' : 'disabled'} for ${site.getBaseURL()}.`
+        : ` :warning: No primary site resolved, so the \`${BRAND_CLAIMS_AUDIT_TYPE}\` audit was left unchanged.`;
+      await say(`:white_check_mark: Brand claims *${enabled ? 'enabled' : 'disabled'}* for brand "${brand.name}" (${brand.id}).${auditNote}`);
     } catch (error) {
       log.error(error);
       await postErrorMessage(say, error);

--- a/src/support/slack/commands/toggle-brand-claims.js
+++ b/src/support/slack/commands/toggle-brand-claims.js
@@ -115,28 +115,50 @@ function BrandClaimsCommand(context) {
       // brand flag: enabling opts the brand's primary site into the scheduled
       // audit, disabling opts it back out. The URL branch already has the site;
       // otherwise resolve the brand's primary site from the returned `site_id`.
+      //
+      // The brand flag is already committed to Postgres at this point, so the
+      // audit toggle runs in its own try/catch: a failure here leaves the two
+      // halves out of sync (flag flipped, audit not), so we surface that partial
+      // state to the operator rather than a generic error that hides which half
+      // succeeded.
+      const verb = enabled ? 'enabled' : 'disabled';
       let auditToggled = false;
-      if (!site && brand.site_id) {
-        site = await Site.findById(brand.site_id);
-      }
-      if (site) {
-        const configuration = await Configuration.findLatest();
-        if (enabled) {
-          configuration.enableHandlerForSite(BRAND_CLAIMS_AUDIT_TYPE, site);
-        } else {
-          configuration.disableHandlerForSite(BRAND_CLAIMS_AUDIT_TYPE, site);
+      let auditError = null;
+      try {
+        if (!site && brand.site_id) {
+          site = await Site.findById(brand.site_id);
         }
-        await configuration.save();
-        auditToggled = true;
-        log.info(`brand-claims: ${enabled ? 'enabled' : 'disabled'} '${BRAND_CLAIMS_AUDIT_TYPE}' audit for site ${site.getId()} (${site.getBaseURL()})`);
-      } else {
-        log.warn(`brand-claims: brand ${brand.id} has no resolvable primary site; '${BRAND_CLAIMS_AUDIT_TYPE}' audit not ${enabled ? 'enabled' : 'disabled'}`);
+        if (site) {
+          const configuration = await Configuration.findLatest();
+          if (enabled) {
+            configuration.enableHandlerForSite(BRAND_CLAIMS_AUDIT_TYPE, site);
+          } else {
+            configuration.disableHandlerForSite(BRAND_CLAIMS_AUDIT_TYPE, site);
+          }
+          await configuration.save();
+          auditToggled = true;
+          log.info(`brand-claims: ${verb} '${BRAND_CLAIMS_AUDIT_TYPE}' audit for site ${site.getId()} (${site.getBaseURL()})`);
+        } else if (brand.site_id) {
+          // site_id points at a site that no longer resolves (soft-deleted /
+          // unreachable) — distinct from a brand that never had a primary site.
+          log.warn(`brand-claims: brand ${brand.id} primary site ${brand.site_id} not found; '${BRAND_CLAIMS_AUDIT_TYPE}' audit not ${verb}`);
+        } else {
+          log.warn(`brand-claims: brand ${brand.id} has no primary site; '${BRAND_CLAIMS_AUDIT_TYPE}' audit not ${verb}`);
+        }
+      } catch (err) {
+        auditError = err;
+        log.error(`brand-claims: '${BRAND_CLAIMS_AUDIT_TYPE}' audit toggle failed for brand ${brand.id}`, err);
       }
 
-      const auditNote = auditToggled
-        ? ` The \`${BRAND_CLAIMS_AUDIT_TYPE}\` audit was ${enabled ? 'enabled' : 'disabled'} for ${site.getBaseURL()}.`
-        : ` :warning: No primary site resolved, so the \`${BRAND_CLAIMS_AUDIT_TYPE}\` audit was left unchanged.`;
-      await say(`:white_check_mark: Brand claims *${enabled ? 'enabled' : 'disabled'}* for brand "${brand.name}" (${brand.id}).${auditNote}`);
+      let auditNote;
+      if (auditToggled) {
+        auditNote = ` The \`${BRAND_CLAIMS_AUDIT_TYPE}\` audit was ${verb} for ${site.getBaseURL()}.`;
+      } else if (auditError) {
+        auditNote = ` :warning: The brand flag was ${verb}, but toggling the \`${BRAND_CLAIMS_AUDIT_TYPE}\` audit failed: ${auditError.message}. Re-run the command or toggle the audit manually.`;
+      } else {
+        auditNote = ` :warning: No primary site resolved, so the \`${BRAND_CLAIMS_AUDIT_TYPE}\` audit was left unchanged.`;
+      }
+      await say(`:white_check_mark: Brand claims *${verb}* for brand "${brand.name}" (${brand.id}).${auditNote}`);
     } catch (error) {
       log.error(error);
       await postErrorMessage(say, error);

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -2604,6 +2604,8 @@ describe('brands-storage', () => {
   });
 
   describe('setBrandClaimsEnabled', () => {
+    const SITE_ID = '55555555-5555-4555-8555-555555555555';
+
     it('throws when postgrestClient is missing', async () => {
       await expect(setBrandClaimsEnabled({
         brandId: BRAND_ID, enabled: true, postgrestClient: null,
@@ -2624,7 +2626,7 @@ describe('brands-storage', () => {
 
     it('writes brand_claims_enabled, excludes deleted brands, and returns the updated brand', async () => {
       const client = createCapturingClient({
-        brands: [{ data: { id: BRAND_ID, name: 'Acme' }, error: null }],
+        brands: [{ data: { id: BRAND_ID, name: 'Acme', site_id: SITE_ID }, error: null }],
       });
 
       const result = await setBrandClaimsEnabled({
@@ -2636,7 +2638,9 @@ describe('brands-storage', () => {
       expect(brandsUpdate.row.updated_by).to.equal('slack:U1');
       const neqFilter = client.capturedCalls.neq.find((c) => c.table === 'brands' && c.col === 'status');
       expect(neqFilter?.val).to.equal('deleted');
-      expect(result).to.deep.equal({ id: BRAND_ID, name: 'Acme' });
+      // site_id (the brand's primary site) is returned so callers can toggle the
+      // per-site brand-claims audit in lock-step with the flag.
+      expect(result).to.deep.equal({ id: BRAND_ID, name: 'Acme', site_id: SITE_ID });
     });
 
     it('returns null when no brand matches the id', async () => {

--- a/test/support/slack/commands/toggle-brand-claims.test.js
+++ b/test/support/slack/commands/toggle-brand-claims.test.js
@@ -23,12 +23,13 @@ describe('BrandClaimsCommand', () => {
   let setBrandClaimsEnabledStub;
   let getBrandBySiteStub;
   let mockSite;
+  let mockConfiguration;
   let BrandClaimsCommand;
 
   const BRAND_ID = 'a1b2c3d4-5678-90ab-cdef-1234567890ab';
-  const BRAND = { id: BRAND_ID, name: 'Acme' };
   const SITE_ID = '11111111-1111-4111-8111-111111111111';
   const ORG_ID = '22222222-2222-4222-8222-222222222222';
+  const BRAND = { id: BRAND_ID, name: 'Acme', site_id: SITE_ID };
 
   before(async () => {
     setBrandClaimsEnabledStub = sinon.stub();
@@ -52,11 +53,19 @@ describe('BrandClaimsCommand', () => {
       getBaseURL: () => 'https://example.com',
       getOrganizationId: () => ORG_ID,
     };
+    mockConfiguration = {
+      enableHandlerForSite: sinon.stub(),
+      disableHandlerForSite: sinon.stub(),
+      save: sinon.stub().resolves(),
+    };
     context = {
       dataAccess: {
         Site: {
           findByBaseURL: sinon.stub().resolves(mockSite),
           findById: sinon.stub().resolves(mockSite),
+        },
+        Configuration: {
+          findLatest: sinon.stub().resolves(mockConfiguration),
         },
         services: { postgrestClient: { from: sinon.stub() } },
       },
@@ -88,6 +97,19 @@ describe('BrandClaimsCommand', () => {
       expect(slackContext.say.calledWithMatch(/Brand claims \*enabled\* for brand "Acme"/)).to.be.true;
     });
 
+    it('enables the brand-claims audit for the brand primary site (resolved from site_id)', async () => {
+      setBrandClaimsEnabledStub.resolves(BRAND);
+
+      const command = BrandClaimsCommand(context);
+      await command.execute(`enable-brand-claims ${BRAND_ID}`, slackContext);
+
+      expect(context.dataAccess.Site.findById).to.have.been.calledWith(SITE_ID);
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('brand-claims', mockSite);
+      expect(mockConfiguration.disableHandlerForSite).to.not.have.been.called;
+      expect(mockConfiguration.save).to.have.been.calledOnce;
+      expect(slackContext.say.calledWithMatch(/`brand-claims` audit was enabled for https:\/\/example\.com/)).to.be.true;
+    });
+
     it('disables brand claims when the disable keyword is used', async () => {
       setBrandClaimsEnabledStub.resolves(BRAND);
 
@@ -96,7 +118,11 @@ describe('BrandClaimsCommand', () => {
 
       const args = setBrandClaimsEnabledStub.firstCall.args[0];
       expect(args.enabled).to.equal(false);
+      expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('brand-claims', mockSite);
+      expect(mockConfiguration.enableHandlerForSite).to.not.have.been.called;
+      expect(mockConfiguration.save).to.have.been.calledOnce;
       expect(slackContext.say.calledWithMatch(/Brand claims \*disabled\* for brand "Acme"/)).to.be.true;
+      expect(slackContext.say.calledWithMatch(/`brand-claims` audit was disabled for https:\/\/example\.com/)).to.be.true;
     });
 
     it('resolves a brand by site base URL and enables it', async () => {
@@ -111,7 +137,24 @@ describe('BrandClaimsCommand', () => {
       const args = setBrandClaimsEnabledStub.firstCall.args[0];
       expect(args.brandId).to.equal(BRAND_ID);
       expect(args.enabled).to.equal(true);
+      // URL branch already has the site, so it toggles the audit without a findById.
+      expect(context.dataAccess.Site.findById).to.not.have.been.called;
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('brand-claims', mockSite);
+      expect(mockConfiguration.save).to.have.been.calledOnce;
       expect(slackContext.say.calledWithMatch(/Brand claims \*enabled\* for brand "Acme"/)).to.be.true;
+    });
+
+    it('flips the flag but leaves the audit unchanged when the brand has no primary site', async () => {
+      setBrandClaimsEnabledStub.resolves({ id: BRAND_ID, name: 'Acme', site_id: null });
+
+      const command = BrandClaimsCommand(context);
+      await command.execute(`enable-brand-claims ${BRAND_ID}`, slackContext);
+
+      expect(context.dataAccess.Site.findById).to.not.have.been.called;
+      expect(mockConfiguration.enableHandlerForSite).to.not.have.been.called;
+      expect(mockConfiguration.save).to.not.have.been.called;
+      expect(slackContext.say.calledWithMatch(/Brand claims \*enabled\* for brand "Acme"/)).to.be.true;
+      expect(slackContext.say.calledWithMatch(/No primary site resolved/)).to.be.true;
     });
 
     it('errors when the site URL resolves to no site', async () => {

--- a/test/support/slack/commands/toggle-brand-claims.test.js
+++ b/test/support/slack/commands/toggle-brand-claims.test.js
@@ -157,6 +157,35 @@ describe('BrandClaimsCommand', () => {
       expect(slackContext.say.calledWithMatch(/No primary site resolved/)).to.be.true;
     });
 
+    it('warns when brand.site_id is set but Site.findById returns null', async () => {
+      setBrandClaimsEnabledStub.resolves({ id: BRAND_ID, name: 'Acme', site_id: SITE_ID });
+      context.dataAccess.Site.findById.resolves(null);
+
+      const command = BrandClaimsCommand(context);
+      await command.execute(`enable-brand-claims ${BRAND_ID}`, slackContext);
+
+      expect(context.dataAccess.Site.findById).to.have.been.calledWith(SITE_ID);
+      expect(mockConfiguration.enableHandlerForSite).to.not.have.been.called;
+      expect(mockConfiguration.save).to.not.have.been.called;
+      expect(slackContext.say.calledWithMatch(/Brand claims \*enabled\* for brand "Acme"/)).to.be.true;
+      expect(slackContext.say.calledWithMatch(/No primary site resolved/)).to.be.true;
+    });
+
+    it('reports partial state when the flag flips but the audit toggle fails', async () => {
+      setBrandClaimsEnabledStub.resolves(BRAND);
+      mockConfiguration.save.rejects(new Error('config write boom'));
+
+      const command = BrandClaimsCommand(context);
+      await command.execute(`enable-brand-claims ${BRAND_ID}`, slackContext);
+
+      // Flag was flipped (setBrandClaimsEnabled resolved) but the audit toggle threw.
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('brand-claims', mockSite);
+      expect(slackContext.say.calledWithMatch(/Brand claims \*enabled\* for brand "Acme"/)).to.be.true;
+      expect(slackContext.say.calledWithMatch(/the brand flag was enabled, but toggling the `brand-claims` audit failed: config write boom/i)).to.be.true;
+      // The generic error handler must NOT fire — we handle this inline.
+      expect(slackContext.say.calledWithMatch(/Something went wrong/)).to.be.false;
+    });
+
     it('errors when the site URL resolves to no site', async () => {
       context.dataAccess.Site.findByBaseURL.resolves(null);
 


### PR DESCRIPTION
## What

`enable-brand-claims` / `disable-brand-claims` now toggle the per-site `brand-claims` audit handler **in lock-step** with the brand-scoped `brand_claims_enabled` flag:
- **enable** → sets the flag **and** opts the brand's primary site into the scheduled `brand-claims` audit (`configuration.enableHandlerForSite`)
- **disable** → clears the flag **and** opts the site back out (`configuration.disableHandlerForSite`)

## Why

Follows [#3058](https://github.com/adobe/spacecat-api-service/pull/3058), which removes the manual `run-brand-claims` command now that the Brand Claims run is owned by the `brand-claims` audit in [spacecat-audit-worker](https://github.com/adobe/spacecat-audit-worker/pull/2877). With the manual run gone, enabling the brand should be the single operator control — it must set both the mystique consumer's scheduling gate *and* the audit-handler opt-in for the site. Previously it only flipped the flag, leaving the audit un-enabled.

## Changes

- `src/support/brands-storage.js` — `setBrandClaimsEnabled` now also returns the brand's primary `site_id` (`select('id, name, site_id')`) so callers can resolve the site.
- `src/support/slack/commands/toggle-brand-claims.js` — after flipping the flag, resolve the site (already fetched in the URL path, or via `Site.findById(site_id)` in the brand-UUID path) and enable/disable the `brand-claims` handler for it, then `configuration.save()`. If no primary site resolves, the flag is still flipped but the reply warns the audit was left unchanged.
- Tests updated in `test/support/slack/commands/toggle-brand-claims.test.js` and `test/support/brands-storage.test.js`.

## Testing

`toggle-brand-claims.test.js` (14) + `brands-storage.test.js` `setBrandClaimsEnabled` (6) pass; lint clean.

## Notes

- `enableHandlerForSite` throws on unmet handler dependencies; caught by the command's existing try/catch. `brand-claims` has no registered dependencies today.
- Based off `origin/main`, not #3058 — both touch `toggle-brand-claims.js` (that PR only rewords comments), so expect a trivial comment-level conflict depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["David Aurelio", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```