### PR TITLE
fix: honor prompt origin for S2S service callers on brand prompt create (LLMO-7204)

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -6813,11 +6813,14 @@ V2PromptInput:
       default: human
       description: >-
         Who authored the prompt's text. SERVICE-PRINCIPAL-ONLY and read-only for
-        end users: a user-authenticated request (IMS/JWT) has this field IGNORED
+        end users: an end-user request (IMS/JWT session) has this field IGNORED
         (never rejected) and the value derived as `human`; only a service
-        principal (e.g. the generation pipeline) may assert it, validated against
-        the enum. It is never patched on update — it is fixed by the writer that
-        created the row (origin-dimension.md §3).
+        principal may assert it, validated against the enum. A service principal
+        is an S2S consumer/admin or a scoped/legacy API key — e.g. the DRS
+        generation pipeline, which posts `origin: ai`. Note an S2S caller
+        authenticates with a JWT, so the principal is resolved from the token's
+        S2S claims, not the auth type alone. It is never patched on update — it is
+        fixed by the writer that created the row (origin-dimension.md §3).
     intent:
       type: string
       description: >-

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -51,6 +51,7 @@ import {
   resolveBrandUuid,
   findPromptsBlockingRegionRemoval,
   deriveV2PromptOrigin,
+  isServicePrincipal,
 } from '../support/prompts-storage.js';
 import {
   listBrands,
@@ -713,29 +714,17 @@ function BrandsController(ctx, log, env) {
       }
 
       // `origin` is derived from the request PRINCIPAL, never trusted from the
-      // body (origin-dimension.md §3): an end-user (IMS/JWT session) write is
-      // `human`, body ignored; a service principal is believed and its body
-      // `origin` honoured. Stamp it here so the store writes the derived value on
-      // insert; on update the stored origin is preserved (upsertPrompts) and never
-      // patched (updatePromptById).
+      // body (origin-dimension.md §3): an end-user write is `human`, body ignored;
+      // a service principal is believed and its body `origin` honoured. Stamp it
+      // here so the store writes the derived value on insert; on update the stored
+      // origin is preserved (upsertPrompts) and never patched (updatePromptById).
       //
-      // A service principal is one of: a non-jwt/ims auth type (scoped/legacy API
-      // key), OR — the case that matters in production — an S2S consumer/admin.
-      // The latter authenticates with a JWT, so its `authType` is `jwt`,
-      // indistinguishable BY TYPE from an end-user session. The x-api-key path DRS
-      // used to take was removed (SITES-34224); DRS now posts `origin: 'ai'` over
-      // an S2S JWT, so classifying by `authType` alone forced every generated
-      // prompt to `human`. Consult the token's own S2S claims
-      // (`isS2SConsumer()` / `isS2SAdmin()`) to recover the true principal —
-      // these are signature-validated JWT claims, not caller-controlled body input.
-      //
-      // Fail SAFE to the least-privileged (USER) principal: an ABSENT or
-      // indeterminate auth type with no S2S signal must NEVER fall through to the
-      // service path that honours a body-supplied `origin`. `authWrapper` blocks
-      // unauthenticated requests today, but a future unwrapped caller (an internal
-      // queue consumer, re-ordered middleware) must not silently gain service
-      // privilege — hence `!authType → user`, and a non-function `getType` /
-      // `isS2S*` resolves to falsy (→ user) rather than throwing.
+      // `isServicePrincipal` carries the classification (and its fail-safe rules):
+      // crucially, an S2S consumer/admin authenticates with a JWT — same
+      // `authType` as an end-user session — so it is recognised by its S2S claim,
+      // not its auth type. Classifying by auth type alone forced DRS's generated
+      // prompts (posted `origin: 'ai'` over an S2S JWT) to `human`, since the
+      // x-api-key service path DRS used to take was removed (SITES-34224).
       //
       // `source` (the producing system) has NO write surface (source-dimension.md
       // §1 item 6): a caller-supplied `source` is ignored, so a v2 create becomes
@@ -745,13 +734,7 @@ function BrandsController(ctx, log, env) {
       // it. `updatePromptById` likewise never patches source (producer is fixed at
       // creation).
       const { authInfo } = context.attributes ?? {};
-      const authType = typeof authInfo?.getType === 'function' ? authInfo.getType() : undefined;
-      const isS2SConsumer = typeof authInfo?.isS2SConsumer === 'function'
-        && !!authInfo.isS2SConsumer();
-      const isS2SAdmin = typeof authInfo?.isS2SAdmin === 'function'
-        && !!authInfo.isS2SAdmin();
-      const isUserPrincipal = !isS2SConsumer && !isS2SAdmin
-        && (!authType || authType === 'jwt' || authType === 'ims');
+      const isUserPrincipal = !isServicePrincipal(authInfo);
       const derivedPrompts = prompts.map(({ source: _, ...p }) => ({
         ...p,
         origin: deriveV2PromptOrigin(p?.origin, isUserPrincipal),

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -713,23 +713,29 @@ function BrandsController(ctx, log, env) {
       }
 
       // `origin` is derived from the request PRINCIPAL, never trusted from the
-      // body (origin-dimension.md §3): a user (IMS/JWT) write is `human`, body
-      // ignored; a service principal (e.g. DRS via admin x-api-key, whose auth
-      // type is neither `ims` nor `jwt`) is believed. The auth type is read from
-      // the per-request context — the same source as `updatedBy` above — so it
-      // reflects the actual caller. Stamp it here so the store writes the derived
-      // value on insert; on update the stored origin is preserved (upsertPrompts)
-      // and never patched (updatePromptById).
+      // body (origin-dimension.md §3): an end-user (IMS/JWT session) write is
+      // `human`, body ignored; a service principal is believed and its body
+      // `origin` honoured. Stamp it here so the store writes the derived value on
+      // insert; on update the stored origin is preserved (upsertPrompts) and never
+      // patched (updatePromptById).
+      //
+      // A service principal is one of: a non-jwt/ims auth type (scoped/legacy API
+      // key), OR — the case that matters in production — an S2S consumer/admin.
+      // The latter authenticates with a JWT, so its `authType` is `jwt`,
+      // indistinguishable BY TYPE from an end-user session. The x-api-key path DRS
+      // used to take was removed (SITES-34224); DRS now posts `origin: 'ai'` over
+      // an S2S JWT, so classifying by `authType` alone forced every generated
+      // prompt to `human`. Consult the token's own S2S claims
+      // (`isS2SConsumer()` / `isS2SAdmin()`) to recover the true principal —
+      // these are signature-validated JWT claims, not caller-controlled body input.
       //
       // Fail SAFE to the least-privileged (USER) principal: an ABSENT or
-      // indeterminate auth type must NEVER fall through to the privileged service
-      // path that honours a body-supplied `origin`. Only a KNOWN non-user auth
-      // type (jwt/ims are user; anything else, e.g. DRS admin x-api-key, is
-      // service) is trusted as a service principal. `authWrapper` blocks
+      // indeterminate auth type with no S2S signal must NEVER fall through to the
+      // service path that honours a body-supplied `origin`. `authWrapper` blocks
       // unauthenticated requests today, but a future unwrapped caller (an internal
       // queue consumer, re-ordered middleware) must not silently gain service
-      // privilege — hence `!authType → user`, and a non-function `getType` resolves
-      // to `undefined` (→ user) rather than throwing.
+      // privilege — hence `!authType → user`, and a non-function `getType` /
+      // `isS2S*` resolves to falsy (→ user) rather than throwing.
       //
       // `source` (the producing system) has NO write surface (source-dimension.md
       // §1 item 6): a caller-supplied `source` is ignored, so a v2 create becomes
@@ -740,7 +746,12 @@ function BrandsController(ctx, log, env) {
       // creation).
       const { authInfo } = context.attributes ?? {};
       const authType = typeof authInfo?.getType === 'function' ? authInfo.getType() : undefined;
-      const isUserPrincipal = !authType || authType === 'jwt' || authType === 'ims';
+      const isS2SConsumer = typeof authInfo?.isS2SConsumer === 'function'
+        && !!authInfo.isS2SConsumer();
+      const isS2SAdmin = typeof authInfo?.isS2SAdmin === 'function'
+        && !!authInfo.isS2SAdmin();
+      const isUserPrincipal = !isS2SConsumer && !isS2SAdmin
+        && (!authType || authType === 'jwt' || authType === 'ims');
       const derivedPrompts = prompts.map(({ source: _, ...p }) => ({
         ...p,
         origin: deriveV2PromptOrigin(p?.origin, isUserPrincipal),

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -38,21 +38,25 @@ const DEFAULT_ORIGIN = 'human';
  * §3). `origin` records who authored the prompt's text and is read-only wherever a
  * user can reach it:
  *
- *   - a USER-authenticated principal (IMS / JWT) always writes `human`; any
- *     `origin` in the body is IGNORED (never rejected — the derived value is
- *     authoritative, so the caller loses nothing);
- *   - a SERVICE principal (e.g. DRS via admin `x-api-key`) is believed: its body
- *     value is honoured, validated against {@link V2_PROMPT_ORIGINS}, defaulting
- *     to `human` only when absent or out-of-vocabulary. This is the DRS contract
- *     (`origin: 'ai'`); dropping it would relabel every generated prompt `human`
- *     on its next upsert (origin-dimension.md §3 consequence 1).
+ *   - a USER-authenticated principal (an end-user IMS / JWT session) always writes
+ *     `human`; any `origin` in the body is IGNORED (never rejected — the derived
+ *     value is authoritative, so the caller loses nothing);
+ *   - a SERVICE principal (an S2S consumer/admin, or a scoped/legacy API key) is
+ *     believed: its body value is honoured, validated against
+ *     {@link V2_PROMPT_ORIGINS}, defaulting to `human` only when absent or
+ *     out-of-vocabulary. This is the DRS contract (`origin: 'ai'`); dropping it
+ *     would relabel every generated prompt `human` on its next upsert
+ *     (origin-dimension.md §3 consequence 1). NOTE: an S2S caller authenticates
+ *     with a JWT, so `isUserPrincipal` CANNOT be decided by auth type alone — the
+ *     caller (`createPromptsByBrand`) consults the token's S2S claims first.
  *
  * This governs CREATE only — `origin` is never patched on update (it is fixed by
  * the writer that created the row), which the update path enforces by not writing
  * the column at all.
  *
  * @param {unknown} bodyOrigin - the caller-supplied `origin`, or undefined.
- * @param {boolean} isUserPrincipal - true for an IMS/JWT user request.
+ * @param {boolean} isUserPrincipal - false for a service principal (S2S
+ *   consumer/admin or scoped/legacy API key); true for an end-user IMS/JWT session.
  * @returns {string} the origin to store (`ai` or `human`).
  */
 export function deriveV2PromptOrigin(bodyOrigin, isUserPrincipal) {

--- a/src/support/prompts-storage.js
+++ b/src/support/prompts-storage.js
@@ -69,6 +69,38 @@ export function deriveV2PromptOrigin(bodyOrigin, isUserPrincipal) {
 }
 
 /**
+ * Classifies a request PRINCIPAL as a SERVICE principal (vs. an end user), for the
+ * purpose of the {@link deriveV2PromptOrigin} decision. A service principal is:
+ *
+ *   - an S2S consumer or admin — these authenticate with a JWT, so `getType()` is
+ *     `'jwt'`, indistinguishable BY TYPE from an end-user session; they are
+ *     identified only by the signature-validated `is_s2s_consumer` /
+ *     `is_s2s_admin` claim (surfaced as `isS2SConsumer()` / `isS2SAdmin()`), never
+ *     by caller-controlled body input; OR
+ *   - a non-jwt/ims auth type (a scoped/legacy API key).
+ *
+ * Fails SAFE to the least-privileged (USER) principal: an ABSENT or indeterminate
+ * auth type with no S2S signal, or a non-function `getType` / `isS2S*`, resolves to
+ * `false` (→ user) rather than throwing or silently gaining service privilege. This
+ * is why a future unwrapped caller (an internal queue consumer, re-ordered
+ * middleware) cannot slip into the service path.
+ *
+ * @param {*} authInfo - the request's AuthInfo (`context.attributes.authInfo`).
+ * @returns {boolean} true for a service principal (its body `origin` is honoured).
+ */
+export function isServicePrincipal(authInfo) {
+  const isS2SConsumer = typeof authInfo?.isS2SConsumer === 'function'
+    && !!authInfo.isS2SConsumer();
+  const isS2SAdmin = typeof authInfo?.isS2SAdmin === 'function'
+    && !!authInfo.isS2SAdmin();
+  if (isS2SConsumer || isS2SAdmin) {
+    return true;
+  }
+  const authType = typeof authInfo?.getType === 'function' ? authInfo.getType() : undefined;
+  return !!authType && authType !== 'jwt' && authType !== 'ims';
+}
+
+/**
  * Per-client cache of whether `prompts.intent` is selectable/writable. Keyed by
  * the PostgREST client so unit tests (fresh mock clients) never bleed state and
  * production detects once per client instance. Absent = unknown (try with

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -1018,10 +1018,12 @@ describe('Brands Controller', () => {
       expect(body).to.have.property('prompts');
     });
 
-    it('createPromptsByBrand honours a SERVICE principal\'s origin: ai (DRS contract, origin-dimension.md §3)', async () => {
-      // A non-ims/non-jwt principal (e.g. DRS via admin x-api-key) is believed:
-      // its asserted `origin` rides through to the store. Deleting or ignoring it
-      // would relabel every DRS-written prompt `human` on its next upsert.
+    it('createPromptsByBrand honours an S2S consumer\'s origin: ai (DRS contract, origin-dimension.md §3)', async () => {
+      // An S2S consumer (e.g. DRS) authenticates with a JWT — authType is `jwt`,
+      // identical to an end-user session — but is a SERVICE principal, identified
+      // by the token's `is_s2s_consumer` claim (authInfo.isS2SConsumer()). Its
+      // asserted `origin` rides through to the store; classifying it as a user by
+      // auth type alone would relabel every DRS-written prompt `human` on write.
       const thenable = (v) => ({ then: (resolve) => resolve(v), catch: () => thenable(v) });
       const insertStub = sandbox.stub()
         .returns({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) });
@@ -1047,7 +1049,13 @@ describe('Brands Controller', () => {
 
       const response = await brandsController.createPromptsByBrand({
         ...context,
-        attributes: { authInfo: { getType: () => 'apikey', profile: { email: 'drs@service' } } },
+        attributes: {
+          authInfo: {
+            getType: () => 'jwt',
+            isS2SConsumer: () => true,
+            profile: { email: 'drs@service', is_s2s_consumer: true },
+          },
+        },
         params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
         data: [{ prompt: 'P', regions: ['us'], origin: 'ai' }],
         dataAccess: mockDataAccess,
@@ -1056,6 +1064,53 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(201);
       const inserted = insertStub.firstCall.args[0];
       expect(inserted[0].origin).to.equal('ai');
+    });
+
+    it('createPromptsByBrand coerces a plain end-user JWT\'s origin: ai to human (no S2S claim)', async () => {
+      // Regression for the S2S-vs-user fix: a real end-user session JWT also has
+      // authType `jwt`, but WITHOUT an `is_s2s_consumer`/`is_s2s_admin` claim it is
+      // a user principal and its body `origin` is ignored — proving the fix keys
+      // off the S2S claim, not merely off the auth type.
+      const thenable = (v) => ({ then: (resolve) => resolve(v), catch: () => thenable(v) });
+      const insertStub = sandbox.stub()
+        .returns({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) });
+      mockDataAccess.services.postgrestClient.from = sandbox.stub().callsFake((table) => {
+        if (table === 'prompts') {
+          return {
+            select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+            insert: insertStub,
+            update: () => ({ eq: () => thenable({ error: null }) }),
+          };
+        }
+        const chain = {
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          maybeSingle: sandbox.stub().resolves({ data: { id: BRAND_UUID }, error: null }),
+        };
+        if (table === 'llmo_customer_config') {
+          chain.maybeSingle = sandbox.stub()
+            .resolves({ data: { config: { customer: { brands: [] } } }, error: null });
+        }
+        return chain;
+      });
+
+      const response = await brandsController.createPromptsByBrand({
+        ...context,
+        attributes: {
+          authInfo: {
+            getType: () => 'jwt',
+            isS2SConsumer: () => false,
+            profile: { email: 'user@test.com' },
+          },
+        },
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: [{ prompt: 'P', regions: ['us'], origin: 'ai' }],
+        dataAccess: mockDataAccess,
+      });
+
+      expect(response.status).to.equal(201);
+      const inserted = insertStub.firstCall.args[0];
+      expect(inserted[0].origin).to.equal('human');
     });
 
     it('createPromptsByBrand coerces a USER principal\'s origin: ai to human (body ignored, never rejected)', async () => {

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -1053,7 +1053,55 @@ describe('Brands Controller', () => {
           authInfo: {
             getType: () => 'jwt',
             isS2SConsumer: () => true,
-            profile: { email: 'drs@service', is_s2s_consumer: true },
+            isS2SAdmin: () => false,
+            profile: { email: 'drs@service' },
+          },
+        },
+        params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
+        data: [{ prompt: 'P', regions: ['us'], origin: 'ai' }],
+        dataAccess: mockDataAccess,
+      });
+
+      expect(response.status).to.equal(201);
+      const inserted = insertStub.firstCall.args[0];
+      expect(inserted[0].origin).to.equal('ai');
+    });
+
+    it('createPromptsByBrand honours an S2S admin\'s origin: ai (is_s2s_admin claim over a JWT)', async () => {
+      // An S2S admin also authenticates with a JWT (authType `jwt`) and is a
+      // SERVICE principal, identified by the `is_s2s_admin` claim
+      // (authInfo.isS2SAdmin()). Its asserted `origin` rides through to the store.
+      const thenable = (v) => ({ then: (resolve) => resolve(v), catch: () => thenable(v) });
+      const insertStub = sandbox.stub()
+        .returns({ select: () => thenable({ data: [{ prompt_id: 'new-1' }], error: null }) });
+      mockDataAccess.services.postgrestClient.from = sandbox.stub().callsFake((table) => {
+        if (table === 'prompts') {
+          return {
+            select: () => ({ eq: () => ({ eq: () => thenable({ data: [], error: null }) }) }),
+            insert: insertStub,
+            update: () => ({ eq: () => thenable({ error: null }) }),
+          };
+        }
+        const chain = {
+          select: sandbox.stub().returnsThis(),
+          eq: sandbox.stub().returnsThis(),
+          maybeSingle: sandbox.stub().resolves({ data: { id: BRAND_UUID }, error: null }),
+        };
+        if (table === 'llmo_customer_config') {
+          chain.maybeSingle = sandbox.stub()
+            .resolves({ data: { config: { customer: { brands: [] } } }, error: null });
+        }
+        return chain;
+      });
+
+      const response = await brandsController.createPromptsByBrand({
+        ...context,
+        attributes: {
+          authInfo: {
+            getType: () => 'jwt',
+            isS2SConsumer: () => false,
+            isS2SAdmin: () => true,
+            profile: { email: 'svc-admin@service' },
           },
         },
         params: { spaceCatId: ORGANIZATION_ID, brandId: BRAND_UUID },
@@ -1100,6 +1148,7 @@ describe('Brands Controller', () => {
           authInfo: {
             getType: () => 'jwt',
             isS2SConsumer: () => false,
+            isS2SAdmin: () => false,
             profile: { email: 'user@test.com' },
           },
         },

--- a/test/support/prompts-storage.test.js
+++ b/test/support/prompts-storage.test.js
@@ -31,6 +31,7 @@ import {
   findPromptsBlockingRegionRemoval,
   getIntentsByPromptIds,
   deriveV2PromptOrigin,
+  isServicePrincipal,
 } from '../../src/support/prompts-storage.js';
 
 use(chaiAsPromised);
@@ -94,6 +95,50 @@ describe('prompts-storage', () => {
     it('defaults a SERVICE principal to `human` when the body value is out-of-vocabulary', () => {
       expect(deriveV2PromptOrigin('robot', false)).to.equal('human');
       expect(deriveV2PromptOrigin('', false)).to.equal('human');
+    });
+  });
+
+  describe('isServicePrincipal (origin-dimension.md §3)', () => {
+    it('classifies an S2S consumer (JWT) as a service principal', () => {
+      // authType is `jwt` (same as an end user) — recognised only by the claim.
+      expect(isServicePrincipal({
+        getType: () => 'jwt',
+        isS2SConsumer: () => true,
+        isS2SAdmin: () => false,
+      })).to.equal(true);
+    });
+
+    it('classifies an S2S admin (JWT) as a service principal', () => {
+      expect(isServicePrincipal({
+        getType: () => 'jwt',
+        isS2SConsumer: () => false,
+        isS2SAdmin: () => true,
+      })).to.equal(true);
+    });
+
+    it('classifies a scoped/legacy API key (non-jwt/ims authType) as a service principal', () => {
+      expect(isServicePrincipal({ getType: () => 'scopedApiKey' })).to.equal(true);
+      expect(isServicePrincipal({ getType: () => 'legacyApiKey' })).to.equal(true);
+    });
+
+    it('classifies an end-user JWT/IMS session (no S2S claim) as NOT a service principal', () => {
+      expect(isServicePrincipal({
+        getType: () => 'jwt',
+        isS2SConsumer: () => false,
+        isS2SAdmin: () => false,
+      })).to.equal(false);
+      expect(isServicePrincipal({ getType: () => 'ims' })).to.equal(false);
+    });
+
+    it('fails SAFE to a user principal for absent / indeterminate auth', () => {
+      // no authInfo at all
+      expect(isServicePrincipal(undefined)).to.equal(false);
+      expect(isServicePrincipal(null)).to.equal(false);
+      // authInfo present but non-function getType and no S2S signal
+      expect(isServicePrincipal({})).to.equal(false);
+      expect(isServicePrincipal({ getType: 'not-a-function' })).to.equal(false);
+      // absent authType (getType returns undefined) with no S2S signal
+      expect(isServicePrincipal({ getType: () => undefined })).to.equal(false);
     });
   });
 


### PR DESCRIPTION
## Problem

Prompts created via `POST /v2/orgs/:org/brands/:brand/prompts` were always stored with `origin='human'`, even when the caller explicitly sent `origin='ai'`. This silently mislabels every AI-generated prompt:

- The **DRS generation pipeline** posts `origin: 'ai'` for every generated prompt (`V2Prompt.origin` in `llmo-data-retrieval-service`), but it authenticates with an **S2S session token (JWT)** — so its `origin` was dropped and stored as `human`.
- The **brand-config migration** ([mysticat-data-service#986](https://github.com/adobe/mysticat-data-service/pull/986)) hit the same wall for AI-sourced prompts, regardless of auth mode.

## Root cause

`createPromptsByBrand` derived the request principal from **auth type alone**:

```js
const isUserPrincipal = !authType || authType === 'jwt' || authType === 'ims';
```

`deriveV2PromptOrigin` then forces `human` for user principals and only honors the body `origin` for a service principal. But an **S2S consumer/admin authenticates with a JWT**, so its `authType` is `'jwt'` — indistinguishable by type from an end-user session — and it was misclassified as a user. The old code's comment assumed a service caller arrives via `x-api-key` (auth type "neither ims nor jwt"), but that path was retired (SITES-34224); every real service integration now uses S2S JWT, so the honored branch was unreachable for actual callers.

Introduced by #2866 (`feat(serenity): derive + inject prompt origin server-side`).

## Fix

Classify an S2S consumer/admin as a service principal by consulting the token's own signature-validated S2S claims, not just the auth type:

```js
const isS2SConsumer = typeof authInfo?.isS2SConsumer === 'function' && !!authInfo.isS2SConsumer();
const isS2SAdmin    = typeof authInfo?.isS2SAdmin    === 'function' && !!authInfo.isS2SAdmin();
const isUserPrincipal = !isS2SConsumer && !isS2SAdmin
  && (!authType || authType === 'jwt' || authType === 'ims');
```

- **Fail-safe preserved:** absent/indeterminate auth with no S2S signal → user → `human`. A non-function `getType`/`isS2S*` resolves to falsy (→ user).
- **No escalation risk:** `is_s2s_consumer`/`is_s2s_admin` are signature-validated JWT claims, never caller-controlled body input; the worst case is a cosmetic label, not an authz decision.
- Behavior for end users is unchanged (still forced to `human`).

Also in this PR:
- Fixed a **masking unit test** that used a fictitious `getType: () => 'apikey'` — a value no real auth handler returns — so it exercised a path that never occurs in production. Replaced with a real S2S-JWT shape, plus a new regression proving a plain end-user JWT (no S2S claim) is still coerced to `human`.
- Refreshed the stale "DRS via admin x-api-key" comment and the `deriveV2PromptOrigin` JSDoc.
- Updated the OpenAPI `V2PromptInput.origin` description to describe the S2S-JWT mechanism.

## API spec

- [x] Updated `docs/openapi/schemas.yaml` (`V2PromptInput.origin` description). No schema/enum/contract change — `origin` remains `enum: [ai, human]`, default `human`. `npm run docs:lint` passes.

## Testing

- `test/controllers/brands.test.js` — origin cases: S2S-consumer JWT→`ai`, plain end-user JWT→`human`, IMS→`human`, legacyApiKey→`ai`, fail-safe (absent/non-function auth)→`human`.
- Full suites green: **444** brands + **181** prompts-storage tests. `npm run lint` and pre-commit `type-check:strict` pass.

## Not in this PR (follow-ups)

- **Repairing already-mislabeled rows.** `upsertPrompts` never re-writes `origin` on update, so re-pushing won't repair existing rows — the prompts already stored as `human` (migrated + DRS-generated) need delete+recreate or a targeted DB `UPDATE origin='ai'`.
- An S2S-consumer **integration test** (needs a seeded Consumer with `organization:write` capability for this route) — unit tests already prove the classification.

## Related Issues

LLMO-7204

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Niccolò Toccane", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```