### PR TITLE
feat: introduce top youtube cited videos from semrush brand presence data

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -200,6 +200,8 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-subreddits'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/reddit-threads:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-reddit-threads'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/youtube-videos:
+    $ref: './serenity-api.yaml#/v2-serenity-brand-presence-youtube-videos'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-topics'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/topics/{topicId}/prompts:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12809,7 +12809,7 @@ SerenityBrandPresenceYoutubeVideoRow:
   properties:
     channel:
       type: string
-      description: YouTube channel name. `-` when the element has no channel data for this video.
+      description: YouTube channel name. Empty string when the element has no channel data for this video.
       example: 'Lovesac'
     citations:
       type: integer

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12802,6 +12802,56 @@ SerenityBrandPresenceRedditThreads:
       type: integer
       example: 42
 
+SerenityBrandPresenceYoutubeVideoRow:
+  type: object
+  description: A single YouTube video ranked by citation count.
+  required: [channel, citations, link, prompts, video, views]
+  properties:
+    channel:
+      type: string
+      description: YouTube channel name. `-` when the element has no channel data for this video.
+      example: 'Lovesac'
+    citations:
+      type: integer
+      description: Number of AI responses citing this video. Endpoint's ranking metric ("citation count").
+      example: 53
+    link:
+      type: string
+      description: Video URL.
+      example: 'https://www.youtube.com/watch?v=4ECf112-SSc'
+    prompts:
+      type: integer
+      description: Number of prompts whose responses cited this video.
+      example: 47
+    video:
+      type: string
+      description: Video title, as returned by the element.
+      example: 'Lovesac Product Guide - CitySac Overview'
+    views:
+      type: integer
+      description: View count, coerced to 0 when the element has no tracked view count for this video.
+      example: 106100
+    urlCbf:
+      type: string
+      description: Opaque Semrush custom-field-value key for the video URL.
+      example: '59bfcb03-11df-44ff-867a-ac2b30c49578:eq:https_C0L_//www.youtube.com/watch?v=4ECf112-SSc'
+
+SerenityBrandPresenceYoutubeVideos:
+  type: object
+  description: |
+    Top YouTube videos from the Semrush "YouTube Videos" element (05e624db), sorted by
+    `citations` descending (tie-broken by `urlCbf`) and paginated. `totalCount` is the
+    full pre-pagination row count.
+  required: [videos, totalCount]
+  properties:
+    videos:
+      type: array
+      items:
+        $ref: '#/SerenityBrandPresenceYoutubeVideoRow'
+    totalCount:
+      type: integer
+      example: 42
+
 SerenityBrandPresenceTopics:
   type: object
   description: |

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1697,7 +1697,8 @@ v2-serenity-brand-presence-youtube-videos:
       Returns the top YouTube videos (channel, citations, link, prompts, video title,
       views) from the Semrush "YouTube Videos" element (05e624db). Rows are sorted by
       `citations` descending (tie-broken by an internal video key) and paginated
-      server-side.
+      after retrieval (the full result set is fetched from the upstream element and
+      sliced in-memory; a large page offset is not a cheap upstream query).
 
       Brand-scoped via the brand's Semrush sub-workspace (resolved from `:brandId`).
       A single upstream call: the element aggregates across the whole workspace when

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1674,6 +1674,128 @@ v2-serenity-brand-presence-reddit-threads:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
       '500': { $ref: './responses.yaml#/500' }
 
+v2-serenity-brand-presence-youtube-videos:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Top YouTube videos by citation count for the Serenity brand presence dashboard
+    description: |
+      Returns the top YouTube videos (channel, citations, link, prompts, video title,
+      views) from the Semrush "YouTube Videos" element (05e624db). Rows are sorted by
+      `citations` descending (tie-broken by an internal video key) and paginated
+      server-side.
+
+      Brand-scoped via the brand's Semrush sub-workspace (resolved from `:brandId`).
+      A single upstream call: the element aggregates across the whole workspace when
+      no `projectId` is sent, and scopes to one project when it is. `model`/`platform`
+      are translated to a Semrush model server-side.
+    operationId: listSerenityBrandPresenceYoutubeVideos
+    security:
+      - session_token: []
+    parameters:
+      - name: startDate
+        in: query
+        required: true
+        description: Inclusive range start (YYYY-MM-DD). Range must not exceed 366 days.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        required: true
+        description: Inclusive range end (YYYY-MM-DD). Range must not exceed 366 days.
+        schema: { type: string, format: date }
+      - name: model
+        in: query
+        required: false
+        description: |
+          AI model to scope to. Accepts a Semrush Elements model name directly, or a
+          SpaceCat/UI platform code (translated server-side). Defaults to `search-gpt`
+          when omitted or unrecognized.
+        schema:
+          type: string
+          x-canonical-values:
+            - google-ai-mode
+            - grok-3
+            - google-ai-overview
+            - microsoft-copilot
+            - open-evidence
+            - gemini-2.5-flash
+            - claude-sonnet-4
+            - gpt-5
+            - deepseek
+            - search-gpt
+            - perplexity
+          x-known-aliases:
+            copilot: microsoft-copilot
+            gemini: gemini-2.5-flash
+            openai: gpt-5
+            chatgpt: search-gpt
+      - name: platform
+        in: query
+        required: false
+        description: Legacy alias for `model`; `model` takes precedence when both are given.
+        schema: { type: string }
+      - name: projectId
+        in: query
+        required: false
+        description: |
+          Comma-separated Semrush project UUIDs. Alias `project_id`. Omitted →
+          the element aggregates across all of the brand's markets. Each id must be a
+          valid UUID (400 otherwise). Note: this endpoint scopes to a SINGLE project —
+          only the first id is forwarded to the element; the rest are validated for
+          ownership but not used (multi-project merge is not implemented).
+        schema: { type: string, pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}){0,7}$' }
+      - name: project_id
+        in: query
+        required: false
+        description: Snake_case alias for `projectId`.
+        schema: { type: string }
+      - name: page
+        in: query
+        required: false
+        description: 0-based page index. Defaults to 0.
+        schema: { type: integer, minimum: 0, default: 0 }
+      - name: pageSize
+        in: query
+        required: false
+        description: Page size (1..1000). Defaults to 50.
+        schema: { type: integer, minimum: 1, maximum: 1000, default: 50 }
+    responses:
+      '200':
+        description: YouTube video stats retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityBrandPresenceYoutubeVideos' }
+      '400': { $ref: './responses.yaml#/400' }
+      '403':
+        description: Caller lacks access to the organization, or a supplied projectId is not owned by the brand.
+      '404':
+        description: Organization not found, brand not found for this organization, or the brand has no resolvable Semrush workspace.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '503':
+        description: PostgREST client not available (required to resolve the brand's Semrush workspace before the element call).
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
 v2-serenity-brand-presence-topics:
   parameters:
     - name: spaceCatId

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -973,6 +973,72 @@ export default function ElementsController(context, log, env) {
   /* c8 ignore stop */
 
   /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/youtube-videos
+   * Returns top YouTube videos by citation count (channel, citations, prompts, views) from
+   * the YouTube Videos element (05e624db). Single upstream call (the element aggregates
+   * workspace-wide; a supplied projectId scopes to one project).
+   */
+  /* c8 ignore start -- SITES-POC youtube-videos endpoint; unit tests intentionally deferred */
+  const listYoutubeVideos = async (ctx) => {
+    try {
+      const auth = await authorizeOrg(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      const { workspaceId, brand } = auth;
+      const query = extractQuery(ctx);
+
+      // Date range is required + validated (mirrors reddit-threads/subreddits) —
+      // never silently default to a rolling window nor forward a malformed date to Semrush.
+      const startDate = query.startDate || query.start_date;
+      const endDate = query.endDate || query.end_date;
+      if (!hasText(startDate) || !hasText(endDate)) {
+        return badRequest('startDate and endDate are required (YYYY-MM-DD)');
+      }
+      if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+        return badRequest('startDate and endDate must be valid YYYY-MM-DD dates');
+      }
+      if (startDate > endDate) {
+        return badRequest('startDate must not be after endDate');
+      }
+      const MAX_RANGE_DAYS = 366;
+      const spanDays = (Date.parse(`${endDate}T00:00:00Z`)
+        - Date.parse(`${startDate}T00:00:00Z`)) / 86400000;
+      if (spanDays > MAX_RANGE_DAYS) {
+        return badRequest(`Date range must not exceed ${MAX_RANGE_DAYS} days`);
+      }
+
+      const service = await buildService(ctx);
+
+      // Project scoping: caller-supplied projectId(s) (CSV) scope to a single Semrush
+      // project (the service uses the first); absent → the element aggregates across all of
+      // the brand's markets. Any supplied id must belong to this brand.
+      const projectIds = extractProjectIds(query);
+      const { BrandSemrushProject } = ctx?.dataAccess ?? {};
+      const brandSemrushProjects = await fetchBrandSemrushProjects(BrandSemrushProject, [brand]);
+      const ownershipError = checkProjectIdsOwnership(projectIds, brandSemrushProjects);
+      if (ownershipError) {
+        return ownershipError;
+      }
+
+      const params = {
+        projectIds,
+        model: query.model || query.platform,
+        startDate,
+        endDate,
+        page: query.page,
+        pageSize: query.pageSize,
+      };
+
+      const result = await service.getYoutubeVideos(workspaceId, params);
+      return ok(result);
+    } catch (e) {
+      return mapError(e, log, reqCtxOf(ctx));
+    }
+  };
+  /* c8 ignore stop */
+
+  /**
    * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview
    * Returns per-week brand sentiment (positive/neutral/negative percentages) sourced from
    * the Semrush Sentiment element, in the legacy `{ weeklyTrends: [...] }` contract so the
@@ -2115,6 +2181,7 @@ export default function ElementsController(context, log, env) {
     listCitedDomains,
     listSubreddits,
     listRedditThreads,
+    listYoutubeVideos,
     listSentimentOverview,
     listTopics,
     listTopicPrompts,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -891,6 +891,7 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': 'llmo/can_view',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/youtube-videos': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -272,6 +272,8 @@ export default function getRouteHandlers(
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': elementsController.listSubreddits,
     // Top Reddit threads by response count (Reddit Threads element 5af96fd9).
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': elementsController.listRedditThreads,
+    // Top YouTube videos by citation count (YouTube Videos element 05e624db).
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/youtube-videos': elementsController.listYoutubeVideos,
     // Data Insights per-topic table (grouped from the prompts-by-topic element).
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': elementsController.listTopics,
     // Data Insights per-prompt drill-down: :topicId is the URL-encoded topic NAME.

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -330,6 +330,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/youtube-videos': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls': 'brand:read',

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -35,6 +35,7 @@ export {
 } from './cited-domains.js';
 export { buildSubredditsPayload, transformSubredditsResponse } from './subreddits.js';
 export { buildRedditThreadsPayload, transformRedditThreadsResponse } from './reddit-threads.js';
+export { buildYoutubeVideosPayload, transformYoutubeVideosResponse } from './youtube-videos.js';
 export { buildTopicPromptsPayload, transformTopicPromptsResponse } from './topic-prompts.js';
 export { aggregateTopicsFromPrompts } from './topics-insights.js';
 export {

--- a/src/support/elements/definitions/youtube-videos.js
+++ b/src/support/elements/definitions/youtube-videos.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+import { derivePreviousPeriod } from './kpi-headlines.js';
+
+/* c8 ignore start -- SITES-POC youtube-videos endpoint; unit tests intentionally deferred */
+/**
+ * Builds the payload for the YouTube Videos element (05e624db). The element is a `table`
+ * returning one row per video with channel/citations/prompts/views over the given window,
+ * ranked by the caller (this endpoint sorts by `citations` descending).
+ *
+ * Same shape as the Reddit Threads element (5af96fd9):
+ *  - Date range is `CBF_date__start`/`CBF_date__end` in the `advanced` block; `CBF_model`
+ *    sits inside an `or` block within `advanced`.
+ *  - Carries a comparison window (`CBF_date__start_comparison`/`CBF_date__end_comparison`)
+ *    and `comparison_data_formatting: 'join'`, derived as the immediately-preceding period
+ *    of equal length via {@link derivePreviousPeriod}.
+ *  - `project_id` is OPTIONAL (set on BOTH the top-level and `filters.simple`). Omitted →
+ *    `simple` stays `{}`.
+ *  - Brand scoping is via the request's sub-workspace, not a filter.
+ *
+ * @param {object} [params]
+ * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
+ *   code), translated + validated via {@link resolveElementModel}. Omitted or unknown →
+ *   defaults to `search-gpt` (the resolver's fallback), consistent with sibling definitions.
+ * @param {string} params.startDate - ISO date (YYYY-MM-DD). Required — the controller
+ *   validates it and rejects a missing/invalid range with 400, so there is no default here.
+ * @param {string} params.endDate - ISO date (YYYY-MM-DD). Required (see startDate).
+ * @param {string} [params.projectId] - Semrush project id to scope to (top-level +
+ *   simple). Omitted → all of the workspace's projects.
+ */
+export function buildYoutubeVideosPayload({
+  model, startDate, endDate, projectId,
+} = {}) {
+  const resolvedModel = resolveElementModel(model);
+  const { comparisonStartDate, comparisonEndDate } = derivePreviousPeriod(startDate, endDate);
+
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+    { op: 'gte', val: startDate, col: 'CBF_date__start' },
+    { op: 'lte', val: endDate, col: 'CBF_date__end' },
+    { op: 'gte', val: comparisonStartDate, col: 'CBF_date__start_comparison' },
+    { op: 'lte', val: comparisonEndDate, col: 'CBF_date__end_comparison' },
+  ];
+
+  return {
+    ...(projectId && { project_id: projectId }),
+    comparison_data_formatting: 'join',
+    filters: {
+      simple: { ...(projectId && { project_id: projectId }) },
+      advanced: { op: 'and', filters: advancedFilters },
+    },
+  };
+}
+
+/**
+ * Parses the pagination params (0-based `page`, `pageSize`), mirroring reddit-threads
+ * (default 50, clamped to [1, 1000]).
+ */
+function parsePagination({ page, pageSize } = {}) {
+  return {
+    page: Math.max(0, Number.parseInt(page, 10) || 0),
+    pageSize: Math.min(Math.max(1, Number.parseInt(pageSize, 10) || 50), 1000),
+  };
+}
+
+/**
+ * Transforms the raw YouTube Videos element response (`table`, rows in `blocks.data`) into
+ * a normalized, camelCased contract:
+ *   { videos: [{ channel, citations, link, prompts, video, views, urlCbf }],
+ *     totalCount }
+ *
+ * Numeric fields (including `views`, which may be `null` upstream) use `Number(x) || 0`
+ * (not `Number(x ?? 0)`) so a non-numeric or missing value coerces to 0 instead of NaN.
+ * Rows are sorted by `citations` descending (the ranking metric for this endpoint),
+ * tie-broken by `urlCbf` so pagination is deterministic when counts are equal, then
+ * paginated client-side (Semrush has no server-side paging); `totalCount` is the
+ * pre-slice row count.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @param {object} [params] - Query params (page, pageSize).
+ * @returns {{ videos: Array<object>, totalCount: number }}
+ */
+export function transformYoutubeVideosResponse(raw, params = {}) {
+  const rows = (raw?.blocks?.data ?? [])
+    .filter((row) => row && row.link != null)
+    .map((row) => ({
+      channel: row.channel || '',
+      citations: Number(row.citations) || 0,
+      link: row.link || '',
+      prompts: Number(row.prompts) || 0,
+      video: row.video || '',
+      views: Number(row.views) || 0,
+      urlCbf: row.url_cbf || '',
+    }))
+    .sort((a, b) => b.citations - a.citations || a.urlCbf.localeCompare(b.urlCbf));
+
+  const { page, pageSize } = parsePagination(params);
+  const totalCount = rows.length;
+  const offset = page * pageSize;
+  return { videos: rows.slice(offset, offset + pageSize), totalCount };
+}
+/* c8 ignore stop */

--- a/src/support/elements/element-ids.js
+++ b/src/support/elements/element-ids.js
@@ -54,6 +54,16 @@ export const ELEMENT_IDS = Object.freeze({
   // sub-workspace, not a filter.
   REDDIT_THREADS: '5af96fd9-4f62-44d3-96c6-5c0604330f6a',
 
+  // YouTube Videos — top YouTube videos by citation count (`table`), one row per video:
+  // { channel, citations, link, prompts, video, views, url_cbf }. Honors date
+  // (`CBF_date__start`/`__end`) + `CBF_model`, plus a comparison window
+  // (`CBF_date__start_comparison`/`__end_comparison`) and `comparison_data_formatting: 'join'`,
+  // same shape as Reddit Threads. Optional top-level `project_id` (also set in
+  // `filters.simple`) scopes to a single project; omitted → workspace-wide. Brand scoping
+  // is via the request's sub-workspace, not a filter. `views` may be `null` upstream (not
+  // every video has a tracked view count).
+  YOUTUBE_VIDEOS: '05e624db-0314-4f93-9337-1fae5148f057',
+
   // URL Inspector — Owned URLs ("Your cited URLs" table). Two elements, both
   // scoped by a top-level `project_id` (region/market) + date + `CBF_model`;
   // neither honors a server-side content-type filter, so `domain_type='Owned'`

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -45,6 +45,8 @@ import {
   transformSubredditsResponse,
   buildRedditThreadsPayload,
   transformRedditThreadsResponse,
+  buildYoutubeVideosPayload,
+  transformYoutubeVideosResponse,
   buildTopicPromptsPayload,
   transformTopicPromptsResponse,
   aggregateTopicsFromPrompts,
@@ -381,6 +383,32 @@ export function createElementsService(transport, log) {
         buildRedditThreadsPayload({ ...rest, projectId }),
       );
       return transformRedditThreadsResponse(raw, rest);
+    },
+
+    /**
+     * Fetches top YouTube videos by citation count from the YouTube Videos element
+     * (05e624db), normalized into `{ videos: [...], totalCount }`. (Inside the
+     * surrounding c8-ignore region — same POC coverage treatment as the sibling
+     * methods here.)
+     *
+     * Single call (no per-project fan-out), mirroring `getRedditThreads`. A
+     * caller-supplied project id scopes to that one project; `projectIds` (a CSV the
+     * controller already parsed + ownership-checked) is narrowed to its first id here.
+     *
+     * @param {string} workspaceId - Semrush workspace UUID.
+     * @param {object} params - Query params (model/platform, startDate, endDate,
+     *   projectIds, page, pageSize).
+     * @returns {Promise<{ videos: object[], totalCount: number }>}
+     */
+    async getYoutubeVideos(workspaceId, params) {
+      const { projectIds, ...rest } = params;
+      const projectId = Array.isArray(projectIds) ? projectIds.find(hasText) : undefined;
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.YOUTUBE_VIDEOS,
+        buildYoutubeVideosPayload({ ...rest, projectId }),
+      );
+      return transformYoutubeVideosResponse(raw, rest);
     },
 
     /**

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -532,6 +532,29 @@ const FIXTURES = {
       totalCount: 42,
     },
   },
+  listSerenityBrandPresenceYoutubeVideos: {
+    expectedStatus: 200,
+    usesElementsController: true,
+    controllerMethod: 'listYoutubeVideos',
+    serviceMethod: 'getYoutubeVideos',
+    // startDate/endDate are required + validated by the controller before the
+    // service is called (see listYoutubeVideos) — supply them via query.
+    query: { startDate: '2026-06-01', endDate: '2026-07-16' },
+    // getYoutubeVideos returns the final { videos, totalCount } shape; the
+    // controller passes it straight through via ok().
+    handlerResult: {
+      videos: [{
+        channel: 'Lovesac',
+        citations: 53,
+        link: 'https://www.youtube.com/watch?v=4ECf112-SSc',
+        prompts: 47,
+        video: 'Lovesac Product Guide - CitySac Overview',
+        views: 106100,
+        urlCbf: '59bfcb03-11df-44ff-867a-ac2b30c49578:eq:https_C0L_//www.youtube.com/watch?v=4ECf112-SSc',
+      }],
+      totalCount: 42,
+    },
+  },
   listSerenityBrandPresenceTopics: {
     expectedStatus: 200,
     usesElementsController: true,

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1025,6 +1025,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/youtube-videos',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/topics/:topicId/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/owned-urls',


### PR DESCRIPTION
## Summary: Add YouTube Videos endpoint

New read-only endpoint mirroring the existing `reddit-threads` endpoint pattern:

**`GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/youtube-videos`**

Backed by Semrush Elements API element `05e624db-0314-4f93-9337-1fae5148f057` ("YouTube Videos"), returning the top videos ranked by **citation count**.

### Response contract

```json
{
  "videos": [
    { "channel", "citations", "link", "prompts", "video", "views", "urlCbf" }
  ],
  "totalCount": 0
}
```

Sorted by citations descending, tie-broken by urlCbf, paginated client-side (page/pageSize). views coerces non-numeric/null to 0 (same treatment as the other numeric fields).

### Verification done

- npx eslint on all touched/added files — clean
- npm run docs:lint — spec valid (api.yaml: validated); only pre-existing unrelated warnings, none referencing the new schema/path

### Still to run

- npm run docs:build
- npm test (full unit suite, including the new contract-test fixture and route-registration assertion)
- npm run type-check

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```