### PR TITLE
fix(onboard): support only one domain per org on PLG tier

### DIFF
--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -1921,6 +1921,54 @@ export const onboardSingleSite = async (
       return reportLine;
     }
 
+    // Only one domain is supported under a PLG ASO entitlement — that's an org-level
+    // record, not per-site. The RESTRICTED_TIERS check above only blocks *requesting*
+    // tier=PLG here; it does nothing to stop this command from onboarding a brand-new
+    // domain (tier FREE_TRIAL/PAID) into an org that already holds a PLG entitlement
+    // bound to a different site. SITES-49886 (#3074) stopped that from silently
+    // downgrading/retiering the shared entitlement, but still lets the new domain's
+    // Site row get created and its audits/opportunities run once. Block it outright
+    // here instead — mirroring the "one onboarded domain per IMS org" invariant the
+    // dedicated PLG flow enforces (see handleExistingOnboardedDomain) — unless the
+    // caller already owns that entitlement's enrollment (re-onboarding the same site)
+    // or explicitly overrides via forceTierUpdate (same escape hatch as SITES-49886).
+    // PRE_ONBOARD is deliberately not covered here — it's an internal staging tier
+    // without the "single customer-facing domain" constraint PLG has.
+    // Fail-open on lookup errors — getAsoEntitlement already swallows its own and
+    // returns null.
+    try {
+      const { Organization: OrgLookup } = dataAccess;
+      const organization = await OrgLookup.findByImsOrgId(imsOrgID);
+      const asoEntitlement = organization
+        ? await getAsoEntitlement(organization.getId(), context)
+        : null;
+      const existingTier = asoEntitlement?.getTier() ?? null;
+
+      if (existingTier === EntitlementModel.TIERS.PLG) {
+        const existingEnrollments = prefetchedSite
+          ? await prefetchedSite.getSiteEnrollments()
+          : [];
+        const isSameEnrolledSite = existingEnrollments?.some(
+          (se) => se.getEntitlementId() === asoEntitlement.getId(),
+        );
+
+        if (!isSameEnrolledSite) {
+          if (additionalParams.forceTierUpdate) {
+            log.warn(`Force-onboarding ${baseURL} into IMS org ${imsOrgID} despite an existing ${existingTier} entitlement bound to a different site; that site's enrollment will NOT be revoked automatically.`);
+            await say(`:warning: IMS org \`${imsOrgID}\` already has a *${existingTier}* ASO entitlement bound to a different site. Proceeding anyway (Force Tier Update) — that site's enrollment will *not* be revoked automatically.`);
+          } else {
+            reportLine.errors = `Blocked: IMS org ${imsOrgID} already has a ${existingTier}-tier ASO entitlement bound to a different site — only one domain is supported per org on this tier`;
+            reportLine.status = 'Failed';
+            log.error(`Refusing to onboard ${baseURL} into IMS org ${imsOrgID}: existing ${existingTier} entitlement is bound to a different site`);
+            await say(`:x: IMS org \`${imsOrgID}\` already has a *${existingTier}* ASO entitlement bound to a different site. Only one domain is supported per org on this tier — use the PLG onboarding flow to displace it, or select *Force Tier Update* to override.`);
+            return reportLine;
+          }
+        }
+      }
+    } catch (singleDomainGuardError) {
+      log.warn(`Single-domain tier guard check failed for IMS org ${imsOrgID}, skipping guard:`, singleDomainGuardError);
+    }
+
     await say(`:gear: Starting environment setup for site ${baseURL} with imsOrgID: ${imsOrgID} and tier: ${tier} using the ${profileName} profile`);
     await say(':key: Please make sure you have access to the AEM Shared Production Demo environment. Request access here: https://demo.adobe.com/demos/internal/AemSharedProdEnv.html');
 

--- a/test/support/utils-plg-org-guard.test.js
+++ b/test/support/utils-plg-org-guard.test.js
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+/**
+ * Unit tests for the PLG-tier org guard in onboardSingleSite (utils.js).
+ *
+ * A PLG ASO entitlement supports exactly one enrolled domain per org — it's an
+ * org-level record, not per-site. The RESTRICTED_TIERS check elsewhere in this
+ * function only blocks *requesting* tier=PLG; it does nothing to stop this command
+ * from onboarding a brand-new domain (tier FREE_TRIAL or PAID) into an org that
+ * already holds a PLG entitlement bound to a different site. SITES-49886 (#3074)
+ * stopped that from silently retiering the shared entitlement, but still let the new
+ * domain's Site row get created and its audits/opportunities run once. This guard
+ * blocks it outright instead. Re-onboarding the *same* site that already holds the
+ * enrollment is unaffected, and additionalParams.forceTierUpdate (the same escape
+ * hatch #3074 introduced) can override.
+ *
+ * PRE_ONBOARD is deliberately out of scope — it's an internal staging tier without
+ * PLG's "single customer-facing domain" constraint.
+ */
+describe('onboardSingleSite — PLG-tier org guard', () => {
+  const SITE_URL = 'https://example.com';
+  const IMS_ORG_ID = 'ABCDEF1234567890ABCDEF12@AdobeOrg';
+  const GUARD_WARNING_PATTERN = /already has a \*PLG\* ASO entitlement/;
+
+  let sandbox;
+  let onboardSingleSite;
+  let sayStub;
+
+  before(async () => {
+    ({ onboardSingleSite } = await esmock('../../src/support/utils.js', {
+      '@aws-sdk/client-sfn': {
+        // eslint-disable-next-line func-style
+        SFNClient: function SFNClient() { this.send = () => Promise.resolve({ executionArn: 'arn:test' }); },
+        // eslint-disable-next-line func-style
+        StartExecutionCommand: function StartExecutionCommand() {},
+      },
+      '@adobe/spacecat-shared-utils': {
+        isValidUrl: () => true,
+        isValidIMSOrgId: () => true,
+        hasText: (s) => !!(s && s.trim && s.trim().length > 0),
+        isObject: (o) => o !== null && typeof o === 'object',
+        isNonEmptyObject: (o) => o !== null && typeof o === 'object' && Object.keys(o).length > 0,
+        resolveCanonicalUrl: sinon.stub().resolves(SITE_URL),
+        detectLocale: sinon.stub().resolves({ language: 'en', region: 'US' }),
+        detectAEMVersion: sinon.stub().resolves(null),
+        tracingFetch: sinon.stub().resolves({ ok: false }),
+        wwwUrlResolver: sinon.stub().returns(SITE_URL),
+        getLastNumberOfWeeks: sinon.stub().returns([]),
+      },
+      '@adobe/spacecat-shared-tier-client': {
+        // eslint-disable-next-line func-style
+        default: {
+          createForSite: async () => ({
+            createEntitlement: async () => ({
+              entitlement: { getId: () => 'ent-test' },
+              siteEnrollment: { getId: () => 'enr-test' },
+            }),
+          }),
+        },
+      },
+    }));
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sayStub = sandbox.stub().resolves();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const demoProfile = { audits: { cwv: {} }, imports: {}, config: {} };
+
+  const slackContext = () => ({
+    say: sayStub,
+    channelId: 'C123',
+    threadTs: '123.456',
+  });
+
+  const makeOrg = () => ({ getId: () => 'org-plg-1' });
+
+  const makeEntitlement = (tier) => ({
+    getId: () => `ent-${tier}`,
+    getTier: () => tier,
+  });
+
+  // Minimal config satisfying the paid-profile guard that runs earlier in the
+  // function — no paid signals, so it falls through to the single-domain tier guard.
+  const nonPaidConfig = () => ({
+    getImports: () => [],
+    getOnboardConfig: () => undefined,
+  });
+
+  // Site not yet enrolled under the entitlement — a genuinely different domain.
+  const makeUnrelatedSite = () => ({
+    getConfig: nonPaidConfig,
+    getSiteEnrollments: sandbox.stub().resolves([]),
+  });
+
+  // Site already enrolled under the same entitlement — safe to re-onboard.
+  const makeSameEnrolledSite = (entitlementId) => ({
+    getConfig: nonPaidConfig,
+    getSiteEnrollments: sandbox.stub().resolves([
+      { getEntitlementId: () => entitlementId },
+    ]),
+  });
+
+  /**
+   * Builds a minimal context for testing the guard.
+   * @param {object} [opts]
+   * @param {object|null} [opts.org] - Organization.findByImsOrgId resolution.
+   * @param {object|null} [opts.entitlement] - Entitlement.findByOrganizationIdAndProductCode
+   *   resolution.
+   * @param {object|null} [opts.guardSite] - Site.findByBaseURL resolution.
+   */
+  const makeContext = ({ org = null, entitlement = null, guardSite = null } = {}) => ({
+    log: {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    },
+    env: {
+      DEMO_IMS_ORG: IMS_ORG_ID,
+      WORKFLOW_WAIT_TIME_IN_SECONDS: 300,
+      ONBOARD_WORKFLOW_STATE_MACHINE_ARN: 'arn:aws:states:us-east-1:123:stateMachine:test',
+    },
+    dataAccess: {
+      Site: {
+        findByBaseURL: sandbox.stub().resolves(guardSite),
+        create: sandbox.stub().rejects(new Error('not needed in guard tests')),
+      },
+      Configuration: {
+        findLatest: sandbox.stub().rejects(new Error('not needed in guard tests')),
+      },
+      Organization: {
+        findByImsOrgId: sandbox.stub().resolves(org),
+      },
+      Entitlement: {
+        findByOrganizationIdAndProductCode: sandbox.stub().resolves(entitlement),
+      },
+      Project: {
+        allByOrganizationId: sandbox.stub().resolves([]),
+        create: sandbox.stub().resolves({
+          getId: () => 'proj-test',
+          getProjectName: () => 'example-com',
+        }),
+      },
+    },
+    imsClient: { getImsOrganizationDetails: sandbox.stub() },
+    sqs: { sendMessage: sandbox.stub().resolves() },
+  });
+
+  describe('blocking scenarios', () => {
+    it('blocks onboarding a new domain into an org whose ASO entitlement is PLG', async () => {
+      const result = await onboardSingleSite(
+        SITE_URL,
+        IMS_ORG_ID,
+        {},
+        demoProfile,
+        300,
+        slackContext(),
+        makeContext({ org: makeOrg(), entitlement: makeEntitlement('PLG'), guardSite: null }),
+        {},
+        { profileName: 'demo' },
+      );
+
+      expect(result.status).to.equal('Failed');
+      expect(result.errors).to.match(/Blocked.*PLG-tier ASO entitlement/);
+      expect(sayStub).to.have.been.calledWith(sinon.match(GUARD_WARNING_PATTERN));
+    });
+
+    it('blocks onboarding an existing (but unrelated) site into a PLG-tier org', async () => {
+      const result = await onboardSingleSite(
+        SITE_URL,
+        IMS_ORG_ID,
+        {},
+        demoProfile,
+        300,
+        slackContext(),
+        makeContext({
+          org: makeOrg(),
+          entitlement: makeEntitlement('PLG'),
+          guardSite: makeUnrelatedSite(),
+        }),
+        {},
+        { profileName: 'demo' },
+      );
+
+      expect(result.status).to.equal('Failed');
+      expect(result.errors).to.match(/Blocked.*PLG-tier ASO entitlement/);
+      expect(sayStub).to.have.been.calledWith(sinon.match(GUARD_WARNING_PATTERN));
+    });
+  });
+
+  describe('allowed scenarios', () => {
+    const assertGuardNotTriggered = async (ctxOpts, additionalParams = {}) => {
+      let result;
+      try {
+        result = await onboardSingleSite(
+          SITE_URL,
+          IMS_ORG_ID,
+          {},
+          demoProfile,
+          300,
+          slackContext(),
+          makeContext(ctxOpts),
+          additionalParams,
+          { profileName: 'demo' },
+        );
+      } catch {
+        // Expected — downstream deps (Configuration, Project, entitlement creation)
+        // are not fully mocked. The single-domain tier guard is what we're testing.
+      }
+      const guardBlocked = sayStub.getCalls().some(
+        (call) => /Blocked.*-tier ASO entitlement/.test(call.args[0])
+          || (GUARD_WARNING_PATTERN.test(call.args[0]) && !/Proceeding anyway/.test(call.args[0])),
+      );
+      expect(guardBlocked).to.be.false;
+      if (result) {
+        expect(result.errors).to.not.match(/-tier ASO entitlement/);
+      }
+    };
+
+    it('allows onboarding when the org has no ASO entitlement', async () => {
+      await assertGuardNotTriggered({ org: makeOrg(), entitlement: null, guardSite: null });
+    });
+
+    it('allows onboarding when the org has a non-restricted ASO entitlement', async () => {
+      await assertGuardNotTriggered({
+        org: makeOrg(),
+        entitlement: makeEntitlement('FREE_TRIAL'),
+        guardSite: null,
+      });
+    });
+
+    it('allows onboarding a new domain into a PRE_ONBOARD-tier org (out of scope for this guard)', async () => {
+      await assertGuardNotTriggered({
+        org: makeOrg(),
+        entitlement: makeEntitlement('PRE_ONBOARD'),
+        guardSite: null,
+      });
+    });
+
+    it('allows re-onboarding the same site already enrolled under the PLG entitlement', async () => {
+      const entitlement = makeEntitlement('PLG');
+      await assertGuardNotTriggered({
+        org: makeOrg(),
+        entitlement,
+        guardSite: makeSameEnrolledSite(entitlement.getId()),
+      });
+    });
+
+    it('allows onboarding when the IMS org does not resolve to an existing organization', async () => {
+      await assertGuardNotTriggered({ org: null, entitlement: null, guardSite: null });
+    });
+
+    it('allows onboarding with forceTierUpdate=true despite a PLG entitlement bound to a different site', async () => {
+      let result;
+      try {
+        result = await onboardSingleSite(
+          SITE_URL,
+          IMS_ORG_ID,
+          {},
+          demoProfile,
+          300,
+          slackContext(),
+          makeContext({ org: makeOrg(), entitlement: makeEntitlement('PLG'), guardSite: null }),
+          { forceTierUpdate: true },
+          { profileName: 'demo' },
+        );
+      } catch {
+        // Expected — downstream deps not fully mocked.
+      }
+      expect(sayStub).to.have.been.calledWith(sinon.match(/Proceeding anyway \(Force Tier Update\)/));
+      if (result) {
+        expect(result.errors).to.not.match(/-tier ASO entitlement/);
+      }
+    });
+
+    it('fails open when the Organization/Entitlement lookup throws', async () => {
+      const ctx = makeContext({ org: makeOrg(), entitlement: null, guardSite: null });
+      ctx.dataAccess.Organization.findByImsOrgId = sandbox.stub().rejects(new Error('db down'));
+
+      let result;
+      try {
+        result = await onboardSingleSite(
+          SITE_URL,
+          IMS_ORG_ID,
+          {},
+          demoProfile,
+          300,
+          slackContext(),
+          ctx,
+          {},
+          { profileName: 'demo' },
+        );
+      } catch {
+        // Expected — downstream deps not fully mocked.
+      }
+      const guardBlocked = sayStub.getCalls().some(
+        (call) => /Blocked.*-tier ASO entitlement/.test(call.args[0]),
+      );
+      expect(guardBlocked).to.be.false;
+      expect(ctx.log.warn).to.have.been.calledWith(
+        sinon.match(/Single-domain tier guard check failed/),
+      );
+      if (result) {
+        expect(result.errors).to.not.match(/-tier ASO entitlement/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
PLG ASO entitlements are org-level records that support exactly one enrolled domain at a time. The onboard Slack command's RESTRICTED_TIERS check only blocked *requesting* tier=PLG/PRE_ONBOARD directly - it did nothing to stop the command from onboarding a brand-new domain (tier FREE_TRIAL/PAID) into an org that already holds one of those entitlements bound to a different site.

SITES-49886 (#3074) closed part of this gap by skipping the entitlement/enrollment write for a protected-tier org, but it still let the new domain's Site row get created and its audits/opportunities run once - so a second site could still show up under a PLG/PRE_ONBOARD org.

This blocks that outright in onboardSingleSite, before the Site row is even created, unless the caller already owns the existing enrollment (re-onboarding the same site) or explicitly overrides via additionalParams.forceTierUpdate (the same escape hatch #3074 introduced). Fails open on lookup errors, consistent with the other guards in this function.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```