### PR TITLE
fix(autofix): roll back IN_PROGRESS suggestions when SQS dispatch fails (SITES-49388)

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1602,6 +1602,23 @@ function SuggestionsController(ctx, sqs, env) {
         try {
           promiseTokenResponse = await getIMSPromiseToken(context);
         } catch (e) {
+          // The suggestions were flipped to IN_PROGRESS above; a promise-token
+          // failure returns before any dispatch, so roll them back to NEW instead
+          // of stranding them IN_PROGRESS with no consumer (SITES-49388). Assess
+          // requests never flip status (succeededSuggestions === validSuggestions,
+          // still in their original state), so they must not be rolled back.
+          if (!isAssessAction && isNonEmptyArray(succeededSuggestions)) {
+            try {
+              await Suggestion.bulkUpdateStatus(
+                succeededSuggestions,
+                SuggestionModel.STATUSES.NEW,
+              );
+            } catch (rollbackError) {
+              context.log.error(
+                `[autofix] failed to roll back IN_PROGRESS after promise-token failure: ${rollbackError.message}`,
+              );
+            }
+          }
           if (e instanceof ErrorWithStatusCode) {
             return badRequest(e.message);
           }
@@ -1648,45 +1665,91 @@ function SuggestionsController(ctx, sqs, env) {
       url: urlParam,
       ...(precheckOnly === true && { precheckOnly: true }),
     });
-    if (shouldGroupSuggestionsForAutofix(opportunity.getType())) {
-      await Promise.all(
-        suggestionGroups.map(({
-          groupedSuggestions,
-          url,
-          relationshipContext,
-        }) => sendAutofixMessage(
-          sqs,
-          queueUrl,
-          siteId,
-          opportunityId,
-          groupedSuggestions.map((s) => s.getId()),
-          promiseTokenResponse,
-          variations,
-          action,
-          customData,
-          {
-            ...autofixOptions(url),
-            ...(isObject(relationshipContext) && { relationshipContext }),
-          },
-        )),
-      );
-    } else {
-      await sendAutofixMessage(
+    // Build dispatch units (one per URL group, or one for the whole batch) so each
+    // send can be settled independently — one group's send failure must not
+    // fail-fast the rest (the old bare Promise.all) or strand its already-
+    // IN_PROGRESS suggestions with no rollback (SITES-49388).
+    const dispatchUnits = shouldGroupSuggestionsForAutofix(opportunity.getType())
+      ? suggestionGroups.map(({ groupedSuggestions, url, relationshipContext }) => ({
+        ids: groupedSuggestions.map((s) => s.getId()),
+        options: {
+          ...autofixOptions(url),
+          ...(isObject(relationshipContext) && { relationshipContext }),
+        },
+      }))
+      : [{
+        ids: succeededSuggestions.map((s) => s.getId()),
+        options: autofixOptions(requestUrl),
+      }];
+
+    const sendResults = await Promise.allSettled(
+      dispatchUnits.map((unit) => sendAutofixMessage(
         sqs,
         queueUrl,
         siteId,
         opportunityId,
-        succeededSuggestions.map((s) => s.getId()),
+        unit.ids,
         promiseTokenResponse,
         variations,
         action,
         customData,
-        autofixOptions(requestUrl),
-      );
+        unit.options,
+      )),
+    );
+
+    // Roll back suggestions whose dispatch failed: they were flipped to IN_PROGRESS
+    // but no consumer will pick them up, so return them to NEW (re-appliable)
+    // instead of leaving them stuck forever. No FixEntity exists for a failed
+    // dispatch, so a plain status flip is safe (SITES-49388).
+    const failedDispatchIds = new Set(
+      sendResults.flatMap(
+        (res, i) => (res.status === 'rejected' ? dispatchUnits[i].ids : []),
+      ),
+    );
+    if (failedDispatchIds.size > 0) {
+      sendResults.forEach((res, i) => {
+        if (res.status === 'rejected') {
+          context.log.error(
+            `[autofix] dispatch failed for site ${siteId} opportunity ${opportunityId} `
+            + `suggestions [${dispatchUnits[i].ids.join(',')}]: ${res.reason?.message || res.reason}`,
+          );
+        }
+      });
+      // Only apply/apply-all flipped suggestions to IN_PROGRESS; assess never did,
+      // so its rows must not be flipped to NEW even when the dispatch fails.
+      const toRollBack = isAssessAction
+        ? []
+        : succeededSuggestions.filter((s) => failedDispatchIds.has(s.getId()));
+      if (isNonEmptyArray(toRollBack)) {
+        try {
+          await Suggestion.bulkUpdateStatus(toRollBack, SuggestionModel.STATUSES.NEW);
+        } catch (rollbackError) {
+          context.log.error(
+            `[autofix] failed to roll back IN_PROGRESS after dispatch failure: ${rollbackError.message}`,
+          );
+        }
+      }
+      // Reflect the failures in the 207 response so the caller doesn't treat them
+      // as in-flight successes.
+      response.suggestions = response.suggestions.map((entry) => (
+        failedDispatchIds.has(entry.uuid)
+          ? { ...entry, statusCode: 502, message: 'Failed to dispatch autofix' }
+          : entry
+      ));
+      response.metadata = {
+        ...response.metadata,
+        success: response.metadata.success - failedDispatchIds.size,
+        failed: response.metadata.failed + failedDispatchIds.size,
+      };
     }
 
-    if (!precheckOnly && succeededSuggestions.length > 0) {
-      context.log.info('[autofix-triggered]', auditFields);
+    // Log the trigger against the post-rollback success count: if every dispatch
+    // failed and all rows were rolled back, nothing was actually triggered.
+    if (!precheckOnly && response.metadata.success > 0) {
+      context.log.info('[autofix-triggered]', {
+        ...auditFields,
+        succeededSuggestionCount: response.metadata.success,
+      });
     }
 
     return createResponse(response, 207);

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -5341,6 +5341,178 @@ describe('Suggestions Controller', () => {
       expect(context.log.info).to.have.been.calledWith('[autofix-triggered]', expectedFields);
     });
 
+    it('rolls back IN_PROGRESS suggestions to NEW and marks them 502 when the SQS dispatch fails (SITES-49388)', async () => {
+      opportunity.getType = sandbox.stub().returns('meta-tags');
+      mockSuggestion.allByOpportunityId.resolves([mockSuggestionEntity(suggs[0])]);
+      mockSuggestion.bulkUpdateStatus.resolves([
+        mockSuggestionEntity({ ...suggs[0], status: 'IN_PROGRESS' }),
+      ]);
+      // The SQS send rejects → dispatch fails after the IN_PROGRESS flip.
+      mockSqs.sendMessage.rejects(new Error('SQS unavailable'));
+
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+      });
+
+      expect(response.status).to.equal(207);
+      const body = await response.json();
+      // The failed dispatch is reflected as a failure, not an in-flight success.
+      expect(body.metadata).to.have.property('success', 0);
+      expect(body.metadata).to.have.property('failed', 1);
+      expect(body.suggestions[0]).to.have.property('statusCode', 502);
+      // The IN_PROGRESS rows were rolled back to NEW (a 2nd bulkUpdateStatus call).
+      expect(mockSuggestion.bulkUpdateStatus).to.have.been.calledWith(sinon.match.any, 'NEW');
+      expect(context.log.error).to.have.been.called;
+    });
+
+    it('does NOT roll back on dispatch failure for an assess request (assess never flipped to IN_PROGRESS) (SITES-49388)', async () => {
+      opportunity.getType = sandbox.stub().returns('alt-text');
+      mockSuggestion.allByOpportunityId.resolves([
+        mockSuggestionEntity(altTextSuggs[0]),
+        mockSuggestionEntity(altTextSuggs[1]),
+      ]);
+      mockSqs.sendMessage.rejects(new Error('SQS unavailable'));
+
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0], SUGGESTION_IDS[1]], action: 'assess' },
+        ...context,
+      });
+
+      // The dispatch failure is still surfaced as a failure...
+      expect(response.status).to.equal(207);
+      const body = await response.json();
+      expect(body.metadata).to.have.property('success', 0);
+      expect(body.metadata).to.have.property('failed', 2);
+      // ...but assess rows were never flipped to IN_PROGRESS, so nothing is rolled back.
+      expect(mockSuggestion.bulkUpdateStatus).to.not.have.been.called;
+    });
+
+    it('rolls back IN_PROGRESS suggestions to NEW when promise-token creation fails pre-dispatch (SITES-49388)', async () => {
+      const rejectingTokenController = await esmock('../../src/controllers/suggestions.js', {
+        '../../src/support/utils.js': {
+          getIMSPromiseToken: async () => { throw new Error('IMS down'); },
+          getIsSummitPlgEnabled: async () => true,
+        },
+      });
+      const controller = rejectingTokenController({
+        dataAccess: mockSuggestionDataAccess,
+        pathInfo: { headers: { 'x-product': 'abcd' } },
+        ...authContext,
+      }, mockSqs, {
+        AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+        LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+      });
+
+      opportunity.getType = sandbox.stub().returns('meta-tags');
+      mockSuggestion.allByOpportunityId.resolves([mockSuggestionEntity(suggs[0])]);
+      mockSuggestion.bulkUpdateStatus.resolves([
+        mockSuggestionEntity({ ...suggs[0], status: 'IN_PROGRESS' }),
+      ]);
+
+      const response = await controller.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+      });
+
+      expect(response.status).to.equal(500);
+      // Flipped to IN_PROGRESS, then rolled back to NEW when the token failed before dispatch.
+      expect(mockSuggestion.bulkUpdateStatus).to.have.been.calledWith(sinon.match.any, 'NEW');
+      // No message was ever dispatched.
+      expect(mockSqs.sendMessage).to.not.have.been.called;
+    });
+
+    it('does NOT roll back on promise-token failure for an assess request (SITES-49388)', async () => {
+      const rejectingTokenController = await esmock('../../src/controllers/suggestions.js', {
+        '../../src/support/utils.js': {
+          getIMSPromiseToken: async () => { throw new Error('IMS down'); },
+          getIsSummitPlgEnabled: async () => true,
+        },
+      });
+      const controller = rejectingTokenController({
+        dataAccess: mockSuggestionDataAccess,
+        pathInfo: { headers: { 'x-product': 'abcd' } },
+        ...authContext,
+      }, mockSqs, {
+        AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+        LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+      });
+
+      opportunity.getType = sandbox.stub().returns('alt-text');
+      mockSuggestion.allByOpportunityId.resolves([mockSuggestionEntity(altTextSuggs[0])]);
+
+      const response = await controller.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        // precheckOnly false → the assess path still creates a promise token.
+        data: { suggestionIds: [SUGGESTION_IDS[0]], action: 'assess', precheckOnly: false },
+        ...context,
+      });
+
+      expect(response.status).to.equal(500);
+      // Assess never flipped status, so a token failure must not touch suggestion status.
+      expect(mockSuggestion.bulkUpdateStatus).to.not.have.been.called;
+    });
+
+    it('logs and swallows when the rollback itself fails after a dispatch failure (SITES-49388)', async () => {
+      opportunity.getType = sandbox.stub().returns('meta-tags');
+      mockSuggestion.allByOpportunityId.resolves([mockSuggestionEntity(suggs[0])]);
+      // 1st call = IN_PROGRESS flip (ok); 2nd call = rollback to NEW (throws).
+      mockSuggestion.bulkUpdateStatus
+        .onFirstCall().resolves([mockSuggestionEntity({ ...suggs[0], status: 'IN_PROGRESS' })])
+        .onSecondCall().rejects(new Error('db down'));
+      mockSqs.sendMessage.rejects(new Error('SQS unavailable'));
+
+      const response = await suggestionsControllerWithMock.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+      });
+
+      // The failed rollback is logged and swallowed — the 207 response still returns.
+      expect(response.status).to.equal(207);
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/failed to roll back IN_PROGRESS after dispatch failure/),
+      );
+    });
+
+    it('logs and swallows when the rollback itself fails after a promise-token failure (SITES-49388)', async () => {
+      const rejectingTokenController = await esmock('../../src/controllers/suggestions.js', {
+        '../../src/support/utils.js': {
+          getIMSPromiseToken: async () => { throw new Error('IMS down'); },
+          getIsSummitPlgEnabled: async () => true,
+        },
+      });
+      const controller = rejectingTokenController({
+        dataAccess: mockSuggestionDataAccess,
+        pathInfo: { headers: { 'x-product': 'abcd' } },
+        ...authContext,
+      }, mockSqs, {
+        AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+        LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+      });
+
+      opportunity.getType = sandbox.stub().returns('meta-tags');
+      mockSuggestion.allByOpportunityId.resolves([mockSuggestionEntity(suggs[0])]);
+      // 1st call = IN_PROGRESS flip (ok); 2nd call = rollback to NEW (throws).
+      mockSuggestion.bulkUpdateStatus
+        .onFirstCall().resolves([mockSuggestionEntity({ ...suggs[0], status: 'IN_PROGRESS' })])
+        .onSecondCall().rejects(new Error('db down'));
+
+      const response = await controller.autofixSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: { suggestionIds: [SUGGESTION_IDS[0]] },
+        ...context,
+      });
+
+      expect(response.status).to.equal(500);
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/failed to roll back IN_PROGRESS after promise-token failure/),
+      );
+    });
+
     it('logs triggeredBy as unknown when profile email is absent', async () => {
       const savedProfile = context.attributes.authInfo.profile;
       context.attributes.authInfo.profile = null;


### PR DESCRIPTION
## What & why (SITES-49388)

Batch canonical deploys stuck at "Deployment in progress" — suggestions flipped to `IN_PROGRESS` but never picked up. Root cause: the batch was routed to the SpaceCat auto-fix lane (SQS → autofix-worker), and canonical has no consumer case there, so the message was dropped with the rows left stuck. This PR hardens the **send side**: if dispatch (or the pre-dispatch promise-token mint) fails, the `IN_PROGRESS` rows are rolled back to `NEW` instead of being stranded, and the failure is surfaced in the 207 response.

Companion consumer-side reset: adobe/spacecat-autofix-worker PR (`xfeng/autofix-consumer-reset-sites-49388`).

Credit: the send-time `Promise.allSettled` + rollback framing is Venkatesh Papineni's proposal; this extends it to the promise-token path and the audit log.

## Changes
- `Promise.allSettled` per dispatch unit — one URL group's SQS failure no longer fail-fasts the rest or strands its rows.
- Failed-dispatch rows roll back `IN_PROGRESS → NEW`; response entries marked `502`, metadata `success`/`failed` corrected.
- Promise-token mint failure rolls back the `IN_PROGRESS` flip before returning.
- `assess` requests never flip status, so both rollback paths are gated `!isAssessAction` (no clobbering of `PENDING_VALIDATION`/other states).
- `[autofix-triggered]` audit log keys on the post-rollback success count.

## Tests
+4 targeted (dispatch-failure rollback; assess dispatch-failure no-op; promise-token rollback; assess promise-token no-op). Full auto-fix suite (72) green, lint clean. **Requires Node 24** (repo engine).
