### PR TITLE
fix(prompts): chunk upsertPrompts' existing-rows lookup past 1000 ids

### DIFF
--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -824,15 +824,32 @@ export async function upsertPrompts({
       const cols = includeIntent
         ? 'id,prompt_id,text,regions,status,source,intent'
         : 'id,prompt_id,text,regions,status,source';
-      let q = postgrestClient
+      const baseQuery = () => postgrestClient
         .from('prompts')
         .select(cols)
         .eq('organization_id', organizationId)
         .eq('brand_id', brandUuid);
-      if (incomingIds.length > 0) {
-        q = q.in('prompt_id', incomingIds);
+      if (incomingIds.length === 0) {
+        return baseQuery();
       }
-      return q;
+      // Chunk the `prompt_id=in.(...)` filter the same way getIntentsByPromptIds
+      // does (INTENT_LOOKUP_CHUNK_SIZE) — PostgREST caps any single response at
+      // 1000 rows, so an unchunked IN-list over a brand with >1000 matching
+      // existing prompts silently drops the excess. Those dropped rows then look
+      // "new" below and get misrouted to INSERT, colliding with
+      // uq_prompt_text_region_source_per_brand (confirmed live, 2026-08-24: a
+      // 1000-id batch against a brand with ~1200 existing prompts came back
+      // missing ~200 of them, and the resulting INSERT 409'd).
+      return Promise.all(
+        chunkArray(incomingIds, INTENT_LOOKUP_CHUNK_SIZE)
+          .map((batch) => baseQuery().in('prompt_id', batch)),
+      ).then((results) => {
+        const firstError = results.find((r) => r.error)?.error || null;
+        if (firstError) {
+          return { data: null, error: firstError };
+        }
+        return { data: results.flatMap((r) => r.data || []), error: null };
+      });
     }),
     buildLookupMaps(organizationId, postgrestClient),
   ]);

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -2715,6 +2715,79 @@ describe('prompts-storage', () => {
       expect(result.created).to.equal(0);
       expect(result.updated).to.equal(1);
     });
+
+    // Confirmed live 2026-08-24: a brand with >1000 existing prompts matching the
+    // incoming batch's ids returned an unchunked `.in('prompt_id', incomingIds)`
+    // response silently truncated at PostgREST's 1000-row default cap, so ~200
+    // already-existing rows were absent from `existing` and got misrouted to
+    // INSERT, which then 409'd against uq_prompt_text_region_source_per_brand.
+    // The existing-rows fetch must chunk the id list (mirroring
+    // getIntentsByPromptIds' INTENT_LOOKUP_CHUNK_SIZE=100 pattern) and merge every
+    // chunk's rows before matching, so no existing row is ever silently dropped.
+    it('chunks the existing-rows lookup so no match is dropped above the id-batch chunk size (regression)', async () => {
+      const TOTAL = 150; // > INTENT_LOOKUP_CHUNK_SIZE (100) — forces 2 chunks (100 + 50)
+      const incoming = Array.from({ length: TOTAL }, (_, i) => ({
+        id: `p-${i}`,
+        prompt: `Prompt number ${i}`,
+        regions: ['us'],
+      }));
+      const existingRowsById = new Map(incoming.map((p) => [p.id, {
+        id: `row-${p.id}`,
+        prompt_id: p.id,
+        text: p.prompt,
+        regions: p.regions,
+        status: 'active',
+        source: 'config',
+      }]));
+
+      const inStub = sinon.stub().callsFake((column, ids) => thenable({
+        data: ids.map((id) => existingRowsById.get(id)).filter(Boolean),
+        error: null,
+      }));
+      const insertStub = sinon.stub().returns({
+        select: () => thenable({ data: [], error: null }),
+      });
+      const updateStub = sinon.stub().returns({ eq: () => thenable({ error: null }) });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: inStub,
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: updateStub,
+            };
+          }
+          return makeChain({});
+        },
+      };
+
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: incoming,
+        postgrestClient: client,
+      });
+
+      // Chunked into 2 `.in()` calls, not one unchunked call over all 150 ids.
+      expect(inStub.callCount).to.equal(2);
+      const batchSizes = inStub.getCalls().map((c) => c.args[1].length).sort((a, b) => b - a);
+      expect(batchSizes).to.deep.equal([100, 50]);
+
+      // Every one of the 150 already-existing rows must be found and routed to
+      // UPDATE — none silently dropped and misrouted to INSERT.
+      expect(result.updated).to.equal(TOTAL);
+      expect(result.created).to.equal(0);
+      expect(insertStub.called).to.equal(false);
+      // Updates are issued per-row (UPDATE_CONCURRENCY workers), not bulk.
+      expect(updateStub.callCount).to.equal(TOTAL);
+    });
   });
 
   describe('updatePromptById', () => {
@@ -3942,6 +4015,47 @@ describe('prompts-storage', () => {
       // First attempt carried intent; retry stripped it.
       expect(insertStub.firstCall.args[0][0]).to.have.property('intent', 'informational');
       expect(insertStub.secondCall.args[0][0]).to.not.have.property('intent');
+    });
+
+    it('upsertPrompts retries the chunked existing-rows select without intent when the column is missing', async () => {
+      // The existing-rows fetch (id-filtered branch) now runs as one or more
+      // chunked `.in()` calls merged into a single {data, error} result before
+      // withMissingIntentFallback inspects it — this pins that the missing-
+      // intent-column retry still fires correctly through that merge.
+      const inStub = sinon.stub();
+      inStub.onFirstCall().returns(thenable({ data: null, error: MISSING_INTENT_SELECT }));
+      inStub.onSecondCall().returns(thenable({ data: [], error: null }));
+      const insertStub = sinon.stub().returns({
+        select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }),
+      });
+      const client = {
+        from: (table) => {
+          if (table === 'prompts') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    ...thenable({ data: [], error: null }),
+                    in: inStub,
+                  }),
+                }),
+              }),
+              insert: insertStub,
+              update: () => ({ eq: () => thenable({ error: null }) }),
+            };
+          }
+          return makeChain({});
+        },
+      };
+      const result = await upsertPrompts({
+        organizationId: ORG_ID,
+        brandUuid: BRAND_UUID,
+        prompts: [{ id: 'a', prompt: 'hello', regions: [] }],
+        postgrestClient: client,
+      });
+      expect(result.created).to.equal(1);
+      // First select attempt (with intent col) errors; retry without intent succeeds.
+      expect(inStub.callCount).to.equal(2);
     });
 
     it('upsertPrompts skips intent up front on a second call with the same client', async () => {


### PR DESCRIPTION
## Problem

`upsertPrompts` decides whether to update or insert each incoming prompt by first fetching the existing ones that match. That fetch is a single, unpaginated query — but PostgREST caps any response at 1000 rows. If a brand already has more than 1000 matching prompts, the extra ones silently don't come back, so the code treats them as new and tries to insert them. That insert then collides with the unique constraint on (text, region, source), and the whole request fails with a 409.

This isn't hypothetical — it happened in prod. DRS posted a batch of 1000 prompts to a brand that already had ~1200 matching prompts. About 200 were missing from the fetch, got routed to insert, and the request failed.

The same class of bug already came up once in this file: `getIntentsByPromptIds` chunks its lookups at 100 ids specifically to stay under this cap. `upsertPrompts` never got the same fix.

## Fix

Chunk the existing-prompts lookup the same way, using the existing `chunkArray` / `INTENT_LOOKUP_CHUNK_SIZE` helpers, and merge the results before continuing. The `withMissingIntentFallback` contract is unchanged (first error still wins).

Known gap, not fixed here: when none of the incoming prompts have an id, the lookup has no filter at all and could still hit the same cap for a brand with >1000 prompts. Fixing that needs range-based pagination instead of id-chunking, and it's a rare case in practice (DRS's client always sends ids). Flagging it, not fixing it now.

## Tests

Two new tests in `test/support/prompts-storage.test.js`:
- A 150-id batch (forces 2 chunks) — confirms every existing row is found and updated, none dropped into an insert.
- The missing-intent-column retry still works through the new chunked lookup.

Full suite passes, lint and type-check clean.

## Context

Found while debugging a live prod failure from DRS re-posting prompt data. Root cause came from a CloudWatch investigation, not a filed issue — happy to open one if that's preferred, or let me know if this file needs sign-off from a specific team first.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```