### PR TITLE
fix(llmo-akamai): guard on the fail-action2 marker + idempotent header injection

### DIFF
--- a/src/controllers/llmo/llmo-akamai-utils.js
+++ b/src/controllers/llmo/llmo-akamai-utils.js
@@ -24,18 +24,23 @@
  * and dependency-free so it can be unit-tested and previewed offline (no Akamai credentials).
  */
 
-// Loop guard: one of the headers the routing rule ALREADY injects via
-// modifyIncomingRequestHeader (see buildRoutingRule). No real client ever sends this on its own —
-// only this rule sets it. On the first pass it doesn't exist yet; on Akamai's internal failover
-// retry of the SAME request it is still attached (the retry continues the same request context,
-// not a fresh replay), so a DOES_NOT_EXIST check detects "is this a retry" using a header we need
-// anyway — no advanced XML or dedicated marker required.
-const LOOP_GUARD_HEADER = 'x-edgeoptimize-api-key';
-
-// A header we never set. The routing rule's loop guard requires it to be ABSENT, and the
-// failover-test rule keys on its absence too. Kept as a named constant so both rules reference the
-// same header name.
+// Failover marker, and the routing rule's loop guard.
+//
+// This header is set ONLY by the fail-action2 Advanced XML, when Akamai recreates a request that
+// failed against live.edgeoptimize.net. It is never present on a fresh client request, and — this
+// is the important part — it stays absent however many times the rule tree is evaluated on the way
+// to origin (edge, parent tier in a tiered distribution, and so on).
+//
+// A header that the routing rule injects itself cannot be used for this. It is present from the
+// moment the rule first matches, so any later re-evaluation of the tree sees the rule's own output
+// and stops matching, sending traffic to the property's default origin instead of Edge Optimize.
+//
+// The Advanced XML that sets this marker CANNOT be deployed through PAPI — advanced behaviors are
+// read-only and only Akamai representatives can add them. The rule set below is deployed without
+// it, and the customer is told to have Akamai support add the snippet; until they do, failover is
+// not functional.
 const FAILOVER_MARKER_HEADER = 'x-edgeoptimize-request';
+const FAILOVER_MARKER_VALUE = 'fo';
 
 // Stable defaults for the managed rule config. These mirror the doc 1:1 and are service-owned
 // (not caller-supplied); only the per-site hostname and the LLMO API key are injected at runtime
@@ -210,12 +215,19 @@ const behaviorCaching = () => ({
   },
 });
 
-// Every request-header criterion we emit is a presence check (EXISTS / DOES_NOT_EXIST): PAPI
-// ignores value/match flags for those, and including them wouldn't match what PAPI itself emits.
-const criterionRequestHeader = (header, matchOperator) => ({
-  name: 'requestHeader',
-  options: { headerName: header, matchOperator },
-});
+// Presence checks (EXISTS / DOES_NOT_EXIST) carry no value/match flags — PAPI ignores them and
+// including them wouldn't match what PAPI itself emits. Value checks (IS_ONE_OF / IS_NOT_ONE_OF)
+// do; the field names below mirror what PAPI emits for a value-matching requestHeader criterion.
+const criterionRequestHeader = (header, matchOperator, values) => {
+  const options = { headerName: header, matchOperator };
+  if (matchOperator === 'IS_ONE_OF' || matchOperator === 'IS_NOT_ONE_OF') {
+    options.values = [...(values || [])];
+    options.matchCaseSensitiveValue = true;
+    options.matchWildcardName = false;
+    options.matchWildcardValue = false;
+  }
+  return { name: 'requestHeader', options };
+};
 
 const criterionMatchResponseCode = (lower, upper) => ({
   name: 'matchResponseCode',
@@ -258,7 +270,10 @@ export function buildSiteFailoverRule(cfg) {
     behaviors: [behaviorFailActionAlternateHostname(cfg.failover.alternateHostname)],
     children: [],
     comments: 'Managed by Adobe LLM Optimizer (Optimize at Edge). On origin failure, fails over '
-      + "to the property's normal origin so the end user still gets a response.",
+      + "to the property's normal origin so the end user still gets a response. "
+      + 'ACTION REQUIRED: ask Akamai support to add the fail-action2 Advanced XML to this rule so '
+      + 'the recreated request is tagged with x-edgeoptimize-request: fo. Advanced behaviors '
+      + 'cannot be added through the API. Until it is added, failover is not functional.',
   };
 }
 
@@ -304,26 +319,15 @@ export function buildRoutingRule(cfg) {
     criterionUserAgent(cfg.match.userAgents),
     criterionFileExtension(cfg.match.fileExtensions),
   );
-  // Loop guard: exclude requests that already carry one of the headers this rule injects (see
-  // LOOP_GUARD_HEADER) — true for Akamai's internal failover retry of the SAME request, never
-  // true for a fresh client request.
+  // Loop guard: skip requests already tagged by the failover marker, i.e. Akamai's recreate of a
+  // request that failed against Edge Optimize. See FAILOVER_MARKER_HEADER for why the marker has
+  // to come from the fail-action2 XML rather than from a header this rule sets itself.
   //
   // TRUST ASSUMPTION: this keys on the mere presence of a client-suppliable header, so a client
-  // that forges x-edgeoptimize-api-key (or x-edgeoptimize-request) can suppress Optimize-at-Edge
-  // routing for itself or force a false x-edgeoptimize-fo. That is acceptable here: the only party
-  // harmed is the forging client (it opts itself out of optimization), and stripping/validating
-  // these at the edge before rule evaluation would require Advanced Metadata, which this GA-only
-  // rule set deliberately avoids. Revisit if these headers ever gate anything security-sensitive.
-  const incomingHeaders = cfg.incomingRequestHeaders;
-  const guardHeader = LOOP_GUARD_HEADER in incomingHeaders
-    ? LOOP_GUARD_HEADER
-    : Object.keys(incomingHeaders)[0];
-  if (guardHeader) {
-    criteria.push(criterionRequestHeader(guardHeader, 'DOES_NOT_EXIST'));
-  }
-  // Belt-and-suspenders: also require the failover marker header to be absent. We never set it, so
-  // this is always true today, but it keeps the routing rule symmetric with the failover-test rule
-  // and future-proofs against a marker being introduced.
+  // that forges x-edgeoptimize-request can suppress Optimize-at-Edge routing for itself or force a
+  // false x-edgeoptimize-fo. That is acceptable here: the only party harmed is the forging client
+  // (it opts itself out of optimization). Revisit if this header ever gates anything
+  // security-sensitive.
   criteria.push(criterionRequestHeader(FAILOVER_MARKER_HEADER, 'DOES_NOT_EXIST'));
 
   return {
@@ -340,11 +344,10 @@ export function buildRoutingRule(cfg) {
  * The sibling "EdgeOptimize Failover - Test Header" rule. Must be a SIBLING of the routing rule
  * (same hierarchy level) so it is evaluated on the failover-recreated request.
  *
- * Detection is XML-free / no Advanced Metadata: the routing rule injects the
- * `x-edgeoptimize-api-key` request header on the first pass and it PERSISTS into Akamai's internal
- * failover recreate, whereas the advanced fail-action2 marker (`x-edgeoptimize-request`) is not
- * used. So "api-key header EXISTS AND the failover marker DOES_NOT_EXIST" identifies the
- * recreated request, and we surface it as the `x-edgeoptimize-fo` response header.
+ * The recreated request is identified by the failover marker that the fail-action2 Advanced XML
+ * attaches to it (`x-edgeoptimize-request: fo`), and we surface it as the `x-edgeoptimize-fo`
+ * response header. That XML cannot be deployed through PAPI, so this rule stays inert until an
+ * Akamai representative adds the snippet to the Site Failover Behavior rule.
  * @param {object} cfg
  * @returns {object}
  */
@@ -352,14 +355,14 @@ export function buildFailoverTestRule(cfg) {
   return {
     name: cfg.ruleNames.failoverTest,
     criteria: [
-      criterionRequestHeader(LOOP_GUARD_HEADER, 'EXISTS'),
-      criterionRequestHeader(FAILOVER_MARKER_HEADER, 'DOES_NOT_EXIST'),
+      criterionRequestHeader(FAILOVER_MARKER_HEADER, 'IS_ONE_OF', [FAILOVER_MARKER_VALUE]),
     ],
     criteriaMustSatisfy: 'all',
     behaviors: [behaviorModifyOutgoingResponseHeader('x-edgeoptimize-fo', 'true')],
     children: [],
     comments: 'Managed by Adobe LLM Optimizer (Optimize at Edge). Surfaces failover as the '
-      + 'x-edgeoptimize-fo response header, detected without advanced metadata.',
+      + 'x-edgeoptimize-fo response header. Requires the fail-action2 Advanced XML, which only '
+      + 'Akamai support can add.',
   };
 }
 

--- a/src/controllers/llmo/llmo-akamai-utils.js
+++ b/src/controllers/llmo/llmo-akamai-utils.js
@@ -161,14 +161,21 @@ const behaviorSetVariable = (name, value) => ({
   },
 });
 
+// MODIFY, not ADD. The routing rule matches on every Akamai server that handles the request —
+// edge AND any parent server in a tiered distribution — so these behaviors execute more than once
+// for the same request. ADD would append a second copy each time (e.g. a duplicated
+// X-Forwarded-Host, which the edge worker rejects with a 403). MODIFY sets the value, so running it
+// N times yields one
+// header carrying our value, regardless of how many tiers evaluate the tree.
+// avoidDuplicateHeaders is belt-and-suspenders for the same reason.
 const behaviorModifyHeader = (name, header, value) => ({
   name,
   options: {
-    action: 'ADD',
-    standardAddHeaderName: 'OTHER',
+    action: 'MODIFY',
+    standardModifyHeaderName: 'OTHER',
     customHeaderName: header,
-    headerValue: value,
-    avoidDuplicateHeaders: false,
+    newHeaderValue: value,
+    avoidDuplicateHeaders: true,
   },
 });
 
@@ -603,9 +610,17 @@ export function redactSecrets(tree) {
     }
     (rule.behaviors || []).forEach((b) => {
       if (b?.name === 'modifyIncomingRequestHeader' && SECRET_HEADERS.has(b.options?.customHeaderName)) {
-        // Mutating a deep clone we own, not the caller's tree.
-        // eslint-disable-next-line no-param-reassign
-        b.options.headerValue = REDACTED;
+        // Mutating a deep clone we own, not the caller's tree. MODIFY behaviors carry the value in
+        // newHeaderValue; legacy ADD behaviors (older deployed properties) carry it in headerValue.
+        // Redact whichever is present so a secret never leaks regardless of which the tree uses.
+        /* eslint-disable no-param-reassign */
+        if (typeof b.options.newHeaderValue === 'string') {
+          b.options.newHeaderValue = REDACTED;
+        }
+        if (typeof b.options.headerValue === 'string') {
+          b.options.headerValue = REDACTED;
+        }
+        /* eslint-enable no-param-reassign */
       }
     });
     (rule.children || []).forEach(walk);
@@ -670,11 +685,14 @@ export function getManagedFetcherKey(tree) {
       return;
     }
     (rule.behaviors || []).forEach((b) => {
+      // MODIFY behaviors carry the value in newHeaderValue; legacy ADD behaviors carry it in
+      // headerValue. Read whichever is present so this works against both forms.
+      const value = b?.options?.newHeaderValue ?? b?.options?.headerValue;
       if (found === null
         && b?.name === 'modifyIncomingRequestHeader'
         && b.options?.customHeaderName === FETCHER_KEY_HEADER
-        && typeof b.options?.headerValue === 'string') {
-        found = b.options.headerValue;
+        && typeof value === 'string') {
+        found = value;
       }
     });
     (rule.children || []).forEach(walk);

--- a/test/controllers/llmo/llmo-akamai-utils.test.js
+++ b/test/controllers/llmo/llmo-akamai-utils.test.js
@@ -117,7 +117,11 @@ describe('llmo-akamai-utils', () => {
       const apiKeyHeader = routing.behaviors.find(
         (b) => b.name === 'modifyIncomingRequestHeader' && b.options.customHeaderName === 'x-edgeoptimize-api-key',
       );
-      expect(apiKeyHeader.options.headerValue).to.equal(API_KEY);
+      expect(apiKeyHeader.options.newHeaderValue).to.equal(API_KEY);
+      // Idempotent under multi-tier (edge + parent) re-evaluation: MODIFY sets the value
+      // rather than appending, and avoidDuplicateHeaders guards against a second copy.
+      expect(apiKeyHeader.options.action).to.equal('MODIFY');
+      expect(apiKeyHeader.options.avoidDuplicateHeaders).to.equal(true);
       const cacheId = findBehavior(routing, 'cacheId');
       expect(cacheId.options.variableName).to.equal(cfg.cacheKeyVariable.name);
     });
@@ -183,7 +187,7 @@ describe('llmo-akamai-utils', () => {
       expect(marker.options.matchCaseSensitiveValue).to.equal(true);
       const resp = findBehavior(rule, 'modifyOutgoingResponseHeader');
       expect(resp.options.customHeaderName).to.equal('x-edgeoptimize-fo');
-      expect(resp.options.headerValue).to.equal('true');
+      expect(resp.options.newHeaderValue).to.equal('true');
     });
   });
 

--- a/test/controllers/llmo/llmo-akamai-utils.test.js
+++ b/test/controllers/llmo/llmo-akamai-utils.test.js
@@ -127,8 +127,17 @@ describe('llmo-akamai-utils', () => {
         (c) => c.name === 'requestHeader' && c.options.matchOperator === 'DOES_NOT_EXIST',
       );
       const guardedHeaders = guards.map((g) => g.options.headerName);
-      expect(guardedHeaders).to.include('x-edgeoptimize-api-key');
       expect(guardedHeaders).to.include('x-edgeoptimize-request');
+    });
+
+    it('does not guard on a header the routing rule injects itself', () => {
+      // A self-injected header is present from the first match onwards, so any later
+      // re-evaluation of the rule tree (parent tier and so on) would stop matching.
+      const injected = Object.keys(cfg.incomingRequestHeaders);
+      const guardedHeaders = routing.criteria
+        .filter((c) => c.name === 'requestHeader')
+        .map((c) => c.options.headerName);
+      guardedHeaders.forEach((h) => expect(injected).to.not.include(h));
     });
 
     it('nests a Site Failover child rule pointing back at the site hostname', () => {
@@ -162,17 +171,16 @@ describe('llmo-akamai-utils', () => {
   });
 
   describe('buildFailoverTestRule', () => {
-    it('detects the failover recreate via persisted api-key + absent marker (no advanced metadata)', () => {
+    it('detects the failover recreate via the fail-action2 marker value', () => {
       const cfg = buildRuleConfig({ hostname: HOSTNAME, apiKey: API_KEY });
       const rule = buildFailoverTestRule(cfg);
       expect(rule.criteriaMustSatisfy).to.equal('all');
-      const ops = Object.fromEntries(
-        rule.criteria
-          .filter((c) => c.name === 'requestHeader')
-          .map((c) => [c.options.headerName, c.options.matchOperator]),
+      const marker = rule.criteria.find(
+        (c) => c.name === 'requestHeader' && c.options.headerName === 'x-edgeoptimize-request',
       );
-      expect(ops['x-edgeoptimize-api-key']).to.equal('EXISTS');
-      expect(ops['x-edgeoptimize-request']).to.equal('DOES_NOT_EXIST');
+      expect(marker.options.matchOperator).to.equal('IS_ONE_OF');
+      expect(marker.options.values).to.deep.equal(['fo']);
+      expect(marker.options.matchCaseSensitiveValue).to.equal(true);
       const resp = findBehavior(rule, 'modifyOutgoingResponseHeader');
       expect(resp.options.customHeaderName).to.equal('x-edgeoptimize-fo');
       expect(resp.options.headerValue).to.equal('true');
@@ -533,14 +541,14 @@ describe('llmo-akamai-utils', () => {
       expect(rule.behaviors.some((b) => b.name === 'modifyIncomingResponseHeader')).to.equal(false);
     });
 
-    it('falls back to the first incoming header for the loop guard when the api-key header is absent', () => {
+    it('guards on the failover marker regardless of which headers are injected', () => {
       const cfg = base();
       cfg.incomingRequestHeaders = { 'x-custom-first': 'v', 'x-edgeoptimize-config': 'c' };
       const rule = buildRoutingRule(cfg);
       const guards = rule.criteria.filter(
         (c) => c.name === 'requestHeader' && c.options.matchOperator === 'DOES_NOT_EXIST',
       );
-      expect(guards.map((g) => g.options.headerName)).to.include('x-custom-first');
+      expect(guards.map((g) => g.options.headerName)).to.deep.equal(['x-edgeoptimize-request']);
     });
 
     it('merges into a tree whose default rule has no children array', () => {

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -287,10 +287,10 @@ describe('LlmoAkamaiController', () => {
       // The header is present (deploy adds it too), but its value is redacted in the returned tree.
       const fetcher = headers.find((o) => o.customHeaderName === 'x-edgeoptimize-fetcher-key');
       expect(fetcher).to.exist;
-      expect(fetcher.headerValue).to.equal('***');
+      expect(fetcher.newHeaderValue).to.equal('***');
       // redactSecrets also redacts the LLMO API key.
       const apiKey = headers.find((o) => o.customHeaderName === 'x-edgeoptimize-api-key');
-      expect(apiKey.headerValue).to.equal('***');
+      expect(apiKey.newHeaderValue).to.equal('***');
     });
 
     it('redacts the LLMO API key from the previewed merged tree', async () => {
@@ -423,9 +423,9 @@ describe('LlmoAkamaiController', () => {
       const fetcher = headers.find((o) => o.customHeaderName === 'x-edgeoptimize-fetcher-key');
       expect(fetcher).to.exist;
       // 32 random bytes as hex (`openssl rand -hex 32`).
-      expect(fetcher.headerValue).to.match(/^[0-9a-f]{64}$/);
+      expect(fetcher.newHeaderValue).to.match(/^[0-9a-f]{64}$/);
       // The deployed key is returned once and matches what was baked into the rule.
-      expect(body.fetcherKey).to.equal(fetcher.headerValue);
+      expect(body.fetcherKey).to.equal(fetcher.newHeaderValue);
     });
 
     it('mints a fresh fetcher key on each deploy (rotation)', async () => {


### PR DESCRIPTION
Two related fixes for Optimize at Edge routing when the Akamai property has a **parent tier** (Tiered Distribution / SureRoute). Both stem from the same fact: **every Akamai server that handles a request — edge *and* parent — executes the full property rule tree.** So the OAE routing rule runs more than once per request.

## Fix 1 — loop guard (commit 1)

The routing rule guarded on `x-edgeoptimize-api-key does not exist`, but that header is **injected by the routing rule itself**. Present from the first match, so the parent re-evaluation sees it, stops matching, and sends the request to the customer's default origin instead of Edge Optimize.

Verified live on `optimize.stage.adobe.com`: v38 (no api-key criterion) routes; v39 (api-key criterion added — the *only* diff) does not; disabling Tiered Distribution on v39 makes it route again.

Guard switched to `x-edgeoptimize-request`, set **only** by the `fail-action2` failover XML — absent on a fresh request no matter how many tiers evaluate the tree.

| | old | new |
|---|---|---|
| Routing-rule guard | `x-edgeoptimize-api-key DOES_NOT_EXIST` (+marker) | `x-edgeoptimize-request DOES_NOT_EXIST` |
| Failover-test rule | api-key `EXISTS` AND marker `DOES_NOT_EXIST` | marker `IS_ONE_OF ['fo']` |

## Fix 2 — idempotent header injection (commit 2)

Fix 1 makes the routing rule correctly match at **both** the edge and the parent — which means the header-injection behaviors now run **twice**. They used `action: ADD`, which appends a second copy each time: a duplicated `X-Forwarded-Host` (which the edge worker **403s**) and duplicated `x-edgeoptimize-api-key` / `-config` / `-url` / `-fetcher-key`.

Switched the shared modify-header builder to **`action: MODIFY` + `avoidDuplicateHeaders: true`**, matching the known-good manual reference config. MODIFY sets the value, so N evaluations yield one header. `redactSecrets` and `getManagedFetcherKey` read/redact whichever value field is present (`newHeaderValue` for MODIFY, `headerValue` for any already-deployed ADD property), so both stay correct.

## Known limitation (unchanged)

[Advanced behaviors are read-only in PAPI](https://techdocs.akamai.com/property-mgr/reference/advanced-and-locked-features) — the `fail-action2` snippet can't be deployed by automation. The rule set deploys without it; the companion elmo-ui PR (#2944) tells the customer to have Akamai support add it. Until then, failover is not functional (routing works). Follow-up option: an account-level [custom behavior](https://techdocs.akamai.com/property-mgr/reference/custom-behaviors-and-overrides) wrapping the XML, referenceable by PAPI.

## Testing

- `llmo-akamai-utils.test.js` **63 passing** (guard tests updated; new assertions for MODIFY + avoidDuplicateHeaders; legacy `headerValue` fixtures still pass, proving reader back-compat)
- `llmo.test.js` **381 passing**; `tsc` + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fa4UfUiWtSbpdW4UxWm8Y