### PR TITLE
fix(serenity): remove empty-units best-effort quota-405 swallow (SITES-49206)

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -1489,13 +1489,10 @@ function SerenityController(context, log, env) {
               // the project is published empty (no prompts) — today's default.
               generateTopics: generatePrompts,
               topicCap: generatePrompts ? MAX_TOPICS_ON_CREATE : 0,
-              // A project with neither models nor generated prompts publishes
-              // "empty units" → Semrush's disguised quota 405. Tolerate it
-              // (best-effort, leaves a draft) rather than failing activation; a
-              // project with models OR prompts has real units and must publish.
-              publishMode: marketModelIds.length > 0 || generatePrompts
-                ? 'require'
-                : 'best-effort',
+              // SITES-49206: Semrush no longer enforces AI limits, so an empty-units
+              // publish no longer 405s — every market now publishes with 'require'
+              // regardless of whether it has models/prompts attached.
+              publishMode: 'require',
               brandAliases,
               brandUrlSources,
               competitors,

--- a/src/support/serenity/brand-aliases.js
+++ b/src/support/serenity/brand-aliases.js
@@ -18,7 +18,7 @@ import {
   regionApplies,
   normalizeBenchmarkDomain,
   marketOf,
-  republishBestEffort,
+  republish,
 } from './brand-urls.js';
 import {
   dedupeAliases,
@@ -72,8 +72,8 @@ export function collectAliasNames(aliases, market) {
  * Re-syncs a brand's aliases onto every market/project in its sub-workspace (the
  * brand-edit path). For each project: region-filter the aliases for that market,
  * then — when drifted — PATCH the project's `brand_names` (display name + aliases)
- * and PUT its own-brand benchmark's `brand_aliases`, republishing (best-effort)
- * when anything changed. PATCH/PUT errors propagate so the edit hard-fails (an
+ * and PUT its own-brand benchmark's `brand_aliases`, republishing when anything
+ * changed. PATCH/PUT/republish errors propagate so the edit hard-fails (an
  * already-live brand must not silently diverge). `rejected` aggregates the aliases
  * Semrush refused per market, so the caller can surface them.
  *
@@ -234,7 +234,7 @@ export async function syncBrandAliasesAcrossMarkets(
 
       if (changed) {
         // eslint-disable-next-line no-await-in-loop
-        await republishBestEffort(transport, workspaceId, projectId, log);
+        await republish(transport, workspaceId, projectId, log);
       }
     } catch (e) {
       // Name WHICH market split so the brand-edit hard-fail (brands.js) is

--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -215,21 +215,15 @@ export async function provisionBrandSubworkspace(context, {
 
   // LLMO-5492 publish-after-populate: defer-publish flag ON → leave the project a
   // DRAFT ('skip') for a later finalize step (prompts + models pushed, published
-  // once). OFF (default) preserves inline publish: a project with models OR
-  // generated prompts has real units and must publish ('require'); an empty
-  // project would publish "empty units" (a disguised quota 405), so leave it a
-  // draft ('best-effort') instead of failing the create. Checked against
-  // resolvedModelIds, not the raw caller-supplied modelIds: LLMO-6554 resolves an
-  // empty/omitted modelIds to the canonical net-new default, so resolvedModelIds
-  // is non-empty in the common case — checking the raw list would wrongly fall
-  // through to 'best-effort' (leaving a model-bearing project as an unpublished
-  // draft) whenever the caller omitted modelIds.
-  /** @type {'require' | 'best-effort' | 'skip'} */
-  let publishMode = 'best-effort';
+  // once). OFF (default) publishes inline regardless of whether the project has
+  // any models/prompts attached: SITES-49206 confirmed Semrush no longer enforces
+  // AI limits, so an empty-units publish no longer 405s and there is no more
+  // 'best-effort' mode to fall back to (a quota 405 now always propagates as a
+  // real "Quota exceeded" error — see `handleCreateMarketSubworkspace`).
+  /** @type {'require' | 'skip'} */
+  let publishMode = 'require';
   if (isSerenityDeferPublishEnabled(context.env)) {
     publishMode = 'skip';
-  } else if ((Array.isArray(resolvedModelIds) && resolvedModelIds.length > 0) || generateTopics) {
-    publishMode = 'require';
   }
 
   let result;

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -335,9 +335,8 @@ export function marketOf(project) {
  * Re-syncs a brand's URL set onto every market/project in its sub-workspace
  * (the brand-edit path). For each project: builds the region-filtered desired
  * set, diffs it against the benchmark's live brand URLs, creates the additions,
- * deletes the removals, and republishes (best-effort) when anything changed.
- * Create/delete errors propagate so the edit hard-fails; a quota 405 on the
- * republish alone is tolerated.
+ * deletes the removals, and republishes when anything changed.
+ * Create/delete/republish errors propagate so the edit hard-fails.
  *
  * @param {SerenityTransport} transport
  * @param {object} sources - the brand's URL sources ({ urls?, socialAccounts?,
@@ -414,12 +413,11 @@ export async function syncBrandUrlsAcrossMarkets(
       }
       // Invariant: a read must target the same view the writes act on. Creates and
       // deletes act on the DRAFT (a publish then promotes it), so the draft — not
-      // the published view — is the state this sync converges on. Published lags
-      // the draft whenever the project has unpublished changes, which is exactly
-      // what a swallowed quota 405 on the republish below leaves behind. Reading
-      // published there would report an EMPTY existing set, so a URL the user
-      // removed would never be deleted (and every URL would be re-submitted on
-      // each sync).
+      // the published view — is the state this sync converges on. Creates/deletes
+      // land before this sync's own republish runs, so the published view can
+      // legitimately lag the draft at read time. Reading published there would
+      // report an EMPTY existing set, so a URL the user removed would never be
+      // deleted (and every URL would be re-submitted on each sync).
       // eslint-disable-next-line no-await-in-loop
       const existingResp = await transport.listBrandUrls(
         workspaceId,

--- a/src/support/serenity/brand-urls.js
+++ b/src/support/serenity/brand-urls.js
@@ -14,7 +14,7 @@
 
 import { hasText } from '@adobe/spacecat-shared-utils';
 
-import { isSemrushTransportError } from './errors.js';
+import { isSemrushTransportError, isMeteredQuota, toQuotaExceededError } from './errors.js';
 import { benchmarkAliases } from './aliases.js';
 import { resolveProjects } from './resolve-projects.js';
 
@@ -296,21 +296,27 @@ export async function attachBrandUrlsToProject(
   return { created: entries.length };
 }
 
-// Best-effort republish after an edit-time change so the live view reflects it.
-// Swallows a quota 405 (publishing an empty-units child 405s as a disguised
-// quota rejection — same convention as the market-create path); any other
-// failure propagates so the edit hard-fails. Shared by the brand-URL and
-// CI-competitor edit re-syncs.
+// Republish after an edit-time change so the live view reflects it. Shared by the brand-URL,
+// CI-competitor, and tag edit re-syncs.
+//
+// SITES-49206: this used to swallow a quota 405 (publishing an empty-units child 405s as a
+// disguised quota rejection) and leave the project a draft instead of failing the edit. Semrush
+// no longer enforces AI project/prompt limits for proxy-routed LLMO workspaces (confirmed live,
+// including a direct empty-units publish probe against a throwaway workspace, 2026-08-17) — a
+// quota 405 here would mean Semrush is enforcing again, which every OTHER publish call site in
+// this codebase already treats as a real, surfaced error (classify via `isMeteredQuota`, throw
+// `toQuotaExceededError()`) rather than something to tolerate silently. This function now matches
+// that convention instead of being the one place a live re-enforcement would go unnoticed.
 /** @param {SerenityTransport} transport */
-export async function republishBestEffort(transport, workspaceId, projectId, log) {
+export async function republish(transport, workspaceId, projectId, log) {
   try {
     await transport.publishProject(workspaceId, projectId);
   } catch (e) {
-    if (isSemrushTransportError(e) && e.status === 405) {
-      log?.warn?.('brand-urls: republish skipped — quota 405, project left as draft', {
+    if (isMeteredQuota(e)) {
+      log?.warn?.('republish: quota exceeded — Semrush is enforcing AI limits again (see ADR-009)', {
         workspaceId, projectId,
       });
-      return;
+      throw toQuotaExceededError();
     }
     throw e;
   }
@@ -448,7 +454,7 @@ export async function syncBrandUrlsAcrossMarkets(
       }
       if (toCreate.length > 0 || toDelete.length > 0) {
         // eslint-disable-next-line no-await-in-loop
-        await republishBestEffort(transport, workspaceId, projectId, log);
+        await republish(transport, workspaceId, projectId, log);
       }
     } catch (e) {
       // A mid-fan-out failure must name WHICH market split so the brand-edit

--- a/src/support/serenity/competitor-benchmarks.js
+++ b/src/support/serenity/competitor-benchmarks.js
@@ -18,7 +18,7 @@ import {
   regionApplies,
   normalizeBenchmarkDomain,
   marketOf,
-  republishBestEffort,
+  republish,
 } from './brand-urls.js';
 import {
   dedupeAliases,
@@ -391,9 +391,9 @@ export async function syncCompetitorBenchmarksForProject(
 /**
  * Re-syncs a brand's competitors as benchmarks across every market/project in
  * its sub-workspace (the brand-edit path): per project, region-filter + create
- * additions + update alias drift + delete removals, then republish (best-effort)
- * when anything changed. Create/update/delete errors propagate; a quota 405 on
- * republish is tolerated. `rejected` aggregates the per-market competitor aliases
+ * additions + update alias drift + delete removals, then republish when anything
+ * changed. Create/update/delete/republish errors propagate. `rejected` aggregates
+ * the per-market competitor aliases
  * Semrush refused, tagged with their project/market, so the caller can surface them.
  *
  * @param {SerenityTransport} transport
@@ -473,7 +473,7 @@ export async function syncCompetitorBenchmarksAcrossMarkets(
       rejected.push(...result.rejected.map((r) => ({ projectId, market, ...r })));
       if (result.changed) {
         // eslint-disable-next-line no-await-in-loop
-        await republishBestEffort(transport, workspaceId, projectId, log);
+        await republish(transport, workspaceId, projectId, log);
       }
     } catch (e) {
       // A mid-fan-out failure must name WHICH market split so the brand-edit

--- a/src/support/serenity/competitor-benchmarks.js
+++ b/src/support/serenity/competitor-benchmarks.js
@@ -393,8 +393,8 @@ export async function syncCompetitorBenchmarksForProject(
  * its sub-workspace (the brand-edit path): per project, region-filter + create
  * additions + update alias drift + delete removals, then republish when anything
  * changed. Create/update/delete/republish errors propagate. `rejected` aggregates
- * the per-market competitor aliases
- * Semrush refused, tagged with their project/market, so the caller can surface them.
+ * the per-market competitor aliases Semrush refused, tagged with their project/market, so the
+ * caller can surface them.
  *
  * @param {SerenityTransport} transport
  * @param {Array<{name?: string, url?: string, regions?: string[], aliases?: string[]}>}

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -515,10 +515,11 @@ async function generateAndAttachPrompts(transport, workspaceId, projectId, {
  *   competitor list (region-filtered, domain-only). Read-merged with Semrush's
  *   existing/auto-generated list before publish. Best-effort: a failed sync is
  *   logged (non-fatal) and never aborts the create.
- * @param {'require'|'best-effort'|'skip'} [options.publishMode='require'] - how
- *   to publish: `require` throws on failure (the default markets endpoint);
- *   `best-effort` swallows a quota 405 (empty-units publish, workspace doc §5)
- *   and leaves the project a draft; `skip` does not publish at all.
+ * @param {'require'|'skip'} [options.publishMode='require'] - how to publish:
+ *   `require` throws on failure (the default markets endpoint, and — since
+ *   SITES-49206 — every create, including an empty-units project: Semrush no
+ *   longer enforces AI limits, so there is no quota 405 left to tolerate);
+ *   `skip` does not publish at all (LLMO-5492 defer-publish).
  * @param {any} [options.dataAccess] - when supplied, upserts the
  *   `brand_to_semrush_projects` mapping row for this project (best-effort,
  *   never fails the create). Omit for a `brand` that is not yet a persisted
@@ -754,9 +755,12 @@ export async function handleCreateMarketSubworkspace(
     });
   }
 
-  // Publish per mode. 'best-effort' swallows a quota 405 (publishing an
-  // empty-units child 405s as a disguised quota rejection, workspace doc §5) and
-  // leaves the project a draft so the brand still succeeds.
+  // Publish per mode. SITES-49206: Semrush no longer enforces AI project/prompt limits for
+  // proxy-routed LLMO workspaces (confirmed live, including a direct empty-units publish probe
+  // against a throwaway workspace, 2026-08-17), so there is no longer a 'best-effort' mode that
+  // tolerates a quota 405 by leaving an empty-units project a draft — every publish (including an
+  // empty one) now always runs this same 'require' path. A 405 here would mean Semrush is
+  // enforcing again, which is exactly what this classify-and-throw exists to catch.
   let published = false;
   if (publishMode === 'require') {
     try {
@@ -789,41 +793,6 @@ export async function handleCreateMarketSubworkspace(
         throw toQuotaExceededError();
       }
       throw e;
-    }
-  } else if (publishMode === 'best-effort') {
-    try {
-      await transport.publishProject(workspaceId, projectId);
-      published = true;
-    } catch (e) {
-      if (isMeteredQuota(e)) {
-        // Swallowed by design (best-effort provisioning must not fail the brand create), but this
-        // IS a quota rejection and the event that creates the dark draft market a customer later
-        // trips over — serenity-docs#72 §5 requires it to alert even though nothing failed here.
-        // The call below is side-effect-only (its returned error is intentionally discarded, never
-        // thrown — best-effort swallows it) purely to run `recordRejection('quotaExceeded')`
-        // inside it, so the CloudWatch metric this alarm will key on fires here too, keeping the
-        // classifier + alerting signal consistent between this swallowed path and the `require`
-        // path above (MysticatBot review, non-blocking nit).
-        toQuotaExceededError();
-        log?.warn?.('handleCreateMarketSubworkspace: publish skipped — quota exceeded, project left as draft', {
-          workspaceId, projectId,
-        });
-        // serenity-docs#72 §5 bullet 2: "the swallow is still a quota rejection... MUST emit the
-        // same (deduplicated) alert, marked as originating from the best-effort provisioning
-        // path" — the event that creates the dark draft market a customer later trips over.
-        // Awaited for the same Lambda-freeze reason as the require branch above.
-        await alertQuotaRejection({
-          orgId,
-          brandId: brand.getId(),
-          workspaceId,
-          market: `${body.market}/${languageCode}`,
-          caseType: 'brandCarveExhausted',
-          dimension: 'prompts',
-          swallowed: true,
-        }, env, log);
-      } else {
-        throw e;
-      }
     }
   }
 

--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -32,7 +32,7 @@ import {
   assertParentPlacement,
   assertParentWithinDimension,
 } from '../tag-tree.js';
-import { republishBestEffort } from '../brand-urls.js';
+import { republish } from '../brand-urls.js';
 
 /** @typedef {import('../rest-transport.js').SerenityTransport} SerenityTransport */
 
@@ -408,11 +408,11 @@ export async function handleCreateTag(
       brandId, geoTargetId, languageCode, type, name, created,
     });
     // A create leaves the project in `live_with_unpublished_updates`; publish so
-    // the new value is live (only when we actually seeded one). Best-effort:
-    // republishBestEffort swallows the quota-405 disguise, matching the brand-URL
-    // / alias / benchmark write paths.
+    // the new value is live (only when we actually seeded one).
+    // Errors (including a real quota rejection) propagate, matching the brand-URL
+    // / alias / benchmark write paths (SITES-49206 — see brand-urls.js `republish`).
     if (created) {
-      await republishBestEffort(transport, semrushWorkspaceId, projectId, log);
+      await republish(transport, semrushWorkspaceId, projectId, log);
     }
     return {
       status: 200,
@@ -446,8 +446,8 @@ export async function handleCreateTag(
     brandId, geoTargetId, languageCode, name, parentId: targetParentId,
   });
   // Publish so the newly created tag is live rather than left as a draft
-  // (`live_with_unpublished_updates`). Best-effort — see the closed-path note.
-  await republishBestEffort(transport, semrushWorkspaceId, projectId, log);
+  // (`live_with_unpublished_updates`). See the closed-path note above.
+  await republish(transport, semrushWorkspaceId, projectId, log);
   return {
     status: 201,
     body: {
@@ -499,9 +499,9 @@ export async function handleCreateTagSubworkspace(
     log?.info?.('handleCreateTagSubworkspace: resolved server-owned-dimension value', {
       geoTargetId, languageCode, type, name, created,
     });
-    // Publish the seeded value so it is live (best-effort). See handleCreateTag.
+    // Publish the seeded value so it is live. See handleCreateTag.
     if (created) {
-      await republishBestEffort(transport, workspaceId, projectId, log);
+      await republish(transport, workspaceId, projectId, log);
     }
     return {
       status: 200,
@@ -529,8 +529,8 @@ export async function handleCreateTagSubworkspace(
   log?.info?.('handleCreateTagSubworkspace: registered tag', {
     geoTargetId, languageCode, name, parentId: targetParentId,
   });
-  // Publish so the newly created tag is live rather than a draft (best-effort).
-  await republishBestEffort(transport, workspaceId, projectId, log);
+  // Publish so the newly created tag is live rather than a draft.
+  await republish(transport, workspaceId, projectId, log);
   return {
     status: 201,
     body: {
@@ -774,8 +774,8 @@ export async function handleUpdateTag(
   log?.info?.('handleUpdateTag: updated tag', {
     brandId, geoTargetId, languageCode, tagId: id, name, parentId: parentIdToSend,
   });
-  // Publish so the rename / re-parent is live rather than a draft (best-effort).
-  await republishBestEffort(transport, semrushWorkspaceId, projectId, log);
+  // Publish so the rename / re-parent is live rather than a draft.
+  await republish(transport, semrushWorkspaceId, projectId, log);
   return {
     status: 200,
     body: {
@@ -836,8 +836,8 @@ export async function handleUpdateTagSubworkspace(
   log?.info?.('handleUpdateTagSubworkspace: updated tag', {
     geoTargetId, languageCode, tagId: id, name, parentId: parentIdToSend,
   });
-  // Publish so the rename / re-parent is live rather than a draft (best-effort).
-  await republishBestEffort(transport, workspaceId, projectId, log);
+  // Publish so the rename / re-parent is live rather than a draft.
+  await republish(transport, workspaceId, projectId, log);
   return {
     status: 200,
     body: {

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2159,14 +2159,15 @@ describe('SerenityController', () => {
       // Read once for the whole batch, not per market.
       expect(getBrandAliasesStub).to.have.been.calledOnceWith(BRAND);
       // Both market creates receive the same aliases in their options arg (index 7).
-      // No modelIds + no generatePrompts → empty units → best-effort publish. The
-      // loaded brand is already persisted, so dataAccess is threaded through for
-      // the mapping-row upsert (mapping-rows.js).
+      // SITES-49206: no modelIds + no generatePrompts used to mean "empty units" → best-effort
+      // publish; Semrush no longer enforces AI limits, so this now still requires publish like
+      // every other market create. The loaded brand is already persisted, so dataAccess is
+      // threaded through for the mapping-row upsert (mapping-rows.js).
       const expectedOpts = {
         modelIds: [],
         generateTopics: false,
         topicCap: 0,
-        publishMode: 'best-effort',
+        publishMode: 'require',
         brandAliases: ['Acme Inc'],
         brandUrlSources: { urls: [], socialAccounts: [], earnedContent: [] },
         competitors: [],

--- a/test/support/serenity/brand-provisioning.test.js
+++ b/test/support/serenity/brand-provisioning.test.js
@@ -280,7 +280,7 @@ describe('provisionBrandSubworkspace', () => {
     });
   });
 
-  it('falls back to US/EN and publishes best-effort when generateTopics is false with no market or models', async () => {
+  it('falls back to US/EN and still requires publish when generateTopics is false with no market or models', async () => {
     const { provisionBrandSubworkspace } = await loadModule({
       resolveWorkspaceId, handleCreateMarketSubworkspace,
     });
@@ -297,10 +297,12 @@ describe('provisionBrandSubworkspace', () => {
     expect(body.market).to.equal('US');
     expect(body.languageCode).to.equal('en');
     expect(body.name).to.equal(undefined);
-    // No prompts + no models → empty units → best-effort publish (leaves a draft).
+    // SITES-49206: no prompts + no models used to mean "empty units" → best-effort publish
+    // (leaves a draft). Semrush no longer enforces AI limits, so this now still requires publish
+    // like every other create.
     expect(options.generateTopics).to.equal(false);
     expect(options.topicCap).to.equal(0);
-    expect(options.publishMode).to.equal('best-effort');
+    expect(options.publishMode).to.equal('require');
   });
 
   it('leaves the initial market a DRAFT (publishMode "skip") when SERENITY_DEFER_PUBLISH is on (LLMO-5492)', async () => {

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -26,6 +26,7 @@ import {
   syncBrandUrlsAcrossMarkets,
 } from '../../../src/support/serenity/brand-urls.js';
 import { SerenityTransportError } from '../../../src/support/serenity/rest-transport.js';
+import { ERROR_CODES } from '../../../src/support/serenity/errors.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -413,10 +414,10 @@ describe('brand-urls helpers', () => {
 
     it('diffs against the DRAFT view, so a removal still lands on an unpublished project', async () => {
       // A brand URL is written into the project's DRAFT; only a publish promotes it
-      // into the published view. `republishBestEffort` swallows a quota 405, which
-      // leaves the project unpublished — so the published view reports an EMPTY set
-      // while the draft holds the rows. Diffing the published view there would make
-      // `toDelete` empty and a user's removal would silently never reach Semrush.
+      // into the published view. Creates/deletes act on the draft before this sync's
+      // own republish runs, so the published view can legitimately lag the draft at
+      // read time — diffing the published view there would make `toDelete` empty and
+      // a user's removal would silently never reach Semrush.
       const sources = { urls: ['https://acme.com'] };
       const listBrandUrls = sandbox.stub();
       // Published view: stale/empty (the pending rows are invisible to it).
@@ -434,8 +435,7 @@ describe('brand-urls helpers', () => {
         listBrandUrls,
         createBrandUrls: sandbox.stub().resolves({}),
         deleteBrandUrls: sandbox.stub().resolves({}),
-        // The republish quota-405 that strands the project as a draft in the first place.
-        publishProject: sandbox.stub().rejects(new SerenityTransportError(405, 'quota')),
+        publishProject: sandbox.stub().resolves({}),
       };
 
       const result = await syncBrandUrlsAcrossMarkets(transport, sources, WS, undefined);
@@ -578,21 +578,27 @@ describe('brand-urls helpers', () => {
       expect(result).to.deep.equal({ markets: 0, created: 0, deleted: 0 });
     });
 
-    it('tolerates a quota 405 on republish (best-effort)', async () => {
+    it('propagates a quotaExceeded 409 when republish 405s on quota (SITES-49206)', async () => {
+      // Pinned disguised-405 shape (LLMO-6190, live-verified): a bare string/HTML body, never
+      // JSON — isMeteredQuota keys on this SHAPE, not the bare status. Semrush no longer enforces
+      // AI limits, so this used-to-be-tolerated case now means it's enforcing again and must
+      // surface, not get swallowed.
       const sources = { urls: ['https://acme.com'] };
-      const warn = sandbox.stub();
       const transport = {
         listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
         listBenchmarks: sandbox.stub().resolves(benchOk()),
         listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
         createBrandUrls: sandbox.stub().resolves({}),
         deleteBrandUrls: sandbox.stub().resolves({}),
-        publishProject: sandbox.stub().rejects(new SerenityTransportError(405, 'quota')),
+        publishProject: sandbox.stub().rejects(
+          new SerenityTransportError(405, 'publish failed: 405', '<html>405 Not Allowed</html>'),
+        ),
       };
-      const logger = { warn, info: () => {} };
-      const result = await syncBrandUrlsAcrossMarkets(transport, sources, WS, logger);
-      expect(result).to.deep.equal({ markets: 1, created: 1, deleted: 0 });
-      expect(warn).to.have.been.called;
+      const err = await syncBrandUrlsAcrossMarkets(transport, sources, WS, undefined)
+        .then(() => null, (e) => e);
+      expect(err).to.not.equal(null);
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal(ERROR_CODES.QUOTA_EXCEEDED);
     });
 
     it('propagates a non-405 republish failure (hard-fail)', async () => {

--- a/test/support/serenity/brand-urls.test.js
+++ b/test/support/serenity/brand-urls.test.js
@@ -601,6 +601,27 @@ describe('brand-urls helpers', () => {
       expect(err.code).to.equal(ERROR_CODES.QUOTA_EXCEEDED);
     });
 
+    it('propagates a genuine JSON-bodied 405 through republish (not misclassified as quota)', async () => {
+      // isMeteredQuota keys on body SHAPE (string = disguised quota, JSON = a genuine app-level
+      // error), so a real "Method Not Allowed" (JSON body) must NOT be swallowed or misclassified
+      // as quotaExceeded — it must propagate as the ordinary 405 upstream error. This boundary was
+      // previously pinned in markets-subworkspace.test.js's now-deleted best-effort suite; this is
+      // the equivalent coverage for the shared `republish` function (SITES-49206).
+      const sources = { urls: ['https://acme.com'] };
+      const transport = {
+        listProjects: sandbox.stub().resolves({ items: [projectWith('p-us', 'us')] }),
+        listBenchmarks: sandbox.stub().resolves(benchOk()),
+        listBrandUrls: sandbox.stub().resolves({ brand_urls: [] }),
+        createBrandUrls: sandbox.stub().resolves({}),
+        deleteBrandUrls: sandbox.stub().resolves({}),
+        publishProject: sandbox.stub().rejects(
+          new SerenityTransportError(405, 'Method Not Allowed', { message: 'Method Not Allowed' }),
+        ),
+      };
+      await expect(syncBrandUrlsAcrossMarkets(transport, sources, WS, undefined))
+        .to.be.rejectedWith(/Method Not Allowed/);
+    });
+
     it('propagates a non-405 republish failure (hard-fail)', async () => {
       const sources = { urls: ['https://acme.com'] };
       const transport = {

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -642,58 +642,9 @@ describe('markets-subworkspace handlers', () => {
     // rather than passing 'quota' as the (unused) `message` arg (MysticatBot review).
     const quota405 = () => new SerenityTransportError(405, 'publish failed: 405', '<html>405 Not Allowed</html>');
 
-    it('best-effort publish swallows a quota 405 and keeps the project a draft', async () => {
-      const transport = makeTransport({
-        publishProject: sinon.stub().rejects(quota405()),
-      });
-      const res = await handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' });
-      expect(res.status).to.equal(201);
-      expect(res.body.published).to.equal(false);
-      expect(transport.publishProject).to.have.been.calledOnce;
-    });
-
-    // MysticatBot review (blocking): the best-effort branch's `toQuotaExceededError()` call is
-    // side-effect-only (its return value is discarded) purely to emit the `recordRejection`
-    // CloudWatch metric — assert that side effect directly so a future edit that drops the line
-    // as apparently-dead-code fails a test instead of silently going metric-blind. Spies on
-    // `toQuotaExceededError` itself (the entry's DIRECT dependency) rather than reaching two hops
-    // through to `allocation-metrics.js` (an errors.js-internal dependency esmock does not
-    // transitively override from this entry point), while still calling through to the real
-    // implementation so the emitted error/thrown-vs-swallowed behavior is unchanged.
-    it('best-effort publish emits the quotaExceeded rejection metric even though it swallows the error', async () => {
-      const errorsModule = await import('../../../../src/support/serenity/errors.js');
-      const toQuotaExceededError = sinon.spy(errorsModule.toQuotaExceededError);
-      const { handleCreateMarketSubworkspace: mocked } = await esmock(
-        '../../../../src/support/serenity/handlers/markets-subworkspace.js',
-        { '../../../../src/support/serenity/errors.js': { ...errorsModule, toQuotaExceededError } },
-      );
-      const transport = makeTransport({
-        publishProject: sinon.stub().rejects(quota405()),
-      });
-      await mocked(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' });
-      expect(toQuotaExceededError).to.have.been.calledOnce;
-    });
-
-    it('best-effort publish re-throws a non-405 upstream error', async () => {
-      const transport = makeTransport({
-        publishProject: sinon.stub().rejects(new SerenityTransportError(500, 'boom')),
-      });
-      await expect(handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' })).to.be.rejectedWith(/boom/);
-    });
-
-    // MysticatBot review: isMeteredQuota keys on body SHAPE (string = disguised quota, JSON = a
-    // genuine app-level error), so a real "Method Not Allowed" (JSON body) must NOT be swallowed
-    // or misclassified as quotaExceeded — it must propagate as the ordinary 405 upstream error.
-    it('best-effort publish re-throws a genuine JSON-bodied 405 (not misclassified as quota)', async () => {
-      const transport = makeTransport({
-        publishProject: sinon.stub().rejects(
-          new SerenityTransportError(405, 'Method Not Allowed', { message: 'Method Not Allowed' }),
-        ),
-      });
-      await expect(
-        handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log, null, null, { publishMode: 'best-effort' }),
-      ).to.be.rejectedWith(/Method Not Allowed/);
-    });
+    // SITES-49206: 'best-effort' publish mode was removed — Semrush no longer enforces AI limits,
+    // so every publish (including empty-units) now goes through 'require' below, which already
+    // covers the quota-405-swallow-vs-propagate distinction that used to need a separate mode.
 
     // serenity-docs#72 §2/§4.1 — case 1 (brand carve exhausted, allocator OFF): a quota 405 on a
     // REQUIRED publish must surface as the stable `quotaExceeded` 409 token, not the raw upstream
@@ -874,23 +825,6 @@ describe('markets-subworkspace handlers', () => {
         [genItemMatch('most comfortable sandals')],
         [...GENERATED_IDS, TAG_IDS.typeNonBranded],
       );
-    });
-
-    it('best-effort publish marks the project published when the publish succeeds', async () => {
-      const transport = makeTransport();
-      const res = await handleCreateMarketSubworkspace(
-        transport,
-        makeBrand(),
-        PARENT,
-        createBody,
-        log,
-        null,
-        null,
-        { publishMode: 'best-effort' },
-      );
-      expect(res.status).to.equal(201);
-      expect(res.body.published).to.equal(true);
-      expect(transport.publishProject).to.have.been.calledOnce;
     });
 
     it('reads topics from the { items: [...] } envelope shape returned by getBrandTopics', async () => {

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -19,6 +19,7 @@ import esmock from 'esmock';
 import { TAG_IDS, dimensionTreeLevels, makeListProjectTagsStub } from '../fixtures/tag-tree.js';
 import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
 import { SerenityTransportError } from '../../../../src/support/serenity/rest-transport.js';
+import { ERROR_CODES } from '../../../../src/support/serenity/errors.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -129,22 +130,29 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(transport.publishProject).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-1');
     });
 
-    it('still returns 201 when the post-create republish 405s on quota (left as draft)', async () => {
+    it('propagates a quotaExceeded 409 when the post-create republish 405s on quota (SITES-49206)', async () => {
+      // Pinned disguised-405 shape (LLMO-6190, live-verified): a bare string/HTML body, never
+      // JSON — isMeteredQuota keys on this SHAPE, not the bare status.
       const transport = makeTransport({
-        publishProject: sinon.stub().rejects(new SerenityTransportError(405, 'quota')),
+        publishProject: sinon.stub().rejects(
+          new SerenityTransportError(405, 'publish failed: 405', '<html>405 Not Allowed</html>'),
+        ),
       });
       const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
-      const res = await handler.handleCreateTag(
+      // SITES-49206: `republish` (brand-urls.js) no longer swallows a quota 405 — Semrush no
+      // longer enforces AI limits, so a 405 here means it's enforcing again and must surface as
+      // the stable quotaExceeded 409 token, matching every other publish call site.
+      const err = await handler.handleCreateTag(
         transport,
         dataAccess,
         BRAND,
         WORKSPACE,
         validBody,
         fakeLog(),
-      );
-      // The quota-405 disguise is swallowed by republishBestEffort — the create
-      // itself must not fail just because the follow-up publish was rejected.
-      expect(res.status).to.equal(201);
+      ).then(() => null, (e) => e);
+      expect(err).to.not.equal(null);
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal(ERROR_CODES.QUOTA_EXCEEDED);
       expect(transport.publishProject).to.have.been.calledOnce;
     });
 


### PR DESCRIPTION
## Summary
- §10.3 on [PR #2995](https://github.com/adobe/spacecat-api-service/pull/2995)'s follow-up checklist asked: verify whether the empty-units `publishMode:'best-effort'` rejection is a distinct upstream check that survives the AI-limits removal; only then remove `republishBestEffort`'s 405 swallow and the competitor/alias/brand-URL best-effort paths.
- **Live probe (2026-08-17)**, against the same throwaway dev sub-workspace used for the SITES-49206 §10.7 canary: created a project with zero models and zero prompts, called `publishProject` directly — **it succeeded, no 405**. This confirms the empty-units rejection was the same disguised quota-405 mechanism ADR-009 already confirmed Semrush stopped enforcing, not a separate still-live check.
- `errors.js`'s `isMeteredQuota` is the only disguised-405 classifier in the repo (no separate "empty-units" classifier/`ERROR_CODES` entry exists), and `docs/serenity.md` documents Semrush disabling AI product metering **outright** (`limits_enabled: false`) on parent workspaces — consistent with the probe result.

## Changes
- `brand-urls.js`: `republishBestEffort` → `republish`. Instead of swallowing any 405, it now classifies via `isMeteredQuota` and throws `toQuotaExceededError()` — matching every other publish call site in this codebase — so a real future re-enforcement surfaces instead of going unnoticed. Same rename at all 8 call sites (`brand-aliases.js`, `competitor-benchmarks.js`, `handlers/tags.js`).
- `handlers/markets-subworkspace.js`: removed the `publishMode: 'best-effort'` branch entirely (`require`/`skip` cover every remaining case).
- `brand-provisioning.js` / `controllers/serenity.js`: publish-mode selection no longer special-cases an empty-units project — always `'require'` unless LLMO-5492 defer-publish is on (`'skip'`).
- Updated/removed tests asserting the old swallow-and-succeed behavior; added tests confirming a quota 405 now propagates as a 409 `QUOTA_EXCEEDED`.

**Deliberately out of scope** (this is §10.3, not §10.6): `isMeteredQuota` / `toQuotaExceededError` / `quota-alerts.js` / `allocation-metrics.js` themselves, and the `wrapPublish` identity seams in `handlers/markets.js` / `handlers/prompts.js` — those remain for §10.6's still-open, separate scope.

## Test plan
- [x] `npx eslint` on all touched files — clean
- [x] `npm run type-check` (all touched files opt into `// @ts-check`) — clean
- [x] Full targeted `mocha` run across all touched + dependent test files — 558 passing, 0 failures
- [x] Live probe against a real throwaway workspace (see Summary) — this is what motivated the change in the first place

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```