### PR TITLE
fix(serenity): bind a created market to its own Site, not its brand's

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -812,6 +812,31 @@ function SerenityController(context, log, env) {
       // `siteId` instead of a raw `brandDomain`. Captured once for both the
       // domain derivation and the direct site link below. Absent → unchanged.
       const suppliedSiteId = hasText(requestBody.siteId) ? requestBody.siteId : null;
+      // A supplied Site is resolved and ownership-checked HERE, before either mode
+      // dispatches, because the id the caller names decides what the market's
+      // project analyses: it lands on `brand_to_semrush_projects.site_id`, the
+      // per-market source of truth for `settings.ai.primary_url`. Neither handler
+      // can make that check — the sub-workspace one has no Site access, and the
+      // flat one has no organization — so a Site from another organization would
+      // otherwise be recorded verbatim and point this project at someone else's
+      // site. Unresolvable and cross-org both answer the same 400: whether the id
+      // is unknown or simply not yours is not the caller's business.
+      let suppliedSiteIdentity = null;
+      if (suppliedSiteId) {
+        const orgId = ctx?.params?.spaceCatId;
+        suppliedSiteIdentity = await resolveSiteIdentity(
+          ctx.dataAccess,
+          suppliedSiteId,
+          log,
+          orgId,
+        );
+        if (!suppliedSiteIdentity?.domain || !hasText(suppliedSiteIdentity.domain)) {
+          return createResponse(
+            { error: 'invalidRequest', message: 'siteId did not resolve to a site domain' },
+            400,
+          );
+        }
+      }
       let result;
       if (auth.mode === 'subworkspace') {
         const brand = await loadBrand(ctx, auth.brandUuid);
@@ -827,22 +852,15 @@ function SerenityController(context, log, env) {
           ...requestBody,
           primaryUrl: siteIdentityFromUrlString(requestBody.brandDomain),
         };
-        if (suppliedSiteId && !hasText(requestBody.brandDomain)) {
-          // Both values from one read, for the same reason the domain is derived
-          // here at all: the handler has no Site access. Only `primaryUrl` can
-          // carry a subpath — `brandDomain` is a bare FQDN because a path there is
-          // rejected upstream.
-          const identity = await resolveSiteIdentity(ctx.dataAccess, suppliedSiteId, log);
-          if (!identity?.domain || !hasText(identity.domain)) {
-            return createResponse(
-              { error: 'invalidRequest', message: 'siteId did not resolve to a site domain' },
-              400,
-            );
-          }
+        if (suppliedSiteIdentity && !hasText(requestBody.brandDomain)) {
+          // Both values from the read above, for the same reason the domain is
+          // derived here at all: the handler has no Site access. Only `primaryUrl`
+          // can carry a subpath — `brandDomain` is a bare FQDN because a path there
+          // is rejected upstream.
           effectiveBody = {
             ...effectiveBody,
-            brandDomain: identity.domain,
-            primaryUrl: identity.primaryUrl ?? undefined,
+            brandDomain: suppliedSiteIdentity.domain,
+            primaryUrl: suppliedSiteIdentity.primaryUrl ?? undefined,
           };
         }
         // Brand aliases are brand-level but region-scoped: the create handler

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -956,7 +956,9 @@ function SerenityController(context, log, env) {
           const projectId = result.body && 'projectId' in result.body
             ? result.body.projectId
             : null;
-          if (!projectId) {
+          if (projectId) {
+            await linkSiteToRow(ctx.dataAccess, projectId, linkedSiteId, log);
+          } else {
             // Unreachable while the handler keeps its 201 contract (a created
             // market always names its project). Worth a line if that ever
             // changes: the market silently keeps no site otherwise, which is
@@ -965,7 +967,6 @@ function SerenityController(context, log, env) {
               brandId: auth.brandUuid, siteId: linkedSiteId,
             });
           }
-          await linkSiteToRow(ctx.dataAccess, projectId, linkedSiteId, log);
         }
       } else {
         // Flat handler self-derives brandDomain from siteId (it has Site access).

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -956,6 +956,15 @@ function SerenityController(context, log, env) {
           const projectId = result.body && 'projectId' in result.body
             ? result.body.projectId
             : null;
+          if (!projectId) {
+            // Unreachable while the handler keeps its 201 contract (a created
+            // market always names its project). Worth a line if that ever
+            // changes: the market silently keeps no site otherwise, which is
+            // exactly the failure this whole path exists to have fixed.
+            log?.warn?.('serenity create-market: 201 without a projectId — market left unlinked', {
+              brandId: auth.brandUuid, siteId: linkedSiteId,
+            });
+          }
           await linkSiteToRow(ctx.dataAccess, projectId, linkedSiteId, log);
         }
       } else {

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -88,7 +88,11 @@ import {
   unlinkMarketSiteIfOrphaned,
 } from '../support/serenity/site-linkage.js';
 import { X_PROMISE_TOKEN_HEADER, PROMISE_TOKEN_REQUIRED_ERROR_CODE } from '../utils/constants.js';
-import { tombstoneAllForBrand, linkSiteToLiveRows } from '../support/serenity/mapping-rows.js';
+import {
+  tombstoneAllForBrand,
+  linkSiteToLiveRows,
+  linkSiteToRow,
+} from '../support/serenity/mapping-rows.js';
 import { logUpstreamError } from '../support/serenity/upstream-log.js';
 
 const MAX_ERR_MSG_LEN = 500;
@@ -913,11 +917,22 @@ function SerenityController(context, log, env) {
         // Semrush project is created. Best-effort: never fails a live market.
         if (result?.status === 201) {
           const linkedSiteId = await ensureMarketSite(ctx, {
-            // Optional-chained so a missing/throwing accessor can't 500 a market
-            // that is already live upstream — the mirror is best-effort.
-            organizationId: brand.getOrganizationId?.(),
+            // The org from the route, which is the same org the brand belongs to
+            // (resolveBrandUuid scopes the brand lookup to it). It cannot come
+            // from the Brand model: that schema deliberately does not map
+            // `organization_id` (brand.schema.js), so there is no accessor for it
+            // — and asking for one yields `undefined`, which `ensureMarketSite`
+            // treats as bad input and returns null for WITHOUT logging. That is
+            // the one silent path it has, which is why a market never carried a
+            // site despite every visible step succeeding.
+            organizationId: ctx?.params?.spaceCatId,
             brandId: auth.brandUuid,
-            domain: effectiveBody.brandDomain,
+            // The url this market TRACKS, which is what its Site must mirror —
+            // `brandDomain` is the host it is filed under and drops any subpath.
+            // The two coincide whenever both derive from one input; they part as
+            // soon as a market carries a url of its own, and the Site must follow
+            // the tracked value, never the host.
+            domain: effectiveBody.primaryUrl ?? effectiveBody.brandDomain,
             // When the caller supplied a siteId, link THAT site directly (skip the
             // domain→Site find-or-create); the client already holds the identity.
             siteId: suppliedSiteId ?? undefined,
@@ -929,10 +944,19 @@ function SerenityController(context, log, env) {
             requireLink: false,
             log,
           });
-          // Bind the market↔site on the live mapping rows — the DTO's source of
-          // truth (surfaced by the sub-workspace list/get enrichment). Scope-guarded
-          // to unlinked live rows (mapping-rows.js); never overwrites an existing link.
-          await linkSiteToLiveRows(ctx.dataAccess, auth.brandUuid, linkedSiteId, log);
+          // Bind the market↔site on THIS market's row — the per-market source of
+          // truth for the url its project tracks, and what the sub-workspace
+          // list/get enrichment surfaces. Scoped to the one row named by the new
+          // project id: a market created against its own url must not have that
+          // site spread across whichever sibling rows are unlinked (mapping-rows.js).
+          // `in` rather than a cast: the handler returns a success|error union
+          // that a `status === 201` test cannot narrow, and this both satisfies
+          // that and stays a real runtime guard — a future error shape reaching
+          // here feeds no id to the link instead of `undefined` silently.
+          const projectId = result.body && 'projectId' in result.body
+            ? result.body.projectId
+            : null;
+          await linkSiteToRow(ctx.dataAccess, projectId, linkedSiteId, log);
         }
       } else {
         // Flat handler self-derives brandDomain from siteId (it has Site access).

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -12,7 +12,7 @@
 
 // @ts-check
 
-import { hasText, siteIdentityFromUrlString } from '@adobe/spacecat-shared-utils';
+import { hasText, isValidUUID, siteIdentityFromUrlString } from '@adobe/spacecat-shared-utils';
 
 import { ErrorWithStatusCode } from '../../utils.js';
 import {
@@ -227,6 +227,13 @@ function validateCreateBody(body) {
   // domain and the tracked url from it (resolveSiteUrls). One of the two is required.
   if (!hasText(body?.brandDomain) && !hasText(body?.siteId)) {
     errors.push('brandDomain or siteId is required');
+  }
+  // Validated even though only the sub-workspace path resolves it: flat mode
+  // records it straight onto `brand_to_semrush_projects.site_id`, a uuid column,
+  // so a malformed value that gets this far surfaces as a write failure rather
+  // than as the bad request it is.
+  if (hasText(body?.siteId) && !isValidUUID(body.siteId)) {
+    errors.push('siteId must be a valid UUID');
   }
   if (!Array.isArray(body?.brandNames) || body.brandNames.length === 0
       || !body.brandNames.every(hasText)) {

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -457,6 +457,15 @@ export async function handleCreateMarket(
       semrushProjectId,
       geoTargetId: location.geoTargetId,
       languageCode,
+      // The market's own Site, when the caller named one — the per-market source
+      // of truth for the url this project tracks. It is the identity the project
+      // was just provisioned against (`resolveSiteIdentity` above derived both
+      // `brandDomain` and `primaryUrl` from it), so recording it here is what
+      // stops the market resolving to its brand's anchor by fallback later.
+      // A `brandDomain`-only create records none: flat mode resolves no Site from
+      // a raw domain, and inventing the brand's anchor would assert a per-market
+      // fact nobody stated.
+      ...(hasText(body.siteId) ? { siteId: body.siteId } : {}),
     });
   } catch (e) {
     log?.error?.(

--- a/src/support/serenity/mapping-rows.js
+++ b/src/support/serenity/mapping-rows.js
@@ -280,6 +280,9 @@ export async function linkSiteToLiveRows(dataAccess, brandId, siteId, log) {
  */
 export async function linkSiteToRow(dataAccess, semrushProjectId, siteId, log) {
   const BrandSemrushProject = dataAccess?.BrandSemrushProject;
+  // `!x || !hasText(x)` rather than `hasText` alone: hasText is typed `(string)`
+  // and these params are `string|null|undefined`, so the truthiness check is what
+  // narrows them for the type-check gate. Same shape as `linkSiteToLiveRows`.
   if (!BrandSemrushProject || !semrushProjectId || !hasText(semrushProjectId)
       || !siteId || !hasText(siteId)) {
     return;

--- a/src/support/serenity/mapping-rows.js
+++ b/src/support/serenity/mapping-rows.js
@@ -252,3 +252,49 @@ export async function linkSiteToLiveRows(dataAccess, brandId, siteId, log) {
     });
   }
 }
+
+/**
+ * Links `siteId` onto the ONE live mapping row named by `semrushProjectId`.
+ *
+ * The per-market counterpart to `linkSiteToLiveRows`. A market's `site_id` is
+ * the per-market source of truth for the url its project tracks, so a market
+ * created against its own url must record ITS site — not have the brand's
+ * anchor stand in for it, and not have its site spread to whichever siblings
+ * happen to be unlinked. `linkSiteToLiveRows` remains correct where it is used:
+ * activation provisions every market in one batch against a single resolved
+ * brand url, so one Site genuinely answers for all of them.
+ *
+ * Targeting the row by its own unique key also closes a race the by-brand sweep
+ * cannot: two concurrent creates on one brand each leave an unlinked row behind
+ * before either links, so the first caller's `siteId IS NULL` scan would sweep up
+ * the second caller's market and give it the wrong site.
+ *
+ * Never overwrites an existing link — same invariant as `linkSiteToLiveRows`.
+ * A row that already names a site has been spoken for; correcting a wrong link
+ * is a deliberate act, not a side effect of a create.
+ *
+ * @param {any} dataAccess
+ * @param {string|null|undefined} semrushProjectId - the row's unique key.
+ * @param {string|null|undefined} siteId - the market's own Site.
+ * @param {any} [log]
+ */
+export async function linkSiteToRow(dataAccess, semrushProjectId, siteId, log) {
+  const BrandSemrushProject = dataAccess?.BrandSemrushProject;
+  if (!BrandSemrushProject || !semrushProjectId || !hasText(semrushProjectId)
+      || !siteId || !hasText(siteId)) {
+    return;
+  }
+  try {
+    const row = await BrandSemrushProject.findBySemrushProjectId(semrushProjectId);
+    // Gone, tombstoned, or already linked — nothing to do in any of the three.
+    if (!row || row.getDeletedAt?.() || row.getSiteId?.()) {
+      return;
+    }
+    row.setSiteId(siteId);
+    await row.save();
+  } catch (e) {
+    log?.error?.(`serenity mapping row: ${WRITE_FAILED_TOKEN} — site link failed`, {
+      semrushProjectId, siteId, op: 'link-site-row', error: e?.message,
+    });
+  }
+}

--- a/src/support/serenity/site-linkage.js
+++ b/src/support/serenity/site-linkage.js
@@ -340,15 +340,18 @@ export async function ensureMarketSite(ctx, {
  * detection does not report a difference that is not there.
  *
  * Best-effort: returns null (never throws) on missing input, unavailable
- * data-access, an unknown site, or a lookup failure.
+ * data-access, an unknown site, a cross-org site, or a lookup failure.
  *
  * @param {object} dataAccess - `ctx.dataAccess` (reads `dataAccess.Site`).
  * @param {string|null|undefined} siteId - the SpaceCat Site UUID to resolve.
  * @param {object} [log] - logger.
+ * @param {string} [organizationId] - when given, the Site must belong to this
+ *   organization or nothing resolves. Omit only where the caller genuinely has
+ *   no organization to check against.
  * @returns {Promise<{domain: string|null, primaryUrl: string|null}|null>} the
  *   derived values, or null when the site cannot be resolved.
  */
-export async function resolveSiteIdentity(dataAccess, siteId, log) {
+export async function resolveSiteIdentity(dataAccess, siteId, log, organizationId) {
   if (!siteId || !hasText(siteId)) {
     return null;
   }
@@ -361,6 +364,17 @@ export async function resolveSiteIdentity(dataAccess, siteId, log) {
     const site = await Site.findById(siteId);
     if (!site) {
       log?.warn?.('resolveSiteIdentity: site not found', { siteId });
+      return null;
+    }
+    // Same-org guard, when the caller can state the organization. A Site named by
+    // the request decides what the market's project analyses (its url reaches
+    // `settings.ai.primary_url` via brand_to_semrush_projects.site_id), so a Site
+    // belonging to another organization must not resolve — it would point one
+    // customer's project at another's site.
+    if (organizationId && hasText(organizationId) && site.getOrganizationId() !== organizationId) {
+      log?.warn?.('resolveSiteIdentity: site belongs to another organization; refusing to resolve', {
+        siteId, siteOrg: site.getOrganizationId(), brandOrg: organizationId,
+      });
       return null;
     }
     const baseURL = site.getBaseURL();

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1445,7 +1445,7 @@ describe('SerenityController', () => {
       // The row is keyed by project id, so without one there is nothing to bind
       // to — the market keeps no site. Unreachable while the handler holds its
       // contract, which is why it must not fail silently if that ever changes.
-      expect(linkSiteToRowStub).to.have.been.calledOnceWith(ctx.dataAccess, null, 'site-uuid-1');
+      expect(linkSiteToRowStub).to.not.have.been.called;
       expect(log.warn).to.have.been.calledWithMatch(/201 without a projectId/);
     });
 

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1427,7 +1427,29 @@ describe('SerenityController', () => {
       expect(linkSiteToLiveRowsStub).to.not.have.been.called;
     });
 
-    it('createMarket mirrors the url the market TRACKS, not the host it is filed under', async () => {
+    it('createMarket warns and links nothing when a 201 names no project', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({
+        status: 201,
+        body: { brandId: BRAND, geoTargetId: 2840, languageCode: 'en' },
+      });
+      ensureMarketSiteStub.resolves('site-uuid-1');
+      const log = fakeLog();
+      const controller = SerenityController({ env: {} }, log, {});
+      const ctx = fakeContext({
+        data: {
+          market: 'us', languageCode: 'en', brandDomain: 'x.com', brandNames: ['X'],
+        },
+      });
+      const response = await controller.createMarket(ctx);
+      expect(response.status).to.equal(201);
+      // The row is keyed by project id, so without one there is nothing to bind
+      // to — the market keeps no site. Unreachable while the handler holds its
+      // contract, which is why it must not fail silently if that ever changes.
+      expect(linkSiteToRowStub).to.have.been.calledOnceWith(ctx.dataAccess, null, 'site-uuid-1');
+      expect(log.warn).to.have.been.calledWithMatch(/201 without a projectId/);
+    });
+
+    it('createMarket mirrors the brand host when the market carries no url of its own', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({
         status: 201,
         body: {
@@ -1439,10 +1461,11 @@ describe('SerenityController', () => {
         data: {
           market: 'us',
           languageCode: 'en',
-          // A subpath survives into primaryUrl; brandDomain is host-only because
-          // a path there is rejected upstream. The market's Site must mirror the
-          // tracked value — anchoring it to the host would record a brand
-          // analysing nba.com/kings against the root nba.com Site.
+          // The fallback arm: with no siteId, primaryUrl is derived from
+          // brandDomain and the two coincide. The arm where they diverge — a
+          // supplied siteId whose Site carries a subpath — is asserted by the
+          // `derives brandDomain from a supplied siteId` case below, which is
+          // the only way a market gets a url the brand host does not express.
           brandDomain: 'nba.com',
           brandNames: ['X'],
         },

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -183,6 +183,7 @@ describe('SerenityController', () => {
   let getBrandBaseSiteIdStub;
   let exchangePromiseTokenStub;
   let linkSiteToLiveRowsStub;
+  let linkSiteToRowStub;
   let tombstoneAllForBrandStub;
   let createAndEnqueueJobStub;
   let MockTransportError;
@@ -220,6 +221,7 @@ describe('SerenityController', () => {
     getBrandBaseSiteIdStub = sinon.stub().resolves(null);
     exchangePromiseTokenStub = sinon.stub().resolves('exchanged-ims-token');
     linkSiteToLiveRowsStub = sinon.stub().resolves();
+    linkSiteToRowStub = sinon.stub().resolves();
     tombstoneAllForBrandStub = sinon.stub().resolves();
     createAndEnqueueJobStub = sinon.stub().resolves({
       getId: () => 'job-abc', getStatus: () => 'IN_PROGRESS',
@@ -313,6 +315,7 @@ describe('SerenityController', () => {
       },
       '../../src/support/serenity/mapping-rows.js': {
         linkSiteToLiveRows: linkSiteToLiveRowsStub,
+        linkSiteToRow: linkSiteToRowStub,
         tombstoneAllForBrand: tombstoneAllForBrandStub,
       },
       '../../src/support/serenity/async-job-runner.js': {
@@ -1400,8 +1403,13 @@ describe('SerenityController', () => {
       expect(opts).to.include({ organizationId: ORG, brandId: BRAND, domain: 'x.com' });
     });
 
-    it('createMarket links the mirrored site onto the mapping row on 201', async () => {
-      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: { brandId: BRAND, geoTargetId: 2840, languageCode: 'en' } });
+    it('createMarket links the mirrored site onto THIS market\'s mapping row on 201', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({
+        status: 201,
+        body: {
+          brandId: BRAND, geoTargetId: 2840, languageCode: 'en', projectId: 'P-NEW',
+        },
+      });
       ensureMarketSiteStub.resolves('site-uuid-1');
       const controller = SerenityController({ env: {} }, fakeLog(), {});
       const ctx = fakeContext({
@@ -1411,7 +1419,37 @@ describe('SerenityController', () => {
       });
       const response = await controller.createMarket(ctx);
       expect(response.status).to.equal(201);
-      expect(linkSiteToLiveRowsStub).to.have.been.calledOnceWith(ctx.dataAccess, BRAND, 'site-uuid-1');
+      // Scoped to the row named by the new project id. A market created against
+      // its own url must not have that site spread across whichever sibling rows
+      // happen to be unlinked — site_id is the PER-MARKET source of truth for the
+      // url a project tracks (serenity-docs#356).
+      expect(linkSiteToRowStub).to.have.been.calledOnceWith(ctx.dataAccess, 'P-NEW', 'site-uuid-1');
+      expect(linkSiteToLiveRowsStub).to.not.have.been.called;
+    });
+
+    it('createMarket mirrors the url the market TRACKS, not the host it is filed under', async () => {
+      handlers.handleCreateMarketSubworkspace.resolves({
+        status: 201,
+        body: {
+          brandId: BRAND, geoTargetId: 2840, languageCode: 'en', projectId: 'P-NEW',
+        },
+      });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.createMarket(fakeContext({
+        data: {
+          market: 'us',
+          languageCode: 'en',
+          // A subpath survives into primaryUrl; brandDomain is host-only because
+          // a path there is rejected upstream. The market's Site must mirror the
+          // tracked value — anchoring it to the host would record a brand
+          // analysing nba.com/kings against the root nba.com Site.
+          brandDomain: 'nba.com',
+          brandNames: ['X'],
+        },
+      }));
+      expect(response.status).to.equal(201);
+      const opts = ensureMarketSiteStub.firstCall.args[1];
+      expect(opts.domain).to.equal('nba.com');
     });
 
     it('createMarket does NOT mirror a Site when the upstream create did not return 201', async () => {
@@ -1445,9 +1483,14 @@ describe('SerenityController', () => {
       // the controller does not pass this the subpath is lost for good and the
       // project silently tracks the parent domain.
       expect(handlerBody.primaryUrl).to.equal('acme.com/markets');
-      // ensureMarketSite links THAT site directly (siteId + derived domain).
+      // ensureMarketSite links THAT site directly. `domain` carries the tracked
+      // url rather than the host — the Site must mirror what the market analyses,
+      // subpath included. It is moot on this path (a supplied siteId takes the
+      // fast path and skips domain resolution entirely) and load-bearing on the
+      // brandDomain-only path, so it is asserted here to pin the value the
+      // controller actually hands over.
       const opts = ensureMarketSiteStub.firstCall.args[1];
-      expect(opts).to.include({ siteId: 'site-onboarded', domain: 'acme.com' });
+      expect(opts).to.include({ siteId: 'site-onboarded', domain: 'acme.com/markets' });
     });
 
     it('createMarket 400s when a supplied siteId does not resolve to a domain', async () => {

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1487,6 +1487,29 @@ describe('SerenityController', () => {
       expect(ensureMarketSiteStub).to.not.have.been.called;
     });
 
+    it('createMarket 400s on a siteId the caller does not own, even alongside a brandDomain', async () => {
+      // The unguarded shape: with brandDomain present nothing used to read the
+      // Site, so a foreign UUID was recorded verbatim as the market's own — and
+      // that value decides what the project analyses. The org check runs on every
+      // supplied siteId now, before either mode dispatches.
+      resolveSiteIdentityStub.resolves(null);
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const ctx = fakeContext({
+        data: {
+          market: 'us',
+          languageCode: 'en',
+          brandDomain: 'x.com',
+          siteId: '00000000-0000-4000-8000-00000000f0f0',
+          brandNames: ['X'],
+        },
+      });
+      const response = await controller.createMarket(ctx);
+      expect(response.status).to.equal(400);
+      // The organization is what makes the check possible, so it must be passed.
+      expect(resolveSiteIdentityStub).to.have.been.calledWith(ctx.dataAccess, '00000000-0000-4000-8000-00000000f0f0', sinon.match.any, ORG);
+      expect(handlers.handleCreateMarketSubworkspace).to.not.have.been.called;
+    });
+
     it('createMarket derives brandDomain from a supplied siteId and links THAT site (LLMO-6405)', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: { brandId: BRAND, geoTargetId: 2840, languageCode: 'en' } });
       resolveSiteIdentityStub.resolves({ domain: 'acme.com', primaryUrl: 'acme.com/markets' });

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -12,7 +12,7 @@
 
 import { expect } from 'chai';
 import {
-  ORG_1_ID, BRAND_1_ID, SITE_1_ID,
+  ORG_1_ID, BRAND_1_ID, SITE_1_ID, SITE_2_ID,
 } from '../seed-ids.js';
 import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
 
@@ -660,12 +660,39 @@ export default function serenityTests(
       // absent key).
       expect(slice.promptsCount).to.equal(0);
       expect(slice.modelsCount).to.equal(0);
-      // NOTE (LLMO-6405): the sub-workspace market DTO also carries `siteId`
-      // (enriched from the brand_to_semrush_projects mapping row). The round-trip
-      // siteId assertions were removed pending live verification of the mapping-row
-      // enrichment in the IT stack — the field is additive and the UI degrades to
-      // domain-keying when it is null, so this does not block the feature. Unit
-      // coverage for the create-time binding lives in site-linkage.test.js.
+    });
+
+    it('binds each market to its OWN site, so two markets of one brand differ', async () => {
+      // The point of serenity-docs#356. `brand_to_semrush_projects.site_id` is
+      // the per-market source of truth for the url a project tracks, but every
+      // derivation used to resolve ONE url per brand and apply it to every market
+      // in that brand's sub-workspace — so a brand whose GB market genuinely
+      // tracks a different site than its US market could not be expressed at all.
+      //
+      // Same language, two countries: the two markets differ only in the Site
+      // they were created from, which is exactly the axis under test.
+      const GB_GEO = 2826; // GB: 2000 + ISO numeric 826.
+      const us = await getHttpClient().admin.post(`${base}/markets`, {
+        market: 'US', languageCode: 'en', siteId: SITE_1_ID, brandNames: ['Test Brand'],
+      });
+      expect(us.status).to.equal(201);
+      const gb = await getHttpClient().admin.post(`${base}/markets`, {
+        market: 'GB', languageCode: 'en', siteId: SITE_2_ID, brandNames: ['Test Brand'],
+      });
+      expect(gb.status).to.equal(201);
+
+      const res = await getHttpClient().admin.get(`${base}/markets`);
+      expect(res.status).to.equal(200);
+      const bySlice = (geo) => res.body.items.find(
+        (m) => m.geoTargetId === geo && m.languageCode === 'en',
+      );
+      expect(bySlice(US_GEO), 'the US market should round-trip').to.exist;
+      expect(bySlice(GB_GEO), 'the GB market should round-trip').to.exist;
+      // Each row carries the Site it was created from. Binding by brand instead
+      // would give both markets whichever site was resolved first.
+      expect(bySlice(US_GEO).siteId).to.equal(SITE_1_ID);
+      expect(bySlice(GB_GEO).siteId).to.equal(SITE_2_ID);
+      expect(bySlice(US_GEO).siteId).to.not.equal(bySlice(GB_GEO).siteId);
     });
 
     it('GET /serenity/markets/:geo/:lang resolves a created+published market', async () => {

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -341,6 +341,56 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     expect(transport.createProject.firstCall.args[1].domain).to.equal('acme.com');
   });
 
+  it('records the market\'s own Site on the mapping row when the caller names one', async () => {
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(null);
+    dataAccess.BrandSemrushProject.create.resolves();
+    dataAccess.Site.findById.resolves({ getBaseURL: () => 'https://kisqali.de' });
+    const transport = {
+      listLanguages: sinon.stub().resolves({ items: [{ id: 'lang-de', name: 'German' }] }),
+      createProject: sinon.stub().resolves({ id: 'proj-de' }),
+      updateProject: sinon.stub().resolves(),
+      publishProject: sinon.stub().resolves(),
+    };
+
+    await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'DE', languageCode: 'de', siteId: 'site-de', brandNames: ['Kisqali'],
+    }, fakeLog());
+
+    // site_id is the PER-MARKET source of truth for the url a project tracks
+    // (serenity-docs#356). It is the identity this project was just provisioned
+    // against, so recording it here is what stops the market resolving to its
+    // brand's anchor by fallback later.
+    expect(dataAccess.BrandSemrushProject.create).to.have.been.calledOnceWithExactly({
+      brandId: BRAND,
+      semrushProjectId: 'proj-de',
+      geoTargetId: 2276,
+      languageCode: 'de',
+      siteId: 'site-de',
+    });
+  });
+
+  it('records no Site when the market was created from a bare brandDomain', async () => {
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(null);
+    dataAccess.BrandSemrushProject.create.resolves();
+    const transport = {
+      listLanguages: sinon.stub().resolves({ items: [{ id: 'lang-en', name: 'English' }] }),
+      createProject: sinon.stub().resolves({ id: 'proj-new' }),
+      updateProject: sinon.stub().resolves(),
+      publishProject: sinon.stub().resolves(),
+    };
+
+    await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'US', languageCode: 'en', brandDomain: 'adobe.com', brandNames: ['Adobe'],
+    }, fakeLog());
+
+    // Flat mode resolves no Site from a raw domain, and inventing the brand's
+    // anchor here would assert a per-market fact nobody stated.
+    const created = dataAccess.BrandSemrushProject.create.firstCall.args[0];
+    expect(created).to.not.have.property('siteId');
+  });
+
   it('PATCHes the tracked url with the site path the domain cannot carry', async () => {
     const dataAccess = makeDataAccess([]);
     dataAccess.BrandSemrushProject.findBySlice.resolves(null);

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -166,6 +166,19 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     expect(result.body.error).to.equal('invalidRequest');
   });
 
+  it('400s on a siteId that is not a UUID', async () => {
+    // Flat mode records the value straight onto a uuid column, so a malformed one
+    // has to be rejected here rather than at the write.
+    const transport = {};
+    const dataAccess = makeDataAccess([]);
+    const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'US', languageCode: 'en', brandDomain: 'adobe.com', siteId: 'not-a-uuid', brandNames: ['Adobe'],
+    }, fakeLog());
+    expect(result.status).to.equal(400);
+    expect(result.body.error).to.equal('invalidRequest');
+    expect(result.body.message).to.match(/siteId must be a valid UUID/);
+  });
+
   it('400s on unknown market', async () => {
     const transport = {};
     const dataAccess = makeDataAccess([]);
@@ -332,11 +345,11 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     };
 
     const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
-      market: 'US', languageCode: 'en', siteId: 'site-42', brandNames: ['Adobe'],
+      market: 'US', languageCode: 'en', siteId: '00000000-0000-4000-8000-000000000042', brandNames: ['Adobe'],
     }, fakeLog());
 
     expect(result.status).to.equal(201);
-    expect(dataAccess.Site.findById).to.have.been.calledOnceWith('site-42');
+    expect(dataAccess.Site.findById).to.have.been.calledOnceWith('00000000-0000-4000-8000-000000000042');
     // The Semrush project domain is the hostname resolved from the site base_url.
     expect(transport.createProject.firstCall.args[1].domain).to.equal('acme.com');
   });
@@ -354,7 +367,7 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     };
 
     await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
-      market: 'DE', languageCode: 'de', siteId: 'site-de', brandNames: ['Kisqali'],
+      market: 'DE', languageCode: 'de', siteId: '00000000-0000-4000-8000-0000000000de', brandNames: ['Kisqali'],
     }, fakeLog());
 
     // site_id is the PER-MARKET source of truth for the url a project tracks
@@ -366,7 +379,7 @@ describe('handlers/markets.js — handleCreateMarket', () => {
       semrushProjectId: 'proj-de',
       geoTargetId: 2276,
       languageCode: 'de',
-      siteId: 'site-de',
+      siteId: '00000000-0000-4000-8000-0000000000de',
     });
   });
 
@@ -404,7 +417,7 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     };
 
     const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
-      market: 'US', languageCode: 'en', siteId: 'site-42', brandNames: ['Kings'],
+      market: 'US', languageCode: 'en', siteId: '00000000-0000-4000-8000-000000000042', brandNames: ['Kings'],
     }, fakeLog());
 
     expect(result.status).to.equal(201);
@@ -455,7 +468,7 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     const log = fakeLog();
 
     const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
-      market: 'US', languageCode: 'en', siteId: 'site-42', brandNames: ['Kings'],
+      market: 'US', languageCode: 'en', siteId: '00000000-0000-4000-8000-000000000042', brandNames: ['Kings'],
     }, log);
 
     // The subpath identity was derived from the Site and attempted...
@@ -485,7 +498,7 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     };
 
     const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
-      market: 'US', languageCode: 'en', brandDomain: 'adobe.com', siteId: 'site-42', brandNames: ['Adobe'],
+      market: 'US', languageCode: 'en', brandDomain: 'adobe.com', siteId: '00000000-0000-4000-8000-000000000042', brandNames: ['Adobe'],
     }, fakeLog());
 
     expect(result.status).to.equal(201);
@@ -502,7 +515,7 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     };
 
     const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
-      market: 'US', languageCode: 'en', siteId: 'site-missing', brandNames: ['Adobe'],
+      market: 'US', languageCode: 'en', siteId: '00000000-0000-4000-8000-00000000dead', brandNames: ['Adobe'],
     }, fakeLog());
 
     expect(result.status).to.equal(400);

--- a/test/support/serenity/mapping-rows.test.js
+++ b/test/support/serenity/mapping-rows.test.js
@@ -15,6 +15,7 @@ import sinon from 'sinon';
 
 import {
   upsertMappingRow, tombstoneMappingRow, tombstoneAllForBrand, linkSiteToLiveRows,
+  linkSiteToRow,
 } from '../../../src/support/serenity/mapping-rows.js';
 
 const BRAND = 'brand-1';
@@ -296,6 +297,89 @@ describe('serenity mapping-rows', () => {
       expect(log.error).to.have.been.calledOnce;
       expect(log.error.firstCall.args[0]).to.include('SERENITY_MAPPING_ROW_WRITE_FAILED');
       expect(log.error.firstCall.args[1]).to.include({ failed: 1, total: 2 });
+    });
+  });
+
+  describe('linkSiteToRow', () => {
+    const PROJECT = 'proj-new';
+    const SITE = 'site-1';
+
+    it('no-ops when dataAccess has no BrandSemrushProject, projectId, or siteId is missing', async () => {
+      const findBySemrushProjectId = sinon.stub().resolves(fakeRow());
+      await linkSiteToRow({}, PROJECT, SITE, log);
+      await linkSiteToRow({ BrandSemrushProject: { findBySemrushProjectId } }, '', SITE, log);
+      await linkSiteToRow({ BrandSemrushProject: { findBySemrushProjectId } }, PROJECT, '', log);
+
+      expect(findBySemrushProjectId).to.not.have.been.called;
+      expect(log.error).to.not.have.been.called;
+    });
+
+    it('links the site onto the one row named by the project id', async () => {
+      const row = fakeRow();
+      const findBySemrushProjectId = sinon.stub().resolves(row);
+      await linkSiteToRow({ BrandSemrushProject: { findBySemrushProjectId } }, PROJECT, SITE, log);
+
+      expect(findBySemrushProjectId).to.have.been.calledOnceWith(PROJECT);
+      expect(row.setSiteId).to.have.been.calledOnceWith(SITE);
+      expect(row.save).to.have.been.calledOnce;
+    });
+
+    it('never overwrites an existing link', async () => {
+      // A row that already names a site has been spoken for — correcting a wrong
+      // link is a deliberate act, not a side effect of creating a market.
+      const row = fakeRow({ siteId: 'site-already-there' });
+      const findBySemrushProjectId = sinon.stub().resolves(row);
+      await linkSiteToRow({ BrandSemrushProject: { findBySemrushProjectId } }, PROJECT, SITE, log);
+
+      expect(row.setSiteId).to.not.have.been.called;
+      expect(row.save).to.not.have.been.called;
+    });
+
+    it('leaves a tombstoned row alone', async () => {
+      const row = fakeRow({ deletedAt: '2026-08-19T00:00:00.000Z' });
+      const findBySemrushProjectId = sinon.stub().resolves(row);
+      await linkSiteToRow({ BrandSemrushProject: { findBySemrushProjectId } }, PROJECT, SITE, log);
+
+      expect(row.setSiteId).to.not.have.been.called;
+      expect(row.save).to.not.have.been.called;
+    });
+
+    it('is a no-op (no throw) when no row matches the project id', async () => {
+      const findBySemrushProjectId = sinon.stub().resolves(null);
+      await linkSiteToRow({ BrandSemrushProject: { findBySemrushProjectId } }, PROJECT, SITE, log);
+      expect(log.error).to.not.have.been.called;
+    });
+
+    it('logs the alarmed token and swallows a save failure', async () => {
+      const row = fakeRow();
+      row.save.rejects(new Error('boom'));
+      const findBySemrushProjectId = sinon.stub().resolves(row);
+      await linkSiteToRow({ BrandSemrushProject: { findBySemrushProjectId } }, PROJECT, SITE, log);
+
+      expect(log.error).to.have.been.calledOnce;
+      expect(log.error.firstCall.args[0]).to.include('SERENITY_MAPPING_ROW_WRITE_FAILED');
+      expect(log.error.firstCall.args[1]).to.include({ op: 'link-site-row' });
+    });
+
+    it('does not touch a sibling market of the same brand', async () => {
+      // The race the by-brand sweep cannot close: two concurrent creates on one
+      // brand each leave an unlinked row behind before either links, so a
+      // siteId-IS-NULL scan would give the second caller's market the first
+      // caller's site.
+      const mine = fakeRow();
+      const sibling = fakeRow();
+      const findBySemrushProjectId = sinon.stub().resolves(mine);
+      const allByBrandId = sinon.stub().resolves([mine, sibling]);
+      await linkSiteToRow(
+        { BrandSemrushProject: { findBySemrushProjectId, allByBrandId } },
+        PROJECT,
+        SITE,
+        log,
+      );
+
+      expect(mine.setSiteId).to.have.been.calledOnceWith(SITE);
+      expect(sibling.setSiteId).to.not.have.been.called;
+      expect(allByBrandId).to.not.have.been.called;
     });
   });
 });

--- a/test/support/serenity/site-linkage.test.js
+++ b/test/support/serenity/site-linkage.test.js
@@ -446,6 +446,28 @@ describe('serenity site-linkage: resolveSiteIdentity', () => {
     expect(Site.findById).to.have.been.calledOnceWith('site-1');
   });
 
+  it('refuses a Site owned by another organization', async () => {
+    // The resolved url reaches `settings.ai.primary_url` through the mapping row,
+    // so resolving a foreign Site would point one customer's project at another's.
+    Site.findById.resolves({
+      getBaseURL: () => 'https://acme.com',
+      getOrganizationId: () => 'org-other',
+    });
+    expect(await resolveSiteIdentity(dataAccess, 'site-1', log, 'org-mine')).to.equal(null);
+    expect(log.warn).to.have.been.calledWithMatch(/another organization/);
+  });
+
+  it('resolves a Site of the stated organization', async () => {
+    Site.findById.resolves({
+      getBaseURL: () => 'https://acme.com',
+      getOrganizationId: () => 'org-mine',
+    });
+    expect(await resolveSiteIdentity(dataAccess, 'site-1', log, 'org-mine')).to.deep.equal({
+      domain: 'acme.com',
+      primaryUrl: 'acme.com',
+    });
+  });
+
   it('primaryUrl is scheme-less so it matches the stored upstream value', async () => {
     Site.findById.resolves({ getBaseURL: () => 'https://quickbooks.intuit.com/au/' });
     const { primaryUrl } = await resolveSiteIdentity(dataAccess, 'site-1', log);


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

Binds a newly created Serenity market to its **own** SpaceCat Site on `brand_to_semrush_projects.site_id`, instead of stamping one resolved Site across every unlinked row of the brand — and fixes the reason market creation was never linking a Site at all.

## 2. Reasoning

`brand_to_semrush_projects.site_id` is the per-market source of truth for the URL a Semrush project tracks (`settings.ai.primary_url`), which scopes what that project analyses. Creating a market wrote the resolved Site onto every unlinked live row of the brand, so one market's URL landed on whichever siblings happened to be unlinked, and a market created against its own URL was indistinguishable from one taking the brand's.

While adding integration coverage for that binding, it turned out the binding never happened at all. `ensureMarketSite` was passed `brand.getOrganizationId?.()`, and the `Brand` schema deliberately does not map `organization_id` (`brand.schema.js`), so no accessor is generated and the call evaluated to `undefined`. `ensureMarketSite` treats that as bad input and returns null through the one early return it has that logs nothing — so every visible step of market creation succeeded while the market silently kept no Site, and no warning was emitted.

That explains a fact visible in prod: of the 484 live mapping rows, the 46 with no `site_id` were **all** written by this service (`created_by = 'system'`), while every row written by the migration CLI carries one. It is also why the integration suite's `siteId` round-trip assertions were previously removed as "pending live verification" — they could not have passed.

## 3. High-level overview of the changes

**Per-market binding.** `linkSiteToRow` writes the Site onto the single row named by the new project id. `linkSiteToLiveRows` stays where it is still correct — activation provisions every market in one batch against a single resolved brand URL, so one Site genuinely answers for all of them. Scoping by project id also closes a race the by-brand sweep could not: two concurrent creates on one brand each leave an unlinked row behind before either links, so a `siteId IS NULL` scan could hand the second caller's market the first caller's Site. The helper never overwrites an existing link, matching the invariant the column now carries.

**The Site mirrors the URL the market tracks, not the host it is filed under.** `brandDomain` is host-only by contract because a path is rejected upstream, so anchoring the mirror to it recorded a brand analysing `nba.com/kings` against the root `nba.com` Site. The two values coincide whenever both derive from one input and part as soon as a market carries a URL of its own.

**Organization resolution.** It now comes from the route, which is what the brand-create path already does. This is the fix that makes any of the above observable: before it, the whole site-linkage step was a silent no-op on this path.

**A caller-named Site is validated and must be the caller's own.** `siteId` is the per-market source of truth for the url a project tracks, so it decides what that project analyses — which makes an unchecked value more than a cosmetic concern. It is rejected as a 400 unless it is a well-formed UUID (version-agnostic: Site ids come from `uuid_generate_v7`, so a v4 assertion would reject every real one) and resolves to a Site in the request's organization. The check runs in the controller, before either mode dispatches, because neither handler can perform it: the sub-workspace one has no Site access and the flat one has no organization. Unresolvable and cross-org answer the same 400 — whether an id is unknown or merely not yours is not the caller's business — and the sub-workspace domain derivation reuses that read rather than repeating it.

**Flat mode** records the caller's `siteId` on the row it creates. It deliberately records none for a bare `brandDomain`: flat mode resolves no Site from a raw domain, and substituting the brand's anchor would assert a per-market fact nobody stated.

No wire contract changes. `siteId` is already documented on both the market response and the create request; this makes the response field actually carry a per-market value rather than a brand-wide one (or nothing).

## 4. Required information

- Jira / issue: https://github.com/adobe/serenity-docs/issues/356
- Other: related https://github.com/adobe/serenity-docs/issues/348 and https://github.com/adobe/serenity-docs/issues/349 ; unblocks https://github.com/adobe/serenity-docs/issues/357

## 5. Affected / used mysticat-workspace projects

- **mysticat-data-service** — changed, in a companion PR. It owns the schema and the read/plan/reconcile side of the same column, and until it lands its reconcile flattens a per-market `site_id` back to the brand anchor. Contract shared with this PR.
- **spacecat-shared** — consumed. `BrandSemrushProject.siteId` (data-access) is the model this writes through; no change required there.

## 6. Additional information outside the code

The silent-null failure was not deduced from reading — it was observed. Running the serenity integration suite with the linkage inputs logged showed `org: undefined` with a valid `suppliedSiteId` and a valid `projectId`, and `linkedSiteId: null` as a result, on both market creates. After sourcing the organization from the route, the same suite links both markets.

Verified against **prod** (read-only) on 2026-08-19: 484 live mapping rows, 438 carrying a Site, **0** whose Site differs from their brand's anchor, 46 carrying none — and all 46 attributable to this service by `created_by`. That is the population this change stops growing.

## 7. Test plan

**Locally, beyond unit tests:** the serenity integration suite was run to completion against the real Postgres + Semrush mock stack. It now includes a round-trip case that creates two markets on one brand from two different Sites and asserts, through `GET /serenity/markets`, that the two mapping rows carry distinct and correct `siteId`s — the assertion the suite previously carried a note about deferring. This is the issue's third validation gate.

Worth knowing for anyone re-running it: the integration harness's docker-compose uses fixed container names and never resets the stack it attaches to, so two worktrees running this suite concurrently share one database and corrupt each other's seed. Run it alone, and `docker compose -f test/it/postgres/docker-compose.yml down -v` if a previous run left the stack dirty. `IT_SERVER_PORT` moves the dev server if 3002 is taken.

**dev:** after deploy, create a market from an already-onboarded Site and read it back:

```
POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets  { "market": "...", "languageCode": "...", "siteId": "<site uuid>", "brandNames": ["..."] }
GET  /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets
```

The listed market must carry that `siteId`, and a second market created from a different Site must carry the other one. Before this change the field comes back null.

**prod:** no operator action. The change affects new market creations only; existing rows are untouched, and nothing here rewrites a Site that is already recorded.

## 8. Deployment & merge order

- https://github.com/adobe/mysticat-data-service — related (coordinated cross-repo change). It owns the read, plan and persistence side of the same column.

**Order: either.** Neither blocks the other. Note only that until the companion merges, a per-market Site written here is reset to the brand's anchor by the next `serenity_migration` reconcile of that organization — the value is correct when written and not yet durable. That is a delay in the benefit, not a failure mode, and it is the state prod is in today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```