### PR TITLE
fix: allow x-view-full-experience header in CORS (SITES-49888)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ function localCORSWrapper(fn) {
       response.headers.set(
         'Access-Control-Allow-Headers',
         'Content-Type, Authorization, x-api-key, x-ims-org-id, x-client-type, x-import-api-key, '
-        + 'x-trigger-audits, x-requested-with, origin, accept, x-view-as-trial, x-product, x-promise-token, x-promise-audience',
+        + 'x-trigger-audits, x-requested-with, origin, accept, x-view-as-trial, x-view-full-experience, x-product, x-promise-token, x-promise-audience',
       );
       response.headers.set('Access-Control-Max-Age', '86400');
     }
@@ -227,7 +227,7 @@ async function run(request, context) {
   if (method === 'OPTIONS') {
     return noContent({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-promise-token, x-promise-audience',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-view-full-experience, x-promise-token, x-promise-audience',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -220,7 +220,7 @@ describe('Index Tests', () => {
     expect(resp.status).to.equal(204);
     expect(resp.headers.plain()).to.eql({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-promise-token, x-promise-audience',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-view-full-experience, x-promise-token, x-promise-audience',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
       'content-type': 'application/json; charset=utf-8',


### PR DESCRIPTION
## What & why

Follow-up to #3087 (already merged). That PR added the admin-gated `x-view-full-experience` override in `getIsSummitPlgEnabled`, but the **CORS allow-header** for the new request header was missing — it merged before that commit landed. Without it, the browser's cross-origin preflight for `x-view-full-experience` is rejected, so every ASO-UI opportunity/suggestion read carrying the header is blocked (surfaces as a storm of failed `/opportunities` calls / a page that never finishes loading).

## Change

Add `x-view-full-experience` to both CORS allow-lists in `src/index.js` (the main response header and the `OPTIONS` preflight), alongside the existing `x-view-as-trial`, and update the matching `test/index.test.js` assertion.

Backward-compatible — it only *permits* a header; no behaviour change. Safe to deploy immediately, and needs to reach the environment the ASO UI hits before the UI's "View full experience" toggle (SITES-49888) can work there.

## Related Issues

- [SITES-49888](https://jira.corp.adobe.com/browse/SITES-49888)
- Follows #3087 (admin-gated override)
- Paired ASO UI PR: OneAdobe/experience-success-studio-ui#2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```