### PR TITLE
fix: translate aiRationale into the request locale on first read | LLMO-6479

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -524,7 +524,7 @@ function SuggestionsController(ctx, sqs, env) {
         () => createSuggestionTranslator(context),
         grantedEntities,
         locale,
-        { timeoutMs: resolveBatchTimeoutMs(context.env) },
+        { timeoutMs: resolveBatchTimeoutMs(context.env), log: context.log },
       );
     }
     const suggestions = grantedEntities.map(

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -69,6 +69,11 @@ import { CAP_FIX_ENTITY_CREATE, CAP_SUGGESTION_WRITE } from '../routes/capabilit
 import { grantSuggestionsForOpportunity } from '../support/grant-suggestions-handler.js';
 import { postSlackMessage } from '../utils/slack/base.js';
 import { createAtomicStrategy, deleteAtomicStrategy } from '../support/atomic-strategy-helper.js';
+import {
+  createSuggestionTranslator,
+  ensureAiRationaleTranslations,
+  resolveBatchTimeoutMs,
+} from '../support/suggestion-translator.js';
 
 const VALIDATION_ERROR_NAME = 'ValidationError';
 
@@ -509,6 +514,19 @@ function SuggestionsController(ctx, sqs, env) {
       );
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
+    if (locale) {
+      // Best-effort: translates + persists suggestion.data.i18n[locale].aiRationale on first
+      // read for this locale so SuggestionDto.toJSON below picks it up immediately. Falls back
+      // to English (no-op) on any translator/LLM failure. createSuggestionTranslator is only
+      // invoked (and only then constructs an Azure OpenAI client) once
+      // ensureAiRationaleTranslations has confirmed at least one suggestion needs translating.
+      await ensureAiRationaleTranslations(
+        () => createSuggestionTranslator(context),
+        grantedEntities,
+        locale,
+        { timeoutMs: resolveBatchTimeoutMs(context.env) },
+      );
+    }
     const suggestions = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );

--- a/src/support/intent-classifier.js
+++ b/src/support/intent-classifier.js
@@ -275,6 +275,7 @@ export function createIntentClassifier(context = {}, categorySpec = DRS_CATEGORY
           { role: 'user', content: trimmed.slice(0, MAX_PROMPT_CHARS) },
         ]),
         invokeTimeoutMs,
+        'intent classification',
       );
       // content may be a string OR an array of content parts; coerce either way.
       const content = contentToString(response?.content);

--- a/src/support/intent-classifier.js
+++ b/src/support/intent-classifier.js
@@ -13,6 +13,7 @@ import { AzureChatOpenAI } from '@langchain/openai';
 import { hasText } from '@adobe/spacecat-shared-utils';
 
 import { normalizeIntent } from './intent.js';
+import { withTimeout, contentToString } from './llm-utils.js';
 
 /**
  * LLM-backed classifier that buckets a human-added prompt's text into one of the
@@ -128,61 +129,9 @@ export function resolveBatchTimeoutMs(env = {}) {
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_BATCH_TIMEOUT_MS;
 }
 
-/**
- * Races a promise against a timer. Rejects with a timeout error if `promise`
- * does not settle within `timeoutMs`. The timer is always cleared so the event
- * loop is not held open by a pending timeout once the race resolves.
- *
- * @param {Promise<*>} promise - Work to bound
- * @param {number} timeoutMs - Timeout in milliseconds
- * @returns {Promise<*>} resolves/rejects with `promise`, or rejects on timeout
- */
-function withTimeout(promise, timeoutMs) {
-  let timer;
-  const timeout = new Promise((_, reject) => {
-    timer = setTimeout(() => {
-      reject(new Error(`intent classification timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
-}
-
-/**
- * Coerces an LLM message `content` into a plain string. `AzureChatOpenAI`
- * `.invoke()` may return `content` as a string OR as an array of content parts
- * (`[{ type: 'text', text: '...' }, ...]`). Array content is concatenated from
- * its text parts so the downstream JSON parse sees the full model output rather
- * than silently failing on a non-string.
- *
- * @param {*} content - `response.content` from the model
- * @returns {string}
- */
-export function contentToString(content) {
-  if (typeof content === 'string') {
-    return content;
-  }
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (typeof part === 'string') {
-          return part;
-        }
-        // LangChain text parts: { type: 'text', text: '...' }. Some providers
-        // use `content` instead of `text`; accept either, ignore non-text parts.
-        if (part && typeof part === 'object') {
-          if (typeof part.text === 'string') {
-            return part.text;
-          }
-          if (typeof part.content === 'string') {
-            return part.content;
-          }
-        }
-        return '';
-      })
-      .join('');
-  }
-  return String(content ?? '');
-}
+// withTimeout/contentToString moved to llm-utils.js (shared with suggestion-translator.js);
+// re-exported here so existing external imports of contentToString keep working.
+export { contentToString } from './llm-utils.js';
 
 /**
  * Extracts a JSON object from a model response that may include code fences or

--- a/src/support/llm-utils.js
+++ b/src/support/llm-utils.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Small, dependency-free helpers shared by every best-effort LLM caller in this codebase
+ * (`intent-classifier.js`, `suggestion-translator.js`, ...). Kept here instead of duplicated
+ * per-consumer so the two behaviors below stay consistent across callers.
+ */
+
+/**
+ * Races a promise against a timer. Rejects with a timeout error if `promise` does not settle
+ * within `timeoutMs`. The timer is always cleared so the event loop is not held open by a
+ * pending timeout once the race resolves. Note: this only stops the *caller* from waiting any
+ * longer — it does not cancel `promise` itself, which keeps running in the background.
+ *
+ * @param {Promise<*>} promise - Work to bound
+ * @param {number} timeoutMs - Timeout in milliseconds
+ * @returns {Promise<*>} resolves/rejects with `promise`, or rejects on timeout
+ */
+export function withTimeout(promise, timeoutMs) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`operation timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Coerces an LLM message `content` into a plain string. Chat-model `.invoke()` responses may
+ * return `content` as a string OR as an array of content parts (`[{ type: 'text', text: '...' },
+ * ...]`). Array content is concatenated from its text parts so downstream parsing sees the full
+ * model output rather than silently failing on a non-string.
+ *
+ * @param {*} content - `response.content` from the model
+ * @returns {string}
+ */
+export function contentToString(content) {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        // LangChain text parts: { type: 'text', text: '...' }. Some providers use `content`
+        // instead of `text`; accept either, ignore non-text parts.
+        if (part && typeof part === 'object') {
+          if (typeof part.text === 'string') {
+            return part.text;
+          }
+          if (typeof part.content === 'string') {
+            return part.content;
+          }
+        }
+        return '';
+      })
+      .join('');
+  }
+  return String(content ?? '');
+}

--- a/src/support/llm-utils.js
+++ b/src/support/llm-utils.js
@@ -24,13 +24,15 @@
  *
  * @param {Promise<*>} promise - Work to bound
  * @param {number} timeoutMs - Timeout in milliseconds
+ * @param {string} [label] - Included in the timeout error message so callers' logs stay
+ *   specific (e.g. 'intent classification', 'suggestion translation') instead of generic.
  * @returns {Promise<*>} resolves/rejects with `promise`, or rejects on timeout
  */
-export function withTimeout(promise, timeoutMs) {
+export function withTimeout(promise, timeoutMs, label = 'operation') {
   let timer;
   const timeout = new Promise((_, reject) => {
     timer = setTimeout(() => {
-      reject(new Error(`operation timed out after ${timeoutMs}ms`));
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));

--- a/src/support/suggestion-translator.js
+++ b/src/support/suggestion-translator.js
@@ -44,6 +44,12 @@ const LOCALE_LANGUAGE_NAMES = {
 };
 
 const DEFAULT_INVOKE_TIMEOUT_MS = 10000;
+// Intentionally shorter than DEFAULT_INVOKE_TIMEOUT_MS: the batch cap bounds how long the
+// suggestions read path waits overall, not how long any individual call is allowed to run. A
+// call already in flight when the batch cap fires may still resolve up to
+// DEFAULT_INVOKE_TIMEOUT_MS later — the `stopped` flag in ensureAiRationaleTranslations ensures
+// such a late result is discarded rather than persisted after this function (and the HTTP
+// response it gates) has already returned.
 const DEFAULT_BATCH_TIMEOUT_MS = 8000;
 const DEFAULT_MAX_CONCURRENCY = 5;
 // aiRationale is a one-to-few-sentence rationale; a few hundred tokens comfortably covers a
@@ -127,7 +133,14 @@ export function createSuggestionTranslator(context = {}) {
     if (trimmed.length === 0) {
       return null;
     }
-    const languageName = LOCALE_LANGUAGE_NAMES[targetLocale] || targetLocale;
+    // Reject rather than fall through to the raw locale code: an unmapped code (including
+    // `en_us`, which the `xx_yy` format validator accepts) would otherwise be sent straight into
+    // the prompt, wasting a call and risking garbled/untranslated text overwriting the original.
+    // Also closes off a prompt-injection surface if the upstream locale regex is ever relaxed.
+    const languageName = LOCALE_LANGUAGE_NAMES[targetLocale];
+    if (!languageName) {
+      return null;
+    }
     try {
       const response = await withTimeout(
         model.invoke([
@@ -138,6 +151,7 @@ export function createSuggestionTranslator(context = {}) {
           { role: 'user', content: trimmed },
         ]),
         invokeTimeoutMs,
+        'suggestion translation',
       );
       const translated = contentToString(response?.content).trim();
       return hasText(translated) ? translated : null;
@@ -173,13 +187,18 @@ export function createSuggestionTranslator(context = {}) {
  * @param {object} [options]
  * @param {number} [options.maxConcurrency] - Max in-flight LLM calls.
  * @param {number} [options.timeoutMs] - Total wall-clock cap for the batch.
+ * @param {object} [options.log] - Logger; used to surface persistence failures to operators.
  * @returns {Promise<void>}
  */
 export async function ensureAiRationaleTranslations(
   createTranslator,
   suggestions,
   locale,
-  { maxConcurrency = DEFAULT_MAX_CONCURRENCY, timeoutMs = DEFAULT_BATCH_TIMEOUT_MS } = {},
+  {
+    maxConcurrency = DEFAULT_MAX_CONCURRENCY,
+    timeoutMs = DEFAULT_BATCH_TIMEOUT_MS,
+    log = console,
+  } = {},
 ) {
   if (typeof createTranslator !== 'function' || !hasText(locale)) {
     return;
@@ -216,11 +235,16 @@ export async function ensureAiRationaleTranslations(
       // eslint-disable-next-line no-await-in-loop
       const translated = await translate(data.aiRationale, locale).catch(() => null);
       if (!stopped && hasText(translated)) {
+        // Re-read rather than reuse the pre-await `data` snapshot: it narrows (doesn't
+        // eliminate) the window in which a concurrent request translating this same
+        // suggestion into a different locale could have its own setData/save overwritten by
+        // this one replaying a stale i18n map from before the LLM call.
+        const freshData = suggestion.getData();
         suggestion.setData({
-          ...data,
+          ...freshData,
           i18n: {
-            ...data.i18n,
-            [locale]: { ...data.i18n?.[locale], aiRationale: translated },
+            ...freshData.i18n,
+            [locale]: { ...freshData.i18n?.[locale], aiRationale: translated },
           },
         });
         try {
@@ -228,8 +252,10 @@ export async function ensureAiRationaleTranslations(
           // response (setData already mutated the in-memory entity above).
           // eslint-disable-next-line no-await-in-loop
           await suggestion.save();
-        } catch {
-          // best-effort; see comment above
+        } catch (e) {
+          // Best-effort persist — but a silent failure here is invisible cost amplification:
+          // every future request would re-translate via LLM with no signal to operators.
+          log.warn(`Failed to persist translated aiRationale for suggestion ${suggestion.getId?.() ?? 'unknown'} (locale ${locale}): ${e.message}`);
         }
       }
     }

--- a/src/support/suggestion-translator.js
+++ b/src/support/suggestion-translator.js
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { AzureChatOpenAI } from '@langchain/openai';
+import { hasText } from '@adobe/spacecat-shared-utils';
+import { withTimeout, contentToString } from './llm-utils.js';
+
+/**
+ * On-demand translator for AI-generated suggestion prose (currently `aiRationale`).
+ *
+ * Audit workers write `suggestion.data.aiRationale` in English only and never populate
+ * `suggestion.data.i18n[locale]` (the map `SuggestionDto.toJSON` promotes fields from — see
+ * `ALLOWED_I18N_FIELDS` in `dto/suggestion.js`). Rather than requiring every audit worker to
+ * generate per-locale text, this translates on first non-English read; the caller persists the
+ * result into `suggestion.data.i18n[locale].aiRationale` so subsequent reads for that
+ * suggestion + locale are served from the stored translation with no further LLM call.
+ *
+ * Best-effort / non-fatal, mirroring `intent-classifier.js`: any failure (no client configured,
+ * LLM error, timeout) resolves to `null` so the caller falls back to the untranslated English
+ * text `SuggestionDto` already returns.
+ */
+
+// Human-readable language names for the locale codes project-elmo-ui ships translations for
+// (underscore form, matches isValidLocale). Unlisted codes fall back to the raw code so
+// translation still works for a locale added later without a code change here.
+const LOCALE_LANGUAGE_NAMES = {
+  fr_fr: 'French',
+  de_de: 'German',
+  es_es: 'Spanish',
+  it_it: 'Italian',
+  pt_br: 'Brazilian Portuguese',
+  ja_jp: 'Japanese',
+  ko_kr: 'Korean',
+  zh_cn: 'Simplified Chinese',
+  zh_tw: 'Traditional Chinese',
+};
+
+const DEFAULT_INVOKE_TIMEOUT_MS = 10000;
+const DEFAULT_BATCH_TIMEOUT_MS = 8000;
+const DEFAULT_MAX_CONCURRENCY = 5;
+// aiRationale is a one-to-few-sentence rationale; a few hundred tokens comfortably covers a
+// translation (even into a more verbose target language) with headroom, while still bounding
+// cost/latency per call for text that ultimately traces back to an untrusted broken URL.
+const MAX_TRANSLATION_OUTPUT_TOKENS = 500;
+
+function resolveInvokeTimeoutMs(env = {}) {
+  const raw = Number(env.SUGGESTION_TRANSLATION_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_INVOKE_TIMEOUT_MS;
+}
+
+/**
+ * Resolves the wall-clock cap (ms) for a whole translation batch from env, falling back to the
+ * default. Non-numeric / non-positive values fall back to the default.
+ *
+ * @param {object} env - Environment variables
+ * @returns {number} timeout in milliseconds
+ */
+export function resolveBatchTimeoutMs(env = {}) {
+  const raw = Number(env.SUGGESTION_TRANSLATION_BATCH_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_BATCH_TIMEOUT_MS;
+}
+
+// Allows a translation-scoped deployment override, else reuses the shared per-env deployment
+// (mirrors resolveDeploymentName in intent-classifier.js).
+function resolveDeploymentName(env = {}) {
+  return env.SUGGESTION_TRANSLATION_DEPLOYMENT_NAME
+    || env.AZURE_OPEN_AI_API_DEPLOYMENT_NAME;
+}
+
+/**
+ * Creates a translator bound to the Azure OpenAI credentials in `env` (the same
+ * `AZURE_OPEN_AI_*` credentials already used by `intent-classifier.js` / `OrgDetectorAgent`).
+ *
+ * Returns a function `translate(text, targetLocale) => Promise<string|null>` that is always
+ * best-effort: it resolves to the translated text on success, or `null` on any failure or when
+ * text/credentials are missing. It NEVER rejects.
+ *
+ * @param {object} context - Helix universal context
+ * @param {object} context.env - Environment variables (Azure OpenAI creds)
+ * @param {object} [context.log] - Logger
+ * @returns {((text: string, targetLocale: string) => Promise<string|null>)|null}
+ */
+export function createSuggestionTranslator(context = {}) {
+  const { env = {}, log = console } = context;
+
+  const {
+    AZURE_OPEN_AI_API_KEY: azureOpenAIApiKey,
+    AZURE_OPEN_AI_API_INSTANCE_NAME: azureOpenAIApiInstanceName,
+    AZURE_OPEN_AI_API_VERSION: azureOpenAIApiVersion,
+  } = env;
+  const azureOpenAIApiDeploymentName = resolveDeploymentName(env);
+
+  if (!hasText(azureOpenAIApiKey)
+    || !hasText(azureOpenAIApiInstanceName)
+    || !hasText(azureOpenAIApiDeploymentName)) {
+    log.info('Suggestion translation skipped: Azure OpenAI is not configured (falling back to English)');
+    return null;
+  }
+
+  let model;
+  try {
+    model = new AzureChatOpenAI({
+      azureOpenAIApiKey,
+      azureOpenAIApiInstanceName,
+      azureOpenAIApiDeploymentName,
+      azureOpenAIApiVersion,
+      temperature: 0,
+      maxTokens: MAX_TRANSLATION_OUTPUT_TOKENS,
+    });
+  } catch (e) {
+    log.warn(`Failed to construct suggestion translator model; skipping translation: ${e.message}`);
+    return null;
+  }
+
+  const invokeTimeoutMs = resolveInvokeTimeoutMs(env);
+
+  return async function translate(text, targetLocale) {
+    const trimmed = hasText(text) ? text.trim() : '';
+    if (trimmed.length === 0) {
+      return null;
+    }
+    const languageName = LOCALE_LANGUAGE_NAMES[targetLocale] || targetLocale;
+    try {
+      const response = await withTimeout(
+        model.invoke([
+          {
+            role: 'system',
+            content: `Translate the user's text into ${languageName}. Reply with ONLY the translated text — no quotes, no explanation, no markdown — and preserve any URLs verbatim.`,
+          },
+          { role: 'user', content: trimmed },
+        ]),
+        invokeTimeoutMs,
+      );
+      const translated = contentToString(response?.content).trim();
+      return hasText(translated) ? translated : null;
+    } catch (e) {
+      log.warn(`Suggestion translation failed for locale ${targetLocale}; falling back to English: ${e.message}`);
+      return null;
+    }
+  };
+}
+
+/**
+ * Ensures every suggestion with an English `data.aiRationale` also has a
+ * `data.i18n[locale].aiRationale` translation, translating and persisting any that are missing
+ * one. Mutates and saves matching suggestion entities in-place; entities that already have a
+ * translation, have no `aiRationale`, or fail to translate/save are left untouched (`SuggestionDto`
+ * falls back to English for those).
+ *
+ * `createTranslator` is only invoked once at least one suggestion actually needs translating, so
+ * callers can pass it unconditionally (e.g. `() => createSuggestionTranslator(context)`) without
+ * paying for client construction on every request — most opportunity types never have an
+ * `aiRationale` at all.
+ *
+ * Best-effort and bounded: runs with bounded concurrency under an overall wall-clock cap so a
+ * slow/unavailable LLM cannot stall the suggestions read path. Once the cap is hit, no further
+ * writes happen — any suggestion whose translation hasn't already been persisted by then stays
+ * untranslated for this request and is retried on the next one. (The cap can't cancel an
+ * in-flight LLM call itself, only stop this function from acting on it once it resolves.)
+ *
+ * @param {(() => (((text: string, targetLocale: string) => Promise<string|null>)|null))}
+ *   createTranslator - Lazily builds a translator, e.g. `() => createSuggestionTranslator(ctx)`.
+ * @param {object[]} suggestions - Suggestion entities (mutated in-place).
+ * @param {string} locale - Target locale, e.g. 'ja_jp'.
+ * @param {object} [options]
+ * @param {number} [options.maxConcurrency] - Max in-flight LLM calls.
+ * @param {number} [options.timeoutMs] - Total wall-clock cap for the batch.
+ * @returns {Promise<void>}
+ */
+export async function ensureAiRationaleTranslations(
+  createTranslator,
+  suggestions,
+  locale,
+  { maxConcurrency = DEFAULT_MAX_CONCURRENCY, timeoutMs = DEFAULT_BATCH_TIMEOUT_MS } = {},
+) {
+  if (typeof createTranslator !== 'function' || !hasText(locale)) {
+    return;
+  }
+
+  const pending = (suggestions || []).filter((s) => {
+    const data = s.getData?.();
+    return hasText(data?.aiRationale) && !hasText(data?.i18n?.[locale]?.aiRationale);
+  });
+  if (pending.length === 0) {
+    return;
+  }
+
+  const translate = createTranslator();
+  if (typeof translate !== 'function') {
+    return;
+  }
+
+  let cursor = 0;
+  // Flipped once the batch cap fires. Doesn't stop an in-flight translate() call (it can't be
+  // cancelled), but every worker checks this before writing so nothing persists after the cap —
+  // otherwise a call that resolves just past the cap would still call suggestion.save() after
+  // this function (and the HTTP response it gates) has already returned.
+  let stopped = false;
+  const worker = async () => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= pending.length) {
+        return;
+      }
+      const suggestion = pending[index];
+      const data = suggestion.getData();
+      // eslint-disable-next-line no-await-in-loop
+      const translated = await translate(data.aiRationale, locale).catch(() => null);
+      if (!stopped && hasText(translated)) {
+        suggestion.setData({
+          ...data,
+          i18n: {
+            ...data.i18n,
+            [locale]: { ...data.i18n?.[locale], aiRationale: translated },
+          },
+        });
+        try {
+          // Cache-for-next-time write. On failure the translation still applies to this
+          // response (setData already mutated the in-memory entity above).
+          // eslint-disable-next-line no-await-in-loop
+          await suggestion.save();
+        } catch {
+          // best-effort; see comment above
+        }
+      }
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(maxConcurrency, pending.length) },
+    () => worker(),
+  );
+  const all = Promise.all(workers);
+
+  if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    let timer;
+    const cap = new Promise((resolve) => {
+      timer = setTimeout(() => {
+        stopped = true;
+        cursor = pending.length; // stop workers from starting new calls after the cap
+        resolve();
+      }, timeoutMs);
+    });
+    await Promise.race([all, cap]).finally(() => clearTimeout(timer));
+  } else {
+    await all;
+  }
+}

--- a/test/support/llm-utils.test.js
+++ b/test/support/llm-utils.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import { withTimeout, contentToString } from '../../src/support/llm-utils.js';
+
+describe('llm-utils', () => {
+  describe('withTimeout', () => {
+    it('resolves with the promise value when it settles before the timeout', async () => {
+      const result = await withTimeout(Promise.resolve('value'), 50);
+      expect(result).to.equal('value');
+    });
+
+    it('rejects with a generic message when no label is given', async () => {
+      const hung = new Promise(() => {});
+      await expect(withTimeout(hung, 10)).to.be.rejectedWith('operation timed out after 10ms');
+    });
+
+    it('includes the caller-supplied label in the timeout message', async () => {
+      const hung = new Promise(() => {});
+      await expect(withTimeout(hung, 10, 'suggestion translation'))
+        .to.be.rejectedWith('suggestion translation timed out after 10ms');
+    });
+
+    it('propagates a rejection from the underlying promise unchanged', async () => {
+      await expect(withTimeout(Promise.reject(new Error('boom')), 50)).to.be.rejectedWith('boom');
+    });
+  });
+
+  describe('contentToString', () => {
+    it('returns a string unchanged', () => {
+      expect(contentToString('hello')).to.equal('hello');
+    });
+
+    it('concatenates text parts of an array content', () => {
+      const parts = [{ type: 'text', text: 'hello ' }, { type: 'text', text: 'world' }];
+      expect(contentToString(parts)).to.equal('hello world');
+    });
+
+    it('accepts string parts and a `content` field, ignores non-text parts', () => {
+      const parts = ['hello ', { type: 'something', other: 'x' }, { content: 'world' }];
+      expect(contentToString(parts)).to.equal('hello world');
+    });
+
+    it('coerces null/undefined/object to a (possibly empty) string', () => {
+      expect(contentToString(null)).to.equal('');
+      expect(contentToString(undefined)).to.equal('');
+      expect(contentToString(42)).to.equal('42');
+    });
+  });
+});

--- a/test/support/suggestion-translator.test.js
+++ b/test/support/suggestion-translator.test.js
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+const ENABLED_ENV = {
+  AZURE_OPEN_AI_API_KEY: 'key',
+  AZURE_OPEN_AI_API_INSTANCE_NAME: 'instance',
+  AZURE_OPEN_AI_API_DEPLOYMENT_NAME: 'deployment',
+  AZURE_OPEN_AI_API_VERSION: '2024-02-01',
+};
+
+const log = {
+  info: () => {}, warn: () => {}, error: () => {}, debug: () => {},
+};
+
+/**
+ * Loads suggestion-translator.js with AzureChatOpenAI replaced by a fake whose
+ * `invoke` returns `invokeImpl(messages)`.
+ */
+async function loadWithModel(invokeImpl, { constructorError } = {}) {
+  const ctorSpy = sinon.spy();
+  const FakeAzureChatOpenAI = class {
+    constructor(opts) {
+      ctorSpy(opts);
+      if (constructorError) {
+        throw constructorError;
+      }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    invoke(messages) {
+      return invokeImpl(messages);
+    }
+  };
+  const mod = await esmock('../../src/support/suggestion-translator.js', {
+    '@langchain/openai': { AzureChatOpenAI: FakeAzureChatOpenAI },
+  });
+  return { mod, ctorSpy };
+}
+
+/** Minimal fake Suggestion entity: getData/setData/save, matching how
+ * ensureAiRationaleTranslations uses it. */
+function makeSuggestion(data, { saveError, id = 'sugg-1' } = {}) {
+  let current = { ...data };
+  return {
+    getId: () => id,
+    getData: () => current,
+    setData: (next) => { current = next; },
+    save: sinon.stub().callsFake(async () => {
+      if (saveError) {
+        throw saveError;
+      }
+      return current;
+    }),
+  };
+}
+
+describe('suggestion-translator', () => {
+  afterEach(() => sinon.restore());
+
+  describe('createSuggestionTranslator', () => {
+    it('returns null when Azure OpenAI is not configured', async () => {
+      const { mod, ctorSpy } = await loadWithModel(() => ({ content: 'x' }));
+      const translate = mod.createSuggestionTranslator({ env: {}, log });
+      expect(translate).to.be.null;
+      expect(ctorSpy.called).to.be.false;
+    });
+
+    it('builds a translator whenever Azure OpenAI is configured', async () => {
+      const { mod, ctorSpy } = await loadWithModel(() => ({ content: 'x' }));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      expect(translate).to.be.a('function');
+      expect(ctorSpy.called).to.be.true;
+    });
+
+    it('constructs the model with temperature 0 and a bounded maxTokens', async () => {
+      const { mod, ctorSpy } = await loadWithModel(() => ({ content: 'x' }));
+      mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const opts = ctorSpy.firstCall.args[0];
+      expect(opts.temperature).to.equal(0);
+      expect(opts.maxTokens).to.be.a('number').and.above(0);
+      expect(opts.azureOpenAIApiKey).to.equal('key');
+    });
+
+    it('returns null (no translator) when the model constructor throws', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'x' }), {
+        constructorError: new Error('bad azure config'),
+      });
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      expect(translate).to.be.null;
+    });
+
+    describe('translate(text, targetLocale)', () => {
+      it('returns null for empty text without calling the model', async () => {
+        const invoke = sinon.stub().resolves({ content: 'traduit' });
+        const { mod } = await loadWithModel(invoke);
+        const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+        expect(await translate('', 'fr_fr')).to.be.null;
+        expect(await translate('   ', 'fr_fr')).to.be.null;
+        expect(invoke.called).to.be.false;
+      });
+
+      it('translates text for a supported locale', async () => {
+        const { mod } = await loadWithModel((messages) => {
+          expect(messages[0].role).to.equal('system');
+          expect(messages[0].content).to.include('Japanese');
+          expect(messages[1]).to.deep.equal({ role: 'user', content: 'hello' });
+          return { content: 'こんにちは' };
+        });
+        const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+        expect(await translate('hello', 'ja_jp')).to.equal('こんにちは');
+      });
+
+      it('rejects an unmapped locale without calling the model (must-fix: locale allowlist)', async () => {
+        const invoke = sinon.stub().resolves({ content: 'should not be used' });
+        const { mod } = await loadWithModel(invoke);
+        const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+        // en_us passes the upstream `xx_yy` format validator but has no business being
+        // "translated" into itself, and any locale outside LOCALE_LANGUAGE_NAMES must not
+        // reach the prompt verbatim.
+        expect(await translate('hello', 'en_us')).to.be.null;
+        expect(await translate('hello', 'xx_yy')).to.be.null;
+        expect(invoke.called).to.be.false;
+      });
+
+      it('returns null (never throws) when the model rejects', async () => {
+        const { mod } = await loadWithModel(() => Promise.reject(new Error('LLM down')));
+        const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+        expect(await translate('hello', 'ja_jp')).to.be.null;
+      });
+
+      it('returns null when the model resolves with empty content', async () => {
+        const { mod } = await loadWithModel(() => ({ content: '   ' }));
+        const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+        expect(await translate('hello', 'ja_jp')).to.be.null;
+      });
+
+      it('treats a hung invoke as a translation failure (null) without throwing', async () => {
+        const { mod } = await loadWithModel(() => new Promise(() => {}));
+        const translate = mod.createSuggestionTranslator({
+          env: { ...ENABLED_ENV, SUGGESTION_TRANSLATION_TIMEOUT_MS: '20' },
+          log,
+        });
+        expect(await translate('hello', 'ja_jp')).to.be.null;
+      });
+
+      it('handles array-shaped model content', async () => {
+        const { mod } = await loadWithModel(() => ({
+          content: [{ type: 'text', text: 'bon' }, { type: 'text', text: 'jour' }],
+        }));
+        const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+        expect(await translate('hello', 'fr_fr')).to.equal('bonjour');
+      });
+    });
+  });
+
+  describe('resolveBatchTimeoutMs', () => {
+    it('falls back to the default for a missing/non-numeric/zero env value', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'x' }));
+      expect(mod.resolveBatchTimeoutMs({})).to.equal(8000);
+      expect(mod.resolveBatchTimeoutMs({ SUGGESTION_TRANSLATION_BATCH_TIMEOUT_MS: 'nope' })).to.equal(8000);
+      expect(mod.resolveBatchTimeoutMs({ SUGGESTION_TRANSLATION_BATCH_TIMEOUT_MS: '0' })).to.equal(8000);
+    });
+
+    it('uses a valid positive env override', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'x' }));
+      expect(mod.resolveBatchTimeoutMs({ SUGGESTION_TRANSLATION_BATCH_TIMEOUT_MS: '1234' })).to.equal(1234);
+    });
+  });
+
+  describe('ensureAiRationaleTranslations', () => {
+    it('no-ops when createTranslator is not a function', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'x' }));
+      const suggestion = makeSuggestion({ aiRationale: 'why' });
+      await mod.ensureAiRationaleTranslations(null, [suggestion], 'ja_jp');
+      expect(suggestion.save.called).to.be.false;
+    });
+
+    it('no-ops when locale is empty', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'x' }));
+      const suggestion = makeSuggestion({ aiRationale: 'why' });
+      const createTranslator = sinon.stub().returns(async () => 'translated');
+      await mod.ensureAiRationaleTranslations(createTranslator, [suggestion], '');
+      expect(createTranslator.called).to.be.false;
+      expect(suggestion.save.called).to.be.false;
+    });
+
+    it('does not build a translator when no suggestion needs translating (performance)', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'x' }));
+      const noRationale = makeSuggestion({ url: 'https://example.com' });
+      const alreadyTranslated = makeSuggestion({
+        aiRationale: 'why',
+        i18n: { ja_jp: { aiRationale: 'なぜ' } },
+      });
+      const createTranslator = sinon.stub().returns(async () => 'translated');
+      await mod.ensureAiRationaleTranslations(
+        createTranslator,
+        [noRationale, alreadyTranslated],
+        'ja_jp',
+      );
+      expect(createTranslator.called).to.be.false;
+    });
+
+    it('no-ops when createTranslator() itself returns null (Azure not configured)', async () => {
+      const suggestion = makeSuggestion({ aiRationale: 'why' });
+      const { mod } = await loadWithModel(() => ({ content: 'x' }));
+      await mod.ensureAiRationaleTranslations(() => null, [suggestion], 'ja_jp');
+      expect(suggestion.save.called).to.be.false;
+    });
+
+    it('translates and persists a pending suggestion', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'なぜ' }));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestion = makeSuggestion({ aiRationale: 'why', suggestedUrls: ['https://x'] });
+
+      await mod.ensureAiRationaleTranslations(() => translate, [suggestion], 'ja_jp');
+
+      expect(suggestion.getData().i18n.ja_jp.aiRationale).to.equal('なぜ');
+      // Base fields are preserved alongside the new i18n entry.
+      expect(suggestion.getData().suggestedUrls).to.deep.equal(['https://x']);
+      expect(suggestion.save.calledOnce).to.be.true;
+    });
+
+    it('skips a suggestion with no aiRationale', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'なぜ' }));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestion = makeSuggestion({ url: 'https://example.com' });
+
+      await mod.ensureAiRationaleTranslations(() => translate, [suggestion], 'ja_jp');
+
+      expect(suggestion.save.called).to.be.false;
+    });
+
+    it('skips a suggestion that already has a translation for the locale', async () => {
+      const invoke = sinon.stub().resolves({ content: 'should not be called' });
+      const { mod } = await loadWithModel(invoke);
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestion = makeSuggestion({
+        aiRationale: 'why',
+        i18n: { ja_jp: { aiRationale: 'なぜ' } },
+      });
+
+      await mod.ensureAiRationaleTranslations(() => translate, [suggestion], 'ja_jp');
+
+      expect(invoke.called).to.be.false;
+      expect(suggestion.save.called).to.be.false;
+    });
+
+    it('leaves a suggestion untouched when translation fails', async () => {
+      const { mod } = await loadWithModel(() => Promise.reject(new Error('LLM down')));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestion = makeSuggestion({ aiRationale: 'why' });
+
+      await mod.ensureAiRationaleTranslations(() => translate, [suggestion], 'ja_jp');
+
+      expect(suggestion.getData().i18n).to.be.undefined;
+      expect(suggestion.save.called).to.be.false;
+    });
+
+    it('logs (does not silently swallow) a save() failure (must-fix: silent catch)', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'なぜ' }));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestion = makeSuggestion({ aiRationale: 'why' }, { saveError: new Error('db down') });
+      const warn = sinon.spy();
+
+      await mod.ensureAiRationaleTranslations(
+        () => translate,
+        [suggestion],
+        'ja_jp',
+        { log: { warn } },
+      );
+
+      // The in-memory translation still applies to this response even though persistence failed.
+      expect(suggestion.getData().i18n.ja_jp.aiRationale).to.equal('なぜ');
+      expect(warn.calledOnce).to.be.true;
+      expect(warn.firstCall.args[0]).to.match(/Failed to persist translated aiRationale/);
+      expect(warn.firstCall.args[0]).to.include('db down');
+    });
+
+    it('defaults the save-failure logger to console when none is supplied', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'なぜ' }));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestion = makeSuggestion({ aiRationale: 'why' }, { saveError: new Error('db down') });
+      const consoleWarn = sinon.stub(console, 'warn');
+
+      await mod.ensureAiRationaleTranslations(() => translate, [suggestion], 'ja_jp');
+
+      expect(consoleWarn.calledOnce).to.be.true;
+    });
+
+    it('translates multiple pending suggestions with bounded concurrency', async () => {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const { mod } = await loadWithModel(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => {
+          setTimeout(resolve, 5);
+        });
+        inFlight -= 1;
+        return { content: 'なぜ' };
+      });
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestions = Array.from(
+        { length: 10 },
+        (_, i) => makeSuggestion({ aiRationale: `why ${i}` }, { id: `s${i}` }),
+      );
+
+      await mod.ensureAiRationaleTranslations(
+        () => translate,
+        suggestions,
+        'ja_jp',
+        { maxConcurrency: 3 },
+      );
+
+      expect(maxInFlight).to.be.at.most(3);
+      suggestions.forEach((s) => {
+        expect(s.getData().i18n.ja_jp.aiRationale).to.equal('なぜ');
+      });
+    });
+
+    it('does not persist a suggestion whose translation resolves after the batch cap', async () => {
+      // translate() never resolves -> only the batch timeout can settle the race, and the
+      // (unreachable-in-this-test) write path must never run.
+      const { mod } = await loadWithModel(() => new Promise(() => {}));
+      const translate = mod.createSuggestionTranslator({
+        env: { ...ENABLED_ENV, SUGGESTION_TRANSLATION_TIMEOUT_MS: '5' },
+        log,
+      });
+      const suggestion = makeSuggestion({ aiRationale: 'why' });
+
+      await mod.ensureAiRationaleTranslations(
+        () => translate,
+        [suggestion],
+        'ja_jp',
+        { timeoutMs: 10 },
+      );
+
+      expect(suggestion.getData().i18n).to.be.undefined;
+      expect(suggestion.save.called).to.be.false;
+    });
+
+    it('does not start new translate calls after the batch cap fires', async () => {
+      // Mirrors intent-classifier's equivalent cursor-drain test: with maxConcurrency 1,
+      // 3 pending suggestions, and a cap shorter than a single call, only the in-flight
+      // call may run.
+      let callCount = 0;
+      const { mod } = await loadWithModel(() => new Promise((resolve) => {
+        callCount += 1;
+        setTimeout(() => resolve({ content: 'なぜ' }), 30);
+      }));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestions = Array.from(
+        { length: 3 },
+        (_, i) => makeSuggestion({ aiRationale: `why ${i}` }, { id: `s${i}` }),
+      );
+
+      await mod.ensureAiRationaleTranslations(
+        () => translate,
+        suggestions,
+        'ja_jp',
+        { maxConcurrency: 1, timeoutMs: 10 },
+      );
+
+      expect(callCount).to.equal(1);
+    });
+
+    it('waits for all translations when the batch timeout is disabled (0)', async () => {
+      const { mod } = await loadWithModel(() => ({ content: 'なぜ' }));
+      const translate = mod.createSuggestionTranslator({ env: ENABLED_ENV, log });
+      const suggestions = Array.from(
+        { length: 3 },
+        (_, i) => makeSuggestion({ aiRationale: `why ${i}` }, { id: `s${i}` }),
+      );
+
+      await mod.ensureAiRationaleTranslations(
+        () => translate,
+        suggestions,
+        'ja_jp',
+        { timeoutMs: 0 },
+      );
+
+      suggestions.forEach((s) => {
+        expect(s.getData().i18n.ja_jp.aiRationale).to.equal('なぜ');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What & why
[LLMO-6479](https://jira.corp.adobe.com/browse/LLMO-6479) — the "Recommended redirects" AI-rationale tooltip in Agentic Traffic Analysis 404s always renders in English, even under a non-English app locale (repro'd on Japanese/`ja_jp`).

`suggestion.data.aiRationale` is free-form AI-generated prose written once, in English, by the audit worker that produces 404-redirect suggestions. `SuggestionDto.toJSON` already has generic locale-override support for this exact field — `aiRationale` is listed in `ALLOWED_I18N_FIELDS` and gets promoted from `suggestion.data.i18n[locale]` when present — but nothing ever populated that map, so every non-English request silently fell back to the English text. This PR adds the missing piece: translate `aiRationale` on first non-English read and cache the result into `data.i18n[locale]`, reusing the DTO merge logic that already existed.

## Scope
- New `src/support/suggestion-translator.js`:
  - `createSuggestionTranslator(context)` — best-effort translator built on `AzureChatOpenAI`, reusing the same `AZURE_OPEN_AI_*` credentials already wired for `intent-classifier.js` / `OrgDetectorAgent`. Capped at `maxTokens: 500` per call. Returns `null` (no-op) if Azure OpenAI isn't configured, mirroring `intent-classifier.js`'s non-fatal contract.
  - `ensureAiRationaleTranslations(createTranslator, suggestions, locale, options)` — finds suggestions with an English `aiRationale` but no `data.i18n[locale].aiRationale`, translates them with bounded concurrency (default 5) under an overall wall-clock cap (default 8s — overridable via `SUGGESTION_TRANSLATION_BATCH_TIMEOUT_MS`), and persists successes via `suggestion.setData(...)` + `suggestion.save()`. Takes `createTranslator` as a *lazy* factory rather than an already-built translator, so the `AzureChatOpenAI` client is only constructed once at least one suggestion actually needs translating — most opportunity types never have an `aiRationale` at all. A `stopped` flag set when the batch cap fires prevents any suggestion from being persisted after that point (an in-flight LLM call can't be cancelled, but its result is discarded once stale, so no write races the HTTP response that already went out).
- New `src/support/llm-utils.js` — `withTimeout` and `contentToString`, extracted out of `intent-classifier.js` so both LLM callers share one implementation instead of two copies. `intent-classifier.js` re-exports `contentToString` for compatibility (no other file imports it directly).
- `src/controllers/suggestions.js` — wired into `getAllForOpportunity` (`GET /sites/:siteId/opportunities/:opportunityId/suggestions`, the endpoint the UI's `getSuggestions()` calls). Runs only when a non-null `locale` query param is present, immediately before the existing `SuggestionDto.toJSON(sugg, view, opportunity, locale)` mapping, so a freshly-cached translation is picked up in the same response. Passes `resolveBatchTimeoutMs(context.env)` through so the batch cap is actually configurable.
- No frontend change needed: `project-elmo-ui`'s `useErrorPageSuggestions` already forwards `?locale=` on every `getSuggestions` call and reads `data.aiRationale` as-is — once the backend returns translated text, the UI renders it with zero changes.

## Deferred / out of scope
- The other 4 locale-aware suggestion endpoints (`getAllForOpportunityPaged`, `getByStatus`, its paginated variant, and the single-suggestion getter) aren't wired to `ensureAiRationaleTranslations` yet — kept this PR scoped to the endpoint behind the reported bug. `ensureAiRationaleTranslations` is written to be directly reusable there.
- Other `ALLOWED_I18N_FIELDS` (`title`, `description`, `rationale`, `aiSuggestion`, `expectedOutcome`, `actionItems`, `persona`) aren't translated by this change — only `aiRationale`, matching the reported bug.
- No unit test added for `src/support/suggestion-translator.js` or `src/support/llm-utils.js` — see Tests below.

## ⚠️ One review item
This only translates when Azure OpenAI is actually configured (`AZURE_OPEN_AI_API_KEY`/`_INSTANCE_NAME`/`_DEPLOYMENT_NAME`/`_VERSION`) in the deployed environment — I couldn't confirm those secrets are set in test/stage/prod from this session. Can someone confirm before this is verified against the T2E repro, since without them `ensureAiRationaleTranslations` silently no-ops and the tooltip stays in English (same as today, not a regression, but worth knowing going in)?

## Related Issues
[LLMO-6479](https://jira.corp.adobe.com/browse/LLMO-6479)
