### PR TITLE
fix(facs): add aso/can_configure to PATCH /organizations/:organizationId

### DIFF
--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -989,6 +989,7 @@ const routeFacsCapabilities = {
       // cdn / ims-org-access / contact-sales / consent-banner /
       // import-tools / scrape-tools)
       // ------------------------------------------------------------------
+      'PATCH /organizations/:organizationId': 'aso/can_configure',
       'PATCH /sites/:siteId': 'aso/can_configure',
       'PATCH /sites/:siteId/config/cdn-logs': 'aso/can_configure',
       'PATCH /sites/:siteId/config/scraper': 'aso/can_configure',


### PR DESCRIPTION
## Summary

- ASO UI saves task-management config defaults via `PATCH /organizations/:organizationId` without `x-product` header
- Route was only registered in `PRODUCTS_ROUTES.LLMO` (`llmo/can_configure`), blocking ASO UI callers with 403 "x-product header required"
- Added route to `PRODUCTS_ROUTES.ASO` under `aso/can_configure` — ASO UI now passes `x-product: aso` and hits this capability

## Test plan

- [ ] Verify `facs-capabilities` test suite passes: `npx mocha test/routes/facs-capabilities.test.js`
- [ ] Verify ASO UI Jira integration settings save without 403
- [ ] Verify LLMO callers with `x-product: llmo` still work (unchanged)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```