### PR TITLE
feat(LLMO-6973): add structured audit_orchestration logging for offsite audit types

### DIFF
--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -26,24 +26,11 @@ import {
   postSiteNotFoundMessage,
 } from '../../../utils/slack/base.js';
 
-import { triggerAuditForSite } from '../../utils.js';
+import { isOffsiteAuditType, triggerAuditForSite } from '../../utils.js';
 
 const PHRASES = ['run audit'];
 const LHS_MOBILE = 'lhs-mobile';
 const PRERENDER = 'prerender';
-
-// Offsite Opportunities audit types (LLMO-6973). Structured `audit_orchestration_start` /
-// `audit_orchestration_spacecat_request_dispatched` logging below is gated on this list so
-// every other audit type's existing behavior and log lines are left completely unchanged —
-// this command dispatches every audit type in the system through the same shared code path.
-const OFFSITE_AUDIT_TYPES = [
-  'offsite-brand-presence',
-  'cited-analysis',
-  'reddit-analysis',
-  'youtube-analysis',
-  'wikipedia-analysis',
-];
-const isOffsiteAuditType = (auditType) => OFFSITE_AUDIT_TYPES.includes(auditType);
 
 // Structured logging taxonomy constants (05-logging.md, "Structured logging taxonomy").
 // `domain` is a fixed marker on every line in this family. `audit` maps this command's
@@ -326,8 +313,12 @@ function RunAuditCommand(context) {
             );
             log.info(`${getQueuedOffsiteMessage(auditType)} domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_spacecat_request_dispatched outcome=success peer=spacecat-audit-worker direction=outbound siteId=${site.getId()}`);
           } catch (error) {
+            // Own this failure fully here (structured log + user-facing reply) rather than
+            // re-throwing into the generic outer catch below, which would log a second,
+            // unstructured "Error running audit..." line for the same single SQS failure
+            // (catch-log-throw) and inflate error counts for on-call triage.
             log.error(`Failed to queue offsite analysis for site domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_spacecat_request_dispatched outcome=failure peer=spacecat-audit-worker direction=outbound siteId=${site.getId()} reason=sqs_send_failed ${renderErrorField('errorName', error.name)} ${renderErrorField('errorMessage', error.message)}`);
-            throw error;
+            await postErrorMessage(say, error);
           }
         } else {
           await triggerAuditForSite(

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -31,6 +31,79 @@ import { triggerAuditForSite } from '../../utils.js';
 const PHRASES = ['run audit'];
 const LHS_MOBILE = 'lhs-mobile';
 const PRERENDER = 'prerender';
+
+// Offsite Opportunities audit types (LLMO-6973). Structured `audit_orchestration_start` /
+// `audit_orchestration_spacecat_request_dispatched` logging below is gated on this list so
+// every other audit type's existing behavior and log lines are left completely unchanged —
+// this command dispatches every audit type in the system through the same shared code path.
+const OFFSITE_AUDIT_TYPES = [
+  'offsite-brand-presence',
+  'cited-analysis',
+  'reddit-analysis',
+  'youtube-analysis',
+  'wikipedia-analysis',
+];
+const isOffsiteAuditType = (auditType) => OFFSITE_AUDIT_TYPES.includes(auditType);
+
+// Structured logging taxonomy constants (05-logging.md, "Structured logging taxonomy").
+// `domain` is a fixed marker on every line in this family. `audit` maps this command's
+// own audit-type strings to the short taxonomy values used across the doc/runbooks and
+// by spacecat-audit-worker's own AUDIT enum (offsite-logging.js) — match those exactly.
+const OFFSITE_DOMAIN = 'offsite';
+const OFFSITE_AUDIT_LOG_TYPE = {
+  'offsite-brand-presence': 'brand-presence',
+  'cited-analysis': 'cited',
+  'reddit-analysis': 'reddit',
+  'youtube-analysis': 'youtube',
+  'wikipedia-analysis': 'wikipedia',
+};
+const toOffsiteAuditLogType = (auditType) => OFFSITE_AUDIT_LOG_TYPE[auditType];
+
+/**
+ * Builds the success message for `audit_orchestration_spacecat_request_dispatched`.
+ * `offsite-brand-presence` uses its own wording to match the message
+ * `spacecat-jobs-dispatcher` emits for the same event/audit type.
+ * @param {string} auditType - The resolved offsite audit type.
+ * @returns {string} The message text.
+ */
+const getQueuedOffsiteMessage = (auditType) => (auditType === 'offsite-brand-presence'
+  ? 'Queued offsite-brand-presence for site'
+  : 'Queued offsite analysis for site');
+
+/**
+ * Strips control characters (including DEL) from externally-influenced error text
+ * (e.g. an SQS/AWS SDK error's `.name`/`.message`) before it goes into a structured log
+ * line, replacing each with a single space. Mirrors the narrow sanitization rule from
+ * spacecat-audit-worker's offsite-logging.js `sanitizeForLog` — this only guards against
+ * control-character injection into the log line, not a full port of that logger.
+ * @param {*} value - The raw value to sanitize.
+ * @returns {string} The sanitized string.
+ */
+function sanitizeErrorText(value) {
+  if (value == null) {
+    return '';
+  }
+  let out = '';
+  for (const ch of String(value)) {
+    const code = ch.codePointAt(0);
+    out += (code < 0x20 || code === 0x7f) ? ' ' : ch;
+  }
+  return out;
+}
+
+/**
+ * Renders a single `key=value` structured-log field for externally-influenced error text,
+ * quoting (and escaping embedded double quotes) whenever the sanitized value contains
+ * whitespace, `"`, or `=` — otherwise a raw AWS error message would break the field
+ * boundary of the line it's appended to. Mirrors offsite-logging.js's `renderField`.
+ * @param {string} key - The field name.
+ * @param {*} value - The raw value.
+ * @returns {string} The rendered `key=value` (or `key="value"`) field.
+ */
+function renderErrorField(key, value) {
+  const str = sanitizeErrorText(value);
+  return /[\s"=]/.test(str) ? `${key}="${str.replace(/"/g, "'")}"` : `${key}=${str}`;
+}
 const PRERENDER_MODES = {
   ALL: 'all',
   AI_ONLY: 'ai-only',
@@ -168,6 +241,9 @@ function RunAuditCommand(context) {
       const configuration = await Configuration.findLatest();
 
       if (!isNonEmptyObject(site)) {
+        if (isOffsiteAuditType(auditType)) {
+          log.error(`No site found with base URL domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=failure reason=site_not_found`);
+        }
         await postSiteNotFoundMessage(say, baseURL);
         return;
       }
@@ -223,23 +299,45 @@ function RunAuditCommand(context) {
 
         // Block audit if site has no enrollment for any of the product codes
         if (!entitlementChecks.some((hasEnrollment) => hasEnrollment)) {
+          if (isOffsiteAuditType(auditType)) {
+            log.error(`Site not entitled for this audit type domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=failure siteId=${site.getId()} reason=not_entitled`);
+          }
           await say(`:x: Will not audit site '${baseURL}' because site is not entitled for this audit.`);
           return;
         }
 
         // Block audit if the handler is explicitly disabled for this site (deny-list).
         if (configuration.isHandlerDisabledForSite(auditType, site)) {
+          if (isOffsiteAuditType(auditType)) {
+            log.error(`Handler disabled for this site domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=failure siteId=${site.getId()} reason=handler_disabled`);
+          }
           await say(`:x: Audit \`${auditType}\` is explicitly disabled for site \`${baseURL}\`. Re-enable it via the audit configuration before running on-demand.`);
           return;
         }
 
-        await triggerAuditForSite(
-          site,
-          auditType,
-          auditData,
-          slackContext,
-          context,
-        );
+        if (isOffsiteAuditType(auditType)) {
+          try {
+            await triggerAuditForSite(
+              site,
+              auditType,
+              auditData,
+              slackContext,
+              context,
+            );
+            log.info(`${getQueuedOffsiteMessage(auditType)} domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_spacecat_request_dispatched outcome=success peer=spacecat-audit-worker direction=outbound siteId=${site.getId()}`);
+          } catch (error) {
+            log.error(`Failed to queue offsite analysis for site domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_spacecat_request_dispatched outcome=failure peer=spacecat-audit-worker direction=outbound siteId=${site.getId()} reason=sqs_send_failed ${renderErrorField('errorName', error.name)} ${renderErrorField('errorMessage', error.message)}`);
+            throw error;
+          }
+        } else {
+          await triggerAuditForSite(
+            site,
+            auditType,
+            auditData,
+            slackContext,
+            context,
+          );
+        }
       }
     } catch (error) {
       log.error(`Error running audit ${auditType} for site ${baseURL}`, error);
@@ -355,7 +453,15 @@ function RunAuditCommand(context) {
         [baseURLInputArg, auditTypeInputArg, auditDataInputArg] = positionalArgs;
       }
 
-      log.info(`run-audit: baseURL="${baseURLInputArg}", auditType="${auditTypeInputArg}", auditData="${auditDataInputArg}"`);
+      if (isOffsiteAuditType(auditTypeInputArg)) {
+        log.info(
+          `run-audit: baseURL="${baseURLInputArg}", auditType="${auditTypeInputArg}", auditData="${auditDataInputArg}" `
+          + `domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditTypeInputArg)} `
+          + `event=audit_orchestration_start outcome=start auditType=${auditTypeInputArg} baseURL=${baseURLInputArg}`,
+        );
+      } else {
+        log.info(`run-audit: baseURL="${baseURLInputArg}", auditType="${auditTypeInputArg}", auditData="${auditDataInputArg}"`);
+      }
 
       const hasFiles = isNonEmptyArray(files);
       const baseURL = extractURLFromSlackInput(baseURLInputArg);

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -229,7 +229,11 @@ function RunAuditCommand(context) {
 
       if (!isNonEmptyObject(site)) {
         if (isOffsiteAuditType(auditType)) {
-          log.error(`No site found with base URL domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=failure reason=site_not_found`);
+          // Nothing was owed here — an operator's manual command hitting a site that doesn't
+          // exist is an expected business-logic outcome, not a system fault. `warn` keeps it
+          // visible for dashboards without paging; error stays reserved for outcome=failure
+          // (see the SQS dispatch failure below, which genuinely loses completed work).
+          log.warn(`No site found with base URL domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=skip reason=site_not_found`);
         }
         await postSiteNotFoundMessage(say, baseURL);
         return;
@@ -287,7 +291,9 @@ function RunAuditCommand(context) {
         // Block audit if site has no enrollment for any of the product codes
         if (!entitlementChecks.some((hasEnrollment) => hasEnrollment)) {
           if (isOffsiteAuditType(auditType)) {
-            log.error(`Site not entitled for this audit type domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=failure siteId=${site.getId()} reason=not_entitled`);
+            // Expected business-logic outcome (a site simply isn't entitled), not a system
+            // fault — see the site_not_found warn above for the same reasoning.
+            log.warn(`Site not entitled for this audit type domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=skip siteId=${site.getId()} reason=not_entitled`);
           }
           await say(`:x: Will not audit site '${baseURL}' because site is not entitled for this audit.`);
           return;
@@ -296,7 +302,9 @@ function RunAuditCommand(context) {
         // Block audit if the handler is explicitly disabled for this site (deny-list).
         if (configuration.isHandlerDisabledForSite(auditType, site)) {
           if (isOffsiteAuditType(auditType)) {
-            log.error(`Handler disabled for this site domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=failure siteId=${site.getId()} reason=handler_disabled`);
+            // Expected business-logic outcome (an admin explicitly disabled this handler for
+            // this site), not a system fault — see the site_not_found warn above.
+            log.warn(`Handler disabled for this site domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_start outcome=skip siteId=${site.getId()} reason=handler_disabled`);
           }
           await say(`:x: Audit \`${auditType}\` is explicitly disabled for site \`${baseURL}\`. Re-enable it via the audit configuration before running on-demand.`);
           return;
@@ -445,10 +453,16 @@ function RunAuditCommand(context) {
       }
 
       if (isOffsiteAuditType(auditTypeInputArg)) {
+        // baseURLInputArg is raw Slack user input, not yet validated by
+        // extractURLFromSlackInput/isValidUrl below — sanitize it before it goes into this
+        // structured field, same as an error's name/message would be, so a crafted value
+        // (e.g. containing a space and its own key=value pairs) can't inject fake fields
+        // into this line. auditTypeInputArg needs no such treatment here: isOffsiteAuditType
+        // already gates it to a fixed whitelist.
         log.info(
           `run-audit: baseURL="${baseURLInputArg}", auditType="${auditTypeInputArg}", auditData="${auditDataInputArg}" `
           + `domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditTypeInputArg)} `
-          + `event=audit_orchestration_start outcome=start auditType=${auditTypeInputArg} baseURL=${baseURLInputArg}`,
+          + `event=audit_orchestration_start outcome=start auditType=${auditTypeInputArg} ${renderErrorField('baseURL', baseURLInputArg)}`,
         );
       } else {
         log.info(`run-audit: baseURL="${baseURLInputArg}", auditType="${auditTypeInputArg}", auditData="${auditDataInputArg}"`);

--- a/src/support/slack/commands/run-audit.js
+++ b/src/support/slack/commands/run-audit.js
@@ -44,7 +44,10 @@ const OFFSITE_AUDIT_LOG_TYPE = {
   'youtube-analysis': 'youtube',
   'wikipedia-analysis': 'wikipedia',
 };
-const toOffsiteAuditLogType = (auditType) => OFFSITE_AUDIT_LOG_TYPE[auditType];
+// Falls back to the raw auditType if a new offsite type is ever added to
+// OFFSITE_AUDIT_TYPES (utils.js) without a matching entry here, so a missing mapping
+// shows up as e.g. `audit=some-new-analysis` in the log line instead of `audit=undefined`.
+const toOffsiteAuditLogType = (auditType) => OFFSITE_AUDIT_LOG_TYPE[auditType] ?? auditType;
 
 /**
  * Builds the success message for `audit_orchestration_spacecat_request_dispatched`.
@@ -326,7 +329,14 @@ function RunAuditCommand(context) {
             // unstructured "Error running audit..." line for the same single SQS failure
             // (catch-log-throw) and inflate error counts for on-call triage.
             log.error(`Failed to queue offsite analysis for site domain=${OFFSITE_DOMAIN} audit=${toOffsiteAuditLogType(auditType)} event=audit_orchestration_spacecat_request_dispatched outcome=failure peer=spacecat-audit-worker direction=outbound siteId=${site.getId()} reason=sqs_send_failed ${renderErrorField('errorName', error.name)} ${renderErrorField('errorMessage', error.message)}`);
-            await postErrorMessage(say, error);
+            try {
+              await postErrorMessage(say, error);
+            } catch {
+              // The structured log line above already captured this failure; a broken
+              // Slack reply on top of it must not escape into the outer catch below,
+              // which would log a second, misleading, unstructured error line for the
+              // same single SQS failure and attempt yet another Slack reply.
+            }
           }
         } else {
           await triggerAuditForSite(

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -322,19 +322,17 @@ export const sendAuditMessages = async (
  * @param {Object} lambdaContext - The Lambda context object.
  * @return {Promise} - A promise representing the audit trigger operation.
  */
-// Offsite Opportunities audit types (LLMO-6973). Kept in sync with the identically-named
-// list in src/support/slack/commands/run-audit.js. Duplicated rather than imported to avoid
-// a shared-utils-style import cycle risk and to keep this shared framework module
-// (triggerAuditForSite/sendAuditMessage, used by every audit type in the system) free of any
-// dependency on a single Slack command's module.
-const OFFSITE_AUDIT_TYPES = [
+// Offsite Opportunities audit types (LLMO-6973). Single source of truth — imported by
+// src/support/slack/commands/run-audit.js, which already depends on this module for
+// triggerAuditForSite, so importing this predicate back into it introduces no new cycle.
+export const OFFSITE_AUDIT_TYPES = [
   'offsite-brand-presence',
   'cited-analysis',
   'reddit-analysis',
   'youtube-analysis',
   'wikipedia-analysis',
 ];
-const isOffsiteAuditType = (auditType) => OFFSITE_AUDIT_TYPES.includes(auditType);
+export const isOffsiteAuditType = (auditType) => OFFSITE_AUDIT_TYPES.includes(auditType);
 
 export const triggerAuditForSite = async (
   site,

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -322,6 +322,20 @@ export const sendAuditMessages = async (
  * @param {Object} lambdaContext - The Lambda context object.
  * @return {Promise} - A promise representing the audit trigger operation.
  */
+// Offsite Opportunities audit types (LLMO-6973). Kept in sync with the identically-named
+// list in src/support/slack/commands/run-audit.js. Duplicated rather than imported to avoid
+// a shared-utils-style import cycle risk and to keep this shared framework module
+// (triggerAuditForSite/sendAuditMessage, used by every audit type in the system) free of any
+// dependency on a single Slack command's module.
+const OFFSITE_AUDIT_TYPES = [
+  'offsite-brand-presence',
+  'cited-analysis',
+  'reddit-analysis',
+  'youtube-analysis',
+  'wikipedia-analysis',
+];
+const isOffsiteAuditType = (auditType) => OFFSITE_AUDIT_TYPES.includes(auditType);
+
 export const triggerAuditForSite = async (
   site,
   auditType,
@@ -338,6 +352,15 @@ export const triggerAuditForSite = async (
       channelId: slackContext.channelId,
       threadTs: slackContext.threadTs,
     },
+    // LLMO-6973: stamp the dispatching service into the message's auditContext, scoped
+    // strictly to the five offsite audit types — spacecat-audit-worker reads this (via an
+    // `origin` marker, see the audit_orchestration_spacecat_request_received "trigger"/"peer"
+    // fields) to tell a scheduled run apart from a Slack-triggered one, but only for offsite
+    // analyses. Gated here (rather than added unconditionally) to keep this shared framework
+    // code's message shape byte-for-byte unchanged for every other audit type in the system,
+    // mirroring how spacecat-jobs-dispatcher's equivalent change stays strictly scoped to
+    // offsite-brand-presence in its own shared dispatch path.
+    ...(isOffsiteAuditType(auditType) && { origin: 'api-service' }),
     ...auditContext,
   },
   site.getId(),

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -1247,15 +1247,16 @@ describe('RunAuditCommand', () => {
       expect(context.log.info).to.not.have.been.calledWithMatch(/event=audit_orchestration_start/);
     });
 
-    it('logs a structured, alertable error when the site is not found for an offsite audit type', async () => {
+    it('logs a structured, dashboard-visible warning when the site is not found for an offsite audit type', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(null);
 
       const command = RunAuditCommand(context);
       await command.handleExecution(['unknownsite.com', 'audit:cited-analysis'], slackContext);
 
-      expect(context.log.error).to.have.been.calledWith(
-        'No site found with base URL domain=offsite audit=cited event=audit_orchestration_start outcome=failure reason=site_not_found',
+      expect(context.log.warn).to.have.been.calledWith(
+        'No site found with base URL domain=offsite audit=cited event=audit_orchestration_start outcome=skip reason=site_not_found',
       );
+      expect(context.log.error).to.not.have.been.called;
       expect(slackContext.say).to.have.been.calledWith(":x: No site found with base URL 'https://unknownsite.com'.");
     });
 
@@ -1265,21 +1266,22 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['unknownsite.com', 'audit:wikipedia-analysis'], slackContext);
 
-      expect(context.log.error).to.have.been.calledWith(
-        'No site found with base URL domain=offsite audit=wikipedia event=audit_orchestration_start outcome=failure reason=site_not_found',
+      expect(context.log.warn).to.have.been.calledWith(
+        'No site found with base URL domain=offsite audit=wikipedia event=audit_orchestration_start outcome=skip reason=site_not_found',
       );
     });
 
-    it('does not log an error when the site is not found for a non-offsite audit type', async () => {
+    it('does not log a site-not-found line when the site is not found for a non-offsite audit type', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(null);
 
       const command = RunAuditCommand(context);
       await command.handleExecution(['unknownsite.com'], slackContext);
 
       expect(context.log.error).to.not.have.been.called;
+      expect(context.log.warn).to.not.have.been.calledWithMatch(/reason=site_not_found/);
     });
 
-    it('logs a structured error when an offsite audit type is not entitled', async () => {
+    it('logs a structured, dashboard-visible warning when an offsite audit type is not entitled', async () => {
       const site = { getId: () => '123' };
       dataAccessStub.Site.findByBaseURL.resolves(site);
       dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('cited-analysis', ['LLMO']));
@@ -1290,13 +1292,14 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['validsite.com', 'audit:cited-analysis'], slackContext);
 
-      expect(context.log.error).to.have.been.calledWith(
-        'Site not entitled for this audit type domain=offsite audit=cited event=audit_orchestration_start outcome=failure siteId=123 reason=not_entitled',
+      expect(context.log.warn).to.have.been.calledWith(
+        'Site not entitled for this audit type domain=offsite audit=cited event=audit_orchestration_start outcome=skip siteId=123 reason=not_entitled',
       );
+      expect(context.log.error).to.not.have.been.called;
       expect(sqsStub.sendMessage.called).to.be.false;
     });
 
-    it('does not log a not-entitled structured error for a non-offsite audit type', async () => {
+    it('does not log a not-entitled structured line for a non-offsite audit type', async () => {
       dataAccessStub.Site.findByBaseURL.resolves({ getId: () => '123' });
       dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('lhs-mobile', ['LLMO']));
       mockTierClient.createForSite.resolves({
@@ -1306,10 +1309,10 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['validsite.com'], slackContext);
 
-      expect(context.log.error).to.not.have.been.calledWithMatch(/reason=not_entitled/);
+      expect(context.log.warn).to.not.have.been.calledWithMatch(/reason=not_entitled/);
     });
 
-    it('logs a structured error when the handler is disabled for an offsite audit type', async () => {
+    it('logs a structured, dashboard-visible warning when the handler is disabled for an offsite audit type', async () => {
       const site = { getId: () => '123' };
       dataAccessStub.Site.findByBaseURL.resolves(site);
       dataAccessStub.Configuration.findLatest.resolves({
@@ -1321,13 +1324,14 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['validsite.com', 'audit:reddit-analysis'], slackContext);
 
-      expect(context.log.error).to.have.been.calledWith(
-        'Handler disabled for this site domain=offsite audit=reddit event=audit_orchestration_start outcome=failure siteId=123 reason=handler_disabled',
+      expect(context.log.warn).to.have.been.calledWith(
+        'Handler disabled for this site domain=offsite audit=reddit event=audit_orchestration_start outcome=skip siteId=123 reason=handler_disabled',
       );
+      expect(context.log.error).to.not.have.been.called;
       expect(sqsStub.sendMessage.called).to.be.false;
     });
 
-    it('does not log a handler-disabled structured error for a non-offsite audit type', async () => {
+    it('does not log a handler-disabled structured line for a non-offsite audit type', async () => {
       const site = { getId: () => '123' };
       dataAccessStub.Site.findByBaseURL.resolves(site);
       dataAccessStub.Configuration.findLatest.resolves({
@@ -1339,7 +1343,7 @@ describe('RunAuditCommand', () => {
       const command = RunAuditCommand(context);
       await command.handleExecution(['validsite.com'], slackContext);
 
-      expect(context.log.error).to.not.have.been.calledWithMatch(/reason=handler_disabled/);
+      expect(context.log.warn).to.not.have.been.calledWithMatch(/reason=handler_disabled/);
     });
 
     it('logs a structured success line on successful dispatch for offsite-brand-presence (matching jobs-dispatcher wording)', async () => {

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -1247,6 +1247,30 @@ describe('RunAuditCommand', () => {
       expect(context.log.info).to.not.have.been.calledWithMatch(/event=audit_orchestration_start/);
     });
 
+    it('falls back to the raw auditType for audit= when a new offsite type has no OFFSITE_AUDIT_LOG_TYPE mapping', async () => {
+      // A type that isOffsiteAuditType treats as offsite (so the structured-logging path
+      // runs) but that OFFSITE_AUDIT_LOG_TYPE has no entry for — simulating a new offsite
+      // audit type added to OFFSITE_AUDIT_TYPES without a matching entry here.
+      const RunAuditCommandWithUnmappedType = await esmock(
+        '../../../../src/support/slack/commands/run-audit.js',
+        {
+          '@adobe/spacecat-shared-tier-client': { default: mockTierClient },
+          '../../../../src/support/utils.js': {
+            isOffsiteAuditType: (auditType) => auditType === 'new-offsite-analysis',
+            triggerAuditForSite: sinon.stub().resolves(),
+          },
+        },
+      );
+      dataAccessStub.Site.findByBaseURL.resolves(null);
+
+      const command = RunAuditCommandWithUnmappedType(context);
+      await command.handleExecution(['unknownsite.com', 'audit:new-offsite-analysis'], slackContext);
+
+      expect(context.log.warn).to.have.been.calledWith(
+        'No site found with base URL domain=offsite audit=new-offsite-analysis event=audit_orchestration_start outcome=skip reason=site_not_found',
+      );
+    });
+
     it('logs a structured, dashboard-visible warning when the site is not found for an offsite audit type', async () => {
       dataAccessStub.Site.findByBaseURL.resolves(null);
 
@@ -1412,6 +1436,26 @@ describe('RunAuditCommand', () => {
       );
       expect(context.log.error).to.have.been.calledOnce;
       expect(slackContext.say).to.have.been.calledWith(':nuclear-warning: Oops! Something went wrong: SQS unavailable');
+    });
+
+    it('swallows a broken Slack reply after the SQS send fails, without escaping to the generic outer catch', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('youtube-analysis', ['LLMO']));
+      const sendError = new Error('SQS unavailable');
+      sendError.name = 'SqsError';
+      sqsStub.sendMessage.rejects(sendError);
+      slackContext.say = sinon.stub().rejects(new Error('Slack is down'));
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:youtube-analysis'], slackContext);
+
+      expect(context.log.error).to.have.been.calledWith(
+        'Failed to queue offsite analysis for site domain=offsite audit=youtube event=audit_orchestration_spacecat_request_dispatched outcome=failure peer=spacecat-audit-worker direction=outbound siteId=123 reason=sqs_send_failed errorName=SqsError errorMessage="SQS unavailable"',
+      );
+      // A second, unstructured "Error running audit..." line from the outer catch would
+      // mean the broken Slack reply escaped the inner catch instead of being swallowed.
+      expect(context.log.error).to.have.been.calledOnce;
     });
 
     it('sanitizes and quotes an error field whose value contains whitespace, "=", or a double quote', async () => {

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -1386,7 +1386,7 @@ describe('RunAuditCommand', () => {
       );
     });
 
-    it('logs a structured failure line (additive to the existing log.error/say) when the SQS send fails for an offsite audit type', async () => {
+    it('logs a single structured failure line and replies, without re-throwing into the generic outer catch, when the SQS send fails for an offsite audit type', async () => {
       const site = { getId: () => '123' };
       dataAccessStub.Site.findByBaseURL.resolves(site);
       dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('youtube-analysis', ['LLMO']));
@@ -1400,11 +1400,13 @@ describe('RunAuditCommand', () => {
       expect(context.log.error).to.have.been.calledWith(
         'Failed to queue offsite analysis for site domain=offsite audit=youtube event=audit_orchestration_spacecat_request_dispatched outcome=failure peer=spacecat-audit-worker direction=outbound siteId=123 reason=sqs_send_failed errorName=SqsError errorMessage="SQS unavailable"',
       );
-      // Existing behavior preserved: the generic catch still logs and replies with the error.
-      expect(context.log.error).to.have.been.calledWith(
+      // The offsite dispatch failure is not re-thrown, so the generic outer catch's
+      // unstructured "Error running audit..." line must not also fire for the same failure
+      // (catch-log-throw would otherwise double-count this as two ERROR lines).
+      expect(context.log.error).to.not.have.been.calledWith(
         sinon.match(/Error running audit youtube-analysis for site/),
-        sendError,
       );
+      expect(context.log.error).to.have.been.calledOnce;
       expect(slackContext.say).to.have.been.calledWith(':nuclear-warning: Oops! Something went wrong: SQS unavailable');
     });
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -1175,4 +1175,290 @@ describe('RunAuditCommand', () => {
       );
     });
   });
+
+  describe('Offsite structured logging (LLMO-6973)', () => {
+    const OFFSITE_AUDIT_TYPES = [
+      'offsite-brand-presence',
+      'cited-analysis',
+      'reddit-analysis',
+      'youtube-analysis',
+      'wikipedia-analysis',
+    ];
+
+    // Mirrors the mapping in run-audit.js (and spacecat-audit-worker's own AUDIT enum) —
+    // used here to prove the log lines carry the correct short taxonomy value per type,
+    // not a hardcoded/single value.
+    const OFFSITE_AUDIT_LOG_TYPE = {
+      'offsite-brand-presence': 'brand-presence',
+      'cited-analysis': 'cited',
+      'reddit-analysis': 'reddit',
+      'youtube-analysis': 'youtube',
+      'wikipedia-analysis': 'wikipedia',
+    };
+
+    it('emits a structured audit_orchestration_start line for each offsite audit type', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves({ getId: () => '123' });
+
+      for (const auditType of OFFSITE_AUDIT_TYPES) {
+        context.log.info.resetHistory();
+        dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock(auditType, ['LLMO']));
+
+        const command = RunAuditCommand(context);
+        // eslint-disable-next-line no-await-in-loop
+        await command.handleExecution(['validsite.com', `audit:${auditType}`], slackContext);
+
+        expect(context.log.info).to.have.been.calledWith(
+          sinon.match(`domain=offsite audit=${OFFSITE_AUDIT_LOG_TYPE[auditType]} event=audit_orchestration_start outcome=start auditType=${auditType} baseURL=validsite.com`),
+        );
+      }
+    });
+
+    it('puts domain and audit before event/outcome on the start line, for two distinct offsite types', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves({ getId: () => '123' });
+
+      for (const [auditType, expectedAudit] of [['cited-analysis', 'cited'], ['wikipedia-analysis', 'wikipedia']]) {
+        context.log.info.resetHistory();
+        dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock(auditType, ['LLMO']));
+
+        const command = RunAuditCommand(context);
+        // eslint-disable-next-line no-await-in-loop
+        await command.handleExecution(['validsite.com', `audit:${auditType}`], slackContext);
+
+        const call = context.log.info.getCalls().find(
+          (c) => c.args[0].includes('event=audit_orchestration_start'),
+        );
+        expect(call, `no audit_orchestration_start line logged for ${auditType}`).to.not.be.undefined;
+        expect(call.args[0]).to.match(
+          new RegExp(`domain=offsite audit=${expectedAudit} event=audit_orchestration_start outcome=start`),
+        );
+      }
+    });
+
+    it('does not add structured fields to the start log line for a non-offsite audit type', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves({ getId: () => '123' });
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('lhs-mobile', ['LLMO']));
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com'], slackContext);
+
+      expect(context.log.info).to.have.been.calledWith(
+        'run-audit: baseURL="validsite.com", auditType="undefined", auditData="undefined"',
+      );
+      expect(context.log.info).to.not.have.been.calledWithMatch(/event=audit_orchestration_start/);
+    });
+
+    it('logs a structured, alertable error when the site is not found for an offsite audit type', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(null);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['unknownsite.com', 'audit:cited-analysis'], slackContext);
+
+      expect(context.log.error).to.have.been.calledWith(
+        'No site found with base URL domain=offsite audit=cited event=audit_orchestration_start outcome=failure reason=site_not_found',
+      );
+      expect(slackContext.say).to.have.been.calledWith(":x: No site found with base URL 'https://unknownsite.com'.");
+    });
+
+    it('maps the audit= field correctly for a second offsite audit type on the site-not-found line', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(null);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['unknownsite.com', 'audit:wikipedia-analysis'], slackContext);
+
+      expect(context.log.error).to.have.been.calledWith(
+        'No site found with base URL domain=offsite audit=wikipedia event=audit_orchestration_start outcome=failure reason=site_not_found',
+      );
+    });
+
+    it('does not log an error when the site is not found for a non-offsite audit type', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(null);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['unknownsite.com'], slackContext);
+
+      expect(context.log.error).to.not.have.been.called;
+    });
+
+    it('logs a structured error when an offsite audit type is not entitled', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('cited-analysis', ['LLMO']));
+      mockTierClient.createForSite.resolves({
+        checkValidEntitlement: sinon.stub().resolves({ siteEnrollment: null }),
+      });
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:cited-analysis'], slackContext);
+
+      expect(context.log.error).to.have.been.calledWith(
+        'Site not entitled for this audit type domain=offsite audit=cited event=audit_orchestration_start outcome=failure siteId=123 reason=not_entitled',
+      );
+      expect(sqsStub.sendMessage.called).to.be.false;
+    });
+
+    it('does not log a not-entitled structured error for a non-offsite audit type', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves({ getId: () => '123' });
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('lhs-mobile', ['LLMO']));
+      mockTierClient.createForSite.resolves({
+        checkValidEntitlement: sinon.stub().resolves({ siteEnrollment: null }),
+      });
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com'], slackContext);
+
+      expect(context.log.error).to.not.have.been.calledWithMatch(/reason=not_entitled/);
+    });
+
+    it('logs a structured error when the handler is disabled for an offsite audit type', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves({
+        isHandlerEnabledForSite: () => true,
+        isHandlerDisabledForSite: () => true,
+        getHandlers: () => ({ 'reddit-analysis': { productCodes: ['LLMO'] } }),
+      });
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:reddit-analysis'], slackContext);
+
+      expect(context.log.error).to.have.been.calledWith(
+        'Handler disabled for this site domain=offsite audit=reddit event=audit_orchestration_start outcome=failure siteId=123 reason=handler_disabled',
+      );
+      expect(sqsStub.sendMessage.called).to.be.false;
+    });
+
+    it('does not log a handler-disabled structured error for a non-offsite audit type', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves({
+        isHandlerEnabledForSite: () => true,
+        isHandlerDisabledForSite: () => true,
+        getHandlers: () => ({ 'lhs-mobile': { productCodes: ['LLMO'] } }),
+      });
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com'], slackContext);
+
+      expect(context.log.error).to.not.have.been.calledWithMatch(/reason=handler_disabled/);
+    });
+
+    it('logs a structured success line on successful dispatch for offsite-brand-presence (matching jobs-dispatcher wording)', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('offsite-brand-presence', ['LLMO']));
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:offsite-brand-presence'], slackContext);
+
+      expect(context.log.info).to.have.been.calledWith(
+        'Queued offsite-brand-presence for site domain=offsite audit=brand-presence event=audit_orchestration_spacecat_request_dispatched outcome=success peer=spacecat-audit-worker direction=outbound siteId=123',
+      );
+    });
+
+    it('logs a structured success line on successful dispatch for the other offsite audit types', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+
+      for (const auditType of ['cited-analysis', 'reddit-analysis', 'youtube-analysis', 'wikipedia-analysis']) {
+        context.log.info.resetHistory();
+        dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock(auditType, ['LLMO']));
+
+        const command = RunAuditCommand(context);
+        // eslint-disable-next-line no-await-in-loop
+        await command.handleExecution(['validsite.com', `audit:${auditType}`], slackContext);
+
+        expect(context.log.info).to.have.been.calledWith(
+          `Queued offsite analysis for site domain=offsite audit=${OFFSITE_AUDIT_LOG_TYPE[auditType]} event=audit_orchestration_spacecat_request_dispatched outcome=success peer=spacecat-audit-worker direction=outbound siteId=123`,
+        );
+      }
+    });
+
+    it('follows the canonical domain, audit, event, outcome, peer, direction, siteId field order on the dispatched-success line', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('reddit-analysis', ['LLMO']));
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:reddit-analysis'], slackContext);
+
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/domain=offsite audit=reddit event=audit_orchestration_spacecat_request_dispatched outcome=success peer=spacecat-audit-worker direction=outbound siteId=123/),
+      );
+    });
+
+    it('logs a structured failure line (additive to the existing log.error/say) when the SQS send fails for an offsite audit type', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('youtube-analysis', ['LLMO']));
+      const sendError = new Error('SQS unavailable');
+      sendError.name = 'SqsError';
+      sqsStub.sendMessage.rejects(sendError);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:youtube-analysis'], slackContext);
+
+      expect(context.log.error).to.have.been.calledWith(
+        'Failed to queue offsite analysis for site domain=offsite audit=youtube event=audit_orchestration_spacecat_request_dispatched outcome=failure peer=spacecat-audit-worker direction=outbound siteId=123 reason=sqs_send_failed errorName=SqsError errorMessage="SQS unavailable"',
+      );
+      // Existing behavior preserved: the generic catch still logs and replies with the error.
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/Error running audit youtube-analysis for site/),
+        sendError,
+      );
+      expect(slackContext.say).to.have.been.calledWith(':nuclear-warning: Oops! Something went wrong: SQS unavailable');
+    });
+
+    it('sanitizes and quotes an error field whose value contains whitespace, "=", or a double quote', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('cited-analysis', ['LLMO']));
+      const sendError = new Error('bad response: status=500 body="oops"');
+      sendError.name = 'SqsError';
+      sqsStub.sendMessage.rejects(sendError);
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:cited-analysis'], slackContext);
+
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/errorMessage="bad response: status=500 body='oops'"/),
+      );
+    });
+
+    it('stamps origin: api-service into the dispatched auditContext for an offsite audit type', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('wikipedia-analysis', ['LLMO']));
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com', 'audit:wikipedia-analysis'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext).to.include({ origin: 'api-service' });
+    });
+
+    it('does NOT stamp origin into the dispatched auditContext for a non-offsite audit type (message payload unchanged)', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('lhs-mobile', ['LLMO']));
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['validsite.com'], slackContext);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      expect(sqsStub.sendMessage.firstCall.args[1].auditContext).to.not.have.property('origin');
+      // Byte-for-byte: the message payload for a non-offsite audit type is exactly what
+      // it was before LLMO-6973 — no extra keys anywhere in the auditContext.
+      expect(sqsStub.sendMessage.firstCall.args[1]).to.deep.equal({
+        type: 'lhs-mobile',
+        siteId: '123',
+        auditContext: {
+          slackContext: {
+            channelId: undefined,
+            threadTs: undefined,
+          },
+        },
+        data: undefined,
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Summary

Adds the audit_orchestration_start and audit_orchestration_spacecat_request_dispatched structured log lines to the Slack run-audit command, scoped strictly to the five offsite audit types (offsite-brand-presence, cited-analysis, reddit-analysis, youtube-analysis, wikipedia-analysis). Every other audit type keeps its existing plain-text logging and behavior unchanged.

- run-audit.js: upgrade the parse-time log line to carry event=audit_orchestration_start/outcome=start for offsite types; add previously-silent error-level failure rows (reason=site_not_found, reason=not_entitled, reason=handler_disabled) under the same event; add success/failure logging around the SQS dispatch (event=audit_orchestration_spacecat_request_dispatched), additive to the existing error log + Slack error reply.
- utils.js: stamp origin: 'api-service' into triggerAuditForSite's auditContext unconditionally (purely additive for every audit type; audit-worker only reads it for offsite types).
- test: cover all new structured log lines and the origin stamp, plus explicit regression coverage that non-offsite audit types are unaffected.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```