### PR TITLE
fix: revoke suggestion grants when a suggestion is deleted

### DIFF
--- a/src/controllers/opportunities.js
+++ b/src/controllers/opportunities.js
@@ -380,6 +380,11 @@ function OpportunitiesController(ctx) {
 
     try {
       await revokeGrantsForOpportunity(dataAccess, opportunity);
+    } catch (revokeError) {
+      ctx.log?.warn?.(`Failed to revoke grants for opportunity ${opportunityId} on site ${siteId}`, revokeError?.message ?? revokeError);
+    }
+
+    try {
       await opportunity.remove(); // also removes suggestions associated with opportunity
       return noContent();
     } catch (e) {

--- a/src/controllers/opportunities.js
+++ b/src/controllers/opportunities.js
@@ -33,6 +33,7 @@ import AccessControlUtil from '../support/access-control-util.js';
 import {
   grantSuggestionsForOpportunity,
   revokeExistingGrants,
+  revokeGrantsForOpportunity,
 } from '../support/grant-suggestions-handler.js';
 import { getIsSummitPlgEnabled } from '../support/utils.js';
 
@@ -378,6 +379,7 @@ function OpportunitiesController(ctx) {
     }
 
     try {
+      await revokeGrantsForOpportunity(dataAccess, opportunity);
       await opportunity.remove(); // also removes suggestions associated with opportunity
       return noContent();
     } catch (e) {

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1735,6 +1735,11 @@ function SuggestionsController(ctx, sqs, env) {
 
     try {
       await revokeGrantsForSuggestions(SuggestionGrant, [suggestionId]);
+    } catch (revokeError) {
+      context.log.warn(`Failed to revoke grants for suggestion ${suggestionId}`, revokeError?.message ?? revokeError);
+    }
+
+    try {
       await suggestion.remove();
       return noContent();
     } catch (e) {

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -66,7 +66,10 @@ import {
 import AccessControlUtil, { X_PRODUCT_HEADER } from '../support/access-control-util.js';
 import { redactFeedbackContent } from '../support/feedback-redaction.js';
 import { CAP_FIX_ENTITY_CREATE, CAP_SUGGESTION_WRITE } from '../routes/capability-constants.js';
-import { grantSuggestionsForOpportunity } from '../support/grant-suggestions-handler.js';
+import {
+  grantSuggestionsForOpportunity,
+  revokeGrantsForSuggestions,
+} from '../support/grant-suggestions-handler.js';
 import { postSlackMessage } from '../utils/slack/base.js';
 import { createAtomicStrategy, deleteAtomicStrategy } from '../support/atomic-strategy-helper.js';
 
@@ -1731,6 +1734,7 @@ function SuggestionsController(ctx, sqs, env) {
     }
 
     try {
+      await revokeGrantsForSuggestions(SuggestionGrant, [suggestionId]);
       await suggestion.remove();
       return noContent();
     } catch (e) {

--- a/src/support/grant-suggestions-handler.js
+++ b/src/support/grant-suggestions-handler.js
@@ -228,6 +228,45 @@ async function revokeGrants(SuggestionGrant, grantIds) {
 }
 
 /**
+ * Revokes any active grants tied to the given suggestion IDs — used when suggestions are
+ * deleted (individually, or cascaded via an opportunity delete) so a removed suggestion
+ * doesn't leave an orphaned grant still counted against the site's token budget (SITES-50360).
+ *
+ * @param {Object} SuggestionGrant - SuggestionGrant collection.
+ * @param {string[]} suggestionIds - Suggestion IDs being deleted.
+ * @returns {Promise<void>}
+ */
+export async function revokeGrantsForSuggestions(SuggestionGrant, suggestionIds) {
+  if (!suggestionIds?.length) {
+    return;
+  }
+  const rows = await SuggestionGrant.findBySuggestionIds(suggestionIds);
+  const grantIds = [...new Set(rows.map((r) => r.grant_id))];
+  await revokeGrants(SuggestionGrant, grantIds);
+}
+
+/**
+ * Revokes grants for every suggestion under an opportunity — used before a cascading
+ * opportunity delete removes all its suggestions (SITES-50360).
+ *
+ * @param {Object} dataAccess - Data access collections.
+ * @param {Object} opportunity - Opportunity model (getId()).
+ * @returns {Promise<void>}
+ */
+export async function revokeGrantsForOpportunity(dataAccess, opportunity) {
+  const { Suggestion, SuggestionGrant } = dataAccess ?? {};
+  const opptyId = opportunity?.getId();
+
+  if (!Suggestion || !SuggestionGrant || !opptyId) {
+    return;
+  }
+
+  const suggestions = await Suggestion.allByOpportunityId(opptyId);
+  const suggestionIds = suggestions.map((s) => s.getId());
+  await revokeGrantsForSuggestions(SuggestionGrant, suggestionIds);
+}
+
+/**
  * Revokes outstanding grants for an opportunity's suggestions that are still
  * in NEW status (i.e. never applied/approved) — used when an opportunity
  * moves to a terminal RESOLVED state so a superseding opportunity of the

--- a/test/controllers/opportunities.test.js
+++ b/test/controllers/opportunities.test.js
@@ -185,6 +185,8 @@ describe('Opportunities Controller', () => {
 
   let mockOpportunityDataAccess;
   let mockOpportunity;
+  let mockOpportunitySuggestion;
+  let mockOpportunitySuggestionGrant;
   let opportunitiesController;
   let mockSite;
   let mockContext;
@@ -228,9 +230,20 @@ describe('Opportunities Controller', () => {
       }),
     };
 
+    mockOpportunitySuggestion = {
+      allByOpportunityId: sandbox.stub().resolves([]),
+    };
+
+    mockOpportunitySuggestionGrant = {
+      findBySuggestionIds: sandbox.stub().resolves([]),
+      revokeSuggestionGrant: sandbox.stub().resolves({ success: true }),
+    };
+
     mockOpportunityDataAccess = {
       Opportunity: mockOpportunity,
       Site: mockSite,
+      Suggestion: mockOpportunitySuggestion,
+      SuggestionGrant: mockOpportunitySuggestionGrant,
     };
 
     mockContext = {
@@ -1010,6 +1023,54 @@ describe('Opportunities Controller', () => {
     expect(response.status).to.equal(404);
     const error = await response.json();
     expect(error).to.have.property('message', 'Opportunity not found');
+  });
+
+  it('revokes grants for the opportunity\'s suggestions before removing it', async () => {
+    const s1 = { getId: () => 'sugg-1' };
+    mockOpportunitySuggestion.allByOpportunityId.resolves([s1]);
+    mockOpportunitySuggestionGrant.findBySuggestionIds.resolves([
+      { suggestion_id: 'sugg-1', grant_id: 'grant-1' },
+    ]);
+    const removeSpy = sandbox.spy(mockOpptyEntity, 'remove');
+    const response = await opportunitiesController.removeOpportunity({
+      params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+      data: {},
+    });
+    expect(response.status).to.equal(204);
+    expect(mockOpportunitySuggestion.allByOpportunityId).to.have.been.calledOnceWith(
+      OPPORTUNITY_ID,
+    );
+    expect(mockOpportunitySuggestionGrant.revokeSuggestionGrant)
+      .to.have.been.calledOnceWith('grant-1');
+    expect(mockOpportunitySuggestionGrant.revokeSuggestionGrant)
+      .to.have.been.calledBefore(removeSpy);
+  });
+
+  it('removes an opportunity with no suggestions without attempting a revoke', async () => {
+    const response = await opportunitiesController.removeOpportunity({
+      params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+      data: {},
+    });
+    expect(response.status).to.equal(204);
+    expect(mockOpportunitySuggestionGrant.revokeSuggestionGrant).to.not.have.been.called;
+  });
+
+  it('returns 500 and does not remove the opportunity when revoking its grants fails', async () => {
+    const s1 = { getId: () => 'sugg-1' };
+    mockOpportunitySuggestion.allByOpportunityId.resolves([s1]);
+    mockOpportunitySuggestionGrant.findBySuggestionIds.resolves([
+      { suggestion_id: 'sugg-1', grant_id: 'grant-1' },
+    ]);
+    mockOpportunitySuggestionGrant.revokeSuggestionGrant.rejects(new Error('rpc failure'));
+    const removeSpy = sandbox.spy(mockOpptyEntity, 'remove');
+    const response = await opportunitiesController.removeOpportunity({
+      params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+      data: {},
+    });
+    expect(response.status).to.equal(500);
+    const error = await response.json();
+    expect(error).to.have.property('message', 'Error removing opportunity');
+    expect(removeSpy).to.not.have.been.called;
   });
 
   it('returns 500 when removing an opportunity if there is a data access layer error', async () => {

--- a/test/controllers/opportunities.test.js
+++ b/test/controllers/opportunities.test.js
@@ -1055,7 +1055,7 @@ describe('Opportunities Controller', () => {
     expect(mockOpportunitySuggestionGrant.revokeSuggestionGrant).to.not.have.been.called;
   });
 
-  it('returns 500 and does not remove the opportunity when revoking its grants fails', async () => {
+  it('still removes the opportunity and logs a warning when revoking its grants fails', async () => {
     const s1 = { getId: () => 'sugg-1' };
     mockOpportunitySuggestion.allByOpportunityId.resolves([s1]);
     mockOpportunitySuggestionGrant.findBySuggestionIds.resolves([
@@ -1067,10 +1067,9 @@ describe('Opportunities Controller', () => {
       params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
       data: {},
     });
-    expect(response.status).to.equal(500);
-    const error = await response.json();
-    expect(error).to.have.property('message', 'Error removing opportunity');
-    expect(removeSpy).to.not.have.been.called;
+    expect(response.status).to.equal(204);
+    expect(removeSpy).to.have.been.calledOnce;
+    expect(mockContext.log.warn).to.have.been.calledOnce;
   });
 
   it('returns 500 when removing an opportunity if there is a data access layer error', async () => {

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -7019,7 +7019,7 @@ describe('Suggestions Controller', () => {
       expect(removeStub).to.have.been.calledOnce;
     });
 
-    it('returns internal server error and does not remove the suggestion when revoke fails', async () => {
+    it('still removes the suggestion and logs a warning when revoking its grant fails', async () => {
       mockSuggestionGrant.findBySuggestionIds.resolves([
         { suggestion_id: SUGGESTION_IDS[0], grant_id: 'grant-1' },
       ]);
@@ -7032,10 +7032,9 @@ describe('Suggestions Controller', () => {
         },
         ...context,
       });
-      expect(response.status).to.equal(500);
-      const errorResponse = await response.json();
-      expect(errorResponse).to.have.property('message', 'Error removing suggestion');
-      expect(removeStub).to.not.have.been.called;
+      expect(response.status).to.equal(204);
+      expect(removeStub).to.have.been.calledOnce;
+      expect(context.log.warn).to.have.been.calledOnce;
     });
   });
 

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -490,6 +490,7 @@ describe('Suggestions Controller', () => {
       }),
       isSuggestionGranted: sandbox.stub().resolves(true),
       revokeSuggestionGrant: sandbox.stub().resolves({ success: true, revokedCount: 1 }),
+      findBySuggestionIds: sandbox.stub().resolves([]),
     };
 
     mockSuggestionDataAccess = {
@@ -6980,6 +6981,61 @@ describe('Suggestions Controller', () => {
       expect(mockSuggestionDataAccess.Suggestion.findById).to.have.been.calledOnce;
       expect(mockSuggestionDataAccess.Opportunity.findById).to.have.been.calledOnce;
       expect(removeStub).to.have.been.calledOnce;
+    });
+
+    it('revokes an existing grant before removing the suggestion', async () => {
+      mockSuggestionGrant.findBySuggestionIds.resolves([
+        { suggestion_id: SUGGESTION_IDS[0], grant_id: 'grant-1' },
+      ]);
+      const response = await suggestionsController.removeSuggestion({
+        params: {
+          siteId: SITE_ID,
+          opportunityId: OPPORTUNITY_ID,
+          suggestionId: SUGGESTION_IDS[0],
+        },
+        ...context,
+      });
+      expect(response.status).to.equal(204);
+      expect(mockSuggestionGrant.findBySuggestionIds).to.have.been.calledOnceWith(
+        [SUGGESTION_IDS[0]],
+      );
+      expect(mockSuggestionGrant.revokeSuggestionGrant).to.have.been.calledOnceWith('grant-1');
+      expect(mockSuggestionGrant.revokeSuggestionGrant)
+        .to.have.been.calledBefore(removeStub);
+      expect(removeStub).to.have.been.calledOnce;
+    });
+
+    it('removes the suggestion without revoking when it has no grant', async () => {
+      const response = await suggestionsController.removeSuggestion({
+        params: {
+          siteId: SITE_ID,
+          opportunityId: OPPORTUNITY_ID,
+          suggestionId: SUGGESTION_IDS[0],
+        },
+        ...context,
+      });
+      expect(response.status).to.equal(204);
+      expect(mockSuggestionGrant.revokeSuggestionGrant).to.not.have.been.called;
+      expect(removeStub).to.have.been.calledOnce;
+    });
+
+    it('returns internal server error and does not remove the suggestion when revoke fails', async () => {
+      mockSuggestionGrant.findBySuggestionIds.resolves([
+        { suggestion_id: SUGGESTION_IDS[0], grant_id: 'grant-1' },
+      ]);
+      mockSuggestionGrant.revokeSuggestionGrant.rejects(new Error('rpc failure'));
+      const response = await suggestionsController.removeSuggestion({
+        params: {
+          siteId: SITE_ID,
+          opportunityId: OPPORTUNITY_ID,
+          suggestionId: SUGGESTION_IDS[0],
+        },
+        ...context,
+      });
+      expect(response.status).to.equal(500);
+      const errorResponse = await response.json();
+      expect(errorResponse).to.have.property('message', 'Error removing suggestion');
+      expect(removeStub).to.not.have.been.called;
     });
   });
 

--- a/test/support/grant-suggestions-handler.test.js
+++ b/test/support/grant-suggestions-handler.test.js
@@ -18,6 +18,8 @@ import {
   getTopSuggestions,
   grantSuggestionsForOpportunity,
   revokeExistingGrants,
+  revokeGrantsForSuggestions,
+  revokeGrantsForOpportunity,
 } from '../../src/support/grant-suggestions-handler.js';
 
 use(chaiAsPromised);
@@ -1506,6 +1508,121 @@ describe('grant-suggestions-handler', () => {
       } catch (err) {
         expect(err.message).to.equal('Failed to revoke 1/1 grants');
       }
+    });
+  });
+
+  describe('revokeGrantsForSuggestions', () => {
+    it('does nothing when suggestionIds is empty or missing', async () => {
+      const SuggestionGrant = {
+        findBySuggestionIds: sandbox.stub(),
+        revokeSuggestionGrant: sandbox.stub(),
+      };
+      await revokeGrantsForSuggestions(SuggestionGrant, []);
+      await revokeGrantsForSuggestions(SuggestionGrant, undefined);
+
+      expect(SuggestionGrant.findBySuggestionIds).to.not.have.been.called;
+    });
+
+    it('does nothing when no grant is found for the suggestions', async () => {
+      const SuggestionGrant = {
+        findBySuggestionIds: sandbox.stub().resolves([]),
+        revokeSuggestionGrant: sandbox.stub(),
+      };
+      await revokeGrantsForSuggestions(SuggestionGrant, ['sugg-1']);
+
+      expect(SuggestionGrant.findBySuggestionIds).to.have.been.calledOnceWith(['sugg-1']);
+      expect(SuggestionGrant.revokeSuggestionGrant).to.not.have.been.called;
+    });
+
+    it('revokes each unique grant found for the given suggestion IDs', async () => {
+      const SuggestionGrant = {
+        findBySuggestionIds: sandbox.stub().resolves([
+          { suggestion_id: 'sugg-1', grant_id: 'grant-1' },
+          { suggestion_id: 'sugg-2', grant_id: 'grant-1' },
+          { suggestion_id: 'sugg-3', grant_id: 'grant-2' },
+        ]),
+        revokeSuggestionGrant: sandbox.stub().resolves({ success: true }),
+      };
+      await revokeGrantsForSuggestions(SuggestionGrant, ['sugg-1', 'sugg-2', 'sugg-3']);
+
+      expect(SuggestionGrant.findBySuggestionIds).to.have.been.calledOnceWith(
+        ['sugg-1', 'sugg-2', 'sugg-3'],
+      );
+      expect(SuggestionGrant.revokeSuggestionGrant).to.have.been.calledTwice;
+      expect(SuggestionGrant.revokeSuggestionGrant).to.have.been.calledWith('grant-1');
+      expect(SuggestionGrant.revokeSuggestionGrant).to.have.been.calledWith('grant-2');
+    });
+
+    it('propagates an error when a revoke fails', async () => {
+      const SuggestionGrant = {
+        findBySuggestionIds: sandbox.stub().resolves([
+          { suggestion_id: 'sugg-1', grant_id: 'grant-1' },
+        ]),
+        revokeSuggestionGrant: sandbox.stub().rejects(new Error('rpc failure')),
+      };
+      try {
+        await revokeGrantsForSuggestions(SuggestionGrant, ['sugg-1']);
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err.message).to.equal('Failed to revoke 1/1 grants');
+      }
+    });
+  });
+
+  describe('revokeGrantsForOpportunity', () => {
+    const opptyId = 'oppty-uuid';
+    const opportunity = { getId: () => opptyId };
+
+    it('returns early when dataAccess is missing', async () => {
+      expect(await revokeGrantsForOpportunity(null, opportunity)).to.be.undefined;
+      expect(await revokeGrantsForOpportunity(undefined, opportunity)).to.be.undefined;
+    });
+
+    it('returns early when opportunity is missing', async () => {
+      const Suggestion = { allByOpportunityId: sandbox.stub() };
+      const SuggestionGrant = { findBySuggestionIds: sandbox.stub() };
+      await revokeGrantsForOpportunity({ Suggestion, SuggestionGrant }, null);
+      expect(Suggestion.allByOpportunityId).to.not.have.been.called;
+    });
+
+    it('returns early when Suggestion or SuggestionGrant is missing from dataAccess', async () => {
+      const Suggestion = { allByOpportunityId: sandbox.stub() };
+      const SuggestionGrant = { findBySuggestionIds: sandbox.stub() };
+      await revokeGrantsForOpportunity({ Suggestion, SuggestionGrant: null }, opportunity);
+      await revokeGrantsForOpportunity({ Suggestion: null, SuggestionGrant }, opportunity);
+      expect(Suggestion.allByOpportunityId).to.not.have.been.called;
+      expect(SuggestionGrant.findBySuggestionIds).to.not.have.been.called;
+    });
+
+    it('does nothing when the opportunity has no suggestions', async () => {
+      const Suggestion = { allByOpportunityId: sandbox.stub().resolves([]) };
+      const SuggestionGrant = { findBySuggestionIds: sandbox.stub() };
+      await revokeGrantsForOpportunity({ Suggestion, SuggestionGrant }, opportunity);
+
+      expect(Suggestion.allByOpportunityId).to.have.been.calledOnceWith(opptyId);
+      expect(SuggestionGrant.findBySuggestionIds).to.not.have.been.called;
+    });
+
+    it('revokes grants for every suggestion under the opportunity', async () => {
+      const s1 = { getId: () => 'sugg-1' };
+      const s2 = { getId: () => 'sugg-2' };
+      const Suggestion = { allByOpportunityId: sandbox.stub().resolves([s1, s2]) };
+      const SuggestionGrant = {
+        findBySuggestionIds: sandbox.stub().resolves([
+          { suggestion_id: 'sugg-1', grant_id: 'grant-1' },
+          { suggestion_id: 'sugg-2', grant_id: 'grant-2' },
+        ]),
+        revokeSuggestionGrant: sandbox.stub().resolves({ success: true }),
+      };
+      await revokeGrantsForOpportunity({ Suggestion, SuggestionGrant }, opportunity);
+
+      expect(Suggestion.allByOpportunityId).to.have.been.calledOnceWith(opptyId);
+      expect(SuggestionGrant.findBySuggestionIds).to.have.been.calledOnceWith(
+        ['sugg-1', 'sugg-2'],
+      );
+      expect(SuggestionGrant.revokeSuggestionGrant).to.have.been.calledTwice;
+      expect(SuggestionGrant.revokeSuggestionGrant).to.have.been.calledWith('grant-1');
+      expect(SuggestionGrant.revokeSuggestionGrant).to.have.been.calledWith('grant-2');
     });
   });
 });


### PR DESCRIPTION
removeSuggestion deleted a suggestion without checking for an active grant, leaving suggestion_grants rows orphaned and permanently consuming the site's token budget. removeOpportunity has the same gap via its cascading suggestion delete.

Adds revokeGrantsForSuggestions and revokeGrantsForOpportunity to grant-suggestions-handler.js (reusing the existing revokeGrants primitive), and calls them before the delete in both controllers. Revocation is best-effort: it's wrapped in its own try/catch, a failure is logged as a warning, and the suggestion/opportunity delete always proceeds regardless of whether the grant revoke succeeded.

SITES-50360

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [x] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [x] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [x] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [x] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Abhinav Saraswat", "Anshul Kumar", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```