### PR TITLE
fix(onboard): resolve PLG org guard from the site's own org, not imsO…

### DIFF
--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -1936,12 +1936,21 @@ export const onboardSingleSite = async (
     // without the "single customer-facing domain" constraint PLG has.
     // Fail-open on lookup errors — getAsoEntitlement already swallows its own and
     // returns null.
+    //
+    // Resolve the org from the site itself when it already exists, not from imsOrgID.
+    // createSiteAndOrganization ignores imsOrgID entirely for an existing site and always
+    // keys off site.getOrganizationId() — imsOrgID can legitimately point elsewhere (it
+    // defaults to env.DEMO_IMS_ORG when the caller omits it on a re-onboard). Checking
+    // imsOrgID's org here would look at the wrong org's entitlement, let a re-onboard that
+    // should be blocked run its full pipeline (audits, CDN detection, brand-profile) for
+    // nothing, and only have the later protected-tier check (which does use the site's real
+    // org) skip the entitlement write after all that work already happened. Only fall back
+    // to resolving by imsOrgID for a genuinely new site, where there's no existing org to read.
     try {
-      const { Organization: OrgLookup } = dataAccess;
-      const organization = await OrgLookup.findByImsOrgId(imsOrgID);
-      const asoEntitlement = organization
-        ? await getAsoEntitlement(organization.getId(), context)
-        : null;
+      const orgId = prefetchedSite
+        ? prefetchedSite.getOrganizationId()
+        : (await dataAccess.Organization.findByImsOrgId(imsOrgID))?.getId();
+      const asoEntitlement = orgId ? await getAsoEntitlement(orgId, context) : null;
       const existingTier = asoEntitlement?.getTier() ?? null;
 
       if (existingTier === EntitlementModel.TIERS.PLG) {

--- a/test/support/utils-plg-org-guard.test.js
+++ b/test/support/utils-plg-org-guard.test.js
@@ -33,6 +33,14 @@ use(sinonChai);
  *
  * PRE_ONBOARD is deliberately out of scope — it's an internal staging tier without
  * PLG's "single customer-facing domain" constraint.
+ *
+ * Org resolution: when the site already exists, the guard reads the org straight off
+ * `prefetchedSite.getOrganizationId()` instead of resolving `Organization.findByImsOrgId
+ * (imsOrgID)` — mirroring createSiteAndOrganization, which does the same and ignores
+ * imsOrgID entirely for an existing site. imsOrgID can legitimately point elsewhere (it
+ * defaults to env.DEMO_IMS_ORG when the caller omits it on a re-onboard); resolving by
+ * imsOrgID in that case would check the wrong org's entitlement and silently let a
+ * re-onboard that should be blocked run its full pipeline for nothing.
  */
 describe('onboardSingleSite — PLG-tier org guard', () => {
   const SITE_URL = 'https://example.com';
@@ -43,7 +51,9 @@ describe('onboardSingleSite — PLG-tier org guard', () => {
   let onboardSingleSite;
   let sayStub;
 
-  before(async () => {
+  before(async function beforeHook() {
+    // esmock's cold load of utils.js can exceed the 2s default hook timeout.
+    this.timeout(15000);
     ({ onboardSingleSite } = await esmock('../../src/support/utils.js', {
       '@aws-sdk/client-sfn': {
         // eslint-disable-next-line func-style
@@ -112,12 +122,14 @@ describe('onboardSingleSite — PLG-tier org guard', () => {
   // Site not yet enrolled under the entitlement — a genuinely different domain.
   const makeUnrelatedSite = () => ({
     getConfig: nonPaidConfig,
+    getOrganizationId: () => 'org-plg-1',
     getSiteEnrollments: sandbox.stub().resolves([]),
   });
 
   // Site already enrolled under the same entitlement — safe to re-onboard.
   const makeSameEnrolledSite = (entitlementId) => ({
     getConfig: nonPaidConfig,
+    getOrganizationId: () => 'org-plg-1',
     getSiteEnrollments: sandbox.stub().resolves([
       { getEntitlementId: () => entitlementId },
     ]),
@@ -208,6 +220,47 @@ describe('onboardSingleSite — PLG-tier org guard', () => {
       expect(result.status).to.equal('Failed');
       expect(result.errors).to.match(/Blocked.*PLG-tier ASO entitlement/);
       expect(sayStub).to.have.been.calledWith(sinon.match(GUARD_WARNING_PATTERN));
+    });
+
+    it('resolves the org from the existing site itself, ignoring a mismatched imsOrgID (regression: DEMO_IMS_ORG default)', async () => {
+      const REAL_ORG_ID = 'org-real-plg';
+      const IMS_LOOKUP_ORG_ID = 'org-demo-unrelated';
+
+      const guardSite = {
+        getConfig: nonPaidConfig,
+        getOrganizationId: () => REAL_ORG_ID,
+        // Unrelated to the entitlement bound to the site's real org — no matching enrollment.
+        getSiteEnrollments: sandbox.stub().resolves([]),
+      };
+
+      const ctx = makeContext({
+        org: { getId: () => IMS_LOOKUP_ORG_ID },
+        guardSite,
+      });
+      // The site's real org holds the PLG entitlement; the org imsOrgID/DEMO_IMS_ORG
+      // resolves to has none — proving the guard must not use the latter.
+      ctx.dataAccess.Entitlement.findByOrganizationIdAndProductCode = sandbox.stub();
+      ctx.dataAccess.Entitlement.findByOrganizationIdAndProductCode
+        .withArgs(REAL_ORG_ID, sinon.match.any).resolves(makeEntitlement('PLG'));
+      ctx.dataAccess.Entitlement.findByOrganizationIdAndProductCode
+        .withArgs(IMS_LOOKUP_ORG_ID, sinon.match.any).resolves(null);
+
+      const result = await onboardSingleSite(
+        SITE_URL,
+        IMS_ORG_ID,
+        {},
+        demoProfile,
+        300,
+        slackContext(),
+        ctx,
+        {},
+        { profileName: 'demo' },
+      );
+
+      expect(result.status).to.equal('Failed');
+      expect(result.errors).to.match(/Blocked.*PLG-tier ASO entitlement/);
+      // Site already exists — imsOrgID must never even be resolved to an org.
+      expect(ctx.dataAccess.Organization.findByImsOrgId).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
…rgID

The single-domain PLG guard added in #3115 resolved the org to check via Organization.findByImsOrgId(imsOrgID). For an existing site being re-onboarded without an explicit org (imsOrgID defaults to env.DEMO_IMS_ORG), that can resolve a completely different org than the site's real one — so the guard checked the wrong org's entitlement, let the re-onboard through, and only the later protected-tier check (SITES-49886, which correctly uses the site's real org) caught it — after the full onboarding pipeline (project assignment, CDN detection, audits, brand-profile) had already run for nothing.

createSiteAndOrganization already ignores imsOrgID entirely for an existing site and keys off site.getOrganizationId() instead. Mirror that here: read the org straight off prefetchedSite when it exists, and only fall back to resolving by imsOrgID for a genuinely new site.

Adds a regression test reproducing the exact failure: an existing site whose real org differs from what imsOrgID resolves to.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```