### PR TITLE
feat: serenity introduce top reddit threads endpoints

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -196,6 +196,8 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-sentiment-overview'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/subreddits:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-subreddits'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/reddit-threads:
+    $ref: './serenity-api.yaml#/v2-serenity-brand-presence-reddit-threads'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-topics'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics/{topicId}/prompts:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12706,6 +12706,55 @@ SerenityBrandPresenceSubreddits:
       type: integer
       example: 107
 
+SerenityBrandPresenceRedditThreadRow:
+  type: object
+  description: A single Reddit thread ranked by response count.
+  required: [link, mentions, prompts, responses, subreddit, thread]
+  properties:
+    link:
+      type: string
+      description: Thread URL.
+      example: 'https://www.reddit.com/r/BuyItForLife/comments/1kqgvja/lovesac_sactional_is_it_worth_it'
+    mentions:
+      type: integer
+      example: 75
+    prompts:
+      type: integer
+      description: Number of prompts whose responses cited this thread.
+      example: 28
+    responses:
+      type: integer
+      description: Number of AI responses citing this thread. Endpoint's ranking metric ("citation count").
+      example: 62
+    subreddit:
+      type: string
+      description: Subreddit the thread belongs to (with the `r/` prefix).
+      example: 'r/BuyItForLife'
+    thread:
+      type: string
+      description: Thread title, as returned by the element.
+      example: 'LoveSac Sactional, is it worth it? : r/BuyItForLife - Reddit'
+    urlCbf:
+      type: string
+      description: Opaque Semrush custom-field-value key for the thread URL.
+      example: '59bfcb03-11df-44ff-867a-ac2b30c49578:eq:https_C0L_//www.reddit.com/r/BuyItForLife/comments/1kqgvja/lovesac_sactional_is_it_worth_it'
+
+SerenityBrandPresenceRedditThreads:
+  type: object
+  description: |
+    Top Reddit threads from the Semrush "Reddit Threads" element (5af96fd9), sorted by
+    `responses` descending (tie-broken by `urlCbf`) and paginated. `totalCount` is the
+    full pre-pagination row count.
+  required: [threads, totalCount]
+  properties:
+    threads:
+      type: array
+      items:
+        $ref: '#/SerenityBrandPresenceRedditThreadRow'
+    totalCount:
+      type: integer
+      example: 42
+
 SerenityBrandPresenceTopics:
   type: object
   description: |

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1495,6 +1495,128 @@ v2-serenity-brand-presence-subreddits:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
       '500': { $ref: './responses.yaml#/500' }
 
+v2-serenity-brand-presence-reddit-threads:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Top Reddit threads by response count for the Serenity brand presence dashboard
+    description: |
+      Returns the top Reddit threads (link, mentions, prompts, responses, subreddit,
+      thread title) from the Semrush "Reddit Threads" element (5af96fd9). Rows are
+      sorted by `responses` descending (tie-broken by an internal thread key) and
+      paginated server-side.
+
+      Brand-scoped via the brand's Semrush sub-workspace (resolved from `:brandId`).
+      A single upstream call: the element aggregates across the whole workspace when
+      no `projectId` is sent, and scopes to one project when it is. `model`/`platform`
+      are translated to a Semrush model server-side.
+    operationId: listSerenityBrandPresenceRedditThreads
+    security:
+      - session_token: []
+    parameters:
+      - name: startDate
+        in: query
+        required: true
+        description: Inclusive range start (YYYY-MM-DD). Range must not exceed 366 days.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        required: true
+        description: Inclusive range end (YYYY-MM-DD). Range must not exceed 366 days.
+        schema: { type: string, format: date }
+      - name: model
+        in: query
+        required: false
+        description: |
+          AI model to scope to. Accepts a Semrush Elements model name directly, or a
+          SpaceCat/UI platform code (translated server-side). Defaults to `search-gpt`
+          when omitted or unrecognized.
+        schema:
+          type: string
+          x-canonical-values:
+            - google-ai-mode
+            - grok-3
+            - google-ai-overview
+            - microsoft-copilot
+            - open-evidence
+            - gemini-2.5-flash
+            - claude-sonnet-4
+            - gpt-5
+            - deepseek
+            - search-gpt
+            - perplexity
+          x-known-aliases:
+            copilot: microsoft-copilot
+            gemini: gemini-2.5-flash
+            openai: gpt-5
+            chatgpt: search-gpt
+      - name: platform
+        in: query
+        required: false
+        description: Legacy alias for `model`; `model` takes precedence when both are given.
+        schema: { type: string }
+      - name: projectId
+        in: query
+        required: false
+        description: |
+          Comma-separated Semrush project UUIDs. Alias `project_id`. Omitted →
+          the element aggregates across all of the brand's markets. Each id must be a
+          valid UUID (400 otherwise). Note: this endpoint scopes to a SINGLE project —
+          only the first id is forwarded to the element; the rest are validated for
+          ownership but not used (multi-project merge is not implemented).
+        schema: { type: string, pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}){0,7}$' }
+      - name: project_id
+        in: query
+        required: false
+        description: Snake_case alias for `projectId`.
+        schema: { type: string }
+      - name: page
+        in: query
+        required: false
+        description: 0-based page index. Defaults to 0.
+        schema: { type: integer, minimum: 0, default: 0 }
+      - name: pageSize
+        in: query
+        required: false
+        description: Page size (1..1000). Defaults to 50.
+        schema: { type: integer, minimum: 1, maximum: 1000, default: 50 }
+    responses:
+      '200':
+        description: Reddit thread stats retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityBrandPresenceRedditThreads' }
+      '400': { $ref: './responses.yaml#/400' }
+      '403':
+        description: Caller lacks access to the organization, or a supplied projectId is not owned by the brand.
+      '404':
+        description: Organization not found, brand not found for this organization, or the brand has no resolvable Semrush workspace.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '503':
+        description: PostgREST client not available (required to resolve the brand's Semrush workspace before the element call).
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
 v2-serenity-brand-presence-topics:
   parameters:
     - name: spaceCatId

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -907,6 +907,72 @@ export default function ElementsController(context, log, env) {
   /* c8 ignore stop */
 
   /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads
+   * Returns top Reddit threads by response count (mentions, prompts, responses) from
+   * the Reddit Threads element (5af96fd9). Single upstream call (the element aggregates
+   * workspace-wide; a supplied projectId scopes to one project).
+   */
+  /* c8 ignore start -- SITES-POC reddit-threads endpoint; unit tests intentionally deferred */
+  const listRedditThreads = async (ctx) => {
+    try {
+      const auth = await authorizeOrg(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { workspaceId, brand } = auth;
+      const query = extractQuery(ctx);
+
+      // Date range is required + validated (mirrors subreddits/cited-domains) —
+      // never silently default to a rolling window nor forward a malformed date to Semrush.
+      const startDate = query.startDate || query.start_date;
+      const endDate = query.endDate || query.end_date;
+      if (!hasText(startDate) || !hasText(endDate)) {
+        return badRequest('startDate and endDate are required (YYYY-MM-DD)');
+      }
+      if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+        return badRequest('startDate and endDate must be valid YYYY-MM-DD dates');
+      }
+      if (startDate > endDate) {
+        return badRequest('startDate must not be after endDate');
+      }
+      const MAX_RANGE_DAYS = 366;
+      const spanDays = (Date.parse(`${endDate}T00:00:00Z`)
+        - Date.parse(`${startDate}T00:00:00Z`)) / 86400000;
+      if (spanDays > MAX_RANGE_DAYS) {
+        return badRequest(`Date range must not exceed ${MAX_RANGE_DAYS} days`);
+      }
+
+      const service = await buildService(ctx);
+
+      // Project scoping: caller-supplied projectId(s) (CSV) scope to a single Semrush
+      // project (the service uses the first); absent → the element aggregates across all of
+      // the brand's markets. Any supplied id must belong to this brand.
+      const projectIds = extractProjectIds(query);
+      const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+      const brandSemrushProjects = await fetchBrandSemrushProjects(BrandSemrushProject, [brand]);
+      const ownershipError = checkProjectIdsOwnership(projectIds, brandSemrushProjects);
+      if (ownershipError) {
+        return ownershipError;
+      }
+
+      const params = {
+        projectIds,
+        model: query.model || query.platform,
+        startDate,
+        endDate,
+        page: query.page,
+        pageSize: query.pageSize,
+      };
+
+      const result = await service.getRedditThreads(workspaceId, params);
+      return ok(result);
+    } catch (e) {
+      return mapError(e, log, reqCtxOf(ctx));
+    }
+  };
+  /* c8 ignore stop */
+
+  /**
    * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview
    * Returns per-week brand sentiment (positive/neutral/negative percentages) sourced from
    * the Semrush Sentiment element, in the legacy `{ weeklyTrends: [...] }` contract so the
@@ -2048,6 +2114,7 @@ export default function ElementsController(context, log, env) {
     listPrompts,
     listCitedDomains,
     listSubreddits,
+    listRedditThreads,
     listSentimentOverview,
     listTopics,
     listTopicPrompts,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -889,6 +889,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -269,6 +269,8 @@ export default function getRouteHandlers(
     // Per-subreddit Reddit stats (Subreddits element faf56e29).
     // eslint-disable-next-line max-len
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': elementsController.listSubreddits,
+    // Top Reddit threads by response count (Reddit Threads element 5af96fd9).
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': elementsController.listRedditThreads,
     // Data Insights per-topic table (grouped from the prompts-by-topic element).
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': elementsController.listTopics,
     // Data Insights per-prompt drill-down: :topicId is the URL-encoded topic NAME.

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -328,6 +328,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'brand:read',

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -34,6 +34,7 @@ export {
   buildCitedDomainsPayload, transformCitedDomainsResponse, transformCitedDomainsResponses,
 } from './cited-domains.js';
 export { buildSubredditsPayload, transformSubredditsResponse } from './subreddits.js';
+export { buildRedditThreadsPayload, transformRedditThreadsResponse } from './reddit-threads.js';
 export { buildTopicPromptsPayload, transformTopicPromptsResponse } from './topic-prompts.js';
 export { aggregateTopicsFromPrompts } from './topics-insights.js';
 export {

--- a/src/support/elements/definitions/reddit-threads.js
+++ b/src/support/elements/definitions/reddit-threads.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+import { derivePreviousPeriod } from './kpi-headlines.js';
+
+/* c8 ignore start -- SITES-POC reddit-threads endpoint; unit tests intentionally deferred */
+/**
+ * Builds the payload for the Reddit Threads element (5af96fd9). The element is a `table`
+ * returning one row per thread with mentions/prompts/responses over the given window,
+ * ranked by the caller (this endpoint sorts by `responses` descending).
+ *
+ * Quirks (from the discovery payload; not yet verified live against real data):
+ *  - Date range is `CBF_date__start`/`CBF_date__end` in the `advanced` block; `CBF_model`
+ *    sits inside an `or` block within `advanced`, same shape as Subreddits.
+ *  - Unlike Subreddits, the discovery payload also carries a comparison window
+ *    (`CBF_date__start_comparison`/`CBF_date__end_comparison`) and
+ *    `comparison_data_formatting: 'join'` (Subreddits uses `'union'` and omits the
+ *    comparison columns as a verified no-op). Since this element hasn't been verified
+ *    live yet, the comparison window is included rather than assumed inert, derived as
+ *    the immediately-preceding period of equal length via {@link derivePreviousPeriod}.
+ *  - `project_id` is OPTIONAL, mirroring Subreddits: supplied → scope to that one project
+ *    (set on BOTH the top-level and `filters.simple`). Omitted → `simple` stays `{}`.
+ *  - Brand scoping is via the request's sub-workspace, not a filter.
+ *
+ * @param {object} [params]
+ * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
+ *   code), translated + validated via {@link resolveElementModel}. Omitted or unknown →
+ *   defaults to `search-gpt` (the resolver's fallback), consistent with sibling definitions.
+ * @param {string} params.startDate - ISO date (YYYY-MM-DD). Required — the controller
+ *   validates it and rejects a missing/invalid range with 400, so there is no default here.
+ * @param {string} params.endDate - ISO date (YYYY-MM-DD). Required (see startDate).
+ * @param {string} [params.projectId] - Semrush project id to scope to (top-level +
+ *   simple). Omitted → all of the workspace's projects.
+ */
+export function buildRedditThreadsPayload({
+  model, startDate, endDate, projectId,
+} = {}) {
+  const resolvedModel = resolveElementModel(model);
+  const { comparisonStartDate, comparisonEndDate } = derivePreviousPeriod(startDate, endDate);
+
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+    { op: 'gte', val: startDate, col: 'CBF_date__start' },
+    { op: 'lte', val: endDate, col: 'CBF_date__end' },
+    { op: 'gte', val: comparisonStartDate, col: 'CBF_date__start_comparison' },
+    { op: 'lte', val: comparisonEndDate, col: 'CBF_date__end_comparison' },
+  ];
+
+  return {
+    ...(projectId && { project_id: projectId }),
+    comparison_data_formatting: 'join',
+    filters: {
+      simple: { ...(projectId && { project_id: projectId }) },
+      advanced: { op: 'and', filters: advancedFilters },
+    },
+  };
+}
+
+/**
+ * Parses the pagination params (0-based `page`, `pageSize`), mirroring subreddits
+ * (default 50, clamped to [1, 1000]).
+ */
+function parsePagination({ page, pageSize } = {}) {
+  return {
+    page: Math.max(0, Number.parseInt(page, 10) || 0),
+    pageSize: Math.min(Math.max(1, Number.parseInt(pageSize, 10) || 50), 1000),
+  };
+}
+
+/**
+ * Transforms the raw Reddit Threads element response (`table`, rows in `blocks.data`) into
+ * a normalized, camelCased contract:
+ *   { threads: [{ link, mentions, prompts, responses, subreddit, thread, urlCbf }],
+ *     totalCount }
+ *
+ * Numeric fields use `Number(x) || 0` (not `Number(x ?? 0)`) so a non-numeric value coerces
+ * to 0 instead of NaN. Rows are sorted by `responses` descending (the "citation count" for
+ * this endpoint), tie-broken by `urlCbf` so pagination is deterministic when counts are
+ * equal, then paginated client-side (Semrush has no server-side paging); `totalCount` is
+ * the pre-slice row count.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @param {object} [params] - Query params (page, pageSize).
+ * @returns {{ threads: Array<object>, totalCount: number }}
+ */
+export function transformRedditThreadsResponse(raw, params = {}) {
+  const rows = (raw?.blocks?.data ?? [])
+    .filter((row) => row && row.link != null)
+    .map((row) => ({
+      link: row.link || '',
+      mentions: Number(row.mentions) || 0,
+      prompts: Number(row.prompts) || 0,
+      responses: Number(row.responses) || 0,
+      subreddit: row.subreddit || '',
+      thread: row.thread || '',
+      urlCbf: row.url_cbf || '',
+    }))
+    .sort((a, b) => b.responses - a.responses || a.urlCbf.localeCompare(b.urlCbf));
+
+  const { page, pageSize } = parsePagination(params);
+  const totalCount = rows.length;
+  const offset = page * pageSize;
+  return { threads: rows.slice(offset, offset + pageSize), totalCount };
+}
+/* c8 ignore stop */

--- a/src/support/elements/element-ids.js
+++ b/src/support/elements/element-ids.js
@@ -43,6 +43,17 @@ export const ELEMENT_IDS = Object.freeze({
   // is via the request's sub-workspace, not a filter.
   SUBREDDITS: 'faf56e29-ddda-4480-b639-586d526c9080',
 
+  // Reddit Threads — top Reddit threads by response count (`table`), one row per thread:
+  // { link, mentions, prompts, responses, subreddit, thread, url_cbf }. Honors date
+  // (`CBF_date__start`/`__end`) + `CBF_model`, plus a comparison window
+  // (`CBF_date__start_comparison`/`__end_comparison`) and `comparison_data_formatting: 'join'`
+  // — unlike Subreddits, this element's discovery payload carries comparison columns, and
+  // (not yet verified live) they are assumed load-bearing rather than dropped. Optional
+  // top-level `project_id` — mirrors Subreddits' optional scoping (unverified for this
+  // element; assumed workspace-wide when omitted). Brand scoping is via the request's
+  // sub-workspace, not a filter.
+  REDDIT_THREADS: '5af96fd9-4f62-44d3-96c6-5c0604330f6a',
+
   // URL Inspector — Owned URLs ("Your cited URLs" table). Two elements, both
   // scoped by a top-level `project_id` (region/market) + date + `CBF_model`;
   // neither honors a server-side content-type filter, so `domain_type='Owned'`

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -43,6 +43,8 @@ import {
   transformCitedDomainsResponses,
   buildSubredditsPayload,
   transformSubredditsResponse,
+  buildRedditThreadsPayload,
+  transformRedditThreadsResponse,
   buildTopicPromptsPayload,
   transformTopicPromptsResponse,
   aggregateTopicsFromPrompts,
@@ -353,6 +355,32 @@ export function createElementsService(transport, log) {
         buildSubredditsPayload({ ...rest, projectId }),
       );
       return transformSubredditsResponse(raw, rest);
+    },
+
+    /**
+     * Fetches top Reddit threads by response count from the Reddit Threads element
+     * (5af96fd9), normalized into `{ threads: [...], totalCount }`. (Inside the
+     * surrounding c8-ignore region — same POC coverage treatment as the sibling
+     * methods here.)
+     *
+     * Single call (no per-project fan-out), mirroring `getSubreddits`. A
+     * caller-supplied project id scopes to that one project; `projectIds` (a CSV the
+     * controller already parsed + ownership-checked) is narrowed to its first id here.
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} params - Query params (model/platform, startDate, endDate,
+     *   projectIds, page, pageSize).
+     * @returns {Promise<{ threads: object[], totalCount: number }>}
+     */
+    async getRedditThreads(workspaceId, params) {
+      const { projectIds, ...rest } = params;
+      const projectId = Array.isArray(projectIds) ? projectIds.find(hasText) : undefined;
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.REDDIT_THREADS,
+        buildRedditThreadsPayload({ ...rest, projectId }),
+      );
+      return transformRedditThreadsResponse(raw, rest);
     },
 
     /**

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -483,6 +483,29 @@ const FIXTURES = {
       totalCount: 107,
     },
   },
+  listSerenityBrandPresenceRedditThreads: {
+    expectedStatus: 200,
+    usesElementsController: true,
+    controllerMethod: 'listRedditThreads',
+    serviceMethod: 'getRedditThreads',
+    // startDate/endDate are required + validated by the controller before the
+    // service is called (see listRedditThreads) — supply them via query.
+    query: { startDate: '2026-06-01', endDate: '2026-07-16' },
+    // getRedditThreads returns the final { threads, totalCount } shape; the
+    // controller passes it straight through via ok().
+    handlerResult: {
+      threads: [{
+        link: 'https://www.reddit.com/r/BuyItForLife/comments/1kqgvja/lovesac_sactional_is_it_worth_it',
+        mentions: 75,
+        prompts: 28,
+        responses: 62,
+        subreddit: 'r/BuyItForLife',
+        thread: 'LoveSac Sactional, is it worth it? : r/BuyItForLife - Reddit',
+        urlCbf: '59bfcb03-11df-44ff-867a-ac2b30c49578:eq:https_C0L_//www.reddit.com/r/BuyItForLife/comments/1kqgvja/lovesac_sactional_is_it_worth_it',
+      }],
+      totalCount: 42,
+    },
+  },
   listSerenityBrandPresenceTopics: {
     expectedStatus: 200,
     usesElementsController: true,

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1023,6 +1023,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls',


### PR DESCRIPTION
## Summary

Adds a new read-only Serenity Brand Presence endpoint that returns the top Reddit threads ranked by citation/response count, sourced from a new Semrush Elements API element.

### New endpoint
`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads`

### Behavior
- Backed by the Semrush **Reddit Threads** element (`5af96fd9-4f62-44d3-96c6-5c0604330f6a`).
- Requires validated `startDate`/`endDate` (`YYYY-MM-DD`, range ≤ 366 days); optional `model`/`platform` and `projectId`(s), same as the sibling `subreddits` endpoint.
- Single upstream call — no per-project fan-out. Omitting `projectId` aggregates workspace-wide; supplying one scopes to that project.
- Unlike `subreddits`,cludes a comparisonwindow (`CBF_date__start_comparison`/`__end_comparison`, `comparison_data_formas the immediatelypreceding period of equal length via the existing                      `derivePreviousPeriod`
- Response is normalized to:                                             ```json
  { "threads": [{ "link", "mentions", "prompts", "responses",          "subreddit", "thread",: 0 }
  sorted by responses descending (the "citation count" ranking metric, per your confirmation)d paginatedclient-side.
- Route classified llmability map; staticpath, so no new :param classification was needed.

Files changed

┌──────────────────────────────────┬───────────────────────────────┐
│               File  Change             │
├──────────────────────────────────┼───────────────────────────────┤
│ src/support/elementsT_THREADS element  │
│ .js                              │ UUID + quirk notes            │
├────────────────────────────────────────┤
│ src/support/elements/definitions │ buildRedditThreadsPayload + t │
│ /reddit-threads.js (ditThreadsResponse │
├──────────────────────────────────┼───────────────────────────────┤
│ src/support/elementsdefinition         │
│ /index.js                        │ functions                     │
├────────────────────────────────────────┤
│ src/support/elements/elements-se │ Added                         │
│ rvice.js            reads(workspaceId, │
│                                  │  params)                      │
├────────────────────────────────────────┤
│                                  │ Added listRedditThreads       │
│ src/controllers/elemlidation, auth,    │
│                                  │ project ownership)            │
├────────────────────────────────────────┤
│ src/routes/index.js              │ Registered the new route      │
├────────────────────────────────────────┤
│ src/routes/required-capabilities │ brand:read capability mapping │
│ .js                                    │
├──────────────────────────────────┼───────────────────────────────┤
│ src/routes/facs-capaew FACS mapping    │
├──────────────────────────────────┼───────────────────────────────┤
│ docs/openapi/api.yamperation, and      │
│ serenity-api.yaml, schemas.yaml  │ SerenityBrandPresenceRedditTh │
│                     eads schemas       │
├──────────────────────────────────┼───────────────────────────────┤
│ test/openapi-contracxture for the new  │
│ pi.test.js                       │ operationId                   │
├────────────────────────────────────────┤
│ test/routes/index.test.js        │ Route registration assertion  │
└────────────────────────────────────────┘

Testing / verification

- Full unit suite: 17,
- npm run lint, npm run type-check, npm run docs:lint: clean.
- test/routes/facs-captest/routes/required-capabilities.test.js: passing (no drift).
- docs/index.html leftegenerated copy waspure hash/markup churn from a non-canonical toolchain, per repo
  convention.

Notably a POC, matchin

- No unit or integratiervice method/payloadbuilder — all wrapped in /* c8 ignore start/stop */, consistent with
  every other brand-prddits,sentiment-overview, cited-domains, etc.).
- The comparison-date ven in the samplepayload rather than assumed to be a no-op, since (unlike subreddits) this element hasn't lagged in the codecomments for future verification.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Char", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```