### PR TITLE
fix(serenity): resolve the activate path's organization from the route

### DIFF
--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -1643,8 +1643,13 @@ function SerenityController(context, log, env) {
       let linkedSiteId = null;
       if (allMarketsLive) {
         linkedSiteId = await ensureMarketSite(ctx, {
-          // Optional-chained so a missing/throwing accessor can't 500 the call.
-          organizationId: brand.getOrganizationId?.(),
+          // From the route, not the Brand entity: `brand.schema.js` deliberately
+          // does not map `organization_id`, so no accessor is generated for it and
+          // `brand.getOrganizationId?.()` is always `undefined`. `ensureMarketSite`
+          // reads that as bad input and returns null through its one early return
+          // that logs nothing, which would keep an activating brand `pending` with
+          // every visible step reporting success.
+          organizationId: ctx?.params?.spaceCatId,
           brandId: auth.brandUuid,
           domain: brandPrimaryUrl,
           updatedBy: 'serenity-activate',
@@ -1671,7 +1676,7 @@ function SerenityController(context, log, env) {
           // so this is where an active Serenity brand becomes site-anchored — same
           // authoritative brands.site_id contract as the brandalf activate path.
           await updateBrand({
-            organizationId: brand.getOrganizationId(),
+            organizationId: ctx?.params?.spaceCatId,
             brandId: brandUuid,
             updates: {
               status: 'active',

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -1647,8 +1647,10 @@ function SerenityController(context, log, env) {
           // does not map `organization_id`, so no accessor is generated for it and
           // `brand.getOrganizationId?.()` is always `undefined`. `ensureMarketSite`
           // reads that as bad input and returns null through its one early return
-          // that logs nothing, which would keep an activating brand `pending` with
-          // every visible step reporting success.
+          // that logs nothing — every market goes live upstream while the site
+          // link never lands, so activation answers a permanent 207 with
+          // `baseSiteId` never written and nothing warning. The route org is
+          // exact here: authorize() resolved the brand scoped to it.
           organizationId: ctx?.params?.spaceCatId,
           brandId: auth.brandUuid,
           domain: brandPrimaryUrl,

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1884,8 +1884,11 @@ describe('SerenityController', () => {
       // entity has no `getOrganizationId` at all — the fixture above fabricates one.
       // A brand shaped like the real thing is what the deployed code actually sees:
       // if the org is read off the entity, `ensureMarketSite` gets `undefined`,
-      // returns null through its one silent early return, and the brand never
-      // activates while every visible step reports success.
+      // returns null through its one silent early return, and the activation
+      // answers 207 with the site link and `baseSiteId` never written — while
+      // every visible step reports success. (Only an already-active brand
+      // reaches this path: a pending brand activates sub-workspace-only and
+      // returns before it.)
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
       const brand = makeBrandModel({ getStatus: () => 'active', getOrganizationId: undefined });
       const controller = SerenityController({ env: {} }, fakeLog(), {});

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -1879,6 +1879,39 @@ describe('SerenityController', () => {
       expect(opts).to.include({ organizationId: ORG, brandId: BRAND, domain: 'x.com' });
     });
 
+    it('activate resolves the organization from the route, not from the Brand entity', async () => {
+      // `brand.schema.js` deliberately does not map `organization_id`, so the real
+      // entity has no `getOrganizationId` at all — the fixture above fabricates one.
+      // A brand shaped like the real thing is what the deployed code actually sees:
+      // if the org is read off the entity, `ensureMarketSite` gets `undefined`,
+      // returns null through its one silent early return, and the brand never
+      // activates while every visible step reports success.
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      const brand = makeBrandModel({ getStatus: () => 'active', getOrganizationId: undefined });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandDomain: 'x.com', brandNames: ['X'], markets: [{ market: 'us', languageCode: 'en' }] },
+      }));
+      expect(response.status).to.equal(200);
+      expect(ensureMarketSiteStub.firstCall.args[1]).to.include({ organizationId: ORG });
+    });
+
+    it('activate writes the status flip against the route organization on a brand with no org accessor', async () => {
+      // The same defect one line further on, where it was NOT optional-chained: a
+      // real Brand entity would throw a TypeError here rather than degrade.
+      handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
+      ensureMarketSiteStub.resolves('primary-site-uuid');
+      const brand = makeBrandModel({ getStatus: () => 'active', getOrganizationId: undefined });
+      const controller = SerenityController({ env: {} }, fakeLog(), {});
+      const response = await controller.activate(fakeContext({
+        brand,
+        data: { brandDomain: 'x.com', brandNames: ['X'], markets: [{ market: 'us', languageCode: 'en' }] },
+      }));
+      expect(response.status).to.equal(200);
+      expect(updateBrandStub.firstCall.args[0]).to.include({ organizationId: ORG });
+    });
+
     it('activate passes a body-supplied market\'s modelIds into the options arg (LLMs applied at activation)', async () => {
       handlers.handleCreateMarketSubworkspace.resolves({ status: 201, body: {} });
       const brand = makeBrandModel({ getStatus: () => 'active' });

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -607,9 +607,16 @@ export default function serenityTests(
         brandNames: ['Test Brand'],
         markets: [{ market: 'US', languageCode: 'en' }],
       });
-      // 207 Multi-Status: per-market results, each a published 201.
-      expect(activated.status).to.equal(207);
+      // 200, not 207: every market published AND the brand_sites mirror linked, which
+      // is what full activation means. 207 is the partial-failure code — the brand stays
+      // active but something in the chain did not land. This asserted 207 for as long as
+      // the organization was read from the Brand entity, which has no accessor for it:
+      // `ensureMarketSite` got `undefined`, returned null through its one silent early
+      // return, and the site link failed on every single activation.
+      expect(activated.status).to.equal(200);
       expect(activated.body.status).to.equal('active');
+      // Only the 200 body carries it, and only a real linked Site produces one.
+      expect(activated.body.baseSiteId).to.be.a('string').and.not.empty;
       expect(activated.body.markets).to.be.an('array').that.is.not.empty;
       expect(activated.body.markets[0].status).to.equal(201);
       expect(activated.body.markets[0].body.published).to.equal(true);


### PR DESCRIPTION


## 1. Abstract

Resolves the organization from the route on the Serenity **activate** path, where it was read from an accessor the `Brand` entity does not have.

## 2. Reasoning

`brand.schema.js` is a deliberately minimal projection of the `brands` table and does not map `organization_id` — the comment there says so outright. The data-access `BaseModel` generates accessors only for declared attributes, so `getOrganizationId` does not exist on a `Brand`, and `brand.getOrganizationId?.()` evaluates to `undefined`.

Activation reads it twice, both on the body-driven markets path. Only an already-**active** brand reaches that path — a pending brand activates sub-workspace-only and returns before it (LLMO-6405) — so the affected call is an active brand's reactivation with markets in the body, which is exactly what the onboarding API drives.

The first read feeds `ensureMarketSite`. A missing organization is bad input there, and it returns null through the one early return it has that logs nothing. The `brand_sites` mirror is a required activation step, so every market goes live upstream while the site link never lands: the call answers a permanent 207 with the brand still `active` but `baseSiteId` never written and the `brand_sites` mirror never created — while every visible provisioning step reported success and nothing warned. A full 200 activation was unreachable on this path.

The second read, one branch further on in the site-anchoring write, is **not** optional-chained. On a real entity it is a `TypeError`, not a degraded value. It has never fired because the first read gates it: the brand cannot reach that write without a linked site.

Both now come from the route, which is provably the brand's own organization: `authorize()` resolves the brand via `resolveBrandUuid`, which scopes the lookup to `organization_id = spaceCatId`, so a brand from any other org 404s before activation runs. This is also what the brand-create path already does.

## 3. High-level overview of the changes

Two call sites in `activate` take `ctx.params.spaceCatId` instead of the entity accessor. No contract, response shape, or control flow changes — an activation that could not complete can now finish the same path it was already attempting.

The unit fixture is the reason this survived: `makeBrandModel` fabricates `getOrganizationId`, so the suite has been asserting the org flows correctly through a method production does not have. Rather than change a fixture the rest of the suite depends on, the two new cases construct a brand shaped like the real entity — no accessor — and assert the organization still reaches both writers. Both fail against the current code, the first with the exact 207 the defect produces.

The IT activation flow now asserts full success — 200 with a populated `baseSiteId` — instead of the 207 the defect forced it to accept.

## 4. Required information

- Other: found while implementing https://github.com/adobe/serenity-docs/issues/356 ; the same defect on the market-create path is fixed in https://github.com/adobe/spacecat-api-service/pull/3102

Introduced by: N/A

## 5. Affected / used mysticat-workspace projects

- **spacecat-shared** — consumed, unchanged. `brand.schema.js` (data-access) is the source of the constraint: it maps no `organization_id`, by design, because brands are created and owned elsewhere.

## 6. Additional information outside the code

The sibling defect on the market-create path was confirmed against a live environment rather than deduced: with the linkage inputs logged, dev showed `org: undefined` alongside a valid site and project id, and the market silently kept no Site. That path is fixed separately; this one is the same accessor, on the same file, two branches away.

Its prod signature is visible too — of the 484 live `brand_to_semrush_projects` rows, the 46 carrying no `site_id` were all written by this service, while every row the migration CLI wrote carries one.

## 7. Test plan

**Locally, beyond unit tests:** the two added cases were run against the unmodified source to confirm they fail, then against the fix to confirm they pass. Without the fix, the activation answers 207 with `baseSiteId` never populated, which is the customer-visible symptom.

**dev:** re-activate an active Serenity brand with at least one market in the body and read it back — the response must be 200 with `baseSiteId` populated, and the brand must carry its site anchor (`brands.site_id`) plus a `brand_sites` row. Before this change the same call answers 207 with neither written.

**prod:** no operator action; no data is rewritten. Brands whose activation answered 207 this way were left active without a site anchor, and simply complete on a retry.

## 8. Deployment &amp; merge order

- https://github.com/adobe/spacecat-api-service/pull/3102 — touches the same file (the create path&#39;s copy of this defect, at a different call site). No ordering requirement; merge either first and the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```