### PR TITLE
fix: onboard LLMO/ASO to FACS; bypass not-yet-onboarded products (ACO)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@adobe/spacecat-shared-data-access": "4.21.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
-        "@adobe/spacecat-shared-http-utils": "1.35.0",
+        "@adobe/spacecat-shared-http-utils": "1.35.2",
         "@adobe/spacecat-shared-ims-client": "1.16.0",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.1",
         "@adobe/spacecat-shared-project-engine-client": "1.18.1",
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-http-utils": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.35.0.tgz",
-      "integrity": "sha512-mLh6bakjYaS/dv5eQst/9BuUXXTeJ+FLXwUPJG5PQhz4C6Gt+m0dvuwl8kDxcfXF4eYkbjpiPnX338al/TQ+4g==",
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-http-utils/-/spacecat-shared-http-utils-1.35.2.tgz",
+      "integrity": "sha512-853LJutM63i6/3B4f5Kj9j94BFHEt2DnK6YZSTSqD6OrZkvqL/DjSwgd7BZ/5wch9U1uSIZFn1DQKRVJNTaTAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@adobe/spacecat-shared-data-access": "4.21.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
-    "@adobe/spacecat-shared-http-utils": "1.35.0",
+    "@adobe/spacecat-shared-http-utils": "1.35.2",
     "@adobe/spacecat-shared-ims-client": "1.16.0",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.1",
     "@adobe/spacecat-shared-project-engine-client": "1.18.1",

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -244,16 +244,10 @@ const routeFacsCapabilities = {
   ],
 
   /**
-   * Products with FACS enforcement live. A product that has a `PRODUCTS_ROUTES`
-   * entry below but is NOT listed here is treated as "recognized but not yet
-   * onboarded": `facsWrapper` bypasses the FACS layer for it entirely, leaving
-   * its routes governed by the controller-level ACL (the same posture legacy IMS
-   * tokens already have). This is what keeps ACO — whose `PRODUCTS_ROUTES` map is
-   * still empty (`ACO: {}`) — from 403-ing on routes that LLMO/ASO also declare.
-   *
-   * A missing or unrecognized `x-product` is deliberately NOT covered by this
-   * list: the wrapper still fail-closes on those so FACS cannot be evaded with a
-   * bogus header. Add a product here the moment its routes go live under FACS.
+   * Products with FACS enforcement live (consumed by `facsWrapper` — see its
+   * `FACS_ONBOARDED_PRODUCTS` docs for the fail-closed semantics). Any product with
+   * routes below MUST be listed here, or those routes silently bypass FACS —
+   * enforced by `test/routes/facs-capabilities.test.js`. Add one when its routes go live.
    */
   FACS_ONBOARDED_PRODUCTS: ['LLMO', 'ASO'],
 

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -243,6 +243,20 @@ const routeFacsCapabilities = {
     'POST /consumers/register', // admin
   ],
 
+  /**
+   * Products with FACS enforcement live. A product that has a `PRODUCTS_ROUTES`
+   * entry below but is NOT listed here is treated as "recognized but not yet
+   * onboarded": `facsWrapper` bypasses the FACS layer for it entirely, leaving
+   * its routes governed by the controller-level ACL (the same posture legacy IMS
+   * tokens already have). This is what keeps ACO — whose `PRODUCTS_ROUTES` map is
+   * still empty (`ACO: {}`) — from 403-ing on routes that LLMO/ASO also declare.
+   *
+   * A missing or unrecognized `x-product` is deliberately NOT covered by this
+   * list: the wrapper still fail-closes on those so FACS cannot be evaded with a
+   * bogus header. Add a product here the moment its routes go live under FACS.
+   */
+  FACS_ONBOARDED_PRODUCTS: ['LLMO', 'ASO'],
+
   PRODUCTS_ROUTES: {
   // LLMO — first product to enrol in FACS.
   //

--- a/test/routes/facs-capabilities.test.js
+++ b/test/routes/facs-capabilities.test.js
@@ -130,6 +130,20 @@ describe('routeFacsCapabilities', () => {
       expect(orphans, `onboarded products missing from PRODUCTS_ROUTES: ${orphans.join(', ')}`)
         .to.deep.equal([]);
     });
+
+    it('every product with a non-empty route map is onboarded', () => {
+      // Inverse guard: a product that declares FACS-governed routes but is NOT in
+      // FACS_ONBOARDED_PRODUCTS would have those routes silently bypass FACS (they
+      // look protected but the wrapper never enforces them) — the more dangerous
+      // failure mode. ACO is intentionally excluded: its map is still empty ({}).
+      const onboarded = routeFacsCapabilities.FACS_ONBOARDED_PRODUCTS;
+      const populated = Object.entries(routeFacsCapabilities.PRODUCTS_ROUTES)
+        .filter(([, routes]) => Object.keys(routes).length > 0)
+        .map(([product]) => product);
+      const unenforced = populated.filter((product) => !onboarded.includes(product));
+      expect(unenforced, `products with routes but not onboarded (routes silently bypass FACS): ${unenforced.join(', ')}`)
+        .to.deep.equal([]);
+    });
   });
 
   describe('INTERNAL_ROUTES', () => {

--- a/test/routes/facs-capabilities.test.js
+++ b/test/routes/facs-capabilities.test.js
@@ -91,6 +91,7 @@ describe('routeFacsCapabilities', () => {
       // flow through JWT.facs_permissions + state-layer org-scoped rows.
       expect(routeFacsCapabilities).to.have.all.keys(
         'INTERNAL_ROUTES',
+        'FACS_ONBOARDED_PRODUCTS',
         'PRODUCTS_ROUTES',
         'PRODUCTS_FACS_RESOURCE_PARAM_ALIASES',
         'PRODUCTS_FACS_SECONDARY_RESOURCE',
@@ -104,6 +105,30 @@ describe('routeFacsCapabilities', () => {
 
     it('PRODUCTS_ROUTES is an object', () => {
       expect(routeFacsCapabilities.PRODUCTS_ROUTES).to.be.an('object');
+    });
+  });
+
+  describe('FACS_ONBOARDED_PRODUCTS', () => {
+    it('is an array of unique uppercase product codes', () => {
+      const onboarded = routeFacsCapabilities.FACS_ONBOARDED_PRODUCTS;
+      expect(onboarded).to.be.an('array');
+      onboarded.forEach((product) => {
+        expect(product, `onboarded product '${product}'`).to.be.a('string');
+        expect(product, `onboarded product '${product}' must be uppercase`)
+          .to.equal(product.toUpperCase());
+      });
+      expect(new Set(onboarded).size, 'FACS_ONBOARDED_PRODUCTS has duplicate entries')
+        .to.equal(onboarded.length);
+    });
+
+    it('every onboarded product has a PRODUCTS_ROUTES entry', () => {
+      // A product cannot be enforced by facsWrapper without a route map, and the
+      // wrapper only bypasses *recognized* products, so the two lists must agree.
+      const productKeys = Object.keys(routeFacsCapabilities.PRODUCTS_ROUTES);
+      const orphans = routeFacsCapabilities.FACS_ONBOARDED_PRODUCTS
+        .filter((product) => !productKeys.includes(product));
+      expect(orphans, `onboarded products missing from PRODUCTS_ROUTES: ${orphans.join(', ')}`)
+        .to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
## What

Adds `FACS_ONBOARDED_PRODUCTS: ['LLMO', 'ASO']` to `routeFacsCapabilities` and bumps `@adobe/spacecat-shared-http-utils` to **1.35.2** (which ships the product-onboarding gate — adobe/spacecat-shared#1893). `facsWrapper` uses the list to keep LLMO and ASO FACS-enforced while a **recognized-but-not-onboarded** product like **ACO** (`ACO: {}`) bypasses the FACS layer entirely — ACO routes remain governed by the controller-level ACL. `ACO: {}` is left in place: an empty-but-present entry is what marks ACO a *recognized* product (so a bogus `x-product` still fails closed).

## Why

Fixes the `403 {"message":"x-product header required for FACS-governed routes"}` returned on ACO calls that use a Spacecat-signed JWT, e.g.:

```
GET https://aco.experiencecloud.live/api/v1/organizations/by-ims-org-id/<ims-org>   (x-product: ACO)
```

`GET /organizations/by-ims-org-id/:imsOrgId` is declared under LLMO and ASO but `PRODUCTS_ROUTES.ACO` is empty, so the wrapper treated the call as "governed route called with a non-matching product" and denied it. Legacy IMS tokens bypassed FACS (step-1b) and worked; the JWT path does not, which is why the switch to Spacecat-signed JWTs surfaced this.

## Tests

- `test/routes/facs-capabilities.test.js`: `FACS_ONBOARDED_PRODUCTS` added to the strict top-level-keys assertion, plus a validation block (uppercase & unique codes; every onboarded product exists in `PRODUCTS_ROUTES`).
- Suite green (33 passing).

## Dependency

- [x] adobe/spacecat-shared#1893 merged & released as `@adobe/spacecat-shared-http-utils@1.35.2`.
- [x] `@adobe/spacecat-shared-http-utils` bumped `1.35.0` → `1.35.2` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```