### PR TITLE
chore(it): bump data-service IT image to v5.110.0 + catch up drifted tests

### DIFF
--- a/test/it/postgres/docker-compose.yml
+++ b/test/it/postgres/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   data-service:
-    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.90.0
+    image: 682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service:v5.110.0
     container_name: spacecat-it-data-service
     depends_on:
       db:

--- a/test/it/postgres/seed-data/brands.js
+++ b/test/it/postgres/seed-data/brands.js
@@ -14,7 +14,7 @@
  * Baseline brands for IT tests.
  *
  * BRAND_1 belongs to ORG_1 (accessible org) and is Semrush-managed
- * (`semrush_workspace_id` set), with its primary site SITE_1. This anchors the
+ * (`semrush_sub_workspace_id` set), with its primary site SITE_1. This anchors the
  * PATCH /sites URL-immutability guard IT: changing SITE_1's baseURL must 403
  * because the site backs a Semrush-managed brand whose tracked domain lives on
  * its Semrush projects (no upstream domain-update path).
@@ -34,7 +34,11 @@ export const brands = [
     // project/model/prompt/market — not just an unknown workspace that 404s.
     // Import the shared constant (not a literal) so a mock-seed change updates
     // both sides in lock-step.
-    semrush_workspace_id: SERENITY_MOCK_WORKSPACE_ID,
+    // Data-service renamed brands.semrush_workspace_id -> semrush_sub_workspace_id
+    // (dropped the old column + its sync trigger). serenity brand resolution reads
+    // getSemrushSubWorkspaceId() (brand-provisioning.js), so set the sub-workspace
+    // column directly.
+    semrush_sub_workspace_id: SERENITY_MOCK_WORKSPACE_ID,
     status: 'active',
     origin: 'human',
     regions: ['us'],

--- a/test/it/shared/tests/audit-policy.js
+++ b/test/it/shared/tests/audit-policy.js
@@ -62,7 +62,9 @@ export default function auditPolicyTests(getHttpClient, resetData, seedAuditScop
       });
       expect(res.status).to.equal(200);
       expect(res.body.version).to.equal(1);
-      expect(res.body.exclusionGlobs).to.deep.equal(['/checkout/*']);
+      // SITES-49858: wrpc_upsert_audit_policy roots bare-path globs at the site
+      // base_url on write, so the stored/returned glob is fully qualified.
+      expect(res.body.exclusionGlobs).to.deep.equal([`${SITE_1_BASE_URL}/checkout/*`]);
     });
 
     it('inclusions add unions into manualUrls and bumps the version', async () => {
@@ -79,7 +81,9 @@ export default function auditPolicyTests(getHttpClient, resetData, seedAuditScop
     it('exclusions/delete removes a glob via set-difference', async () => {
       const http = getHttpClient();
       const res = await http.admin.post(`/sites/${SITE_1_ID}/audit-policy/exclusions/delete`, {
-        values: ['/checkout/*'],
+        // The stored glob was rooted at base_url on add (SITES-49858); delete by
+        // that fully-qualified form so the set-difference matches.
+        values: [`${SITE_1_BASE_URL}/checkout/*`],
         reason: 'remove checkout exclusion',
       });
       expect(res.status).to.equal(200);

--- a/test/it/shared/tests/brands.js
+++ b/test/it/shared/tests/brands.js
@@ -36,6 +36,9 @@ export default function brandsTests(getHttpClient, resetData) {
           brandContext: '  Context for claims extraction  ',
           mentionSentimentGuidance: '  Sentiment guidance text  ',
           region: ['US'],
+          // SITES-49202: active brands now require a base site (site_id); a
+          // URL-less create must be pending (matches the flat-mode idiom below).
+          status: 'pending',
         },
       );
       expect(createRes.status).to.equal(201);
@@ -104,6 +107,8 @@ export default function brandsTests(getHttpClient, resetData) {
       // the data layer without triggering the upstream Semrush re-sync.
       const createRes = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
         name: 'Aliases Roundtrip Brand',
+        // SITES-49202: URL-less create must be pending (active now needs site_id).
+        status: 'pending',
         region: ['us', 'de'],
         brandAliases: [
           { name: 'Acme', regions: [] },
@@ -294,7 +299,7 @@ export default function brandsTests(getHttpClient, resetData) {
       //    renaming the row to `${NAME}_deleted` (uq_brand_name_per_org spans
       //    deleted rows, so keeping the original name would block recreation).
       const createA = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
-        name: NAME, region: ['US'],
+        name: NAME, region: ['US'], status: 'pending',
       });
       expect(createA.status).to.equal(201);
       const brandAId = createA.body.id;
@@ -305,7 +310,7 @@ export default function brandsTests(getHttpClient, resetData) {
       // 2. Recreating a brand with the ORIGINAL name now succeeds (previously
       //    rejected by uq_brand_name_per_org) and yields a NEW brand id.
       const createB = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
-        name: NAME, region: ['US'],
+        name: NAME, region: ['US'], status: 'pending',
       });
       expect(createB.status).to.equal(201);
       expect(createB.body.id).to.not.equal(brandAId);
@@ -319,7 +324,7 @@ export default function brandsTests(getHttpClient, resetData) {
 
       // 4. The name is still free — a third create with the same name succeeds.
       const createC = await http.admin.post(`/v2/orgs/${ORG_1_ID}/brands`, {
-        name: NAME, region: ['US'],
+        name: NAME, region: ['US'], status: 'pending',
       });
       expect(createC.status).to.equal(201);
       expect(createC.body.id).to.not.equal(brandAId);


### PR DESCRIPTION
## What

The IT harness pinned `mysticat-data-service:v5.90.0` — ~19 releases behind current main. This bumps it to **v5.110.0** (matches the live dev/prod schema) and realigns the IT tests that the intervening schema/behavior changes break.

## Why

Several data-service changes shipped between v5.90.0 and v5.110.0 that the pinned IT image was hiding:

| Area | Change | Fix here |
|---|---|---|
| brands seed | `brands.semrush_workspace_id` renamed → `semrush_sub_workspace_id` (old col + sync trigger dropped) | seed sets `semrush_sub_workspace_id` directly (serenity resolves via `getSemrushSubWorkspaceId()`) |
| audit-policy | **SITES-49858**: `wrpc_upsert_audit_policy` roots bare-path exclusion globs at the site `base_url` on write | expect the fully-qualified glob; delete by that form |
| brands v2 create | **SITES-49202**: `chk_active_brand_has_site_id` — an active brand now requires a base site | 3 URL-less creates that defaulted to active (→400) now pass `status: 'pending'` (the flat-mode idiom already used across the suite) |

## Open question for brand owners

Should a URL-less `POST /v2/orgs/:id/brands` default to `pending` **server-side**, rather than requiring the caller to pass it? This PR only realigns the tests to the shipped schema — flagging the product/code question separately.

## Note

Local `type-check` needs `npm install` first (current main uses a newer `@adobe/spacecat-shared-utils`); unrelated to this change. Test-only diff.

Unblocks the composite-key IT tests on #3085 (they need the migration columns present in the IT DB image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)