### PR TITLE
fix(schedules): pass site_id through providerParameters on recurring prompt-suggestion schedules

### DIFF
--- a/src/support/prompt-suggestion-schedules.js
+++ b/src/support/prompt-suggestion-schedules.js
@@ -155,6 +155,11 @@ export async function registerPromptSuggestionSchedule({
     description: `${providerId} prompt-suggestion schedule (onboarding)`,
     enableBrandPresence: false,
     triggerImmediately: true,
+    // Mirrors the trial-path submitJob call above: the runner reads snake_case
+    // `site_id` from job.parameters (no camel fallback) and fails
+    // "site_id missing from job parameters" without it (LLMO-7065) — DRS does
+    // NOT derive this server-side from the schedule's own siteId.
+    providerParameters: { [providerId]: { site_id: siteId } },
   });
 
   log.info(`Registered DRS ${providerId} schedule ${result?.scheduleId ?? 'unknown'} `

--- a/test/support/prompt-suggestion-schedules.test.js
+++ b/test/support/prompt-suggestion-schedules.test.js
@@ -72,6 +72,15 @@ describe('prompt-suggestion-schedules support module', () => {
       expect(drsClient.createSchedule).to.have.been.calledThrice;
       expect(drsClient.submitJob).to.not.have.been.called;
       expect(results.map((r) => r.status)).to.deep.equal(['created', 'created', 'created']);
+      // LLMO-7065: providerParameters MUST carry snake_case site_id per
+      // provider — the Fargate runner reads job.parameters.site_id only (no
+      // camel fallback, no server-side derivation from the schedule's siteId)
+      // and raises "site_id missing from job parameters" without it.
+      drsClient.createSchedule.getCalls().forEach((call) => {
+        const [{ providerIds, providerParameters }] = call.args;
+        const [providerId] = providerIds;
+        expect(providerParameters).to.deep.equal({ [providerId]: { site_id: SITE_ID } });
+      });
     });
 
     it('reports already-existed as success (idempotent)', async () => {


### PR DESCRIPTION
## Summary
- `registerPromptSuggestionSchedule`'s paying-site branch (`src/support/prompt-suggestion-schedules.js`) called `drsClient.createSchedule(...)` without `providerParameters`, so `site_id` never reached `job.parameters` for recurring `prompt_generation_semrush` / `prompt_generation_agentic_traffic` / `prompt_generation_synthetic_personas` schedules.
- The Fargate runner (`llmo-data-retrieval-service/src/pipelines/prompt_generation_semrush/fargate/runner.py:302-306`) reads `job.parameters.site_id` with **no camel fallback and no server-side derivation** from the schedule's own `site_id` — so it raised `PipelineInvalidInputError("site_id missing from job parameters")` before doing anything.
- Confirmed **308 of 309** `prompt_generation_semrush` schedules fleet-wide are affected — found while retriggering the pipeline for Chow Tai Fook to verify the unrelated citation-gaps fix (#2986/#2991 in `llmo-data-retrieval-service`). Filed as [LLMO-7065](https://jira.corp.adobe.com/browse/LLMO-7065).
- Fix mirrors the existing trial-path `submitJob` call directly above it, which already sends `parameters: { site_id: siteId }` for the same providers — same convention, just missing on the recurring-schedule path.
- Verified the rest of the chain already supports this correctly end-to-end without any changes: `@adobe/spacecat-shared-drs-client`'s `createSchedule`/`#buildScheduleBody` already accepts and forwards `providerParameters` → `job_config.provider_parameters`; `llmo-data-retrieval-service`'s `create_schedule.py` already validates/stores `provider_parameters` generically; `scheduler.py`'s `submit_job_for_schedule` already does `parameters = provider_parameters[provider_id].copy()` when present. This was the only gap in the chain.

## Test plan
- [x] Added an assertion to the existing "creates a recurring schedule per pipeline (paying)" test asserting `providerParameters` carries `{ [providerId]: { site_id } }` for every `createSchedule` call — mirrors the existing trial-path `site_id` assertion.
- [x] `npx mocha test/support/prompt-suggestion-schedules.test.js test/controllers/llmo/prompt-suggestion-schedules.test.js` — 23 passed.
- [x] `npx eslint src/support/prompt-suggestion-schedules.js test/support/prompt-suggestion-schedules.test.js` — clean.

## Follow-up
- The 308 already-broken schedules need a data backfill (existing schedule records won't retroactively get `provider_parameters` from this code fix) — tracked as part of LLMO-7065, separate backfill script in `llmo-data-retrieval-service`.

LLMO-7065

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```