### PR TITLE
fix(serenity): drop semrush_sub_workspace_id as an upsertBrand anchor (SITES-49449)

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -1353,7 +1353,7 @@ function SerenityController(context, log, env) {
           ctx.dataAccess.services.postgrestClient,
         );
         if (!existingSiteId) {
-          throw new ErrorWithStatusCode('Brand has no onboarded primary site', 400);
+          throw new ErrorWithStatusCode(`Brand has no onboarded primary site: ${brandUuid}`, 400);
         }
         const pendingWorkspaceId = await ensureSubworkspace(
           transport,

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -1336,10 +1336,25 @@ function SerenityController(context, log, env) {
       // Markets are Semrush projects added afterwards from the Markets tab, never
       // auto-created at activation — so a pending brand activates to just its
       // sub-workspace (the anchor, persisted by ensureSubworkspace) plus a status
-      // flip. The brand's primary site (brands.site_id) was set at create.
+      // flip. The brand's primary site (brands.site_id) was set at create for
+      // every brand created after LLMO-6405 — but SITES-49449 tightened
+      // chk_active_brand_has_site_id to require site_id unconditionally, so a
+      // legacy pre-LLMO-6405 pending brand with none would otherwise provision a
+      // live sub-workspace upstream and THEN fail the active-flip write with a
+      // raw DB constraint violation. Guard it upfront instead of wasting that
+      // provisioning call, mirroring the flat-brand activate handler's own guard
+      // (brands.js) for the same legacy-drain scenario.
       // Reactivation of an already ACTIVE brand (body-driven markets) is handled
       // by the branches below.
       if (wasPending) {
+        const existingSiteId = await getBrandBaseSiteId(
+          /** @type {string} */ (ctx?.params?.spaceCatId),
+          brandUuid,
+          ctx.dataAccess.services.postgrestClient,
+        );
+        if (!existingSiteId) {
+          throw new ErrorWithStatusCode('Brand has no onboarded primary site', 400);
+        }
         const pendingWorkspaceId = await ensureSubworkspace(
           transport,
           brand,

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -1123,14 +1123,12 @@ export async function upsertBrand({
     throw new Error(`Failed to look up existing brand "${brand.name}": ${existingError.message}`);
   }
 
-  // An active brand must be anchored by either a SpaceCat base site OR a Semrush
-  // sub-workspace (serenity dual-mode): a Semrush brand has no SpaceCat site, but
-  // its sub-workspace (semrush_sub_workspace_id, set on the serenity-first create
-  // path) is a valid anchor — mirrors the relaxed chk_active_brand_has_site_id
-  // DB constraint. Respect persisted site_id on the update path.
-  const hasAnchor = hasText(brand.baseSiteId)
-    || hasText(existing?.site_id)
-    || hasText(semrushSubWorkspaceId);
+  // An active brand must be anchored by a SpaceCat base site (chk_active_brand_has_site_id,
+  // SITES-49449). A Semrush sub-workspace brand is NOT exempt from this — the
+  // brand/market management model (LLMO-6405) makes site_id mandatory on every
+  // create path, subworkspace mode or not, so semrush_sub_workspace_id is no
+  // longer a substitute anchor. Respect persisted site_id on the update path.
+  const hasAnchor = hasText(brand.baseSiteId) || hasText(existing?.site_id);
   const status = (!hasAnchor && (brand.status || 'active') === 'active')
     ? 'pending'
     : (brand.status || 'active');

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1929,11 +1929,29 @@ describe('SerenityController', () => {
       expect(ensureSubworkspaceStub).to.not.have.been.called;
     });
 
+    it('activate 400s a pending brand with no primary site instead of provisioning a doomed sub-workspace (SITES-49449)', async () => {
+      // getBrandBaseSiteIdStub defaults to resolves(null) — a legacy pre-LLMO-6405
+      // pending brand that never got a site_id. chk_active_brand_has_site_id now
+      // requires site_id unconditionally, so ensureSubworkspace must never run:
+      // a live sub-workspace would provision upstream and then the active-flip
+      // save would still fail with a raw DB constraint violation.
+      const brand = makeBrandModel({});
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.activate(fakeContext({ brand, data: { brandNames: ['X'] } }));
+      expect(response.status).to.equal(400);
+      expect(ensureSubworkspaceStub).to.not.have.been.called;
+      expect(brand.setStatus).to.not.have.been.called;
+      expect(brand.save).to.not.have.been.called;
+    });
+
     it('activate of a pending brand with an empty body is sub-workspace-only (200, no project)', async () => {
       // LLMO-6405: a pending brand activates to just its sub-workspace + a status
       // flip. The wizard supplies no markets/URL; none are needed — no project is
       // created.
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      // SITES-49449: chk_active_brand_has_site_id requires site_id unconditionally —
+      // the brand's primary site was set at create (LLMO-6405), verified upfront.
+      getBrandBaseSiteIdStub.resolves('primary-site');
       const brand = makeBrandModel({});
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const response = await controller.activate(fakeContext({ brand, data: { brandNames: ['X'] } }));
@@ -1955,6 +1973,7 @@ describe('SerenityController', () => {
       // Sub-workspace ensured upstream but the active-status save diverges → the
       // brand stays pending; a retry converges (the sub-workspace 409s idempotently).
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      getBrandBaseSiteIdStub.resolves('primary-site');
       const brand = makeBrandModel({ save: sinon.stub().rejects(new Error('db down')) });
       const log = fakeLog();
       const controller = SerenityController({ env: {} }, log, {});
@@ -2807,6 +2826,7 @@ describe('SerenityController', () => {
     // primary URL these route to the sub-workspace-only activation (200).
     it('activate falls back to {} body when ctx.data is absent (pending brand → sub-workspace-only 200)', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      getBrandBaseSiteIdStub.resolves('primary-site');
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const ctx = fakeContext();
       ctx.data = undefined;

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1190,7 +1190,7 @@ describe('brands-storage', () => {
       expect(brandsUpsert.row).to.not.have.property('semrush_sub_workspace_id');
     });
 
-    it('keeps the brand active with a null site_id when only a semrush_sub_workspace_id anchors it (no baseSiteId)', async () => {
+    it('downgrades to pending with a null site_id when only a semrush_sub_workspace_id is supplied (SITES-49449, no baseSiteId)', async () => {
       const client = createCapturingClient({
         brands: [
           { data: null, error: null },
@@ -1207,10 +1207,10 @@ describe('brands-storage', () => {
       });
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
-      expect(brandsUpsert.row.status).to.equal('active');
+      // SITES-49449: semrush_sub_workspace_id is no longer a substitute anchor —
+      // site_id is required for 'active', so this downgrades to 'pending' instead.
+      expect(brandsUpsert.row.status).to.equal('pending');
       expect(brandsUpsert.row.semrush_sub_workspace_id).to.equal('ws-1');
-      // A fresh create always writes an explicit site_id — null when no baseSiteId
-      // is supplied. The sub-workspace is what keeps it active (LLMO-6405).
       expect(brandsUpsert.row.site_id).to.equal(null);
     });
 


### PR DESCRIPTION
## Summary
Companion to [mysticat-data-service#936](https://github.com/adobe/mysticat-data-service/pull/936), which tightens `brands.chk_active_brand_has_anchor` back to `chk_active_brand_has_site_id` — `semrush_sub_workspace_id` is retired as a substitute anchor for an active brand (SITES-49449, part of the SITES-49196 Post-GA cleanup epic).

This PR is the app-layer half, in two parts:

1. `upsertBrand`'s `hasAnchor` check in `src/support/brands-storage.js` also treated `semrushSubWorkspaceId` as sufficient on its own. Dropping that clause means a sub-workspace-only create demotes to `pending` in the app layer (nice error) instead of letting the request through and hitting the new DB constraint raw (ugly error). Real create paths already supply `baseSiteId` for subworkspace-mode brands (LLMO-6405 — the primary Site is chosen up front at creation), so this only changes behavior for a caller that omits it.
2. `serenity.js`'s `activate` handler (the dual-mode/subworkspace activation path) never checked `site_id` before flipping a pending brand to `active` — it assumed LLMO-6405's "site chosen at creation" invariant held for every brand, which isn't true for legacy pre-LLMO-6405 pending brands (the SITES-49448 population). Added an upfront guard — see below.

## Bonus fix
While verifying this, found that `rethrowCheckViolation` / `setBrandStatus`'s error-mapping (from PR #2504 / LLMO-5183) has been checking `error.message?.includes('chk_active_brand_has_site_id')` — but SITES-49202's widening (2026-06-16) silently renamed the live constraint to `chk_active_brand_has_anchor`, so that mapping has been dead code for ~2 months (any real violation fell through to a generic 500 instead of the intended typed 400 "Cannot activate a brand without a base site URL"). mysticat-data-service#936 renames the constraint back to `chk_active_brand_has_site_id`, which restores this mapping automatically — no code change needed here, just noting it since it's a real behavioral fix riding along.

## Must-fix found in self-review
`serenity.js`'s `activate` provisions a live Semrush sub-workspace via `ensureSubworkspace` and THEN flips status via `brand.save()` — for a legacy pending brand with no `site_id`, that save would now hit the tightened DB constraint and fail, after already creating an unusable upstream sub-workspace, surfacing a misleading 502 that implies a retryable transient failure. Added an upfront check via the already-imported `getBrandBaseSiteId`, returning a clean 400 ("Brand has no onboarded primary site", matching the flat-brand handler's parallel guard) before any provisioning happens.

## Test plan
- [x] `npx mocha test/support/brands-storage.test.js` — 209 passing (updated 1 test to match new behavior)
- [x] `npx mocha test/controllers/brands.test.js` — 433 passing, unaffected
- [x] `npx mocha test/controllers/serenity.test.js` — 215 passing (added 1 test for the new guard, updated 3 existing tests to reflect the LLMO-6405 assumption explicitly)
- [x] `npx eslint src/support/brands-storage.js src/controllers/serenity.js test/support/brands-storage.test.js test/controllers/serenity.test.js` — clean
- [x] `npm run type-check` — clean

## Sequencing
Should merge together with (or after) mysticat-data-service#936 — deploying this without the DB tightening is a no-op (site_id already required by every real create/activate path this PR touches). Deploying the DB tightening (#936) **without** this PR is no longer safe as a standalone step: without the `serenity.js` guard here, a legacy pending brand hitting `/serenity/activate` would get the misleading 502 described above instead of a clean 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```