### PR TITLE
fix(brands): reject anchoring a brand to another org's site

### DIFF
--- a/docs/openapi/brands-v2-api.yaml
+++ b/docs/openapi/brands-v2-api.yaml
@@ -92,11 +92,18 @@ v2-brands-for-org:
         $ref: './responses.yaml#/404-organization-not-found-with-id'
       '409':
         description: |
-          Conflict. A by-name upsert matched an existing **active** brand and the
-          supplied `status` would demote it to `pending`. Silent demotion is
-          rejected (`code: brand_status_demotion_not_allowed`). Use
-          `PATCH /v2/orgs/{spaceCatId}/brands/{brandId}/status` for intentional
-          status transitions.
+          Conflict. One of (disambiguated by the `code` field in the response body,
+          where present):
+          - A by-name upsert matched an existing **active** brand and the supplied
+            `status` would demote it to `pending`. Silent demotion is rejected
+            (`code: brand_status_demotion_not_allowed`). Use
+            `PATCH /v2/orgs/{spaceCatId}/brands/{brandId}/status` for intentional
+            status transitions.
+          - The supplied `baseSiteId` is a fresh anchor (the brand has no
+            persisted primary site yet) but that site belongs to a different
+            organization (`code: brand_site_org_mismatch`).
+          - The brand's primary URL is already the primary URL (base site) of
+            another brand in this organization.
         headers:
           X-Error:
             $ref: './headers.yaml#/xError'
@@ -215,6 +222,10 @@ v2-brand-for-org:
             persisted `updatedAt` — another write landed after this client last
             loaded the brand (`code: brand_stale_write`). Reload the brand and
             reapply the edit rather than retrying with the same body.
+          - The supplied `baseSiteId` is a fresh anchor (the brand has no
+            persisted primary site, or is `pending` and re-pointing) but that
+            site belongs to a different organization
+            (`code: brand_site_org_mismatch`).
           - The brand's primary URL is already the primary URL (base site) of
             another brand in this organization.
         headers:

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -24,7 +24,6 @@ import {
   noContent,
   createResponse,
   forbidden,
-  internalServerError,
 } from '@adobe/spacecat-shared-http-utils';
 import {
   composeBaseURL,
@@ -375,7 +374,18 @@ function BrandsController(ctx, log, env) {
         { [HEADER_ERROR]: cleanupHeaderValue(appErr.message || 'Error') },
       );
     }
-    return internalServerError(cleanupHeaderValue(appErr.message || 'Internal server error'));
+    // Same split as the typed-status branch above: internalServerError() would
+    // set the header AND the body from one value, so a non-ASCII character in
+    // a bare Error's message would strip from the body too — operators
+    // debugging a 500 lose it there for no reason (the raw error is still in
+    // the logs regardless). Build the response directly instead so only the
+    // header copy is sanitized.
+    const rawMessage = appErr.message || 'Internal server error';
+    return createResponse(
+      { message: rawMessage },
+      500,
+      { [HEADER_ERROR]: cleanupHeaderValue(rawMessage) },
+    );
   }
 
   function validateBrandGuidanceFields(brandData = {}) {

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -14,6 +14,7 @@
 
 import { randomUUID } from 'crypto';
 
+import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 import BrandClient, { BrandGovernanceClient } from '@adobe/spacecat-shared-brand-client';
 import DrsClient from '@adobe/spacecat-shared-drs-client';
 import {
@@ -363,13 +364,18 @@ function BrandsController(ctx, log, env) {
       // client distinguish error cases without regex-matching the message text
       // (LLMO-6591; see the `uq_brand_name_per_org` TODO this same pattern
       // predates in elmo-ui's getBrandSaveErrorDescriptor).
+      // cleanupHeaderValue strips chars HTTP headers can't carry (CR/LF and
+      // non-ASCII that would otherwise throw ERR_INVALID_CHAR — caught via the
+      // it-postgres IT suite when this guard's own message used an em dash,
+      // serenity-docs#346). The JSON body keeps the raw message; only the
+      // header copy needs sanitizing.
       return createResponse(
         { message: appErr.message, ...(appErr.code ? { code: appErr.code } : {}) },
         appErr.status,
-        { [HEADER_ERROR]: appErr.message },
+        { [HEADER_ERROR]: cleanupHeaderValue(appErr.message || 'Error') },
       );
     }
-    return internalServerError(appErr.message);
+    return internalServerError(cleanupHeaderValue(appErr.message || 'Internal server error'));
   }
 
   function validateBrandGuidanceFields(brandData = {}) {

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -1370,7 +1370,7 @@ export async function updateBrand({
   if (needsExistingFetch) {
     const { data: current, error: currentError } = await postgrestClient
       .from('brands')
-      .select('site_id, status, updated_at')
+      .select('name, site_id, status, updated_at')
       .eq('id', brandId)
       .maybeSingle();
     // Fail closed: a swallowed read error leaves `current` null, so the guard
@@ -1439,7 +1439,8 @@ export async function updateBrand({
   } else if (hasText(updates.baseSiteId) && (!existing?.site_id || isPending)) {
     // serenity-docs#346: same org-ID mismatch guard as upsertBrand — verify the
     // new/re-pointed site actually belongs to this brand's org before persisting.
-    await assertSiteBelongsToOrg(postgrestClient, updates.baseSiteId, organizationId, brandId);
+    const brandLabel = existing?.name || brandId;
+    await assertSiteBelongsToOrg(postgrestClient, updates.baseSiteId, organizationId, brandLabel);
     patch.site_id = updates.baseSiteId;
   }
 

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -337,6 +337,47 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
 }
 
 /**
+ * Verifies a candidate primary site (`baseSiteId`) belongs to the same org as the
+ * brand being anchored to it, before that site_id is ever persisted.
+ *
+ * serenity-docs#346: `brand.organization_id != site.organization_id` is exactly the
+ * org-ID mismatch pattern the investigation traced (Tata Capital, BMW, Toyota, ...) —
+ * a brand silently anchored to a *different* org's site. Both upsertBrand (fresh
+ * create / first anchor) and updateBrand (first set, or pending re-point) must call
+ * this before writing site_id; the immutable-once-set branches in each are
+ * unaffected, since they already refuse to change an existing active site_id.
+ *
+ * @param {object} postgrestClient - PostgREST client
+ * @param {string} siteId - Candidate `brands.site_id`
+ * @param {string} organizationId - SpaceCat organization UUID the brand belongs to
+ * @param {string} brandName - Brand name, for the error message only
+ * @throws {Error} status 409, code 'brand_site_org_mismatch', if the site does not
+ *   belong to organizationId (including if it doesn't exist at all)
+ */
+async function assertSiteBelongsToOrg(postgrestClient, siteId, organizationId, brandName) {
+  const { data: anchorSite, error: anchorSiteError } = await postgrestClient
+    .from('sites')
+    .select('id')
+    .eq('id', siteId)
+    .eq('organization_id', organizationId)
+    .maybeSingle();
+  if (anchorSiteError) {
+    throw new Error(
+      `Failed to verify primary site org for brand "${brandName}": ${anchorSiteError.message}`,
+    );
+  }
+  if (!anchorSite) {
+    const err = new Error(
+      `Cannot anchor brand "${brandName}" to site ${siteId} — that site `
+      + `does not belong to organization ${organizationId}.`,
+    );
+    err.status = 409;
+    err.code = 'brand_site_org_mismatch';
+    throw err;
+  }
+}
+
+/**
  * Fully replaces brand_sites for a brand. Groups submitted URLs by normalized base URL
  * (via composeBaseURL) so that multiple paths under the same site share one brand_sites row.
  */
@@ -1201,6 +1242,18 @@ export async function upsertBrand({
   // (which left Semrush brands' site_id NULL) is removed; a genuine collision with
   // another brand's primary site still surfaces as the brands_base_site_unique 409
   // handled below.
+  // serenity-docs#346: a brand's primary site must belong to the same org as the
+  // brand itself — anchoring to another org's site is exactly the org-ID mismatch
+  // pattern the investigation traced (Tata Capital, BMW, Toyota, ...). Verify on
+  // both paths that assign a *new* anchor (fresh create, or first anchor for a
+  // previously Semrush-only brand); the immutable-once-set branch below is
+  // unaffected since it already refuses to change an existing site_id.
+  const wantsNewAnchor = hasText(brand.baseSiteId)
+    && (existing === null || !hasText(existing.site_id));
+  if (wantsNewAnchor) {
+    await assertSiteBelongsToOrg(postgrestClient, brand.baseSiteId, organizationId, brand.name);
+  }
+
   if (existing === null) {
     row.site_id = hasText(brand.baseSiteId) ? brand.baseSiteId : null;
   } else if (hasText(brand.baseSiteId) && !hasText(existing.site_id)) {
@@ -1380,6 +1433,9 @@ export async function updateBrand({
       patch.site_id = null;
     }
   } else if (hasText(updates.baseSiteId) && (!existing?.site_id || isPending)) {
+    // serenity-docs#346: same org-ID mismatch guard as upsertBrand — verify the
+    // new/re-pointed site actually belongs to this brand's org before persisting.
+    await assertSiteBelongsToOrg(postgrestClient, updates.baseSiteId, organizationId, brandId);
     patch.site_id = updates.baseSiteId;
   }
 

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -350,11 +350,14 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
  * @param {object} postgrestClient - PostgREST client
  * @param {string} siteId - Candidate `brands.site_id`
  * @param {string} organizationId - SpaceCat organization UUID the brand belongs to
- * @param {string} brandName - Brand name, for the error message only
+ * @param {string} brandLabel - Whatever identifies the brand in the caller's context,
+ *   for the error message only — upsertBrand passes the brand name (not yet
+ *   persisted, so no id exists yet), updateBrand passes the brand id (no
+ *   guaranteed name on hand there without an extra fetch).
  * @throws {Error} status 409, code 'brand_site_org_mismatch', if the site does not
  *   belong to organizationId (including if it doesn't exist at all)
  */
-async function assertSiteBelongsToOrg(postgrestClient, siteId, organizationId, brandName) {
+async function assertSiteBelongsToOrg(postgrestClient, siteId, organizationId, brandLabel) {
   const { data: anchorSite, error: anchorSiteError } = await postgrestClient
     .from('sites')
     .select('id')
@@ -363,12 +366,12 @@ async function assertSiteBelongsToOrg(postgrestClient, siteId, organizationId, b
     .maybeSingle();
   if (anchorSiteError) {
     throw new Error(
-      `Failed to verify primary site org for brand "${brandName}": ${anchorSiteError.message}`,
+      `Failed to verify primary site org for brand "${brandLabel}": ${anchorSiteError.message}`,
     );
   }
   if (!anchorSite) {
     const err = new Error(
-      `Cannot anchor brand "${brandName}" to site ${siteId} — that site `
+      `Cannot anchor brand "${brandLabel}" to site ${siteId} — that site `
       + `does not belong to organization ${organizationId}.`,
     );
     err.status = 409;

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -352,8 +352,8 @@ async function replaceChildRows(table, brandId, rows, onConflict, postgrestClien
  * @param {string} organizationId - SpaceCat organization UUID the brand belongs to
  * @param {string} brandLabel - Whatever identifies the brand in the caller's context,
  *   for the error message only — upsertBrand passes the brand name (not yet
- *   persisted, so no id exists yet), updateBrand passes the brand id (no
- *   guaranteed name on hand there without an extra fetch).
+ *   persisted, so no id exists yet); updateBrand passes the fetched brand's
+ *   name when its existing-row read found one, else falls back to brandId.
  * @throws {Error} status 409, code 'brand_site_org_mismatch', if the site does not
  *   belong to organizationId (including if it doesn't exist at all)
  */
@@ -372,7 +372,7 @@ async function assertSiteBelongsToOrg(postgrestClient, siteId, organizationId, b
   if (!anchorSite) {
     const err = new Error(
       `Cannot anchor brand "${brandLabel}" to site ${siteId} — that site `
-      + `does not belong to organization ${organizationId}.`,
+      + `does not exist, or does not belong to organization ${organizationId}.`,
     );
     err.status = 409;
     err.code = 'brand_site_org_mismatch';

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -370,8 +370,15 @@ async function assertSiteBelongsToOrg(postgrestClient, siteId, organizationId, b
     );
   }
   if (!anchorSite) {
+    // Plain ASCII (no em dash) to match this file's other thrown, client-facing
+    // messages: an em dash here previously crashed createErrorResponse's
+    // X-Error header (@adobe/fetch rejects non-Latin1 header content with a
+    // raw TypeError, surfacing as a 500 instead of this 409 — caught by the
+    // it-postgres IT suite, not the mocked unit tests). createErrorResponse
+    // now sanitizes the header regardless (serenity-docs#346), but this stays
+    // ASCII too rather than leaning on that alone.
     const err = new Error(
-      `Cannot anchor brand "${brandLabel}" to site ${siteId} — that site `
+      `Cannot anchor brand "${brandLabel}" to site ${siteId}: that site `
       + `does not exist, or does not belong to organization ${organizationId}.`,
     );
     err.status = 409;

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -7265,6 +7265,41 @@ describe('Brands Controller', () => {
       }
     });
 
+    it('strips a header-unsafe character from the X-Error header without altering the JSON body (serenity-docs#346)', async () => {
+      // A brand name is customer-controlled, and any 409/500 whose message
+      // echoes it (this guard, brand_status_demotion_not_allowed, ...) would
+      // previously crash createErrorResponse's X-Error header with a raw
+      // TypeError [ERR_INVALID_CHAR] instead of returning the intended
+      // status, if that message contained a character outside the header-safe
+      // range (printable ASCII + Latin-1, 0x20-0x7E/0x80-0xFF — plain accented
+      // characters like "é" are actually fine; an em dash is not). This is
+      // exactly what the it-postgres IT suite caught for an em dash in this
+      // guard's own message.
+      const err = new Error(
+        'Cannot anchor brand "Global — Direct" to site abc: that site does not belong to organization xyz.',
+      );
+      err.status = 409;
+      err.code = 'brand_site_org_mismatch';
+      const updateBrandStub = sinon.stub().rejects(err);
+
+      const controller = await buildUpdateController({ updateBrand: updateBrandStub });
+      const response = await controller.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { baseSiteId: 'some-other-orgs-site' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(409);
+      const body = await response.json();
+      expect(body.code).to.equal('brand_site_org_mismatch');
+      expect(body.message).to.equal(err.message); // body keeps the full, unsanitized message
+      expect(response.headers.get('x-error')).to.equal(
+        'Cannot anchor brand "Global  Direct" to site abc: that site does not belong to organization xyz.',
+      );
+    });
+
     it('succeeds when expectedUpdatedAt matches the persisted row (LLMO-6591)', async () => {
       const response = await brandsController.updateBrandForOrg({
         ...context,

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -7300,6 +7300,29 @@ describe('Brands Controller', () => {
       );
     });
 
+    it('sanitizes only the X-Error header on the untyped-error (500) fallback too, keeping the body raw', async () => {
+      // Same split as the 409 case above, on the OTHER branch of
+      // createErrorResponse: a bare Error with no .status (e.g. the
+      // anchorSiteError DB-failure path) must not have its body message
+      // sanitized just because the header copy needs to be.
+      const err = new Error('DB read failed — connection reset');
+      const updateBrandStub = sinon.stub().rejects(err);
+
+      const controller = await buildUpdateController({ updateBrand: updateBrandStub });
+      const response = await controller.updateBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: { baseSiteId: 'some-other-orgs-site' },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+      });
+
+      expect(response.status).to.equal(500);
+      const body = await response.json();
+      expect(body.message).to.equal(err.message); // body keeps the full, unsanitized message
+      expect(response.headers.get('x-error')).to.equal('DB read failed  connection reset');
+    });
+
     it('succeeds when expectedUpdatedAt matches the persisted row (LLMO-6591)', async () => {
       const response = await brandsController.updateBrandForOrg({
         ...context,

--- a/test/it/shared/tests/brands.js
+++ b/test/it/shared/tests/brands.js
@@ -16,7 +16,7 @@ import {
   BRAND_1_ID,
   SITE_2_ID,
   SITE_2_BASE_URL,
-  SITE_3_ID,
+  SITE_3_ID, // belongs to ORG_2, not ORG_1 (seed-data/sites.js) — used for cross-org tests
   MARKET_SITE_1_ID,
   MARKET_SITE_1_BASE_URL,
 } from '../seed-ids.js';

--- a/test/it/shared/tests/brands.js
+++ b/test/it/shared/tests/brands.js
@@ -16,6 +16,7 @@ import {
   BRAND_1_ID,
   SITE_2_ID,
   SITE_2_BASE_URL,
+  SITE_3_ID,
   MARKET_SITE_1_ID,
   MARKET_SITE_1_BASE_URL,
 } from '../seed-ids.js';
@@ -234,6 +235,50 @@ export default function brandsTests(getHttpClient, resetData) {
       });
       expect(reuse.status).to.equal(200);
       expect(reuse.body.baseSiteId).to.equal(SITE_2_ID);
+    });
+  });
+
+  describe('Brands v2 rejects a cross-org baseSiteId (serenity-docs#346)', () => {
+    before(() => resetData());
+
+    it('rejects a fresh create anchored to another org\'s site', async () => {
+      const http = getHttpClient();
+
+      // SITE_3_ID belongs to ORG_2 (seed-data/sites.js) — anchoring an ORG_1
+      // brand to it is exactly the org-ID mismatch signature the investigation
+      // traced (a brand silently pointing at a different org's site).
+      //
+      // status: 'pending' defers ALL Semrush provisioning (see createBrandForOrg),
+      // so this stays a plain flat-mode create regardless of ORG_1's serenity
+      // rollout flag — the guard fires on the baseSiteId anchor check itself,
+      // independent of that unrelated machinery.
+      const res = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
+        name: 'Cross-Org Anchor Attempt', region: ['US'], status: 'pending', baseSiteId: SITE_3_ID,
+      });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.code).to.equal('brand_site_org_mismatch');
+    });
+
+    it('rejects setting an existing pending brand\'s baseSiteId to another org\'s site', async () => {
+      const http = getHttpClient();
+
+      const create = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
+        name: 'Pending Brand For Cross-Org Attempt', region: ['US'], status: 'pending',
+      });
+      expect(create.status).to.equal(201);
+      const { id: brandId } = create.body;
+
+      const res = await http.admin.patch(`/v2/orgs/${ORG_1_ID}/brands/${brandId}`, {
+        baseSiteId: SITE_3_ID,
+      });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.code).to.equal('brand_site_org_mismatch');
+
+      // The brand must be untouched — no partial write.
+      const getRes = await http.admin.get(`/v2/orgs/${ORG_1_ID}/brands/${brandId}`);
+      expect(getRes.body.baseSiteId == null).to.equal(true);
     });
   });
 

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -2546,6 +2546,31 @@ describe('brands-storage', () => {
       expect(sitesEq).to.deep.include({ table: 'sites', col: 'organization_id', val: ORG_ID });
     });
 
+    it('rejects re-pointing a pending brand to a cross-org site (serenity-docs#346)', async () => {
+      // Distinct code path from the "first set" test above: this brand already
+      // HAS a site_id, so the guard only fires via the isPending re-point
+      // sub-condition, not the !existing?.site_id one.
+      const client = createCapturingClient({
+        brands: [
+          { data: { name: 'Pending Re-pointer', site_id: 'old-site', status: 'pending' }, error: null },
+        ],
+        sites: { data: null, error: null }, // site not found under this org
+      });
+
+      const err = await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { baseSiteId: 'other-orgs-site' },
+        postgrestClient: client,
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal('brand_site_org_mismatch');
+      // Uses the fetched brand's name, not the raw brandId, in the message.
+      expect(err.message).to.contain('Pending Re-pointer');
+      expect(client.capturedCalls.update).to.have.lengthOf(0);
+    });
+
     it('sets baseSiteId when brand has no site_id yet', async () => {
       const fullBrandRow = makeBrandRow({ site_id: 'new-site-id' });
 

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1075,6 +1075,7 @@ describe('brands-storage', () => {
           { data: null, error: null }, // existing lookup OK (no brand)
           { data: null, error: { code: '23505', message: 'brands_base_site_unique' } }, // upsert 409
         ],
+        sites: { data: { id: 'some-site-id' }, error: null }, // site belongs to org
       });
 
       const err = await upsertBrand({
@@ -1118,6 +1119,7 @@ describe('brands-storage', () => {
           { data: { id: BRAND_ID, name: 'Test' }, error: null },
           { data: fullBrandRow, error: null },
         ],
+        sites: { data: { id: 'site-uuid' }, error: null }, // site belongs to org
       });
 
       const result = await upsertBrand({
@@ -1136,6 +1138,7 @@ describe('brands-storage', () => {
           { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
           { data: makeBrandRow({ name: 'Test', site_id: 'new-site' }), error: null },
         ],
+        sites: { data: { id: 'new-site' }, error: null }, // site belongs to org
       });
 
       await upsertBrand({
@@ -1221,6 +1224,7 @@ describe('brands-storage', () => {
           { data: { id: BRAND_ID, name: 'Test' }, error: null },
           { data: makeBrandRow({ name: 'Test' }), error: null },
         ],
+        sites: { data: { id: 'primary-site-id' }, error: null }, // site belongs to org
       });
 
       await upsertBrand({
@@ -1355,6 +1359,26 @@ describe('brands-storage', () => {
       expect(log.warn).to.have.been.calledWithMatch('immutable');
     });
 
+    it('rejects a fresh create whose baseSiteId belongs to a different org (serenity-docs#346)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null }, // no existing brand
+        ],
+        sites: { data: null, error: null }, // site not found under this org
+      });
+
+      const err = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'other-orgs-site' },
+        postgrestClient: client,
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal('brand_site_org_mismatch');
+      expect(err.message).to.contain('other-orgs-site');
+      expect(client.capturedCalls.upsert).to.have.lengthOf(0);
+    });
+
     it('does not warn when re-upserting with the same site_id', async () => {
       const log = { warn: sinon.stub(), info: sinon.stub(), error: sinon.stub() };
       const client = createCapturingClient({
@@ -1385,6 +1409,7 @@ describe('brands-storage', () => {
           { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
           { data: makeBrandRow({ name: 'Test', site_id: 'new-site' }), error: null },
         ],
+        sites: { data: { id: 'new-site' }, error: null }, // site belongs to org
       });
 
       await upsertBrand({
@@ -2461,6 +2486,7 @@ describe('brands-storage', () => {
           // 2nd call: update fails with unique constraint
           { data: null, error: { code: '23505', message: 'brands_base_site_unique' } },
         ],
+        sites: { data: { id: 'some-site-id' }, error: null }, // site belongs to org
       });
 
       const err = await updateBrand({
@@ -2472,6 +2498,27 @@ describe('brands-storage', () => {
 
       expect(err.message).to.equal('This site is already the primary URL for another brand');
       expect(err.status).to.equal(409);
+    });
+
+    it('rejects setting baseSiteId to a site owned by a different org (serenity-docs#346)', async () => {
+      const postgrestClient = createCapturingClient({
+        brands: [
+          // 1st call: select current site_id (null → allow setting)
+          { data: { site_id: null }, error: null },
+        ],
+        sites: { data: null, error: null }, // site not found under this org
+      });
+
+      const err = await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { baseSiteId: 'other-orgs-site' },
+        postgrestClient,
+      }).catch((e) => e);
+
+      expect(err.status).to.equal(409);
+      expect(err.code).to.equal('brand_site_org_mismatch');
+      expect(postgrestClient.capturedCalls.update).to.have.lengthOf(0);
     });
 
     it('sets baseSiteId when brand has no site_id yet', async () => {
@@ -2486,6 +2533,7 @@ describe('brands-storage', () => {
           // 3rd call: getBrandById re-fetch
           { data: fullBrandRow, error: null },
         ],
+        sites: { data: { id: 'new-site-id' }, error: null }, // site belongs to org
       });
 
       const result = await updateBrand({
@@ -2578,6 +2626,7 @@ describe('brands-storage', () => {
           // 3rd call: getBrandById re-fetch
           { data: makeBrandRow({ site_id: 'different-site-id', status: 'pending' }), error: null },
         ],
+        sites: { data: { id: 'different-site-id' }, error: null }, // site belongs to org
       });
 
       await updateBrand({
@@ -2599,6 +2648,7 @@ describe('brands-storage', () => {
           // 2nd call: update fails with unique constraint
           { data: null, error: { code: '23505', message: 'brands_base_site_unique' } },
         ],
+        sites: { data: { id: 'taken-site-id' }, error: null }, // site belongs to org
       });
 
       const err = await updateBrand({
@@ -3181,6 +3231,7 @@ describe('brands-storage', () => {
             },
           },
         ],
+        sites: { data: { id: 'site-1' }, error: null }, // site belongs to org
       });
 
       const err = await upsertBrand({

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -978,7 +978,7 @@ describe('brands-storage', () => {
   // so tests can verify which filters were applied to queries.
   function createCapturingClient(tableMap) {
     const calls = {
-      upsert: [], update: [], delete: [], or: [], neq: [],
+      upsert: [], update: [], delete: [], or: [], neq: [], eq: [],
     };
     const callCounts = {};
     const makeQuery = (table) => {
@@ -1020,6 +1020,12 @@ describe('brands-storage', () => {
           if (prop === 'neq') {
             return (col, val) => {
               calls.neq.push({ table, col, val });
+              return new Proxy({}, handler);
+            };
+          }
+          if (prop === 'eq') {
+            return (col, val) => {
+              calls.eq.push({ table, col, val });
               return new Proxy({}, handler);
             };
           }
@@ -1377,6 +1383,14 @@ describe('brands-storage', () => {
       expect(err.code).to.equal('brand_site_org_mismatch');
       expect(err.message).to.contain('other-orgs-site');
       expect(client.capturedCalls.upsert).to.have.lengthOf(0);
+
+      // Verify the guard queried with the RIGHT siteId/organizationId pair,
+      // not just that a `sites` lookup happened at all — a swapped or
+      // mismatched pair here would still 409 in this test's fake, but would
+      // be a real cross-tenant hole against a real database.
+      const sitesEq = client.capturedCalls.eq.filter((c) => c.table === 'sites');
+      expect(sitesEq).to.deep.include({ table: 'sites', col: 'id', val: 'other-orgs-site' });
+      expect(sitesEq).to.deep.include({ table: 'sites', col: 'organization_id', val: ORG_ID });
     });
 
     it('does not warn when re-upserting with the same site_id', async () => {
@@ -2519,6 +2533,13 @@ describe('brands-storage', () => {
       expect(err.status).to.equal(409);
       expect(err.code).to.equal('brand_site_org_mismatch');
       expect(postgrestClient.capturedCalls.update).to.have.lengthOf(0);
+
+      // Same query-argument check as upsertBrand's guard test — proves the
+      // guard used THIS brand's org and THIS candidate site, not just that
+      // some sites lookup happened.
+      const sitesEq = postgrestClient.capturedCalls.eq.filter((c) => c.table === 'sites');
+      expect(sitesEq).to.deep.include({ table: 'sites', col: 'id', val: 'other-orgs-site' });
+      expect(sitesEq).to.deep.include({ table: 'sites', col: 'organization_id', val: ORG_ID });
     });
 
     it('sets baseSiteId when brand has no site_id yet', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1393,6 +1393,32 @@ describe('brands-storage', () => {
       expect(sitesEq).to.deep.include({ table: 'sites', col: 'organization_id', val: ORG_ID });
     });
 
+    it('fails closed with an untyped error when the sites org-membership lookup errors (serenity-docs#346)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null }, // no existing brand
+        ],
+        sites: { data: null, error: { message: 'connection reset' } }, // PostgREST failure
+      });
+
+      const err = await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'some-site' },
+        postgrestClient: client,
+      }).catch((e) => e);
+
+      expect(err.message).to.equal(
+        'Failed to verify primary site org for brand "Test": connection reset',
+      );
+      // Deliberately untyped: a DB-read failure is not the same class of
+      // problem as a genuine org mismatch, so it must NOT carry the 409
+      // brand_site_org_mismatch status/code — it surfaces as a plain 500
+      // via the controller's generic error path instead.
+      expect(err.status).to.be.undefined;
+      expect(err.code).to.be.undefined;
+      expect(client.capturedCalls.upsert).to.have.lengthOf(0);
+    });
+
     it('does not warn when re-upserting with the same site_id', async () => {
       const log = { warn: sinon.stub(), info: sinon.stub(), error: sinon.stub() };
       const client = createCapturingClient({


### PR DESCRIPTION
## Summary
- serenity-docs#346 traced a recurring defect where a brand's `organization_id` diverges from its own site's `organization_id` (Tata Capital, BMW, Toyota, KDDI, ...), introduced by hand re-parents/backfills with no guardrail.
- `upsertBrand` and `updateBrand` had no check that a new `baseSiteId` actually belongs to the brand's org before persisting `site_id`. Adds `assertSiteBelongsToOrg()`, called from both functions on every path that assigns a *new* anchor (fresh create / first anchor, and the update-side first-set / pending re-point) — the immutable-once-set branches are unaffected since they already refuse to change an existing site_id.
- Rejects with a typed 409 (`brand_site_org_mismatch`) instead of silently persisting the mismatch.

## Test plan
- [x] `npx mocha test/support/brands-storage.test.js` — 220 passing, including 2 new tests covering the guard directly (fresh create + update paths) and updated mocks for existing baseSiteId tests
- [x] `npm test` (full suite) — 16989 passing
- [x] `npm run lint` — clean

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```