### PR TITLE
fix(llmo): drop temp-onboarding/skip-helix-query flags, always register dataFolder | LLMO-7141

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ npm run docs:lint         # Validate OpenAPI specs
 npm run docs:serve        # Preview docs locally
 ```
 
+**`docs/index.html` non-determinism:** `docs:build` regenerates this file's styled-components CSS as inline hashed class names, and the hash assignment order is not stable across Redocly CLI/Node versions — an environment other than the canonical CI toolchain can produce a diff of tens of thousands of lines that is pure hash/markup churn, not a content change (verify by diffing for the actual OpenAPI content you touched, e.g. `grep` for the field/path name in old vs new). Don't commit a hash-noise diff from a non-canonical environment: either regenerate on the canonical CI toolchain, or note the exception in the PR description (spec files are the source of truth and are what reviewers should verify) and leave `docs/index.html` as committed on `main`.
+
 ### Deployment
 ```bash
 npm run build             # Build production bundle with Helix Deploy

--- a/docs/llmo-http-onboard-notes.md
+++ b/docs/llmo-http-onboard-notes.md
@@ -46,6 +46,9 @@ Offboarding and other paths reuse **`validateSiteNotOnboarded`** / **`performLlm
 
 ## History: removal of `temp-onboarding` (LLMO-7141)
 
+Removed as a durable follow-up to LLMO-6320, which has the full incident writeup (root cause,
+affected customer sites, and the bug class this flag caused).
+
 LLMO-4024 (PR #2098, 2026-04-01) introduced a **`temp-onboarding`** flag (HTTP body field, and
 **`--skip-helix-query`** / **`--temp-onboarding`** Slack flags) that let onboarding skip the
 **`updateIndexConfig`** step entirely, leaving a site's dataFolder unregistered in

--- a/docs/llmo-http-onboard-notes.md
+++ b/docs/llmo-http-onboard-notes.md
@@ -1,6 +1,6 @@
-# LLMO onboarding: HTTP API, Slack command, and `temp-onboarding`
+# LLMO onboarding: HTTP API and Slack command
 
-This document summarizes **`POST /llmo/onboard`**, the Slack **`onboard-llmo`** command, shared onboarding steps, and the optional **`temp-onboarding`** behavior (skip **`helix-query.yaml`** / **`updateIndexConfig`**).
+This document summarizes **`POST /llmo/onboard`**, the Slack **`onboard-llmo`** command, and the shared onboarding steps.
 
 ---
 
@@ -9,7 +9,6 @@ This document summarizes **`POST /llmo/onboard`**, the Slack **`onboard-llmo`** 
 - **Route:** `src/routes/index.js` → `llmoController.onboardCustomer` in `src/controllers/llmo/llmo.js`.
 - **Access:** LLMO administrator only (`accessControlUtil.isLLMOAdministrator()`).
 - **Body:** Object with required **`domain`** and **`brandName`**. Optional **`imsOrgId`** (Adobe IMS format); if omitted, org is taken from JWT (`profile.tenants[0].id@AdobeOrg`).
-- **Optional:** **`"temp-onboarding": true`** — see [Feature: `temp-onboarding`](#feature-temp-onboarding).
 - **Flow:**
   1. Resolve **`baseURL`** / **`dataFolder`**.
   2. **`validateSiteNotOnboarded`** (SharePoint folder + SpaceCat site/org checks).
@@ -21,15 +20,13 @@ This document summarizes **`POST /llmo/onboard`**, the Slack **`onboard-llmo`** 
 ## Slack: `onboard-llmo` command
 
 - **Command:** `src/support/slack/commands/llmo-onboard.js` (phrase: **`onboard-llmo`**).
-- **Usage:** `onboard-llmo <site url> [--skip-helix-query | --temp-onboarding]`
-  - **`--skip-helix-query`** and **`--temp-onboarding`** are equivalent: both set the same internal **`tempOnboarding`** flag as HTTP **`"temp-onboarding": true`**.
-  - Flags can appear before or after the URL; URL tokens are the remaining non-flag arguments joined with spaces.
+- **Usage:** `onboard-llmo <site url>`
 - **Flow:**
   1. User runs the command → bot posts a **Start Onboarding** button (or alternate actions if the site is already onboarded with LLMO brand).
   2. **Start Onboarding** → action **`start_llmo_onboarding`** → `src/support/slack/actions/onboard-llmo-modal.js` → **`startLLMOOnboarding`**.
-  3. Modal opens (**`fullOnboardingModal`** for a net-new SpaceCat site, **`elmoOnboardingModal`** if a site already exists). **`private_metadata`** includes **`brandURL`** and, when applicable, **`tempOnboarding: true`**.
-  4. On submit → **`onboardLLMOModal`** → **`onboardSite`** → **`performLlmoOnboarding`** with **`tempOnboarding`** when set.
-- **Button `value`:** JSON **`{ "brandURL": "<url>", "tempOnboarding": true }`** when skipping helix-query; otherwise **`{ "brandURL": "<url>" }`**. **`parseStartLlmoOnboardingButtonValue`** in **`onboard-llmo-modal.js`** also accepts legacy **plain URL** strings (no JSON) for older messages; those default to full **`helix-query.yaml`** update.
+  3. Modal opens (**`fullOnboardingModal`** for a net-new SpaceCat site, **`elmoOnboardingModal`** if a site already exists). **`private_metadata`** includes **`brandURL`**.
+  4. On submit → **`onboardLLMOModal`** → **`onboardSite`** → **`performLlmoOnboarding`**.
+- **Button `value`:** JSON **`{ "brandURL": "<url>" }`**. **`parseStartLlmoOnboardingButtonValue`** in **`onboard-llmo-modal.js`** also accepts legacy **plain URL** strings (no JSON) for older messages.
 
 ---
 
@@ -40,70 +37,30 @@ This document summarizes **`POST /llmo/onboard`**, the Slack **`onboard-llmo`** 
 | Org / site | **`createOrFindOrganization`**, **`resolveLlmoOnboardingMode`**, **`createOrFindSite`**, **`createEntitlementAndEnrollment`**. |
 | SharePoint | **`copyFilesToSharepoint`**: creates **`/sites/elmo-ui-data/{dataFolder}/`** if needed; copies **`template/query-index.xlsx`** → **`{dataFolder}/query-index.xlsx`**. |
 | Publish trigger | **`enqueueLlmoOnboardingPublish`**: SQS message **`trigger:llmo-onboarding-publish`** with **`siteId`** + **`auditContext.dataFolder`**. Audit worker calls **`publishToAdminHlx`** for **`{dataFolder}/query-index.json`** on Helix admin preview + live (`project-elmo-ui-data`). Enqueue failure is logged only. |
-| Helix query config | **`updateIndexConfig`**: commits an entry to **`helix-query.yaml`** in **`adobe/project-elmo-ui-data`** (`main` in prod, **`onboarding-bot-dev`** otherwise). **Skipped when `params.tempOnboarding` is true.** |
+| Helix query config | **`updateIndexConfig`**: commits an entry to **`helix-query.yaml`** in **`adobe/project-elmo-ui-data`** (`main` in prod, **`onboarding-bot-dev`** otherwise). **Always runs as part of onboarding** (see LLMO-7141 note below). |
 | Rest | Enable audits/imports, LLMO brand + data folder on site config, optional **`overrideBaseURL`**, v2 customer config / Brandalf / DRS jobs as applicable, **`triggerAudits`**, DRS prompt generation, etc. |
 
 Offboarding and other paths reuse **`validateSiteNotOnboarded`** / **`performLlmoOnboarding`** patterns (e.g. Slack modal) where noted in code.
 
 ---
 
-## Feature: `temp-onboarding`
+## History: removal of `temp-onboarding` (LLMO-7141)
 
-**Purpose:** Skip the **`updateIndexConfig`** step (no GitHub change to **`helix-query.yaml`**) for temporary or test onboarding — available from **HTTP** and **Slack**.
+LLMO-4024 (PR #2098, 2026-04-01) introduced a **`temp-onboarding`** flag (HTTP body field, and
+**`--skip-helix-query`** / **`--temp-onboarding`** Slack flags) that let onboarding skip the
+**`updateIndexConfig`** step entirely, leaving a site's dataFolder unregistered in
+**`helix-query.yaml`**. It was a workaround for a 2026-03-19 Helix bulk-indexing capacity
+incident above ~1,000 index definitions.
 
-### HTTP request
+That capacity issue was fixed by the Helix team the same day, and Helix confirmed there is no
+hard limit — `helix-query.yaml` is now well past 1,783 definitions with no recurrence. The skip
+flag turned out to be the root cause of the entire LLMO-6320 bug class: every site onboarded
+with the flag never got its index registered and was never reliably backfilled, causing real
+customer sites (some paying) to go dark in LLMO dashboards for months.
 
-- Optional boolean field: **`"temp-onboarding": true`** in the JSON body.
-- Only strict **`true`** is honored (`=== true`). Omitted, `false`, or non-boolean values run the normal path (step runs).
-
-### Slack request
-
-- Append **`--skip-helix-query`** or **`--temp-onboarding`** to the **`onboard-llmo`** command (see [Slack: `onboard-llmo` command](#slack-onboard-llmo-command)).
-- The flag is carried through the button **`value`**, modal **`private_metadata`**, and **`onboardSite`** into **`performLlmoOnboarding`**.
-
-### Implementation (shared)
-
-- **`src/controllers/llmo/llmo.js` (HTTP):** Reads `data['temp-onboarding']`, passes **`tempOnboarding`** into **`performLlmoOnboarding`**.
-
-- **`src/controllers/llmo/llmo-onboarding.js`:** If **`params.tempOnboarding`**:
-  - Logs that **`helix-query.yaml`** update is skipped.
-  - Calls **`say`** with an informational line when **`say`** is provided (HTTP does not use **`say`**; Slack **`onboardSite`** does).
-  - Does **not** call **`updateIndexConfig`**.
-
-- **`src/support/slack/commands/llmo-onboard.js`:** Parses flags, encodes **`brandURL`** / **`tempOnboarding`** on the **Start Onboarding** button **`value`**.
-
-- **`src/support/slack/actions/onboard-llmo-modal.js`:** **`parseStartLlmoOnboardingButtonValue`**, **`startLLMOOnboarding`**, modals’ **`private_metadata`**, **`onboardLLMOModal`**, **`onboardSite`** → **`performLlmoOnboarding`**.
-
-### API spec
-
-- **`docs/openapi/llmo-api.yaml`:** `POST` onboard request body documents optional **`temp-onboarding`**.
-
-### Tests
-
-- **`test/controllers/llmo/llmo.test.js`:** Asserts **`performLlmoOnboarding`** receives **`tempOnboarding: true`** when body includes **`'temp-onboarding': true`**.
-- **`test/controllers/llmo/llmo-onboarding.test.js`:** When **`tempOnboarding: true`**, GitHub **`createOrUpdateFileContents`** is not used and skip is logged.
-- **`test/support/slack/commands/llmo-onboard.test.js`:** Command usage, JSON button **`value`**, **`--skip-helix-query`** encoding.
-- **`test/support/slack/actions/onboard-llmo-modal.test.js`:** **`parseStartLlmoOnboardingButtonValue`**, **`startLLMOOnboarding`** / **`private_metadata`**, **`onboardSite`** with **`tempOnboarding: true`** (no Octokit / **`helix-query.yaml`** update).
-
-### Lint
-
-- ESLint: multi-line object for **`performLlmoOnboarding`** call where applicable; JSDoc line length for **`tempOnboarding`** param.
-
-### Example HTTP body
-
-```json
-{
-  "domain": "example.com",
-  "brandName": "Example",
-  "temp-onboarding": true
-}
-```
-
-### Example Slack invocation
-
-```text
-onboard-llmo https://example.com --skip-helix-query
-```
+The flag was removed entirely (LLMO-7141): registration via **`updateIndexConfig`** now always
+runs unconditionally as part of **`performLlmoOnboarding`**, for both the HTTP and Slack
+onboarding paths. There is no remaining way to skip it.
 
 ---
 

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -1085,11 +1085,6 @@ llmo-onboard:
                 type: string
                 description: The brand name for the site
                 example: "Example Brand"
-              temp-onboarding:
-                type: boolean
-                description: |
-                  When true, skips updating helix-query.yaml in the project-elmo-ui-data GitHub repo
-                  (temporary onboarding; default is false).
               region:
                 type: string
                 pattern: '^[A-Z]{2}$'

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1587,8 +1587,6 @@ export async function activateBrandAndGeneratePrompts({
  * @param {string} params.brandName - The brand name
  * @param {string} params.imsOrgId - The IMS Organization ID
  * @param {string} [params.deliveryType] - The delivery type for site creation
- * @param {boolean} [params.tempOnboarding] - When true, skips updating helix-query.yaml in GitHub.
- *   HTTP clients set this via the `temp-onboarding` body field.
  * @param {string} [params.region] - Optional ISO 3166-1 alpha-2 region code forwarded to V1 DRS
  *   prompt generation. Omitted → DRS client default ('US') applies.
  * @param {boolean} [params.siteOnly=false] - Site-only onboarding (LLMO-5606). When true, stands
@@ -1602,7 +1600,7 @@ export async function activateBrandAndGeneratePrompts({
 export async function performLlmoOnboarding(params, context, say = () => {}) {
   const {
     domain, baseURL: providedBaseURL, brandName, imsOrgId, deliveryType,
-    tempOnboarding, region, siteOnly = false,
+    region, siteOnly = false,
   } = params;
   const { env, log } = context;
 
@@ -1642,13 +1640,11 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       log.warn(`Failed to enqueue ${LLMO_ONBOARDING_PUBLISH_TRIGGER} for site ${site.getId()}: ${error.message}`);
     }
 
-    // Update helix-query.yaml in project-elmo-ui-data (skip for temporary onboarding)
-    if (tempOnboarding) {
-      log.info(`Skipping helix-query.yaml update (temp-onboarding) for data folder ${dataFolder}`);
-      await say(`:information_source: Skipping helix-query.yaml update (temp-onboarding) for ${dataFolder}`);
-    } else {
-      await updateIndexConfig(dataFolder, context, say);
-    }
+    // Update helix-query.yaml in project-elmo-ui-data. This registration must always run
+    // during onboarding (LLMO-7141): the former temp-onboarding skip was a workaround for a
+    // since-fixed (same-day) Helix bulk-indexing capacity issue, and skipping registration was
+    // the root cause of the LLMO-6320 bug class (sites silently going dark in dashboards).
+    await updateIndexConfig(dataFolder, context, say);
 
     // Site-only onboarding (LLMO-5606) omits llmo-customer-analysis entirely — it
     // belongs to the prompt-gen/brand path (Piece 2) which site-only skips, and it

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -935,8 +935,6 @@ function LlmoController(ctx) {
    * @param {string} [context.data.imsOrgId] - Optional IMS org ID override
    *   (must match `/^[a-z0-9]{24}@AdobeOrg$/i`). When omitted the org ID
    *   is read from the authenticated user's JWT token.
-   * @param {boolean} [context.data['temp-onboarding']] - When true, skips updating
-   *   helix-query.yaml in project-elmo-ui-data during onboarding.
    * @returns {Promise<Response>} The onboarding response.
    */
   const onboardCustomer = async (context) => {
@@ -956,7 +954,6 @@ function LlmoController(ctx) {
       const {
         domain, brandName, imsOrgId: payloadImsOrgId, cadence, region,
       } = data;
-      const tempOnboarding = data['temp-onboarding'] === true;
 
       if (!domain || !brandName) {
         return badRequest('domain and brandName are required');
@@ -1022,7 +1019,6 @@ function LlmoController(ctx) {
           brandName,
           imsOrgId,
           cadence,
-          tempOnboarding,
           ...(region ? { region } : {}),
         },
         context,

--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -52,34 +52,31 @@ function buildRegionInputBlock() {
 
 /**
  * Slack button `value` for `start_llmo_onboarding`: plain URL (legacy) or JSON
- * `{ brandURL, tempOnboarding?: true }`.
+ * `{ brandURL }`.
  *
  * @param {string} [raw]
- * @returns {{ brandURL: string, tempOnboarding: boolean }}
+ * @returns {{ brandURL: string }}
  */
 export function parseStartLlmoOnboardingButtonValue(raw) {
   if (raw == null || raw === '') {
-    return { brandURL: '', tempOnboarding: false };
+    return { brandURL: '' };
   }
   const trimmed = String(raw).trim();
   if (trimmed.startsWith('{')) {
     try {
       const parsed = JSON.parse(trimmed);
       if (parsed && typeof parsed.brandURL === 'string') {
-        return {
-          brandURL: parsed.brandURL.trim(),
-          tempOnboarding: parsed.tempOnboarding === true,
-        };
+        return { brandURL: parsed.brandURL.trim() };
       }
     } catch {
       // fall through to raw string
     }
   }
-  return { brandURL: trimmed, tempOnboarding: false };
+  return { brandURL: trimmed };
 }
 
 // site isn't on spacecat yet
-async function fullOnboardingModal(body, client, respond, brandURL, tempOnboarding = false) {
+async function fullOnboardingModal(body, client, respond, brandURL) {
   const { user } = body;
 
   // Update the original message to show user's choice
@@ -101,7 +98,6 @@ async function fullOnboardingModal(body, client, respond, brandURL, tempOnboardi
         originalChannel,
         originalThreadTs,
         brandURL,
-        ...(tempOnboarding ? { tempOnboarding: true } : {}),
       }),
       title: {
         type: 'plain_text',
@@ -208,7 +204,7 @@ async function fullOnboardingModal(body, client, respond, brandURL, tempOnboardi
 }
 
 // site is already on spacecat
-async function elmoOnboardingModal(body, client, respond, brandURL, tempOnboarding = false) {
+async function elmoOnboardingModal(body, client, respond, brandURL) {
   const { user } = body;
 
   // Update the original message to show user's choice
@@ -230,7 +226,6 @@ async function elmoOnboardingModal(body, client, respond, brandURL, tempOnboardi
         originalChannel,
         originalThreadTs,
         brandURL,
-        ...(tempOnboarding ? { tempOnboarding: true } : {}),
       }),
       title: {
         type: 'plain_text',
@@ -361,18 +356,18 @@ export function startLLMOOnboarding(lambdaContext) {
       const { Site } = dataAccess;
 
       // check current onboarding status
-      const { brandURL, tempOnboarding } = parseStartLlmoOnboardingButtonValue(
+      const { brandURL } = parseStartLlmoOnboardingButtonValue(
         actions?.[0]?.value,
       );
       const site = await Site.findByBaseURL(brandURL);
 
       if (!site) {
-        await fullOnboardingModal(body, client, respond, brandURL, tempOnboarding);
+        await fullOnboardingModal(body, client, respond, brandURL);
         log.debug(`User ${user.id} started full onboarding process for ${brandURL}.`);
         return;
       }
 
-      await elmoOnboardingModal(body, client, respond, brandURL, tempOnboarding);
+      await elmoOnboardingModal(body, client, respond, brandURL);
       log.debug(`User ${user.id} started LLMO onboarding process for ${brandURL} with existing site ${site.getId()}.`);
     } catch (e) {
       log.error('Error handling start onboarding:', e);
@@ -390,7 +385,6 @@ export function startLLMOOnboarding(lambdaContext) {
  * @param {string} input.brandName
  * @param {string} input.imsOrgId
  * @param {string} [input.deliveryType]
- * @param {boolean} [input.tempOnboarding] If true, skip helix-query.yaml update.
  * @param {string} [input.region] Optional ISO 3166-1 alpha-2 region code (LLMO-4683)
  *   forwarded to DRS prompt generation. Omitted → DRS client default ('US') applies.
  * @param {Object} lambdaCtx
@@ -400,7 +394,7 @@ export async function onboardSite(input, lambdaCtx, slackCtx) {
   const { log, env } = lambdaCtx;
   const { say } = slackCtx;
   const {
-    baseURL, brandName, imsOrgId, deliveryType, tempOnboarding, region,
+    baseURL, brandName, imsOrgId, deliveryType, region,
   } = input;
 
   const dataFolder = generateDataFolder(baseURL, env.ENV);
@@ -427,7 +421,6 @@ export async function onboardSite(input, lambdaCtx, slackCtx) {
         brandName,
         imsOrgId,
         deliveryType,
-        ...(tempOnboarding ? { tempOnboarding: true } : {}),
         ...(region ? { region } : {}),
       },
       lambdaCtx,
@@ -478,14 +471,12 @@ export function onboardLLMOModal(lambdaContext) {
       let originalChannel;
       let originalThreadTs;
       let brandURL;
-      let tempOnboarding;
       try {
         /* c8 ignore next */
         const metadata = JSON.parse(view.private_metadata || '{}');
         originalChannel = metadata.originalChannel;
         originalThreadTs = metadata.originalThreadTs;
         brandURL = metadata.brandURL;
-        tempOnboarding = metadata.tempOnboarding === true;
       } catch (error) {
         log.warn('Failed to parse private metadata:', error);
       }
@@ -525,7 +516,6 @@ export function onboardLLMOModal(lambdaContext) {
         brandURL,
         originalChannel,
         originalThreadTs,
-        tempOnboarding: tempOnboarding === true,
       });
 
       // eslint-disable-next-line max-statements-per-line
@@ -555,7 +545,6 @@ export function onboardLLMOModal(lambdaContext) {
         baseURL: brandURL,
         imsOrgId,
         deliveryType,
-        ...(tempOnboarding ? { tempOnboarding: true } : {}),
         ...(region ? { region } : {}),
       }, lambdaContext, slackContext);
 

--- a/src/support/slack/commands/llmo-onboard.js
+++ b/src/support/slack/commands/llmo-onboard.js
@@ -19,19 +19,6 @@ import BaseCommand from './base.js';
 
 const PHRASES = ['onboard-llmo'];
 
-/** Flags that skip updating helix-query.yaml (same effect as HTTP `temp-onboarding`). */
-const TEMP_ONBOARDING_FLAGS = new Set(['--skip-helix-query', '--temp-onboarding']);
-
-/**
- * @param {string[]} args
- * @returns {{ siteInput: string, tempOnboarding: boolean }}
- */
-function splitLlmoOnboardCommandArgs(args) {
-  const urlTokens = args.filter((a) => !TEMP_ONBOARDING_FLAGS.has(a));
-  const tempOnboarding = args.some((a) => TEMP_ONBOARDING_FLAGS.has(a));
-  return { siteInput: urlTokens.join(' '), tempOnboarding };
-}
-
 /**
  * Factory function to create the LlmoOnboardCommand object.
  *
@@ -45,7 +32,7 @@ function LlmoOnboardCommand(context) {
     name: 'Onboard LLMO',
     description: 'Onboards a site for LLMO (Large Language Model Optimizer) through a modal interface.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} <site url> [${[...TEMP_ONBOARDING_FLAGS].join(' | ')}]`,
+    usageText: `${PHRASES[0]} <site url>`,
   });
 
   const { log } = context;
@@ -62,8 +49,7 @@ function LlmoOnboardCommand(context) {
     const { say, threadTs } = slackContext;
     const { dataAccess } = context;
 
-    const { siteInput, tempOnboarding } = splitLlmoOnboardCommandArgs(args);
-    const normalizedSite = extractURLFromSlackInput(siteInput);
+    const normalizedSite = extractURLFromSlackInput(args.join(' '));
 
     if (!normalizedSite) {
       await say(baseCommand.usage());
@@ -165,7 +151,6 @@ function LlmoOnboardCommand(context) {
                   },
                   value: JSON.stringify({
                     brandURL: normalizedSite,
-                    ...(tempOnboarding ? { tempOnboarding: true } : {}),
                   }),
                   action_id: 'start_llmo_onboarding',
                   style: 'primary',

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -3772,7 +3772,7 @@ describe('LLMO Onboarding Functions', () => {
       );
     });
 
-    it('should skip helix-query.yaml update when tempOnboarding is true', async () => {
+    it('should always update helix-query.yaml, even if a stray tempOnboarding param is passed (LLMO-7141: flag removed)', async () => {
       const mockOrganization = {
         getId: sinon.stub().returns('org123'),
         getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
@@ -3839,13 +3839,12 @@ describe('LLMO Onboarding Functions', () => {
         domain: 'example.com',
         brandName: 'Test Brand',
         imsOrgId: 'ABC123@AdobeOrg',
+        // Stray/unsupported param — must have zero effect now that the temp-onboarding
+        // skip path has been removed. Registration always runs.
         tempOnboarding: true,
       }, context);
 
-      expect(createOrUpdateFileContents).to.not.have.been.called;
-      expect(mockLog.info).to.have.been.calledWith(
-        sinon.match(/Skipping helix-query.yaml update \(temp-onboarding\)/),
-      );
+      expect(createOrUpdateFileContents).to.have.been.called;
     });
 
     it('should call cleanup functions when site.save() throws an error', async () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -3007,7 +3007,7 @@ describe('LlmoController', () => {
       expect(triggerBrandProfileAgentStub).to.have.been.calledOnce;
     });
 
-    it('should pass tempOnboarding when temp-onboarding is true', async () => {
+    it('should ignore a temp-onboarding body field (LLMO-7141: flag removed, registration always runs)', async () => {
       const LlmoControllerOnboard = await esmock('../../../src/controllers/llmo/llmo.js', {
         '../../../src/controllers/llmo/llmo-onboarding.js': {
           validateSiteNotOnboarded: validateSiteNotOnboardedStub,
@@ -3050,7 +3050,9 @@ describe('LlmoController', () => {
 
       expect(result.status).to.equal(200);
       expect(performLlmoOnboardingStub).to.have.been.calledOnce;
-      expect(performLlmoOnboardingStub.firstCall.args[0].tempOnboarding).to.equal(true);
+      // The temp-onboarding flag no longer exists — a caller still sending it must not
+      // be forwarded as tempOnboarding into performLlmoOnboarding.
+      expect(performLlmoOnboardingStub.firstCall.args[0]).to.not.have.property('tempOnboarding');
     });
 
     ['data', 'domain', 'brandName', 'authInfo', 'profile', 'tenants', 'tenant ID'].forEach((field) => {

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -489,12 +489,13 @@ describe('onboard-llmo-modal', () => {
       expect(successCall.args[0]).to.not.include(':globe_with_meridians:');
     });
 
-    it('should not call GitHub when tempOnboarding skips helix-query.yaml update', async () => {
+    it('should always call GitHub to update helix-query.yaml, ignoring a stray tempOnboarding param (LLMO-7141)', async () => {
       const input = {
         baseURL: 'https://example.com',
         brandName: 'Test Brand',
         imsOrgId: 'ABC123@AdobeOrg',
         deliveryType: 'aem_edge',
+        // No longer a supported input — must have zero effect.
         tempOnboarding: true,
       };
 
@@ -507,7 +508,7 @@ describe('onboard-llmo-modal', () => {
 
       await onboardSite(input, lambdaCtx, slackCtx);
 
-      expect(octokitMock).to.not.have.been.called;
+      expect(octokitMock).to.have.been.called;
       expect(triggerBrandProfileAgentStub).to.have.been.calledOnce;
     });
 
@@ -1241,13 +1242,12 @@ example-com:
         brandURL: 'https://example.com',
         originalChannel: 'C1234567890',
         originalThreadTs: '1234567890.123456',
-        tempOnboarding: false,
       });
       expect(lambdaCtx.log.debug).to.have.been.calledWith('Onboard LLMO modal processed for user U1234567890, site https://example.com');
       expect(mockAck).to.have.been.calledOnce;
     });
 
-    it('should pass tempOnboarding from private_metadata to onboarding (log and onboardSite)', async () => {
+    it('should ignore a stray tempOnboarding in private_metadata (LLMO-7141: flag removed)', async () => {
       const mockBody = {
         view: {
           state: {
@@ -1289,6 +1289,8 @@ example-com:
 
       await handler({ ack: mockAck, body: mockBody, client: mockClient });
 
+      // A stray tempOnboarding in legacy private_metadata must not surface anywhere —
+      // no such field is read, logged, or forwarded any more.
       expect(lambdaCtx.log.info).to.have.been.calledWith('Onboarding request with parameters:', {
         brandName: 'Test Brand',
         imsOrgId: 'ABC123@AdobeOrg',
@@ -1297,7 +1299,6 @@ example-com:
         brandURL: 'https://example.com',
         originalChannel: 'C1234567890',
         originalThreadTs: '1234567890.123456',
-        tempOnboarding: true,
       });
     });
 
@@ -1353,7 +1354,6 @@ example-com:
         brandURL: 'https://example.com',
         originalChannel: 'C1234567890',
         originalThreadTs: '1234567890.123456',
-        tempOnboarding: false,
       });
     });
 
@@ -1621,7 +1621,6 @@ example-com:
         brandURL: undefined, // Should be undefined when parsing fails
         originalChannel: undefined,
         originalThreadTs: undefined,
-        tempOnboarding: false,
       });
     });
   });
@@ -1631,24 +1630,22 @@ example-com:
       const { parseStartLlmoOnboardingButtonValue } = mockedModule;
       expect(parseStartLlmoOnboardingButtonValue('https://example.com')).to.deep.equal({
         brandURL: 'https://example.com',
-        tempOnboarding: false,
       });
     });
 
-    it('parses JSON payload with tempOnboarding', () => {
+    it('parses JSON payload, ignoring any stray tempOnboarding field (LLMO-7141)', () => {
       const { parseStartLlmoOnboardingButtonValue } = mockedModule;
       expect(parseStartLlmoOnboardingButtonValue(JSON.stringify({
         brandURL: 'https://example.com',
         tempOnboarding: true,
       }))).to.deep.equal({
         brandURL: 'https://example.com',
-        tempOnboarding: true,
       });
     });
 
     it('returns empty brandURL when raw is null, undefined, or empty string', () => {
       const { parseStartLlmoOnboardingButtonValue } = mockedModule;
-      const empty = { brandURL: '', tempOnboarding: false };
+      const empty = { brandURL: '' };
       expect(parseStartLlmoOnboardingButtonValue(null)).to.deep.equal(empty);
       expect(parseStartLlmoOnboardingButtonValue(undefined)).to.deep.equal(empty);
       expect(parseStartLlmoOnboardingButtonValue('')).to.deep.equal(empty);
@@ -1658,7 +1655,6 @@ example-com:
       const { parseStartLlmoOnboardingButtonValue } = mockedModule;
       expect(parseStartLlmoOnboardingButtonValue('{invalid-json')).to.deep.equal({
         brandURL: '{invalid-json',
-        tempOnboarding: false,
       });
     });
   });
@@ -1706,7 +1702,7 @@ example-com:
       expect(meta.tempOnboarding).to.be.undefined;
     });
 
-    it('should pass tempOnboarding into full onboarding modal private_metadata', async () => {
+    it('should ignore a stray tempOnboarding in the button value for full onboarding modal (LLMO-7141)', async () => {
       const mockBody = {
         user: { id: 'user123' },
         actions: [{
@@ -1740,7 +1736,7 @@ example-com:
       });
 
       const meta = JSON.parse(mockClient.views.open.getCall(0).args[0].view.private_metadata);
-      expect(meta.tempOnboarding).to.equal(true);
+      expect(meta.tempOnboarding).to.be.undefined;
     });
 
     it('should call elmoOnboardingModal when site is found but no brand configured', async () => {
@@ -1787,7 +1783,7 @@ example-com:
       expect(lambdaCtx.log.debug).to.have.been.calledWith('User user123 started LLMO onboarding process for https://example.com with existing site site123.');
     });
 
-    it('should pass tempOnboarding into elmo onboarding modal private_metadata', async () => {
+    it('should ignore a stray tempOnboarding in the button value for elmo onboarding modal (LLMO-7141)', async () => {
       const mockBody = {
         user: { id: 'user123' },
         actions: [{
@@ -1827,7 +1823,7 @@ example-com:
       });
 
       const meta = JSON.parse(mockClient.views.open.getCall(0).args[0].view.private_metadata);
-      expect(meta.tempOnboarding).to.equal(true);
+      expect(meta.tempOnboarding).to.be.undefined;
     });
 
     it('should call elmoOnboardingModal when site is found with brand configured', async () => {

--- a/test/support/slack/commands/llmo-onboard.test.js
+++ b/test/support/slack/commands/llmo-onboard.test.js
@@ -77,7 +77,7 @@ describe('LlmoOnboardCommand', () => {
       await command.handleExecution([], slackContext);
 
       expect(slackContext.say).to.have.been.calledWith(
-        'Usage: _onboard-llmo <site url> [--skip-helix-query | --temp-onboarding]_',
+        'Usage: _onboard-llmo <site url>_',
       );
     });
 
@@ -85,7 +85,7 @@ describe('LlmoOnboardCommand', () => {
       await command.handleExecution(['invalid-url'], slackContext);
 
       expect(slackContext.say).to.have.been.calledWith(
-        'Usage: _onboard-llmo <site url> [--skip-helix-query | --temp-onboarding]_',
+        'Usage: _onboard-llmo <site url>_',
       );
     });
 
@@ -119,7 +119,7 @@ describe('LlmoOnboardCommand', () => {
       expect(button.style).to.equal('primary');
     });
 
-    it('should encode skip helix-query flag on Start Onboarding button', async () => {
+    it('should ignore trailing tokens after the URL (LLMO-7141: --skip-helix-query no longer a supported flag)', async () => {
       mockDataAccess.Site.findByBaseURL.resolves(null);
 
       await command.handleExecution(
@@ -129,9 +129,9 @@ describe('LlmoOnboardCommand', () => {
 
       const message = slackContext.say.getCall(0).args[0];
       const button = message.blocks.find((block) => block.type === 'actions').elements[0];
+      // No special flag handling remains — the button value only ever carries brandURL.
       expect(JSON.parse(button.value)).to.deep.equal({
         brandURL: 'https://example.com',
-        tempOnboarding: true,
       });
     });
 


### PR DESCRIPTION
## Summary

Implements item 1 of [LLMO-7141](https://jira.corp.adobe.com/browse/LLMO-7141): remove the `temp-onboarding` / `--skip-helix-query` skip-registration path introduced by LLMO-4024 (#2098), so registering a site's `dataFolder` in `adobe/project-elmo-ui-data`'s `helix-query.yaml` always happens during onboarding.

**Root-cause framing:** LLMO-4024 added the flag as a workaround for a 2026-03-19 Helix bulk-indexing capacity incident above ~1,000 index definitions. That capacity issue was fixed by the Helix team **the same day**, and Helix confirmed there is no hard limit — `helix-query.yaml` is now past 1,783 definitions with no recurrence. The skip flag turned out to be the root cause of the entire **LLMO-6320** bug class: every site onboarded with the flag never got its index registered and was never reliably backfilled, leaving real (some paying) customer sites dark in LLMO dashboards for months. This PR removes the flag entirely rather than restricting it, since the original justification no longer exists.

## Changes

- `src/controllers/llmo/llmo.js` — `POST /llmo/onboard` no longer reads `data['temp-onboarding']` or forwards a `tempOnboarding` param.
- `src/controllers/llmo/llmo-onboarding.js` — `performLlmoOnboarding` no longer accepts a `tempOnboarding` param; `updateIndexConfig` (the `helix-query.yaml` registration step) now runs unconditionally.
- `src/support/slack/commands/llmo-onboard.js` — the `onboard-llmo` Slack command no longer accepts `--skip-helix-query` / `--temp-onboarding`; usage text updated. The `splitLlmoOnboardCommandArgs` helper that stripped these flags out of the args before URL-parsing is removed entirely (not just simplified) — there's no flag left to strip, so args are joined and passed straight to `extractURLFromSlackInput`. A caller who still types `--skip-helix-query` after the URL now has it silently absorbed into that free-text parse rather than treated as a flag; since registration can no longer be skipped, this has no behavioral effect either way (test-covered).
- `src/support/slack/actions/onboard-llmo-modal.js` — `parseStartLlmoOnboardingButtonValue`, the onboarding modals' `private_metadata`, `onboardLLMOModal`, and `onboardSite` no longer read/forward `tempOnboarding`.
- `docs/openapi/llmo-api.yaml` — removed the `temp-onboarding` request body field from the onboard-endpoint spec.
- `docs/llmo-http-onboard-notes.md` — rewritten to drop the temp-onboarding feature section and add a short history note explaining the LLMO-7141 removal.
- Tests updated/added in `test/controllers/llmo/llmo.test.js`, `test/controllers/llmo/llmo-onboarding.test.js`, `test/support/slack/commands/llmo-onboard.test.js`, and `test/support/slack/actions/onboard-llmo-modal.test.js` to assert registration always runs and that a stray `tempOnboarding`/`--skip-helix-query` from an old caller has zero effect (rather than asserting the old skip behavior).

Item 2 of LLMO-7141 (the recurring schedule/index reconciliation job) is being handled separately in a different repo and is not part of this PR.

## Ambiguity check (per ticket step 4)

Searched `spacecat-api-service` and every other locally reachable repo (`project-elmo-ui`, `project-elmo-ui-data`, `spacecat-shared`, `spacecat-mcp-server`, `llmo-data-retrieval-service`, `serenity-docs`) for callers passing `temp-onboarding: true` / `--skip-helix-query` / `--temp-onboarding`. Found **no active production callers** — only historical documentation in `serenity-docs` (`docs/onboarding/brandalf-onboarding-semrush.md`, `docs/onboarding/semrush-onboarding-orchestration.md`) describing the current (now-removed) behavior, which is out of scope for this repo and should be updated separately. No evidence of a genuinely-temporary demo/workshop use case relying on this flag today, consistent with the ticket's framing that the capacity concern (the only stated reason for the flag) no longer applies. Proceeded with full removal.

## Test plan

- [x] `npx eslint` on all changed source/test files — clean
- [x] `npx mocha` on the four affected test files — 625 passing, 0 failing
- [x] `npm test` (full suite) — passing, 0 failing
- [x] `npm run docs:lint` — valid (pre-existing unrelated warnings only)
- [x] `npm run docs:build` — regenerated `docs/index.html` but produced a ~34k line diff of non-deterministic styled-components hashes/markup (looks like environment-specific redoc rendering drift, not a real content change — historical commits touching this file are tens/hundreds of lines). Reverted `docs/index.html` rather than commit that noise; a maintainer with the normal CI toolchain should regenerate it if desired.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```