### PR TITLE
fix(brands): remove dead brand-level semrushWorkspaceId field

### DIFF
--- a/docs/openapi/brands-v2-api.yaml
+++ b/docs/openapi/brands-v2-api.yaml
@@ -196,7 +196,7 @@ v2-brand-for-org:
           Forbidden. One of:
           - the user does not have access to this organization;
           - the edit would re-sync a sub-workspace brand to Semrush (a URL,
-            competitor, or alias change on a brand carrying a `semrushWorkspaceId`)
+            competitor, or alias change on a brand carrying a `semrushSubWorkspaceId`)
             while the org-wide serenity feature flag (`LLMO/serenity`) is inactive —
             the edit is refused rather than left to drift (body message: "Serenity is
             not active for this organization");

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -3932,14 +3932,6 @@ Brand:
       description: Read-only. The base URL of the primary site, resolved from baseSiteId.
       type: string
       readOnly: true
-    semrushWorkspaceId:
-      description: >-
-        Read-only. DEPRECATED — kept for backward compatibility only, mirrored
-        from semrushSubWorkspaceId (below). Prefer semrushSubWorkspaceId; this
-        field will be removed once every direct consumer has migrated.
-      type: [string, 'null']
-      readOnly: true
-      deprecated: true
     semrushSubWorkspaceId:
       description: >-
         Read-only. The brand's own Semrush sub-workspace id (dual-mode) — the

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -332,13 +332,6 @@ function mapDbBrandToV2(row) {
     name: row.name,
     baseSiteId: row.base_site?.id || row.site_id || null,
     baseUrl: row.base_site?.base_url || null,
-    // DEPRECATED (serenity-docs brand-semrush-mapping-maintenance.md §10
-    // rename, write-of-record cutover): read-only BC mirror of
-    // semrushSubWorkspaceId below, maintained by the mysticat-data-service
-    // brands_sync_semrush_workspace_id trigger. Kept for any consumer still
-    // reading this field directly; new/updated consumers should read
-    // semrushSubWorkspaceId instead.
-    semrushWorkspaceId: row.semrush_workspace_id || null,
     // Read-only: the brand's own Semrush sub-workspace (dual-mode) — the
     // write-of-record column. Null for brands still in flat mode (no
     // sub-workspace minted yet). Consumers use it to scope per-brand Semrush

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -363,26 +363,6 @@ describe('brands-storage', () => {
       expect(acme.siteId).to.equal('shared-site');
     });
 
-    it('maps semrush_workspace_id to semrushWorkspaceId (deprecated BC mirror), null when absent', async () => {
-      const subWsRow = makeBrandRow({ semrush_workspace_id: 'ws-sub-123' });
-      const subWsQuery = createChainableQuery({ data: subWsRow, error: null });
-      const subWsResult = await getBrandById(
-        ORG_ID,
-        BRAND_ID,
-        { from: sinon.stub().returns(subWsQuery) },
-      );
-      expect(subWsResult.semrushWorkspaceId).to.equal('ws-sub-123');
-
-      // Flat-mode brand: no sub-workspace column → null.
-      const flatQuery = createChainableQuery({ data: makeBrandRow(), error: null });
-      const flatResult = await getBrandById(
-        ORG_ID,
-        BRAND_ID,
-        { from: sinon.stub().returns(flatQuery) },
-      );
-      expect(flatResult.semrushWorkspaceId).to.equal(null);
-    });
-
     it('maps semrush_sub_workspace_id to semrushSubWorkspaceId (write-of-record), null when absent', async () => {
       const mirroredRow = makeBrandRow({ semrush_sub_workspace_id: 'ws-sub-123' });
       const mirroredQuery = createChainableQuery({ data: mirroredRow, error: null });


### PR DESCRIPTION
## Summary
- Removes the dead `semrushWorkspaceId` mapping (and its stale deprecation comment) from the brand row mapper in `src/support/brands-storage.js` — the backing column `brands.semrush_workspace_id` and its sync trigger were dropped in mysticat-data-service (v5.96.0, adobe/mysticat-data-service#927), so the field has been permanently `null` since.
- `brands.semrush_sub_workspace_id` (exposed as `semrushSubWorkspaceId`) is the sole write-of-record for a brand's Semrush sub-workspace and stays untouched.
- Removes the corresponding `Brand.semrushWorkspaceId` property from `docs/openapi/schemas.yaml`, and fixes a stale field-name reference in `docs/openapi/brands-v2-api.yaml` (prose said `semrushWorkspaceId`, the actual gating field is `semrushSubWorkspaceId`).
- Removes the covering unit test for the dropped mirror in `test/support/brands-storage.test.js`.
- Every other `semrushWorkspaceId` usage in the repo is the distinct **org-level** `organizations.semrush_workspace_id` (Organization schema, serenity workspace-resolver/handlers, provisioning) — left untouched per the issue.

Closes #3088

## Test plan
- [x] `npx mocha test/support/brands-storage.test.js` — 218 passing
- [x] `npx mocha test/controllers/brands.test.js` — 431 passing
- [x] `npm run docs:lint` — valid, no new warnings introduced
- [x] pre-commit hooks (lint, docs:lint, type-check) passed on push

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```