### PR TITLE
chore: retire the legacy Semrush proxy host from examples, tests, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,7 +120,7 @@ SEO_CLIENT_SECRET=
 # hackathon host (dx_mysticat/dev/api-service value as of 2026-05-22); leave
 # it commented in the checked-in template so `cp .env.example .env` doesn't
 # silently point a fresh local stack at the live upstream.
-# SEMRUSH_PROJECTS_BASE_URL=https://adobe-hackathon.semrush.com
+# SEMRUSH_PROJECTS_BASE_URL=https://www.semrush.com
 
 # ── CDN log delivery (LLMO CloudFront onboarding, cdn-logs provisioning) ──────
 # 12-digit AWS account ID that owns the Adobe cross-account cdn-logs delivery

--- a/docs/decisions/008-no-subworkspace-resource-carve.md
+++ b/docs/decisions/008-no-subworkspace-resource-carve.md
@@ -54,7 +54,7 @@ ever size a child.
 
 ### Evidence
 
-Live probe against the LLMO-Dev-2 parent on `adobe-hackathon.semrush.com`, 2026-07-28. A child
+Live probe against the LLMO-Dev-2 parent on `www.semrush.com`, 2026-07-28. A child
 created with no `resources` body:
 
 - settled to `created` and reported `projects 0/0  prompts 0/0`;

--- a/docs/elements/semrush-elements-api-reference.md
+++ b/docs/elements/semrush-elements-api-reference.md
@@ -461,6 +461,6 @@ Upstream error bodies are **never forwarded to clients** — they are logged ser
 
 | Variable | Source | Used by |
 |---|---|---|
-| `SEMRUSH_PROJECTS_BASE_URL` | Vault `dx_mysticat/<env>/api-service` | `elements-transport.js` `baseUrl()` — the Elements API base host (e.g. `https://adobe-hackathon.semrush.com`) |
+| `SEMRUSH_PROJECTS_BASE_URL` | Vault `dx_mysticat/<env>/api-service` | `elements-transport.js` `baseUrl()` — the Elements API base host (e.g. `https://www.semrush.com`) |
 
 No additional secrets are required. The Elements transport reuses the same `SEMRUSH_PROJECTS_BASE_URL` already configured for the Serenity (prompts/markets) transport.

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1,6 +1,6 @@
 # ── Serenity API ──
 # Public surface for AI-visibility prompts and markets. The upstream is
-# currently Semrush AIO (proxied via adobe-hackathon.semrush.com); upstream
+# currently Semrush AIO (proxied via www.semrush.com); upstream
 # routing details (`workspaceId`, internal project ids) are NOT exposed.
 #
 # The client sends its IMS user token; api-service forwards it; the upstream

--- a/docs/serenity.md
+++ b/docs/serenity.md
@@ -4,7 +4,7 @@ This document is the runtime reference for the `/v2/orgs/:spaceCatId/brands/:bra
 
 ## Architecture in one paragraph
 
-api-service exposes nine endpoints that front the Adobe-hosted Semrush AIO API at `https://adobe-hackathon.semrush.com`. Authentication is IMS-bearer-only: the client sends an `Authorization: Bearer <ims_user_token>`, api-service forwards that header verbatim to Semrush, and the Adobe gateway exchanges the IMS token for Semrush's internal credential server-side. There are no Semrush cookies, API keys, or service accounts in api-service — every outbound request carries the caller's IMS user token. The brand-to-project mapping lives in the `brand_to_semrush_projects` table in mysticat-data-service; the Semrush workspace per org is read from `organizations.semrush_workspace_id` (already in place since PR #2403).
+api-service exposes nine endpoints that front the Adobe-hosted Semrush AIO API at `https://www.semrush.com`. Authentication is IMS-bearer-only: the client sends an `Authorization: Bearer <ims_user_token>`, api-service forwards that header verbatim to Semrush, and the Adobe gateway exchanges the IMS token for Semrush's internal credential server-side. There are no Semrush cookies, API keys, or service accounts in api-service — every outbound request carries the caller's IMS user token. The brand-to-project mapping lives in the `brand_to_semrush_projects` table in mysticat-data-service; the Semrush workspace per org is read from `organizations.semrush_workspace_id` (already in place since PR #2403).
 
 ## Environment configuration
 
@@ -23,11 +23,11 @@ vault login -method=oidc   # opens browser
 
 # value used for all three today; production target host may differ later
 vault kv patch dx_mysticat/dev/api-service \
-  SEMRUSH_PROJECTS_BASE_URL=https://adobe-hackathon.semrush.com
+  SEMRUSH_PROJECTS_BASE_URL=https://www.semrush.com
 vault kv patch dx_mysticat/stage/api-service \
-  SEMRUSH_PROJECTS_BASE_URL=https://adobe-hackathon.semrush.com
+  SEMRUSH_PROJECTS_BASE_URL=https://www.semrush.com
 vault kv patch dx_mysticat/prod/api-service \
-  SEMRUSH_PROJECTS_BASE_URL=https://adobe-hackathon.semrush.com
+  SEMRUSH_PROJECTS_BASE_URL=https://www.semrush.com
 
 # verify (must export VAULT_ADDR — the CLI default is 127.0.0.1:8200)
 export VAULT_ADDR=https://vault-amer.adobe.net
@@ -320,7 +320,7 @@ If step 5, 6 or 7 fails, no row is written and the caller may safely retry with 
 
 ## Delete-market semantics
 
-`DELETE /serenity/markets/:geoTargetId/:languageCode` removes a slice from the brand. Upstream support was verified 2026-05-28 against `adobe-hackathon.semrush.com`:
+`DELETE /serenity/markets/:geoTargetId/:languageCode` removes a slice from the brand. Upstream support was verified 2026-05-28 against `www.semrush.com`:
 
 ```
 OPTIONS /v1/workspaces/{ws}/projects/{pid} → 405, allow: DELETE, GET, PATCH
@@ -441,7 +441,7 @@ What that means operationally: a market carrying this token is **live and usable
 Greppable failure tokens worth alerting on: `SERENITY_MARKET_LINK_REJECTED` (the `brand_sites.type='serenity'` migration is not deployed in the env — every market create/activate then produces a Semrush project + Site with no link), `SERENITY_ACTIVATE_LINK_INCOMPLETE` (markets live upstream but the brand stayed pending because the site mirror failed), and `SERENITY_ACTIVATE_SAVE_DIVERGENCE` / `SERENITY_DEACTIVATE_SAVE_DIVERGENCE` (upstream succeeded but the status/pointer persist failed).
 
 Expected fields in the structured log payload:
-- outbound host: `adobe-hackathon.semrush.com`
+- outbound host: `www.semrush.com`
 - outbound auth: `Authorization: Bearer ...` (the token itself is redacted by the platform)
 - the IMS sub of the caller in the `actor` field
 
@@ -547,10 +547,10 @@ Negative-path checks worth covering: non-UUID `:brandId` → 400 `invalidRequest
 After the walkthrough, verify Splunk has the outbound traces:
 
 ```spl
-index=dx_aem_engineering sourcetype=dx_aem_sites_spacecat_backend_<env> service=api-service "adobe-hackathon.semrush.com" | head 30
+index=dx_aem_engineering sourcetype=dx_aem_sites_spacecat_backend_<env> service=api-service "www.semrush.com" | head 30
 ```
 
-Expected: outbound host `adobe-hackathon.semrush.com`, IMS sub of the caller in `actor`, no `SerenityTransportError` entries beyond the deliberate 404/409 cases above.
+Expected: outbound host `www.semrush.com`, IMS sub of the caller in `actor`, no `SerenityTransportError` entries beyond the deliberate 404/409 cases above.
 
 ## Troubleshooting
 

--- a/docs/specs/2026-05-28-prompts-api-abstraction.md
+++ b/docs/specs/2026-05-28-prompts-api-abstraction.md
@@ -183,7 +183,7 @@ Both `/serenity/tags` and `/serenity/models` require `geoTargetId` + `languageCo
 
 ### 3.5 DELETE market semantics
 
-**Upstream support verified 2026-05-28** against `adobe-hackathon.semrush.com`:
+**Upstream support verified 2026-05-28** against `www.semrush.com`:
 
 ```
 OPTIONS /enterprise/projects/api/v1/workspaces/{ws}/projects/{pid}
@@ -290,7 +290,7 @@ No `@deprecated` aliasing, no parallel surface, no decoder fallback. Any in-flig
 
 ### Pre-flight — upstream capability check (before Phase 1)
 
-Verify whether `DELETE /v1/workspaces/{ws}/projects/{pid}` is supported on `adobe-hackathon.semrush.com`. Quick `curl` with an IMS bearer + workspace + project id from the dev environment. Result determines whether §3.5 Option A or Option B ships.
+Verify whether `DELETE /v1/workspaces/{ws}/projects/{pid}` is supported on `www.semrush.com`. Quick `curl` with an IMS bearer + workspace + project id from the dev environment. Result determines whether §3.5 Option A or Option B ships.
 
 **Validation gate:** decision recorded in the api-service PR description (Option A / Option B). If Option B, the operator runbook (`docs/serenity.md`) gains an "orphan project cleanup" section.
 

--- a/src/support/serenity/rest-transport.js
+++ b/src/support/serenity/rest-transport.js
@@ -770,7 +770,7 @@ export function createSerenityTransport({ env, imsToken }) {
      *
      * NESTING (1-level category tree): pass `parentId` to create the names as
      * CHILDREN of that upstream tag id — a single call, no separate re-parent
-     * needed (verified live 2026-07-01 against adobe-hackathon.semrush.com: the
+     * needed (verified live 2026-07-01 against www.semrush.com: the
      * child comes back with `parent_id` set and lists under the parent). The one
      * `parent_id` applies to every name in the batch. Omit for a flat/root tag.
      *
@@ -896,7 +896,7 @@ export function createSerenityTransport({ env, imsToken }) {
     /**
      * DELETE /v1/workspaces/{ws}/projects/{pid} — removes an upstream
      * project. Upstream support verified 2026-05-28 against
-     * adobe-hackathon.semrush.com:
+     * www.semrush.com:
      *
      *   OPTIONS /v1/workspaces/{ws}/projects/{pid} → 405, allow: DELETE, GET, PATCH
      *   DELETE  /v1/workspaces/{ws}/projects/<bogus> → 404 {"message":"not found"}

--- a/test/support/serenity/rest-transport-metadata.test.js
+++ b/test/support/serenity/rest-transport-metadata.test.js
@@ -22,7 +22,7 @@ use(sinonChai);
 const IMS = 'ims-bearer-test-token';
 const WS = '11111111-2222-3333-4444-555555555555';
 const PID = 'proj-xyz';
-const TEST_ENV = { SEMRUSH_PROJECTS_BASE_URL: 'https://adobe-hackathon.semrush.com' };
+const TEST_ENV = { SEMRUSH_PROJECTS_BASE_URL: 'https://www.semrush.com' };
 
 /**
  * The v3 prompt-authorship-metadata write methods (LLMO-6289) call facade

--- a/test/support/serenity/rest-transport.test.js
+++ b/test/support/serenity/rest-transport.test.js
@@ -36,7 +36,7 @@ const PARENT_WS = 'bb0f4e1c-8bb1-402e-88f2-f68618ea7397';
 // Strict mode: rest-transport now requires SEMRUSH_PROJECTS_BASE_URL to be
 // supplied via env (Vault-backed in dev/stage/prod). Tests inject a
 // deterministic value so the URL-based assertions below stay stable.
-const TEST_ENV = { SEMRUSH_PROJECTS_BASE_URL: 'https://adobe-hackathon.semrush.com' };
+const TEST_ENV = { SEMRUSH_PROJECTS_BASE_URL: 'https://www.semrush.com' };
 
 // All transport methods now route through the typed Semrush clients (Project
 // Engine + User Manager, both openapi-fetch), which call the injected fetch with
@@ -130,7 +130,7 @@ describe('Semrush REST transport', () => {
       await transport.publishProject(WORKSPACE_ID, PROJECT_ID);
 
       const call = await callOf(fetchStub);
-      expect(call.url).to.match(/^https:\/\/adobe-hackathon\.semrush\.com\//);
+      expect(call.url).to.match(/^https:\/\/www\.semrush\.com\//);
     });
 
     it('throws if SEMRUSH_PROJECTS_BASE_URL is missing (no source default)', () => {
@@ -1141,7 +1141,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('DELETE');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}`,
+        `https://www.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}`,
       );
       expect(call.body).to.equal(undefined);
     });
@@ -1173,7 +1173,7 @@ describe('Semrush REST transport', () => {
       // V2: identical schema to v1, drop-in (createBenchmarks precedent). The
       // sibling list/delete ai_models routes have no v2 variant and stay on v1.
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/ai_models`,
+        `https://www.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/ai_models`,
       );
       expect(JSON.parse(call.body)).to.deep.equal({ model_id: 'cat-gpt-4o' });
       expect(result.id).to.equal('new-assignment-uuid');
@@ -1190,7 +1190,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('DELETE');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/ai_models`,
+        `https://www.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/ai_models`,
       );
       expect(JSON.parse(call.body)).to.deep.equal({ ids: ['assign-1', 'assign-2'] });
     });
@@ -1206,7 +1206,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
       expect(call.url).to.equal(
-        'https://adobe-hackathon.semrush.com/enterprise/projects/api/v1/ai_models?page=1&limit=100',
+        'https://www.semrush.com/enterprise/projects/api/v1/ai_models?page=1&limit=100',
       );
       expect(result.items[0].id).to.equal('cat-gpt');
     });
@@ -1223,7 +1223,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('POST');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/tags`,
+        `https://www.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/tags`,
       );
       expect(JSON.parse(call.body)).to.deep.equal({ names });
     });
@@ -1291,7 +1291,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('PATCH');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/tags/tag-1`,
+        `https://www.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/tags/tag-1`,
       );
       expect(JSON.parse(call.body)).to.deep.equal({ name: 'category:Renamed', parent_id: 'parent-1' });
       expect(result).to.deep.equal({ id: 'tag-1', name: 'category:Renamed', parent_id: 'parent-1' });
@@ -1360,7 +1360,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/brand-topics?domain=example.com&country=US`,
+        `https://www.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/brand-topics?domain=example.com&country=US`,
       );
       expect(result[0].topic).to.equal('Running');
     });
@@ -1377,7 +1377,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('POST');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/users/api/v2/workspaces/${PARENT_WS}/child`,
+        `https://www.semrush.com/enterprise/users/api/v2/workspaces/${PARENT_WS}/child`,
       );
       // `resources` is REQUIRED by createWorkspaceV2Form; `{}` is the schema-valid "no
       // allocation" body. Omitting the key is contract-violating even though live tolerates it.
@@ -1397,7 +1397,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}/status`,
+        `https://www.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}/status`,
       );
       expect(result.status).to.equal('created');
     });
@@ -1415,7 +1415,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}/resources`,
+        `https://www.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}/resources`,
       );
       expect(result.product_resources.ai.resources.projects.total).to.equal(13);
     });
@@ -1431,7 +1431,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/users/api/v1/workspaces/${PARENT_WS}/family`,
+        `https://www.semrush.com/enterprise/users/api/v1/workspaces/${PARENT_WS}/family`,
       );
       expect(result.items[0].id).to.equal('subworkspace-ws-1');
     });
@@ -1449,7 +1449,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('DELETE');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}`,
+        `https://www.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}`,
       );
       expect(call.body).to.equal(undefined);
     });
@@ -1486,7 +1486,7 @@ describe('Semrush REST transport', () => {
       const call = await callOf(fetchStub);
       expect(call.method).to.equal('GET');
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/projects?type=ai`,
+        `https://www.semrush.com/enterprise/projects/api/v1/workspaces/${WORKSPACE_ID}/projects?type=ai`,
       );
       expect(result.items[0].id).to.equal(PROJECT_ID);
     });
@@ -1504,7 +1504,7 @@ describe('Semrush REST transport', () => {
       // v2 (not v1): project-engine-client 1.2.0 moved init_status to /v2 and
       // dropped the /v1 route.
       expect(call.url).to.equal(
-        `https://adobe-hackathon.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/init_status`,
+        `https://www.semrush.com/enterprise/projects/api/v2/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/aio/init_status`,
       );
       expect(result.initialized).to.equal(false);
     });
@@ -1549,7 +1549,7 @@ describe('Semrush REST transport', () => {
     it('attaches the upstream URL path as endpoint on SerenityTransportError (SITES-49993)', async () => {
       const resp = fetchFail(422, { code: 'bad_request' });
       Object.defineProperty(resp, 'url', {
-        value: `https://adobe-hackathon.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}/status`,
+        value: `https://www.semrush.com/enterprise/users/api/v1/workspaces/${WORKSPACE_ID}/status`,
       });
       fetchStub.resolves(resp);
       const transport = createSerenityTransport({ env: TEST_ENV, imsToken: IMS });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Replaces the legacy `adobe-hackathon` Semrush proxy host with `https://www.semrush.com` everywhere it appears in this repo — the `.env` example, serenity transport test fixtures, source comments, and docs. No behavior change.

## 2. Reasoning
The legacy proxy host is being decommissioned: Semrush UDH accepts Adobe IMS tokens natively at `https://www.semrush.com`, and the prod Vault value of `SEMRUSH_PROJECTS_BASE_URL` was flipped to the new host on 2026-08-19. The base URL has always been env/Vault-only with no source default, so nothing functional lives in this repo — but examples, fixtures, and docs still named the old host, and anything copied from them would target a host that is about to be shut down.

## 3. High-level overview of the changes
- `.env.example`: the commented `SEMRUSH_PROJECTS_BASE_URL` sample now shows the UDH host.
- `test/support/serenity/rest-transport*.test.js`: the fixture base URL and its URL assertions use the new host (a pure fixture rename — the transport builds URLs from whatever env provides).
- `src/support/serenity/rest-transport.js`: two comments citing live-verification runs now name the UDH host; UDH is the same backend (reads verified byte-identical across both hosts on 2026-07-29), so the documented behavior is unchanged.
- `docs/`: `serenity.md`, the serenity OpenAPI spec examples, the prompts-API spec, ADR 008, and the elements API reference no longer name the retired host.

## 4. Required information
- Other: part of a coordinated sweep removing the legacy proxy host; the only functional change lives in https://github.com/adobe/mysticat-data-service/pull/947 (script default), with docs/examples-only companions in spacecat-shared and serenity-docs.

## 7. Test plan
- Nothing runtime-visible to verify: the deployed base URL comes exclusively from Vault (`dx_mysticat/{env}/api-service`), which this PR does not touch. Prod already runs against `https://www.semrush.com`; the dev/stage Vault flips are owned and validated by the team driving the UDH migration.

## 8. Deployment & merge order
- https://github.com/adobe/mysticat-data-service/pull/947 — related (same sweep, independent to merge).

No ordering constraints; all sweep PRs are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)