### PR TITLE
fix(elements): make the cited-domains drilldown site-scope aware

### DIFF
--- a/docs/llmo-semrush-apis/filter-dimensions-apis.md
+++ b/docs/llmo-semrush-apis/filter-dimensions-apis.md
@@ -417,7 +417,7 @@ Phase 2 of the URL Inspector **"Cited Third Party URLs"** expandable tree: expan
 |---|---|---|---|
 | `spaceCatId` | path | ✅ | SpaceCat organisation UUID |
 | `brandId` | path | ✅ | SpaceCat brand UUID. Selects the brand's Semrush **sub-workspace** (flat-mode falls back to the org parent). LLMO ReBAC `brand` resource (FACS `llmo/can_view`); requires `brand:read`. `404` if not in the org |
-| `hostname` / `domain` | query | ❌ | Optional registered domain to drill into, as returned by Cited Domains. Matched host-or-subdomain (see below). When omitted, all source hosts are returned before pagination. |
+| `hostname` / `domain` | query | ❌ | Optional scope to drill into: a registered domain as returned by Cited Domains (`intuit.com`), a subdomain (`quickbooks.intuit.com`), or a `host/path` scope (`nba.com/kings`). Matched host-or-subdomain, narrowed by the path prefix when one is given (see below). `400` when non-empty but not parseable as a host. When omitted, all source hosts are returned before pagination. |
 | `model` / `platform` | query | ❌ | AI model filter (`model` wins). Default `search-gpt` |
 | `startDate` / `start_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing, malformed, or after `endDate` |
 | `endDate` / `end_date` | query | ✅ | `YYYY-MM-DD`. `400` if missing or malformed |
@@ -437,7 +437,13 @@ Scoped by top-level `project_id` + date + `CBF_model`. The endpoint fans out **p
 
 ### What it returns
 
-The element has **no server-side domain filter** (verified live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq` + `contains`, all return the full project table), so `hostname` is applied **client-side** — the same pattern Owned URLs uses for `domain_type='Owned'`. Cited Domains reports the **registered domain** (e.g. `openai.com`), but `source` hosts are often subdomains (`help.openai.com`), so a row matches when its host **equals `hostname` or is a subdomain of it** (`host === hostname || host.endsWith('.'+hostname)`, `www.`-stripped, lowercased). Exact-host matching would miss most URLs — e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`. When `hostname` is omitted, all source hosts are retained before applying `channel`, sorting, and pagination. An optional `channel` (content-type) filter is then applied client-side on `contentType`. URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full post-filter count. Field mapping:
+The element has **no server-side domain filter** (verified live: `CBF_domain`/`cbf_domain`/`CBF_source`, `eq` + `contains`, all return the full project table), so `hostname` is applied **client-side** — the same pattern Owned URLs uses for `domain_type='Owned'`. The value is parsed as a `{host, pathPrefix}` scope (`src/support/elements/url-scope.js`) and matched against each row's `source` URL:
+
+- **Host matching folds subdomains in**: Cited Domains reports the **registered domain** (e.g. `openai.com`), but `source` hosts are often subdomains (`help.openai.com`), so a row matches when its host equals the requested host or is a subdomain of it (`www.`-stripped, lowercased). Exact-host matching would miss most URLs — e.g. `cambridge.org` is only ever cited via `dictionary.cambridge.org`.
+- **A path-bearing scope narrows further**: `hostname=nba.com/kings` keeps only rows whose pathname sits at or under `/kings` (segment boundary — `/kingsx` does not match).
+- **The brand's own site anchor is respected**: the brand's primary-site `base_url` defines the site's own scope. Requesting exactly that scope (`quickbooks.intuit.com`, or `nba.com/kings` for a subpath site) returns only the site's subtree. Requesting a **proper ancestor** of it (`intuit.com` for a `quickbooks.intuit.com` brand; `nba.com` for `nba.com/kings`) returns the fold **minus** the site's own subtree — the site's URLs never appear under its parent's third-party row. Brands without a primary site keep the plain fold everywhere.
+
+When `hostname` is omitted, all source hosts are retained before applying `channel`, sorting, and pagination. An optional `channel` (content-type) filter is then applied client-side on `contentType`. URLs are sorted by `citations` **descending** and sliced client-side; `totalCount` is the full post-filter count. Field mapping:
 
 - **`url`** ← `source`; **`citations`** ← `citations`; **`promptsCited`** ← `prompts_with_citation`
 - **`contentType`** ← `domain_type`

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -1282,7 +1282,7 @@ export default function ElementsController(context, log, env) {
    * domain (`hostname`, which also accepts a `host/path` scope) client-side
    * instead of `domain_type='Owned'`. The brand's own site anchor is passed
    * along so a subdomain/subpath site's subtree stays separable from its
-   * parent domain's fold (see `matchesRequestedScope` in url-scope.js).
+   * parent domain's fold (see `createScopeMatcher` in url-scope.js).
    */
   const listDomainUrls = async (ctx) => {
     try {

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -23,6 +23,7 @@ import { ElementsTransportError } from '../support/elements/errors.js';
 import { createElementsService } from '../support/elements/elements-service.js';
 import { fetchOwnedUrlsTraffic, mergeOwnedUrlsTraffic } from '../support/elements/owned-urls-traffic.js';
 import { mapWithConcurrency } from '../support/elements/concurrency.js';
+import { splitScope } from '../support/elements/url-scope.js';
 import { addDaysToDate } from '../support/elements/week-utils.js';
 import { resolveBrandWorkspace } from '../support/serenity/workspace-resolver.js';
 import { isSerenityActiveForBrand } from '../support/serenity/serenity-active.js';
@@ -371,7 +372,8 @@ async function authorizeOrgAccess(ctx) {
  * `:brandId`. `workspaceId` is the brand's Semrush sub-workspace ID, falling
  * back to the org's parent workspace when the brand hasn't been provisioned
  * one yet (per `resolveBrandWorkspace`'s dual-mode resolution). `brand` is
- * looked up via {@link getBrandIdentity} (a lightweight `id, name` select) —
+ * looked up via {@link getBrandIdentity} (a lightweight `id, name, baseUrl`
+ * select) —
  * a missing PostgREST client is reported as 503, not masked as a brand 404.
  *
  * Returns `{ workspaceId, brand }` on success or `{ error: Response }` on failure.
@@ -1277,7 +1279,10 @@ export default function ElementsController(context, log, env) {
    * Phase 2 of the Cited Third-Party tree: expand a cited domain → its URLs.
    * Same Semrush element as owned-urls (Stats-per-URL 9af5ed83) minus the trend
    * element and the Postgres traffic hybrid, optionally filtered to a single
-   * domain (`hostname`) client-side instead of `domain_type='Owned'`.
+   * domain (`hostname`, which also accepts a `host/path` scope) client-side
+   * instead of `domain_type='Owned'`. The brand's own site anchor is passed
+   * along so a subdomain/subpath site's subtree stays separable from its
+   * parent domain's fold (see `matchesRequestedScope` in url-scope.js).
    */
   const listDomainUrls = async (ctx) => {
     try {
@@ -1334,6 +1339,12 @@ export default function ElementsController(context, log, env) {
       // Normalize whitespace-only hostname to "no filter" explicitly at the API
       // boundary, rather than relying on the transform's downstream `.trim()`.
       const hostname = (query.hostname || query.domain || '').trim() || undefined;
+      // Reject a hostname that parses to no host (e.g. a bare path) here at the
+      // boundary, mirroring the date validation above; the transform's own
+      // empty-result guard stays as defense-in-depth.
+      if (hostname && !splitScope(hostname)) {
+        return badRequest('hostname must be a domain or host/path scope');
+      }
 
       // The transform optionally host-filters, sorts by citations desc, and slices
       // client-side (Semrush has no server-side pagination); totalCount is the full
@@ -1341,6 +1352,9 @@ export default function ElementsController(context, log, env) {
       const result = await service.getDomainUrls(workspaceId, {
         projects,
         hostname,
+        // The brand's own site anchor (subdomain/subpath aware): scopes the
+        // site's row to its own subtree and keeps it out of ancestor folds.
+        siteBaseUrl: brand.baseUrl,
         channel: query.channel || query.selectedChannel,
         model: query.model || query.platform,
         startDate,

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -697,18 +697,23 @@ export async function getBrandById(organizationId, brandId, postgrestClient) {
 }
 
 /**
- * Lightweight brand/org-membership + display-name lookup. Selects only `id, name`
- * — unlike {@link getBrandById}, which pays for a wide 8-table join
+ * Lightweight brand/org-membership + display-name lookup. Selects `id, name`
+ * plus the primary site's `base_url` (one indexed `sites!site_id` FK join) —
+ * unlike {@link getBrandById}, which pays for a wide 8-table join
  * (`BRAND_SELECT`: aliases, social accounts, earned sources, competitors, sites,
  * urls) to build the full brand DTO. Callers that only need to confirm a brand
  * belongs to an org and want its display name (e.g. auth guards enriching a
- * filter-dimensions response) should use this instead.
+ * filter-dimensions response) should use this instead. `baseUrl` carries the
+ * brand's own site scope (may include a subdomain or a subpath, e.g.
+ * `https://nba.com/kings`); it is null for a serenity shell without a
+ * `site_id`.
  *
  * @param {string} organizationId - SpaceCat organization UUID.
  * @param {string} brandId - Brand UUID.
  * @param {object} postgrestClient - PostgREST client.
- * @returns {Promise<{id: string, name: string} | null>} the brand's id + name,
- *   or null if it doesn't exist / doesn't belong to the org.
+ * @returns {Promise<{id: string, name: string, baseUrl: string|null} | null>}
+ *   the brand's id, name, and primary-site base URL, or null if it doesn't
+ *   exist / doesn't belong to the org.
  */
 export async function getBrandIdentity(organizationId, brandId, postgrestClient) {
   if (!postgrestClient?.from || !hasText(brandId)) {
@@ -717,7 +722,7 @@ export async function getBrandIdentity(organizationId, brandId, postgrestClient)
 
   const { data, error } = await postgrestClient
     .from('brands')
-    .select('id, name')
+    .select('id, name, base_site:sites!site_id(base_url)')
     .eq('organization_id', organizationId)
     .eq('id', brandId)
     .maybeSingle();
@@ -725,7 +730,11 @@ export async function getBrandIdentity(organizationId, brandId, postgrestClient)
   if (error) {
     throw new Error(`Failed to get brand identity: ${error.message}`);
   }
-  return data ?? null;
+  if (!data) {
+    return null;
+  }
+  // Same derivation as mapDbBrandToV2's `baseUrl` (BRAND_SELECT's base_site join).
+  return { id: data.id, name: data.name, baseUrl: data.base_site?.base_url || null };
 }
 
 /**

--- a/src/support/elements/definitions/domain-urls.js
+++ b/src/support/elements/definitions/domain-urls.js
@@ -11,6 +11,7 @@
  */
 
 import { isAllPlatforms, resolveElementModel } from '../constants.js';
+import { createScopeMatcher, parseCandidateUrl, splitScope } from '../url-scope.js';
 
 /**
  * Builds the payload for the Stats-per-URL element (9af5ed83, `table`) scoped to a
@@ -58,37 +59,6 @@ export function buildDomainUrlsPayload({
   };
 }
 
-/* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
-
-/**
- * Extracts the registrable-domain-agnostic host of a URL: lowercased, `www.`-stripped.
- * Returns null for unparseable values (defensive — Semrush `source` is always a URL).
- */
-function hostOf(url) {
-  try {
-    return new URL(url).hostname.replace(/^www\./, '').toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
-/**
- * True when `host` is `hostname` itself or a subdomain of it.
- *
- * The incoming `hostname` comes from the cited-domains element (98b91d00), which
- * reports the REGISTERED domain (eTLD+1, e.g. `openai.com`, `cambridge.org`). But the
- * Stats-per-URL element's `source` hosts are often subdomains (`help.openai.com`,
- * `dictionary.cambridge.org`). So an exact-host match would drop most (or, for
- * `cambridge.org`, ALL) of a domain's URLs. Matching `host === hostname ||
- * host.endsWith('.'+hostname)` captures the apex + every subdomain without a
- * public-suffix list, and the leading-dot guard prevents `notopenai.com` from
- * matching `openai.com`. Verified live (2026-07-10): `cambridge.org` → 46 URLs, all
- * under `dictionary.cambridge.org`; exact match would have returned 0.
- */
-function hostMatches(host, hostname) {
-  return host === hostname || host.endsWith(`.${hostname}`);
-}
-
 /**
  * Parses the pagination params (0-based `page`, `pageSize`) mirroring the legacy
  * parsePaginationParams (defaultPageSize 50, clamped to [1, 1000]).
@@ -117,22 +87,35 @@ function parsePagination({ page, pageSize } = {}) {
  * `regions`/`categories` are STRINGS here (the legacy contract + the UI `DomainUrlRow`
  * type), NOT arrays like owned-urls.
  *
- * When `hostname` is supplied, only rows whose `source` host matches it
- * (host-or-subdomain, see {@link hostMatches}) are kept. When omitted, all source
- * hosts are kept. An optional `channel` (content-type) filter is then applied
+ * When `hostname` is supplied it is parsed as a `{host, pathPrefix}` scope
+ * (`intuit.com`, `quickbooks.intuit.com`, `nba.com/kings` are all expressible)
+ * and only rows within that scope are kept — the eTLD+1 fold for host-only
+ * scopes, narrowed by the path prefix when one is given. When `siteBaseUrl`
+ * (the brand's own site anchor) is supplied and the requested scope is a
+ * proper ancestor of it, rows in the site's own subtree are excluded from the
+ * fold — the site's own URLs are addressable by requesting the site scope
+ * itself (see {@link createScopeMatcher}). When `hostname` is omitted, all
+ * source hosts are kept. An optional `channel` (content-type) filter is then applied
  * client-side on `contentType` (case-insensitive) — the element has no server-side
  * content-type filter, so this mirrors cited-domains + the legacy RPC's `p_channel`.
  * Semrush has no server-side pagination, so after filtering we sort by citations
  * desc and slice client-side; `totalCount` is the post-filter, pre-slice count.
  *
  * @param {Array<{region?: string, stats: object}>} projectResults
- * @param {object} params - { hostname, channel, page, pageSize }.
+ * @param {object} params - { hostname, siteBaseUrl, channel, page, pageSize }.
  * @returns {{ urls: Array<object>, totalCount: number }}
  */
 export function transformDomainUrlsResponse(projectResults = [], params = {}) {
   const { page, pageSize } = parsePagination(params);
-  const hostname = String(params.hostname ?? '').trim().replace(/^www\./, '').toLowerCase();
-  const filterByHostname = hostname !== '';
+  const rawHostname = String(params.hostname ?? '').trim();
+  const requestedScope = splitScope(rawHostname);
+  // A non-empty hostname that parses to no host (e.g. a bare path) can match
+  // nothing — return empty rather than silently dropping the filter.
+  if (rawHostname !== '' && !requestedScope) {
+    return { urls: [], totalCount: 0 };
+  }
+  const siteScope = splitScope(params.siteBaseUrl);
+  const matchesScope = requestedScope && createScopeMatcher(requestedScope, siteScope);
   const channel = typeof params.channel === 'string' ? params.channel.trim() : '';
   const byUrl = new Map();
 
@@ -142,8 +125,8 @@ export function transformDomainUrlsResponse(projectResults = [], params = {}) {
         // eslint-disable-next-line no-continue
         continue;
       }
-      const host = hostOf(row.source);
-      if (!host || (filterByHostname && !hostMatches(host, hostname))) {
+      const candidate = parseCandidateUrl(row.source);
+      if (!candidate || (matchesScope && !matchesScope(candidate))) {
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -192,4 +175,3 @@ export function transformDomainUrlsResponse(projectResults = [], params = {}) {
   const offset = page * pageSize;
   return { urls: urls.slice(offset, offset + pageSize), totalCount };
 }
-/* c8 ignore stop */

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -551,7 +551,11 @@ export function createElementsService(transport, log) {
      * @param {object} params
      * @param {Array<{region?: string, projectId?: string}>} [params.projects] -
      *   Projects to query. Empty → one unscoped (workspace-wide) fetch.
-     * @param {string} params.hostname - Registered domain to drill into (required).
+     * @param {string} params.hostname - Domain (or `host/path` scope) to drill
+     *   into (required).
+     * @param {string} [params.siteBaseUrl] - The brand's own site anchor
+     *   (`sites.base_url`); lets the transform separate the site's subtree from
+     *   an ancestor-domain fold.
      * @param {string} [params.channel] - Content-type filter, applied client-side.
      * @param {string} [params.model] / [params.platform] - AI model filter.
      * @param {string} params.startDate / params.endDate - Required YYYY-MM-DD.
@@ -561,8 +565,8 @@ export function createElementsService(transport, log) {
      */
     /* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
     async getDomainUrls(workspaceId, {
-      projects = [], hostname, channel, model, platform, startDate, endDate, category,
-      page, pageSize,
+      projects = [], hostname, siteBaseUrl, channel, model, platform, startDate, endDate,
+      category, page, pageSize,
     }) {
       const scopes = projects.length > 0 ? projects : [{}];
       // Bound the per-project fan-out (mirrors owned-urls) so a brand with many
@@ -583,7 +587,7 @@ export function createElementsService(transport, log) {
         },
       );
       return transformDomainUrlsResponse(projectResults, {
-        hostname, channel, page, pageSize,
+        hostname, siteBaseUrl, channel, page, pageSize,
       });
     },
     /* c8 ignore stop */

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -563,7 +563,6 @@ export function createElementsService(transport, log) {
      * @param {string|number} [params.page] / [params.pageSize] - Client-side slice.
      * @returns {Promise<{ urls: object[], totalCount: number }>} Legacy contract.
      */
-    /* c8 ignore start -- LLMO-6160 POC endpoint; unit tests intentionally deferred */
     async getDomainUrls(workspaceId, {
       projects = [], hostname, siteBaseUrl, channel, model, platform, startDate, endDate,
       category, page, pageSize,
@@ -590,7 +589,6 @@ export function createElementsService(transport, log) {
         hostname, siteBaseUrl, channel, page, pageSize,
       });
     },
-    /* c8 ignore stop */
 
     /**
      * Fetches weekly per-competitor mentions + citations for the Competitor

--- a/src/support/elements/url-scope.js
+++ b/src/support/elements/url-scope.js
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { siteIdentityFromUrlString, stripWWW } from '@adobe/spacecat-shared-utils';
+
+/**
+ * URL-scope matching for the Semrush elements read paths (LLMO-7138).
+ *
+ * A "scope" is a `{host, pathPrefix}` pair naming a section of the web:
+ * a whole registered domain (`intuit.com`), one subdomain
+ * (`quickbooks.intuit.com`), or a subtree of a domain (`nba.com/kings`).
+ * Sites can be anchored at any of these granularities (`sites.base_url`
+ * preserves subdomains and paths), while the Semrush cited-domains element
+ * reports only registered (eTLD+1) domains — so the drilldown filter has to
+ * reconcile a coarse requested key with a potentially finer site anchor.
+ *
+ * All matching here is case-insensitive: hosts are lowercased by the URL
+ * parser, and path prefixes/pathnames are lowercased on extraction (site
+ * base URLs are stored lowercased; Semrush `source` URLs may not be).
+ *
+ * @typedef {object} UrlScope
+ * @property {string} host - lowercased, `www.`-stripped hostname.
+ * @property {string} pathPrefix - lowercased path with a leading `/` and no
+ *   trailing slash, or `''` when the scope covers the whole host.
+ */
+
+/**
+ * Splits a scope value — a bare host (`quickbooks.intuit.com`), a host+path
+ * (`nba.com/kings`), or a full URL — into a {@link UrlScope}. Delegates the
+ * tolerant host/path parsing to `siteIdentityFromUrlString` (which lowercases
+ * the host, strips a single trailing slash, and returns null for empty or
+ * unparseable input), then strips a leading `www.` — the elements fold has
+ * always treated `www` and the apex as the same site.
+ *
+ * @param {string|null|undefined} value
+ * @returns {UrlScope|null} the parsed scope, or null when there is none.
+ */
+export function splitScope(value) {
+  const identity = siteIdentityFromUrlString(value);
+  if (!identity) {
+    return null;
+  }
+  const slash = identity.indexOf('/');
+  const host = stripWWW(slash === -1 ? identity : identity.slice(0, slash));
+  if (host === '') {
+    return null;
+  }
+  // Trailing slashes (siteIdentityFromUrlString strips only one) would break
+  // the segment-boundary match, so drop them all; a bare '/' degrades to a
+  // whole-host scope.
+  const pathPrefix = slash === -1 ? '' : identity.slice(slash).toLowerCase().replace(/\/+$/, '');
+  return { host, pathPrefix };
+}
+
+/**
+ * Extracts the `{host, pathname}` of a row's source URL for scope matching:
+ * host lowercased and `www.`-stripped, pathname lowercased with trailing
+ * slashes trimmed (so `/kings/` and `/kings` agree; the root becomes `''`,
+ * mirroring a whole-host scope's `pathPrefix`). Returns null for unparseable
+ * values (defensive — Semrush `source` is always a URL).
+ *
+ * @param {string} url
+ * @returns {{host: string, pathname: string}|null}
+ */
+export function parseCandidateUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const host = stripWWW(parsed.hostname).toLowerCase();
+    const pathname = parsed.pathname.toLowerCase().replace(/\/+$/, '');
+    return { host, pathname };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `candidateHost` is `scopeHost` itself or a subdomain of it.
+ *
+ * This is the deliberate eTLD+1 fold: the cited-domains element (98b91d00)
+ * reports REGISTERED domains (`cambridge.org`), while Stats-per-URL `source`
+ * hosts are often subdomains (`dictionary.cambridge.org`) — an exact-host
+ * match would drop most (or all) of a domain's URLs. Verified live
+ * (2026-07-10): `cambridge.org` → 46 URLs, all under
+ * `dictionary.cambridge.org`; exact match would have returned 0. The
+ * leading-dot guard prevents `notopenai.com` from matching `openai.com`.
+ *
+ * @param {string} candidateHost
+ * @param {string} scopeHost
+ * @returns {boolean}
+ */
+export function hostMatches(candidateHost, scopeHost) {
+  return candidateHost === scopeHost || candidateHost.endsWith(`.${scopeHost}`);
+}
+
+/**
+ * Segment-boundary path-prefix match: `/kings` matches `/kings` and
+ * `/kings/roster`, but not `/kingsx`. An empty prefix (whole-host scope)
+ * matches every pathname.
+ *
+ * @param {string} pathname
+ * @param {string} pathPrefix
+ * @returns {boolean}
+ */
+export function isWithinPathPrefix(pathname, pathPrefix) {
+  return pathPrefix === '' || pathname === pathPrefix || pathname.startsWith(`${pathPrefix}/`);
+}
+
+/**
+ * True when a candidate `{host, pathname}` falls inside `scope`: host equal
+ * to or a subdomain of the scope host, and pathname within the scope's path
+ * prefix.
+ *
+ * @param {UrlScope} scope
+ * @param {{host: string, pathname: string}} candidate
+ * @returns {boolean}
+ */
+export function scopeContains(scope, candidate) {
+  return hostMatches(candidate.host, scope.host)
+    && isWithinPathPrefix(candidate.pathname, scope.pathPrefix);
+}
+
+/**
+ * True when `requestedScope` is a strictly broader ancestor of `siteScope`:
+ * `intuit.com` is a proper ancestor of `quickbooks.intuit.com`, and `nba.com`
+ * of `nba.com/kings` — but a scope is never an ancestor of itself, of a
+ * sibling, or of a broader scope.
+ *
+ * @param {UrlScope} requestedScope
+ * @param {UrlScope} siteScope
+ * @returns {boolean}
+ */
+export function isProperAncestor(requestedScope, siteScope) {
+  const equal = requestedScope.host === siteScope.host
+    && requestedScope.pathPrefix === siteScope.pathPrefix;
+  return !equal
+    && hostMatches(siteScope.host, requestedScope.host)
+    && isWithinPathPrefix(siteScope.pathPrefix, requestedScope.pathPrefix);
+}
+
+/**
+ * Builds the per-row predicate for one drilldown request, given the site's
+ * own scope (from its `base_url`; null when the brand has no primary site or
+ * the value is unparseable). The requested-vs-site relationship is resolved
+ * once here, not per row — only the candidate varies inside the row loop:
+ *
+ *  - When the requested scope is a proper ancestor of the site scope
+ *    (drilling `intuit.com` for a `quickbooks.intuit.com` site, or `nba.com`
+ *    for `nba.com/kings`), rows inside the site's own subtree are EXCLUDED —
+ *    the fold covers everything else under the requested domain, and the
+ *    site's own URLs are addressable by requesting the site scope itself.
+ *  - Otherwise plain containment: the eTLD+1 fold for host-only scopes,
+ *    narrowed by the path prefix when the requested scope carries one. A
+ *    request for the site's own scope therefore returns exactly the site's
+ *    subtree; with no site scope every request behaves as a plain fold.
+ *
+ * @param {UrlScope} requestedScope - non-null; callers skip filtering when
+ *   there is no requested scope.
+ * @param {UrlScope|null} siteScope
+ * @returns {(candidate: {host: string, pathname: string}) => boolean}
+ */
+export function createScopeMatcher(requestedScope, siteScope) {
+  const excludeScope = siteScope && isProperAncestor(requestedScope, siteScope) ? siteScope : null;
+  return (candidate) => scopeContains(requestedScope, candidate)
+    && !(excludeScope && scopeContains(excludeScope, candidate));
+}

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -1816,6 +1816,45 @@ describe('ElementsController', () => {
       const [, params] = serviceStub.getDomainUrls.firstCall.args;
       expect(params.hostname).to.be.undefined;
     });
+
+    it('rejects a hostname without a parseable host with 400', async () => {
+      const ctx = fakeContext({
+        url: domainUrlsUrl('?startDate=2026-07-01&endDate=2026-07-14&hostname=%2Fjust%2Fa%2Fpath'),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listDomainUrls(ctx);
+
+      expect(res.status).to.equal(400);
+      expect(serviceStub.getDomainUrls).to.not.have.been.called;
+    });
+
+    it('passes the brand primary-site base URL to the service as siteBaseUrl', async () => {
+      getBrandIdentityStub.resolves({
+        id: BRAND_ID, name: 'Adobe Brand', baseUrl: 'https://nba.com/kings',
+      });
+      const ctx = fakeContext({
+        url: domainUrlsUrl('?startDate=2026-07-01&endDate=2026-07-14&hostname=nba.com'),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listDomainUrls(ctx);
+
+      expect(res.status).to.equal(200);
+      const [, params] = serviceStub.getDomainUrls.firstCall.args;
+      expect(params.siteBaseUrl).to.equal('https://nba.com/kings');
+    });
+
+    it('passes no siteBaseUrl for a brand without a primary site', async () => {
+      getBrandIdentityStub.resolves({ id: BRAND_ID, name: 'Adobe Brand', baseUrl: null });
+      const ctx = fakeContext({
+        url: domainUrlsUrl('?startDate=2026-07-01&endDate=2026-07-14'),
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      const res = await ctrl.listDomainUrls(ctx);
+
+      expect(res.status).to.equal(200);
+      const [, params] = serviceStub.getDomainUrls.firstCall.args;
+      expect(params.siteBaseUrl).to.be.null;
+    });
   });
 
   // The 4th URL Inspector KPI card, split out of getUrlInspectorStats — shares

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -482,13 +482,33 @@ describe('brands-storage', () => {
       expect(await getBrandIdentity(ORG_ID, '', { from: () => {} })).to.be.null;
     });
 
-    it('returns the { id, name } identity unchanged, without mapping through the full brand DTO', async () => {
-      const query = createChainableQuery({ data: { id: BRAND_ID, name: 'TestBrand' }, error: null });
+    it('returns { id, name, baseUrl } with baseUrl from the base_site join', async () => {
+      const query = createChainableQuery({
+        data: {
+          id: BRAND_ID,
+          name: 'TestBrand',
+          base_site: { base_url: 'https://quickbooks.intuit.com' },
+        },
+        error: null,
+      });
       const postgrestClient = { from: sinon.stub().returns(query) };
 
       const result = await getBrandIdentity(ORG_ID, BRAND_ID, postgrestClient);
 
-      expect(result).to.deep.equal({ id: BRAND_ID, name: 'TestBrand' });
+      expect(result).to.deep.equal({
+        id: BRAND_ID,
+        name: 'TestBrand',
+        baseUrl: 'https://quickbooks.intuit.com',
+      });
+    });
+
+    it('returns baseUrl null for a brand without a primary site (no base_site join row)', async () => {
+      const query = createChainableQuery({ data: { id: BRAND_ID, name: 'TestBrand', base_site: null }, error: null });
+      const postgrestClient = { from: sinon.stub().returns(query) };
+
+      const result = await getBrandIdentity(ORG_ID, BRAND_ID, postgrestClient);
+
+      expect(result).to.deep.equal({ id: BRAND_ID, name: 'TestBrand', baseUrl: null });
     });
 
     it('returns null when the brand does not exist in the org', async () => {

--- a/test/support/elements/definitions/domain-urls.test.js
+++ b/test/support/elements/definitions/domain-urls.test.js
@@ -60,6 +60,20 @@ describe('domain-urls definitions', () => {
 
       expect(modelFilter(payload)).to.be.undefined;
     });
+
+    it('adds the category tag filter and the top-level project_id when provided', () => {
+      const payload = buildDomainUrlsPayload({
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        category: 'category__foo',
+        projectId: 'proj-1',
+      });
+
+      expect(payload.project_id).to.equal('proj-1');
+      expect(payload.filters.advanced.filters).to.deep.include(
+        { op: 'eq', val: 'category__foo', col: 'CBF_tags' },
+      );
+    });
   });
 
   describe('transformDomainUrlsResponse', () => {
@@ -178,6 +192,156 @@ describe('domain-urls definitions', () => {
       expect(result.urls.map((url) => url.url)).to.deep.equal([
         'https://adobe.com/b',
       ]);
+    });
+
+    it('skips statless projects, null rows, sourceless rows, and unparseable sources', () => {
+      const result = transformDomainUrlsResponse([
+        { region: 'DE', stats: undefined },
+        {
+          stats: {
+            blocks: {
+              data: [
+                null,
+                { citations: 3, prompts_with_citation: 1, domain_type: 'Other' },
+                {
+                  source: 'not a url', citations: 3, prompts_with_citation: 1, domain_type: 'Other',
+                },
+                { source: 'https://adobe.com/a', citations: 5 },
+              ],
+            },
+          },
+        },
+      ], {});
+
+      expect(result.totalCount).to.equal(1);
+      // Missing domain_type / prompts_with_citation default to '' / 0; no region
+      // on the project → the row's regions string stays empty.
+      expect(result.urls[0]).to.include({
+        url: 'https://adobe.com/a', contentType: '', promptsCited: 0, regions: '',
+      });
+    });
+
+    it('merges the same URL across projects, summing counts and joining regions', () => {
+      const row = {
+        source: 'https://adobe.com/a', citations: 5, prompts_with_citation: 3, domain_type: 'Owned',
+      };
+      const result = transformDomainUrlsResponse([
+        { region: 'US', stats: { blocks: { data: [row] } } },
+        { region: 'DE', stats: { blocks: { data: [{ ...row, citations: 'oops' }] } } },
+      ], { page: 0, pageSize: 10 });
+
+      expect(result.totalCount).to.equal(1);
+      expect(result.urls[0]).to.include({
+        url: 'https://adobe.com/a', citations: 5, promptsCited: 6, regions: 'DE,US',
+      });
+    });
+  });
+
+  describe('transformDomainUrlsResponse site scoping', () => {
+    const project = (rows) => [{ region: 'US', stats: { blocks: { data: rows } } }];
+    const row = (source, citations = 1) => ({
+      source, citations, prompts_with_citation: 1, domain_type: 'Other',
+    });
+    const urlsOf = (result) => result.urls.map((u) => u.url);
+
+    const intuitRows = project([
+      row('https://quickbooks.intuit.com/pricing', 9),
+      row('https://help.quickbooks.intuit.com/faq', 8),
+      row('https://turbotax.intuit.com/deals', 7),
+      row('https://www.intuit.com/company', 6),
+    ]);
+    const nbaRows = project([
+      row('https://www.nba.com/kings', 9),
+      row('https://nba.com/kings/roster', 8),
+      row('https://nba.com/kingsx', 7),
+      row('https://nba.com/celtics', 6),
+      row('https://cdn.espn.com/kings', 5),
+    ]);
+
+    it('returns only the site subtree when the site host is requested (subdomain site)', () => {
+      const result = transformDomainUrlsResponse(intuitRows, {
+        hostname: 'quickbooks.intuit.com',
+        siteBaseUrl: 'https://quickbooks.intuit.com',
+      });
+
+      expect(urlsOf(result)).to.deep.equal([
+        'https://quickbooks.intuit.com/pricing',
+        'https://help.quickbooks.intuit.com/faq',
+      ]);
+    });
+
+    it('excludes the site subtree from the parent-domain fold (subdomain site)', () => {
+      const result = transformDomainUrlsResponse(intuitRows, {
+        hostname: 'intuit.com',
+        siteBaseUrl: 'https://quickbooks.intuit.com',
+      });
+
+      expect(urlsOf(result)).to.deep.equal([
+        'https://turbotax.intuit.com/deals',
+        'https://www.intuit.com/company',
+      ]);
+    });
+
+    it('returns only the path subtree when the site scope is requested (subpath site)', () => {
+      const result = transformDomainUrlsResponse(nbaRows, {
+        hostname: 'nba.com/kings',
+        siteBaseUrl: 'https://www.nba.com/kings',
+      });
+
+      expect(urlsOf(result)).to.deep.equal([
+        'https://www.nba.com/kings',
+        'https://nba.com/kings/roster',
+      ]);
+    });
+
+    it('excludes the path subtree from the host fold (subpath site)', () => {
+      const result = transformDomainUrlsResponse(nbaRows, {
+        hostname: 'nba.com',
+        siteBaseUrl: 'https://www.nba.com/kings',
+      });
+
+      expect(urlsOf(result)).to.deep.equal([
+        'https://nba.com/kingsx',
+        'https://nba.com/celtics',
+      ]);
+    });
+
+    it('keeps the plain fold for third-party domains regardless of the site scope', () => {
+      const result = transformDomainUrlsResponse(nbaRows, {
+        hostname: 'espn.com',
+        siteBaseUrl: 'https://www.nba.com/kings',
+      });
+
+      expect(urlsOf(result)).to.deep.equal(['https://cdn.espn.com/kings']);
+    });
+
+    it('keeps the whole fold when no site scope is supplied (legacy behavior)', () => {
+      const result = transformDomainUrlsResponse(intuitRows, { hostname: 'intuit.com' });
+
+      expect(result.totalCount).to.equal(4);
+    });
+
+    it('narrows a path-bearing third-party scope by its path prefix', () => {
+      const result = transformDomainUrlsResponse(nbaRows, {
+        hostname: 'nba.com/celtics',
+        siteBaseUrl: 'https://www.nba.com/kings',
+      });
+
+      expect(urlsOf(result)).to.deep.equal(['https://nba.com/celtics']);
+    });
+
+    it('matches nothing for a non-empty hostname without a parseable host', () => {
+      const result = transformDomainUrlsResponse(nbaRows, { hostname: '/just/a/path' });
+
+      expect(result).to.deep.equal({ urls: [], totalCount: 0 });
+    });
+
+    it('keeps all rows when hostname is omitted, even with a site scope present', () => {
+      const result = transformDomainUrlsResponse(nbaRows, {
+        siteBaseUrl: 'https://www.nba.com/kings',
+      });
+
+      expect(result.totalCount).to.equal(5);
     });
   });
 });

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -258,6 +258,50 @@ describe('createElementsService', () => {
     });
   });
 
+  describe('getDomainUrls', () => {
+    const statsFor = (source, citations) => ({
+      blocks: {
+        data: [{
+          source, citations, prompts_with_citation: 1, domain_type: 'Other',
+        }],
+      },
+    });
+
+    it('fans out one Stats-per-URL call per project and threads the scope params', async () => {
+      transport.fetchElement.onFirstCall().resolves(statsFor('https://quickbooks.intuit.com/a', 5));
+      transport.fetchElement.onSecondCall().resolves(statsFor('https://turbotax.intuit.com/b', 3));
+
+      const result = await service.getDomainUrls('ws-1', {
+        projects: [{ region: 'US', projectId: 'p1' }, { region: 'AU', projectId: 'p2' }],
+        hostname: 'intuit.com',
+        siteBaseUrl: 'https://quickbooks.intuit.com',
+        startDate: '2026-07-01',
+        endDate: '2026-07-28',
+      });
+
+      expect(transport.fetchElement).to.have.been.calledTwice;
+      expect(transport.fetchElement.firstCall.args[1]).to.equal(ELEMENT_IDS.STATS_PER_URL);
+      expect(transport.fetchElement.firstCall.args[2].project_id).to.equal('p1');
+      expect(transport.fetchElement.secondCall.args[2].project_id).to.equal('p2');
+      // The site's own subtree is excluded from the ancestor fold; regions ride along.
+      expect(result.totalCount).to.equal(1);
+      expect(result.urls[0]).to.include({ url: 'https://turbotax.intuit.com/b', regions: 'AU' });
+    });
+
+    it('falls back to a single unscoped call when no projects are given', async () => {
+      transport.fetchElement.resolves(statsFor('https://reddit.com/x', 2));
+
+      const result = await service.getDomainUrls('ws-1', {
+        startDate: '2026-07-01',
+        endDate: '2026-07-28',
+      });
+
+      expect(transport.fetchElement).to.have.been.calledOnce;
+      expect(transport.fetchElement.firstCall.args[2].project_id).to.be.undefined;
+      expect(result.urls.map((u) => u.url)).to.deep.equal(['https://reddit.com/x']);
+    });
+  });
+
   describe('getPrompts', () => {
     const RAW_PROMPTS = {
       type: 'table',

--- a/test/support/elements/url-scope.test.js
+++ b/test/support/elements/url-scope.test.js
@@ -103,6 +103,7 @@ describe('url-scope', () => {
 
   describe('isWithinPathPrefix', () => {
     it('matches everything under an empty prefix', () => {
+      expect(isWithinPathPrefix('', '')).to.be.true;
       expect(isWithinPathPrefix('/', '')).to.be.true;
       expect(isWithinPathPrefix('/anything', '')).to.be.true;
     });

--- a/test/support/elements/url-scope.test.js
+++ b/test/support/elements/url-scope.test.js
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  splitScope,
+  parseCandidateUrl,
+  hostMatches,
+  isWithinPathPrefix,
+  scopeContains,
+  isProperAncestor,
+  createScopeMatcher,
+} from '../../../src/support/elements/url-scope.js';
+
+describe('url-scope', () => {
+  describe('splitScope', () => {
+    it('parses a bare host', () => {
+      expect(splitScope('intuit.com')).to.deep.equal({ host: 'intuit.com', pathPrefix: '' });
+    });
+
+    it('parses a subdomain host', () => {
+      expect(splitScope('quickbooks.intuit.com'))
+        .to.deep.equal({ host: 'quickbooks.intuit.com', pathPrefix: '' });
+    });
+
+    it('parses a host/path scope', () => {
+      expect(splitScope('nba.com/kings')).to.deep.equal({ host: 'nba.com', pathPrefix: '/kings' });
+    });
+
+    it('parses a full URL, stripping www and the trailing slash', () => {
+      expect(splitScope('https://www.nba.com/kings/'))
+        .to.deep.equal({ host: 'nba.com', pathPrefix: '/kings' });
+    });
+
+    it('lowercases the host and the path prefix', () => {
+      expect(splitScope('WWW.NBA.com/Kings'))
+        .to.deep.equal({ host: 'nba.com', pathPrefix: '/kings' });
+    });
+
+    it('returns null for empty, whitespace-only, and non-string input', () => {
+      expect(splitScope('')).to.be.null;
+      expect(splitScope('   ')).to.be.null;
+      expect(splitScope(undefined)).to.be.null;
+      expect(splitScope(null)).to.be.null;
+    });
+
+    it('returns null for a bare path (no host)', () => {
+      expect(splitScope('/just/a/path')).to.be.null;
+    });
+
+    it('returns null when stripping www leaves no host', () => {
+      expect(splitScope('www.')).to.be.null;
+    });
+
+    it('drops repeated trailing slashes from the path prefix', () => {
+      expect(splitScope('nba.com/kings//')).to.deep.equal({ host: 'nba.com', pathPrefix: '/kings' });
+    });
+  });
+
+  describe('parseCandidateUrl', () => {
+    it('extracts host and pathname, stripping www and lowercasing', () => {
+      expect(parseCandidateUrl('https://WWW.NBA.com/Kings/Roster'))
+        .to.deep.equal({ host: 'nba.com', pathname: '/kings/roster' });
+    });
+
+    it('trims trailing slashes from a non-root pathname', () => {
+      expect(parseCandidateUrl('https://nba.com/kings/'))
+        .to.deep.equal({ host: 'nba.com', pathname: '/kings' });
+      expect(parseCandidateUrl('https://nba.com/kings//'))
+        .to.deep.equal({ host: 'nba.com', pathname: '/kings' });
+    });
+
+    it('reduces the root pathname to the empty string (whole-host form)', () => {
+      expect(parseCandidateUrl('https://nba.com/'))
+        .to.deep.equal({ host: 'nba.com', pathname: '' });
+    });
+
+    it('returns null for an unparseable value', () => {
+      expect(parseCandidateUrl('not a url')).to.be.null;
+    });
+  });
+
+  describe('hostMatches', () => {
+    it('matches the host itself and its subdomains', () => {
+      expect(hostMatches('openai.com', 'openai.com')).to.be.true;
+      expect(hostMatches('help.openai.com', 'openai.com')).to.be.true;
+    });
+
+    it('rejects lookalike and unrelated hosts', () => {
+      expect(hostMatches('notopenai.com', 'openai.com')).to.be.false;
+      expect(hostMatches('reddit.com', 'openai.com')).to.be.false;
+    });
+  });
+
+  describe('isWithinPathPrefix', () => {
+    it('matches everything under an empty prefix', () => {
+      expect(isWithinPathPrefix('/', '')).to.be.true;
+      expect(isWithinPathPrefix('/anything', '')).to.be.true;
+    });
+
+    it('matches the prefix itself and deeper segments', () => {
+      expect(isWithinPathPrefix('/kings', '/kings')).to.be.true;
+      expect(isWithinPathPrefix('/kings/roster', '/kings')).to.be.true;
+    });
+
+    it('rejects a sibling path that only shares the prefix string', () => {
+      expect(isWithinPathPrefix('/kingsx', '/kings')).to.be.false;
+      expect(isWithinPathPrefix('/celtics', '/kings')).to.be.false;
+    });
+  });
+
+  describe('scopeContains', () => {
+    const scope = { host: 'nba.com', pathPrefix: '/kings' };
+
+    it('contains candidates on the host (and subdomains) within the path prefix', () => {
+      expect(scopeContains(scope, { host: 'nba.com', pathname: '/kings/roster' })).to.be.true;
+      expect(scopeContains(scope, { host: 'shop.nba.com', pathname: '/kings' })).to.be.true;
+    });
+
+    it('rejects candidates outside the path prefix or on another host', () => {
+      expect(scopeContains(scope, { host: 'nba.com', pathname: '/celtics' })).to.be.false;
+      expect(scopeContains(scope, { host: 'espn.com', pathname: '/kings' })).to.be.false;
+    });
+  });
+
+  describe('isProperAncestor', () => {
+    it('recognizes a parent domain as ancestor of a subdomain site', () => {
+      expect(isProperAncestor(
+        { host: 'intuit.com', pathPrefix: '' },
+        { host: 'quickbooks.intuit.com', pathPrefix: '' },
+      )).to.be.true;
+    });
+
+    it('recognizes the host root as ancestor of a subpath site', () => {
+      expect(isProperAncestor(
+        { host: 'nba.com', pathPrefix: '' },
+        { host: 'nba.com', pathPrefix: '/kings' },
+      )).to.be.true;
+    });
+
+    it('is false for the scope itself', () => {
+      expect(isProperAncestor(
+        { host: 'nba.com', pathPrefix: '/kings' },
+        { host: 'nba.com', pathPrefix: '/kings' },
+      )).to.be.false;
+    });
+
+    it('is false when the requested scope is narrower than the site scope', () => {
+      expect(isProperAncestor(
+        { host: 'quickbooks.intuit.com', pathPrefix: '' },
+        { host: 'intuit.com', pathPrefix: '' },
+      )).to.be.false;
+      expect(isProperAncestor(
+        { host: 'nba.com', pathPrefix: '/kings' },
+        { host: 'nba.com', pathPrefix: '' },
+      )).to.be.false;
+    });
+
+    it('is false for unrelated hosts and non-boundary path overlaps', () => {
+      expect(isProperAncestor(
+        { host: 'espn.com', pathPrefix: '' },
+        { host: 'nba.com', pathPrefix: '/kings' },
+      )).to.be.false;
+      expect(isProperAncestor(
+        { host: 'nba.com', pathPrefix: '/ki' },
+        { host: 'nba.com', pathPrefix: '/kings' },
+      )).to.be.false;
+    });
+  });
+
+  describe('createScopeMatcher', () => {
+    const siteSubdomain = { host: 'quickbooks.intuit.com', pathPrefix: '' };
+    const siteSubpath = { host: 'nba.com', pathPrefix: '/kings' };
+
+    it('excludes the site subtree from an ancestor-domain fold (subdomain site)', () => {
+      const matches = createScopeMatcher({ host: 'intuit.com', pathPrefix: '' }, siteSubdomain);
+      expect(matches({ host: 'turbotax.intuit.com', pathname: '/x' })).to.be.true;
+      expect(matches({ host: 'intuit.com', pathname: '/' })).to.be.true;
+      expect(matches({ host: 'quickbooks.intuit.com', pathname: '/x' })).to.be.false;
+      expect(matches({ host: 'help.quickbooks.intuit.com', pathname: '/y' })).to.be.false;
+    });
+
+    it('excludes the site subtree from the host-root fold (subpath site)', () => {
+      const matches = createScopeMatcher({ host: 'nba.com', pathPrefix: '' }, siteSubpath);
+      expect(matches({ host: 'nba.com', pathname: '/celtics' })).to.be.true;
+      expect(matches({ host: 'nba.com', pathname: '/kingsx' })).to.be.true;
+      expect(matches({ host: 'nba.com', pathname: '/kings' })).to.be.false;
+      expect(matches({ host: 'nba.com', pathname: '/kings/roster' })).to.be.false;
+    });
+
+    it('returns exactly the site subtree when the site scope itself is requested', () => {
+      const matchesPath = createScopeMatcher(siteSubpath, siteSubpath);
+      expect(matchesPath({ host: 'nba.com', pathname: '/kings/roster' })).to.be.true;
+      expect(matchesPath({ host: 'nba.com', pathname: '/celtics' })).to.be.false;
+      const matchesHost = createScopeMatcher(siteSubdomain, siteSubdomain);
+      expect(matchesHost({ host: 'help.quickbooks.intuit.com', pathname: '/x' })).to.be.true;
+      expect(matchesHost({ host: 'turbotax.intuit.com', pathname: '/x' })).to.be.false;
+    });
+
+    it('applies the plain fold when there is no site scope', () => {
+      const matches = createScopeMatcher({ host: 'intuit.com', pathPrefix: '' }, null);
+      expect(matches({ host: 'quickbooks.intuit.com', pathname: '/x' })).to.be.true;
+      expect(matches({ host: 'reddit.com', pathname: '/x' })).to.be.false;
+    });
+
+    it('leaves third-party scopes unaffected by the site scope', () => {
+      const matches = createScopeMatcher({ host: 'cambridge.org', pathPrefix: '' }, siteSubpath);
+      expect(matches({ host: 'dictionary.cambridge.org', pathname: '/de' })).to.be.true;
+    });
+
+    it('narrows a path-bearing third-party scope by its own path prefix', () => {
+      const matches = createScopeMatcher({ host: 'cambridge.org', pathPrefix: '/dictionary' }, siteSubpath);
+      expect(matches({ host: 'www2.cambridge.org', pathname: '/dictionary/english' })).to.be.true;
+      expect(matches({ host: 'cambridge.org', pathname: '/press' })).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Makes the AI Visibility cited-domains drilldown (`GET .../serenity/brand-presence/url-inspector/domain-urls`) site-scope aware: the `hostname` filter now understands subdomain- and subpath-anchored sites instead of folding everything into the registered domain.

## 2. Reasoning
The drilldown keyed every row on a bare `www.`-stripped hostname and folded every subdomain into its parent domain. For a subdomain-anchored site (`quickbooks.intuit.com`), opening the `intuit.com` row showed TurboTax/Mint/corporate URLs mixed into the customer's drilldown, and the site's own host could never be separated. For a subpath-anchored site (`nba.com/kings`), the path was discarded entirely, so Lakers/Knicks/league URLs appeared as the customer's own — and a path-bearing filter was inexpressible. Reported in
https://github.com/adobe/spacecat-api-service/issues/3113
as part of the ABV subdomain/subpath support work.

## 3. High-level overview of the changes
- The `hostname` / `domain` query param is now parsed as a `{host, pathPrefix}` scope: `intuit.com`, `quickbooks.intuit.com`, `nba.com/kings`, and full URLs are all accepted. A non-empty value that parses to no host (for example a bare path) is rejected with 400 at the API boundary; before it silently matched nothing.
- The brand's own site anchor now participates in the filtering. The controller resolves the brand's primary-site `base_url` (the brand identity lookup now joins `sites!site_id(base_url)`) and passes it to the transform:
  - Requesting exactly the site's own scope returns only the site's subtree — its host plus its own subdomain children, narrowed to the path prefix for a subpath site. Before, a subpath scope was inexpressible and the subdomain case was unreachable from the UI.
  - Requesting a proper ancestor of the site scope (`intuit.com` for a `quickbooks.intuit.com` brand, `nba.com` for `nba.com/kings`) returns the fold minus the site's own subtree, so the customer's own URLs no longer surface under their parent domain's third-party row.
  - Third-party domains keep today's deliberate eTLD+1 fold unchanged (`cambridge.org` still collects `dictionary.cambridge.org`), optionally narrowed when the caller passes a path.
  - Brands without a primary site (serenity shells) and requests without a `hostname` behave exactly as before.
- The scope primitives live in a new pure module, `src/support/elements/url-scope.js`, so the sibling cited-domains/owned-urls surfaces and the collection-side SUBFOLDER work under the umbrella ticket can reuse them.
- The endpoint's contract reference (`docs/llmo-semrush-apis/filter-dimensions-apis.md`, section 6) is updated to the new matching semantics.

Note on scope: cited-domains (phase 1 of the tree) still emits Semrush's eTLD+1 rows whose counts include the site's subtree, so an ancestor row's counts will not reconcile with its (now subtree-excluding) drilldown until the collection side of the umbrella work lands. The site-scope drilldown key is expressible via the API today but not yet emitted by the UI.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/3113 — umbrella https://jira.corp.adobe.com/browse/LLMO-7138
- Other: sibling DRS-side research https://github.com/adobe-rnd/llmo-data-retrieval-service/issues/3018

Fixes https://github.com/adobe/spacecat-api-service/issues/3113

## 6. Affected / used mysticat-workspace projects
- `project-elmo-ui` — consumes this endpoint's contract. No UI change required for this PR; ancestor-row drilldowns for subdomain/subpath brands change visibly (site's own URLs disappear from the parent's third-party row). Making the UI send the site-scope key (`nba.com/kings`) is umbrella-ticket follow-up.
- `mysticat-data-service` — consumed contract: the brand identity read now embeds the primary site's `base_url` via the existing `brands.site_id -> sites` FK (same join shape `BRAND_SELECT` already uses).

## 7. Additional information outside the code
- In-process runtime check of the real controller-service-transform composition (only the Semrush HTTP transport stubbed): all five behavior-matrix scenarios — site scope requested for a subdomain site, ancestor fold minus subtree, subpath site scope against a mixed-case source URL, host-root fold minus path subtree, and the no-site-scope legacy fold — returned the expected row sets.

## 8. Test plan
- Locally, beyond unit tests: the composition check described in section 7, driving `getDomainUrls` end to end over fixture rows shaped like live Stats-per-URL responses.
- On dev/prod after deploy (the endpoint is Semrush-backed, no eph surface): for a subdomain brand (e.g. the QuickBooks brand, site `quickbooks.intuit.com`), call the drilldown with `hostname=intuit.com` and `hostname=quickbooks.intuit.com` over the same date window and confirm the two result sets partition the previous single fold (no `quickbooks.intuit.com` URLs under `intuit.com`, only they appear under `quickbooks.intuit.com`). Confirm a third-party drilldown (`hostname=cambridge.org`-style) is unchanged, and that `hostname=<host>/<path>` returns only path-prefixed rows for a subpath brand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
