### PR TITLE
feat(serenity): add brand-presence subreddits element endpoint

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -194,6 +194,8 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-access'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/sentiment-overview:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-sentiment-overview'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/subreddits:
+    $ref: './serenity-api.yaml#/v2-serenity-brand-presence-subreddits'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-topics'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics/{topicId}/prompts:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12651,6 +12651,7 @@ SerenityBrandPresenceSentimentOverview:
 SerenityBrandPresenceSubredditRow:
   type: object
   description: Per-subreddit Reddit stats for one (subreddit, project).
+  required: [subreddit, subredditKey, mentions, prompts, responsesWithCitations, threads, visibility]
   properties:
     subreddit:
       type: string

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12648,6 +12648,63 @@ SerenityBrandPresenceSentimentOverview:
             description: Stubbed empty (parity with the legacy contract).
             items: { type: object }
 
+SerenityBrandPresenceSubredditRow:
+  type: object
+  description: Per-subreddit Reddit stats for one (subreddit, project).
+  properties:
+    subreddit:
+      type: string
+      description: Subreddit display name (with the `r/` prefix).
+      example: 'r/Lovesac'
+    subredditKey:
+      type: string
+      description: Subreddit name without the `r/` prefix.
+      example: 'Lovesac'
+    link:
+      type: string
+      description: Subreddit link/handle as returned by the element.
+      example: 'r/Lovesac'
+    mentions:
+      type: integer
+      example: 4407
+    prompts:
+      type: integer
+      description: Number of prompts whose responses cited this subreddit.
+      example: 430
+    responsesWithCitations:
+      type: integer
+      example: 2603
+    threads:
+      type: integer
+      example: 1879
+    visibility:
+      type: number
+      format: float
+      description: Within-window visibility share for the subreddit (0..1).
+      example: 0.7477736282677392
+    projectId:
+      type: string
+      format: uuid
+      description: Semrush project the row belongs to.
+      example: 'cb4f6443-e01f-4075-a586-85511f136e31'
+
+SerenityBrandPresenceSubreddits:
+  type: object
+  description: |
+    Per-subreddit Reddit stats from the Semrush "Subreddits" element (faf56e29),
+    sorted by `mentions` descending (tie-broken by `subredditKey`) and paginated.
+    `totalCount` is the full pre-pagination row count. In workspace-wide mode (no
+    `projectId`) the same subreddit can appear once per project.
+  required: [subreddits, totalCount]
+  properties:
+    subreddits:
+      type: array
+      items:
+        $ref: '#/SerenityBrandPresenceSubredditRow'
+    totalCount:
+      type: integer
+      example: 107
+
 SerenityBrandPresenceTopics:
   type: object
   description: |

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1451,9 +1451,11 @@ v2-serenity-brand-presence-subreddits:
         in: query
         required: false
         description: |
-          Comma-separated Semrush project UUIDs to scope to (e.g.
-          `projectId=<uuid1>,<uuid2>`). Alias `project_id`. Omitted →
-          aggregate across the brand's markets. Maximum 8 ids; each must be a valid UUID (400 otherwise).
+          Comma-separated Semrush project UUIDs. Alias `project_id`. Omitted →
+          the element aggregates across all of the brand's markets. Each id must be a
+          valid UUID (400 otherwise). Note: this endpoint scopes to a SINGLE project —
+          only the first id is forwarded to the element; the rest are validated for
+          ownership but not used (multi-project merge is not implemented).
         schema: { type: string, pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}){0,7}$' }
       - name: project_id
         in: query

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1372,6 +1372,127 @@ v2-serenity-brand-presence-sentiment-overview:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
       '500': { $ref: './responses.yaml#/500' }
 
+v2-serenity-brand-presence-subreddits:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Per-subreddit Reddit stats for the Serenity brand presence dashboard
+    description: |
+      Returns per-subreddit Reddit stats (mentions, prompts, threads,
+      responses-with-citations, visibility) from the Semrush "Subreddits" element
+      (faf56e29). Rows are sorted by `mentions` descending (tie-broken by
+      `subredditKey`) and paginated server-side.
+
+      Brand-scoped via the brand's Semrush sub-workspace (resolved from `:brandId`).
+      A single upstream call: the element aggregates across the whole workspace when
+      no `projectId` is sent, and scopes to one project when it is. In workspace-wide
+      mode the same subreddit can appear once per project. `model`/`platform` are
+      translated to a Semrush model server-side.
+    operationId: listSerenityBrandPresenceSubreddits
+    security:
+      - session_token: []
+    parameters:
+      - name: startDate
+        in: query
+        required: true
+        description: Inclusive range start (YYYY-MM-DD). Range must not exceed 366 days.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        required: true
+        description: Inclusive range end (YYYY-MM-DD). Range must not exceed 366 days.
+        schema: { type: string, format: date }
+      - name: model
+        in: query
+        required: false
+        description: |
+          AI model to scope to. Accepts a Semrush Elements model name directly, or a
+          SpaceCat/UI platform code (translated server-side). Defaults to `search-gpt`
+          when omitted or unrecognized.
+        schema:
+          type: string
+          x-canonical-values:
+            - google-ai-mode
+            - grok-3
+            - google-ai-overview
+            - microsoft-copilot
+            - open-evidence
+            - gemini-2.5-flash
+            - claude-sonnet-4
+            - gpt-5
+            - deepseek
+            - search-gpt
+            - perplexity
+          x-known-aliases:
+            copilot: microsoft-copilot
+            gemini: gemini-2.5-flash
+            openai: gpt-5
+            chatgpt: search-gpt
+      - name: platform
+        in: query
+        required: false
+        description: Legacy alias for `model`; `model` takes precedence when both are given.
+        schema: { type: string }
+      - name: projectId
+        in: query
+        required: false
+        description: |
+          Comma-separated Semrush project UUIDs to scope to (e.g.
+          `projectId=<uuid1>,<uuid2>`). Alias `project_id`. Omitted →
+          aggregate across the brand's markets. Maximum 8 ids; each must be a valid UUID (400 otherwise).
+        schema: { type: string, pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}){0,7}$' }
+      - name: project_id
+        in: query
+        required: false
+        description: Snake_case alias for `projectId`.
+        schema: { type: string }
+      - name: page
+        in: query
+        required: false
+        description: 0-based page index. Defaults to 0.
+        schema: { type: integer, minimum: 0, default: 0 }
+      - name: pageSize
+        in: query
+        required: false
+        description: Page size (1..1000). Defaults to 50.
+        schema: { type: integer, minimum: 1, maximum: 1000, default: 50 }
+    responses:
+      '200':
+        description: Subreddit stats retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityBrandPresenceSubreddits' }
+      '400': { $ref: './responses.yaml#/400' }
+      '403':
+        description: Caller lacks access to the organization, or a supplied projectId is not owned by the brand.
+      '404':
+        description: Organization not found, brand not found for this organization, or the brand has no resolvable Semrush workspace.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '503':
+        description: PostgREST client not available (required to resolve the brand's Semrush workspace before the element call).
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
 v2-serenity-brand-presence-topics:
   parameters:
     - name: spaceCatId

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -841,6 +841,72 @@ export default function ElementsController(context, log, env) {
   /* c8 ignore stop */
 
   /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits
+   * Returns per-subreddit Reddit stats (mentions, prompts, threads, visibility,
+   * responses-with-citations) from the Subreddits element (faf56e29). Single upstream
+   * call (the element aggregates workspace-wide; a supplied projectId scopes to one project).
+   */
+  /* c8 ignore start -- SITES-POC subreddits endpoint; unit tests intentionally deferred */
+  const listSubreddits = async (ctx) => {
+    try {
+      const auth = await authorizeOrg(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { workspaceId, brand } = auth;
+      const query = extractQuery(ctx);
+
+      // Date range is required + validated (mirrors cited-domains/sentiment-overview) —
+      // never silently default to a rolling window nor forward a malformed date to Semrush.
+      const startDate = query.startDate || query.start_date;
+      const endDate = query.endDate || query.end_date;
+      if (!hasText(startDate) || !hasText(endDate)) {
+        return badRequest('startDate and endDate are required (YYYY-MM-DD)');
+      }
+      if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+        return badRequest('startDate and endDate must be valid YYYY-MM-DD dates');
+      }
+      if (startDate > endDate) {
+        return badRequest('startDate must not be after endDate');
+      }
+      const MAX_RANGE_DAYS = 366;
+      const spanDays = (Date.parse(`${endDate}T00:00:00Z`)
+        - Date.parse(`${startDate}T00:00:00Z`)) / 86400000;
+      if (spanDays > MAX_RANGE_DAYS) {
+        return badRequest(`Date range must not exceed ${MAX_RANGE_DAYS} days`);
+      }
+
+      const service = await buildService(ctx);
+
+      // Project scoping: caller-supplied projectId(s) (CSV) scope to a single Semrush
+      // project (the service uses the first); absent → the element aggregates across all of
+      // the brand's markets. Any supplied id must belong to this brand.
+      const projectIds = extractProjectIds(query);
+      const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+      const brandSemrushProjects = await fetchBrandSemrushProjects(BrandSemrushProject, [brand]);
+      const ownershipError = checkProjectIdsOwnership(projectIds, brandSemrushProjects);
+      if (ownershipError) {
+        return ownershipError;
+      }
+
+      const params = {
+        projectIds,
+        model: query.model || query.platform,
+        startDate,
+        endDate,
+        page: query.page,
+        pageSize: query.pageSize,
+      };
+
+      const result = await service.getSubreddits(workspaceId, params);
+      return ok(result);
+    } catch (e) {
+      return mapError(e, log, reqCtxOf(ctx));
+    }
+  };
+  /* c8 ignore stop */
+
+  /**
    * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview
    * Returns per-week brand sentiment (positive/neutral/negative percentages) sourced from
    * the Semrush Sentiment element, in the legacy `{ weeklyTrends: [...] }` contract so the
@@ -1981,6 +2047,7 @@ export default function ElementsController(context, log, env) {
     checkAccess,
     listPrompts,
     listCitedDomains,
+    listSubreddits,
     listSentimentOverview,
     listTopics,
     listTopicPrompts,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -888,6 +888,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -266,6 +266,9 @@ export default function getRouteHandlers(
     // eslint-disable-next-line max-len
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': elementsController.listCitedDomains,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': elementsController.listSentimentOverview,
+    // Per-subreddit Reddit stats (Subreddits element faf56e29).
+    // eslint-disable-next-line max-len
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': elementsController.listSubreddits,
     // Data Insights per-topic table (grouped from the prompts-by-topic element).
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': elementsController.listTopics,
     // Data Insights per-prompt drill-down: :topicId is the URL-encoded topic NAME.

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -327,6 +327,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'brand:read',

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -33,6 +33,7 @@ export {
 export {
   buildCitedDomainsPayload, transformCitedDomainsResponse, transformCitedDomainsResponses,
 } from './cited-domains.js';
+export { buildSubredditsPayload, transformSubredditsResponse } from './subreddits.js';
 export { buildTopicPromptsPayload, transformTopicPromptsResponse } from './topic-prompts.js';
 export { aggregateTopicsFromPrompts } from './topics-insights.js';
 export {

--- a/src/support/elements/definitions/subreddits.js
+++ b/src/support/elements/definitions/subreddits.js
@@ -12,21 +12,7 @@
 
 import { resolveElementModel } from '../constants.js';
 
-// Legacy default window is a rolling 28 days (mirrors cited-domains). Kept inline so this
-// definition stays pure and does not import controller code.
-const DEFAULT_WINDOW_DAYS = 28;
-
 /* c8 ignore start -- SITES-POC subreddits endpoint; unit tests intentionally deferred */
-function defaultDateRange() {
-  const end = new Date();
-  const start = new Date();
-  start.setDate(start.getDate() - DEFAULT_WINDOW_DAYS);
-  return {
-    startDate: start.toISOString().slice(0, 10),
-    endDate: end.toISOString().slice(0, 10),
-  };
-}
-
 /**
  * Builds the payload for the Subreddits element (faf56e29). The element is a `table`
  * returning one row per (subreddit, project) with mentions/prompts/threads/
@@ -48,8 +34,9 @@ function defaultDateRange() {
  * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
  *   code). Translated + validated via {@link resolveElementModel}.
  * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
- * @param {string} [params.startDate] - ISO date (YYYY-MM-DD). Defaults to 28 days ago.
- * @param {string} [params.endDate] - ISO date (YYYY-MM-DD). Defaults to today.
+ * @param {string} params.startDate - ISO date (YYYY-MM-DD). Required — the controller
+ *   validates it and rejects a missing/invalid range with 400, so there is no default here.
+ * @param {string} params.endDate - ISO date (YYYY-MM-DD). Required (see startDate).
  * @param {string} [params.projectId] - Semrush project id to scope to (top-level +
  *   simple). Omitted → all of the workspace's projects.
  */
@@ -57,14 +44,11 @@ export function buildSubredditsPayload({
   model, platform, startDate, endDate, projectId,
 } = {}) {
   const resolvedModel = resolveElementModel(model || platform);
-  const defaults = defaultDateRange();
-  const start = startDate || defaults.startDate;
-  const end = endDate || defaults.endDate;
 
   const advancedFilters = [
     { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
-    { op: 'gte', val: start, col: 'CBF_date__start' },
-    { op: 'lte', val: end, col: 'CBF_date__end' },
+    { op: 'gte', val: startDate, col: 'CBF_date__start' },
+    { op: 'lte', val: endDate, col: 'CBF_date__end' },
   ];
 
   return {

--- a/src/support/elements/definitions/subreddits.js
+++ b/src/support/elements/definitions/subreddits.js
@@ -32,8 +32,8 @@ import { resolveElementModel } from '../constants.js';
  *
  * @param {object} [params]
  * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
- *   code). Translated + validated via {@link resolveElementModel}.
- * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
+ *   code), translated + validated via {@link resolveElementModel}. Omitted or unknown →
+ *   defaults to `search-gpt` (the resolver's fallback), consistent with sibling definitions.
  * @param {string} params.startDate - ISO date (YYYY-MM-DD). Required — the controller
  *   validates it and rejects a missing/invalid range with 400, so there is no default here.
  * @param {string} params.endDate - ISO date (YYYY-MM-DD). Required (see startDate).
@@ -41,9 +41,9 @@ import { resolveElementModel } from '../constants.js';
  *   simple). Omitted → all of the workspace's projects.
  */
 export function buildSubredditsPayload({
-  model, platform, startDate, endDate, projectId,
+  model, startDate, endDate, projectId,
 } = {}) {
-  const resolvedModel = resolveElementModel(model || platform);
+  const resolvedModel = resolveElementModel(model);
 
   const advancedFilters = [
     { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
@@ -79,8 +79,9 @@ function parsePagination({ page, pageSize } = {}) {
  *                    responsesWithCitations, threads, visibility, projectId }], totalCount }
  *
  * Numeric fields use `Number(x) || 0` (not `Number(x ?? 0)`) so a non-numeric value coerces
- * to 0 instead of NaN. Rows are sorted by `mentions` descending, then paginated client-side
- * (Semrush has no server-side paging); `totalCount` is the pre-slice row count.
+ * to 0 instead of NaN. Rows are sorted by `mentions` descending, tie-broken by `subredditKey`
+ * so pagination is deterministic when counts are equal, then paginated client-side (Semrush
+ * has no server-side paging); `totalCount` is the pre-slice row count.
  *
  * @param {object} raw - Raw response from the Elements API.
  * @param {object} [params] - Query params (page, pageSize).
@@ -100,7 +101,7 @@ export function transformSubredditsResponse(raw, params = {}) {
       visibility: Number(row.visibility) || 0,
       projectId: row.project_id || '',
     }))
-    .sort((a, b) => b.mentions - a.mentions);
+    .sort((a, b) => b.mentions - a.mentions || a.subredditKey.localeCompare(b.subredditKey));
 
   const { page, pageSize } = parsePagination(params);
   const totalCount = rows.length;

--- a/src/support/elements/definitions/subreddits.js
+++ b/src/support/elements/definitions/subreddits.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+
+// Legacy default window is a rolling 28 days (mirrors cited-domains). Kept inline so this
+// definition stays pure and does not import controller code.
+const DEFAULT_WINDOW_DAYS = 28;
+
+/* c8 ignore start -- SITES-POC subreddits endpoint; unit tests intentionally deferred */
+function defaultDateRange() {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - DEFAULT_WINDOW_DAYS);
+  return {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  };
+}
+
+/**
+ * Builds the payload for the Subreddits element (faf56e29). The element is a `table`
+ * returning one row per (subreddit, project) with mentions/prompts/threads/
+ * responses_with_citations/visibility over the given window.
+ *
+ * Quirks (verified against a live call, 2026-08-25):
+ *  - Date range is `CBF_date__start`/`CBF_date__end` in the `advanced` block; `CBF_model`
+ *    sits inside an `or` block within `advanced`.
+ *  - `project_id` is OPTIONAL. Supplied → scope to that one project (set on BOTH the
+ *    top-level and `filters.simple`, mirroring the discovery payload). Omitted → the
+ *    element aggregates across ALL of the workspace's projects (so no per-project fan-out
+ *    is needed here, unlike cited-domains). An absent project leaves `simple` as `{}`,
+ *    which the element accepts.
+ *  - The comparison-date columns (`CBF_date__*_comparison`) are a no-op for this element
+ *    (byte-identical output with and without) — deliberately omitted.
+ *  - Brand scoping is via the request's sub-workspace, not a filter.
+ *
+ * @param {object} [params]
+ * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
+ *   code). Translated + validated via {@link resolveElementModel}.
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
+ * @param {string} [params.startDate] - ISO date (YYYY-MM-DD). Defaults to 28 days ago.
+ * @param {string} [params.endDate] - ISO date (YYYY-MM-DD). Defaults to today.
+ * @param {string} [params.projectId] - Semrush project id to scope to (top-level +
+ *   simple). Omitted → all of the workspace's projects.
+ */
+export function buildSubredditsPayload({
+  model, platform, startDate, endDate, projectId,
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  const defaults = defaultDateRange();
+  const start = startDate || defaults.startDate;
+  const end = endDate || defaults.endDate;
+
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+    { op: 'gte', val: start, col: 'CBF_date__start' },
+    { op: 'lte', val: end, col: 'CBF_date__end' },
+  ];
+
+  return {
+    ...(projectId && { project_id: projectId }),
+    comparison_data_formatting: 'union',
+    filters: {
+      simple: { ...(projectId && { project_id: projectId }) },
+      advanced: { op: 'and', filters: advancedFilters },
+    },
+  };
+}
+
+/**
+ * Parses the pagination params (0-based `page`, `pageSize`), mirroring cited-domains
+ * (default 50, clamped to [1, 1000]).
+ */
+function parsePagination({ page, pageSize } = {}) {
+  return {
+    page: Math.max(0, Number.parseInt(page, 10) || 0),
+    pageSize: Math.min(Math.max(1, Number.parseInt(pageSize, 10) || 50), 1000),
+  };
+}
+
+/**
+ * Transforms the raw Subreddits element response (`table`, rows in `blocks.data`) into a
+ * normalized, camelCased contract:
+ *   { subreddits: [{ subreddit, subredditKey, link, mentions, prompts,
+ *                    responsesWithCitations, threads, visibility, projectId }], totalCount }
+ *
+ * Numeric fields use `Number(x) || 0` (not `Number(x ?? 0)`) so a non-numeric value coerces
+ * to 0 instead of NaN. Rows are sorted by `mentions` descending, then paginated client-side
+ * (Semrush has no server-side paging); `totalCount` is the pre-slice row count.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @param {object} [params] - Query params (page, pageSize).
+ * @returns {{ subreddits: Array<object>, totalCount: number }}
+ */
+export function transformSubredditsResponse(raw, params = {}) {
+  const rows = (raw?.blocks?.data ?? [])
+    .filter((row) => row && row.subreddit != null)
+    .map((row) => ({
+      subreddit: row.subreddit || '',
+      subredditKey: row.subreddit_key || '',
+      link: row.link || '',
+      mentions: Number(row.mentions) || 0,
+      prompts: Number(row.prompts) || 0,
+      responsesWithCitations: Number(row.responses_with_citations) || 0,
+      threads: Number(row.threads) || 0,
+      visibility: Number(row.visibility) || 0,
+      projectId: row.project_id || '',
+    }))
+    .sort((a, b) => b.mentions - a.mentions);
+
+  const { page, pageSize } = parsePagination(params);
+  const totalCount = rows.length;
+  const offset = page * pageSize;
+  return { subreddits: rows.slice(offset, offset + pageSize), totalCount };
+}
+/* c8 ignore stop */

--- a/src/support/elements/element-ids.js
+++ b/src/support/elements/element-ids.js
@@ -35,6 +35,14 @@ export const ELEMENT_IDS = Object.freeze({
   // Brand scoping is via the request's sub-workspace, not a filter (`CBF_ws_brand` is a no-op).
   CITED_DOMAINS: '98b91d00-9531-4120-b3b5-17cc27489fce',
 
+  // Subreddits — per-subreddit Reddit stats (`table`), one row per (subreddit, project):
+  // { subreddit, subreddit_key, link, mentions, prompts, responses_with_citations,
+  //   threads, visibility, project_id }. Honors date (`CBF_date__start`/`__end`) + `CBF_model`.
+  // Optional top-level `project_id` — omit → workspace-wide across ALL projects (verified
+  // live: omitted returns every project's rows; supplied scopes to that one). Brand scoping
+  // is via the request's sub-workspace, not a filter.
+  SUBREDDITS: 'faf56e29-ddda-4480-b639-586d526c9080',
+
   // URL Inspector — Owned URLs ("Your cited URLs" table). Two elements, both
   // scoped by a top-level `project_id` (region/market) + date + `CBF_model`;
   // neither honors a server-side content-type filter, so `domain_type='Owned'`

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -41,6 +41,8 @@ import {
   buildCitedDomainsPayload,
   transformCitedDomainsResponse,
   transformCitedDomainsResponses,
+  buildSubredditsPayload,
+  transformSubredditsResponse,
   buildTopicPromptsPayload,
   transformTopicPromptsResponse,
   aggregateTopicsFromPrompts,
@@ -325,6 +327,32 @@ export function createElementsService(transport, log) {
         buildCitedDomainsPayload({ ...rest, projectId: ids[0] }),
       );
       return transformCitedDomainsResponse(raw, rest);
+    },
+
+    /**
+     * Fetches per-subreddit Reddit stats from the Subreddits element (faf56e29),
+     * normalized into `{ subreddits: [...], totalCount }`. (Inside the surrounding
+     * c8-ignore region — same POC coverage treatment as the sibling methods here.)
+     *
+     * Single call (no per-project fan-out): the element aggregates across ALL of the
+     * workspace's projects when no `project_id` is supplied (verified live). A
+     * caller-supplied project id scopes to that one project. `projectIds` (a CSV the
+     * controller already parsed + ownership-checked) is narrowed to its first id here.
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} params - Query params (model/platform, startDate, endDate,
+     *   projectIds, page, pageSize).
+     * @returns {Promise<{ subreddits: object[], totalCount: number }>}
+     */
+    async getSubreddits(workspaceId, params) {
+      const { projectIds, ...rest } = params;
+      const projectId = Array.isArray(projectIds) ? projectIds.find(hasText) : undefined;
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.SUBREDDITS,
+        buildSubredditsPayload({ ...rest, projectId }),
+      );
+      return transformSubredditsResponse(raw, rest);
     },
 
     /**

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -458,6 +458,31 @@ const FIXTURES = {
       }],
     },
   },
+  listSerenityBrandPresenceSubreddits: {
+    expectedStatus: 200,
+    usesElementsController: true,
+    controllerMethod: 'listSubreddits',
+    serviceMethod: 'getSubreddits',
+    // startDate/endDate are required + validated by the controller before the
+    // service is called (see listSubreddits) — supply them via query.
+    query: { startDate: '2026-06-01', endDate: '2026-07-16' },
+    // getSubreddits returns the final { subreddits, totalCount } shape; the
+    // controller passes it straight through via ok().
+    handlerResult: {
+      subreddits: [{
+        subreddit: 'r/Lovesac',
+        subredditKey: 'Lovesac',
+        link: 'r/Lovesac',
+        mentions: 4407,
+        prompts: 430,
+        responsesWithCitations: 2603,
+        threads: 1879,
+        visibility: 0.7477736282677392,
+        projectId: 'cb4f6443-e01f-4075-a586-85511f136e31',
+      }],
+      totalCount: 107,
+    },
+  },
   listSerenityBrandPresenceTopics: {
     expectedStatus: 200,
     usesElementsController: true,

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1022,6 +1022,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls',


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a new read-only Serenity Brand Presence endpoint that returns per-subreddit Reddit stats from Semrush: `GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits`.

## 2. Reasoning
The Brand Presence surface needs subreddit-level Reddit data (which subreddits cite a brand, and how much). Semrush exposes this as a new Elements API element (`faf56e29`). This is a Barcelona hackathon POC to wire that element into spacecat behind the existing brand-presence proxy so the UI can consume it through the same auth and workspace-resolution path as the other panels.

## 3. High-level overview of the changes
Before: no way to fetch subreddit-level Reddit metrics through spacecat.

After: one new GET route returns a normalized table of subreddits with their metrics.

- Route `…/serenity/brand-presence/subreddits` → `elementsController.listSubreddits`, a sibling of the existing brand-presence element endpoints. It reuses the same machinery: `authorizeOrg` (brand + org access, sub-workspace resolution), the promise-token / IMS auth flow via `buildService`, and project-ownership checks.
- Requires a validated `startDate`/`endDate` (YYYY-MM-DD, ≤366 days). Optional `model`/`platform` and `projectId`(s).
- A single upstream Elements call. The Semrush element aggregates across the whole workspace when no `project_id` is sent, and scopes to one project when it is — so there is no per-project fan-out (unlike cited-domains). The comparison-date columns the discovery payload carried are a verified no-op and are omitted.
- Response is normalized to `{ subreddits: [{ subreddit, subredditKey, link, mentions, prompts, responsesWithCitations, threads, visibility, projectId }], totalCount }`, sorted by mentions descending and paginated server-side (client-side slice, since Semrush has no paging).
- New route is classified `llmo/can_view` in the FACS capability map; the path is static and `:brandId`/`:spaceCatId` are already classified, so no param-classification change.

This is a POC: no unit or integration tests; the new handler, service method, and definition are wrapped in `c8-ignore`, matching every other brand-presence POC endpoint.

## 4. Required information
- None — hackathon POC, no Jira ticket or spec doc. Approach was captured in a local implementation plan only.

## 6. Affected / used mysticat-workspace projects
- project-elmo-ui — intended future consumer of this endpoint (contract). Not wired in this PR; the UI panel that renders subreddit data is a separate follow-up.

## 7. Additional information outside the code
- Verified the endpoint end-to-end live against the real Semrush element (workspace `3cbb3c36…`) using the repo's own transport + service with a valid Semrush access token, exercising the actual `getSubreddits` path:
  - No `project_id` → the element aggregates workspace-wide (107 rows across 2 projects).
  - With `project_id` → scoped to that one project.
  - Confirmed the comparison-date columns produce byte-identical output, so they were dropped.
- Known gap unrelated to this change: in this worktree the controller test tier cannot load because the installed `@adobe/spacecat-shared-utils` was stale and did not export `siteIdentityFromUrlString` (imported by pre-existing `src/controllers/*` and `src/support/serenity/*`). Reinstalling the pinned `1.126.0` restores the export; flagging so a reviewer running tests locally hits the same and knows the fix.
- Behaviour note for reviewers: in workspace-wide mode the same subreddit can appear once per project (rows are per `(subreddit, project)`). Cross-project merging is intentionally deferred for the POC.

## 8. Test plan
(a) Local end-to-end: called `getSubreddits` against the live Semrush element via the repo transport (see section 7) and confirmed the `{ subreddits, totalCount }` shape and both scoping modes.

(b) Verify on dev:
- Deploy the branch (or hit the running dev API) and call:
  `GET /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/subreddits?startDate=2026-07-27&endDate=2026-08-25`
  with a Serenity-active brand and a valid `x-promise-token` (or IMS bearer).
- Expect `200` with a `subreddits` array (sorted by mentions desc) and `totalCount`.
- Add `&projectId={id}` and confirm results narrow to that project; a `projectId` not owned by the brand returns `403`; a missing/invalid date range returns `400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi", "Vivek Singh"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```