### PR TITLE
feat: admin-gated x-view-full-experience override to bypass PLG limiting (SITES-49888)

### DIFF
--- a/src/controllers/opportunities.js
+++ b/src/controllers/opportunities.js
@@ -69,7 +69,7 @@ function OpportunitiesController(ctx) {
    * @returns {Promise<Array>} Filtered (or unfiltered) opportunities
    */
   async function filterForSummitPlg(site, opportunities, requestContext) {
-    if (await getIsSummitPlgEnabled(site, ctx, requestContext)) {
+    if (await getIsSummitPlgEnabled(site, ctx, requestContext, accessControlUtil)) {
       return opportunities.filter(
         (oppty) => SUMMIT_PLG_ALLOWED_TYPES.includes(oppty.getType()),
       );
@@ -205,7 +205,7 @@ function OpportunitiesController(ctx) {
     if (!oppty || oppty.getSiteId() !== siteId) {
       return notFound('Opportunity not found');
     }
-    if (await getIsSummitPlgEnabled(site, ctx, context)) {
+    if (await getIsSummitPlgEnabled(site, ctx, context, accessControlUtil)) {
       try {
         await grantSuggestionsForOpportunity(dataAccess, site, oppty);
       /* c8 ignore next 3 */

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -426,7 +426,7 @@ function SuggestionsController(ctx, sqs, env) {
    * @returns {Promise<Array>} Filtered suggestion entities.
    */
   const filterByGrantStatus = async (site, suggestions, context) => {
-    if (!await getIsSummitPlgEnabled(site, ctx, context)) {
+    if (!await getIsSummitPlgEnabled(site, ctx, context, accessControlUtil)) {
       return suggestions;
     }
     try {
@@ -493,7 +493,7 @@ function SuggestionsController(ctx, sqs, env) {
         return notFound('Opportunity not found');
       }
     }
-    if (opportunity && await getIsSummitPlgEnabled(site, ctx, context)) {
+    if (opportunity && await getIsSummitPlgEnabled(site, ctx, context, accessControlUtil)) {
       try {
         await grantSuggestionsForOpportunity(dataAccess, site, opportunity);
       /* c8 ignore next 3 */
@@ -783,7 +783,7 @@ function SuggestionsController(ctx, sqs, env) {
     if (!opportunity || opportunity.getSiteId() !== siteId) {
       return notFound();
     }
-    if (await getIsSummitPlgEnabled(site, ctx, context)
+    if (await getIsSummitPlgEnabled(site, ctx, context, accessControlUtil)
       && !(await SuggestionGrant.isSuggestionGranted(suggestion.getId()))) {
       return notFound('Suggestion not found');
     }
@@ -1457,7 +1457,7 @@ function SuggestionsController(ctx, sqs, env) {
     }
 
     // Block auto-deploy on non-granted suggestions for summit-plg users
-    if (await getIsSummitPlgEnabled(site, ctx, context)) {
+    if (await getIsSummitPlgEnabled(site, ctx, context, accessControlUtil)) {
       const { notGrantedIds } = await SuggestionGrant.splitSuggestionsByGrantStatus(suggestionIds);
       if (notGrantedIds.length > 0) {
         const trialSuffix = isViewAsTrialRequest(context)

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -673,19 +673,45 @@ export function isViewAsTrialRequest(requestContext) {
 }
 
 /**
+ * Returns true when the request originates from the sites-optimizer-ui client
+ * and carries the x-view-full-experience header, i.e. an internal user has asked
+ * to view the full (non-PLG-limited) experience. This only inspects the headers;
+ * the admin gate that actually authorises the bypass is applied by the caller
+ * (see getIsSummitPlgEnabled), so a customer sending the header alone changes nothing.
+ * @param {Object} requestContext - Per-request context with pathInfo.headers
+ * @returns {boolean}
+ */
+export function isViewFullExperienceRequest(requestContext) {
+  const headers = requestContext?.pathInfo?.headers;
+  return headers?.['x-client-type'] === 'sites-optimizer-ui'
+    && headers?.['x-view-full-experience'] === 'true';
+}
+
+/**
  * Returns whether the summit-plg audit handler is enabled for the site in configuration.
  * No entitlement check; use when the site was already resolved via TierClient (e.g. sites-resolve).
  * @param {Object} site - Site entity
  * @param {Object} context - Request context with dataAccess, log
  * @param {Object} [requestContext] - Optional per-request context; when provided, the check
  *   is gated on the x-client-type header being 'sites-optimizer-ui'.
+ * @param {Object} [accessControlUtil] - Optional AccessControlUtil for the caller. Required
+ *   to honour the internal "view full experience" override; when the request carries
+ *   x-view-full-experience and the caller has admin access, PLG limiting is bypassed.
  * @returns {Promise<boolean>}
  */
-export async function getIsSummitPlgEnabled(site, context, requestContext) {
+export async function getIsSummitPlgEnabled(site, context, requestContext, accessControlUtil) {
   try {
     if (requestContext) {
       const clientType = requestContext.pathInfo?.headers?.['x-client-type'];
       if (clientType !== 'sites-optimizer-ui') {
+        return false;
+      }
+      // Internal "View full experience" override: an admin caller (e.g. running a
+      // custom demo) can bypass PLG limiting to see the full paid experience without
+      // changing the site's tier. Gated on hasAdminAccess() so a customer cannot
+      // self-unlock entitlement-gated data merely by sending the header.
+      if (isViewFullExperienceRequest(requestContext)
+        && accessControlUtil?.hasAdminAccess?.()) {
         return false;
       }
       if (isViewAsTrialRequest(requestContext)) {

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -37,6 +37,7 @@ import {
   validateSiteForRedirects,
   sendAutofixMessage,
   isViewAsTrialRequest,
+  isViewFullExperienceRequest,
   getImsUserTokenStrict,
   resolveCallerImsUserId,
   sendGlobalImportRunMessage,
@@ -743,6 +744,52 @@ describe('utils', () => {
 
       expect(result).to.be.false;
     });
+
+    it('bypasses PLG limiting (returns false) when x-view-full-experience is set and caller has admin access', async () => {
+      const requestContext = {
+        pathInfo: { headers: { 'x-client-type': 'sites-optimizer-ui', 'x-view-full-experience': 'true' } },
+      };
+      // Entitlement is PLG, but the admin override must win and short-circuit to false
+      context.dataAccess.Entitlement = {
+        findByOrganizationIdAndProductCode: sandbox.stub().resolves({ getTier: () => 'PLG' }),
+      };
+      const accessControlUtil = { hasAdminAccess: () => true };
+
+      const result = await getIsSummitPlgEnabled(site, context, requestContext, accessControlUtil);
+
+      expect(result).to.be.false;
+      // entitlement lookup must not be reached — the override short-circuits first
+      expect(context.dataAccess.Entitlement.findByOrganizationIdAndProductCode)
+        .to.not.have.been.called;
+    });
+
+    it('does NOT bypass PLG limiting for x-view-full-experience when caller lacks admin access', async () => {
+      const requestContext = {
+        pathInfo: { headers: { 'x-client-type': 'sites-optimizer-ui', 'x-view-full-experience': 'true' } },
+      };
+      context.dataAccess.Entitlement = {
+        findByOrganizationIdAndProductCode: sandbox.stub().resolves({ getTier: () => 'PLG' }),
+      };
+      const accessControlUtil = { hasAdminAccess: () => false };
+
+      const result = await getIsSummitPlgEnabled(site, context, requestContext, accessControlUtil);
+
+      // falls through to the entitlement check → PLG → limiting still applies
+      expect(result).to.be.true;
+    });
+
+    it('does NOT bypass PLG limiting for x-view-full-experience when no accessControlUtil is provided', async () => {
+      const requestContext = {
+        pathInfo: { headers: { 'x-client-type': 'sites-optimizer-ui', 'x-view-full-experience': 'true' } },
+      };
+      context.dataAccess.Entitlement = {
+        findByOrganizationIdAndProductCode: sandbox.stub().resolves({ getTier: () => 'PLG' }),
+      };
+
+      const result = await getIsSummitPlgEnabled(site, context, requestContext);
+
+      expect(result).to.be.true;
+    });
   });
 
   describe('getAsoEntitlement / getAsoTier', () => {
@@ -880,6 +927,44 @@ describe('utils', () => {
 
     it('returns false when pathInfo is undefined', () => {
       expect(isViewAsTrialRequest({})).to.be.false;
+    });
+  });
+
+  describe('isViewFullExperienceRequest', () => {
+    it('returns true when both x-client-type and x-view-full-experience headers are correct', () => {
+      const requestContext = {
+        pathInfo: { headers: { 'x-client-type': 'sites-optimizer-ui', 'x-view-full-experience': 'true' } },
+      };
+      expect(isViewFullExperienceRequest(requestContext)).to.be.true;
+    });
+
+    it('returns false when x-client-type is not sites-optimizer-ui', () => {
+      const requestContext = {
+        pathInfo: { headers: { 'x-client-type': 'other-client', 'x-view-full-experience': 'true' } },
+      };
+      expect(isViewFullExperienceRequest(requestContext)).to.be.false;
+    });
+
+    it('returns false when x-view-full-experience header is absent', () => {
+      const requestContext = {
+        pathInfo: { headers: { 'x-client-type': 'sites-optimizer-ui' } },
+      };
+      expect(isViewFullExperienceRequest(requestContext)).to.be.false;
+    });
+
+    it('returns false when x-view-full-experience is not "true"', () => {
+      const requestContext = {
+        pathInfo: { headers: { 'x-client-type': 'sites-optimizer-ui', 'x-view-full-experience': 'false' } },
+      };
+      expect(isViewFullExperienceRequest(requestContext)).to.be.false;
+    });
+
+    it('returns false when requestContext is undefined', () => {
+      expect(isViewFullExperienceRequest(undefined)).to.be.false;
+    });
+
+    it('returns false when pathInfo is undefined', () => {
+      expect(isViewFullExperienceRequest({})).to.be.false;
     });
   });
 


### PR DESCRIPTION
## What & why

The ASO UI ([SITES-49888](https://jira.corp.adobe.com/browse/SITES-49888)) adds an internal-only "View full experience" toggle so a PLG/Pre-onboard site can be shown the **full paid experience** during a custom demo — without changing its entitlement tier. Because PLG limiting is enforced **server-side** (opportunities filtered to 3 types via `filterForSummitPlg`; suggestions filtered by grant status via `filterByGrantStatus`), the UI toggle needs the backend to stop filtering on request. This is the backend half.

## How

- `src/support/utils.js`:
  - New `isViewFullExperienceRequest(requestContext)` header helper (mirrors `isViewAsTrialRequest`).
  - `getIsSummitPlgEnabled(site, context, requestContext, accessControlUtil)` — new 4th arg. It short-circuits to `false` (bypass PLG limiting) only when **all** of: the request carries `x-view-full-experience: true`, `x-client-type` is `sites-optimizer-ui`, and `accessControlUtil.hasAdminAccess()` is `true`.
- `src/controllers/opportunities.js` / `src/controllers/suggestions.js`: pass the already-constructed `accessControlUtil` into the request-scoped `getIsSummitPlgEnabled` calls. The 2-arg revocation path in `opportunities` is left untouched (no `requestContext` → override never fires).

## Security

Gated on `hasAdminAccess()` so a customer **cannot** self-unlock entitlement-gated data merely by sending the header — a non-admin (or a call with no ACL) falls through to the normal PLG entitlement check. Avoids the `utils ↔ access-control-util` circular import by passing the ACL down from the controllers rather than importing the class into `utils.js`.

## Tests

- `test/support/utils.test.js`: `isViewFullExperienceRequest` header cases + `getIsSummitPlgEnabled` admin-bypass cases (admin+header → `false`; non-admin+header → PLG result; missing ACL → PLG result). **172 passing.**
- Controller suites (**601 passing**) confirm the new call-site arg doesn't regress existing behaviour.
- `npm run type-check` and `eslint` clean.

## Related Issues

- [SITES-49888](https://jira.corp.adobe.com/browse/SITES-49888)
- Paired ASO UI PR: OneAdobe/experience-success-studio-ui#2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```