### PR TITLE
fix: preserve site_id on upsertBrand when it already matches

### DIFF
--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -1263,18 +1263,31 @@ export async function upsertBrand({
     await assertSiteBelongsToOrg(postgrestClient, brand.baseSiteId, organizationId, brand.name);
   }
 
-  if (existing === null) {
+  if (existing === null || !hasText(existing.site_id)) {
+    // Fresh create, or first anchor for a previously unanchored brand: assign
+    // whatever baseSiteId the caller supplied (or leave unset if they didn't).
     row.site_id = hasText(brand.baseSiteId) ? brand.baseSiteId : null;
-  } else if (hasText(brand.baseSiteId) && !hasText(existing.site_id)) {
-    row.site_id = brand.baseSiteId;
-  } else if (
-    hasText(brand.baseSiteId)
-    && hasText(existing.site_id)
-    && existing.site_id !== brand.baseSiteId
-  ) {
-    log.warn(`upsertBrand: ignoring baseSiteId change for brand "${brand.name}" `
-      + `(org ${organizationId}) — primary site is immutable `
-      + `(existing=${existing.site_id}, attempted=${brand.baseSiteId})`);
+  } else {
+    // Already anchored (existing.site_id is set) — site_id is immutable once
+    // persisted, so this call never changes it. But it MUST still be carried
+    // forward into `row` explicitly: this upsert always goes through
+    // `.upsert(row, { onConflict: 'organization_id,name' })`, and a column
+    // absent from that payload is not preserved on the resulting UPDATE — it
+    // ends up unset on the written row. Before this fix, re-submitting the
+    // brand's OWN already-correct baseSiteId (the common case: any caller
+    // that reads a brand back and re-upserts it verbatim) omitted site_id
+    // from every one of the three prior branches, silently clearing an
+    // already-anchored brand's site_id and tripping
+    // chk_active_brand_has_site_id — a 400 on a request that never intended
+    // to touch the anchor at all. Found via a brandalf migration script
+    // re-upserting already-onboarded brands (Grainger, Druva, Interface, ABB,
+    // Arkose Labs all hit this identically).
+    if (hasText(brand.baseSiteId) && brand.baseSiteId !== existing.site_id) {
+      log.warn(`upsertBrand: ignoring baseSiteId change for brand "${brand.name}" `
+        + `(org ${organizationId}) — primary site is immutable `
+        + `(existing=${existing.site_id}, attempted=${brand.baseSiteId})`);
+    }
+    row.site_id = existing.site_id;
   }
 
   const { data: upserted, error } = await postgrestClient

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1361,8 +1361,63 @@ describe('brands-storage', () => {
       });
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
-      expect(brandsUpsert.row).to.not.have.property('site_id');
+      // The attempted change to 'different-site' is rejected (warns, doesn't
+      // apply), but site_id must still be carried forward as the EXISTING
+      // value rather than omitted from the row entirely — an omitted column
+      // is not preserved by the upsert and would trip
+      // chk_active_brand_has_site_id on write (see the fix above this branch).
+      expect(brandsUpsert.row.site_id).to.equal('original-site');
       expect(log.warn).to.have.been.calledWithMatch('immutable');
+    });
+
+    it('carries forward site_id when re-upserting an already-anchored brand with the SAME baseSiteId', async () => {
+      // The exact case that was silently broken: a caller (e.g. a migration
+      // script) reads a brand back and re-submits its own already-correct
+      // baseSiteId verbatim. None of the three original branches matched this
+      // (existing !== null, existing.site_id already set, and the "changed"
+      // branch's inequality check is false), so site_id was omitted from the
+      // upsert row entirely — silently clearing an already-anchored brand and
+      // tripping chk_active_brand_has_site_id with a 400 on a request that
+      // never intended to touch the anchor.
+      const client = createCapturingClient({
+        brands: [
+          { data: { site_id: 'same-site' }, error: null }, // existing lookup
+          { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
+          { data: makeBrandRow({ name: 'Test', site_id: 'same-site' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', baseSiteId: 'same-site' },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.site_id).to.equal('same-site');
+    });
+
+    it('carries forward site_id when re-upserting an already-anchored brand with NO baseSiteId in the body', async () => {
+      // Same underlying gap, different trigger: a partial upsert that omits
+      // baseSiteId altogether on an already-anchored brand also hit none of
+      // the three original branches (all three require hasText(baseSiteId)
+      // except the existing===null branch), dropping site_id the same way.
+      const client = createCapturingClient({
+        brands: [
+          { data: { site_id: 'existing-site' }, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test', site_id: 'existing-site' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test' },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.site_id).to.equal('existing-site');
     });
 
     it('rejects a fresh create whose baseSiteId belongs to a different org (serenity-docs#346)', async () => {


### PR DESCRIPTION
## Summary

`upsertBrand`'s `site_id` assignment has three branches (fresh create, first-time anchor, and a rejected-change-with-warning), but no branch covers the case where an already-anchored brand's `site_id` already equals the submitted `baseSiteId` — or where `baseSiteId` is omitted entirely on an update to an already-anchored brand. In both cases `site_id` never makes it into the `row` object passed to `.upsert(row, { onConflict: 'organization_id,name' })`. A column absent from that payload is not preserved on the resulting UPDATE — it ends up unset on the written row, which trips the `chk_active_brand_has_site_id` check constraint and surfaces as a 400 (`Cannot activate a brand without a base site URL`) on a request that never intended to touch the anchor at all.

## How this was found

A brandalf (V1→V2) migration script re-upserting already-onboarded brands hit this on every org it tried: Grainger, Druva, Interface, ABB, and Arkose Labs all have a legacy brand row already correctly anchored to their own site (created independently of the migration, months earlier). Re-submitting that brand's own already-correct `baseSiteId` — the common case for any caller that reads a brand back and re-upserts it — silently clears `site_id` and fails with the 400 above. Confirmed live (dry-run, no writes) that the request body sent the correct `baseSiteId`, matching the org's existing brand exactly; the gap is entirely in `upsertBrand`'s branch logic, not the caller.

## Fix

Restructures the `site_id` assignment into two cases:
- **Unanchored** (`existing === null` or `existing.site_id` not set): assign whatever `baseSiteId` the caller supplied, or leave unset — unchanged from before.
- **Already anchored**: `site_id` is immutable once persisted, so this call never changes it — but it must now be carried forward into `row` explicitly (`row.site_id = existing.site_id`) so it isn't silently dropped from the upsert. Still warns if the caller attempted to change it to a different value, same as before.

## Validation

- [x] Updated the existing `LLMO-5556` test ("does NOT overwrite an existing brand site_id and warns") — it previously asserted `row` has no `site_id` property at all, which was actually asserting the bug. Now asserts `row.site_id` equals the existing value.
- [x] Added a regression test for the exact triggering case: re-upserting an already-anchored brand with the *same* `baseSiteId`.
- [x] Added a regression test for the omitted-`baseSiteId` variant of the same gap.
- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [x] Full `npm test` — 17264 passing, 0 failing
- [x] Pre-commit hooks (lint-staged, docs:lint, type-check) passed on commit

## Introduced by

N/A — this branch of `upsertBrand`'s site_id logic predates this investigation; not tracing to a single prior PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```