### PR TITLE
feat(ai-visibility): dual-mode Semrush credential provider + PR-3a hardening (inert)

### DIFF
--- a/src/support/ai-visibility/grpc-transport.js
+++ b/src/support/ai-visibility/grpc-transport.js
@@ -11,7 +11,7 @@
  */
 
 import { createClient } from '@connectrpc/connect';
-import { createGrpcTransport } from '@connectrpc/connect-node';
+import { createGrpcTransport, Http2SessionManager } from '@connectrpc/connect-node';
 import { BrandService } from '@quazar/ai-seo-ts/v2/brand/service_pb.js';
 import { TopicService } from '@quazar/ai-seo-ts/v2/topic/service_pb.js';
 import { PromptService } from '@quazar/ai-seo-ts/v2/prompt/service_pb.js';
@@ -113,15 +113,23 @@ let maxClientsCacheSize = DEFAULT_MAX_CLIENTS_CACHE_SIZE;
  * Build the gRPC transport + all service clients around a single auth interceptor.
  * The transport options are identical across the shared and per-credential paths;
  * only the interceptor differs.
+ *
+ * Returns the client set together with the {@link Http2SessionManager} that owns the
+ * transport's HTTP/2 connection, so an evicted per-credential entry can close its
+ * connection instead of leaking it ({@link teardownClientPoolEntry}).
+ *
+ * @returns {{ clients: object, sessionManager: Http2SessionManager }}
  */
-function buildClients(interceptor) {
+function buildClientPoolEntry(interceptor) {
+  const sessionManager = new Http2SessionManager(GRPC_BASE_URL);
   const transport = createGrpcTransport({
     baseUrl: GRPC_BASE_URL,
     httpVersion: '2',
     interceptors: [interceptor],
+    sessionManager,
   });
 
-  return {
+  const clients = {
     brandClient: createClient(BrandService, transport),
     topicClient: createClient(TopicService, transport),
     promptClient: createClient(PromptService, transport),
@@ -132,6 +140,17 @@ function buildClients(interceptor) {
     voSourcesClient: createClient(VoSources, transport),
     prRelationsClient: createClient(Relations, transport),
   };
+
+  return { clients, sessionManager };
+}
+
+/**
+ * Tear down a pool entry's transport: abort its HTTP/2 session manager so the
+ * underlying connection is closed rather than leaked when the entry is evicted or the
+ * pool is reset. No-op when the entry has no session manager (e.g. under test mocks).
+ */
+function teardownClientPoolEntry(entry) {
+  entry?.sessionManager?.abort?.();
 }
 
 /**
@@ -150,10 +169,10 @@ function createCredentialInterceptor(env, credential) {
   };
 }
 
-let cachedClients = null;
+let cachedEntry = null;
 
-/** key -> clients, used only on the per-brand (flag-on) path. */
-const perCredentialClients = new Map();
+/** key -> pool entry ({ clients, sessionManager }), used only on the per-brand (flag-on) path. */
+const perCredentialEntries = new Map();
 
 /**
  * Lazy-init gRPC transport + all service clients.
@@ -172,11 +191,11 @@ const perCredentialClients = new Map();
  */
 export function getGrpcClients(env, brand) {
   if (!isPerBrandAuthEnabled(env)) {
-    if (cachedClients) {
-      return cachedClients;
+    if (cachedEntry) {
+      return cachedEntry.clients;
     }
-    cachedClients = buildClients(createAuthInterceptor(env));
-    return cachedClients;
+    cachedEntry = buildClientPoolEntry(createAuthInterceptor(env));
+    return cachedEntry.clients;
   }
 
   const credential = resolveSemrushCredential(brand, env);
@@ -184,26 +203,30 @@ export function getGrpcClients(env, brand) {
     ? credentialPoolKey(credential.key)
     : SHARED_CREDENTIAL_KEY;
 
-  const existing = perCredentialClients.get(key);
+  const existing = perCredentialEntries.get(key);
   if (existing) {
-    return existing;
+    return existing.clients;
   }
 
-  // Bound the pool: evict the oldest (FIFO by build time) transport when at capacity.
-  while (perCredentialClients.size >= maxClientsCacheSize) {
-    const oldestKey = perCredentialClients.keys().next().value;
-    perCredentialClients.delete(oldestKey);
+  // Bound the pool: evict the oldest (FIFO by build time) transport when at capacity,
+  // tearing down its HTTP/2 session so the connection is closed rather than leaked.
+  while (perCredentialEntries.size >= maxClientsCacheSize) {
+    const oldestKey = perCredentialEntries.keys().next().value;
+    teardownClientPoolEntry(perCredentialEntries.get(oldestKey));
+    perCredentialEntries.delete(oldestKey);
   }
 
-  const clients = buildClients(createCredentialInterceptor(env, credential));
-  perCredentialClients.set(key, clients);
-  return clients;
+  const entry = buildClientPoolEntry(createCredentialInterceptor(env, credential));
+  perCredentialEntries.set(key, entry);
+  return entry.clients;
 }
 
 /** @visibleForTesting */
 export function resetGrpcClients() {
-  cachedClients = null;
-  perCredentialClients.clear();
+  teardownClientPoolEntry(cachedEntry);
+  cachedEntry = null;
+  perCredentialEntries.forEach(teardownClientPoolEntry);
+  perCredentialEntries.clear();
   maxClientsCacheSize = DEFAULT_MAX_CLIENTS_CACHE_SIZE;
 }
 
@@ -214,7 +237,7 @@ export function setClientPoolMaxSize(n) {
 
 /** @visibleForTesting */
 export function getClientPoolSize() {
-  return perCredentialClients.size;
+  return perCredentialEntries.size;
 }
 
 export { getAccessToken, createAuthInterceptor };

--- a/src/support/ai-visibility/grpc-transport.js
+++ b/src/support/ai-visibility/grpc-transport.js
@@ -148,9 +148,17 @@ function buildClientPoolEntry(interceptor) {
  * Tear down a pool entry's transport: abort its HTTP/2 session manager so the
  * underlying connection is closed rather than leaked when the entry is evicted or the
  * pool is reset. No-op when the entry has no session manager (e.g. under test mocks).
+ *
+ * Best-effort: a failure to abort one entry must not stop teardown of the others (this
+ * runs in an eviction loop and a `forEach` over the whole pool), so the error is
+ * swallowed rather than propagated.
  */
 function teardownClientPoolEntry(entry) {
-  entry?.sessionManager?.abort?.();
+  try {
+    entry?.sessionManager?.abort?.();
+  } catch {
+    // Swallowed intentionally -- see the best-effort note above.
+  }
 }
 
 /**

--- a/src/support/ai-visibility/semrush-credential-provider.js
+++ b/src/support/ai-visibility/semrush-credential-provider.js
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Dual-mode Semrush credential provider (LLMO-7029, PR-3b preparation).
+ *
+ * Design of record: adobe/mysticat-architecture#248 §6.2/§6.3
+ * (`products/llmo/spec-brand-claims-semrush-ingestion-feed.md`). Upstream blocker:
+ * LLMO-6836.
+ *
+ * The upstream technical-account (TA) decision is still contested along two axes
+ * (spec §6.2 "the two pluggable knobs"). This provider implements BOTH so the eventual
+ * landing is a config flip, not a rewrite:
+ *
+ *   Knob A -- credential granularity: one SHARED technical account (Vivek) vs one
+ *             PER-ORG TA (Ravi/security). Controls only the credential scope/cache KEY.
+ *   Knob B -- workspace selection: `workspaceId` supplied in the REQUEST (Vivek) vs
+ *             `ims_org_id`-from-token -> workspace mapping (Semrush/security-preferred,
+ *             TOKEN_ORG_MAPPING). Controls only whether the descriptor's `workspaceHint`
+ *             is read from the request or from an injected mapping lookup.
+ *
+ * Default-to-code (spec §6.2): PER_ORG + TOKEN_ORG_MAPPING -- the combination most
+ * likely to survive a security review (tenant isolation; Semrush refuses a
+ * `workspaceId` in the payload). Landing on SHARED / REQUEST later is a narrowing,
+ * not a redesign.
+ *
+ * Everything that could bind this to a live credential or to a concrete
+ * brand -> org -> workspace table is an INJECTED seam:
+ *   - resolveOrgId(brand, env)          -> the `ims_org_id` for the request context
+ *   - resolveRequestWorkspace(brand, env) -> the `workspaceId` supplied in the request
+ *                                           (Knob B = REQUEST)
+ *   - lookupWorkspaceForOrg(imsOrgId, env) -> the `workspaceId` for an org
+ *                                           (Knob B = TOKEN_ORG_MAPPING; candidate
+ *                                           mapping source: serenity-docs INDEX.md)
+ *   - mintToken(scope, env)             -> Promise<MintResult> for the resolved scope
+ *
+ * No brand/org/workspace value is hardcoded here -- the built-in context extractors
+ * only read fields off the object the caller passes in. This module registers NOTHING:
+ * the seam stays inert until a future PR (3b) calls `setSemrushCredentialProvider()`
+ * from `semrush-credential-resolver.js` with an instance built here.
+ *
+ * @typedef {import('./semrush-credential-resolver.js').SemrushCredential} SemrushCredential
+ * @typedef {import('./semrush-credential-resolver.js')
+ *   .SemrushCredentialProvider} SemrushCredentialProvider
+ * @typedef {import('./semrush-credential-resolver.js').MintResult} MintResult
+ */
+
+/** Knob A -- how many technical accounts back the feed. */
+export const CredentialGranularity = Object.freeze({
+  /** One shared TA for every brand (Vivek). */
+  SHARED: 'shared',
+  /** One TA per customer org (Ravi/security). */
+  PER_ORG: 'per-org',
+});
+
+/** Knob B -- where the target workspace comes from. */
+export const WorkspaceSource = Object.freeze({
+  /** `workspaceId` is supplied in the request (Vivek). */
+  REQUEST: 'request',
+  /** `ims_org_id`-from-token is mapped to a workspace (Semrush/security-preferred). */
+  TOKEN_ORG_MAPPING: 'token-org-mapping',
+});
+
+/**
+ * Default-to-code combination (spec §6.2): per-org TA + `ims_org_id` -> workspace
+ * mapping.
+ */
+export const DEFAULT_DUAL_MODE_CONFIG = Object.freeze({
+  credentialGranularity: CredentialGranularity.PER_ORG,
+  workspaceSource: WorkspaceSource.TOKEN_ORG_MAPPING,
+});
+
+/** Stable cache/scope key for the single shared TA (Knob A = SHARED). */
+const SHARED_SCOPE_KEY = 'semrush-ta:shared';
+
+/** Per-org cache/scope key (Knob A = PER_ORG). */
+function perOrgScopeKey(imsOrgId) {
+  return `semrush-ta:org:${imsOrgId}`;
+}
+
+/**
+ * Built-in `ims_org_id` extractor: reads the org claim off the request context. Never
+ * consults a hardcoded table -- a bare brand-id string carries no org, so it yields
+ * `null` and the caller falls back to the shared credential path.
+ */
+function defaultResolveOrgId(brand) {
+  if (!brand || typeof brand !== 'object') {
+    return null;
+  }
+  return brand.imsOrgId ?? brand.ims_org_id ?? brand.orgId ?? null;
+}
+
+/**
+ * Built-in request-workspace extractor: reads a `workspaceId` the caller placed on the
+ * request context (Knob B = REQUEST). Never consults a hardcoded table.
+ */
+function defaultResolveRequestWorkspace(brand) {
+  if (!brand || typeof brand !== 'object') {
+    return null;
+  }
+  return brand.workspaceId ?? brand.workspace_id ?? null;
+}
+
+function assertGranularity(value) {
+  if (value !== CredentialGranularity.SHARED && value !== CredentialGranularity.PER_ORG) {
+    throw new Error(
+      `createDualModeSemrushCredentialProvider: unknown credentialGranularity "${value}"`,
+    );
+  }
+}
+
+function assertWorkspaceSource(value) {
+  if (value !== WorkspaceSource.REQUEST && value !== WorkspaceSource.TOKEN_ORG_MAPPING) {
+    throw new Error(
+      `createDualModeSemrushCredentialProvider: unknown workspaceSource "${value}"`,
+    );
+  }
+}
+
+/**
+ * Build a dual-mode credential provider suitable for
+ * {@link import('./semrush-credential-resolver.js').setSemrushCredentialProvider}.
+ *
+ * The returned function has the exact provider shape the resolver expects
+ * (`(brand, env) => SemrushCredential | null`). A `null` result means "no per-brand
+ * credential" and the transport falls back to the shared `client_credentials` path.
+ *
+ * @param {object} [options]
+ * @param {{credentialGranularity?: string, workspaceSource?: string}} [options.config]
+ *   overrides merged over {@link DEFAULT_DUAL_MODE_CONFIG}.
+ * @param {(brand: unknown, env: object) => (string | null)} [options.resolveOrgId]
+ *   resolves the `ims_org_id` for the request context (defaults to reading the org
+ *   claim off the context object).
+ * @param {(brand: unknown, env: object) => (string | null)} [options.resolveRequestWorkspace]
+ *   resolves the request-supplied `workspaceId` (Knob B = REQUEST; defaults to reading
+ *   `workspaceId` off the context object).
+ * @param {(imsOrgId: string, env: object) => (string | null)} [options.lookupWorkspaceForOrg]
+ *   maps an `ims_org_id` to its workspace (Knob B = TOKEN_ORG_MAPPING; REQUIRED for that
+ *   mode; candidate source: serenity-docs INDEX.md). Never hardcode the mapping here.
+ * @param {(scope: object, env: object) => Promise<MintResult>} options.mintToken
+ *   mints the TA token for the resolved credential scope (REQUIRED). Injected so this
+ *   module never holds a live credential.
+ * @returns {SemrushCredentialProvider}
+ */
+export function createDualModeSemrushCredentialProvider(options = {}) {
+  const {
+    config: overrides = {},
+    resolveOrgId = defaultResolveOrgId,
+    resolveRequestWorkspace = defaultResolveRequestWorkspace,
+    lookupWorkspaceForOrg,
+    mintToken,
+  } = options;
+
+  if (typeof mintToken !== 'function') {
+    throw new Error('createDualModeSemrushCredentialProvider: mintToken must be a function');
+  }
+
+  const config = { ...DEFAULT_DUAL_MODE_CONFIG, ...overrides };
+  const { credentialGranularity, workspaceSource } = config;
+  assertGranularity(credentialGranularity);
+  assertWorkspaceSource(workspaceSource);
+
+  if (
+    workspaceSource === WorkspaceSource.TOKEN_ORG_MAPPING
+    && typeof lookupWorkspaceForOrg !== 'function'
+  ) {
+    throw new Error(
+      'createDualModeSemrushCredentialProvider: workspaceSource "token-org-mapping" '
+      + 'requires a lookupWorkspaceForOrg seam',
+    );
+  }
+
+  /** @type {SemrushCredentialProvider} */
+  return function dualModeProvider(brand, env) {
+    const imsOrgId = resolveOrgId(brand, env) || null;
+
+    // Knob A: credential granularity -> credential scope/cache key.
+    let key;
+    if (credentialGranularity === CredentialGranularity.SHARED) {
+      key = SHARED_SCOPE_KEY;
+    } else {
+      // per-org: without an org claim we cannot scope a TA -> defer to the shared
+      // fallback path (a null result, per spec §6.2).
+      if (!imsOrgId) {
+        return null;
+      }
+      key = perOrgScopeKey(imsOrgId);
+    }
+
+    // Knob B: workspace selection -> workspaceHint (advisory; the transport does not
+    // consume it yet -- live wiring is PR-3b).
+    let workspaceHint;
+    if (workspaceSource === WorkspaceSource.REQUEST) {
+      workspaceHint = resolveRequestWorkspace(brand, env) || undefined;
+    } else {
+      // token-org-mapping: the org claim is the join key into the mapping.
+      if (!imsOrgId) {
+        return null;
+      }
+      workspaceHint = lookupWorkspaceForOrg(imsOrgId, env) || undefined;
+    }
+
+    const scope = Object.freeze({
+      credentialKey: key,
+      granularity: credentialGranularity,
+      imsOrgId: imsOrgId ?? undefined,
+      workspaceId: workspaceHint,
+      brand,
+    });
+
+    return {
+      key,
+      getAuthToken: (mintEnv) => mintToken(scope, mintEnv ?? env),
+      workspaceHint,
+    };
+  };
+}

--- a/src/support/ai-visibility/semrush-credential-provider.js
+++ b/src/support/ai-visibility/semrush-credential-provider.js
@@ -149,6 +149,9 @@ function assertWorkspaceSource(value) {
  * @param {(scope: object, env: object) => Promise<MintResult>} options.mintToken
  *   mints the TA token for the resolved credential scope (REQUIRED). Injected so this
  *   module never holds a live credential.
+ * @param {{debug?: (msg: string) => void}} [options.log] optional logger; when present,
+ *   the provider debug-logs a distinct reason on each fall-back path so the null/no-hint
+ *   outcomes are diagnosable once the seam goes live.
  * @returns {SemrushCredentialProvider}
  */
 export function createDualModeSemrushCredentialProvider(options = {}) {
@@ -158,6 +161,7 @@ export function createDualModeSemrushCredentialProvider(options = {}) {
     resolveRequestWorkspace = defaultResolveRequestWorkspace,
     lookupWorkspaceForOrg,
     mintToken,
+    log,
   } = options;
 
   if (typeof mintToken !== 'function') {
@@ -191,6 +195,10 @@ export function createDualModeSemrushCredentialProvider(options = {}) {
       // per-org: without an org claim we cannot scope a TA -> defer to the shared
       // fallback path (a null result, per spec §6.2).
       if (!imsOrgId) {
+        log?.debug?.(
+          '[semrush-credential-provider] no ims_org_id resolved; cannot scope a '
+          + 'per-org credential -- falling back to the shared credential path',
+        );
         return null;
       }
       key = perOrgScopeKey(imsOrgId);
@@ -204,9 +212,19 @@ export function createDualModeSemrushCredentialProvider(options = {}) {
     } else {
       // token-org-mapping: the org claim is the join key into the mapping.
       if (!imsOrgId) {
+        log?.debug?.(
+          '[semrush-credential-provider] no ims_org_id resolved; cannot map a '
+          + 'workspace -- falling back to the shared credential path',
+        );
         return null;
       }
       workspaceHint = lookupWorkspaceForOrg(imsOrgId, env) || undefined;
+      if (!workspaceHint) {
+        log?.debug?.(
+          `[semrush-credential-provider] ims_org_id "${imsOrgId}" has no mapped `
+          + 'workspace -- proceeding without a workspaceHint',
+        );
+      }
     }
 
     const scope = Object.freeze({

--- a/src/support/ai-visibility/semrush-credential-resolver.js
+++ b/src/support/ai-visibility/semrush-credential-resolver.js
@@ -54,6 +54,12 @@ const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
  * expires, so a token handed to the transport is never within the skew window of
  * expiring mid-flight (which would 401). Not applied to the conservative default TTL,
  * which is already well short of any real credential lifetime.
+ *
+ * Sizing assumption: this margin only has to exceed the duration of a *single* gRPC
+ * call, since the token is re-checked (and re-minted if stale) on each request that
+ * builds/uses the transport. It is deliberately much smaller than the ~29s
+ * API-Gateway ceiling, which bounds a whole multi-RPC request rather than one call. If
+ * an individual gRPC call could ever run longer than this margin, raise it.
  */
 const TOKEN_TTL_SKEW_MS = 5 * 1000;
 
@@ -124,13 +130,18 @@ export function resolveSemrushCredential(brand, env) {
  * @param {string} key - stable cache key for the credential scope.
  * @param {() => Promise<MintResult>} mintFn - MUST resolve a non-empty token string
  *   or an object with a string `token`; anything else throws and caches nothing.
- * @param {number} [nowMs=Date.now()] - current time in ms (injectable for tests).
+ * @param {(() => number) | number} [now=Date.now] - clock used to measure expiry. A
+ *   function is read fresh at each point (the production default, so a slow mint's
+ *   expiry is measured from when the token actually exists); a fixed number pins the
+ *   clock deterministically for tests.
  * @returns {Promise<string>} the raw token string.
  * @throws {Error} when `mintFn` violates the contract above.
  */
-export async function getCachedToken(key, mintFn, nowMs = Date.now()) {
+export async function getCachedToken(key, mintFn, now = Date.now) {
+  const clock = typeof now === 'function' ? now : () => now;
+
   const existing = tokenCache.get(key);
-  if (existing && nowMs < existing.expiresAtMs) {
+  if (existing && clock() < existing.expiresAtMs) {
     return existing.token;
   }
 
@@ -142,23 +153,27 @@ export async function getCachedToken(key, mintFn, nowMs = Date.now()) {
 
   const mintPromise = (async () => {
     const minted = await mintFn();
+    // Capture the timestamp AFTER the mint resolves: a slow mint must not make the
+    // cached token expire early (its lifetime starts when the token exists, not when
+    // the request began).
+    const mintedAtMs = clock();
 
     let token;
     let expiresAtMs;
     let providerSuppliedExpiry = false;
     if (typeof minted === 'string') {
       token = minted;
-      expiresAtMs = nowMs + DEFAULT_TOKEN_TTL_MS;
+      expiresAtMs = mintedAtMs + DEFAULT_TOKEN_TTL_MS;
     } else if (minted && typeof minted.token === 'string') {
       token = minted.token;
       if (typeof minted.expiresAtMs === 'number') {
         expiresAtMs = minted.expiresAtMs;
         providerSuppliedExpiry = true;
       } else if (typeof minted.expiresInMs === 'number') {
-        expiresAtMs = nowMs + minted.expiresInMs;
+        expiresAtMs = mintedAtMs + minted.expiresInMs;
         providerSuppliedExpiry = true;
       } else {
-        expiresAtMs = nowMs + DEFAULT_TOKEN_TTL_MS;
+        expiresAtMs = mintedAtMs + DEFAULT_TOKEN_TTL_MS;
       }
     } else {
       // Enforce the mint contract: nothing is cached when it is violated, so the
@@ -169,11 +184,12 @@ export async function getCachedToken(key, mintFn, nowMs = Date.now()) {
     }
 
     // TTL skew: refresh a real token a few seconds before its true expiry. Guard against
-    // moving expiry to/before `nowMs` (would make the entry born-stale and re-mint every
-    // call) -- a token whose real lifetime is shorter than the skew keeps its own expiry.
+    // moving expiry to/before the mint time (would make the entry born-stale and re-mint
+    // every call) -- a token whose real lifetime is shorter than the skew keeps its own
+    // expiry.
     if (providerSuppliedExpiry) {
       const skewed = expiresAtMs - TOKEN_TTL_SKEW_MS;
-      if (skewed > nowMs) {
+      if (skewed > mintedAtMs) {
         expiresAtMs = skewed;
       }
     }

--- a/src/support/ai-visibility/semrush-credential-resolver.js
+++ b/src/support/ai-visibility/semrush-credential-resolver.js
@@ -34,6 +34,8 @@
  * @typedef {object} SemrushCredential
  * @property {string} key - stable cache key for the credential scope (brand/org id).
  * @property {(env: object) => Promise<string>} getAuthToken - yields the raw token.
+ * @property {string} [workspaceHint] - optional target Semrush workspace for the scope.
+ *   Advisory only; the transport does not consume it yet (live wiring is PR-3b).
  */
 
 /**
@@ -47,6 +49,14 @@
 /** Conservative fallback token lifetime when the mint result carries no expiry. */
 const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * Refresh a real (provider-supplied expiry) token this many ms before it actually
+ * expires, so a token handed to the transport is never within the skew window of
+ * expiring mid-flight (which would 401). Not applied to the conservative default TTL,
+ * which is already well short of any real credential lifetime.
+ */
+const TOKEN_TTL_SKEW_MS = 5 * 1000;
+
 /** Default upper bound on distinct credential scopes cached at once. */
 const DEFAULT_MAX_TOKEN_CACHE_SIZE = 1000;
 
@@ -59,6 +69,14 @@ let credentialProvider = null;
 
 /** Per-credential token cache: key -> { token, expiresAtMs }. */
 const tokenCache = new Map();
+
+/**
+ * In-flight mint coalescing: key -> Promise<string>. While a cold/expired mint is
+ * outstanding for a key, concurrent callers share that single Promise instead of each
+ * minting their own token (a 500-item batch on one credential would otherwise fire N
+ * mints at the token endpoint).
+ */
+const inFlightMints = new Map();
 
 /** Mutable so tests can exercise eviction without minting thousands of tokens. */
 let maxTokenCacheSize = DEFAULT_MAX_TOKEN_CACHE_SIZE;
@@ -95,7 +113,13 @@ export function resolveSemrushCredential(brand, env) {
  * `mintFn` may resolve to either the raw token string, or an object
  * `{ token, expiresInMs }` / `{ token, expiresAtMs }` so a provider can pass through
  * the credential's real lifetime. When no expiry is supplied a conservative default
- * TTL is used.
+ * TTL is used. A provider-supplied expiry is shaved by {@link TOKEN_TTL_SKEW_MS} so the
+ * token is refreshed a few seconds early and never used within the skew window of
+ * expiring.
+ *
+ * Concurrent cold/expired callers for the same key are coalesced onto one mint via
+ * {@link inFlightMints}; the shared Promise resolves the same token to all of them (or
+ * rejects them all together, caching nothing).
  *
  * @param {string} key - stable cache key for the credential scope.
  * @param {() => Promise<MintResult>} mintFn - MUST resolve a non-empty token string
@@ -110,45 +134,76 @@ export async function getCachedToken(key, mintFn, nowMs = Date.now()) {
     return existing.token;
   }
 
-  const minted = await mintFn();
+  // Coalesce concurrent cold/expired mints for this key onto a single outstanding call.
+  const pending = inFlightMints.get(key);
+  if (pending) {
+    return pending;
+  }
 
-  let token;
-  let expiresAtMs;
-  if (typeof minted === 'string') {
-    token = minted;
-    expiresAtMs = nowMs + DEFAULT_TOKEN_TTL_MS;
-  } else if (minted && typeof minted.token === 'string') {
-    token = minted.token;
-    if (typeof minted.expiresAtMs === 'number') {
-      expiresAtMs = minted.expiresAtMs;
-    } else if (typeof minted.expiresInMs === 'number') {
-      expiresAtMs = nowMs + minted.expiresInMs;
-    } else {
+  const mintPromise = (async () => {
+    const minted = await mintFn();
+
+    let token;
+    let expiresAtMs;
+    let providerSuppliedExpiry = false;
+    if (typeof minted === 'string') {
+      token = minted;
       expiresAtMs = nowMs + DEFAULT_TOKEN_TTL_MS;
+    } else if (minted && typeof minted.token === 'string') {
+      token = minted.token;
+      if (typeof minted.expiresAtMs === 'number') {
+        expiresAtMs = minted.expiresAtMs;
+        providerSuppliedExpiry = true;
+      } else if (typeof minted.expiresInMs === 'number') {
+        expiresAtMs = nowMs + minted.expiresInMs;
+        providerSuppliedExpiry = true;
+      } else {
+        expiresAtMs = nowMs + DEFAULT_TOKEN_TTL_MS;
+      }
+    } else {
+      // Enforce the mint contract: nothing is cached when it is violated, so the
+      // caller sees a clear error instead of a `Bearer undefined` header downstream.
+      throw new Error(
+        'getCachedToken: mintFn must resolve a token string or { token: string, ... }',
+      );
     }
-  } else {
-    // Enforce the mint contract: nothing is cached when it is violated, so the
-    // caller sees a clear error instead of a `Bearer undefined` header downstream.
-    throw new Error(
-      'getCachedToken: mintFn must resolve a token string or { token: string, ... }',
-    );
-  }
 
-  // FIFO by mint time: a re-mint deletes then re-inserts the key so it sorts last,
-  // but a cache HIT (returned above) does NOT refresh recency -- this is not LRU.
-  tokenCache.delete(key);
-  // Bound the cache: evict oldest entries when at capacity. Brand count can grow.
-  while (tokenCache.size >= maxTokenCacheSize) {
-    const oldestKey = tokenCache.keys().next().value;
-    tokenCache.delete(oldestKey);
+    // TTL skew: refresh a real token a few seconds before its true expiry. Guard against
+    // moving expiry to/before `nowMs` (would make the entry born-stale and re-mint every
+    // call) -- a token whose real lifetime is shorter than the skew keeps its own expiry.
+    if (providerSuppliedExpiry) {
+      const skewed = expiresAtMs - TOKEN_TTL_SKEW_MS;
+      if (skewed > nowMs) {
+        expiresAtMs = skewed;
+      }
+    }
+
+    // FIFO by mint time: a re-mint deletes then re-inserts the key so it sorts last,
+    // but a cache HIT (returned above) does NOT refresh recency -- this is not LRU.
+    tokenCache.delete(key);
+    // Bound the cache: evict oldest entries when at capacity. Brand count can grow.
+    while (tokenCache.size >= maxTokenCacheSize) {
+      const oldestKey = tokenCache.keys().next().value;
+      tokenCache.delete(oldestKey);
+    }
+    tokenCache.set(key, { token, expiresAtMs });
+    return token;
+  })();
+
+  inFlightMints.set(key, mintPromise);
+  try {
+    return await mintPromise;
+  } finally {
+    // Clear the in-flight slot whether the mint succeeded (now cached) or failed
+    // (cached nothing), so the next call re-mints instead of reusing a dead Promise.
+    inFlightMints.delete(key);
   }
-  tokenCache.set(key, { token, expiresAtMs });
-  return token;
 }
 
 /** @visibleForTesting */
 export function resetSemrushCredentialCache() {
   tokenCache.clear();
+  inFlightMints.clear();
   maxTokenCacheSize = DEFAULT_MAX_TOKEN_CACHE_SIZE;
 }
 

--- a/test/support/ai-visibility/grpc-transport-per-brand.test.js
+++ b/test/support/ai-visibility/grpc-transport-per-brand.test.js
@@ -43,6 +43,9 @@ describe('grpc-transport per-brand auth seam', () => {
   let mockCreateGrpcTransport;
   let mockResolve;
   let mockGetCachedToken;
+  // Every Http2SessionManager the transport builder constructs, in build order, so we
+  // can assert the evicted entry's connection is torn down (B2, LLMO-7029).
+  let sessionManagers;
 
   beforeEach(async () => {
     restoreGlobalFetchIfStubbed();
@@ -52,6 +55,13 @@ describe('grpc-transport per-brand auth seam', () => {
     mockCreateGrpcTransport = sandbox.stub().callsFake(() => ({}));
     mockResolve = sandbox.stub();
     mockGetCachedToken = sandbox.stub();
+    sessionManagers = [];
+    const MockHttp2SessionManager = class {
+      constructor() {
+        this.abort = sandbox.stub();
+        sessionManagers.push(this);
+      }
+    };
 
     const mod = await esmock(
       '../../../src/support/ai-visibility/grpc-transport.js',
@@ -59,6 +69,7 @@ describe('grpc-transport per-brand auth seam', () => {
         '@connectrpc/connect': { createClient: mockCreateClient },
         '@connectrpc/connect-node': {
           createGrpcTransport: mockCreateGrpcTransport,
+          Http2SessionManager: MockHttp2SessionManager,
         },
         '../../../third-party/ai-seo-ts/v2/brand/service_pb.js': {
           BrandService: {},
@@ -241,7 +252,7 @@ describe('grpc-transport per-brand auth seam', () => {
       expect(mockCreateGrpcTransport.calledTwice).to.be.true; // one per key
     });
 
-    it('resetGrpcClients clears the per-credential pool', () => {
+    it('resetGrpcClients clears the per-credential pool and tears down its transports', () => {
       mockResolve.returns({ key: 'org-42', getAuthToken: async () => 't' });
       const env = onEnv();
 
@@ -251,6 +262,8 @@ describe('grpc-transport per-brand auth seam', () => {
 
       expect(first).to.not.equal(second);
       expect(mockCreateGrpcTransport.calledTwice).to.be.true;
+      // The first entry's HTTP/2 session was aborted on reset (B2).
+      expect(sessionManagers[0].abort.calledOnce).to.be.true;
     });
 
     it('bounds the client pool and rebuilds an evicted key', () => {
@@ -272,6 +285,21 @@ describe('grpc-transport per-brand auth seam', () => {
       expect(a2).to.not.equal(a1);
       expect(getClientPoolSize()).to.equal(2);
       expect(mockCreateGrpcTransport.callCount).to.equal(4);
+    });
+
+    it('tears down the evicted transport HTTP/2 session on eviction (B2)', () => {
+      setClientPoolMaxSize(1);
+      mockResolve.withArgs('brand-a').returns({ key: 'org-a', getAuthToken: async () => 'a' });
+      mockResolve.withArgs('brand-b').returns({ key: 'org-b', getAuthToken: async () => 'b' });
+      const env = onEnv();
+
+      getGrpcClients(env, 'brand-a'); // sessionManagers[0] -> org-a
+      expect(sessionManagers[0].abort.notCalled).to.be.true;
+
+      getGrpcClients(env, 'brand-b'); // evicts org-a, builds sessionManagers[1]
+      // org-a's session is closed, org-b's stays open.
+      expect(sessionManagers[0].abort.calledOnce).to.be.true;
+      expect(sessionManagers[1].abort.notCalled).to.be.true;
     });
 
     it('enables the per-brand path for boolean true and string "1"', () => {

--- a/test/support/ai-visibility/grpc-transport-per-brand.test.js
+++ b/test/support/ai-visibility/grpc-transport-per-brand.test.js
@@ -172,6 +172,17 @@ describe('grpc-transport per-brand auth seam', () => {
       ]);
       expect(next.calledOnce).to.be.true;
     });
+
+    it('resetGrpcClients tears down the flag-off singleton transport (B2)', () => {
+      const env = { SEO_CLIENT_ID: 'id', SEO_CLIENT_SECRET: 'sec' };
+
+      getGrpcClients(env); // builds the singleton -> sessionManagers[0]
+      expect(sessionManagers[0].abort.notCalled).to.be.true;
+
+      resetGrpcClients();
+      // The default (flag-off) live path's session is closed on reset, not leaked.
+      expect(sessionManagers[0].abort.calledOnce).to.be.true;
+    });
   });
 
   describe('flag ON', () => {

--- a/test/support/ai-visibility/semrush-credential-provider.test.js
+++ b/test/support/ai-visibility/semrush-credential-provider.test.js
@@ -234,6 +234,55 @@ describe('semrush-credential-provider (dual-mode)', () => {
     expect(b.workspaceHint).to.equal('ws-body');
   });
 
+  describe('diagnostic logging on fall-back paths', () => {
+    it('logs distinct reasons for the missing-org and unmapped-workspace paths', () => {
+      const log = { debug: sandbox.stub() };
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        lookupWorkspaceForOrg: sandbox.stub().returns(null),
+        log,
+      });
+
+      // per-org + no org -> null (cannot scope a per-org credential).
+      expect(provider('brand-string', {})).to.equal(null);
+      // org present but unmapped -> descriptor without workspaceHint (distinct reason).
+      const cred = provider({ imsOrgId: 'org-1' }, {});
+      expect(cred.workspaceHint).to.equal(undefined);
+
+      const messages = log.debug.getCalls().map((c) => c.args[0]);
+      expect(messages.some((m) => /cannot scope a per-org credential/.test(m))).to.be.true;
+      expect(messages.some((m) => /has no mapped workspace/.test(m))).to.be.true;
+    });
+
+    it('logs the workspace-mapping reason when mapping mode has no org (shared key)', () => {
+      const log = { debug: sandbox.stub() };
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        lookupWorkspaceForOrg: sandbox.stub().returns('ws'),
+        log,
+        config: {
+          credentialGranularity: CredentialGranularity.SHARED,
+          workspaceSource: WorkspaceSource.TOKEN_ORG_MAPPING,
+        },
+      });
+
+      // Shared key needs no org, but mapping mode does -> null (cannot map a workspace).
+      expect(provider('brand-no-org', {})).to.equal(null);
+      const messages = log.debug.getCalls().map((c) => c.args[0]);
+      expect(messages.some((m) => /cannot map a workspace/.test(m))).to.be.true;
+    });
+
+    it('is silent when no logger is injected', () => {
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        lookupWorkspaceForOrg: sandbox.stub().returns(null),
+      });
+      // No throw despite the fall-back paths firing without a logger.
+      expect(provider('brand-string', {})).to.equal(null);
+      expect(provider({ imsOrgId: 'org-1' }, {}).workspaceHint).to.equal(undefined);
+    });
+  });
+
   describe('installed into the resolver seam', () => {
     it('resolves per-brand and shares one mint per credential key via getCachedToken', async () => {
       const mintToken = sandbox.stub().resolves({ token: 'org-tok', expiresInMs: 60 * 1000 });

--- a/test/support/ai-visibility/semrush-credential-provider.test.js
+++ b/test/support/ai-visibility/semrush-credential-provider.test.js
@@ -1,0 +1,259 @@
+/* eslint-disable header/header */
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import chaiAsPromised from 'chai-as-promised';
+
+import {
+  createDualModeSemrushCredentialProvider,
+  CredentialGranularity,
+  WorkspaceSource,
+  DEFAULT_DUAL_MODE_CONFIG,
+} from '../../../src/support/ai-visibility/semrush-credential-provider.js';
+import {
+  resolveSemrushCredential,
+  setSemrushCredentialProvider,
+  getCachedToken,
+  resetSemrushCredentialCache,
+} from '../../../src/support/ai-visibility/semrush-credential-resolver.js';
+
+use(chaiAsPromised);
+
+describe('semrush-credential-provider (dual-mode)', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    // Restore the seam to its inert default between tests.
+    setSemrushCredentialProvider(null);
+    resetSemrushCredentialCache();
+  });
+
+  describe('seam stays inert by default', () => {
+    it('importing this module registers no provider (resolver still returns null)', () => {
+      // Merely building/importing the dual-mode provider must not wire it in.
+      expect(resolveSemrushCredential({ imsOrgId: 'org-1' }, {})).to.equal(null);
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        lookupWorkspaceForOrg: sandbox.stub().returns('ws'),
+      });
+      expect(provider).to.be.a('function');
+      // Still inert -- nothing installed it.
+      expect(resolveSemrushCredential({ imsOrgId: 'org-1' }, {})).to.equal(null);
+    });
+  });
+
+  describe('construction', () => {
+    it('defaults to per-org TA + ims_org_id -> workspace mapping', () => {
+      expect(DEFAULT_DUAL_MODE_CONFIG).to.deep.equal({
+        credentialGranularity: CredentialGranularity.PER_ORG,
+        workspaceSource: WorkspaceSource.TOKEN_ORG_MAPPING,
+      });
+    });
+
+    it('requires a mintToken seam', () => {
+      expect(() => createDualModeSemrushCredentialProvider({}))
+        .to.throw(/mintToken must be a function/);
+    });
+
+    it('requires a lookupWorkspaceForOrg seam for token-org-mapping mode', () => {
+      expect(() => createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        config: { workspaceSource: WorkspaceSource.TOKEN_ORG_MAPPING },
+      })).to.throw(/requires a lookupWorkspaceForOrg seam/);
+    });
+
+    it('rejects an unknown credentialGranularity', () => {
+      expect(() => createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        config: { credentialGranularity: 'nope', workspaceSource: WorkspaceSource.REQUEST },
+      })).to.throw(/unknown credentialGranularity/);
+    });
+
+    it('rejects an unknown workspaceSource', () => {
+      expect(() => createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        config: { workspaceSource: 'nope' },
+      })).to.throw(/unknown workspaceSource/);
+    });
+
+    it('does not require lookupWorkspaceForOrg in request mode', () => {
+      expect(() => createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        config: { workspaceSource: WorkspaceSource.REQUEST },
+      })).to.not.throw();
+    });
+  });
+
+  describe('default mode (per-org TA + token-org mapping)', () => {
+    let mintToken;
+    let lookupWorkspaceForOrg;
+    let provider;
+
+    beforeEach(() => {
+      mintToken = sandbox.stub().resolves('minted-token');
+      lookupWorkspaceForOrg = sandbox.stub()
+        .callsFake((org) => (org === 'org-42' ? 'ws-42' : null));
+      provider = createDualModeSemrushCredentialProvider({ mintToken, lookupWorkspaceForOrg });
+    });
+
+    it('keys the credential per org and maps org -> workspace', () => {
+      const cred = provider({ imsOrgId: 'org-42' }, { E: 1 });
+
+      expect(cred).to.not.equal(null);
+      expect(cred.key).to.equal('semrush-ta:org:org-42');
+      expect(cred.workspaceHint).to.equal('ws-42');
+      expect(lookupWorkspaceForOrg.calledOnceWith('org-42')).to.be.true;
+    });
+
+    it('returns null (falls back to the shared path) when no org is resolvable', () => {
+      expect(provider('brand-1', {})).to.equal(null); // bare string carries no org
+      expect(provider({}, {})).to.equal(null);
+      expect(mintToken.notCalled).to.be.true;
+      expect(lookupWorkspaceForOrg.notCalled).to.be.true;
+    });
+
+    it('getAuthToken mints for the resolved scope with the request env', async () => {
+      const env = { SECRET: 'x' };
+      const cred = provider({ imsOrgId: 'org-42' }, env);
+
+      const token = await cred.getAuthToken(env);
+
+      expect(token).to.equal('minted-token');
+      const [scope, passedEnv] = mintToken.firstCall.args;
+      expect(scope.credentialKey).to.equal('semrush-ta:org:org-42');
+      expect(scope.granularity).to.equal(CredentialGranularity.PER_ORG);
+      expect(scope.imsOrgId).to.equal('org-42');
+      expect(scope.workspaceId).to.equal('ws-42');
+      expect(passedEnv).to.equal(env);
+    });
+
+    it('never hardcodes a mapping -- an unmapped org yields no workspaceHint', () => {
+      const cred = provider({ imsOrgId: 'org-x' }, {});
+      expect(cred.key).to.equal('semrush-ta:org:org-x');
+      expect(cred.workspaceHint).to.equal(undefined);
+    });
+  });
+
+  describe('Knob A -- credential granularity', () => {
+    it('shared TA uses one constant key and needs no org', () => {
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        config: {
+          credentialGranularity: CredentialGranularity.SHARED,
+          workspaceSource: WorkspaceSource.REQUEST,
+        },
+      });
+
+      const c1 = provider({ workspaceId: 'ws-1' }, {});
+      const c2 = provider({ imsOrgId: 'org-9', workspaceId: 'ws-2' }, {});
+
+      expect(c1.key).to.equal('semrush-ta:shared');
+      expect(c2.key).to.equal('semrush-ta:shared');
+    });
+  });
+
+  describe('Knob B -- workspace selection', () => {
+    it('request mode reads workspaceHint from the request context', () => {
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        config: {
+          credentialGranularity: CredentialGranularity.PER_ORG,
+          workspaceSource: WorkspaceSource.REQUEST,
+        },
+      });
+
+      const cred = provider({ imsOrgId: 'org-1', workspaceId: 'ws-req' }, {});
+
+      expect(cred.key).to.equal('semrush-ta:org:org-1');
+      expect(cred.workspaceHint).to.equal('ws-req');
+    });
+
+    it('honors injected org + request-workspace resolvers (opaque brand, no hardcoding)', () => {
+      const resolveOrgId = sandbox.stub().returns('org-inj');
+      const resolveRequestWorkspace = sandbox.stub().returns('ws-inj');
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken: sandbox.stub().resolves('t'),
+        resolveOrgId,
+        resolveRequestWorkspace,
+        config: { workspaceSource: WorkspaceSource.REQUEST },
+      });
+
+      const cred = provider('opaque-brand', { E: 1 });
+
+      expect(resolveOrgId.calledOnceWith('opaque-brand', { E: 1 })).to.be.true;
+      expect(cred.key).to.equal('semrush-ta:org:org-inj');
+      expect(cred.workspaceHint).to.equal('ws-inj');
+    });
+  });
+
+  it('supports both contested shapes from one set of seams via config alone', () => {
+    const seams = {
+      mintToken: sandbox.stub().resolves('t'),
+      lookupWorkspaceForOrg: sandbox.stub().returns('ws-mapped'),
+      resolveOrgId: () => 'org-7',
+      resolveRequestWorkspace: () => 'ws-body',
+    };
+
+    const perOrgMapping = createDualModeSemrushCredentialProvider({
+      ...seams,
+      config: {
+        credentialGranularity: CredentialGranularity.PER_ORG,
+        workspaceSource: WorkspaceSource.TOKEN_ORG_MAPPING,
+      },
+    });
+    const sharedRequest = createDualModeSemrushCredentialProvider({
+      ...seams,
+      config: {
+        credentialGranularity: CredentialGranularity.SHARED,
+        workspaceSource: WorkspaceSource.REQUEST,
+      },
+    });
+
+    const a = perOrgMapping({}, {});
+    const b = sharedRequest({}, {});
+
+    expect(a.key).to.equal('semrush-ta:org:org-7');
+    expect(a.workspaceHint).to.equal('ws-mapped');
+    expect(b.key).to.equal('semrush-ta:shared');
+    expect(b.workspaceHint).to.equal('ws-body');
+  });
+
+  describe('installed into the resolver seam', () => {
+    it('resolves per-brand and shares one mint per credential key via getCachedToken', async () => {
+      const mintToken = sandbox.stub().resolves({ token: 'org-tok', expiresInMs: 60 * 1000 });
+      const lookupWorkspaceForOrg = sandbox.stub().returns('ws');
+      const provider = createDualModeSemrushCredentialProvider({
+        mintToken,
+        lookupWorkspaceForOrg,
+      });
+      setSemrushCredentialProvider(provider);
+
+      const cred = resolveSemrushCredential({ imsOrgId: 'org-42' }, {});
+      expect(cred.key).to.equal('semrush-ta:org:org-42');
+
+      // Two reads within TTL -> a single mint, exactly as the transport interceptor drives it.
+      const t1 = await getCachedToken(cred.key, () => cred.getAuthToken({}), 0);
+      const t2 = await getCachedToken(cred.key, () => cred.getAuthToken({}), 1000);
+
+      expect(t1).to.equal('org-tok');
+      expect(t2).to.equal('org-tok');
+      expect(mintToken.calledOnce).to.be.true;
+    });
+  });
+});

--- a/test/support/ai-visibility/semrush-credential-resolver.test.js
+++ b/test/support/ai-visibility/semrush-credential-resolver.test.js
@@ -279,5 +279,42 @@ describe('semrush-credential-resolver', () => {
       expect(beforeExpiry).to.equal('a');
       expect(atExpiry).to.equal('b');
     });
+
+    it('applies the skew on the absolute expiresAtMs path too (B3)', async () => {
+      const mint = sandbox.stub();
+      mint.onFirstCall().resolves({ token: 'a', expiresAtMs: 60 * 1000 });
+      mint.onSecondCall().resolves({ token: 'b', expiresAtMs: 60 * 1000 });
+
+      // Absolute expiry = 60000; skewed to 60000 - 5000 = 55000 (independent of `now`).
+      const first = await getCachedToken('k1', mint, 0);
+      const beforeSkew = await getCachedToken('k1', mint, 54999); // still valid
+      const atSkew = await getCachedToken('k1', mint, 55000); // re-mint 5s early
+
+      expect(first).to.equal('a');
+      expect(beforeSkew).to.equal('a');
+      expect(atSkew).to.equal('b');
+      expect(mint.calledTwice).to.be.true;
+    });
+
+    // MUST-FIX 1 -- expiry is measured from AFTER the mint resolves, not request start.
+    it('measures expiry from when the mint resolves, not from the initial call time', async () => {
+      // Clock advances 10s while the mint runs, so the post-mint read sees 10000.
+      let t = 0;
+      const clock = () => t;
+      const mint = sandbox.stub().callsFake(() => {
+        t = 10 * 1000; // the (slow) mint takes 10s
+        return Promise.resolve('tok');
+      });
+
+      await getCachedToken('k1', mint, clock);
+
+      // Default TTL is measured from 10000, so the entry is valid until 10000 + 300000,
+      // not 0 + 300000 -- the slow mint did not shorten the cached lifetime.
+      t = 300 * 1000; // exactly the old (buggy) expiry boundary
+      const stillValidNearOldExpiry = sandbox.stub().resolves('tok-2');
+      const reused = await getCachedToken('k1', stillValidNearOldExpiry, clock);
+      expect(reused).to.equal('tok');
+      expect(stillValidNearOldExpiry.notCalled).to.be.true;
+    });
   });
 });

--- a/test/support/ai-visibility/semrush-credential-resolver.test.js
+++ b/test/support/ai-visibility/semrush-credential-resolver.test.js
@@ -185,5 +185,99 @@ describe('semrush-credential-resolver', () => {
       await getCachedToken('c', mint, 0);
       expect(mint.callCount).to.equal(4);
     });
+
+    // B1 -- in-flight token coalescing.
+    it('coalesces concurrent cold mints for one key into a single mint (B1)', async () => {
+      let resolveMint;
+      const mint = sandbox.stub().returns(
+        new Promise((resolve) => { resolveMint = resolve; }),
+      );
+
+      const p1 = getCachedToken('k1', mint, 0);
+      const p2 = getCachedToken('k1', mint, 0);
+
+      // Both callers wait on the same outstanding mint -- not one mint each.
+      expect(mint.calledOnce).to.be.true;
+
+      resolveMint('tok-shared');
+      const [a, b] = await Promise.all([p1, p2]);
+
+      expect(a).to.equal('tok-shared');
+      expect(b).to.equal('tok-shared');
+      expect(mint.calledOnce).to.be.true;
+
+      // The result is now cached and the in-flight slot cleared.
+      const third = await getCachedToken('k1', mint, 1000);
+      expect(third).to.equal('tok-shared');
+      expect(mint.calledOnce).to.be.true;
+    });
+
+    it('shares a failing in-flight mint with all callers and caches nothing (B1)', async () => {
+      let rejectMint;
+      const mint = sandbox.stub().returns(
+        new Promise((_resolve, reject) => { rejectMint = reject; }),
+      );
+
+      const p1 = getCachedToken('k1', mint, 0);
+      const p2 = getCachedToken('k1', mint, 0);
+      rejectMint(new Error('mint failed'));
+
+      await expect(p1).to.be.rejectedWith('mint failed');
+      await expect(p2).to.be.rejectedWith('mint failed');
+      expect(mint.calledOnce).to.be.true;
+      expect(getTokenCacheSize()).to.equal(0);
+
+      // In-flight slot cleared on failure -> a later call re-mints cleanly.
+      const good = sandbox.stub().resolves('tok-ok');
+      expect(await getCachedToken('k1', good, 0)).to.equal('tok-ok');
+      expect(good.calledOnce).to.be.true;
+    });
+
+    // B3 -- TTL skew margin.
+    it('refreshes a real (provider-supplied) token a few seconds before expiry (B3)', async () => {
+      const mint = sandbox.stub();
+      mint.onFirstCall().resolves({ token: 'a', expiresInMs: 60 * 1000 });
+      mint.onSecondCall().resolves({ token: 'b', expiresInMs: 60 * 1000 });
+
+      // Real expiry = 60000; skewed to 60000 - 5000 = 55000.
+      const first = await getCachedToken('k1', mint, 0);
+      const beforeSkew = await getCachedToken('k1', mint, 54999); // still valid
+      const atSkew = await getCachedToken('k1', mint, 55000); // re-mint 5s early
+
+      expect(first).to.equal('a');
+      expect(beforeSkew).to.equal('a');
+      expect(atSkew).to.equal('b');
+      expect(mint.calledTwice).to.be.true;
+    });
+
+    it('does not skew the conservative default TTL (B3)', async () => {
+      const mint = sandbox.stub();
+      mint.onFirstCall().resolves('a'); // string -> default TTL, no provider expiry
+      mint.onSecondCall().resolves('b');
+      const ttl = 5 * 60 * 1000;
+
+      const first = await getCachedToken('k1', mint, 0);
+      const justBefore = await getCachedToken('k1', mint, ttl - 1); // valid to the boundary
+      const atTtl = await getCachedToken('k1', mint, ttl);
+
+      expect(first).to.equal('a');
+      expect(justBefore).to.equal('a');
+      expect(atTtl).to.equal('b');
+    });
+
+    it('keeps its own expiry when the real TTL is shorter than the skew (B3)', async () => {
+      const mint = sandbox.stub();
+      mint.onFirstCall().resolves({ token: 'a', expiresInMs: 2000 }); // < 5000 skew
+      mint.onSecondCall().resolves({ token: 'b', expiresInMs: 2000 });
+
+      // 2000 - 5000 would be born-stale; the guard keeps the real 2000 expiry instead.
+      const first = await getCachedToken('k1', mint, 0);
+      const beforeExpiry = await getCachedToken('k1', mint, 1999);
+      const atExpiry = await getCachedToken('k1', mint, 2000);
+
+      expect(first).to.equal('a');
+      expect(beforeExpiry).to.equal('a');
+      expect(atExpiry).to.equal('b');
+    });
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Makes the flag-gated per-brand Semrush auth seam (shipped inert in #3064) a seamless drop-in for the eventual S2S wiring, **without turning it on**. Adds a decision-independent dual-mode credential provider and lands the three PR-3a hardening items deferred from that review. Still inert by default — no behavior change in any environment.

## 2. Reasoning
The seam from #3064 is provider-less and flag-off. The upstream technical-account (TA) decision is still contested along two axes (spec §6.2), and the S2S path itself is blocked (LLMO-6836). Rather than wait, this PR pre-builds both contested shapes behind config so the eventual decision is a **config flip, not a rewrite**, and closes the correctness gaps the #3064 review flagged as required-before-flip. Everything remains gated: no provider is registered, the flag defaults off, and the shared `client_credentials` path is byte-identical to today.

## 3. High-level overview of the changes

**Part A — dual-mode credential provider** (`semrush-credential-provider.js`, new)
- `createDualModeSemrushCredentialProvider({ config, resolveOrgId, resolveRequestWorkspace, lookupWorkspaceForOrg, mintToken })` returns a provider with the exact `(brand, env) => SemrushCredential | null` shape the resolver expects.
- Implements **both** contested knobs (spec §6.2) so landing the decision is a config flip:
  - **Knob A — credential granularity:** `SHARED` (one TA) vs `PER_ORG` (one TA per org). Controls only the credential scope/cache key.
  - **Knob B — workspace selection:** `REQUEST` (`workspaceId` from the request) vs `TOKEN_ORG_MAPPING` (`ims_org_id` → workspace via an injected lookup). Controls only the descriptor's `workspaceHint`.
- **Default-to-code:** `PER_ORG` + `TOKEN_ORG_MAPPING` (spec §6.2 — most likely to survive a security review).
- The org resolver, request-workspace resolver, `ims_org_id → workspace` mapping (candidate source: serenity-docs `INDEX.md`), and token minter are all **injected seams**. No brand/org/workspace value is hardcoded; the built-in extractors only read fields off the passed context.
- Registers **nothing** — it is an available implementation, installed only by a future PR (3b) via `setSemrushCredentialProvider`.

**Part B — hardening deferred from the #3064 (PR-3a) review** (`semrush-credential-resolver.js`, `grpc-transport.js`)
1. **In-flight token coalescing:** `getCachedToken` now shares a single outstanding mint across concurrent cold/expired callers for one key (in-flight Promise map), instead of each minting its own token. Directly addresses the thundering-herd suggestion in the #3064 review.
2. **Transport teardown on eviction:** the per-credential client pool now owns an `Http2SessionManager` per entry and `abort()`s it on eviction/reset, so the evicted transport's HTTP/2 session is closed rather than leaked.
3. **TTL skew margin:** `getCachedToken` refreshes a real (provider-supplied expiry) token a few seconds before its true expiry, avoiding a mid-flight 401. The conservative default TTL is unaffected, and a real TTL shorter than the skew keeps its own expiry (never born-stale).

`getGrpcClients` returns the same client set as before; the pool entry now internally carries its session manager, and the external return shape is unchanged.

## 4. Required information
- Jira / issue: [LLMO-7029](https://jira.corp.adobe.com/browse/LLMO-7029) (PR-3b preparation; upstream blocker [LLMO-6836](https://jira.corp.adobe.com/browse/LLMO-6836))
- Spec / design of record: adobe/mysticat-architecture#248 — `products/llmo/spec-brand-claims-semrush-ingestion-feed.md` §6.2 / §6.3 (the two pluggable knobs; default-to-code)
- Predecessor: adobe/spacecat-api-service#3064 (inert seam skeleton)

## Related Issues
- LLMO-7029 (this PR), LLMO-6836 (upstream S2S blocker — gates the live flip), spec adobe/mysticat-architecture#248 §6.3.

## 7. Test plan
(a) Local unit tests:
- `test/support/ai-visibility/semrush-credential-provider.test.js` (new): inert-by-default (importing/building the provider registers nothing — resolver still returns `null`); config validation; default mode (per-org key + org→workspace mapping); Knob A (shared key, no org needed); Knob B (request `workspaceId` vs mapping); both contested shapes from one seam set via config alone; `getAuthToken` mints for the resolved scope; no hardcoded mapping; and an end-to-end install into the resolver seam that shares one mint per credential key via `getCachedToken`.
- `test/support/ai-visibility/semrush-credential-resolver.test.js`: added B1 coalescing (single mint shared across concurrent callers; shared failure caches nothing) and B3 skew (early refresh for real tokens; default TTL unskewed; short-TTL guard).
- `test/support/ai-visibility/grpc-transport-per-brand.test.js`: added B2 teardown assertions (evicted entry and reset both `abort()` the HTTP/2 session) and mocked `Http2SessionManager`; the flag-off byte-identical path is unchanged.
- Commands + results are in the PR conversation; `npm run lint`, `npm run type-check`, and the full `npm test` suite pass.

(b) Per environment: **nothing to verify** — the flag defaults off everywhere, no provider is registered, and the shared `client_credentials` path is byte-identical. Existing `GET /llmo/ai-visibility/*` responses are unchanged. Enabling `AI_VISIBILITY_PER_BRAND_AUTH_ENABLED` with a provider installed is the first live check, and that lands in PR-3b once the contested TA decision (Knob A + Knob B) and LLMO-6836 resolve.

## 8. Deployment & merge order
- **Seam remains OFF / inert. No behavior change.** The live flip is future work (PR-3b) and is gated on LLMO-6836 (upstream S2S) plus the Knob A / Knob B decision.
- adobe/mysticat-architecture#248 — related (design of record, §6.2/§6.3); docs-only, no deploy coupling.
- Stacks on #3064 (already merged to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
