### PR TITLE
feat: default LLMO onboarding to v2 (remove legacy-site cutoff)

### DIFF
--- a/docs/llmo-brandalf-apis/v1-v2-onboarding-consistency-safeguard.md
+++ b/docs/llmo-brandalf-apis/v1-v2-onboarding-consistency-safeguard.md
@@ -40,9 +40,26 @@ defaults to v2. Concretely:
 4. otherwise → **v2**
 
 The `LLMO_ONBOARDING_DEFAULT_VERSION` kill switch is **retained** as a global
-"hold not-yet-migrated orgs on v1" switch. Existing v1 customers are **not
-migrated**: this resolver only runs at onboarding time, and already-onboarded
-orgs keep their `brandalf=false` flag and continue running v1 downstream.
+"hold not-yet-migrated orgs on v1" switch.
+
+**Where the resolver runs.** `resolveLlmoOnboardingMode` is consumed on two
+paths, not just onboarding:
+
+- `performLlmoOnboarding` (write) — on a v2 result it upserts `brandalf=true`
+  **org-wide**, so a single onboarding touch flips *every* existing site of that
+  org to v2 downstream (including sites that have no v2 brand or an empty prompt
+  set). Ops note: the remaining v1 population is dominated by one internal org
+  holding ~159 sites — onboarding any one of its sites flips all 159 at once.
+- `getBrandForOrgSite` in `brands.js` — a read-only GET, hit by BP refresh and
+  the DRS scheduler.
+
+Removing the cutoff flips a flagless pre-cutoff org to v2 on **both** paths: the
+brand resolver now returns the v2 brand where it previously 404'd. The resolver
+does **not** by itself flip an already-onboarded org's `brandalf` flag (only an
+onboarding does that), and DRS gates on the `brandalf` / `brandalf_migration`
+flags independently, so a still-flagless org keeps running v1 downstream until it
+is onboarded/flagged. (A small tracked set of orgs already resolve v1 in DRS while
+owning v2 brand rows — for those, this endpoint now serves the v2 brand.)
 
 The sections below describe the original cutoff-based design (rows referencing
 `LLMO_BRANDALF_GA_CUTOFF_MS` / "pre-cutoff sites") and are retained for

--- a/docs/llmo-brandalf-apis/v1-v2-onboarding-consistency-safeguard.md
+++ b/docs/llmo-brandalf-apis/v1-v2-onboarding-consistency-safeguard.md
@@ -2,16 +2,51 @@
 
 **Jira:** [LLMO-4176](https://jira.corp.adobe.com/browse/LLMO-4176)
 **Epic:** [LLMO-4054 — Brandalf GA (Brandalf v1 fast follows)](https://jira.corp.adobe.com/browse/LLMO-4054)
-**Status:** Implemented and tested on dev
+**Status:** Superseded in part by [LLMO-7108](https://jira.corp.adobe.com/browse/LLMO-7108)
+— the legacy-site cutoff has been removed (see the update note below). The
+`LLMO_ONBOARDING_DEFAULT_VERSION` kill switch is retained; the
+`LLMO_BRANDALF_GA_CUTOFF_MS` cutoff and its helpers are gone.
 **PRs:**
 - api-service: [adobe/spacecat-api-service#2171](https://github.com/adobe/spacecat-api-service/pull/2171)
 - audit-worker: [adobe/spacecat-audit-worker#2380](https://github.com/adobe/spacecat-audit-worker/pull/2380) *(companion fix — required for v1 onboarding to complete successfully)*
 **Lifetime:** **Temporary.** This rule is a stop-gap to keep new and legacy
 customers from drifting into a mixed v1/v2 state. It should be **removed once
 all v1 customers have been migrated to v2**, at which point
-`resolveLlmoOnboardingMode` collapses to "always v2" and both
-`LLMO_ONBOARDING_DEFAULT_VERSION` and `LLMO_BRANDALF_GA_CUTOFF_MS` can be
-deleted.
+`resolveLlmoOnboardingMode` collapses to "always v2" and
+`LLMO_ONBOARDING_DEFAULT_VERSION` can be deleted.
+
+## Update — LLMO-7108: legacy-site cutoff removed
+
+As of [LLMO-7108](https://jira.corp.adobe.com/browse/LLMO-7108) ("stop onboarding
+on v1"), the **legacy-site cutoff has been removed** so that every new onboarding
+defaults to v2. Concretely:
+
+- Deleted from `src/support/llmo-onboarding-mode.js`: `hasPreBrandalfSites`,
+  `resolveBrandalfCutoffMs`, and the `LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT`
+  constant. The `LLMO_BRANDALF_GA_CUTOFF_MS` env var is no longer read.
+- The **row-1 remediation** (which reverted `brandalf=true` → `false` for an org
+  with pre-cutoff sites under an active kill switch) is gone with it — it
+  depended on detecting pre-cutoff sites. A `brandalf=true` org is now **always
+  v2**, even under an active kill switch.
+- The resolver's `readOnly` option was removed: with the row-1 write gone the
+  function has no side effects, so callers (e.g. the `(org, site) → brand`
+  resolver GET in `brands.js`) no longer pass it.
+
+**Current decision order** in `resolveLlmoOnboardingMode`:
+
+1. `brandalf=true` → **v2**
+2. `brandalf_migration=true` → **v2**
+3. `LLMO_ONBOARDING_DEFAULT_VERSION === 'v1'` (global kill switch) → **v1**
+4. otherwise → **v2**
+
+The `LLMO_ONBOARDING_DEFAULT_VERSION` kill switch is **retained** as a global
+"hold not-yet-migrated orgs on v1" switch. Existing v1 customers are **not
+migrated**: this resolver only runs at onboarding time, and already-onboarded
+orgs keep their `brandalf=false` flag and continue running v1 downstream.
+
+The sections below describe the original cutoff-based design (rows referencing
+`LLMO_BRANDALF_GA_CUTOFF_MS` / "pre-cutoff sites") and are retained for
+historical context only — they no longer reflect the shipped code.
 
 ## Problem
 

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1117,13 +1117,9 @@ function BrandsController(ctx, log, env) {
         return unavailable;
       }
 
-      // readOnly: true keeps this GET endpoint idempotent — the resolver's
-      // kill-switch remediation (which writes to feature_flags) only fires
-      // from explicit onboarding/admin write paths, never from a high-traffic
-      // resolver hit by BP refresh and the DRS scheduler.
-      const mode = await resolveLlmoOnboardingMode(spaceCatId, context, {
-        readOnly: true,
-      });
+      // resolveLlmoOnboardingMode is side-effect free — safe to call from this
+      // GET endpoint hit by BP refresh and the DRS scheduler.
+      const mode = await resolveLlmoOnboardingMode(spaceCatId, context);
       if (mode !== LLMO_ONBOARDING_MODE_V2) {
         return notFound('No v2 brand configured for this organization');
       }

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1611,12 +1611,11 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
     // Create or find organization
     const organization = await createOrFindOrganization(imsOrgId, context, say);
 
-    // Create site BEFORE resolving the onboarding mode. createOrFindSite may
-    // re-parent an existing site into the destination org; resolveLlmoOnboardingMode
-    // reads Site.allByOrganizationId, so the re-parent has to be persisted first
-    // (createOrFindSite saves the site in that branch). Otherwise a legacy
-    // pre-cutoff site moved into a brand-new org would be misclassified as v2
-    // and instantly create the mixed state LLMO-4176 was filed to prevent.
+    // Create the site before resolving the onboarding mode so downstream steps
+    // (entitlement, config, audits) have it. createOrFindSite may re-parent an
+    // existing site into the destination org and persists that immediately.
+    // (This ordering historically also fed resolveLlmoOnboardingMode's
+    // legacy-site cutoff check, which was removed in LLMO-7108.)
     site = await createOrFindSite(baseURL, organization.getId(), context, deliveryType);
 
     const onboardingMode = await resolveLlmoOnboardingMode(organization.getId(), context);

--- a/src/support/llmo-onboarding-mode.js
+++ b/src/support/llmo-onboarding-mode.js
@@ -10,22 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import { readFeatureFlag, upsertFeatureFlag } from './feature-flags-storage.js';
+import { readFeatureFlag } from './feature-flags-storage.js';
 
 export const LLMO_FEATURE_FLAG_PRODUCT = 'LLMO';
 export const LLMO_BRANDALF_FLAG = 'brandalf';
 export const LLMO_BRANDALF_MIGRATION_FLAG = 'brandalf_migration';
 export const LLMO_ONBOARDING_MODE_V1 = 'v1';
 export const LLMO_ONBOARDING_MODE_V2 = 'v2';
-
-/**
- * Brandalf GA cutoff in Unix epoch milliseconds (2026-04-01T00:00:00Z).
- * Any site whose createdAt is strictly before this value is treated as v1 (legacy).
- * Override per-environment via LLMO_BRANDALF_GA_CUTOFF_MS without a full redeploy.
- *
- * TEMPORARY — remove once all v1 customers have been migrated to v2.
- */
-export const LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT = Date.UTC(2026, 3, 1);
 
 export async function readBrandalfFlagOverride(organizationId, postgrestClient) {
   if (!organizationId || !postgrestClient?.from) {
@@ -65,105 +56,39 @@ export async function readBrandalfMigrationFlagOverride(organizationId, postgres
 }
 
 /**
- * Resolves the Brandalf GA cutoff from the environment (epoch ms).
- * Falls back to LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT if the env var is missing or invalid.
- *
- * TEMPORARY — remove once all v1 customers have been migrated to v2.
- *
- * @param {object} context - Request context
- * @returns {number} Cutoff timestamp in milliseconds
- */
-export function resolveBrandalfCutoffMs(context) {
-  const raw = context?.env?.LLMO_BRANDALF_GA_CUTOFF_MS;
-  if (raw === undefined || raw === null || raw === '') {
-    return LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT;
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    context?.log?.warn?.(
-      `Invalid LLMO_BRANDALF_GA_CUTOFF_MS "${raw}", using default ${LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT}`,
-    );
-    return LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT;
-  }
-  return parsed;
-}
-
-/**
- * Returns true if the organization has any site whose createdAt is strictly before
- * the resolved cutoff. Sites with missing or unparseable createdAt are ignored (not
- * treated as legacy) to avoid false positives, but logged so monitoring can pick up
- * data-quality issues — silently swallowing them would bias the safeguard toward v2.
- *
- * TEMPORARY — remove once all v1 customers have been migrated to v2.
- *
- * @param {string} organizationId
- * @param {object} context - Request context (must have context.dataAccess.Site)
- * @returns {Promise<boolean>}
- */
-export async function hasPreBrandalfSites(organizationId, context) {
-  const cutoffMs = resolveBrandalfCutoffMs(context);
-  const { Site } = context.dataAccess;
-  const log = context?.log;
-  const sites = await Site.allByOrganizationId(organizationId);
-  return sites.some((s) => {
-    const createdAt = s.getCreatedAt?.();
-    if (createdAt === null || createdAt === undefined) {
-      log?.warn?.(
-        `Site ${s.getId?.() ?? '<unknown>'} in org ${organizationId} has no createdAt — skipping legacy check`,
-      );
-      return false;
-    }
-    const ts = createdAt instanceof Date
-      ? createdAt.getTime()
-      : new Date(createdAt).getTime();
-    if (!Number.isFinite(ts)) {
-      log?.warn?.(
-        `Site ${s.getId?.() ?? '<unknown>'} in org ${organizationId} has unparseable createdAt "${createdAt}" — skipping legacy check`,
-      );
-      return false;
-    }
-    return ts < cutoffMs;
-  });
-}
-
-/**
  * Resolves the LLMO onboarding mode (v1 or v2) for the given organization.
  *
- * Decision order (see decision matrix in v1-v2-onboarding-consistency-safeguard.md):
- *  1. If brandalf=true on the org:
- *     a. If kill switch is v1 AND org has pre-cutoff sites → revert brandalf
- *        flag to false, log warning, return v1 (row 1 remediation).
- *     b. Otherwise → return v2 (rows 3, 5, 7).
+ * Decision order:
+ *  1. If brandalf=true on the org → return v2 (explicit v2 migration).
  *  2. If brandalf_migration=true on the org → return v2. brandalf_migration
  *     marks an existing v1 customer that's mid-migration to v2: v2 brand
- *     entities exist and the org reads v2 config. New onboardings set
- *     brandalf=true directly, so this branch only fires for in-flight
- *     migrations. Runs before the kill switch so ops can't accidentally
- *     pin a brandalf_migration org back to v1.
- *  3. If LLMO_ONBOARDING_DEFAULT_VERSION is 'v1' → return v1 (kill switch, rows 2, 4).
- *  4. If org has pre-cutoff sites → return v1 (legacy protection, row 6).
- *  5. Otherwise → return v2 (new customer default, row 8).
+ *     entities exist and the org reads v2 config. Runs before the kill switch
+ *     so ops can't accidentally pin a brandalf_migration org back to v1.
+ *  3. If LLMO_ONBOARDING_DEFAULT_VERSION is 'v1' → return v1 (global kill
+ *     switch for orgs that have not been migrated to v2).
+ *  4. Otherwise → return v2 (default for everyone else).
  *
- * TEMPORARY — should be removed once all v1 customers have been migrated to v2.
+ * The legacy-site cutoff that previously forced pre-GA customers onto v1
+ * (createdAt before LLMO_BRANDALF_GA_CUTOFF_MS) was removed in LLMO-7108 so that
+ * every new onboarding defaults to v2 unless the kill switch explicitly holds
+ * the org back. This resolver only runs at onboarding time: already-onboarded v1
+ * customers keep their brandalf=false flag and continue running v1 downstream —
+ * it does not migrate existing orgs.
+ *
+ * TEMPORARY — the LLMO_ONBOARDING_DEFAULT_VERSION kill switch and the v1 branch
+ * should be removed once all v1 customers have been migrated to v2, at which
+ * point this collapses to "always v2".
  *
  * @param {string} organizationId
  * @param {object} context - Request context
- * @param {object} [options]
- * @param {boolean} [options.readOnly=false] When true, the resolver computes the
- *   mode but skips the row-1 remediation that flips the brandalf flag back to
- *   false in the database. Read-only callers (e.g. high-traffic resolver
- *   endpoints called from BP refresh and the DRS scheduler) should pass
- *   `readOnly: true` so a GET never mutates org-level feature-flag state.
  * @returns {Promise<'v1'|'v2'>}
  */
-export async function resolveLlmoOnboardingMode(organizationId, context, options = {}) {
-  const { readOnly = false } = options;
+export async function resolveLlmoOnboardingMode(organizationId, context) {
   const { log = console } = context || {};
   const postgrestClient = context?.dataAccess?.services?.postgrestClient;
 
   // 1. Brandalf flag check: if the org has brandalf=true, it has been
-  //    explicitly migrated to v2. Honor it — except when the kill switch
-  //    is active AND the org has pre-cutoff sites (row 1 remediation).
+  //    explicitly migrated to v2. Honor it.
   let brandalfEnabled = false;
   try {
     brandalfEnabled = await readBrandalfFlagOverride(organizationId, postgrestClient) === true;
@@ -199,55 +124,6 @@ export async function resolveLlmoOnboardingMode(organizationId, context, options
   }
 
   if (brandalfEnabled) {
-    const configuredDefault = context?.env?.LLMO_ONBOARDING_DEFAULT_VERSION;
-
-    // Row 1: kill switch active + pre-cutoff sites + brandalf=true
-    // → revert flag to false and force v1. Read-only callers compute the
-    //   same downgrade decision but skip the upsert side effect — write
-    //   paths (onboarding controllers) handle remediation explicitly.
-    if (configuredDefault === LLMO_ONBOARDING_MODE_V1) {
-      try {
-        if (await hasPreBrandalfSites(organizationId, context)) {
-          if (!readOnly) {
-            try {
-              await upsertFeatureFlag({
-                organizationId,
-                product: LLMO_FEATURE_FLAG_PRODUCT,
-                flagName: LLMO_BRANDALF_FLAG,
-                value: false,
-                updatedBy: 'llmo-onboarding-mode-resolution',
-                postgrestClient,
-              });
-              log.warn(
-                `LLMO mode resolution: organization ${organizationId} has brandalf=true but also has `
-                + 'pre-cutoff sites while kill switch is active. Reverted brandalf flag to false. '
-                + 'This org has sites that require migration before it can use v2.',
-              );
-            } catch (revertError) {
-              log.error(
-                `Failed to revert brandalf flag for org ${organizationId}: ${revertError.message}. `
-                + 'Flag may still be true — manual intervention required.',
-              );
-            }
-          } else {
-            log.info(
-              `LLMO mode resolution (read-only): organization ${organizationId} has `
-              + 'brandalf=true but kill switch is active and org has pre-cutoff sites. '
-              + 'Returning v1 without flipping the brandalf flag.',
-            );
-          }
-          return LLMO_ONBOARDING_MODE_V1;
-        }
-      } catch (error) {
-        log.warn(
-          `Failed to check pre-Brandalf sites for org ${organizationId}: ${error.message}`,
-        );
-        // Cannot confirm pre-cutoff sites — fall through to v2
-        // (brandalf=true is still set, so honor the migration).
-      }
-    }
-
-    // Rows 3, 5, 7: brandalf=true without row-1 condition → v2.
     log.info(
       `LLMO mode resolution: organization ${organizationId} has brandalf=true — using v2`,
     );
@@ -263,17 +139,6 @@ export async function resolveLlmoOnboardingMode(organizationId, context, options
   if (configuredDefault && configuredDefault !== LLMO_ONBOARDING_MODE_V2) {
     log.warn(
       `Invalid LLMO_ONBOARDING_DEFAULT_VERSION "${configuredDefault}", falling back to ${LLMO_ONBOARDING_MODE_V2}`,
-    );
-  }
-
-  // 3. Protect legacy customers: any org with a pre-cutoff site stays on v1.
-  try {
-    if (await hasPreBrandalfSites(organizationId, context)) {
-      return LLMO_ONBOARDING_MODE_V1;
-    }
-  } catch (error) {
-    log.warn(
-      `Failed to check pre-Brandalf sites for organization ${organizationId}: ${error.message}`,
     );
   }
 

--- a/src/support/llmo-onboarding-mode.js
+++ b/src/support/llmo-onboarding-mode.js
@@ -69,11 +69,17 @@ export async function readBrandalfMigrationFlagOverride(organizationId, postgres
  *  4. Otherwise → return v2 (default for everyone else).
  *
  * The legacy-site cutoff that previously forced pre-GA customers onto v1
- * (createdAt before LLMO_BRANDALF_GA_CUTOFF_MS) was removed in LLMO-7108 so that
- * every new onboarding defaults to v2 unless the kill switch explicitly holds
- * the org back. This resolver only runs at onboarding time: already-onboarded v1
- * customers keep their brandalf=false flag and continue running v1 downstream —
- * it does not migrate existing orgs.
+ * (createdAt before LLMO_BRANDALF_GA_CUTOFF_MS) was removed in LLMO-7108 so every
+ * new onboarding defaults to v2 unless the kill switch holds the org back.
+ *
+ * This is consumed on two paths, not just onboarding: performLlmoOnboarding
+ * (which upserts brandalf=true org-wide on a v2 result) and the read-only
+ * (org, site) -> brand resolver in brands.js (hit by BP refresh and the DRS
+ * scheduler). Removing the cutoff flips a flagless pre-cutoff org to v2 on both
+ * — the brand resolver now returns the v2 brand where it used to 404. It does
+ * not by itself flip an already-onboarded org's brandalf flag (only an
+ * onboarding does that, org-wide), and DRS gates on the flag independently, so a
+ * still-flagless org keeps running v1 downstream until it is onboarded/flagged.
  *
  * TEMPORARY — the LLMO_ONBOARDING_DEFAULT_VERSION kill switch and the v1 branch
  * should be removed once all v1 customers have been migrated to v2, at which

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -3203,9 +3203,10 @@ describe('Brands Controller', () => {
       expect(resolveLlmoOnboardingModeStub).to.have.been.calledOnce;
       const [orgArg, , optsArg] = resolveLlmoOnboardingModeStub.firstCall.args;
       expect(orgArg).to.equal(ORGANIZATION_ID);
-      // readOnly: true is load-bearing — without it the resolver could write
-      // to feature_flags from a GET (row-1 brandalf-revert side effect).
-      expect(optsArg).to.deep.equal({ readOnly: true });
+      // The resolver is side-effect free since LLMO-7108 removed the legacy-site
+      // cutoff (and with it the row-1 brandalf-revert write), so this GET no
+      // longer passes a readOnly option.
+      expect(optsArg).to.equal(undefined);
       expect(getBrandBySiteStub).to.have.been.calledOnce;
       expect(getBrandBySiteStub.firstCall.args[0]).to.equal(ORGANIZATION_ID);
       expect(getBrandBySiteStub.firstCall.args[1]).to.equal(SITE_ID);

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -37,9 +37,11 @@ describe('LLMO Onboarding Functions', () => {
       Site: {
         findByBaseURL: sinon.stub(),
         create: sinon.stub(),
-        // Default: no pre-cutoff sites → mode resolution returns v2 (the default).
-        // Tests that need v1 mode should set LLMO_ONBOARDING_DEFAULT_VERSION='v1'
-        // in context.env to use the global kill switch.
+        // Mode resolution defaults to v2. Tests that need v1 mode set
+        // LLMO_ONBOARDING_DEFAULT_VERSION='v1' in context.env (global kill switch).
+        // allByOrganizationId is no longer read by resolveLlmoOnboardingMode
+        // (the legacy-site cutoff was removed in LLMO-7108) — kept as a harmless
+        // default for other code paths.
         allByOrganizationId: sinon.stub().resolves([]),
       },
       Organization: {
@@ -1396,9 +1398,7 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockDataAccess.Site.findByBaseURL).to.have.been.calledWith('https://example.com');
       expect(mockSite.getOrganizationId).to.have.been.called;
       expect(mockSite.setOrganizationId).to.have.been.calledWith('new-org-456');
-      // LLMO-4176: re-parent must be persisted before resolveLlmoOnboardingMode
-      // queries Site.allByOrganizationId, otherwise a legacy site moved into a
-      // brand-new org would be misclassified as v2.
+      // createOrFindSite persists a re-parent immediately via save().
       expect(mockSite.save).to.have.been.calledOnce;
     }).timeout(5000);
 
@@ -1996,13 +1996,6 @@ describe('LLMO Onboarding Functions', () => {
         baseURL: 'https://example.com',
         organizationId: 'org123',
       });
-
-      // LLMO-4176 regression guard: resolveLlmoOnboardingMode reads
-      // Site.allByOrganizationId, and that read MUST happen after the site
-      // has been created/re-parented — otherwise a legacy site moved into a
-      // brand-new org gets misclassified as v2.
-      expect(mockDataAccess.Site.allByOrganizationId)
-        .to.have.been.calledAfter(mockDataAccess.Site.findByBaseURL);
 
       // Verify site config was updated
       expect(mockSite.getConfig().updateLlmoBrand).to.have.been.calledWith('Test Brand');

--- a/test/it/postgres/llmo-onboarding.test.js
+++ b/test/it/postgres/llmo-onboarding.test.js
@@ -10,25 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-// transitive dep via @adobe/spacecat-shared-data-access
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { PostgrestClient } from '@supabase/postgrest-js';
 import { ctx } from './harness.js';
 import { resetPostgres } from './seed.js';
-import { POSTGREST_WRITER_JWT } from '../shared/postgrest-jwt.js';
 import llmoOnboardingTests from '../shared/tests/llmo-onboarding.js';
 
-const POSTGREST_PORT = process.env.IT_POSTGREST_PORT || '3300';
-const POSTGREST_URL = `http://localhost:${POSTGREST_PORT}`;
-
-function getPostgrestClient() {
-  return new PostgrestClient(POSTGREST_URL, {
-    schema: 'public',
-    headers: {
-      apikey: POSTGREST_WRITER_JWT,
-      Authorization: `Bearer ${POSTGREST_WRITER_JWT}`,
-    },
-  });
-}
-
-llmoOnboardingTests(() => ctx.httpClient, resetPostgres, getPostgrestClient);
+llmoOnboardingTests(() => ctx.httpClient, resetPostgres);

--- a/test/it/shared/tests/brand-for-org-site.js
+++ b/test/it/shared/tests/brand-for-org-site.js
@@ -18,8 +18,6 @@ import {
   SITE_2_ID,
   SITE_3_ID,
   BRAND_1_ID,
-  ORG_LEGACY_LLMO_ID,
-  SITE_LEGACY_LLMO_ID,
   NON_EXISTENT_ORG_ID,
   NON_EXISTENT_SITE_ID,
 } from '../seed-ids.js';
@@ -31,10 +29,16 @@ import { upsertFeatureFlag } from '../../../../src/support/feature-flags-storage
  * Validates:
  *  - resolver gating on `resolveLlmoOnboardingMode === v2`
  *  - primary `brands.site_id` lookup
- *  - 404 on v1 / brandalf_migration / no-active-brand
+ *  - 200 for brandalf and brandalf_migration orgs; 404 on no-active-brand
  *  - 403 on tenant isolation (site does not belong to org)
  *  - 404 on missing org / site
  *  - 403 on cross-org user access
+ *
+ * The resolver's v1 → 404 gate is covered by controller unit tests
+ * (test/controllers/brands.test.js). It is not exercised here: since LLMO-7108
+ * removed the legacy-site cutoff, the only remaining v1 path is the
+ * LLMO_ONBOARDING_DEFAULT_VERSION kill switch, which is fixed at IT-harness
+ * startup and cannot be toggled per-test over HTTP.
  *
  * Each describe block calls `resetData()` to start from baseline, then uses
  * the postgrestClient directly to set up the brandalf flag and brand→site
@@ -143,44 +147,6 @@ export default function brandForOrgSiteTests(getHttpClient, resetData, getPostgr
         );
         expect(res.status).to.equal(200);
         expect(res.body.id).to.equal(BRAND_1_ID);
-      });
-    });
-
-    describe('v1 org (resolver returns v1)', () => {
-      // ORG_LEGACY_LLMO_ID owns SITE_LEGACY_LLMO_ID with created_at before the
-      // 2026-04-01 Brandalf GA cutoff → resolveLlmoOnboardingMode falls into
-      // the "pre-cutoff sites" branch and returns v1 even without a brandalf
-      // flag set. ORG_1 cannot be used here because all its sites are
-      // post-cutoff, so the resolver returns v2 by default.
-      const LEGACY_BRAND_ID = 'a1ffffff-ffff-4fff-bfff-ffffffffffff';
-
-      before(async () => {
-        await resetData();
-        // Insert a brand for the legacy org bound to the legacy site, so the
-        // test exercises "endpoint correctly 404s even when a brand WOULD have
-        // matched" — proving the resolver gate works.
-        const pg = getPostgrestClient();
-        const { error } = await pg.from('brands').upsert({
-          id: LEGACY_BRAND_ID,
-          organization_id: ORG_LEGACY_LLMO_ID,
-          name: 'Legacy Brand',
-          status: 'active',
-          origin: 'human',
-          regions: ['us'],
-          site_id: SITE_LEGACY_LLMO_ID,
-          updated_by: 'it-setup',
-        });
-        if (error) {
-          throw new Error(`Failed to seed legacy brand: ${error.message}`);
-        }
-      });
-
-      it('returns 404 even when a brand row exists for the site (gating works)', async () => {
-        const http = getHttpClient();
-        const res = await http.admin.get(
-          `/v2/orgs/${ORG_LEGACY_LLMO_ID}/sites/${SITE_LEGACY_LLMO_ID}/brand`,
-        );
-        expect(res.status).to.equal(404);
       });
     });
 

--- a/test/it/shared/tests/llmo-onboarding.js
+++ b/test/it/shared/tests/llmo-onboarding.js
@@ -12,29 +12,21 @@
 
 import { expect } from 'chai';
 
-import {
-  LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT,
-  hasPreBrandalfSites,
-  resolveLlmoOnboardingMode,
-} from '../../../../src/support/llmo-onboarding-mode.js';
-import {
-  ORG_LEGACY_LLMO_ID,
-  ORG_NEW_LLMO_ID,
-  SITE_LEGACY_LLMO_ID,
-  SITE_NEW_LLMO_ID,
-} from '../seed-ids.js';
-
 /**
  * Shared LLMO Onboarding endpoint tests.
  *
  * POST /llmo/onboard — validation tests only (happy path needs LLMO admin auth +
  * external services: SharePoint, SQS, DRS, Configuration).
  *
+ * The onboarding-mode resolution (resolveLlmoOnboardingMode) is unit-tested in
+ * test/support/llmo-onboarding-mode.test.js. The DB-integration tests that
+ * previously exercised the legacy-site cutoff were removed in LLMO-7108 along
+ * with the cutoff itself — the resolver no longer reads site history.
+ *
  * @param {() => object} getHttpClient - Getter returning the initialized HTTP client
  * @param {() => Promise<void>} resetData - Truncates all data and re-seeds baseline
- * @param {() => object} getPostgrestClient - Getter returning an authenticated PostgREST client
  */
-export default function llmoOnboardingTests(getHttpClient, resetData, getPostgrestClient) {
+export default function llmoOnboardingTests(getHttpClient, resetData) {
   describe('LLMO Onboarding', () => {
     before(() => resetData());
 
@@ -81,122 +73,6 @@ export default function llmoOnboardingTests(getHttpClient, resetData, getPostgre
           const body = await res.json();
           expect(body.message).to.not.include('Invalid cadence');
         }
-      });
-    });
-
-    // ── LLMO onboarding mode resolution — integration tests ──
-    //
-    // TEMPORARY: these tests validate resolveLlmoOnboardingMode's legacy-customer
-    // protection using a real PostgREST DB. Remove them along with the
-    // hasPreBrandalfSites / resolveBrandalfCutoffMs helpers once all v1
-    // customers have been migrated to v2.
-
-    describe('resolveLlmoOnboardingMode (DB integration)', () => {
-      /**
-       * Builds a minimal context wiring Site.allByOrganizationId to a direct
-       * PostgREST query, so we can test the mode-resolution logic against the
-       * real Docker DB without spinning up the full middleware stack.
-       */
-      function makeDbContext(postgrestClient, envOverrides = {}) {
-        return {
-          env: {
-            LLMO_BRANDALF_GA_CUTOFF_MS: String(LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT),
-            ...envOverrides,
-          },
-          log: { warn: () => {} },
-          dataAccess: {
-            Site: {
-              allByOrganizationId: async (orgId) => {
-                const { data, error } = await postgrestClient
-                  .from('sites')
-                  .select('id,created_at')
-                  .eq('organization_id', orgId);
-                if (error) {
-                  throw new Error(error.message);
-                }
-                return (data || []).map((row) => ({
-                  getId: () => row.id,
-                  getCreatedAt: () => row.created_at,
-                }));
-              },
-            },
-          },
-        };
-      }
-
-      it('hasPreBrandalfSites → true for an org with a site created before the cutoff', async () => {
-        const ctx = makeDbContext(getPostgrestClient());
-        const result = await hasPreBrandalfSites(ORG_LEGACY_LLMO_ID, ctx);
-        expect(result).to.equal(true);
-      });
-
-      it('hasPreBrandalfSites → false for an org with a site created after the cutoff', async () => {
-        const ctx = makeDbContext(getPostgrestClient());
-        const result = await hasPreBrandalfSites(ORG_NEW_LLMO_ID, ctx);
-        expect(result).to.equal(false);
-      });
-
-      it('hasPreBrandalfSites → false for an org with no sites', async () => {
-        // ORG_LEGACY_LLMO and ORG_NEW_LLMO cover the two main cases;
-        // use NON_EXISTENT_ORG path via an org that has no sites in seed data.
-        // We temporarily insert a bare org for this check.
-        const pgClient = getPostgrestClient();
-        const emptyOrgId = 'fe333333-3333-4333-b333-333333333333';
-        await pgClient.from('organizations').insert({
-          id: emptyOrgId,
-          name: 'Empty Org For Mode Test',
-          ims_org_id: 'EMPTYYYY00000000000000000@AdobeOrg',
-        });
-
-        try {
-          const ctx = makeDbContext(pgClient);
-          const result = await hasPreBrandalfSites(emptyOrgId, ctx);
-          expect(result).to.equal(false);
-        } finally {
-          await pgClient.from('organizations').delete().eq('id', emptyOrgId);
-        }
-      });
-
-      it('resolveLlmoOnboardingMode → v1 for a legacy org (pre-cutoff site)', async () => {
-        const ctx = makeDbContext(getPostgrestClient());
-        const mode = await resolveLlmoOnboardingMode(ORG_LEGACY_LLMO_ID, ctx);
-        expect(mode).to.equal('v1');
-      });
-
-      it('resolveLlmoOnboardingMode → v2 for a new org (post-cutoff site)', async () => {
-        const ctx = makeDbContext(getPostgrestClient());
-        const mode = await resolveLlmoOnboardingMode(ORG_NEW_LLMO_ID, ctx);
-        expect(mode).to.equal('v2');
-      });
-
-      it('resolveLlmoOnboardingMode → v1 when LLMO_ONBOARDING_DEFAULT_VERSION=v1 (kill switch)', async () => {
-        const ctx = makeDbContext(getPostgrestClient(), {
-          LLMO_ONBOARDING_DEFAULT_VERSION: 'v1',
-        });
-        // Even the new org should be v1 when the kill switch is active
-        const mode = await resolveLlmoOnboardingMode(ORG_NEW_LLMO_ID, ctx);
-        expect(mode).to.equal('v1');
-      });
-
-      it('site created_at values are preserved correctly by the DB round-trip', async () => {
-        const pgClient = getPostgrestClient();
-        const { data } = await pgClient
-          .from('sites')
-          .select('id,created_at')
-          .in('id', [SITE_LEGACY_LLMO_ID, SITE_NEW_LLMO_ID]);
-
-        const byId = Object.fromEntries((data || []).map((r) => [r.id, r.created_at]));
-
-        expect(new Date(byId[SITE_LEGACY_LLMO_ID]).getTime())
-          .to.be.lessThan(
-            LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT,
-            'legacy site should be before the cutoff',
-          );
-        expect(new Date(byId[SITE_NEW_LLMO_ID]).getTime())
-          .to.be.greaterThanOrEqual(
-            LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT,
-            'new site should be at or after the cutoff',
-          );
       });
     });
   });

--- a/test/support/llmo-onboarding-mode.test.js
+++ b/test/support/llmo-onboarding-mode.test.js
@@ -16,31 +16,17 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import {
-  LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT,
-  hasPreBrandalfSites,
   readBrandalfFlagOverride,
   readBrandalfMigrationFlagOverride,
-  resolveBrandalfCutoffMs,
   resolveLlmoOnboardingMode,
 } from '../../src/support/llmo-onboarding-mode.js';
 
 use(sinonChai);
 use(chaiAsPromised);
 
-// 2026-04-01T00:00:00Z in ms — matches the default constant
-const CUTOFF = LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT;
-const BEFORE_CUTOFF = new Date(CUTOFF - 1).toISOString(); // 2026-03-31T23:59:59.999Z
-const AT_CUTOFF = new Date(CUTOFF).toISOString(); // 2026-04-01T00:00:00.000Z
-const AFTER_CUTOFF = new Date(CUTOFF + 86400000).toISOString(); // 2026-04-02T00:00:00.000Z
-
-function makeSite(createdAt, id = 'site-id') {
-  return { getCreatedAt: () => createdAt, getId: () => id };
-}
-
 /**
  * Builds a postgrestClient stub whose feature_flags read returns the given value.
  * Pass `null` to simulate a missing row, `'throw'` to simulate a DB error.
- * Also supports the write chain used by `upsertFeatureFlag`.
  */
 function makePostgrestClient(brandalfValue) {
   if (brandalfValue === undefined) {
@@ -61,42 +47,19 @@ function makePostgrestClient(brandalfValue) {
     }),
   });
 
-  // Write branches: from().update().eq().select().single() when the org already
-  // has a row, from().insert().select().single() when it does not.
-  const writeSingle = sinon.stub().resolves({ data: { flag_value: false }, error: null });
-  const writeSelect = sinon.stub().returns({ single: writeSingle });
-  const update = sinon.stub().returns({ eq: sinon.stub().returns({ select: writeSelect }) });
-  const insert = sinon.stub().returns({ select: writeSelect });
-
-  const client = {
-    from: sinon.stub().returns({
-      select: readSelect,
-      update,
-      insert,
-    }),
+  return {
+    from: sinon.stub().returns({ select: readSelect }),
   };
-  // The remediation path only ever runs on an org whose brandalf row exists, so
-  // the flag write is always the update branch.
-  client.getUpsertStub = () => update;
-  client.failWrite = () => writeSingle.resolves({
-    data: null,
-    error: { message: 'upsert failed' },
-  });
-  return client;
 }
 
-function makeContext({
-  sites = [], env = {}, throwOnLookup = false, brandalfValue,
-} = {}) {
+function makeContext({ env = {}, brandalfValue } = {}) {
   const ctx = {
-    env: { LLMO_BRANDALF_GA_CUTOFF_MS: String(CUTOFF), ...env },
+    env: { ...env },
     log: { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() },
     dataAccess: {
-      Site: {
-        allByOrganizationId: throwOnLookup
-          ? sinon.stub().rejects(new Error('DB error'))
-          : sinon.stub().resolves(sites),
-      },
+      // The resolver no longer reads sites — kept as a spy so tests can assert
+      // the legacy-site lookup is never performed (LLMO-7108).
+      Site: { allByOrganizationId: sinon.stub().resolves([]) },
     },
   };
   const postgrestClient = makePostgrestClient(brandalfValue);
@@ -201,191 +164,28 @@ describe('llmo-onboarding-mode', () => {
     });
   });
 
-  // ── resolveBrandalfCutoffMs ───────────────────────────────────────────────
-
-  describe('resolveBrandalfCutoffMs', () => {
-    it('pins LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT to 2026-04-01T00:00:00Z', () => {
-      // Guards against an off-by-one-year regression on the hard-coded fallback.
-      expect(LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT).to.equal(Date.UTC(2026, 3, 1));
-    });
-
-    it('returns the default when env var is not set', () => {
-      expect(resolveBrandalfCutoffMs({ env: {} })).to.equal(LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT);
-    });
-
-    it('returns the default when context is missing', () => {
-      expect(resolveBrandalfCutoffMs()).to.equal(LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT);
-    });
-
-    it('returns the parsed value from a valid env var string', () => {
-      expect(resolveBrandalfCutoffMs({ env: { LLMO_BRANDALF_GA_CUTOFF_MS: '1000000000000' } }))
-        .to.equal(1000000000000);
-    });
-
-    it('returns the default and warns for non-numeric env var', () => {
-      const log = { warn: sinon.stub() };
-      const result = resolveBrandalfCutoffMs({ env: { LLMO_BRANDALF_GA_CUTOFF_MS: 'abc' }, log });
-      expect(result).to.equal(LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT);
-      expect(log.warn).to.have.been.called;
-    });
-
-    it('returns the default and warns for zero', () => {
-      const log = { warn: sinon.stub() };
-      const result = resolveBrandalfCutoffMs({ env: { LLMO_BRANDALF_GA_CUTOFF_MS: '0' }, log });
-      expect(result).to.equal(LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT);
-      expect(log.warn).to.have.been.called;
-    });
-
-    it('returns the default and warns for a negative value', () => {
-      const log = { warn: sinon.stub() };
-      const result = resolveBrandalfCutoffMs({ env: { LLMO_BRANDALF_GA_CUTOFF_MS: '-1' }, log });
-      expect(result).to.equal(LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT);
-      expect(log.warn).to.have.been.called;
-    });
-  });
-
-  // ── hasPreBrandalfSites ───────────────────────────────────────────────────
-
-  describe('hasPreBrandalfSites', () => {
-    it('returns false when the org has no sites', async () => {
-      const ctx = makeContext({ sites: [] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-    });
-
-    it('returns true when at least one site predates the cutoff', async () => {
-      const ctx = makeContext({ sites: [makeSite(BEFORE_CUTOFF)] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(true);
-    });
-
-    it('returns false when the only site is exactly at the cutoff (exclusive comparison)', async () => {
-      const ctx = makeContext({ sites: [makeSite(AT_CUTOFF)] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-    });
-
-    it('returns false when all sites are after the cutoff', async () => {
-      const ctx = makeContext({ sites: [makeSite(AFTER_CUTOFF)] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-    });
-
-    it('returns true when multiple sites exist and one predates the cutoff', async () => {
-      const ctx = makeContext({
-        sites: [makeSite(AFTER_CUTOFF), makeSite(BEFORE_CUTOFF)],
-      });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(true);
-    });
-
-    it('returns false for sites with null createdAt and warns', async () => {
-      const ctx = makeContext({ sites: [makeSite(null)] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-      expect(ctx.log.warn).to.have.been.calledWithMatch(/has no createdAt/);
-    });
-
-    it('returns false for sites with undefined createdAt and warns', async () => {
-      const ctx = makeContext({ sites: [makeSite(undefined)] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-      expect(ctx.log.warn).to.have.been.calledWithMatch(/has no createdAt/);
-    });
-
-    it('returns false for sites with invalid createdAt string and warns', async () => {
-      const ctx = makeContext({ sites: [makeSite('not-a-date')] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-      expect(ctx.log.warn).to.have.been.calledWithMatch(/unparseable createdAt/);
-    });
-
-    it('falls back to <unknown> in the warn when site has no getId (null createdAt)', async () => {
-      // Mirrors a partially-hydrated site model that exposes createdAt but not getId.
-      const ctx = makeContext({ sites: [{ getCreatedAt: () => null }] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-      expect(ctx.log.warn).to.have.been.calledWithMatch(/Site <unknown>.*has no createdAt/);
-    });
-
-    it('falls back to <unknown> in the warn when site has no getId (invalid createdAt)', async () => {
-      const ctx = makeContext({ sites: [{ getCreatedAt: () => 'not-a-date' }] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(false);
-      expect(ctx.log.warn).to.have.been.calledWithMatch(/Site <unknown>.*unparseable createdAt/);
-    });
-
-    it('accepts a Date object for createdAt', async () => {
-      const ctx = makeContext({ sites: [makeSite(new Date(CUTOFF - 1))] });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(true);
-    });
-
-    it('honours a custom LLMO_BRANDALF_GA_CUTOFF_MS from context.env', async () => {
-      const customCutoff = new Date('2026-06-01T00:00:00Z').getTime();
-      const ctx = makeContext({
-        sites: [makeSite(AFTER_CUTOFF)], // after default cutoff but before custom cutoff
-        env: { LLMO_BRANDALF_GA_CUTOFF_MS: String(customCutoff) },
-      });
-      expect(await hasPreBrandalfSites('org-1', ctx)).to.equal(true);
-    });
-  });
-
   // ── resolveLlmoOnboardingMode ─────────────────────────────────────────────
-  // Tests are structured around the 8-row decision matrix
-  // (see v1-v2-onboarding-consistency-safeguard.md).
+  // The legacy-site cutoff was removed in LLMO-7108. The resolver now decides:
+  //   1. brandalf=true            → v2
+  //   2. brandalf_migration=true  → v2
+  //   3. LLMO_ONBOARDING_DEFAULT_VERSION==='v1' (kill switch) → v1
+  //   4. otherwise                → v2
 
   describe('resolveLlmoOnboardingMode', () => {
-    // ── Brandalf flag override (rows 1, 3, 5, 7) ──────────────────────────
+    // ── Brandalf flag → v2 ─────────────────────────────────────────────────
 
     describe('brandalf flag override', () => {
-      it('row 1: kill switch + pre-cutoff + brandalf=true → v1, reverts flag to false', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
-          env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-          brandalfValue: true,
-        });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v1');
-        // Flag was reverted
-        expect(ctx.dataAccess.services.postgrestClient.getUpsertStub()).to.have.been.called;
-        // Warning logged about migration
-        expect(ctx.log.warn).to.have.been.calledWithMatch(/pre-cutoff sites.*kill switch.*Reverted brandalf/);
-      });
-
-      it('row 1: still returns v1 even if upsertFeatureFlag fails', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
-          env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-          brandalfValue: true,
-        });
-        // Make the flag write fail
-        ctx.dataAccess.services.postgrestClient.failWrite();
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v1');
-        expect(ctx.log.error).to.have.been.calledWithMatch(/Failed to revert brandalf flag.*Flag may still be true/);
-      });
-
-      it('row 1 in readOnly mode: returns v1 WITHOUT mutating the brandalf flag', async () => {
-        // LLMO-4716: read-only callers (resolver endpoint hit by BP refresh +
-        // DRS scheduler) must compute the same downgrade decision but never
-        // write to feature_flags from a GET request.
-        const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
-          env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-          brandalfValue: true,
-        });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx, { readOnly: true });
-        expect(mode).to.equal('v1');
-        // No upsert side effect.
-        expect(ctx.dataAccess.services.postgrestClient.getUpsertStub()).to.not.have.been.called;
-        // Info log explains the read-only downgrade for triage.
-        expect(ctx.log.info).to.have.been.calledWithMatch(/read-only.*pre-cutoff.*v1/);
-      });
-
-      it('row 3: kill switch + no pre-cutoff + brandalf=true → v2', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(AFTER_CUTOFF)],
-          env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-          brandalfValue: true,
-        });
+      it('returns v2 when brandalf=true', async () => {
+        const ctx = makeContext({ brandalfValue: true });
         const mode = await resolveLlmoOnboardingMode('org-1', ctx);
         expect(mode).to.equal('v2');
         expect(ctx.log.info).to.have.been.calledWithMatch(/brandalf=true.*using v2/);
       });
 
-      it('row 3: kill switch + no sites + brandalf=true → v2', async () => {
+      it('returns v2 when brandalf=true even with the kill switch active', async () => {
+        // LLMO-7108: without the legacy-site cutoff there is no row-1
+        // remediation — an explicitly migrated org is always honored as v2.
         const ctx = makeContext({
-          sites: [],
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
           brandalfValue: true,
         });
@@ -393,140 +193,61 @@ describe('llmo-onboarding-mode', () => {
         expect(mode).to.equal('v2');
       });
 
-      it('row 5: default v2 + pre-cutoff + brandalf=true → v2', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
-          brandalfValue: true,
-        });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v2');
-        expect(ctx.log.info).to.have.been.calledWithMatch(/brandalf=true.*using v2/);
-      });
-
-      it('row 5: does not check pre-cutoff sites when kill switch is off', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
-          brandalfValue: true,
-        });
+      it('never reads the org sites (legacy-site cutoff removed)', async () => {
+        const ctx = makeContext({ brandalfValue: true });
         await resolveLlmoOnboardingMode('org-1', ctx);
-        // Site lookup not called — brandalf=true + no kill switch = v2 immediately
-        expect(ctx.dataAccess.Site.allByOrganizationId).not.to.have.been.called;
+        expect(ctx.dataAccess.Site.allByOrganizationId).to.not.have.been.called;
       });
 
-      it('row 7: default v2 + no pre-cutoff + brandalf=true → v2', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(AFTER_CUTOFF)],
-          brandalfValue: true,
-        });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v2');
-      });
-
-      it('falls through to default resolution when brandalf flag read fails', async () => {
-        const ctx = makeContext({
-          sites: [],
-          brandalfValue: 'throw',
-        });
+      it('falls through to default resolution when the brandalf flag read fails', async () => {
+        const ctx = makeContext({ brandalfValue: 'throw' });
         const mode = await resolveLlmoOnboardingMode('org-1', ctx);
         expect(mode).to.equal('v2');
         expect(ctx.log.warn).to.have.been.calledWithMatch(/Failed to read brandalf flag/);
       });
-
-      it('row 1: falls through to v2 when hasPreBrandalfSites throws (brandalf=true preserved)', async () => {
-        const ctx = makeContext({
-          env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-          throwOnLookup: true,
-          brandalfValue: true,
-        });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        // Cannot confirm pre-cutoff sites → honor brandalf=true → v2
-        expect(mode).to.equal('v2');
-        expect(ctx.log.warn).to.have.been.calledWithMatch(/Failed to check pre-Brandalf sites/);
-      });
     });
 
-    // ── Kill switch — no brandalf flag (rows 2, 4) ─────────────────────────
+    // ── Kill switch — no brandalf flag ─────────────────────────────────────
 
-    describe('kill switch — no brandalf flag (rows 2, 4)', () => {
-      it('row 2: kill switch + pre-cutoff + no brandalf → v1', async () => {
+    describe('kill switch — no brandalf flag', () => {
+      it('returns v1 when the kill switch is active and the flag row is missing', async () => {
         const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
           brandalfValue: null,
         });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v1');
+        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
       });
 
-      it('row 4: kill switch + no pre-cutoff + no brandalf → v1', async () => {
+      it('returns v1 when the kill switch is active and brandalf=false', async () => {
         const ctx = makeContext({
-          sites: [],
-          env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-          brandalfValue: null,
-        });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v1');
-      });
-
-      it('kill switch skips site lookup when brandalf is false', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(AFTER_CUTOFF)],
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
           brandalfValue: false,
         });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v1');
-        // brandalf=false → falls to kill switch → v1 without site check
-        expect(ctx.dataAccess.Site.allByOrganizationId).not.to.have.been.called;
+        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
+        // brandalf=false → kill switch → v1 without any site lookup.
+        expect(ctx.dataAccess.Site.allByOrganizationId).to.not.have.been.called;
       });
     });
 
-    // ── Default v2 — no brandalf flag (rows 6, 8) ──────────────────────────
+    // ── Default v2 — no brandalf flag ──────────────────────────────────────
 
-    describe('default v2 — no brandalf flag (rows 6, 8)', () => {
-      it('row 6: default v2 + pre-cutoff + no brandalf → v1', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
-          brandalfValue: null,
-        });
-        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
-      });
-
-      it('row 8: default v2 + no pre-cutoff + no brandalf → v2', async () => {
-        const ctx = makeContext({ sites: [], brandalfValue: null });
+    describe('default v2 — no brandalf flag', () => {
+      it('returns v2 when brandalf is unset and no kill switch is configured', async () => {
+        const ctx = makeContext({ brandalfValue: null });
         expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v2');
       });
 
-      it('returns v2 when all sites are at or after the cutoff', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(AT_CUTOFF), makeSite(AFTER_CUTOFF)],
-          brandalfValue: null,
-        });
+      it('returns v2 when brandalf=false and no kill switch is configured', async () => {
+        const ctx = makeContext({ brandalfValue: false });
         expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v2');
       });
 
-      it('returns v1 when org has multiple sites and at least one predates cutoff', async () => {
+      it('returns v2 when LLMO_ONBOARDING_DEFAULT_VERSION is explicitly v2', async () => {
         const ctx = makeContext({
-          sites: [makeSite(AFTER_CUTOFF), makeSite(BEFORE_CUTOFF)],
-          brandalfValue: null,
-        });
-        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
-      });
-
-      it('returns v1 for a legacy org even when LLMO_ONBOARDING_DEFAULT_VERSION = v2', async () => {
-        const ctx = makeContext({
-          sites: [makeSite(BEFORE_CUTOFF)],
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v2' },
           brandalfValue: null,
         });
-        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
-      });
-
-      it('returns v2 and falls through when site lookup throws', async () => {
-        const ctx = makeContext({ throwOnLookup: true, brandalfValue: null });
-        const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v2');
-        expect(ctx.log.warn).to.have.been.calledWithMatch(/Failed to check pre-Brandalf sites/);
+        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v2');
       });
     });
 
@@ -540,7 +261,6 @@ describe('llmo-onboarding-mode', () => {
 
       it('warns and falls back to v2 for invalid LLMO_ONBOARDING_DEFAULT_VERSION', async () => {
         const ctx = makeContext({
-          sites: [],
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'banana' },
           brandalfValue: null,
         });
@@ -549,16 +269,6 @@ describe('llmo-onboarding-mode', () => {
         expect(ctx.log.warn).to.have.been.calledWith(
           'Invalid LLMO_ONBOARDING_DEFAULT_VERSION "banana", falling back to v2',
         );
-      });
-
-      it('custom cutoff: treats a post-default-cutoff site as legacy', async () => {
-        const futureCutoff = new Date('2026-06-01T00:00:00Z').getTime();
-        const ctx = makeContext({
-          sites: [makeSite(AFTER_CUTOFF)],
-          env: { LLMO_BRANDALF_GA_CUTOFF_MS: String(futureCutoff) },
-          brandalfValue: null,
-        });
-        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
       });
     });
 
@@ -570,7 +280,7 @@ describe('llmo-onboarding-mode', () => {
      * test the brandalf_migration short-circuit, which requires reading
      * brandalf and brandalf_migration independently.
      */
-    function makeMultiFlagContext(flags, sites = []) {
+    function makeMultiFlagContext(flags) {
       const flagNameEq = sinon.stub().callsFake((field, flagName) => {
         const value = field === 'flag_name' ? flags[flagName] : undefined;
         return Promise.resolve({
@@ -585,10 +295,10 @@ describe('llmo-onboarding-mode', () => {
         from: sinon.stub().returns({ select }),
       };
       return {
-        env: { LLMO_BRANDALF_GA_CUTOFF_MS: String(CUTOFF) },
+        env: {},
         log: { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() },
         dataAccess: {
-          Site: { allByOrganizationId: sinon.stub().resolves(sites) },
+          Site: { allByOrganizationId: sinon.stub().resolves([]) },
           services: { postgrestClient },
         },
       };
@@ -603,8 +313,7 @@ describe('llmo-onboarding-mode', () => {
         const mode = await resolveLlmoOnboardingMode('org-1', ctx);
         expect(mode).to.equal('v2');
         expect(ctx.log.info).to.have.been.calledWithMatch(/brandalf_migration=true.*using v2/);
-        // Short-circuit: site lookup must not happen — neither for legacy
-        // protection nor for kill-switch downgrade.
+        // Short-circuit: site lookup must not happen.
         expect(ctx.dataAccess.Site.allByOrganizationId).to.not.have.been.called;
       });
 
@@ -630,13 +339,10 @@ describe('llmo-onboarding-mode', () => {
         expect(mode).to.equal('v2');
       });
 
-      it('returns v1 when brandalf_migration=false and org has pre-cutoff sites', async () => {
-        const ctx = makeMultiFlagContext(
-          { brandalf: null, brandalf_migration: false },
-          [makeSite(BEFORE_CUTOFF)],
-        );
+      it('returns v2 when brandalf_migration=false and no kill switch is configured', async () => {
+        const ctx = makeMultiFlagContext({ brandalf: null, brandalf_migration: false });
         const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        expect(mode).to.equal('v1');
+        expect(mode).to.equal('v2');
       });
 
       it('warns and falls through when brandalf_migration read throws', async () => {
@@ -649,7 +355,7 @@ describe('llmo-onboarding-mode', () => {
         const orgEq = sinon.stub().returns({ eq: productEq });
         const select = sinon.stub().returns({ eq: orgEq });
         const ctx = {
-          env: { LLMO_BRANDALF_GA_CUTOFF_MS: String(CUTOFF) },
+          env: {},
           log: { warn: sinon.stub(), error: sinon.stub(), info: sinon.stub() },
           dataAccess: {
             Site: { allByOrganizationId: sinon.stub().resolves([]) },
@@ -657,7 +363,7 @@ describe('llmo-onboarding-mode', () => {
           },
         };
         const mode = await resolveLlmoOnboardingMode('org-1', ctx);
-        // Defaults to v2 via the legacy-customer fallthrough (no pre-cutoff sites).
+        // Defaults to v2 via the no-kill-switch fallthrough.
         expect(mode).to.equal('v2');
         expect(ctx.log.warn).to.have.been.calledWithMatch(/Failed to read brandalf_migration flag/);
       });


### PR DESCRIPTION
## What & why

[LLMO-7108](https://jira.corp.adobe.com/browse/LLMO-7108) — "stop onboarding on v1". Default every new LLMO onboarding to v2 by removing the legacy-site GA cutoff, while keeping v1 reachable via the global kill switch and **not** removing the v1 code path.

The v1/v2 onboarding decision lives in `resolveLlmoOnboardingMode` (`src/support/llmo-onboarding-mode.js`). It previously forced any org with a site created before `LLMO_BRANDALF_GA_CUTOFF_MS` (default 2026-04-01) onto v1. That cutoff is removed here.

## New decision order

1. `brandalf=true` → **v2**
2. `brandalf_migration=true` → **v2**
3. `LLMO_ONBOARDING_DEFAULT_VERSION === 'v1'` (global kill switch) → **v1** — *retained, unchanged*
4. otherwise → **v2**

## Changes

- Delete `hasPreBrandalfSites`, `resolveBrandalfCutoffMs`, and the `LLMO_BRANDALF_GA_CUTOFF_MS_DEFAULT` constant; the `LLMO_BRANDALF_GA_CUTOFF_MS` env var is no longer read.
- Remove the **row-1 remediation** (it depended on detecting pre-cutoff sites). Consequence: a `brandalf=true` org is now always v2, even under an active kill switch — it is no longer reverted to `false`.
- Remove the now-meaningless `readOnly` option — with the row-1 write gone the resolver has no side effects — and drop `{ readOnly: true }` at the `brands.js` `getBrandForOrgSite` caller.
- Update unit + integration tests and the safeguard design doc (`docs/llmo-brandalf-apis/v1-v2-onboarding-consistency-safeguard.md`, with an LLMO-7108 update note; the older cutoff-based matrix is kept as historical context).

## Scope / non-goals

- **No migration of existing orgs.** This change does not backfill or flip flags on already-onboarded orgs — it only changes what mode a *fresh* resolution computes.
- **The resolver runs on two paths, not just onboarding.** `resolveLlmoOnboardingMode` is called by `performLlmoOnboarding` (write — upserts `brandalf=true` **org-wide** on a v2 result, so one onboarding flips every existing site of that org to v2 downstream) and by the read-only `(org,site)→brand` resolver `getBrandForOrgSite` in `brands.js` (hit by BP refresh + the DRS scheduler). Removing the cutoff flips a flagless pre-cutoff org to v2 on **both**; the brand resolver now returns the v2 brand where it previously 404'd. DRS gates on the `brandalf`/`brandalf_migration` flags independently, so a still-flagless org keeps running v1 downstream until onboarded/flagged. (A small tracked set of orgs already resolve v1 in DRS while owning v2 brand rows — for those, this endpoint now serves the v2 brand.)
- The `LLMO_ONBOARDING_DEFAULT_VERSION` kill switch and the v1 branch remain in place; full removal is a later step once all v1 customers are migrated.
- No OpenAPI changes (request/response shapes unchanged).

## Sequencing (per review)

- Merge only **after** the last paying v1 customer migration completes.
- Merge the DRS companion PR (**adobe-rnd/llmo-data-retrieval-service#3004**) first or together — this change accelerates flag-flips onto orgs with incomplete v2 data, exactly the path that PR makes loud (~20 sites currently on the v1 zero-prompt fallback).
- Ops follow-up once merged: drop `LLMO_BRANDALF_GA_CUTOFF_MS` from env config in all environments.

## Relationship to DRS #2807

DRS issue [adobe-rnd/llmo-data-retrieval-service#2807](https://github.com/adobe-rnd/llmo-data-retrieval-service/issues/2807) is the downstream companion (remove the legacy v1 LLMO-config read paths; drain-then-delete). This PR is the upstream "stop producing v1 orgs" step. It **advances but does not close** that issue's Phase 2 gate ("`resolveLlmoOnboardingMode` can never return v1") — the kill switch can still return v1.

## Testing

- ESLint: clean on all changed files.
- `test/support/llmo-onboarding-mode.test.js` — 24 passing (rewritten for the 4-step resolver).
- `test/controllers/brands.test.js` — 433 passing.
- `test/controllers/llmo/llmo-onboarding.test.js` — 162 passing. One **pre-existing** flake (`settleWithin` `before` hook exceeds mocha's default 2000ms doing a cold `esmock` load; passes with `--timeout 20000`) — unrelated to this change.
- Integration tests trimmed: removed the cutoff DB-integration block from `llmo-onboarding.js` and the no-longer-reproducible "v1 org → 404" case from `brand-for-org-site.js` (the v1→404 gate is covered by the controller unit test). Recommend running the PostgreSQL IT suite (`brand-for-org-site.test.js`, `llmo-onboarding.test.js`) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Rainer Friederich", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```