### PR TITLE
feat: scope AI Visibility stats-by-country to subdomain via search_type

### DIFF
--- a/src/support/ai-visibility/handlers/v1/brand/stats-by-country.js
+++ b/src/support/ai-visibility/handlers/v1/brand/stats-by-country.js
@@ -21,6 +21,7 @@ import {
 import {
   engineToLlm,
   responseFromGrpcError,
+  resolveSearchType,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -29,6 +30,7 @@ export async function handleStatsByCountry(sp, clients) {
   const domain = sp.get('domain');
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const date = sp.get('date');
+  const searchType = resolveSearchType(domain);
 
   let statsRequest;
   try {
@@ -38,6 +40,7 @@ export async function handleStatsByCountry(sp, clients) {
         llm: engine,
         target: { domain, name: domain },
         target_date: date,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/test/support/ai-visibility/handlers/v1/brand/stats-by-country.test.js
+++ b/test/support/ai-visibility/handlers/v1/brand/stats-by-country.test.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import { StatsByCountryResponseSchema } from '@quazar/ai-seo-ts/v2/brand/messages_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { handleStatsByCountry } from '../../../../../../src/support/ai-visibility/handlers/v1/brand/stats-by-country.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+describe('AI Visibility – v1 brand/stats-by-country search_type (LLMO-7142)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      brandClient: {
+        statsByCountry: sandbox.stub().resolves(
+          create(StatsByCountryResponseSchema, { byCountry: [] }),
+        ),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleStatsByCountry', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleStatsByCountry(sp('domain=intuit.com'), clients);
+      expect(clients.brandClient.statsByCountry.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleStatsByCountry(sp('domain=quickbooks.intuit.com'), clients);
+      expect(clients.brandClient.statsByCountry.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+
+    it('resolves search_type DOMAIN for a bare www subdomain', async () => {
+      await handleStatsByCountry(sp('domain=www.intuit.com'), clients);
+      expect(clients.brandClient.statsByCountry.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Pass `search_type` to the Semrush `StatsByCountry` gRPC so the AI Visibility stats-by-country endpoint scopes results to a subdomain instead of collapsing to the registrable domain.

## 2. Reasoning
The handler `handlers/v1/brand/stats-by-country.js` built its request with only `llm`, `target`, and `target_date`. Without `search_type`, Semrush interprets a subdomain target as its registrable domain, so `quickbooks.intuit.com` returned the same numbers as `intuit.com`. Semrush (Dima Gulkin) confirmed `StatsByCountry` now honors `search_type`. PR #3093 added this subdomain scoping to the other AI Visibility handlers (competitors, topics, prompts, sources) but not this one.

## 3. High-level overview of the changes
- `handleStatsByCountry` now derives `search_type` from the `domain` query param via `resolveSearchType` and includes it in the `StatsByCountryRequest`.
- `resolveSearchType` returns `SUBDOMAIN` for a non-www subdomain (e.g. `quickbooks.intuit.com`), and `DOMAIN` for an apex host or a bare `www.` host.
- Behaviour delta: a request for a subdomain now returns subdomain-scoped stats. Apex-domain requests are unchanged.
- No response-shape change; the Semrush request now carries one additional field. No proto change — `StatsByCountryRequest` field 7 `search_type` already exists.

## 4. Required information
- Jira / issue: [LLMO-7142](https://jira.corp.adobe.com/browse/LLMO-7142)
- Exemption: mechanical extension of the approved PR #3093 subdomain pattern, grounded in LLMO-7142 - no spec required for this change.

## 6. Affected / used mysticat-workspace projects
- project-elmo-ui — consumer. Its AI Visibility stats-by-country dashboard section reads this endpoint; it will now render subdomain-scoped data when the site is a subdomain. No UI change required (response contract unchanged), but confirm the section sends the subdomain as the `domain` param.

## 7. Additional information outside the code
- Verified live against the Semrush gRPC (prod, `brandClient.statsByCountry`, `llm=ALL`), summing all 118 countries:
  - `intuit.com` `DOMAIN` → 295,698 mentions / 1,279,309,072 audience / 126,298 ownedSources
  - `quickbooks.intuit.com` `DOMAIN` (and unset) → identical to `intuit.com` (parent collapse — the bug)
  - `quickbooks.intuit.com` `SUBDOMAIN` → 222,816 mentions / 682,356,178 audience / 82,024 ownedSources (proper subset)

## 8. Test plan
- (a) No local e2e run; validated the upstream contract directly via the gRPC probe documented in section 7.
- (b) dev/prod: call `GET /llmo/ai-visibility/.../stats-by-country?domain=quickbooks.intuit.com` and confirm the totals differ from `domain=intuit.com`; confirm `domain=intuit.com` is unchanged versus current behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Josep López", "Dima", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```