### PR TITLE
fix(brands): eliminate read-after-write race behind false brand_repoint_not_persisted 500

### DIFF
--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -1507,7 +1507,24 @@ export async function updateBrand({
   if (updates.expectedUpdatedAt !== undefined) {
     updateQuery = updateQuery.eq('updated_at', updates.expectedUpdatedAt);
   }
-  const { data, error } = await updateQuery.select('id').maybeSingle();
+  // serenity-docs#349 / #3131 follow-up (LLMO — live e2e on prod): select the SAME
+  // wide embed getBrandById reads, directly off THIS UPDATE's own
+  // `Prefer: return=representation` — PostgREST embeds resources on an UPDATE's
+  // RETURNING exactly like it does on a GET. That makes `data` below a
+  // guaranteed-fresh snapshot: it comes back on the very request that just
+  // committed the write, and — confirmed against this env's Vault config
+  // (`dx_mysticat/prod/api-service` POSTGREST_URL=`http://data-svc-balanced.internal`)
+  // and mysticat-data-service's `reader.tf` ALB rules — every non-GET/HEAD/OPTIONS
+  // request on that host lands on the writer fleet, no exceptions. A plain
+  // follow-up `getBrandById()` call is a bare GET, and GETs on that same host ARE
+  // routed to a *separate* PostgREST fleet reading Aurora's reader endpoint — a
+  // real, independently-replicating replica with nonzero lag, not the same node
+  // the write just landed on. That is the confirmed mechanism behind the
+  // brand_repoint_not_persisted false-positive: the write commits on the writer,
+  // but the very next GET can still be served stale data by the reader. Selecting
+  // the full embed here means the common case (see below) never needs that
+  // second, possibly-stale GET at all.
+  const { data, error } = await updateQuery.select(BRAND_SELECT).maybeSingle();
 
   if (error) {
     if (error.code === '23505' && error.message?.includes('brands_base_site_unique')) {
@@ -1551,7 +1568,41 @@ export async function updateBrand({
     ]);
   }
 
-  return getBrandById(organizationId, brandId, postgrestClient);
+  // Whether a follow-up read is even needed depends on what this call actually
+  // changed. `data` already reflects this UPDATE's own committed `brands` row —
+  // including the `base_site` join that drives baseSiteId/baseUrl — with none of
+  // the reader-replica staleness risk described above. A request that touched no
+  // child-table collection can therefore return it directly: no second read, no
+  // race, period.
+  const childTablesTouched = updates.brandAliases !== undefined
+    || updates.competitors !== undefined
+    || updates.socialAccounts !== undefined
+    || updates.earnedContent !== undefined
+    || updates.urls !== undefined;
+
+  if (!childTablesTouched) {
+    return mapDbBrandToV2(data);
+  }
+
+  // The child-table syncs above ran as separate requests AFTER this UPDATE
+  // committed, so their effect isn't part of `data`'s RETURNING payload — a
+  // follow-up read is genuinely unavoidable to pick up aliases/competitors/
+  // social/earned/urls. That follow-up is a plain GET, so on this host it CAN be
+  // served by the lagging reader fleet described above. Rather than trust it for
+  // the one field the #3131 safety net downstream actually gates on, override
+  // baseSiteId/baseUrl with the values this call already knows are correct from
+  // `data` — read back on the writer, in this same request, from the very UPDATE
+  // that changed `site_id` (or deliberately left it unchanged). This makes the
+  // re-point contract (returned baseSiteId always reflects the just-applied
+  // write) hold unconditionally, regardless of how stale the follow-up read's
+  // OTHER fields might transiently be.
+  const freshRow = await getBrandById(organizationId, brandId, postgrestClient);
+  if (!freshRow) {
+    return null;
+  }
+  freshRow.baseSiteId = data.base_site?.id || data.site_id || null;
+  freshRow.baseUrl = data.base_site?.base_url || null;
+  return freshRow;
 }
 
 /**

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -1600,7 +1600,7 @@ export async function updateBrand({
   if (!freshRow) {
     return null;
   }
-  freshRow.baseSiteId = data.base_site?.id || data.site_id || null;
+  freshRow.baseSiteId = data.base_site?.id ?? data.site_id ?? null;
   freshRow.baseUrl = data.base_site?.base_url || null;
   return freshRow;
 }

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -2664,16 +2664,44 @@ describe('brands-storage', () => {
         brands: [
           // 1st call: select current row — brand anchored to OLD_SITE.
           { data: { site_id: 'old-primary-site-id', status: 'active' }, error: null },
-          // 2nd call: update succeeds.
-          { data: { id: BRAND_ID }, error: null },
-          // 3rd call: getBrandById re-fetch — site_id now NEW_SITE, and brand_sites
-          // still lists OLD_SITE + NEW_SITE + a third secondary (mirrors the live
-          // bug report: the target was already a secondary URL before the re-point).
+          // 2nd call: the UPDATE's own RETURNING (BRAND_SELECT embed) — what a real
+          // PostgREST `Prefer: return=representation` response looks like on this
+          // UPDATE. site_id now NEW_SITE, and brand_sites still lists OLD_SITE +
+          // NEW_SITE + a third secondary (mirrors the live bug report: the target
+          // was already a secondary URL before the re-point). This call is
+          // guaranteed to land on the writer (see updateBrand's comment), so — per
+          // the fix — updateBrand builds its result directly from THIS row when
+          // (as here) no child-table collection was touched by the same PATCH.
           {
             data: makeBrandRow({
               site_id: 'new-secondary-site-id',
+              base_site: { id: 'new-secondary-site-id', base_url: 'https://example.com' },
               status: 'active',
               updated_at: '2026-01-02T00:00:00Z',
+              brand_sites: [
+                { site_id: 'old-primary-site-id', paths: [], sites: { base_url: 'https://haha.com' } },
+                { site_id: 'new-secondary-site-id', paths: [], sites: { base_url: 'https://example.com' } },
+                { site_id: 'third-site-id', paths: [], sites: { base_url: 'https://you.com' } },
+              ],
+            }),
+            error: null,
+          },
+          // 3rd call: getBrandById re-fetch. Deliberately modeled as STALE — still
+          // shows the OLD site_id/updatedAt — to simulate the CONFIRMED production
+          // mechanism (serenity-docs#349 follow-up): this env's postgrestClient
+          // points at `data-svc-balanced.internal`, where a bare GET can be served
+          // by a lagging Aurora reader replica even though the write already
+          // committed on the writer. Because this PATCH touches no child-table
+          // collection, the fix never issues this call at all. If a future change
+          // reintroduced the old unconditional getBrandById() re-fetch, this stale
+          // fixture would make the assertions below fail — proving this test
+          // actually exercises the race, not just a mock that was never stale.
+          {
+            data: makeBrandRow({
+              site_id: 'old-primary-site-id',
+              base_site: { id: 'old-primary-site-id', base_url: 'https://haha.com' },
+              status: 'active',
+              updated_at: '2026-01-01T00:00:00Z',
               brand_sites: [
                 { site_id: 'old-primary-site-id', paths: [], sites: { base_url: 'https://haha.com' } },
                 { site_id: 'new-secondary-site-id', paths: [], sites: { base_url: 'https://example.com' } },
@@ -2852,9 +2880,13 @@ describe('brands-storage', () => {
     });
 
     it('normalizes brand guidance fields in update patch', async () => {
+      // No baseSiteId/status/expectedUpdatedAt here, so there is no pre-read: the
+      // 1st brands call IS the UPDATE's own RETURNING. Since this PATCH touches no
+      // child-table collection, updateBrand returns straight off this row (no
+      // follow-up read at all) — so it must already carry the applied values, the
+      // same way a real `Prefer: return=representation` response would.
       const client = createCapturingClient({
         brands: [
-          { data: { id: BRAND_ID }, error: null },
           {
             data: makeBrandRow({
               brand_context: null,
@@ -3057,11 +3089,13 @@ describe('brands-storage', () => {
     });
 
     it('handles non-string region values in updates', async () => {
+      // region-only patch: no child-table collection touched, so updateBrand
+      // returns straight off the UPDATE's own RETURNING row (1st/only brands call)
+      // — no follow-up read.
       const fullBrandRow = makeBrandRow({ regions: ['42'] });
 
       const postgrestClient = createTableMockClient({
         brands: [
-          { data: { id: BRAND_ID }, error: null },
           { data: fullBrandRow, error: null },
         ],
       });


### PR DESCRIPTION
## Summary

Live e2e testing on production found that `PATCH /v2/orgs/:orgId/brands/:brandId`
re-pointing `baseSiteId` to a site **already present in the same brand's own
`siteIds`** (as a secondary URL) returned a **500**
`{"code":"brand_repoint_not_persisted"}` — but a fresh page reload immediately
after showed the write had actually succeeded. 100% reproducible on the first
attempt, and this is a very natural, common user action (the whole point of the
site-picker UI is choosing among the brand's known/onboarded sites), so the
re-point feature (serenity-docs#349 / #3123) looked broken for exactly this case.

## Confirmed mechanism (not a guess)

`updateBrand()` (`src/support/brands-storage.js`) ran the actual `brands` UPDATE,
then built its return value from a **separate, independent** `getBrandById()`
read. Traced end-to-end:

- `dx_mysticat/prod/api-service`'s `POSTGREST_URL` (live Vault read) is
  `http://data-svc-balanced.internal` — the **read/write-splitting** host, not
  the writer-only canonical `data-svc.internal`.
- `mysticat-data-service`'s `modules/mysticat_data_service/reader.tf` (ALB
  listener rules) routes `GET/HEAD/OPTIONS` on that host to a **separate**
  PostgREST fleet reading Aurora's **reader** endpoint (`cluster_reader_endpoint`)
  — a real, independently-replicating replica — while every write (PATCH/POST/
  DELETE, including the UPDATE that persists the re-point) lands on the writer
  fleet against the writer endpoint.
- A GET issued immediately after the write (`getBrandById`'s plain
  `.select(BRAND_SELECT)`) can therefore be served by the reader before it
  replicates the just-committed write, returning pre-write data even though the
  write fully committed on the writer.
- #3131's new post-write verification check (merged, `850b0c3de`) then compared
  the requested `baseSiteId` against that stale read and — correctly per its own
  logic — treated the mismatch as a failed write, producing the false 500. #3131
  is doing exactly what it was built to do; the bug is the staleness of the data
  it's checking, not the check itself.

This is a genuine external (infra-level) read-after-write gap, not a defect in
this repo's write-path logic (the `409 siteUrlTaken` eligibility check, Semrush
propagate-before-persist ordering, `brand_stale_write` optimistic concurrency,
and the cross-org guard are all unaffected and unchanged by this PR).

## Fix

`updateBrand`'s primary `brands` UPDATE now selects the full `BRAND_SELECT`
embed (the same shape `getBrandById` reads) directly off its own
`Prefer: return=representation` response, instead of a bare `select('id')`.
This row is guaranteed writer-routed and therefore never stale — it comes back
on the very request that just committed the write.

- When the request touched **no child-table collection**
  (aliases/competitors/social/earned/urls) — the exact shape of the reported
  bug — `updateBrand` returns this row directly. **No follow-up read happens at
  all**, so there is no race to lose.
- When child tables **were** touched in the same PATCH, a follow-up
  `getBrandById` read is still unavoidable to pick up their state (that write
  happens in separate requests after the main UPDATE). For that case,
  `baseSiteId`/`baseUrl` are always overridden from the UPDATE's own row before
  returning, so the one field #3131's safety net actually gates on can never be
  stale, regardless of how fresh the follow-up read's other fields are.

A query-level fix (RETURNING from the write itself) was feasible here and is
what's implemented — no retry loop was needed.

## Test proving it

`test/support/brands-storage.test.js` — the existing "re-points baseSiteId to a
site that is already one of the brand's OWN secondary siteIds" test (added
during #3131 review) is now genuinely regression-proof: its `getBrandById`
follow-up fixture is deliberately set to **stale** data (old `site_id`/
`updated_at`) simulating a lagging reader. Confirmed this test **fails against
the pre-fix code** with the exact production symptom
(`expected 'old-primary-site-id' to equal 'new-secondary-site-id'`), and passes
with the fix, because the fix never issues that follow-up read for this call
shape. This is not a test that could only pass against a mock that was never
stale — it was verified to catch the original bug.

## Test plan

- [x] `npx mocha test/support/brands-storage.test.js` — 214 passing
- [x] `npx mocha test/controllers/brands.test.js test/support/brands-storage.test.js test/support/serenity/site-url-propagation.test.js test/support/serenity/mapping-rows.test.js` — 704 passing
- [x] `npm test` (full suite) — 17200 passing
- [x] `npx eslint src/support/brands-storage.js test/support/brands-storage.test.js` — clean
- [x] `npm run type-check` (base + strict) — clean
- [ ] IT suite (`test/it/postgres/**`) — not run locally (blocked by ECR auth for the postgres harness in this environment); CI will run it

Refs serenity-docs#349, #3123, #3131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```