### PR TITLE
feat(ai-visibility): scope gap-prompts and gap-source-domains to subdomains

### DIFF
--- a/src/support/ai-visibility/handlers/v1/prompt/gap-prompts-export.js
+++ b/src/support/ai-visibility/handlers/v1/prompt/gap-prompts-export.js
@@ -29,6 +29,7 @@ import { GAP_PROMPTS_REQUEST_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/prompt/e
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   brandTarget,
   parseCompetitorDomainsList,
@@ -40,6 +41,7 @@ import {
 /* c8 ignore start */
 export async function handleGapPromptsExport(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const competitorDomains = parseCompetitorDomainsList(sp);
   const competitors = competitorDomains.length > 0
     ? competitorDomains.map(brandTarget)
@@ -71,6 +73,7 @@ export async function handleGapPromptsExport(sp, clients) {
       },
       range: { limit, offset },
       target_date: date,
+      search_type: searchType,
     };
     if (topicId) {
       gapPromptsJson.topic_hash = topicId;

--- a/src/support/ai-visibility/handlers/v1/prompt/gap-prompts-totals.js
+++ b/src/support/ai-visibility/handlers/v1/prompt/gap-prompts-totals.js
@@ -21,6 +21,7 @@ import {
 } from '@quazar/ai-seo-ts/v2/prompt/messages_pb.js';
 import {
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   brandTarget,
   parseCompetitorDomainsList,
@@ -32,6 +33,7 @@ import {
 /* c8 ignore start */
 export async function handleGapPromptsTotals(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const competitorDomains = parseCompetitorDomainsList(sp);
   const competitors = competitorDomains.length > 0
     ? competitorDomains.map(brandTarget)
@@ -51,6 +53,7 @@ export async function handleGapPromptsTotals(sp, clients) {
       target: { domain, name: domain },
       competitors,
       target_date: date,
+      search_type: searchType,
     };
     if (topicId) {
       totalsJson.topic_hash = topicId;

--- a/src/support/ai-visibility/handlers/v1/prompt/gap-prompts.js
+++ b/src/support/ai-visibility/handlers/v1/prompt/gap-prompts.js
@@ -27,6 +27,7 @@ import { GAP_PROMPTS_REQUEST_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/prompt/e
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   brandTarget,
   parseCompetitorDomainsList,
@@ -38,6 +39,7 @@ import {
 /* c8 ignore start */
 export async function handleGapPrompts(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const competitorDomains = parseCompetitorDomainsList(sp);
   const competitors = competitorDomains.length > 0
     ? competitorDomains.map(brandTarget)
@@ -70,6 +72,7 @@ export async function handleGapPrompts(sp, clients) {
       },
       range: { limit, offset },
       target_date: date,
+      search_type: searchType,
     };
     if (topicId) {
       listJson.topic_hash = topicId;
@@ -85,6 +88,7 @@ export async function handleGapPrompts(sp, clients) {
       target: { domain, name: domain },
       competitors,
       target_date: date,
+      search_type: searchType,
     };
     if (topicId) {
       totalsJson.topic_hash = topicId;

--- a/src/support/ai-visibility/handlers/v1/source/gap-source-domains-export.js
+++ b/src/support/ai-visibility/handlers/v1/source/gap-source-domains-export.js
@@ -29,6 +29,7 @@ import { DOMAINS_REQUEST_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/source/enums
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   brandTarget,
   parseCompetitorDomainsList,
@@ -41,6 +42,7 @@ import { buildGapSourceDomainsDimensionFilterQl } from './gap-source-domains.js'
 /* c8 ignore start */
 export async function handleGapSourceDomainsExport(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const competitorDomains = parseCompetitorDomainsList(sp);
   const competitors = competitorDomains.length > 0
     ? competitorDomains.map(brandTarget)
@@ -74,6 +76,7 @@ export async function handleGapSourceDomainsExport(sp, clients) {
         range: { limit, offset },
         dimension_filter_ql: dimensionFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/source/gap-source-domains-totals.js
+++ b/src/support/ai-visibility/handlers/v1/source/gap-source-domains-totals.js
@@ -21,6 +21,7 @@ import {
 } from '@quazar/ai-seo-ts/v2/source/messages_pb.js';
 import {
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   brandTarget,
   parseCompetitorDomainsList,
@@ -33,6 +34,7 @@ import { buildGapSourceDomainsDimensionFilterQl } from './gap-source-domains.js'
 /* c8 ignore start */
 export async function handleGapSourceDomainsTotals(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const competitorDomains = parseCompetitorDomainsList(sp);
   const competitors = competitorDomains.length > 0
     ? competitorDomains.map(brandTarget)
@@ -54,6 +56,7 @@ export async function handleGapSourceDomainsTotals(sp, clients) {
         competitors,
         dimension_filter_ql: dimensionFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/source/gap-source-domains.js
+++ b/src/support/ai-visibility/handlers/v1/source/gap-source-domains.js
@@ -25,6 +25,7 @@ import { DOMAINS_REQUEST_ORDER_BY_ENUM } from '@quazar/ai-seo-ts/v2/source/enums
 import {
   parseLimitOffset,
   resolveCountry,
+  resolveSearchType,
   engineToLlm,
   brandTarget,
   parseCompetitorDomainsList,
@@ -45,6 +46,7 @@ export function buildGapSourceDomainsDimensionFilterQl(sp) {
 
 export async function handleGapSourceDomains(sp, clients) {
   const domain = sp.get('domain');
+  const searchType = resolveSearchType(domain);
   const competitorDomains = parseCompetitorDomainsList(sp);
   const competitors = competitorDomains.length > 0
     ? competitorDomains.map(brandTarget)
@@ -78,6 +80,7 @@ export async function handleGapSourceDomains(sp, clients) {
         range: { limit, offset },
         dimension_filter_ql: dimensionFilterQl,
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/test/support/ai-visibility/handlers/v1/prompt/gap-prompts.test.js
+++ b/test/support/ai-visibility/handlers/v1/prompt/gap-prompts.test.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable max-len -- AI Visibility gap-prompts search_type tests */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import {
+  GapPromptsResponseSchema,
+  GapPromptsTotalsResponseSchema,
+} from '@quazar/ai-seo-ts/v2/prompt/messages_pb.js';
+import { ExportResponseSchema } from '@quazar/ai-seo-ts/v2/common/messages_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { handleGapPrompts } from '../../../../../../src/support/ai-visibility/handlers/v1/prompt/gap-prompts.js';
+import { handleGapPromptsTotals } from '../../../../../../src/support/ai-visibility/handlers/v1/prompt/gap-prompts-totals.js';
+import { handleGapPromptsExport } from '../../../../../../src/support/ai-visibility/handlers/v1/prompt/gap-prompts-export.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+const APEX = 'domain=intuit.com&competitors=rival.com';
+const SUBDOMAIN = 'domain=quickbooks.intuit.com&competitors=rival.com';
+
+describe('AI Visibility – v1 gap-prompts search_type (LLMO-7082)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      promptClient: {
+        gapPrompts: sandbox.stub().resolves(create(GapPromptsResponseSchema, { prompts: [] })),
+        gapPromptsTotals: sandbox.stub().resolves(create(GapPromptsTotalsResponseSchema, { totals: [] })),
+        gapPromptsExport: sandbox.stub().resolves(create(ExportResponseSchema, {})),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleGapPrompts', () => {
+    it('resolves search_type DOMAIN for an apex domain on both list and totals requests', async () => {
+      await handleGapPrompts(sp(APEX), clients);
+      expect(clients.promptClient.gapPrompts.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+      expect(clients.promptClient.gapPromptsTotals.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain on both list and totals requests', async () => {
+      await handleGapPrompts(sp(SUBDOMAIN), clients);
+      expect(clients.promptClient.gapPrompts.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+      expect(clients.promptClient.gapPromptsTotals.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+
+  describe('handleGapPromptsTotals', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleGapPromptsTotals(sp(APEX), clients);
+      expect(clients.promptClient.gapPromptsTotals.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleGapPromptsTotals(sp(SUBDOMAIN), clients);
+      expect(clients.promptClient.gapPromptsTotals.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+
+  describe('handleGapPromptsExport', () => {
+    it('resolves search_type DOMAIN for an apex domain on the nested request', async () => {
+      await handleGapPromptsExport(sp(APEX), clients);
+      expect(clients.promptClient.gapPromptsExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain on the nested request', async () => {
+      await handleGapPromptsExport(sp(SUBDOMAIN), clients);
+      expect(clients.promptClient.gapPromptsExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+});

--- a/test/support/ai-visibility/handlers/v1/source/gap-source-domains.test.js
+++ b/test/support/ai-visibility/handlers/v1/source/gap-source-domains.test.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable max-len -- AI Visibility gap-source-domains search_type tests */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import {
+  GapSourceDomainsResponseSchema,
+  GapSourceDomainsTotalsResponseSchema,
+} from '@quazar/ai-seo-ts/v2/source/messages_pb.js';
+import { ExportResponseSchema } from '@quazar/ai-seo-ts/v2/common/messages_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { handleGapSourceDomains } from '../../../../../../src/support/ai-visibility/handlers/v1/source/gap-source-domains.js';
+import { handleGapSourceDomainsTotals } from '../../../../../../src/support/ai-visibility/handlers/v1/source/gap-source-domains-totals.js';
+import { handleGapSourceDomainsExport } from '../../../../../../src/support/ai-visibility/handlers/v1/source/gap-source-domains-export.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+const APEX = 'domain=intuit.com&competitors=rival.com';
+const SUBDOMAIN = 'domain=quickbooks.intuit.com&competitors=rival.com';
+
+describe('AI Visibility – v1 gap-source-domains search_type (LLMO-7082)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      sourceClient: {
+        gapSourceDomains: sandbox.stub().resolves(create(GapSourceDomainsResponseSchema, { domains: [] })),
+        gapSourceDomainsTotals: sandbox.stub().resolves(create(GapSourceDomainsTotalsResponseSchema, { totals: [] })),
+        gapSourceDomainsExport: sandbox.stub().resolves(create(ExportResponseSchema, {})),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleGapSourceDomains', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleGapSourceDomains(sp(APEX), clients);
+      expect(clients.sourceClient.gapSourceDomains.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleGapSourceDomains(sp(SUBDOMAIN), clients);
+      expect(clients.sourceClient.gapSourceDomains.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+
+  describe('handleGapSourceDomainsTotals', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleGapSourceDomainsTotals(sp(APEX), clients);
+      expect(clients.sourceClient.gapSourceDomainsTotals.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleGapSourceDomainsTotals(sp(SUBDOMAIN), clients);
+      expect(clients.sourceClient.gapSourceDomainsTotals.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+
+  describe('handleGapSourceDomainsExport', () => {
+    it('resolves search_type DOMAIN for an apex domain on the nested request', async () => {
+      await handleGapSourceDomainsExport(sp(APEX), clients);
+      expect(clients.sourceClient.gapSourceDomainsExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain on the nested request', async () => {
+      await handleGapSourceDomainsExport(sp(SUBDOMAIN), clients);
+      expect(clients.sourceClient.gapSourceDomainsExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Wire `resolveSearchType` into the `gap-prompts` and `gap-source-domains` handlers (list, totals, and export variants) so a subdomain target scopes upstream Semrush results.

## 2. Reasoning
LLMO-7016 wired `resolveSearchType` into `gap-topics` and the competitors endpoint so subdomain targets are scoped correctly upstream. At that time the `GapPrompts*` and `GapSourceDomains*` request messages did not carry a `search_type` field, so those two endpoints stayed out of scope and always returned parent-domain results for a subdomain target. The Semrush SDK bump (adobe/spacecat-api-service#3081) added `search_type` to all four request messages, so the integration can now be completed.

## 3. High-level overview of the changes
For a target that carries a non-www subdomain (e.g. `quickbooks.intuit.com`), `resolveSearchType` returns `SEARCH_TYPE_ENUM.SUBDOMAIN`; apex domains and bare `www.` hosts return `DOMAIN`. Each handler now resolves this from the `domain` param and sets `search_type` on the upstream gRPC request.

- `gap-prompts` sets `search_type` on both the list request and the totals request it builds.
- `gap-prompts-totals` sets `search_type` on the totals request.
- `gap-prompts-export` sets `search_type` on the wrapped base request.
- `gap-source-domains`, `gap-source-domains-totals`, and `gap-source-domains-export` do the same for the source-domains requests.

Behaviour delta: selecting a subdomain now scopes the prompts table and the source-domains table to that subdomain. Apex-domain behaviour is unchanged (still resolves to `DOMAIN`).

## 4. Required information
- Jira / issue: [LLMO-7082](https://jira.corp.adobe.com/browse/LLMO-7082)
- Exemption: mechanical pattern replication from LLMO-7016, grounded in LLMO-7082 - no spec required for this change.
- Other: precedent — gap-topics/competitors subdomain scoping (LLMO-7016) in https://github.com/adobe/spacecat-api-service/pull/3072

## 8. Test plan
(a) Local: added unit coverage for all six handlers asserting `search_type` resolves to `DOMAIN` for an apex domain and `SUBDOMAIN` for a non-www subdomain (nested request for the export variants).

(b) Live gRPC verification (planned before merge, per the acceptance criteria): call the gap-prompts and gap-source-domains gRPC directly for an apex target and a subdomain target of the same registrable domain, and confirm the two responses differ.

(c) Per environment (dev / prod): in the LLMO dashboard, select a subdomain target and confirm the prompts table and the source-domains table scope to that subdomain; confirm the apex target is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dima", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```