### PR TITLE
feat(serenity): write settings.ai.primary_url at provisioning (#348)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -33,7 +33,7 @@ import {
 } from '@adobe/spacecat-shared-utils';
 
 import { ErrorWithStatusCode, getImsUserToken, resolveSemrushImsToken } from '../support/utils.js';
-import { hostnameFromUrlString } from '../support/url-utils.js';
+import { hostnameFromUrlString, siteIdentityFromUrlString } from '../support/url-utils.js';
 import {
   STATUS_BAD_REQUEST,
 } from '../utils/constants.js';
@@ -116,6 +116,21 @@ function brandDomainFromPayload(brandData) {
     .map((u) => (typeof u === 'string' ? u : u?.value))
     .find(hasText);
   return hostnameFromUrlString(first);
+}
+
+/**
+ * Derives the brand's full "site identity" (host + any subdomain/subpath) from a
+ * brand-create payload's URLs — the value written to Semrush's
+ * `settings.ai.primary_url` (serenity-docs#348), distinct from the host-only
+ * `domain` {@link brandDomainFromPayload} returns. Same first-URL selection.
+ * Returns null when no usable URL is present.
+ */
+function brandPrimaryUrlFromPayload(brandData) {
+  const urls = Array.isArray(brandData?.urls) ? brandData.urls : [];
+  const first = urls
+    .map((u) => (typeof u === 'string' ? u : u?.value))
+    .find(hasText);
+  return siteIdentityFromUrlString(first);
 }
 
 /**
@@ -1679,6 +1694,7 @@ function BrandsController(ctx, log, env) {
             market,
             languageCode,
             brandDomain,
+            primaryUrl: brandPrimaryUrlFromPayload(brandData) ?? undefined,
             modelIds,
             generateTopics: generatePrompts,
             brandAliases,

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -81,7 +81,7 @@ import {
 } from '../support/brands-storage.js';
 import { ErrorWithStatusCode, resolveSemrushImsToken as resolveImsTokenViaPromise } from '../support/utils.js';
 import { hostnameFromUrlString } from '../support/url-utils.js';
-import { ensureMarketSite, resolveSiteDomain, unlinkMarketSiteIfOrphaned } from '../support/serenity/site-linkage.js';
+import { ensureMarketSite, resolveSiteIdentity, unlinkMarketSiteIfOrphaned } from '../support/serenity/site-linkage.js';
 import { X_PROMISE_TOKEN_HEADER, PROMISE_TOKEN_REQUIRED_ERROR_CODE } from '../utils/constants.js';
 import { tombstoneAllForBrand, linkSiteToLiveRows } from '../support/serenity/mapping-rows.js';
 
@@ -763,14 +763,22 @@ function SerenityController(context, log, env) {
         // brandDomain is absent. A supplied-but-unresolvable siteId is a hard 400.
         let effectiveBody = requestBody;
         if (suppliedSiteId && !hasText(requestBody.brandDomain)) {
-          const derivedDomain = await resolveSiteDomain(ctx.dataAccess, suppliedSiteId, log);
-          if (!derivedDomain || !hasText(derivedDomain)) {
+          // Resolve BOTH the host-only domain and the full primary_url identity
+          // (serenity-docs#348) from the site in one lookup; thread primaryUrl so
+          // the narrowed-dataAccess subworkspace handler can PATCH it (it cannot
+          // re-fetch the Site itself).
+          const identity = await resolveSiteIdentity(ctx.dataAccess, suppliedSiteId, log);
+          if (!identity?.domain || !hasText(identity.domain)) {
             return createResponse(
               { error: 'invalidRequest', message: 'siteId did not resolve to a site domain' },
               400,
             );
           }
-          effectiveBody = { ...requestBody, brandDomain: derivedDomain };
+          effectiveBody = {
+            ...requestBody,
+            brandDomain: identity.domain,
+            primaryUrl: identity.primaryUrl ?? undefined,
+          };
         }
         // Brand aliases are brand-level but region-scoped: the create handler
         // clamps each to the new market's region before writing brand_names.
@@ -1253,6 +1261,13 @@ function SerenityController(context, log, env) {
       const brandDomain = hasText(body.brandDomain)
         ? body.brandDomain
         : hostnameFromUrlString(pendingSemrushProvisioning?.primaryUrl);
+      // serenity-docs#348: the FULL tracked URL (subdomain/subpath preserved),
+      // threaded to the market handler so it PATCHes `settings.ai.primary_url`.
+      // Unlike `brandDomain` above (host-only) this keeps the stashed wizard URL
+      // intact; the handler normalizes it via `siteIdentityFromUrlString`.
+      const brandPrimaryUrl = hasText(body.brandDomain)
+        ? body.brandDomain
+        : (pendingSemrushProvisioning?.primaryUrl ?? null);
 
       // ----- Pending-brand activation is ALWAYS sub-workspace-only (LLMO-6405) -----
       // Markets are Semrush projects added afterwards from the Markets tab, never
@@ -1447,6 +1462,7 @@ function SerenityController(context, log, env) {
           market: m.market,
           languageCode: m.languageCode,
           brandDomain,
+          primaryUrl: brandPrimaryUrl ?? undefined,
           brandNames: body.brandNames,
           brandDisplayName: body.brandDisplayName,
           name: m.name,

--- a/src/support/serenity/brand-provisioning.js
+++ b/src/support/serenity/brand-provisioning.js
@@ -66,7 +66,10 @@ export function initialMarketProjectName(market, languageCode) {
  * @param {string} params.brandName - brand display name (sub-workspace title + brand_name).
  * @param {string} params.market - ISO-2 country code for the initial market.
  * @param {string} params.languageCode - BCP-47 language code for the initial market.
- * @param {string} params.brandDomain - brand domain for the upstream project.
+ * @param {string} params.brandDomain - brand domain (host-only) for the upstream project.
+ * @param {string} [params.primaryUrl] - the full URL the brand tracks (may carry a
+ *   subdomain/subpath), written to `settings.ai.primary_url` (serenity-docs#348).
+ *   Falls back to `brandDomain` when absent.
  * @param {string[]} [params.modelIds] - AI models (LLMs) to attach to the
  *   project. This is always the brand's FIRST-EVER market (the sub-workspace
  *   is freshly created below), so an empty/omitted list resolves to the
@@ -115,7 +118,7 @@ export function initialMarketProjectName(market, languageCode) {
  *   best-effort and never throw.
  */
 export async function provisionBrandSubworkspace(context, {
-  spaceCatId, brandId, brandName, market, languageCode, brandDomain,
+  spaceCatId, brandId, brandName, market, languageCode, brandDomain, primaryUrl,
   modelIds = [], brandAliases = [], brandUrlSources = null, competitors = [],
   generateTopics = true, writeDeadline = computeWriteDeadline(),
 }, log = console) {
@@ -228,6 +231,9 @@ export async function provisionBrandSubworkspace(context, {
         market: resolvedMarket,
         languageCode: resolvedLanguageCode,
         brandDomain,
+        // #348: the full tracked URL for settings.ai.primary_url; the handler
+        // normalizes it and falls back to brandDomain when absent.
+        primaryUrl,
         brandNames: [brandName],
         brandDisplayName: brandName,
         name: initialMarketProjectName(resolvedMarket, resolvedLanguageCode),

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -13,6 +13,7 @@
 // @ts-check
 
 import { hasText } from '@adobe/spacecat-shared-utils';
+import { siteIdentityFromUrlString } from '../../url-utils.js';
 
 import { ErrorWithStatusCode } from '../../utils.js';
 import {
@@ -625,6 +626,35 @@ export async function handleCreateMarketSubworkspace(
     projectId = String(createResp?.id || '');
     if (!hasText(projectId)) {
       return { status: 502, body: { error: 'createNoProjectId', message: 'Upstream createProject returned no id' } };
+    }
+  }
+
+  // serenity-docs#348: record the URL the brand ACTUALLY tracks in
+  // `settings.ai.primary_url` (may carry a subdomain/subpath), distinct from the
+  // host-only `domain` create sends. Semrush IGNORES primary_url on create and
+  // only honors it via PATCH, so set it here — before the single publish below,
+  // so it's part of the published version. Prefer the caller-threaded full
+  // identity (`body.primaryUrl`, e.g. the wizard's draft URL or a subpath site's
+  // base URL); fall back to the host-only brandDomain (a no-op vs the apex).
+  // Best-effort by design, mirroring the brand-URL enrichment below: a failed
+  // PATCH must not abort a market that is otherwise valid upstream — the
+  // data-service drift/backfill pass (serenity-docs#348 WS3/WS4) reconciles any
+  // project left without its primary_url.
+  const primaryUrl = siteIdentityFromUrlString(
+    hasText(body?.primaryUrl) ? body.primaryUrl : body?.brandDomain,
+  );
+  // Truthy check (not hasText) so tsc narrows `string | null` -> `string`;
+  // siteIdentityFromUrlString only ever returns a real host string or null.
+  if (primaryUrl) {
+    try {
+      await transport.updateProject(workspaceId, projectId, {
+        type: 'ai',
+        settings: { ai: { primary_url: primaryUrl } },
+      });
+    } catch (e) {
+      log?.warn?.('handleCreateMarketSubworkspace: best-effort primary_url PATCH failed; project left without primary_url', {
+        workspaceId, projectId, primaryUrl, error: e.message,
+      });
     }
   }
 

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -19,7 +19,8 @@ import { ErrorWithStatusCode } from '../../utils.js';
 import { ERROR_CODES, isUpstreamGone, isSemrushTransportError } from '../errors.js';
 import { normalizeLanguageCode, normalizeGeoTargetId } from '../validation.js';
 import { resolveLocation } from '../locations.js';
-import { resolveSiteDomain } from '../site-linkage.js';
+import { resolveSiteIdentity } from '../site-linkage.js';
+import { siteIdentityFromUrlString } from '../../url-utils.js';
 
 const LANGUAGE_CACHE_TTL_MS = 60 * 60 * 1000;
 export const MAX_MODEL_IDS = 50;
@@ -340,9 +341,23 @@ export async function handleCreateMarket(
   // flat handler holds full `dataAccess` (incl. Site), so it self-derives — the
   // subworkspace handler cannot (narrowed dataAccess) and relies on the controller.
   // A supplied-but-unresolvable siteId is a hard 400 (never silently proceeds).
-  const brandDomain = hasText(body.brandDomain)
-    ? body.brandDomain
-    : await resolveSiteDomain(dataAccess, body.siteId, log);
+  // Derive BOTH values a Semrush project tracks from the same source
+  // (serenity-docs#348): host-only `domain` (unchanged) and the full
+  // `primaryUrl` identity (may carry subdomain/subpath) written to
+  // `settings.ai.primary_url`. A caller-threaded `body.primaryUrl` (the raw
+  // tracked URL) wins over the host-only `brandDomain` fallback.
+  let brandDomain;
+  let brandPrimaryUrl;
+  if (hasText(body.brandDomain)) {
+    brandDomain = body.brandDomain;
+    brandPrimaryUrl = siteIdentityFromUrlString(
+      hasText(body.primaryUrl) ? body.primaryUrl : body.brandDomain,
+    );
+  } else {
+    const identity = await resolveSiteIdentity(dataAccess, body.siteId, log);
+    brandDomain = identity?.domain ?? null;
+    brandPrimaryUrl = identity?.primaryUrl ?? null;
+  }
   if (!hasText(brandDomain)) {
     return {
       status: 400,
@@ -375,6 +390,28 @@ export async function handleCreateMarket(
         message: 'Upstream createProject returned no id',
       },
     };
+  }
+
+  // serenity-docs#348: set `settings.ai.primary_url` (the tracked URL, kept
+  // distinct from the host-only `domain`) via PATCH before publish — Semrush
+  // ignores it on create. Best-effort: a failed PATCH must not abort an
+  // otherwise-valid market; the data-service backfill reconciles it later.
+  // Truthy check (not hasText) so tsc narrows `string | null` -> `string`.
+  if (brandPrimaryUrl) {
+    try {
+      await transport.updateProject(semrushWorkspaceId, semrushProjectId, {
+        type: 'ai',
+        settings: { ai: { primary_url: brandPrimaryUrl } },
+      });
+    } catch (e) {
+      log?.warn?.('handleCreateMarket: best-effort primary_url PATCH failed; project left without primary_url', {
+        brandId,
+        semrushWorkspaceId,
+        semrushProjectId,
+        primaryUrl: brandPrimaryUrl,
+        error: e.message,
+      });
+    }
   }
 
   try {

--- a/src/support/serenity/site-linkage.js
+++ b/src/support/serenity/site-linkage.js
@@ -14,7 +14,7 @@
 
 import { composeBaseURL, hasText } from '@adobe/spacecat-shared-utils';
 import * as dataAccessModels from '@adobe/spacecat-shared-data-access';
-import { hostnameFromUrlString, isPublicHostname } from '../url-utils.js';
+import { hostnameFromUrlString, isPublicHostname, siteIdentityFromUrlString } from '../url-utils.js';
 
 // `Site` is a runtime value (the model class carrying the DELIVERY_TYPES static
 // map) but the data-access package's .d.ts re-exports its models as types only,
@@ -273,16 +273,55 @@ export async function ensureMarketSite(ctx, {
 }
 
 /**
- * Resolves a SpaceCat Site UUID to its bare hostname (the domain a Semrush
- * market/project tracks). Lets a market-create caller supply a `siteId` instead
- * of a `brandDomain`: the site's `base_url` is normalized to a hostname via
- * `hostnameFromUrlString` (the same normalizer every other brand → Semrush
- * domain derivation uses), so the derived domain is identical to what a
- * `brandDomain` caller would have sent.
+ * Resolves a SpaceCat Site UUID to BOTH URL-ish values a Semrush project tracks:
+ * the host-only `domain` (grouping key, `hostnameFromUrlString`) and the full
+ * `primaryUrl` "site identity" (`siteIdentityFromUrlString`, keeping any
+ * subdomain/subpath). The two are deliberately distinct — `domain` is
+ * eTLD+1-normalized upstream and rejects a path, while `primaryUrl` is the URL
+ * the brand actually owns (serenity-docs#348), written to
+ * `settings.ai.primary_url`. Sharing one Site fetch keeps them consistent.
  *
  * Best-effort: returns null (never throws) on missing input, unavailable
- * data-access, an unknown site, or a lookup failure. The caller decides whether
- * a null is a hard 400 (a supplied siteId that cannot resolve) or a silent skip.
+ * data-access, an unknown site, or a lookup failure — same contract as the
+ * former `resolveSiteDomain`, which now delegates here.
+ *
+ * @param {object} dataAccess - `ctx.dataAccess` (reads `dataAccess.Site`).
+ * @param {string|null|undefined} siteId - the SpaceCat Site UUID to resolve.
+ * @param {object} [log] - logger.
+ * @returns {Promise<{domain: string|null, primaryUrl: string|null}|null>} the
+ *   derived values, or null when the site cannot be resolved.
+ */
+export async function resolveSiteIdentity(dataAccess, siteId, log) {
+  if (!siteId || !hasText(siteId)) {
+    return null;
+  }
+  const Site = dataAccess?.Site;
+  if (!Site || typeof Site.findById !== 'function') {
+    log?.warn?.('resolveSiteIdentity: Site data-access unavailable; cannot resolve site', { siteId });
+    return null;
+  }
+  try {
+    const site = await Site.findById(siteId);
+    if (!site) {
+      log?.warn?.('resolveSiteIdentity: site not found', { siteId });
+      return null;
+    }
+    const baseURL = site.getBaseURL();
+    return {
+      domain: hostnameFromUrlString(baseURL),
+      primaryUrl: siteIdentityFromUrlString(baseURL),
+    };
+  } catch (e) {
+    log?.warn?.('resolveSiteIdentity: lookup failed (non-fatal)', { siteId, error: e.message });
+    return null;
+  }
+}
+
+/**
+ * Resolves a SpaceCat Site UUID to its bare hostname (the host-only `domain` a
+ * Semrush market/project tracks). Thin wrapper over {@link resolveSiteIdentity}
+ * kept for the callers that only need the domain. Best-effort: returns null
+ * (never throws) when the site cannot be resolved.
  *
  * @param {object} dataAccess - `ctx.dataAccess` (reads `dataAccess.Site`).
  * @param {string|null|undefined} siteId - the SpaceCat Site UUID to resolve.
@@ -290,25 +329,8 @@ export async function ensureMarketSite(ctx, {
  * @returns {Promise<string|null>} the site's hostname, or null when unresolvable.
  */
 export async function resolveSiteDomain(dataAccess, siteId, log) {
-  if (!siteId || !hasText(siteId)) {
-    return null;
-  }
-  const Site = dataAccess?.Site;
-  if (!Site || typeof Site.findById !== 'function') {
-    log?.warn?.('resolveSiteDomain: Site data-access unavailable; cannot resolve site domain', { siteId });
-    return null;
-  }
-  try {
-    const site = await Site.findById(siteId);
-    if (!site) {
-      log?.warn?.('resolveSiteDomain: site not found', { siteId });
-      return null;
-    }
-    return hostnameFromUrlString(site.getBaseURL());
-  } catch (e) {
-    log?.warn?.('resolveSiteDomain: lookup failed (non-fatal)', { siteId, error: e.message });
-    return null;
-  }
+  const identity = await resolveSiteIdentity(dataAccess, siteId, log);
+  return identity?.domain ?? null;
 }
 
 /**

--- a/src/support/url-utils.js
+++ b/src/support/url-utils.js
@@ -41,6 +41,42 @@ export function hostnameFromUrlString(value) {
 }
 
 /**
+ * Derives a stable "site identity" from a URL or host string: the lowercased
+ * host PLUS its normalized path, no scheme/credentials/port/query/fragment.
+ * Unlike {@link hostnameFromUrlString} (host only) this keeps the path, so a
+ * subpath- or subdomain-scoped brand (`nba.com/kings`, `quickbooks.intuit.com`)
+ * is recorded as what it actually tracks — this is the value written to
+ * Semrush's `settings.ai.primary_url`, distinct from the host-only `domain`.
+ *
+ * Normalization rules mirror `siteIdentityFromUrlString` in
+ * `@adobe/spacecat-shared-utils` (switch to that import once the version
+ * exporting it is published): lowercase host / case-sensitive path; strip a
+ * single trailing slash so `x.com/a/` and `x.com/a` agree; preserve a trailing
+ * `.html` (SITES-49656); do NOT collapse `www.`; null on unparseable input.
+ *
+ * @param {string} value - a URL or host(/path) string, with or without scheme
+ * @returns {string|null} the site identity, or null when absent/unparseable
+ */
+export function siteIdentityFromUrlString(value) {
+  if (!value || !hasText(value)) {
+    return null;
+  }
+  try {
+    const url = new URL(value.includes('://') ? value : `https://${value}`);
+    const host = url.hostname.toLowerCase();
+    if (!host) {
+      return null;
+    }
+    const pathname = url.pathname.endsWith('/')
+      ? url.pathname.slice(0, -1)
+      : url.pathname;
+    return `${host}${pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * True when `hostname` is a routable PUBLIC domain name — i.e. NOT a loopback,
  * link-local, private, single-label, IP-literal, or reserved-TLD host.
  *

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -178,7 +178,7 @@ describe('SerenityController', () => {
   let updateBrandStub;
   let accessControlHasAccessStub;
   let ensureMarketSiteStub;
-  let resolveSiteDomainStub;
+  let resolveSiteIdentityStub;
   let unlinkMarketSiteIfOrphanedStub;
   let getBrandBaseSiteIdStub;
   let exchangePromiseTokenStub;
@@ -215,7 +215,7 @@ describe('SerenityController', () => {
     updateBrandStub = sinon.stub().resolves({ getId: () => BRAND, getStatus: () => 'active' });
     accessControlHasAccessStub = sinon.stub().resolves(true);
     ensureMarketSiteStub = sinon.stub().resolves('site-uuid-1');
-    resolveSiteDomainStub = sinon.stub().resolves('resolved.example.com');
+    resolveSiteIdentityStub = sinon.stub().resolves({ domain: 'resolved.example.com', primaryUrl: 'resolved.example.com' });
     unlinkMarketSiteIfOrphanedStub = sinon.stub().resolves(true);
     getBrandBaseSiteIdStub = sinon.stub().resolves(null);
     exchangePromiseTokenStub = sinon.stub().resolves('exchanged-ims-token');
@@ -303,7 +303,7 @@ describe('SerenityController', () => {
       },
       '../../src/support/serenity/site-linkage.js': {
         ensureMarketSite: ensureMarketSiteStub,
-        resolveSiteDomain: resolveSiteDomainStub,
+        resolveSiteIdentity: resolveSiteIdentityStub,
         unlinkMarketSiteIfOrphaned: unlinkMarketSiteIfOrphanedStub,
       },
       '../../src/support/utils.js': {
@@ -1371,7 +1371,7 @@ describe('SerenityController', () => {
 
     it('createMarket derives brandDomain from a supplied siteId and links THAT site (LLMO-6405)', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: { brandId: BRAND, geoTargetId: 2840, languageCode: 'en' } });
-      resolveSiteDomainStub.resolves('acme.com');
+      resolveSiteIdentityStub.resolves({ domain: 'acme.com', primaryUrl: 'acme.com/markets' });
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const ctx = fakeContext({
         data: {
@@ -1380,17 +1380,19 @@ describe('SerenityController', () => {
       });
       const response = await controller.createMarket(ctx);
       expect(response.status).to.equal(201);
-      expect(resolveSiteDomainStub).to.have.been.calledOnceWith(ctx.dataAccess, 'site-onboarded');
-      // Handler receives the derived brandDomain.
+      expect(resolveSiteIdentityStub).to.have.been.calledOnceWith(ctx.dataAccess, 'site-onboarded');
+      // Handler receives the derived brandDomain (host-only) AND the full
+      // primary_url identity threaded from the site (#348).
       const handlerBody = handlers.handleCreateMarketSubworkspace.firstCall.args[3];
       expect(handlerBody.brandDomain).to.equal('acme.com');
+      expect(handlerBody.primaryUrl).to.equal('acme.com/markets');
       // ensureMarketSite links THAT site directly (siteId + derived domain).
       const opts = ensureMarketSiteStub.firstCall.args[1];
       expect(opts).to.include({ siteId: 'site-onboarded', domain: 'acme.com' });
     });
 
     it('createMarket 400s when a supplied siteId does not resolve to a domain', async () => {
-      resolveSiteDomainStub.resolves(null);
+      resolveSiteIdentityStub.resolves(null);
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const response = await controller.createMarket(fakeContext({
         data: {
@@ -1410,7 +1412,7 @@ describe('SerenityController', () => {
           market: 'us', languageCode: 'en', brandDomain: 'x.com', brandNames: ['X'],
         },
       }));
-      expect(resolveSiteDomainStub).to.not.have.been.called;
+      expect(resolveSiteIdentityStub).to.not.have.been.called;
       const opts = ensureMarketSiteStub.firstCall.args[1];
       expect(opts.domain).to.equal('x.com');
       expect(opts.siteId).to.equal(undefined); // no siteId supplied → link by domain only

--- a/test/it/postgres/docker-compose.yml
+++ b/test/it/postgres/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   data-service:
-    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.70.0
+    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.90.0
     container_name: spacecat-it-data-service
     depends_on:
       db:

--- a/test/it/postgres/docker-compose.yml
+++ b/test/it/postgres/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   data-service:
-    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.90.0
+    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.89.0
     container_name: spacecat-it-data-service
     depends_on:
       db:

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -59,6 +59,7 @@ function makeTransport(overrides = {}) {
     listProjects: sinon.stub().resolves({ items: [] }),
     getInitStatus: sinon.stub().resolves({ initialized: true }),
     createProject: sinon.stub().resolves({ id: 'new-proj' }),
+    updateProject: sinon.stub().resolves(null),
     publishProject: sinon.stub().resolves(null),
     deleteProject: sinon.stub().resolves(null),
     listLanguages: sinon.stub().resolves({ items: [{ id: 'lang-en', name: 'English' }] }),
@@ -276,6 +277,40 @@ describe('markets-subworkspace handlers', () => {
       });
       expect(transport.createProject).to.have.been.calledOnce;
       expect(transport.publishProject).to.have.been.calledOnce;
+    });
+
+    it('PATCHes settings.ai.primary_url from body.primaryUrl before publishing (#348)', async () => {
+      const transport = makeTransport();
+      const body = { ...createBody, brandDomain: 'nba.com', primaryUrl: 'https://www.nba.com/kings/' };
+      const res = await handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, body, log);
+      expect(res.status).to.equal(201);
+      expect(transport.updateProject).to.have.been.calledOnceWith(WS, 'new-proj', {
+        type: 'ai',
+        settings: { ai: { primary_url: 'www.nba.com/kings' } },
+      });
+      // set before publish so it's part of the published version
+      expect(transport.updateProject).to.have.been.calledBefore(transport.publishProject);
+    });
+
+    it('falls back to brandDomain for primary_url when body.primaryUrl is absent (#348)', async () => {
+      const transport = makeTransport();
+      await handleCreateMarketSubworkspace(transport, makeBrand(), PARENT, createBody, log);
+      expect(transport.updateProject).to.have.been.calledOnceWith(WS, 'new-proj', {
+        type: 'ai',
+        settings: { ai: { primary_url: 'example.com' } },
+      });
+    });
+
+    it('a failed primary_url PATCH is best-effort — market still publishes 201 (#348)', async () => {
+      const transport = makeTransport({
+        updateProject: sinon.stub().rejects(new Error('patch boom')),
+      });
+      const spyLog = { info: () => {}, error: () => {}, warn: sinon.spy() };
+      const b = makeBrand();
+      const res = await handleCreateMarketSubworkspace(transport, b, PARENT, createBody, spyLog);
+      expect(res.status).to.equal(201);
+      expect(transport.publishProject).to.have.been.calledOnce;
+      expect(spyLog.warn).to.have.been.called;
     });
 
     it('accepts siteId in place of brandDomain — validation passes (LLMO-6405)', async () => {

--- a/test/support/serenity/site-linkage.test.js
+++ b/test/support/serenity/site-linkage.test.js
@@ -16,6 +16,7 @@ import sinon from 'sinon';
 import {
   ensureMarketSite,
   resolveSiteDomain,
+  resolveSiteIdentity,
   unlinkMarketSiteIfOrphaned,
   SERENITY_BRAND_SITE_TYPE,
 } from '../../../src/support/serenity/site-linkage.js';
@@ -355,6 +356,38 @@ describe('serenity site-linkage: resolveSiteDomain', () => {
     const result = await resolveSiteDomain(dataAccess, 'site-1', log);
     expect(result).to.equal(null);
     expect(log.warn).to.have.been.calledOnce;
+  });
+});
+
+describe('serenity site-linkage: resolveSiteIdentity', () => {
+  let Site;
+  let log;
+  let dataAccess;
+
+  beforeEach(() => {
+    Site = { findById: sinon.stub() };
+    log = { warn: sinon.spy(), error: sinon.spy() };
+    dataAccess = { Site };
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('splits a subpath site into host-only domain + full primaryUrl identity', async () => {
+    Site.findById.resolves({ getBaseURL: () => 'https://www.nba.com/kings/' });
+    const result = await resolveSiteIdentity(dataAccess, 'site-1', log);
+    expect(result).to.deep.equal({ domain: 'www.nba.com', primaryUrl: 'www.nba.com/kings' });
+  });
+
+  it('yields equal domain and primaryUrl for a path-free site', async () => {
+    Site.findById.resolves({ getBaseURL: () => 'https://example.com' });
+    const result = await resolveSiteIdentity(dataAccess, 'site-2', log);
+    expect(result).to.deep.equal({ domain: 'example.com', primaryUrl: 'example.com' });
+  });
+
+  it('returns null (not a partial object) when the site cannot be resolved', async () => {
+    Site.findById.resolves(null);
+    expect(await resolveSiteIdentity(dataAccess, 'missing', log)).to.equal(null);
+    expect(await resolveSiteIdentity(dataAccess, '', log)).to.equal(null);
   });
 });
 

--- a/test/support/url-utils.test.js
+++ b/test/support/url-utils.test.js
@@ -11,7 +11,7 @@
  */
 
 import { expect } from 'chai';
-import { hostnameFromUrlString, isPublicHostname } from '../../src/support/url-utils.js';
+import { hostnameFromUrlString, isPublicHostname, siteIdentityFromUrlString } from '../../src/support/url-utils.js';
 
 describe('url-utils: hostnameFromUrlString', () => {
   it('extracts the hostname from a full URL', () => {
@@ -31,6 +31,43 @@ describe('url-utils: hostnameFromUrlString', () => {
 
   it('returns null for an unparseable URL (new URL throws)', () => {
     expect(hostnameFromUrlString('https://[')).to.equal(null);
+  });
+});
+
+describe('url-utils: siteIdentityFromUrlString', () => {
+  it('keeps the host and preserves the path', () => {
+    expect(siteIdentityFromUrlString('https://www.nba.com/kings/')).to.equal('www.nba.com/kings');
+    expect(siteIdentityFromUrlString('nba.com/kings')).to.equal('nba.com/kings');
+    expect(siteIdentityFromUrlString('quickbooks.intuit.com/au')).to.equal('quickbooks.intuit.com/au');
+  });
+
+  it('returns host-only for path-free URLs (matches hostnameFromUrlString, no trailing slash)', () => {
+    expect(siteIdentityFromUrlString('https://example.com')).to.equal('example.com');
+    expect(siteIdentityFromUrlString('https://example.com/')).to.equal('example.com');
+    expect(siteIdentityFromUrlString('quickbooks.intuit.com')).to.equal('quickbooks.intuit.com');
+  });
+
+  it('strips a single trailing slash but preserves .html and case-sensitive path', () => {
+    expect(siteIdentityFromUrlString('experian.co.uk/business/')).to.equal('experian.co.uk/business');
+    expect(siteIdentityFromUrlString('oklahoma.gov/omes.html')).to.equal('oklahoma.gov/omes.html');
+    expect(siteIdentityFromUrlString('HTTPS://Shop.Example.COM/UK/En')).to.equal('shop.example.com/UK/En');
+  });
+
+  it('strips scheme, userinfo, port, query and fragment', () => {
+    expect(siteIdentityFromUrlString('https://user:pass@shop.example.com:8443/uk?a=1#f'))
+      .to.equal('shop.example.com/uk');
+  });
+
+  it('returns null for empty/whitespace/non-string input', () => {
+    expect(siteIdentityFromUrlString('')).to.equal(null);
+    expect(siteIdentityFromUrlString('   ')).to.equal(null);
+    expect(siteIdentityFromUrlString(undefined)).to.equal(null);
+    expect(siteIdentityFromUrlString(null)).to.equal(null);
+  });
+
+  it('returns null for unparseable input and empty-host URLs', () => {
+    expect(siteIdentityFromUrlString('https://[')).to.equal(null);
+    expect(siteIdentityFromUrlString('file:///etc/passwd')).to.equal(null);
   });
 });
 


### PR DESCRIPTION
## What
Provisioning now records the URL a brand actually tracks in Semrush `settings.ai.primary_url` (may carry a subdomain/subpath), kept distinct from the host-only `domain`.

- `siteIdentityFromUrlString` in `url-utils.js` (local twin of the new `@adobe/spacecat-shared-utils` primitive — will switch to the shared import once published).
- `resolveSiteIdentity` in `site-linkage.js` returns `{domain, primaryUrl}` from one Site fetch; `resolveSiteDomain` delegates to it.
- **create → PATCH(primary_url) → publish** in BOTH the flat (`markets.js`) and sub-workspace (`markets-subworkspace.js`) handlers. Semrush ignores `primary_url` on create, so it's PATCHed before publish. Best-effort: a failed PATCH is logged, never aborts an otherwise-valid market (the data-service backfill reconciles).
- `primaryUrl` threaded through all three provisioning entry points: add-market + pending-activation (`serenity.js`) and brand-create (`brands.js` → `brand-provisioning.js`).

## Why
serenity-docs#348: 96 of 307 active sub-workspace brands are tracked against their parent apex because `primary_url` has never been written.

## Tests
type-check passes; new unit tests for `siteIdentityFromUrlString`, `resolveSiteIdentity`, and the primary_url PATCH (sent before publish; best-effort on failure). Affected suites green.

## Not in scope / follow-up
- `ensureMarketSite` subpath-matching bug — deferred to its own PR.

Base is the session branch (this layers on the #33/serenity subworkspace stack not yet on main); retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)