### PR TITLE
feat: allow prerender-cache-cleanup via the run-global-import Slack command

### DIFF
--- a/src/support/slack/commands/run-global-import.js
+++ b/src/support/slack/commands/run-global-import.js
@@ -27,7 +27,7 @@ const VALIDATE_ONLY_FLAG = '--validate-only';
 const GLOBAL_IMPORTS = [
   'stale-suggestions-cleanup',
   'optimize-at-edge-enabled-marking',
-  'prerender-cache-cleanup',
+  'prerender-object-storage-cleanup',
 ];
 
 /**

--- a/src/support/slack/commands/run-global-import.js
+++ b/src/support/slack/commands/run-global-import.js
@@ -27,6 +27,7 @@ const VALIDATE_ONLY_FLAG = '--validate-only';
 const GLOBAL_IMPORTS = [
   'stale-suggestions-cleanup',
   'optimize-at-edge-enabled-marking',
+  'prerender-cache-cleanup',
 ];
 
 /**

--- a/test/support/slack/commands/run-global-import.test.js
+++ b/test/support/slack/commands/run-global-import.test.js
@@ -137,6 +137,26 @@ describe('RunGlobalImportCommand', () => {
     expect(triggerGlobalImportRunStub).not.to.have.been.called;
   });
 
+  it('accepts prerender-cache-cleanup as a valid global import type', async () => {
+    configStub.getJobs.returns([
+      { group: 'imports', type: 'prerender-cache-cleanup' },
+    ]);
+    const command = RunGlobalImportCommand(context);
+
+    await command.handleExecution(['prerender-cache-cleanup'], slackContext);
+
+    expect(triggerGlobalImportRunStub).to.have.been.calledOnceWith(
+      configStub,
+      'prerender-cache-cleanup',
+      slackContext,
+      context,
+      {
+        siteId: undefined, force: false, forcedBy: 'jdoe', validateOnly: false,
+      },
+    );
+    expect(slackContext.say.firstCall.args[0]).to.include('Triggered global import: *prerender-cache-cleanup*');
+  });
+
   it('triggers a bulk run (no site) and confirms without a site suffix', async () => {
     const command = RunGlobalImportCommand(context);
 

--- a/test/support/slack/commands/run-global-import.test.js
+++ b/test/support/slack/commands/run-global-import.test.js
@@ -137,24 +137,24 @@ describe('RunGlobalImportCommand', () => {
     expect(triggerGlobalImportRunStub).not.to.have.been.called;
   });
 
-  it('accepts prerender-cache-cleanup as a valid global import type', async () => {
+  it('accepts prerender-object-storage-cleanup as a valid global import type', async () => {
     configStub.getJobs.returns([
-      { group: 'imports', type: 'prerender-cache-cleanup' },
+      { group: 'imports', type: 'prerender-object-storage-cleanup' },
     ]);
     const command = RunGlobalImportCommand(context);
 
-    await command.handleExecution(['prerender-cache-cleanup'], slackContext);
+    await command.handleExecution(['prerender-object-storage-cleanup'], slackContext);
 
     expect(triggerGlobalImportRunStub).to.have.been.calledOnceWith(
       configStub,
-      'prerender-cache-cleanup',
+      'prerender-object-storage-cleanup',
       slackContext,
       context,
       {
         siteId: undefined, force: false, forcedBy: 'jdoe', validateOnly: false,
       },
     );
-    expect(slackContext.say.firstCall.args[0]).to.include('Triggered global import: *prerender-cache-cleanup*');
+    expect(slackContext.say.firstCall.args[0]).to.include('Triggered global import: *prerender-object-storage-cleanup*');
   });
 
   it('triggers a bulk run (no site) and confirms without a site suffix', async () => {


### PR DESCRIPTION
## Summary
- Adds `prerender-cache-cleanup` to `GLOBAL_IMPORTS` in `run-global-import.js` so it can be triggered on-demand via `run global import prerender-cache-cleanup`, same as `stale-suggestions-cleanup` and `optimize-at-edge-enabled-marking`.
- Companion handler: adobe/spacecat-import-worker#848. Companion dispatcher registration: adobe/spacecat-jobs-dispatcher#791.

## Still required before this is usable (not code, in this or the companion PRs)
- Vault secrets (`OBJECT_STORAGE_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY`/`OBJECT_STORAGE_BUCKET`/`_REGION`) added to `dx_mysticat/{env}/spacecat-import-worker`.
- A `Configuration` job entry (`group: imports`, `type: prerender-cache-cleanup`) via `PATCH /configurations/latest` - this command already checks for that entry and warns `is not configured in the system` if it's missing, same requirement as the scheduled dispatch path.

## Test plan
- [x] New test: "accepts prerender-cache-cleanup as a valid global import type"
- [x] Full `run-global-import.test.js` suite passing (17/17)
- [x] lint clean

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```