### PR TITLE
fix(onboard): alert plg_onboardings when Force Tier Update downgrades PLG/Pre-onboard → Free_Trial

### DIFF
--- a/src/support/audit-run-scope.js
+++ b/src/support/audit-run-scope.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Dependency-free audit-scope predicates.
+ *
+ * These live in their own leaf module (rather than in the `support/utils.js` hub) so that
+ * low-level modules such as `utils/slack/base.js` can import them without pulling in the hub —
+ * which would create an import cycle once the hub imports slack helpers (SITES-50179). Keep this
+ * file free of any repo imports so it stays a true leaf.
+ */
+
+/**
+ * Checks if the url parameter "url" equals "ALL".
+ * @param {string} url - URL parameter.
+ * @returns {boolean} True if url equals "ALL", false otherwise.
+ */
+export const isAuditForAllUrls = (url) => url.toUpperCase() === 'ALL';
+
+/**
+ * Checks if the deliveryType parameter "deliveryType" equals "ALL".
+ * @param {string} deliveryType - deliveryType parameter.
+ * @returns {boolean} True if deliveryType equals "ALL", false otherwise.
+ */
+export const isAuditForAllDeliveryTypes = (deliveryType) => deliveryType.toUpperCase() === 'ALL';

--- a/src/support/slack/tier-change-alert.js
+++ b/src/support/slack/tier-change-alert.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Internal Slack alerting for the "Force Tier Update" escape hatch (SITES-50179).
+ *
+ * The onboard Slack command preserves an existing PLG/PRE_ONBOARD ASO entitlement by default
+ * (SITES-49886); ticking *Force Tier Update* deliberately overrides that guard. When the override
+ * results in a PLG/PRE_ONBOARD → FREE_TRIAL downgrade, `onboardSingleSite` calls this helper so the
+ * team gets a high-signal alert every time the protection is bypassed — no manual auditing needed.
+ *
+ * Posts to the same `plg_onboardings` channel the PLG onboarding lifecycle notifications already
+ * use (`SLACK_PLG_ONBOARDING_CHANNEL_ID` + `SLACK_BOT_TOKEN`), so the audience is exactly right and
+ * no new infra is required. Fire-and-forget: this is an observability side-channel that must NEVER
+ * throw or affect the onboard's own outcome — a Slack failure is logged, not propagated (mirrors
+ * `postPlgOnboardingNotification` and `alertQuotaRejection`).
+ */
+
+import { postSlackMessage } from '../../utils/slack/base.js';
+
+/**
+ * Builds the high-signal alert message for a forced tier downgrade. Kept visually distinct
+ * (`:rotating_light:` + a "Force Tier Update" heading) so it stands out from the routine
+ * onboarding status traffic in the `plg_onboardings` channel.
+ *
+ * @param {object} p
+ * @param {string} p.baseURL - Site base URL being onboarded.
+ * @param {string} [p.organizationId] - SpaceCat organization id.
+ * @param {string} [p.imsOrgID] - IMS org id.
+ * @param {string} [p.siteId] - Site id.
+ * @param {string} [p.entitlementId] - Id of the (now downgraded) ASO entitlement.
+ * @param {string} p.fromTier - Tier before the override (PLG or PRE_ONBOARD).
+ * @param {string} p.toTier - Tier after the override (FREE_TRIAL).
+ * @param {string} [p.profileName] - Onboarding profile used.
+ * @param {string} [p.sourceChannelId] - Slack channel the onboard was triggered from.
+ * @param {string} [p.sourceThreadTs] - Thread timestamp of the triggering onboard command.
+ * @returns {string}
+ */
+function formatMessage({
+  baseURL, organizationId, imsOrgID, siteId, entitlementId,
+  fromTier, toTier, profileName, sourceChannelId, sourceThreadTs,
+}) {
+  const lines = [
+    `:rotating_light: *Force Tier Update — ASO entitlement tier overridden* \`${fromTier} → ${toTier}\``,
+    `• Site: ${baseURL}`,
+    `• SpaceCat Org: \`${organizationId || 'unknown'}\`  IMS Org: \`${imsOrgID || 'unknown'}\``,
+    `• Site ID: \`${siteId || 'unknown'}\``,
+    `• Entitlement: \`${entitlementId || 'unknown'}\``,
+    `• Profile: \`${profileName || 'unknown'}\``,
+  ];
+  if (sourceChannelId) {
+    const threadPart = sourceThreadTs ? ` (thread_ts \`${sourceThreadTs}\`)` : '';
+    lines.push(`• Source: <#${sourceChannelId}>${threadPart}`);
+  }
+  lines.push(`• ${new Date().toISOString()}`);
+  return lines.join('\n');
+}
+
+/**
+ * Alerts the team that a PLG/PRE_ONBOARD → FREE_TRIAL tier downgrade was forced via the onboard
+ * command's *Force Tier Update* escape hatch (SITES-50179). Fire-and-forget: never throws; a
+ * missing channel/token config or a Slack failure is logged (best-effort) and swallowed.
+ *
+ * @param {object} payload - See {@link formatMessage} for the accepted fields.
+ * @param {object} [env] - Reads `SLACK_PLG_ONBOARDING_CHANNEL_ID` + `SLACK_BOT_TOKEN`.
+ * @param {object} [log] - Optional logger.
+ * @returns {Promise<void>}
+ */
+export async function notifyForcedTierDowngrade(payload, env, log) {
+  const channelId = env?.SLACK_PLG_ONBOARDING_CHANNEL_ID;
+  const token = env?.SLACK_BOT_TOKEN;
+  if (!channelId || !token) {
+    log?.warn?.('FORCE_TIER_DOWNGRADE_ALERT: PLG channel/token not configured — skipping alert');
+    return;
+  }
+  try {
+    await postSlackMessage(channelId, formatMessage(payload), token);
+  } catch (e) {
+    // Fire-and-forget: alerting must never affect the onboard's own outcome.
+    log?.warn?.(`FORCE_TIER_DOWNGRADE_ALERT: failed to post Slack alert: ${e?.message}`);
+  }
+}

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -42,6 +42,7 @@ import {
   PROMISE_TOKEN_REQUIRED_ERROR_CODE,
 } from '../utils/constants.js';
 import { updateRumConfig } from './rum-config-service.js';
+import { notifyForcedTierDowngrade } from './slack/tier-change-alert.js';
 // Two signals indicate a previous paid onboarding:
 // 1. ahref-paid-pages import — unique to the paid profile's import set.
 // 2. onboardConfig.lastProfile === 'paid' — set for sites backfilled via script or onboarded
@@ -85,19 +86,10 @@ export const sanitizeExecutionName = (value) => {
   return executionName.slice(0, 80);
 };
 
-/**
- * Checks if the url parameter "url" equals "ALL".
- * @param {string} url - URL parameter.
- * @returns {boolean} True if url equals "ALL", false otherwise.
- */
-export const isAuditForAllUrls = (url) => url.toUpperCase() === 'ALL';
-
-/**
- * Checks if the deliveryType parameter "deliveryType" equals "ALL".
- * @param {string} deliveryType - deliveryType parameter.
- * @returns {boolean} True if deliveryType equals "ALL", false otherwise.
- */
-export const isAuditForAllDeliveryTypes = (deliveryType) => deliveryType.toUpperCase() === 'ALL';
+// Re-exported from a dependency-free leaf so lower-level modules (e.g. utils/slack/base.js) can
+// use these predicates without importing this hub module — importing them from here would create
+// an import cycle once this module imports slack helpers (SITES-50179).
+export { isAuditForAllUrls, isAuditForAllDeliveryTypes } from './audit-run-scope.js';
 
 /**
  * Sends an audit message for a single URL.
@@ -2045,7 +2037,7 @@ export const onboardSingleSite = async (
       log.info(`Preserving ${existingTier} tier for org ${organizationId} - skipping entitlement/enrollment write during onboard of ${baseURL}`);
       await say(`:lock: Org for \`${baseURL}\` is on the *${existingTier}* tier — onboarding will NOT change the tier, entitlement, or enrollment. Running audits and opportunities only. (Use *Force Tier Update* to override.)`);
     } else {
-      await createEntitlementAndEnrollment(
+      const { entitlement } = await createEntitlementAndEnrollment(
         site,
         context,
         slackContext,
@@ -2053,6 +2045,30 @@ export const onboardSingleSite = async (
         EntitlementModel.PRODUCT_CODES.ASO,
         tier,
       );
+
+      // SITES-50179: the Force Tier Update escape hatch was exercised on a protected org
+      // (isProtectedOrg is only true here when forceTierUpdate bypassed the guard above). If it
+      // downgraded a PLG/PRE_ONBOARD org to FREE_TRIAL — the exact transition that silently exposed
+      // the full opportunity set in the original incident — alert the team so every deliberate
+      // override is visible without manual auditing. Best-effort: never blocks onboarding.
+      if (isProtectedOrg && tier === EntitlementModel.TIERS.FREE_TRIAL) {
+        await notifyForcedTierDowngrade(
+          {
+            baseURL,
+            organizationId,
+            imsOrgID,
+            siteId: site.getId(),
+            entitlementId: entitlement?.getId?.(),
+            fromTier: existingTier,
+            toTier: tier,
+            profileName,
+            sourceChannelId: slackContext.channelId,
+            sourceThreadTs: slackContext.threadTs,
+          },
+          env,
+          log,
+        );
+      }
     }
 
     // Create new project or assign existing project

--- a/src/utils/slack/base.js
+++ b/src/utils/slack/base.js
@@ -22,7 +22,7 @@ import { Readable } from 'stream';
 import { parse } from 'csv';
 
 import { Blocks, Elements, Message } from 'slack-block-builder';
-import { isAuditForAllUrls } from '../../support/utils.js';
+import { isAuditForAllUrls } from '../../support/audit-run-scope.js';
 
 export const BACKTICKS = '```';
 export const BOT_MENTION_REGEX = /^<@[^>]+>\s+/;

--- a/test/support/slack/tier-change-alert.test.js
+++ b/test/support/slack/tier-change-alert.test.js
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+const CONFIGURED_ENV = {
+  SLACK_PLG_ONBOARDING_CHANNEL_ID: 'C_PLG',
+  SLACK_BOT_TOKEN: 'xoxb-test',
+};
+
+const BASE_PAYLOAD = {
+  baseURL: 'https://example.com',
+  organizationId: 'org-123',
+  imsOrgID: 'AB12@AdobeOrg',
+  siteId: 'site-456',
+  entitlementId: 'ent-789',
+  fromTier: 'PLG',
+  toTier: 'FREE_TRIAL',
+  profileName: 'default',
+  sourceChannelId: 'C_SRC',
+  sourceThreadTs: '1700000000.000100',
+};
+
+describe('slack tier-change-alert', () => {
+  let sandbox;
+  let postSlackMessage;
+  let alert;
+  let log;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    postSlackMessage = sandbox.stub().resolves({ channel: 'C_PLG', ts: '1' });
+    log = { warn: sandbox.stub(), info: sandbox.stub(), error: sandbox.stub() };
+    alert = await esmock('../../../src/support/slack/tier-change-alert.js', {
+      '../../../src/utils/slack/base.js': { postSlackMessage },
+    });
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('posts to the PLG onboarding channel with the bot token when configured', async () => {
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, CONFIGURED_ENV, log);
+    expect(postSlackMessage).to.have.been.calledOnceWith('C_PLG', sinon.match.string, 'xoxb-test');
+  });
+
+  it('includes the tier transition and all key identifiers in the message', async () => {
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, CONFIGURED_ENV, log);
+    const [, message] = postSlackMessage.firstCall.args;
+    expect(message).to.match(/Force Tier Update/i);
+    expect(message).to.contain('PLG');
+    expect(message).to.contain('FREE_TRIAL');
+    expect(message).to.contain('https://example.com');
+    expect(message).to.contain('org-123');
+    expect(message).to.contain('AB12@AdobeOrg');
+    expect(message).to.contain('site-456');
+    expect(message).to.contain('ent-789');
+    expect(message).to.contain('default');
+  });
+
+  it('references the source thread when channel/thread are provided', async () => {
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, CONFIGURED_ENV, log);
+    const [, message] = postSlackMessage.firstCall.args;
+    expect(message).to.contain('<#C_SRC>');
+    expect(message).to.contain('1700000000.000100');
+  });
+
+  it('references the source channel without a thread_ts when only the channel is known', async () => {
+    await alert.notifyForcedTierDowngrade(
+      { ...BASE_PAYLOAD, sourceThreadTs: undefined },
+      CONFIGURED_ENV,
+      log,
+    );
+    const [, message] = postSlackMessage.firstCall.args;
+    expect(message).to.contain('<#C_SRC>');
+    expect(message).to.not.contain('thread_ts');
+  });
+
+  it('omits the source-thread line when no source channel is provided (e.g. scheduled run)', async () => {
+    await alert.notifyForcedTierDowngrade(
+      { ...BASE_PAYLOAD, sourceChannelId: undefined, sourceThreadTs: undefined },
+      CONFIGURED_ENV,
+      log,
+    );
+    const [, message] = postSlackMessage.firstCall.args;
+    expect(message).to.not.contain('<#');
+    expect(message).to.not.match(/Source:/i);
+  });
+
+  it("renders 'unknown' placeholders when optional identifiers are missing", async () => {
+    await alert.notifyForcedTierDowngrade(
+      {
+        baseURL: 'https://example.com', fromTier: 'PLG', toTier: 'FREE_TRIAL',
+      },
+      CONFIGURED_ENV,
+      log,
+    );
+    const [, message] = postSlackMessage.firstCall.args;
+    expect(message).to.contain('unknown');
+    // The transition and site are still present even with everything else missing.
+    expect(message).to.contain('PLG');
+    expect(message).to.contain('https://example.com');
+  });
+
+  it('reflects a PRE_ONBOARD origin tier in the message', async () => {
+    await alert.notifyForcedTierDowngrade(
+      { ...BASE_PAYLOAD, fromTier: 'PRE_ONBOARD' },
+      CONFIGURED_ENV,
+      log,
+    );
+    const [, message] = postSlackMessage.firstCall.args;
+    expect(message).to.contain('PRE_ONBOARD');
+    expect(message).to.contain('FREE_TRIAL');
+  });
+
+  it('is a no-op (no Slack post, no throw) when the channel is not configured', async () => {
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, { SLACK_BOT_TOKEN: 'xoxb-test' }, log);
+    expect(postSlackMessage).to.not.have.been.called;
+  });
+
+  it('is a no-op when the bot token is not configured', async () => {
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, { SLACK_PLG_ONBOARDING_CHANNEL_ID: 'C_PLG' }, log);
+    expect(postSlackMessage).to.not.have.been.called;
+  });
+
+  it('is a no-op when env is missing entirely', async () => {
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, undefined, log);
+    expect(postSlackMessage).to.not.have.been.called;
+  });
+
+  it('swallows Slack failures (best-effort) — never throws, logs a warning', async () => {
+    postSlackMessage.rejects(new Error('slack down'));
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, CONFIGURED_ENV, log);
+    expect(log.warn).to.have.been.called;
+  });
+
+  it('does not throw when no logger is provided and Slack fails', async () => {
+    postSlackMessage.rejects(new Error('slack down'));
+    // Must resolve, not reject.
+    await alert.notifyForcedTierDowngrade(BASE_PAYLOAD, CONFIGURED_ENV);
+    expect(postSlackMessage).to.have.been.calledOnce;
+  });
+});

--- a/test/support/utils-protected-tier-guard.test.js
+++ b/test/support/utils-protected-tier-guard.test.js
@@ -87,6 +87,7 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
     const tierCreateForSiteStub = sandbox.stub().resolves({
       createEntitlement: createEntitlementStub,
     });
+    const notifyForcedTierDowngradeStub = sandbox.stub().resolves();
     const { onboardSingleSite } = await esmock('../../src/support/utils.js', {
       '@aws-sdk/client-sfn': {
         // eslint-disable-next-line func-style
@@ -118,9 +119,16 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
       '../../src/support/rum-config-service.js': {
         updateRumConfig: sandbox.stub().resolves(true),
       },
+      '../../src/support/slack/tier-change-alert.js': {
+        notifyForcedTierDowngrade: notifyForcedTierDowngradeStub,
+      },
     });
     return {
-      onboardSingleSite, sfnSendStub, tierCreateForSiteStub, createEntitlementStub,
+      onboardSingleSite,
+      sfnSendStub,
+      tierCreateForSiteStub,
+      createEntitlementStub,
+      notifyForcedTierDowngradeStub,
     };
   };
 
@@ -241,5 +249,78 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
     expect(tierCreateForSiteStub).to.have.been.calledOnce;
     expect(configurationFindLatest).to.have.been.calledOnce;
     expect(result.status).to.equal('Success');
+  });
+
+  /**
+   * SITES-50179: whenever the Force Tier Update escape hatch actually downgrades a PLG/PRE_ONBOARD
+   * org to FREE_TRIAL, the team must get a Slack alert so every deliberate override is visible
+   * without manual auditing. The alert is fire-and-forget (see tier-change-alert.js) — these tests
+   * only assert the wiring: it fires on that exact transition and stays silent otherwise.
+   */
+  describe('force-downgrade alert (SITES-50179)', () => {
+    ['PLG', 'PRE_ONBOARD'].forEach((protectedTier) => {
+      it(`alerts the team when forceTierUpdate downgrades ${protectedTier} → FREE_TRIAL`, async () => {
+        const { onboardSingleSite, notifyForcedTierDowngradeStub } = await loadOnboard();
+        const site = makeHappyPathSite();
+        const { context } = makeContext(site, { getTier: () => protectedTier });
+
+        await run(onboardSingleSite, context, { forceTierUpdate: true });
+
+        expect(notifyForcedTierDowngradeStub).to.have.been.calledOnce;
+        const [payload, env] = notifyForcedTierDowngradeStub.firstCall.args;
+        expect(payload).to.include({
+          fromTier: protectedTier,
+          toTier: 'FREE_TRIAL',
+          baseURL: SITE_URL,
+          siteId: 'site-happy',
+          entitlementId: 'ent-test',
+        });
+        // Source thread is threaded through so the team can see who forced it.
+        expect(payload.sourceChannelId).to.equal('C1');
+        expect(payload.sourceThreadTs).to.equal('1.0');
+        // env is forwarded so the helper can resolve the PLG channel + bot token.
+        expect(env).to.equal(context.env);
+      });
+    });
+
+    it('does NOT alert when the protected tier is preserved (no forceTierUpdate)', async () => {
+      const { onboardSingleSite, notifyForcedTierDowngradeStub } = await loadOnboard();
+      const site = makeHappyPathSite();
+      const { context } = makeContext(site, { getTier: () => 'PLG' });
+
+      await run(onboardSingleSite, context);
+
+      expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
+    });
+
+    it('does NOT alert when the org has no existing ASO entitlement', async () => {
+      const { onboardSingleSite, notifyForcedTierDowngradeStub } = await loadOnboard();
+      const site = makeHappyPathSite();
+      const { context } = makeContext(site, null);
+
+      await run(onboardSingleSite, context, { forceTierUpdate: true });
+
+      expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
+    });
+
+    it('does NOT alert when the existing tier is FREE_TRIAL (not a protected downgrade)', async () => {
+      const { onboardSingleSite, notifyForcedTierDowngradeStub } = await loadOnboard();
+      const site = makeHappyPathSite();
+      const { context } = makeContext(site, { getTier: () => 'FREE_TRIAL' });
+
+      await run(onboardSingleSite, context, { forceTierUpdate: true });
+
+      expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
+    });
+
+    it('does NOT alert when forceTierUpdate targets a non-FREE_TRIAL tier (e.g. PAID upgrade)', async () => {
+      const { onboardSingleSite, notifyForcedTierDowngradeStub } = await loadOnboard();
+      const site = makeHappyPathSite();
+      const { context } = makeContext(site, { getTier: () => 'PLG' });
+
+      await run(onboardSingleSite, context, { forceTierUpdate: true, tier: 'PAID' });
+
+      expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
+    });
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a Slack alert to the onboard command: whenever the **Force Tier Update** escape hatch downgrades a `PLG` or `PRE_ONBOARD` org's ASO entitlement to `FREE_TRIAL`, a notification is posted to the `plg_onboardings` channel.

## 2. Reasoning
Follow-up from the PLG re-onboarding incident where re-running the `onboard` Slack command silently retiered PLG/Pre-onboard orgs to `FREE_TRIAL`, exposing the full opportunity set instead of the PLG-limited three. SITES-49886/49887 fixed the root cause — onboard now preserves an existing PLG/PRE_ONBOARD tier by default, and any deliberate override requires explicitly ticking **Force Tier Update**. The remaining ask (from Hanish Bansal) was visibility: the team wants to know every time that override is actually exercised, so a deliberate bypass of the protection surfaces on its own instead of needing a manual audit.

## 3. High-level overview of the changes
- **Before:** exercising Force Tier Update on a protected (`PLG`/`PRE_ONBOARD`) org downgraded it to `FREE_TRIAL` with no team-visible signal — only the operator's own onboard thread reflected it.
- **After:** the downgrade behaviour itself is unchanged, but the same action now also posts a high-signal `:rotating_light:` alert to the `plg_onboardings` channel. The alert carries the transition (`PLG`/`PRE_ONBOARD` → `FREE_TRIAL`), site URL, SpaceCat + IMS org ids, site id, entitlement id, onboarding profile, and a reference back to the onboard thread so the team can see who triggered it.
- The alert fires **only** on that exact transition, and only after the entitlement write succeeds. It stays silent when the tier is preserved (no Force Tier Update), when the org has no prior ASO entitlement, when the org was already `FREE_TRIAL`, and when the forced target is a non-`FREE_TRIAL` tier (e.g. a `PAID` upgrade).
- The notification is best-effort: it is gated on the already-configured `SLACK_PLG_ONBOARDING_CHANNEL_ID` + `SLACK_BOT_TOKEN` (the same channel/token the existing PLG onboarding lifecycle notifications use) and never throws, so a Slack hiccup can never block or fail an onboard. No new environment/infra is introduced.
- Internal, behaviour-neutral refactor: so the new Slack helper is importable from the onboard path without introducing an import cycle, the two dependency-free `isAuditForAll*` predicates move to a small leaf module; `utils.js` re-exports them (no change for existing importers) and the low-level slack base module now imports them from the leaf, decoupling it from the `utils` hub.

## 4. Required information
- Jira / issue: SITES-50179 — https://jira.corp.adobe.com/browse/SITES-50179
- Spec: docs/plg_tier_requirement_and_design.md — https://github.com/adobe/spacecat-api-service/blob/main/docs/plg_tier_requirement_and_design.md (defines the PRE_ONBOARD → PLG → (optionally) FREE_TRIAL tier model this alert watches)
- Other: builds on SITES-49886 (https://jira.corp.adobe.com/browse/SITES-49886) and SITES-49887 (https://jira.corp.adobe.com/browse/SITES-49887) — the root-cause fixes that added tier preservation and the Force Tier Update checkbox

## 7. Test plan
**(a) Local, beyond unit tests:** After the cycle-break refactor, confirmed the real module graph loads at runtime by directly importing the touched modules (`utils.js`, the slack base module, and the new leaf) — they resolve with no circular-import failure. Unit coverage was added for the notifier (channel/token gating, message content, best-effort swallow on Slack failure) and for the onboard wiring (fires on `PLG`/`PRE_ONBOARD` → `FREE_TRIAL` under Force Tier Update; stays silent when preserved, when there is no prior entitlement, when already `FREE_TRIAL`, and on a forced `PAID` target).

**(b) Per-environment verification (dev / stage, and prod when needed):**
1. Pick a site whose org holds a `PLG` or `PRE_ONBOARD` ASO entitlement.
2. Run the Slack `onboard` command against it with **Force Tier Update** ticked. Confirm (i) the org's ASO entitlement is downgraded to `FREE_TRIAL`, and (ii) a `:rotating_light:` *Force Tier Update* alert appears in the `plg_onboardings` channel naming the site/org/entitlement and linking back to the onboard thread.
3. Negative check: run `onboard` against the same protected org **without** Force Tier Update and confirm the tier is preserved and **no** alert is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```