### PR TITLE
feat(serenity): route subworkspace CSV imports through the async job runner

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -162,6 +162,8 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-prompt-by-id'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/prompts/bulk-delete:
     $ref: './serenity-api.yaml#/v2-serenity-prompts-bulk-delete'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/prompts/jobs/{jobId}:
+    $ref: './serenity-api.yaml#/v2-serenity-prompts-job-by-id'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/markets:
     $ref: './serenity-api.yaml#/v2-serenity-markets'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/markets/{geoTargetId}/{languageCode}:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12065,6 +12065,53 @@ SerenityCreatePromptsResponse:
         were written as drafts and the caller must publish separately
         (serenity-docs#32).
 
+SerenityPromptsJobAccepted:
+  type: object
+  description: |
+    202 body for a CSV-import create (`deferPublish: true`). The write runs
+    asynchronously on the job runner; poll `jobId` at
+    `GET .../serenity/prompts/jobs/{jobId}`.
+  required: [jobId, status]
+  properties:
+    jobId:
+      type: string
+      format: uuid
+    status:
+      type: string
+      description: The job's initial state (IN_PROGRESS at enqueue time).
+      enum: [IN_PROGRESS, COMPLETED, FAILED]
+
+SerenityPromptsJobStatus:
+  type: object
+  description: |
+    Poll response for an async `serenity-classify-prompts` job. Secret-free by
+    design — the job's internal metadata (promise token etc.) is never exposed.
+  required: [jobId, status]
+  properties:
+    jobId:
+      type: string
+      format: uuid
+    status:
+      type: string
+      enum: [IN_PROGRESS, COMPLETED, FAILED]
+    result:
+      description: >
+        The job result once COMPLETED (the same envelope the synchronous create
+        returns: created/skipped/failed/published, plus
+        pendingClassificationCount/requeuedJobId). Null while IN_PROGRESS or on
+        FAILED.
+      oneOf:
+        - { $ref: '#/SerenityCreatePromptsResponse' }
+        - { type: 'null' }
+    error:
+      description: The failure envelope once FAILED; null otherwise.
+      oneOf:
+        - type: object
+          properties:
+            code: { type: string }
+            message: { type: string }
+        - { type: 'null' }
+
 SerenityUpdatePromptRequest:
   type: object
   description: |

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -140,6 +140,15 @@ v2-serenity-prompts:
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityCreatePromptsResponse' }
+      '202':
+        description: |
+          The request was a CSV import (`deferPublish: true`) and was routed to
+          the async job runner (serenity-docs#33). The prompts are classified,
+          created, and published off the request thread. Poll the returned
+          `jobId` at `GET .../serenity/prompts/jobs/{jobId}` for status + result.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityPromptsJobAccepted' }
       '400': { $ref: './responses.yaml#/400' }
       '404':
         description: Organization, brand, or workspace not found, or serenity is not active for the organization.
@@ -268,6 +277,54 @@ v2-serenity-prompts-bulk-delete:
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
+v2-serenity-prompts-job-by-id:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+    - name: jobId
+      in: path
+      required: true
+      description: Async job id returned by the 202 CSV-import create response.
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Poll a Serenity prompt-import (classify) job
+    description: |
+      Returns the status and, on completion, the result of an async
+      `serenity-classify-prompts` job created by the CSV-import path of
+      `POST .../serenity/prompts` (serenity-docs#33). Access is gated by the same
+      org/brand access + serenity-active checks as every other serenity endpoint;
+      a job that does not belong to the addressed brand 404s exactly like a
+      missing job (jobs are never leaked across brands). The response is
+      secret-free — only `{ jobId, status, result, error }`.
+    operationId: getSerenityPromptsJobStatus
+    security:
+      - session_token: []
+    responses:
+      '200':
+        description: Job status (and result when COMPLETED / error when FAILED).
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityPromptsJobStatus' }
+      '400': { $ref: './responses.yaml#/400' }
+      '404':
+        description: Organization, brand, or job not found, serenity is not active for the brand, or the job belongs to a different brand.
       '500': { $ref: './responses.yaml#/500' }
 
 # ─── Markets ──────────────────────────────────────────────────────────────────

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -564,16 +564,20 @@ function SerenityController(context, log, env) {
       if (auth.error) {
         return auth.error;
       }
-      // serenity-docs#33: CSV import is the ONLY bulk write path that routes to
-      // the async job runner — every other write path (single create, single
-      // edit, UI multi-add) stays synchronous. Routing is by SOURCE, not array
-      // length: `deferPublish` is the exact flag CSV-chunking already sets
-      // (see handleCreatePrompts' docstring) precisely because a UI multi-add
-      // never sets it, so a three-prompt UI add never pays queue+worker+publish
-      // latency. Flat-mode brands only for now — see this PR's report for why
-      // subworkspace-mode CSV import stays on the synchronous path.
+      // serenity-docs#33 (Layer 1, #2920): CSV import is the ONLY bulk write path
+      // that routes to the async job runner — every other write path (single
+      // create, single edit, UI multi-add) stays synchronous. Routing is by
+      // SOURCE, not array length: `deferPublish` is the exact flag CSV-chunking
+      // already sets (see handleCreatePrompts' docstring) precisely because a UI
+      // multi-add never sets it, so a three-prompt UI add never pays
+      // queue+worker+publish latency. BOTH modes enqueue: subworkspace is the only
+      // mode that exists in practice (flat brands are effectively extinct), so
+      // gating the async path on flat-only meant it never fired. The worker
+      // reconstructs the write from the metadata below — `authMode` picks the
+      // subworkspace-vs-flat create branch, `workspaceId`/`parentWorkspaceId` give
+      // it the sub-workspace and org parent it needs.
       const body = ctx.data || {};
-      if (auth.mode !== 'subworkspace' && validateDeferPublish(body)) {
+      if (validateDeferPublish(body)) {
         const prompts = Array.isArray(body.prompts) ? body.prompts : [];
         if (prompts.length === 0) {
           return createResponse(
@@ -592,7 +596,18 @@ function SerenityController(context, log, env) {
           metadata: {
             mode: 'create',
             brandId: auth.brandUuid,
+            // Backwards-compatible: the flat worker create path already reads
+            // `semrushWorkspaceId` as the workspace to write to — in subworkspace
+            // mode `auth.workspaceId` IS the sub-workspace, so the same key names
+            // the correct upstream target for both modes.
             semrushWorkspaceId: auth.workspaceId,
+            // Explicit reconstruction fields (this PR): `authMode` selects the
+            // worker's create branch; `workspaceId` is the sub-workspace the live
+            // project listing (buildSliceProjectMap) is enumerated from;
+            // `parentWorkspaceId` is the org parent, carried for completeness.
+            authMode: auth.mode,
+            workspaceId: auth.workspaceId,
+            parentWorkspaceId: auth.parentWorkspaceId,
             prompts,
             // Authorship (LLMO-6289): capture the caller id at enqueue time — from
             // the auth profile, never the forwarded upstream bearer — so the async
@@ -1905,9 +1920,68 @@ function SerenityController(context, log, env) {
     }
   };
 
+  /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId —
+   * polls a serenity-classify-prompts async job (serenity-docs#33 Layer 1, the
+   * companion to createPrompts' 202 CSV-import path). No upstream Semrush call, so
+   * no IMS token is resolved here; access control reuses `authorize` (same
+   * org/brand access + serenity-active gate as every other serenity handler).
+   *
+   * Returns a STABLE, secret-free contract — exactly `{ jobId, status, result,
+   * error }`, camelCase, which the polling UI is built against. `status` is the
+   * AsyncJob state (IN_PROGRESS | COMPLETED | FAILED); `result` is
+   * `job.getResult()` (present when COMPLETED); `error` is `job.getError()`
+   * (present when FAILED, `{ code, message }`). The job's metadata (which carries
+   * the promise token and other internals) is NEVER returned.
+   *
+   * Ownership guard: a job whose metadata `brandId` does not match the addressed
+   * brand 404s exactly like a missing job — a caller must not be able to probe or
+   * read another brand's jobs by id.
+   */
+  const getPromptsJobStatus = async (ctx) => {
+    let auth;
+    try {
+      auth = await authorize(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { jobId } = ctx?.params || {};
+      if (!isValidUUID(jobId)) {
+        return createResponse(
+          { error: 'invalidRequest', message: 'jobId must be a UUID' },
+          400,
+        );
+      }
+      const AsyncJob = ctx?.dataAccess?.AsyncJob;
+      if (!AsyncJob || typeof AsyncJob.findById !== 'function') {
+        return internalServerError('AsyncJob data-access not available');
+      }
+      const job = await AsyncJob.findById(jobId);
+      // A job that does not exist AND a job that belongs to another brand answer
+      // the same 404: whether the id is unknown or simply not yours is not the
+      // caller's business (mirrors authorize's brand-not-found contract).
+      const jobBrandId = job?.getMetadata?.()?.brandId;
+      if (!job || jobBrandId !== auth.brandUuid) {
+        return notFound(`Job not found: ${jobId}`);
+      }
+      return createResponse(
+        {
+          jobId: job.getId(),
+          status: job.getStatus(),
+          result: job.getResult?.() ?? null,
+          error: job.getError?.() ?? null,
+        },
+        200,
+      );
+    } catch (e) {
+      return mapError(e, log, reqCtxOf(ctx, auth));
+    }
+  };
+
   return {
     listPrompts,
     createPrompts,
+    getPromptsJobStatus,
     updatePrompt,
     bulkDeletePrompts,
     listMarkets,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -875,6 +875,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/:promptId': 'llmo/can_view',
       // Serenity proxy (Semrush AIO replacement) — reads under brand
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets/:geoTargetId/:languageCode': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/tags': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -241,6 +241,7 @@ export default function getRouteHandlers(
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': serenityController.listPrompts,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': serenityController.createPrompts,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-delete': serenityController.bulkDeletePrompts,
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId': serenityController.getPromptsJobStatus,
     'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:semrushPromptId': serenityController.updatePrompt,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets': serenityController.listMarkets,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets': serenityController.createMarket,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -305,6 +305,7 @@ const routeRequiredCapabilities = {
   'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/delete': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts/check': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'organization:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId': 'organization:read',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': 'organization:write',
   'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:semrushPromptId': 'organization:write',
   'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-delete': 'organization:write',

--- a/src/support/serenity/handlers/classify-prompts-job.js
+++ b/src/support/serenity/handlers/classify-prompts-job.js
@@ -30,6 +30,7 @@ import {
 } from './prompts.js';
 import { ORIGIN_VALUE } from '../prompt-tags.js';
 import { resolveIntentValueInjection } from '../tag-tree.js';
+import { buildSliceProjectMap, sliceKey } from '../subworkspace-projects.js';
 
 /** @typedef {import('../rest-transport.js').SerenityTransport} SerenityTransport */
 
@@ -139,7 +140,8 @@ async function requeuePending(context, job, semrushWorkspaceId, items) {
  * @param {SerenityTransport} transport - Serenity transport built from the exchanged
  *   access token.
  * @param {object} metadata - the job's metadata (`brandId`, `semrushWorkspaceId`,
- *   `prompts`).
+ *   `prompts`, and — for a subworkspace-mode CSV import — `authMode`,
+ *   `workspaceId`, `parentWorkspaceId`).
  * @returns {Promise<object>} the job result.
  */
 async function createAndClassify(context, job, transport, metadata) {
@@ -149,13 +151,37 @@ async function createAndClassify(context, job, transport, metadata) {
   // Authorship (LLMO-6289): the caller id captured at enqueue time in the create
   // controller, carried through the async job so classified-on-create prompts are
   // stamped with the human/service that submitted them, not the job runner.
-  const { brandId, semrushWorkspaceId, callerId = 'unknown' } = metadata;
+  const {
+    brandId, semrushWorkspaceId, callerId = 'unknown', authMode,
+  } = metadata;
   const inputs = Array.isArray(metadata.prompts) ? metadata.prompts : [];
 
-  const projects = await dataAccess.BrandSemrushProject.allByBrandId(brandId);
-  const projectsBySlice = new Map();
-  for (const p of projects || []) {
-    projectsBySlice.set(`${p.getGeoTargetId()}:${p.getLanguageCode()}`, p);
+  // Slice→project resolution is the ONLY create-path difference between the two
+  // modes (mirrors the sync twins handleCreatePrompts vs
+  // handleCreatePromptsSubworkspace): flat mode reads the BrandSemrushProject DB
+  // mapping, subworkspace resolves projects from ONE live listing of the
+  // sub-workspace (buildSliceProjectMap). Everything downstream — the classifier,
+  // tag/intent injectors, per-slice create + publish-once fan-out, the pending
+  // self-requeue — is the shared, project-id-keyed logic below.
+  const isSubworkspace = authMode === 'subworkspace';
+  /** @type {(geoTargetId: number, languageCode: string) => string | null} */
+  let resolveProjectIdForSlice;
+  if (isSubworkspace) {
+    const projectsBySlice = await buildSliceProjectMap(transport, semrushWorkspaceId, log);
+    resolveProjectIdForSlice = (geoTargetId, languageCode) => {
+      const project = projectsBySlice.get(sliceKey(geoTargetId, languageCode));
+      return project ? String(project.id) : null;
+    };
+  } else {
+    const projects = await dataAccess.BrandSemrushProject.allByBrandId(brandId);
+    const projectsBySlice = new Map();
+    for (const p of projects || []) {
+      projectsBySlice.set(`${p.getGeoTargetId()}:${p.getLanguageCode()}`, p);
+    }
+    resolveProjectIdForSlice = (geoTargetId, languageCode) => {
+      const project = projectsBySlice.get(`${geoTargetId}:${languageCode}`);
+      return project ? project.getSemrushProjectId() : null;
+    };
   }
 
   const classifyPromptType = await buildPromptTypeClassifier(dataAccess, brandId);
@@ -180,8 +206,8 @@ async function createAndClassify(context, job, transport, metadata) {
     if (!input) {
       return { skipped: { text: String(raw?.text || ''), reason: /** @type {string} */ (reason) } };
     }
-    const project = projectsBySlice.get(`${input.geoTargetId}:${input.languageCode}`);
-    if (!project) {
+    const projectId = resolveProjectIdForSlice(input.geoTargetId, input.languageCode);
+    if (!projectId) {
       return {
         skipped: {
           text: input.text,
@@ -189,7 +215,6 @@ async function createAndClassify(context, job, transport, metadata) {
         },
       };
     }
-    const projectId = project.getSemrushProjectId();
     try {
       let typed = await injectComputedTags(projectId, input);
       typed = await injectComputedIntent(projectId, typed);

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2792,10 +2792,56 @@ describe('SerenityController', () => {
         expect(enqueueArgs.jobType).to.equal('serenity-classify-prompts');
         expect(enqueueArgs.metadata).to.deep.equal({
           // callerId captured at enqueue time (LLMO-6289) — no auth profile on the
-          // test context, so it resolves to the `unknown` sentinel.
-          mode: 'create', brandId: BRAND, semrushWorkspaceId: WORKSPACE, prompts, callerId: 'unknown',
+          // test context, so it resolves to the `unknown` sentinel. The default
+          // resolveBrandWorkspaceStub is flat mode, so authMode is 'flat' and both
+          // workspace ids are the org parent WORKSPACE.
+          mode: 'create',
+          brandId: BRAND,
+          semrushWorkspaceId: WORKSPACE,
+          authMode: 'flat',
+          workspaceId: WORKSPACE,
+          parentWorkspaceId: WORKSPACE,
+          prompts,
+          callerId: 'unknown',
         });
         // The synchronous path never runs.
+        expect(handlers.handleCreatePrompts).to.not.have.been.called;
+      });
+
+      it('enqueues a serenity-classify-prompts job and returns 202 for subworkspace-mode CSV import, carrying authMode + parentWorkspaceId', async () => {
+        resolveBrandWorkspaceStub.resolves({
+          mode: 'subworkspace', workspaceId: SUBWS, parentWorkspaceId: WORKSPACE,
+        });
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const prompts = [{
+          text: 'What is your return policy?', geoTargetId: 2840, languageCode: 'en', tagIds: ['tag-1'],
+        }];
+        const response = await controller.createPrompts(fakeContext({
+          data: { deferPublish: true, prompts },
+        }));
+
+        expect(response.status).to.equal(202);
+        const body = await readBody(response);
+        expect(body).to.deep.equal({ jobId: 'job-abc', status: 'IN_PROGRESS' });
+        expect(createAndEnqueueJobStub).to.have.been.calledOnce;
+        const [, enqueueArgs] = createAndEnqueueJobStub.firstCall.args;
+        expect(enqueueArgs.jobType).to.equal('serenity-classify-prompts');
+        expect(enqueueArgs.metadata).to.deep.equal({
+          mode: 'create',
+          brandId: BRAND,
+          // In subworkspace mode `auth.workspaceId` IS the sub-workspace, and it is
+          // carried under both `semrushWorkspaceId` (backwards-compatible worker
+          // key) and the explicit `workspaceId`. `parentWorkspaceId` is the org
+          // parent; `authMode` selects the worker's subworkspace create branch.
+          semrushWorkspaceId: SUBWS,
+          authMode: 'subworkspace',
+          workspaceId: SUBWS,
+          parentWorkspaceId: WORKSPACE,
+          prompts,
+          callerId: 'unknown',
+        });
+        // Neither synchronous create handler runs.
+        expect(handlers.handleCreatePromptsSubworkspace).to.not.have.been.called;
         expect(handlers.handleCreatePrompts).to.not.have.been.called;
       });
 
@@ -2811,14 +2857,14 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePrompts).to.have.been.calledOnce;
       });
 
-      it('stays synchronous for subworkspace-mode brands even when deferPublish is true', async () => {
+      it('stays synchronous for subworkspace-mode brands when deferPublish is absent', async () => {
         resolveBrandWorkspaceStub.resolves({
           mode: 'subworkspace', workspaceId: SUBWS, parentWorkspaceId: WORKSPACE,
         });
         handlers.handleCreatePromptsSubworkspace.resolves({ created: 1, failed: [] });
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
+          data: { prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
         }));
 
         expect(response.status).to.equal(200);
@@ -2847,6 +2893,78 @@ describe('SerenityController', () => {
 
         expect(response.status).to.equal(400);
         expect(createAndEnqueueJobStub).to.not.have.been.called;
+      });
+    });
+
+    describe('getPromptsJobStatus — async job polling (serenity-docs#33 Layer 1)', () => {
+      const JOB = '99999999-8888-7777-6666-555555555555';
+
+      function makeAsyncJob({
+        status = 'COMPLETED', result = null, error = null, brandId = BRAND,
+      } = {}) {
+        return {
+          getId: () => JOB,
+          getStatus: () => status,
+          getResult: () => result,
+          getError: () => error,
+          getMetadata: () => ({ brandId, promiseToken: { promise_token: 'secret' } }),
+        };
+      }
+
+      function ctxWithJob(job, { jobId = JOB } = {}) {
+        const ctx = fakeContext({ params: { jobId } });
+        ctx.dataAccess.AsyncJob = { findById: sinon.stub().resolves(job) };
+        return ctx;
+      }
+
+      it('returns 200 with the stable {jobId,status,result,error} contract for a COMPLETED job', async () => {
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const result = { created: [{ semrushPromptId: 'p1' }], published: true };
+        const response = await controller.getPromptsJobStatus(
+          ctxWithJob(makeAsyncJob({ status: 'COMPLETED', result })),
+        );
+        expect(response.status).to.equal(200);
+        const body = await readBody(response);
+        expect(body).to.deep.equal({
+          jobId: JOB, status: 'COMPLETED', result, error: null,
+        });
+        // Secrets on the job metadata are never exposed.
+        expect(body).to.not.have.property('metadata');
+      });
+
+      it('surfaces the error envelope for a FAILED job', async () => {
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const error = { code: 'NEEDS_REAUTH', message: 'Promise token exchange rejected' };
+        const response = await controller.getPromptsJobStatus(
+          ctxWithJob(makeAsyncJob({ status: 'FAILED', result: null, error })),
+        );
+        expect(response.status).to.equal(200);
+        const body = await readBody(response);
+        expect(body).to.deep.equal({
+          jobId: JOB, status: 'FAILED', result: null, error,
+        });
+      });
+
+      it('404s when the job does not exist', async () => {
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const response = await controller.getPromptsJobStatus(ctxWithJob(null));
+        expect(response.status).to.equal(404);
+      });
+
+      it('404s (does not leak) when the job belongs to another brand', async () => {
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const response = await controller.getPromptsJobStatus(
+          ctxWithJob(makeAsyncJob({ brandId: 'some-other-brand' })),
+        );
+        expect(response.status).to.equal(404);
+      });
+
+      it('400s on a non-UUID jobId', async () => {
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const response = await controller.getPromptsJobStatus(
+          ctxWithJob(makeAsyncJob(), { jobId: 'not-a-uuid' }),
+        );
+        expect(response.status).to.equal(400);
       });
     });
 

--- a/test/it/postgres/seed-data/async-jobs.js
+++ b/test/it/postgres/seed-data/async-jobs.js
@@ -15,10 +15,17 @@
  *
  * JOB_1: A completed preflight job referencing SITE_1.
  *
+ * SERENITY_CLASSIFY_JOB: a COMPLETED serenity-classify-prompts job owned by
+ * BRAND_1 — exercises GET .../serenity/prompts/jobs/{jobId} (serenity-docs#33
+ * Layer 1). Its metadata carries `brandId` (the ownership guard the poll
+ * endpoint enforces) plus a `promiseToken` the poll response must NOT leak.
+ *
  * Note: AsyncJob only exists in v3 (PostgreSQL) — no DynamoDB equivalent.
  *
  * Format: snake_case (v3 / PostgreSQL / PostgREST)
  */
+export const SERENITY_CLASSIFY_JOB_ID = 'eeee3333-3333-4333-a333-333333333333';
+
 export const asyncJobs = [
   {
     id: 'eeee2222-2222-4222-a222-222222222222',
@@ -46,5 +53,30 @@ export const asyncJobs = [
     },
     started_at: '2025-01-20T10:00:00.000Z',
     ended_at: '2025-01-20T10:05:00.000Z',
+  },
+  {
+    id: SERENITY_CLASSIFY_JOB_ID,
+    status: 'COMPLETED',
+    result: {
+      created: [],
+      skipped: [],
+      failed: [],
+      published: true,
+      pendingClassificationCount: 0,
+      requeuedJobId: null,
+    },
+    metadata: {
+      mode: 'create',
+      authMode: 'subworkspace',
+      // BRAND_1_ID — the ownership guard on the poll endpoint compares this to the
+      // authorized brand and 404s a mismatch. Kept as a literal here so this seed
+      // file has no cross-import dependency on seed-ids.js.
+      brandId: 'ab111111-1111-4111-b111-111111111111',
+      jobType: 'serenity-classify-prompts',
+      // Must never appear in the poll response (secret-free contract).
+      promiseToken: { promise_token: 'do-not-leak' },
+    },
+    started_at: '2025-02-01T09:00:00.000Z',
+    ended_at: '2025-02-01T09:01:00.000Z',
   },
 ];

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -15,6 +15,7 @@ import {
   ORG_1_ID, BRAND_1_ID, SITE_1_ID, SITE_2_ID,
 } from '../seed-ids.js';
 import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
+import { SERENITY_CLASSIFY_JOB_ID } from '../../postgres/seed-data/async-jobs.js';
 
 /**
  * End-to-end tests for the /serenity/* surface (LLMO-5190), driven against the
@@ -258,6 +259,40 @@ export default function serenityTests(
       });
       expect(res.status).to.equal(400);
       expect(res.body.message).to.match(/type must be one of/i);
+    });
+  });
+
+  describe('Serenity API — poll a prompt-import (classify) job (serenity-docs#33 Layer 1)', () => {
+    const base = `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}/serenity`;
+
+    it('GET /serenity/prompts/jobs/:jobId returns the secret-free status contract for an owned COMPLETED job', async () => {
+      const res = await getHttpClient().admin.get(`${base}/prompts/jobs/${SERENITY_CLASSIFY_JOB_ID}`);
+      expect(res.status).to.equal(200);
+      // Exactly the four camelCase fields the UI is built against — nothing else.
+      expect(Object.keys(res.body).sort()).to.deep.equal(['error', 'jobId', 'result', 'status']);
+      expect(res.body.jobId).to.equal(SERENITY_CLASSIFY_JOB_ID);
+      expect(res.body.status).to.equal('COMPLETED');
+      expect(res.body.result).to.deep.include({ published: true, pendingClassificationCount: 0 });
+      expect(res.body.error).to.equal(null);
+      // The job's internal metadata (promise token etc.) must never leak.
+      expect(res.body).to.not.have.property('metadata');
+      expect(JSON.stringify(res.body)).to.not.match(/promise/i);
+    });
+
+    it('GET /serenity/prompts/jobs/:jobId 404s for an unknown job id', async () => {
+      const res = await getHttpClient().admin.get(`${base}/prompts/jobs/eeee9999-9999-4999-a999-999999999999`);
+      expect(res.status).to.equal(404);
+    });
+
+    it('GET /serenity/prompts/jobs/:jobId 404s (does not leak) for a job owned by another brand', async () => {
+      // The seeded COMPLETED preflight job carries no matching brandId.
+      const res = await getHttpClient().admin.get(`${base}/prompts/jobs/eeee1111-1111-4111-b111-111111111111`);
+      expect(res.status).to.equal(404);
+    });
+
+    it('GET /serenity/prompts/jobs/:jobId 400s on a non-UUID jobId', async () => {
+      const res = await getHttpClient().admin.get(`${base}/prompts/jobs/not-a-uuid`);
+      expect(res.status).to.equal(400);
     });
   });
 

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -149,6 +149,32 @@ const FIXTURES = {
       }],
     },
   },
+  getSerenityPromptsJobStatus: {
+    expectedStatus: 200,
+    controllerMethod: 'getPromptsJobStatus',
+    // No handler: the controller reads the AsyncJob model directly. Pin a
+    // COMPLETED job owned by BRAND so the documented { jobId, status, result }
+    // shape is exercised. Metadata.brandId MUST match auth.brandUuid (BRAND) or
+    // the controller 404s (jobs are never leaked across brands).
+    params: { jobId: '00000000-0000-4000-8000-000000000000' },
+    asyncJob: {
+      getId: () => '00000000-0000-4000-8000-000000000000',
+      getStatus: () => 'COMPLETED',
+      getResult: () => ({
+        created: [{
+          semrushPromptId: 'sem-1',
+          geoTargetId: 2840,
+          languageCode: 'en',
+          text: 'sample',
+        }],
+        skipped: [],
+        failed: [],
+        published: true,
+      }),
+      getError: () => null,
+      getMetadata: () => ({ brandId: BRAND }),
+    },
+  },
   updateSerenityPrompt: {
     expectedStatus: 200,
     controllerMethod: 'updatePrompt',
@@ -801,7 +827,12 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
         listGlobalModelCatalog: sinon.stub(),
         listLanguageCatalog: sinon.stub(),
       };
-      handlerStubs[fx.handlerName].resolves(fx.handlerResult);
+      // Most serenity ops route through a handler stub; a few (e.g.
+      // getSerenityPromptsJobStatus) read a data-access model directly and pin
+      // their state via `fx.asyncJob` instead of a handler.
+      if (fx.handlerName) {
+        handlerStubs[fx.handlerName].resolves(fx.handlerResult);
+      }
 
       const SerenityController = (await esmock(
         '../../src/controllers/serenity.js',
@@ -904,6 +935,11 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
         data: fx.data,
         query: fx.query || {},
       });
+      // Ops that read an AsyncJob directly (no handler) get their job pinned here.
+      if (fx.asyncJob) {
+        ctx.dataAccess.AsyncJob = { findById: sinon.stub().resolves(fx.asyncJob) };
+      }
+
       const controller = SerenityController(ctx, fakeLog());
       const response = await controller[fx.controllerMethod](ctx);
 

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1004,6 +1004,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-delete',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId',
       'PATCH /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/:semrushPromptId',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/markets',

--- a/test/support/serenity/handlers/classify-prompts-job.test.js
+++ b/test/support/serenity/handlers/classify-prompts-job.test.js
@@ -62,6 +62,16 @@ describe('handlers/classify-prompts-job.js (serenity-docs#33)', () => {
       createPromptsWithMetadata: sinon.stub().resolves({ items: [{ id: 'created-prompt' }] }),
       publishProject: sinon.stub().resolves(),
       updatePromptTagsByIds: sinon.stub().resolves(),
+      // Subworkspace create branch resolves projects from ONE live listing
+      // (buildSliceProjectMap) instead of the BrandSemrushProject DB mapping.
+      // A single project on the (2840, en) slice: settings echo the draft's real
+      // geo/language, mirroring the v1 default view buildSliceProjectMap reads.
+      listProjects: sinon.stub().resolves({
+        items: [{
+          id: 'proj-sw-1',
+          settings: { ai: { location: { id: 2840 }, language: { name: 'en' } } },
+        }],
+      }),
     };
   });
 
@@ -190,6 +200,66 @@ describe('handlers/classify-prompts-job.js (serenity-docs#33)', () => {
         semrushWorkspaceId: WORKSPACE,
         prompts: [{
           text: 'x', geoTargetId: 2840, languageCode: 'en', tagIds: [TAG_IDS.categoryRunningShoes],
+        }],
+      });
+
+      const result = await classifyPromptsHandler(context, job, 'token');
+
+      expect(result.created).to.have.lengthOf(0);
+      expect(result.skipped).to.have.lengthOf(1);
+    });
+  });
+
+  describe('mode: create (subworkspace) — CSV import async path', () => {
+    it('resolves projects from the live listing (not the DB mapping), creates with intent, and publishes', async () => {
+      const intentByTextMap = new Map([['great product', 'Task']]);
+      const createAndEnqueueJobStub = sinon.stub();
+      const { classifyPromptsHandler } = await load({
+        intentByTextMap, createAndEnqueueJobStub, transport,
+      });
+
+      const dataAccess = dataAccessFor([]);
+      const context = { env: {}, log: fakeLog(), dataAccess };
+      const job = makeJob({
+        mode: 'create',
+        authMode: 'subworkspace',
+        brandId: 'brand-1',
+        semrushWorkspaceId: WORKSPACE,
+        workspaceId: WORKSPACE,
+        parentWorkspaceId: 'parent-ws-1',
+        prompts: [{
+          text: 'great product', geoTargetId: 2840, languageCode: 'en', tagIds: [TAG_IDS.categoryRunningShoes],
+        }],
+      });
+
+      const result = await classifyPromptsHandler(context, job, 'token');
+
+      expect(result.created).to.have.lengthOf(1);
+      expect(result.created[0].tagIds).to.include(TAG_IDS.intentTask);
+      expect(result.published).to.equal(true);
+      expect(result.pendingClassificationCount).to.equal(0);
+      // Subworkspace path enumerates the live listing...
+      expect(transport.listProjects).to.have.been.calledWith(WORKSPACE);
+      // ...and never touches the flat-mode DB mapping.
+      expect(dataAccess.BrandSemrushProject.allByBrandId).to.not.have.been.called;
+    });
+
+    it('skips a prompt whose slice has no matching project in the live listing', async () => {
+      const intentByTextMap = new Map([['great product', 'Task']]);
+      const createAndEnqueueJobStub = sinon.stub();
+      transport.listProjects.resolves({ items: [] });
+      const { classifyPromptsHandler } = await load({
+        intentByTextMap, createAndEnqueueJobStub, transport,
+      });
+
+      const context = { env: {}, log: fakeLog(), dataAccess: dataAccessFor([]) };
+      const job = makeJob({
+        mode: 'create',
+        authMode: 'subworkspace',
+        brandId: 'brand-1',
+        semrushWorkspaceId: WORKSPACE,
+        prompts: [{
+          text: 'great product', geoTargetId: 2840, languageCode: 'en', tagIds: [TAG_IDS.categoryRunningShoes],
         }],
       });
 


### PR DESCRIPTION
## The flat-only gap

serenity-docs#186 built an async job runner (SQS + `spacecat-services--serenity-job-runner`). serenity-docs#33 made CSV prompt-import route through it (classify → create-with-tags → publish, off the request thread). But `createPrompts` gated that path on `auth.mode !== 'subworkspace'`, so it only fired for FLAT-mode brands. Every real and test brand is subworkspace mode (flat brands are effectively extinct), so the async path never ran in practice. This is Layer 1 of serenity-docs#33 / the deferred #2920 work.

## What changed

- **`src/controllers/serenity.js` `createPrompts`**: dropped the flat-only guard — **both** modes now enqueue when `validateDeferPublish(body)`. Job metadata gained the reconstruction fields the worker needs (see contract below). Backwards-compatible: the flat worker path still reads `semrushWorkspaceId`.
- **`src/support/serenity/handlers/classify-prompts-job.js` create path**: branches slice→project resolution on `authMode`. Subworkspace resolves projects from ONE live listing (`buildSliceProjectMap`) instead of the `BrandSemrushProject` DB mapping; flat is unchanged. The classifier, tag/intent injectors, per-slice create + publish-once fan-out, and the pending self-requeue (`requeuePending`/`requeuedJobId`) are the shared, project-id-keyed logic — untouched. The worker keeps its no-time-budget classify (`classifyPromptIntentsUnbounded`, same shape the flat worker path already used — no invented Fastly-style deadline) and its terminal-state / token-ownership-transfer semantics. SQS body stays exactly `{ jobId, type }`; the promise token lives only on the AsyncJob metadata.

### Metadata contract addition

The enqueued `serenity-classify-prompts` job metadata now carries:
- `authMode` — `auth.mode`; selects the worker's subworkspace-vs-flat create branch.
- `workspaceId` — `auth.workspaceId` (the sub-workspace the live project listing is enumerated from).
- `parentWorkspaceId` — `auth.parentWorkspaceId` (org parent, carried for completeness).
- `semrushWorkspaceId` — unchanged, still `auth.workspaceId`; kept so old-shape jobs and the flat worker path keep working.

## Poll endpoint (folded into this PR)

The 202 `{ jobId, status }` was unpollable — there was no status route, making the async feature unusable end-to-end. Added:

- `GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/jobs/:jobId` → `getPromptsJobStatus`. Reuses `authorize(ctx)` (same org/brand access + serenity-active gate), loads the `AsyncJob`, guards ownership (`metadata.brandId === auth.brandUuid`, else 404 with no cross-brand leak), and returns exactly `{ jobId, status, result, error }` (camelCase, secret-free — job metadata / promise token never exposed).
- `:jobId` classified in `facs-capabilities.js` (route → `llmo/can_view`; `jobId` already in `FACS_NON_RESOURCE_PARAMS`).
- OpenAPI: new path item + `SerenityPromptsJobStatus` / `SerenityPromptsJobAccepted` schemas, plus a `202` response documented on create. `docs:lint` passes (only pre-existing unrelated warnings). `docs/index.html` intentionally left as-is (hash-noise non-determinism off the canonical CI toolchain — spec yaml is source of truth).

## Tests

- Controller: subworkspace CSV enqueue asserts 202 + full metadata shape (incl. `authMode`/`parentWorkspaceId`); flat metadata assertion updated; `getPromptsJobStatus` cases (COMPLETED-with-result, FAILED-with-error, not-found, wrong-brand 404, non-UUID 400).
- Handler: subworkspace create branch resolves from the live listing (not the DB mapping) and publishes; skips a slice with no live project.
- IT: poll endpoint (owned COMPLETED / unknown / wrong-brand / non-UUID) with a seeded `serenity-classify-prompts` job.

`npm run lint`, `npm run type-check`, and the affected unit suites (270 passing) are green locally.

## Follow-up

Layer 2 (UI 202 + polling) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```