### PR TITLE
feat(serenity): build the tag-display-names mapping seam (WP-D2)

### DIFF
--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1404,7 +1404,10 @@ v2-serenity-brand-presence-sentiment-overview:
         required: false
         description: |
           Full `category__<label>` tag value (caller includes the `category__`
-          prefix), sent to Semrush as-is. `category` is accepted as an alias.
+          prefix), sent to Semrush as-is. `category` is accepted as an alias
+          query-param name; separately, both the current root-name spelling
+          and the bare `category` slug are recognized for the tag prefix
+          itself (tag-display-names.md §1 item 6).
         schema: { type: string }
     responses:
       '200':
@@ -2267,7 +2270,7 @@ v2-serenity-url-inspector-stats:
       - name: categoryId
         in: query
         required: false
-        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is.
+        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is. Both the current root-name spelling and the bare `category` slug are recognized for the prefix (tag-display-names.md §1 item 6).
         schema: { type: string }
       - name: category
         in: query
@@ -2384,7 +2387,7 @@ v2-serenity-url-inspector-prompts-count:
       - name: categoryId
         in: query
         required: false
-        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is.
+        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is. Both the current root-name spelling and the bare `category` slug are recognized for the prefix (tag-display-names.md §1 item 6).
         schema: { type: string }
       - name: category
         in: query
@@ -2534,7 +2537,7 @@ v2-serenity-url-inspector-url-prompts:
       - name: categoryId
         in: query
         required: false
-        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is.
+        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is. Both the current root-name spelling and the bare `category` slug are recognized for the prefix (tag-display-names.md §1 item 6).
         schema: { type: string }
       - name: category
         in: query
@@ -2796,7 +2799,7 @@ v2-serenity-kpi-headlines:
       - name: categoryId
         in: query
         required: false
-        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is.
+        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is. Both the current root-name spelling and the bare `category` slug are recognized for the prefix (tag-display-names.md §1 item 6).
         schema: { type: string }
       - name: category
         in: query
@@ -2934,7 +2937,7 @@ v2-serenity-source-visibility-headline:
       - name: categoryId
         in: query
         required: false
-        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is.
+        description: Full `category__<label>` tag value (caller includes the prefix), sent as-is. Both the current root-name spelling and the bare `category` slug are recognized for the prefix (tag-display-names.md §1 item 6).
         schema: { type: string }
       - name: category
         in: query

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@adobe/spacecat-shared-http-utils": "1.35.2",
         "@adobe/spacecat-shared-ims-client": "1.16.0",
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.1",
-        "@adobe/spacecat-shared-project-engine-client": "1.18.1",
+        "@adobe/spacecat-shared-project-engine-client": "1.20.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.1",
         "@adobe/spacecat-shared-scrape-client": "2.7.1",
         "@adobe/spacecat-shared-slack-client": "1.7.2",
@@ -6924,9 +6924,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-project-engine-client": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.18.1.tgz",
-      "integrity": "sha512-ggMWcJMuiv/bC/APb2maK9c5H2h/bZcJTct3H5miMZEamsot+enIrSyZRAU8+RfiDLokpP3m6uVBt1pP5Eb/Lg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-project-engine-client/-/spacecat-shared-project-engine-client-1.20.0.tgz",
+      "integrity": "sha512-/NhGACmAfLEWd7nYPRkhYDbAz3iGPuFR/NnhtF1hPXlxRYrRvd2aLrx4rwAaQlU7VbFskKoYKZb9J+Yy8mw+ZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@adobe/spacecat-shared-http-utils": "1.35.2",
     "@adobe/spacecat-shared-ims-client": "1.16.0",
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.1",
-    "@adobe/spacecat-shared-project-engine-client": "1.18.1",
+    "@adobe/spacecat-shared-project-engine-client": "1.20.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.1",
     "@adobe/spacecat-shared-scrape-client": "2.7.1",
     "@adobe/spacecat-shared-slack-client": "1.7.2",

--- a/src/support/elements/definitions/topics.js
+++ b/src/support/elements/definitions/topics.js
@@ -16,6 +16,9 @@ import {
   INTENT_ROOT_NAME,
   ORIGIN_ROOT_NAME,
   LEGACY_ORIGIN_ROOT_NAME,
+  DIMENSION,
+  rootNameOfDimension,
+  dimensionOfRootName,
 } from '../../serenity/prompt-tags.js';
 
 /**
@@ -121,15 +124,31 @@ export function transformTopicsForFilterDimensions(raw) {
 }
 
 /**
+ * The `category` dimension's root-name alias set — its current display
+ * spelling ({@link rootNameOfDimension}, IDENTITY PLACEHOLDER today —
+ * tag-display-names.md §1 item 4) and the bare dimension key, deduped. Reused
+ * for both the extraction below and {@link KNOWN_TAG_PREFIXES}, so the two
+ * can never drift from each other.
+ */
+const CATEGORY_ROOT_NAMES = [...new Set([
+  rootNameOfDimension(DIMENSION.CATEGORY), DIMENSION.CATEGORY,
+])];
+
+/**
  * Extracts only "category__"-prefixed entries → `{ id: original tag, label }`,
  * plus `parent_id`/`parent_label` when the tag encodes a "Parent__Child"
- * hierarchy.
+ * hierarchy. Alias-tolerant ({@link CATEGORY_ROOT_NAMES}): both the display
+ * root name and the bare slug are accepted in, mirroring
+ * {@link transformOriginsToFilterDimensions}'s two-spelling tolerance.
  * @param {object} raw - Raw response from the Elements API.
  * @returns {FilterDimensionItem[]}
  */
 export function transformCategoriesToFilterDimensions(raw) {
-  return extractByPrefix(raw, 'category')
-    .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, 'category__') }));
+  return CATEGORY_ROOT_NAMES.flatMap((root) => {
+    const marker = `${root}${SEP}`;
+    return extractByPrefix(raw, root)
+      .map(({ original, stripped }) => ({ id: original, ...splitParent(stripped, marker) }));
+  });
 }
 
 /**
@@ -194,7 +213,7 @@ export function transformOriginsToFilterDimensions(raw) {
 
 const KNOWN_TAG_PREFIXES = [
   'topic__',
-  'category__',
+  ...CATEGORY_ROOT_NAMES.map((root) => `${root}${SEP}`),
   INTENT_MARKER,
   ...ORIGIN_ROOT_NAMES.map((root) => `${root}${SEP}`),
 ];
@@ -221,7 +240,14 @@ const KNOWN_TAG_PREFIXES = [
  * - `prefix__value` tags are grouped by their prefix into a dynamic key
  *   (e.g. `{ type: [{ id: 'type__branded', label: 'branded' }, ...] }`), unless
  *   `prefix` collides with an entry in `reservedResultKeys`, in which case the
- *   tag is routed to the generic `tags` array instead.
+ *   tag is routed to the generic `tags` array instead. The GROUP KEY is folded
+ *   through {@link dimensionOfRootName} first (tag-display-names.md §1 item 6,
+ *   plan WP-D2 item 8: "dynamic group keys ... stay the stable slug keys") —
+ *   `source`/`type` group under their bare dimension key regardless of
+ *   whether the wire prefix is the slug or the (currently identical) display
+ *   spelling, so the Adobe API contract does not churn as the tree renames.
+ *   The `id`/`parent_id` fields still carry the RAW wire prefix verbatim —
+ *   only the grouping key is normalized.
  * - Bare values with no `__` at all are prefix declarations (e.g. a lone
  *   `category` row announcing the dimension itself, with no value) and are
  *   ignored entirely — they are not tag data.
@@ -261,14 +287,18 @@ export function transformOtherTagsForFilterDimensions(raw, reservedResultKeys = 
       // Bare prefix declaration (e.g. "category") — not tag data, ignore.
       return;
     }
-    const prefix = value.slice(0, sepIdx);
+    const rawPrefix = value.slice(0, sepIdx);
     const rest = value.slice(sepIdx + SEP.length);
+    // Fold the GROUP KEY only (never `id`/`parent_id`, which stay wire-exact)
+    // through the alias map — identity for anything outside the taxonomy, so
+    // an arbitrary/unrecognised prefix groups under itself exactly as before.
+    const prefix = dimensionOfRootName(rawPrefix);
     if (reservedResultKeys.includes(prefix)) {
-      tags.push({ id: value, ...splitParent(rest, `${prefix}${SEP}`) });
+      tags.push({ id: value, ...splitParent(rest, `${rawPrefix}${SEP}`) });
       return;
     }
     groups[prefix] = groups[prefix] ?? [];
-    groups[prefix].push({ id: value, ...splitParent(rest, `${prefix}${SEP}`) });
+    groups[prefix].push({ id: value, ...splitParent(rest, `${rawPrefix}${SEP}`) });
   });
 
   return { ...groups, tags };

--- a/src/support/serenity/handlers/classify-prompts-job.js
+++ b/src/support/serenity/handlers/classify-prompts-job.js
@@ -314,7 +314,8 @@ async function createAndClassify(context, job, transport, metadata) {
  * @param {SerenityTransport} transport
  * @param {object} metadata - `{ semrushWorkspaceId, items: [{ projectId,
  *   promptId, text, tagIds }] }` — `tagIds` is the FULL desired tag set minus
- *   `intent` (caller tags + server type/origin), matching the edit handlers'
+ *   `intent` (caller tags + server type/source; `origin` no longer gets its
+ *   own tag, tag-display-names.md §3), matching the edit handlers'
  *   "recompute the whole set, then replace" contract.
  * @returns {Promise<object>} the job result.
  */

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -295,9 +295,12 @@ function validateCreateBody(body) {
  * Generates topics + prompts for (domain, country) via the AI-SEO service
  * (transport.getBrandTopics) and attaches them to the project. Keeps the top
  * `topicCap` topics by search volume (0 = keep all) and tags every prompt with
- * the standard closed-dimension values ({@link STANDARD_PROMPT_TAG_VALUES}, minus
- * its seeded `intent` default), the producing `source/semrush` value, plus a
- * branded / non-branded `type` value derived from `brandNames` (brand name +
+ * the standard closed-dimension values ({@link STANDARD_PROMPT_TAG_VALUES} —
+ * today just its seeded `intent` default, since the `origin` entry it used to
+ * carry is retired, tag-display-names.md §3 — minus that seeded `intent`
+ * default, which is classified per prompt below instead), the producing
+ * `source/semrush` value, plus a branded / non-branded `type` value derived
+ * from `brandNames` (brand name +
  * aliases) and a per-prompt server-classified `intent` value (serenity-docs#32,
  * replacing the seeded `Informational` default). Returns the topic/prompt counts.
  * A generation that yields nothing is a clean no-op (no upstream write).

--- a/src/support/serenity/handlers/markets-subworkspace.js
+++ b/src/support/serenity/handlers/markets-subworkspace.js
@@ -300,9 +300,9 @@ function validateCreateBody(body) {
  * carry is retired, tag-display-names.md §3 — minus that seeded `intent`
  * default, which is classified per prompt below instead), the producing
  * `source/semrush` value, plus a branded / non-branded `type` value derived
- * from `brandNames` (brand name +
- * aliases) and a per-prompt server-classified `intent` value (serenity-docs#32,
- * replacing the seeded `Informational` default). Returns the topic/prompt counts.
+ * from `brandNames` (brand name + aliases) and a per-prompt server-classified
+ * `intent` value (serenity-docs#32, replacing the seeded `Informational`
+ * default). Returns the topic/prompt counts.
  * A generation that yields nothing is a clean no-op (no upstream write).
  *
  * The generated topic name is NOT attached. Under the dimension-root model a

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -228,9 +228,11 @@ export async function handleCreatePromptsSubworkspace(
     }
     const projectId = String(project.id);
     try {
-      // Unified layer: strip caller-supplied type/origin/intent, then inject the
-      // computed type + derived origin (origin-dimension.md §3) and the classified
-      // intent (serenity-docs#32). The injectors act on disjoint dimensions.
+      // Unified layer: strip caller-supplied type/source/intent, then inject the
+      // computed type + the derived `source` (tag-display-names.md §3 — `origin`
+      // no longer gets its own tag, so it is never stripped or injected here) and
+      // the classified intent (serenity-docs#32). The injectors act on disjoint
+      // dimensions.
       let typed = await injectComputedTags(projectId, input);
       typed = await injectComputedIntent(projectId, typed);
       // Intentional (not an inconsistency to fix): each item stamps its OWN

--- a/src/support/serenity/handlers/prompts-subworkspace.js
+++ b/src/support/serenity/handlers/prompts-subworkspace.js
@@ -176,9 +176,10 @@ export async function handleCreatePromptsSubworkspace(
   const deferPublish = validateDeferPublish(body);
 
   const projectsBySlice = await buildSliceProjectMap(transport, workspaceId, log);
-  // CREATE: user-authenticated write → derived `origin` is `human` and producing
-  // `source` is the constant `config` (see the flat-mode twin handleCreatePrompts,
-  // origin-dimension.md §3, source-dimension.md §1).
+  // CREATE: user-authenticated write → `originValue` = `human` feeds
+  // `deriveSource` (tag-display-names.md §3 — `origin` no longer gets its own
+  // tag) and producing `source` is the constant `config` (see the flat-mode
+  // twin handleCreatePrompts, source-dimension.md §1).
   const injectComputedTags = makePromptTagInjector(
     transport,
     workspaceId,

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -1183,10 +1183,11 @@ export async function handleCreatePrompts(
     }
     const projectId = project.getSemrushProjectId();
     try {
-      // Unified layer: strip caller-supplied type/origin/intent, then inject the
-      // computed type + derived origin (origin-dimension.md §3) and the
-      // classified intent (serenity-docs#32). The two injectors act on disjoint
-      // dimensions, so chaining composes cleanly.
+      // Unified layer: strip caller-supplied type/source/intent, then inject the
+      // computed type + the derived `source` (tag-display-names.md §3 — `origin`
+      // no longer gets its own tag, so it is never stripped or injected here) and
+      // the classified intent (serenity-docs#32). The two injectors act on
+      // disjoint dimensions, so chaining composes cleanly.
       let typed = await injectComputedTags(projectId, input);
       typed = await injectComputedIntent(projectId, typed);
       const semrushPromptId = await createOnePrompt(

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -23,7 +23,7 @@ import { invalidateTagCacheForProject } from './markets.js';
 import { resolveTypeValueInjection, resolveIntentValueInjection, resolveServerOwnedValueInjection } from '../tag-tree.js';
 import {
   DIMENSION, ORIGIN_VALUE, INTENT_VALUE, PROXY_CREATE_SOURCE_VALUE,
-  canonicalizeSource, SOURCE_VALUES,
+  canonicalizeSource, SOURCE_VALUES, deriveSource,
 } from '../prompt-tags.js';
 import { classifyPromptIntents } from '../intent-classification.js';
 import { logPromptDeleteEvent } from '../prompt-delete-log.js';
@@ -766,9 +766,9 @@ export async function createOnePrompt(transport, semrushWorkspaceId, projectId, 
 
 /**
  * Builds the per-request prompt-tag injector — the UNIFIED server-owned-dimension
- * layer (serenity-docs#31 for `type`; origin-dimension.md §3 for `origin`). It
- * stamps the two dimensions a client may never set on a prompt: `type` (branded /
- * non-branded, classified from the text) and `origin` (who authored the prompt).
+ * layer (serenity-docs#31 for `type`; source-dimension.md for `source`). It
+ * stamps the dimensions a client may never set on a prompt: `type` (branded /
+ * non-branded, classified from the text) and `source` (the producing system).
  *
  * `injectComputedTags(projectId, input)` STRIPS every caller-supplied tag id that
  * lives under a server-owned dimension's root and APPENDS the pre-resolved
@@ -783,31 +783,38 @@ export async function createOnePrompt(transport, semrushWorkspaceId, projectId, 
  * always safe to recompute. A non-function `classifyPromptType` (defensive) skips
  * the `type` step.
  *
- * **`origin`** — carries the CREATE/UPDATE ASYMMETRY (origin-dimension.md §3
- * item 3). It is a fact about the row's CREATION, never a classification, so:
- *   - on CREATE (`originValue` set, e.g. `human` for a user-authenticated write),
- *     any caller-supplied origin id is stripped and the derived value injected;
- *   - on UPDATE (`originValue` unset) the injector leaves origin ALONE. The stored
- *     value the caller echoes back rides through the full-replace tag write
- *     unchanged. Re-deriving would relabel every edited `ai` prompt `human`;
- *     stripping without injecting would leave the prompt invisible to the
- *     dimension's filter — both are illegal, so the update path does neither.
+ * **`origin` NO LONGER GETS ITS OWN TAG** (tag-display-names.md §3 — the
+ * dimension is retired by remap into `source`). `originValue` SURVIVES as an
+ * OPTION, though, because it is still the only carrier of the CREATE-time
+ * authorship fact on the Serenity-proxy path: there is no Postgres row here to
+ * read `origin` back from, so `originValue` feeds {@link deriveSource} below as
+ * the `origin` half of `derived_source(source, origin)` — it is never written
+ * as a tag of its own again. Deleting `originValue` along with the old
+ * `origin`-tag branch would silently relabel every service-principal proxy
+ * create from the `ai-onboarding` slug to `config`'s, because the injector
+ * would have no way left to tell the two apart.
  *
- * **`source`** — the PRODUCING SYSTEM (source-dimension.md), and like `origin` it
- * is a fact about CREATION, not a classification, so it carries the same asymmetry:
+ * **`source`** — the PRODUCING SYSTEM (source-dimension.md), a fact about
+ * CREATION, not a classification:
  *   - on CREATE (`sourceValue` set — the constant `config` for this proxy dialog,
- *     the value the same prompt gets in Postgres on the v2 path), any caller-supplied
- *     tag id beneath the `source` root is stripped (by RESOLVED ID, never by name — a
- *     customer category may legitimately be called `gsc`) and the derived value
- *     injected. The dimension has no client write surface;
- *   - on UPDATE (`sourceValue` unset) the injector leaves source ALONE — a prompt's
- *     producer is fixed at creation.
+ *     the value the same prompt gets in Postgres on the v2 path, or a validated
+ *     per-item override), the EFFECTIVE value injected is
+ *     `deriveSource(itemSource, originValue)` (tag-display-names.md §3), not the
+ *     raw slug — this is where `origin/ai` + `source/config` folds into
+ *     `ai-onboarding`, and where `llm-generated` folds into it too. Any
+ *     caller-supplied tag id beneath the `source` root is stripped (by RESOLVED
+ *     ID, never by name — a customer category may legitimately be called
+ *     `gsc`) and the derived value injected. The dimension has no client write
+ *     surface;
+ *   - on UPDATE (`sourceValue` and `originValue` both unset) the injector leaves
+ *     source ALONE — a prompt's producer is fixed at creation.
  *
  * Resolution ({@link resolveTypeValueInjection} / {@link resolveServerOwnedValueInjection},
  * two tag-tree reads per distinct value per project — the root level plus the
  * root's children) is memoized for the request, so a bulk create fans out over
- * the distinct computed values rather than over the items. The origin and source
- * values are constant per request, so each resolution is memoized per project.
+ * the distinct computed values rather than over the items. The source value is
+ * effectively constant per request (modulo the rare per-item override), so each
+ * resolution is memoized per (project, derived value).
  *
  * Resolution resolves or throws, so a server tag is always attached; it is never
  * dropped, and a resolution failure aborts the write (which is free — the upstream
@@ -819,8 +826,10 @@ export async function createOnePrompt(transport, semrushWorkspaceId, projectId, 
  * @param {((text: string, geoTargetId: number) => string) | undefined} classifyPromptType
  * @param {object} [log]
  * @param {{ originValue?: string, sourceValue?: string }} [options] - `originValue`
- *   / `sourceValue` are the derived `origin` / `source` to inject on CREATE; omit
- *   each on UPDATE so that dimension is left untouched.
+ *   is the CREATE-time `origin` fact (`ai`/`human`), fed into
+ *   {@link deriveSource} — it is NEVER written as its own tag (tag-display-names.md
+ *   §3). `sourceValue` is the batch-default `source` slug to derive from on
+ *   CREATE. Omit both on UPDATE so `source` is left untouched.
  * @returns {(projectId: string, input: { text: string, geoTargetId: number,
  *   tagIds: string[], source?: string }) =>
  *   Promise<{ text: string, geoTargetId: number, tagIds: string[] }>}
@@ -835,8 +844,6 @@ export function makePromptTagInjector(
   const { originValue, sourceValue } = options;
   /** @type {Map<string, Promise<{ computedId: string, typeTagIds: string[] }>>} */
   const typeCache = new Map();
-  /** @type {Map<string, Promise<{ computedId: string, valueTagIds: string[] }>>} */
-  const originCache = new Map();
   /** @type {Map<string, Promise<{ computedId: string, valueTagIds: string[] }>>} */
   const sourceCache = new Map();
   return async function injectComputedTags(projectId, input) {
@@ -861,34 +868,29 @@ export function makePromptTagInjector(
       tagIds = [...tagIds.filter((id) => !typeTagIds.includes(id)), computedId];
     }
 
-    // origin — CREATE only. `originValue` unset means UPDATE: leave origin alone
-    // (the stored value the caller echoes rides through the replace-mode write).
-    if (originValue) {
-      let pending = originCache.get(projectId);
-      if (!pending) {
-        pending = resolveServerOwnedValueInjection(
-          transport,
-          semrushWorkspaceId,
-          projectId,
-          DIMENSION.ORIGIN,
-          originValue,
-          log,
-        );
-        originCache.set(projectId, pending);
-      }
-      const { computedId, valueTagIds } = await pending;
-      tagIds = [...tagIds.filter((id) => !valueTagIds.includes(id)), computedId];
-    }
+    // `origin` no longer gets its own tag (tag-display-names.md §3) — every
+    // writer that used to stamp one has stopped. `originValue` survives ONLY
+    // as an input to `deriveSource` below, never as a tag id of its own.
 
-    // source — CREATE only, same asymmetry as origin. Per-item `input.source`
-    // (Track flow, LLMO-6556) overrides the batch default (`sourceValue`); absent
-    // on both means UPDATE — leave the producer alone (fixed at creation). Cache
-    // is keyed on (projectId, source) so a mixed-surface batch resolves each
-    // producer's tag independently. Stripped by resolved id, never by name.
-    // `??` not `||` (MysticatBot nit): `normalizePromptInput` yields a valid slug
-    // or `undefined`, so "absent means use the batch default" is exactly the
-    // nullish-coalesce contract.
-    const itemSource = input.source ?? sourceValue;
+    // source — CREATE only, same create/update asymmetry `origin` used to
+    // carry. Per-item `input.source` (Track flow, LLMO-6556) overrides the
+    // batch default (`sourceValue`); absent on both means UPDATE — leave the
+    // producer alone (fixed at creation). `??` not `||` (MysticatBot nit):
+    // `normalizePromptInput` yields a valid slug or `undefined`, so "absent
+    // means use the batch default" is exactly the nullish-coalesce contract.
+    //
+    // The EFFECTIVE value injected is `deriveSource(rawSource, originValue)`
+    // (tag-display-names.md §3), not the raw slug: on the Serenity-proxy path
+    // there is no Postgres row to read `origin` back from, so `originValue` —
+    // set only on CREATE, e.g. `human` for this proxy dialog, or `ai` for a
+    // service-principal caller acting on the AI-onboarding path — is the sole
+    // surviving carrier of that fact, and it is what lets `config`+`ai` (and
+    // `llm-generated`, regardless of origin) fold into the `ai-onboarding`
+    // slug instead of landing under `config`. Cache is keyed on (projectId,
+    // DERIVED value) so a mixed-surface batch resolves each producer's tag
+    // independently. Stripped by resolved id, never by name.
+    const rawSource = input.source ?? sourceValue;
+    const itemSource = rawSource ? deriveSource(rawSource, originValue) : null;
     if (itemSource) {
       const key = `${projectId} ${itemSource}`;
       let pending = sourceCache.get(key);
@@ -1128,12 +1130,11 @@ export async function handleCreatePrompts(
     projectsBySlice.set(`${p.getGeoTargetId()}:${p.getLanguageCode()}`, p);
   }
 
-  // CREATE: user-authenticated write → derived `origin` is `human`
-  // (origin-dimension.md §3). Any caller-supplied origin tag id is stripped and
-  // this value injected; on the twin AI-generation path a service producer stamps
-  // `ai` via STANDARD_PROMPT_TAG_VALUES instead (that path does not run here).
-  // The producing `source` is the constant `config` — this human create dialog is
-  // what the same prompt gets in Postgres on the v2 path (source-dimension.md §1).
+  // CREATE: user-authenticated write → `originValue` = `human` feeds
+  // `deriveSource` below (tag-display-names.md §3 — `origin` no longer gets
+  // its own tag). The producing `source` is the constant `config` — this
+  // human create dialog is what the same prompt gets in Postgres on the v2
+  // path (source-dimension.md §1).
   const injectComputedTags = makePromptTagInjector(
     transport,
     semrushWorkspaceId,

--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -236,6 +236,18 @@ export const TYPE_VALUE_DISPLAY = Object.freeze({
 });
 
 /**
+ * Backing map for {@link valueSlugOfDisplayName}'s `type` branch — built once
+ * from {@link TYPE_VALUE_DISPLAY}, mirroring {@link SOURCE_LABEL_INVERSE}'s
+ * pattern for `source` so the two server-owned display-form inverses stay
+ * structurally consistent as this generalizes to more dimensions.
+ *
+ * @type {Map<string, string>}
+ */
+const TYPE_VALUE_DISPLAY_INVERSE = new Map(
+  Object.entries(TYPE_VALUE_DISPLAY).map(([slug, displayName]) => [displayName, slug]),
+);
+
+/**
  * The CLOSED dimensions and their fixed child vocabularies. A caller may never
  * mint an arbitrary value under these; the values below are provisioned as the
  * root's children on every project. A caller may still "create" one of these
@@ -472,8 +484,7 @@ export function valueSlugOfDisplayName(dimension, displayName) {
     return displayToSlug(displayName);
   }
   if (dimension === DIMENSION.TYPE) {
-    return /** @type {(readonly [string, string])[]} */ (Object.entries(TYPE_VALUE_DISPLAY))
-      .find(([, display]) => display === displayName)?.[0];
+    return TYPE_VALUE_DISPLAY_INVERSE.get(displayName);
   }
   return undefined;
 }

--- a/src/support/serenity/prompt-tags.js
+++ b/src/support/serenity/prompt-tags.js
@@ -91,10 +91,30 @@ export const HIDDEN_TAG_MARKER = '$abv_tags$';
 export const INTENT_ROOT_NAME = `${HIDDEN_TAG_MARKER}intent`;
 
 /**
- * The upstream root NAME a dimension's root is provisioned and resolved by — the
- * dimension key itself for four of the five, {@link INTENT_ROOT_NAME} for
- * `intent`. Anything outside the taxonomy maps to itself, so a caller gets the
- * name it asked for rather than `undefined` flowing into a create.
+ * The customer-facing DISPLAY root name for a dimension whose root gets renamed
+ * (tag-display-names.md §1 item 4) — `category` → `Category`, `type` → `Type`,
+ * `source` → `Source`. `intent` is excluded (permanently hidden under
+ * {@link INTENT_ROOT_NAME}, no display rename) and `origin` is excluded (retired
+ * by remap rather than renamed, tag-display-names.md §3).
+ *
+ * IDENTITY PLACEHOLDER — serenity-docs#407 (the vocabulary sign-off PR) is not
+ * yet merged, so every value here is its own key, verbatim. Do NOT add or remove
+ * keys here; only the orchestrator swaps these VALUES in once #407 merges and the
+ * vocabulary is frozen (tag-display-names.md §7 gate 1).
+ */
+export const ROOT_DISPLAY_NAME = Object.freeze({
+  [DIMENSION.CATEGORY]: DIMENSION.CATEGORY,
+  [DIMENSION.TYPE]: DIMENSION.TYPE,
+  [DIMENSION.SOURCE]: DIMENSION.SOURCE,
+});
+
+/**
+ * The upstream root NAME a dimension's root is provisioned and resolved by
+ * TODAY — {@link INTENT_ROOT_NAME} for `intent`, {@link ROOT_DISPLAY_NAME} for
+ * the three renaming dimensions, the dimension key itself for everything else
+ * (`origin`, and anything outside the taxonomy). Anything outside the taxonomy
+ * maps to itself, so a caller gets the name it asked for rather than `undefined`
+ * flowing into a create.
  *
  * {@link RESERVED_ROOT_NAMES} is derived through this function, so a change to the
  * mapping widens or narrows what a customer tag may not shadow.
@@ -103,7 +123,10 @@ export const INTENT_ROOT_NAME = `${HIDDEN_TAG_MARKER}intent`;
  * @returns {string} the upstream root name.
  */
 export function rootNameOfDimension(dimension) {
-  return dimension === DIMENSION.INTENT ? INTENT_ROOT_NAME : dimension;
+  if (dimension === DIMENSION.INTENT) {
+    return INTENT_ROOT_NAME;
+  }
+  return ROOT_DISPLAY_NAME[/** @type {keyof ROOT_DISPLAY_NAME} */ (dimension)] ?? dimension;
 }
 
 /**
@@ -160,6 +183,10 @@ export const RESERVED_ROOT_NAMES = Object.freeze([...new Set([
   ...DIMENSION_PROVISION_ORDER,
   ...DIMENSION_PROVISION_ORDER.map(rootNameOfDimension),
 ])]);
+// ^ Grows automatically with the display root names (tag-display-names.md §1
+// item 5) once ROOT_DISPLAY_NAME's IDENTITY PLACEHOLDER values become real: this
+// is derived through rootNameOfDimension, so no edit is needed here when that
+// happens. The Set dedupes the case that coincides today (display === slug).
 
 /** `origin` values — who authored the prompt. */
 export const ORIGIN_VALUE = Object.freeze({
@@ -194,6 +221,18 @@ export const INTENT_VALUE = Object.freeze({
 export const TYPE_VALUE = Object.freeze({
   BRANDED: 'branded',
   NON_BRANDED: 'non-branded',
+});
+
+/**
+ * `type` value slug → customer-facing display form (tag-display-names.md §1
+ * item 4: `branded` → `Branded`, `non-branded` → `Non-branded`).
+ *
+ * IDENTITY PLACEHOLDER — do not add/remove keys here; only the orchestrator
+ * swaps these VALUES in once serenity-docs#407 is merged + signed off.
+ */
+export const TYPE_VALUE_DISPLAY = Object.freeze({
+  [TYPE_VALUE.BRANDED]: TYPE_VALUE.BRANDED,
+  [TYPE_VALUE.NON_BRANDED]: TYPE_VALUE.NON_BRANDED,
 });
 
 /**
@@ -310,38 +349,150 @@ export const PROXY_CREATE_SOURCE_VALUE = 'config';
 export const GENERATED_PROMPT_SOURCE_VALUE = 'semrush';
 
 /**
- * Canonical producing-system slug → customer-facing label. FROZEN and EXHAUSTIVE:
- * one entry per {@link SOURCE_VALUES} value, enforced by a unit test that FAILS
- * the moment a canonical value is added without a label. There is deliberately NO
- * pass-through slug default — a `SOURCE_LABEL[x] ?? x` fallback is exactly the
- * mechanism by which an internal slug reaches a customer silently (source-dimension.md
- * §7), and §3.2's product sign-off protects only the values that exist today.
+ * The `source` values that exist ONLY as the output of {@link deriveSource} —
+ * never a legal `prompts.source` input, never accepted by the v2 create
+ * validator or the create-tag closed-value enum (tag-display-names.md §6 item
+ * 3). `ai-onboarding` is the remap target for the retired `origin` dimension
+ * (tag-display-names.md §3): it is a real, structural slug (not a display
+ * placeholder) — it must be disjoint from {@link SOURCE_VALUES} today, exactly
+ * as it will be once the vocabulary freezes. Python twin:
+ * `DERIVED_PROMPT_SOURCES` beside `KNOWN_PROMPT_SOURCES`
+ * (mysticat-data-service `scripts/serenity_migration/tags.py`); keep the two
+ * in sync (slugs, not labels — no drift risk from the identity placeholders).
+ */
+export const DERIVED_SOURCE_VALUES = Object.freeze(['ai-onboarding']);
+
+/** The single derived `source` slug — the remap target of {@link deriveSource}. */
+const AI_ONBOARDING_SOURCE_VALUE = DERIVED_SOURCE_VALUES[0];
+
+/**
+ * Canonical producing-system slug → customer-facing TAG NAME (the tree-write
+ * boundary map, tag-display-names.md §1 item 3 — "the tag-name map"). Covers
+ * every {@link SOURCE_VALUES} entry that can still reach the tree as its own
+ * tag PLUS every {@link DERIVED_SOURCE_VALUES} entry — together, the full
+ * codomain of {@link deriveSource}. `llm-generated` is deliberately ABSENT: it
+ * folds into `ai-onboarding` at the derivation boundary and never becomes a
+ * tag name of its own (tag-display-names.md §1 item 3, §3) — the exhaustiveness
+ * gate counts it as covered-by-fold, not as needing its own entry (§6 item 1).
  *
- * The label question is OPEN (source-dimension.md §3.2): until product signs off,
- * the labels are the canonical machine-name slugs, verbatim. This map is the SINGLE
- * place a display label would land, so whichever way that call goes it changes here
- * and nowhere else. (elmo ships its own display labels behind `SOURCE_BADGE_CONFIG`;
- * WP-S3.)
+ * FROZEN and EXHAUSTIVE over that set, enforced by a unit test that FAILS the
+ * moment a canonical value is added without an entry. There is deliberately NO
+ * pass-through slug default — a `SOURCE_LABEL[x] ?? x` fallback is exactly the
+ * mechanism by which an internal slug reaches a customer silently
+ * (source-dimension.md §7) — and every value in this map must be UNIQUE
+ * (bijective): two slugs may never share one tag name (tag-display-names.md §1
+ * item 3; a duplicate is a hard upstream 500 at create time and an
+ * unresolvable ambiguity at read time).
+ *
+ * IDENTITY PLACEHOLDER — serenity-docs#407 (the vocabulary sign-off PR) is not
+ * yet merged, so every value here is its own key, verbatim. Do NOT add or
+ * remove keys here; only the orchestrator swaps these VALUES in once #407
+ * merges and the vocabulary is frozen (tag-display-names.md §7 gate 1). (elmo
+ * ships its OWN, separate label map behind `SOURCE_BADGE_CONFIG` — the
+ * Postgres-backed "label map" of §1 item 3, which DOES cover `llm-generated`
+ * many-to-one; that map is WP-D3, out of scope here.)
  */
 export const SOURCE_LABEL = Object.freeze(
-  SOURCE_VALUES.reduce((acc, slug) => {
-    acc[slug] = slug;
-    return acc;
-  }, /** @type {Record<string, string>} */ ({})),
+  [...SOURCE_VALUES.filter((slug) => slug !== 'llm-generated'), ...DERIVED_SOURCE_VALUES]
+    .reduce((acc, slug) => {
+      acc[slug] = slug;
+      return acc;
+    }, /** @type {Record<string, string>} */ ({})),
+);
+
+/** Backing map for {@link displayToSlug} — built once from {@link SOURCE_LABEL}. */
+const SOURCE_LABEL_INVERSE = new Map(
+  Object.entries(SOURCE_LABEL).map(([slug, displayName]) => [displayName, slug]),
 );
 
 /**
- * The closed-dimension values applied to EVERY AI-generated prompt: the `origin`
- * value `ai` (AI-authored) plus the default `Informational` intent (the most
- * common intent for brand-topic prompts; re-classification can refine it later).
- * The `type` value is classified per prompt at generation time (branded vs
- * non-branded — see the handler), so it is NOT seeded here.
+ * The true inverse of {@link SOURCE_LABEL}: a `source`-dimension TAG NAME →
+ * the canonical slug it was minted from. `undefined` for anything that is not
+ * a value in {@link SOURCE_LABEL} — in particular a bare slug is NOT
+ * automatically its own display name unless the map says so (which, under
+ * today's identity placeholders, it does for every entry — see
+ * {@link SOURCE_LABEL}'s docs).
+ *
+ * Built as a real inverse of the map (not a shortcut) so this is a no-op
+ * change when {@link SOURCE_LABEL}'s values stop being identity: the read
+ * side (tolerant tag-tree resolvers, the Elements boundary) always goes
+ * through this function first, exactly as tag-display-names.md §1 item 7
+ * requires, with the slug form accepted as its own alias for as long as
+ * un-migrated projects exist.
+ *
+ * @param {string} displayName - a `source`-dimension tag name.
+ * @returns {string | undefined} the canonical slug, or `undefined`.
+ */
+export function displayToSlug(displayName) {
+  return SOURCE_LABEL_INVERSE.get(displayName);
+}
+
+/**
+ * The customer-facing DISPLAY FORM of a value under a SERVER-OWNED dimension —
+ * the value itself for `intent`/`origin` (no display rename planned for
+ * either; tag-display-names.md §1 item 4), {@link SOURCE_LABEL} for `source`,
+ * {@link TYPE_VALUE_DISPLAY} for `type`. Anything outside those maps falls
+ * back to the value unchanged, matching {@link rootNameOfDimension}'s
+ * "anything outside the taxonomy maps to itself" convention.
+ *
+ * IDENTITY PLACEHOLDER by construction today (both underlying maps are), so
+ * this is a no-op fold until the vocabulary freezes — see
+ * {@link valueSlugOfDisplayName} for the inverse the tolerant resolvers pair
+ * this with.
+ *
+ * @param {string} dimension - a server-owned dimension key.
+ * @param {string} value - a bare value under that dimension's root.
+ * @returns {string} the tag name to create/resolve for that value.
+ */
+export function displayNameOfValue(dimension, value) {
+  if (dimension === DIMENSION.SOURCE) {
+    return SOURCE_LABEL[value] ?? value;
+  }
+  if (dimension === DIMENSION.TYPE) {
+    return TYPE_VALUE_DISPLAY[/** @type {keyof TYPE_VALUE_DISPLAY} */ (value)] ?? value;
+  }
+  return value;
+}
+
+/**
+ * The canonical slug a server-owned dimension's DISPLAY FORM denotes — the
+ * inverse of {@link displayNameOfValue}, generalized across dimensions the way
+ * {@link displayToSlug} is `source`-specific. `undefined` when `displayName`
+ * is not a mapped display form for that dimension (including when it is
+ * simply the bare slug itself — callers that also want to accept the slug as
+ * its own alias check for that separately, exactly as the tolerant tag-tree
+ * resolvers do).
+ *
+ * @param {string} dimension - a server-owned dimension key.
+ * @param {string} displayName - a bare value AS IT WOULD APPEAR on the tree.
+ * @returns {string | undefined} the canonical slug, or `undefined`.
+ */
+export function valueSlugOfDisplayName(dimension, displayName) {
+  if (dimension === DIMENSION.SOURCE) {
+    return displayToSlug(displayName);
+  }
+  if (dimension === DIMENSION.TYPE) {
+    return /** @type {(readonly [string, string])[]} */ (Object.entries(TYPE_VALUE_DISPLAY))
+      .find(([, display]) => display === displayName)?.[0];
+  }
+  return undefined;
+}
+
+/**
+ * The closed-dimension values applied to EVERY AI-generated prompt: the
+ * default `Informational` intent (the most common intent for brand-topic
+ * prompts; re-classification can refine it later). The `type` value is
+ * classified per prompt at generation time (branded vs non-branded — see the
+ * handler), so it is NOT seeded here. The `origin` entry this list used to
+ * carry (`{ dimension: 'origin', name: 'ai' }`) is RETIRED
+ * (tag-display-names.md §3): every writer that stamped an `origin` tag stops
+ * doing so, `origin` being derivable from the producer everywhere it still
+ * matters (`derived_source`, above).
  *
  * Each entry names a dimension and the bare value beneath it; the caller resolves
  * the pair to an upstream tag id against the project's tree.
  */
 export const STANDARD_PROMPT_TAG_VALUES = Object.freeze([
-  Object.freeze({ dimension: DIMENSION.ORIGIN, name: ORIGIN_VALUE.AI }),
   Object.freeze({ dimension: DIMENSION.INTENT, name: INTENT_VALUE.INFORMATIONAL }),
 ]);
 
@@ -358,23 +509,46 @@ export function isDimensionRootName(name) {
 }
 
 /**
+ * `dimensionOfRootName`'s lookup table: every root-name SPELLING a project may
+ * currently carry → its dimension key. Built from {@link DIMENSION_PROVISION_ORDER}
+ * so it can never drift from {@link rootNameOfDimension}: for each dimension it
+ * registers BOTH the bare dimension key (the pre-rename / un-migrated spelling,
+ * tag-display-names.md §1 item 6 — "both forms accepted in") AND
+ * `rootNameOfDimension(dimension)` (today's live spelling — `$abv_tags$intent`
+ * for `intent`, the identity-placeholder display name for the three renaming
+ * dimensions, `origin` unchanged). A `Map` (not a plain object) so a dimension
+ * key that collides with `Object.prototype` can never resolve to an inherited
+ * member.
+ */
+const ROOT_NAME_TO_DIMENSION = new Map(
+  DIMENSION_PROVISION_ORDER.flatMap((dimension) => [
+    [dimension, dimension],
+    [rootNameOfDimension(dimension), dimension],
+  ]),
+);
+
+/**
  * The DIMENSION KEY a root name denotes — the inverse of
- * {@link rootNameOfDimension}, and the fold that keeps `$abv_tags$intent` from
- * leaking out of the tag-tree walk into everything that reasons about dimensions
- * by key.
+ * {@link rootNameOfDimension}, tolerant of BOTH the current live spelling and
+ * the bare dimension-key spelling (tag-display-names.md §1 item 6, §5 phase
+ * 1) — resolves `category`/`Category`, `type`/`Type`, `source`/`Source`,
+ * `intent`/`$abv_tags$intent`, and `origin` (unchanged) alike. This is the
+ * fold that keeps `$abv_tags$intent` from leaking out of the tag-tree walk
+ * into everything that reasons about dimensions by key, generalized to every
+ * root that may display-rename.
  *
- * Identity for every other name. That is by construction and cannot single out
- * the bare `intent`, which is why it stays in {@link RESERVED_ROOT_NAMES}: a root
- * named that would be read as the intent dimension. Note the write and read paths
- * deliberately disagree about such a root — this fold makes the write path treat
- * its children as server-owned, while the Elements read path does not claim them
- * as intents. That asymmetry is intended; do not "fix" one side to match the other.
+ * Identity for anything NOT in {@link ROOT_NAME_TO_DIMENSION} — a customer
+ * category name, or any future root this taxonomy does not know about. Note
+ * the write and read paths deliberately disagree about a BARE `intent` root:
+ * this fold makes the write path treat its children as server-owned, while
+ * the Elements read path does not claim them as intents. That asymmetry is
+ * intended; do not "fix" one side to match the other.
  *
  * @param {string} rootName - a tag's root-ancestor name, as upstream spells it.
  * @returns {string} the dimension key.
  */
 export function dimensionOfRootName(rootName) {
-  return rootName === INTENT_ROOT_NAME ? DIMENSION.INTENT : rootName;
+  return ROOT_NAME_TO_DIMENSION.get(rootName) ?? rootName;
 }
 
 /**
@@ -448,6 +622,44 @@ export function canonicalizeSource(value) {
     || canonical.length > MAX_TAG_NAME_LEN
     || isDimensionRootName(canonical)) {
     return null;
+  }
+  return canonical;
+}
+
+/**
+ * `derived_source(source, origin)` (tag-display-names.md §3) — the fold that
+ * retires the `origin` dimension into `source` at the single point a slug
+ * becomes a tag name. REAL, structural logic (it operates on slugs, never on
+ * display strings) — NOT an identity placeholder, unlike the maps above.
+ *
+ *  - `canonicalizeSource(source) === 'config' && origin === 'ai'` → the
+ *    `config` bucket's AI-authored half (origin-dimension.md §3's `origin/ai`
+ *    population) remaps to {@link AI_ONBOARDING_SOURCE_VALUE}.
+ *  - `canonicalizeSource(source) === 'llm-generated'` → folds into the same
+ *    derived value (the "AI generated" collapse, tag-display-names.md §1 item
+ *    4) — `prompts.source` keeps recording `llm-generated` verbatim; only the
+ *    TAG folds.
+ *  - otherwise → `canonicalizeSource(source)`, unchanged (a prompt with a
+ *    specific producer — `gsc`, `drs`, … — carries no information in `origin`,
+ *    which is exactly why the dimension can retire).
+ *
+ * `null` propagates from {@link canonicalizeSource}: "do not tag this prompt",
+ * never a substituted default (mirrors `canonicalizeSource`'s own contract).
+ *
+ * @param {unknown} source - a raw or already-canonical `prompts.source` value.
+ * @param {string | null | undefined} origin - the bare `origin` value
+ *   (`ai`/`human`) for THIS write, or `undefined`/`null` on a path that never
+ *   derives origin (e.g. an UPDATE, where `origin` is never re-derived).
+ * @returns {string | null} the `source`-dimension tag slug to attach, or
+ *   `null` when the prompt must not be tagged at all.
+ */
+export function deriveSource(source, origin) {
+  const canonical = canonicalizeSource(source);
+  if (canonical === null) {
+    return null;
+  }
+  if (canonical === 'llm-generated' || (canonical === 'config' && origin === ORIGIN_VALUE.AI)) {
+    return AI_ONBOARDING_SOURCE_VALUE;
   }
   return canonical;
 }

--- a/src/support/serenity/tag-tree.js
+++ b/src/support/serenity/tag-tree.js
@@ -54,6 +54,8 @@ import {
   INTENT_ROOT_NAME,
   rootNameOfDimension,
   dimensionOfRootName,
+  displayNameOfValue,
+  valueSlugOfDisplayName,
 } from './prompt-tags.js';
 
 /** @typedef {import('./rest-transport.js').SerenityTransport} SerenityTransport */
@@ -116,18 +118,6 @@ export async function indexLevelByName(transport, semrushWorkspaceId, projectId,
 }
 
 /**
- * The names of `wanted` that a level index does not already carry, and therefore
- * still have to be created under that parent.
- *
- * @param {Map<string, string>} level - a level index.
- * @param {readonly string[]} wanted - the names the caller asked for.
- * @returns {string[]} what still has to be created.
- */
-function missingNames(level, wanted) {
-  return wanted.filter((name) => !level.has(name));
-}
-
-/**
  * Creates the missing names under one parent and returns their ids, merged with
  * the ones that already existed. A single upstream call carries every name for
  * one parent, so the batch never straddles two parents (the wire has exactly one
@@ -139,16 +129,35 @@ function missingNames(level, wanted) {
  * a name another writer minted first, or one the upstream echoed but did not
  * persist, is resolved, not claimed.
  *
+ * ALIAS-TOLERANT (tag-display-names.md §5 phase 1): a wanted name resolves if
+ * the level carries that name itself OR any of its {@link aliasesOf} spellings
+ * (e.g. the pre-freeze slug beside the display name once the vocabulary
+ * changes) — only the WANTED (canonical) name is ever created. This is purely
+ * additive: a wanted name resolved via an alias is recorded under BOTH its own
+ * literal tree spelling (unchanged, from `indexLevelByName`) AND the canonical
+ * `wanted` spelling in the returned `byName`, so a caller indexing by either
+ * the literal name (anomaly detection, e.g. {@link ensureDimensionRoots}'s
+ * split-root guardrails) or the canonical name it asked for gets an answer.
+ * Under today's IDENTITY PLACEHOLDER maps every alias set is a singleton (the
+ * canonical name is its own only alias), so this is a no-op — `aliasesOf`
+ * defaults to "no aliases" for every existing caller that does not pass it.
+ *
  * Fails closed: throws a 502 rather than returning a map missing a wanted name.
  *
  * @param {SerenityTransport} transport
  * @param {string} semrushWorkspaceId
  * @param {string} projectId
  * @param {string} parentId - '' to create at the root level.
- * @param {readonly string[]} wanted - bare names that must exist under `parentId`.
+ * @param {readonly string[]} wanted - bare (canonical) names that must exist
+ *   under `parentId`; only these are ever created.
  * @param {object} [log] - logger.
+ * @param {(name: string) => readonly string[]} [aliasesOf] - additional
+ *   spellings that, if already present at this level, resolve a wanted name
+ *   without creating it. Defaults to "no aliases" — every pre-existing caller
+ *   is unaffected.
  * @returns {Promise<{ byName: Map<string, string>, createdNames: string[] }>}
- *   `byName` maps every wanted name to its tag id.
+ *   `byName` maps every wanted name (and any literal tree name it did not ask
+ *   for) to its tag id.
  */
 export async function ensureChildren(
   transport,
@@ -157,9 +166,25 @@ export async function ensureChildren(
   parentId,
   wanted,
   log,
+  aliasesOf = () => [],
 ) {
   const existing = await indexLevelByName(transport, semrushWorkspaceId, projectId, parentId, log);
-  const missing = missingNames(existing, wanted);
+  const missing = [];
+  for (const name of wanted) {
+    if (existing.has(name)) {
+      // Nothing to do — the exact wanted spelling is already there.
+    } else {
+      const alias = aliasesOf(name).find((a) => existing.has(a));
+      if (alias !== undefined) {
+        // Additive only: the alias's own literal key stays exactly as
+        // `indexLevelByName` found it; this adds the canonical spelling as a
+        // second key pointing at the same id.
+        existing.set(name, /** @type {string} */ (existing.get(alias)));
+      } else {
+        missing.push(name);
+      }
+    }
+  }
   if (missing.length === 0) {
     return { byName: existing, createdNames: [] };
   }
@@ -247,6 +272,61 @@ export async function ensureChildren(
 const LEGACY_SOURCE_ROOT_NAME = 'source';
 
 /**
+ * The dimensions whose ROOT may carry a display rename (tag-display-names.md
+ * §1 item 4) — `category`, `type`, `source`. `intent` is excluded (its root is
+ * `$abv_tags$intent` forever, no display rename) and `origin` is excluded
+ * (retired by remap, not renamed) — both already have their OWN dedicated
+ * split-root guardrails above/below, so they are deliberately not folded into
+ * this generalized one.
+ */
+const DISPLAY_RENAMING_DIMENSIONS = [DIMENSION.CATEGORY, DIMENSION.TYPE, DIMENSION.SOURCE];
+
+/**
+ * The alias set {@link ensureChildren} checks for one of
+ * {@link DISPLAY_RENAMING_DIMENSIONS}'s CURRENT root-name spellings — the bare
+ * dimension key, so a project that still carries the pre-freeze slug root
+ * resolves under it rather than minting a second, empty root beside it
+ * (tag-display-names.md §5 phase 1). Under today's IDENTITY PLACEHOLDER
+ * ({@link rootNameOfDimension} returning the dimension key verbatim for these
+ * three) the alias coincides with the name itself, so this returns `[]` — no
+ * behavior change until the vocabulary freezes.
+ *
+ * @param {string} rootName - one of `DIMENSION_PROVISION_ORDER.map(rootNameOfDimension)`.
+ * @returns {string[]}
+ */
+function rootAliasesOf(rootName) {
+  const dimension = DIMENSION_PROVISION_ORDER.find((d) => rootNameOfDimension(d) === rootName);
+  const aliasable = /** @type {readonly string[]} */ (DISPLAY_RENAMING_DIMENSIONS);
+  if (!dimension || !aliasable.includes(dimension) || dimension === rootName) {
+    return [];
+  }
+  return [dimension];
+}
+
+/**
+ * The alias set {@link ensureChildren} checks for a SERVER-OWNED VALUE's
+ * current display form ({@link displayNameOfValue}) — the bare slug it was
+ * derived from, via {@link valueSlugOfDisplayName}, so a project that still
+ * carries the pre-freeze slug-named value resolves under it rather than
+ * minting a second, empty value beside it (tag-display-names.md §5 phase 1).
+ * Only `source`/`type` values can currently diverge from their slug (the
+ * closed `intent`/`origin` vocabularies never display-rename); for those,
+ * {@link valueSlugOfDisplayName} always returns `undefined`, so the alias set
+ * is empty and this is a no-op there too. Under today's IDENTITY PLACEHOLDER
+ * maps (`source`/`type`) the alias coincides with the display name itself, so
+ * this returns `[]` for every value until the vocabulary freezes.
+ *
+ * @param {string} dimension - a server-owned dimension.
+ * @returns {(displayName: string) => string[]}
+ */
+function valueAliasesOf(dimension) {
+  return (displayName) => {
+    const slug = valueSlugOfDisplayName(dimension, displayName);
+    return slug && slug !== displayName ? [slug] : [];
+  };
+}
+
+/**
  * Resolves the five dimension roots, creating any that a project is missing.
  * Older projects predate this taxonomy entirely, so this is the seam that brings
  * them forward on first touch.
@@ -287,6 +367,7 @@ export async function ensureDimensionRoots(transport, semrushWorkspaceId, projec
     '',
     DIMENSION_PROVISION_ORDER.map(rootNameOfDimension),
     log,
+    rootAliasesOf,
   );
 
   // Observability guardrail (no tolerance, no behavior change): freshly minting `origin`
@@ -325,6 +406,35 @@ export async function ensureDimensionRoots(transport, semrushWorkspaceId, projec
       + `\`${INTENT_ROOT_NAME}\` — the intent dimension is split on this project`,
       { semrushWorkspaceId, projectId, event: 'intent-rename-split-root' },
     );
+  }
+
+  // Generalized split-root guardrail (tag-display-names.md §3 step 4, §5 phase
+  // 1) — the value-level analog of the two guardrails above, for the THREE
+  // roots this spec display-renames. `ensureChildren`'s alias resolution
+  // (above) prefers whichever spelling the tree already has, so it can only
+  // ever surface ONE side of a genuine split; this is what surfaces the other.
+  // `byName` carries BOTH the dimension-key entry and the display-name entry
+  // whenever either was literally present on the tree (ensureChildren is
+  // additive, never destructive) — so two DIFFERENT ids under the same
+  // dimension means both spellings exist as distinct root tags.
+  // IDENTITY PLACEHOLDER today: `rootNameOfDimension(dimension) === dimension`
+  // for all three, so this loop body never runs until the vocabulary freezes.
+  for (const dimension of DISPLAY_RENAMING_DIMENSIONS) {
+    const displayName = rootNameOfDimension(dimension);
+    if (displayName !== dimension) {
+      const displayId = byName.get(displayName);
+      const slugId = byName.get(dimension);
+      if (displayId && slugId && displayId !== slugId) {
+        log?.warn?.(
+          `ensureDimensionRoots: both the slug root "${dimension}" and its display root `
+          + `"${displayName}" exist as distinct tags — the display-name migration may `
+          + 'have missed this project',
+          {
+            semrushWorkspaceId, projectId, dimension, event: 'display-rename-split-root',
+          },
+        );
+      }
+    }
   }
 
   // Return the roots keyed by DIMENSION, in canonical order.
@@ -629,18 +739,23 @@ export async function ensureServerOwnedValue(
 ) {
   const roots = await ensureDimensionRoots(transport, semrushWorkspaceId, projectId, log);
   const rootId = requireServerOwnedRootId(roots, dimension);
+  // Resolve/create by the value's CURRENT display form (identity today — see
+  // {@link displayNameOfValue}), tolerating the bare slug as an alias
+  // (tag-display-names.md §5 phase 1).
+  const displayName = displayNameOfValue(dimension, value);
   const { byName, createdNames } = await ensureChildren(
     transport,
     semrushWorkspaceId,
     projectId,
     rootId,
-    [value],
+    [displayName],
     log,
+    valueAliasesOf(dimension),
   );
   return {
-    id: /** @type {string} */ (byName.get(value)),
+    id: /** @type {string} */ (byName.get(displayName)),
     rootId,
-    created: createdNames.includes(value),
+    created: createdNames.includes(displayName),
   };
 }
 
@@ -679,16 +794,19 @@ export async function resolveServerOwnedValueInjection(
 ) {
   const roots = await ensureDimensionRoots(transport, semrushWorkspaceId, projectId, log);
   const rootId = requireServerOwnedRootId(roots, dimension);
+  // Same display-form resolve-or-create as ensureServerOwnedValue, above.
+  const displayName = displayNameOfValue(dimension, wantValue);
   const { byName } = await ensureChildren(
     transport,
     semrushWorkspaceId,
     projectId,
     rootId,
-    [wantValue],
+    [displayName],
     log,
+    valueAliasesOf(dimension),
   );
   return {
-    computedId: /** @type {string} */ (byName.get(wantValue)),
+    computedId: /** @type {string} */ (byName.get(displayName)),
     valueTagIds: [...byName.values()],
   };
 }

--- a/test/it/shared/tests/serenity.js
+++ b/test/it/shared/tests/serenity.js
@@ -605,17 +605,18 @@ export default function serenityTests(
       expect(created.status).to.equal(200);
       expect(created.body.created).to.have.lengthOf(1);
       expect(created.body.created[0].semrushPromptId).to.be.a('string').that.is.not.empty;
-      // The write path server-stamps FOUR dimensions the caller may not set: a
-      // branded/non-branded `type:` tag (classified from the text), the derived
-      // `origin:` tag (`human`, on a user-authenticated create — origin-dimension.md
-      // §3 / WP-O2b), the producing `source:` tag (`config` on this proxy-create
-      // path — source-dimension.md §1 / WP-S2, LLMO-6282), AND an `intent:<Value>`
-      // tag (serenity-docs#31, #32). Azure OpenAI is not configured in this IT
-      // environment, so intent deterministically defaults to `intent:Informational`
-      // (never null/omitted — see the fallback ladder). So the created prompt
-      // carries the two supplied tags plus the four computed ones.
+      // The write path server-stamps THREE dimensions the caller may not set: a
+      // branded/non-branded `type:` tag (classified from the text), the producing
+      // `source:` tag (`config` on this proxy-create path — source-dimension.md
+      // §1 / WP-S2, LLMO-6282), AND an `intent:<Value>` tag (serenity-docs#31,
+      // #32). Azure OpenAI is not configured in this IT environment, so intent
+      // deterministically defaults to `intent:Informational` (never null/omitted
+      // — see the fallback ladder). `origin` no longer gets its own tag
+      // (tag-display-names.md §3 — authorship folds into `source` via
+      // `deriveSource`, WP-D2/SITES-50446). So the created prompt carries the
+      // two supplied tags plus the three computed ones.
       expect(created.body.created[0].tagIds).to.include.members([category.body.id, child.body.id]);
-      expect(created.body.created[0].tagIds).to.have.lengthOf(6);
+      expect(created.body.created[0].tagIds).to.have.lengthOf(5);
       expect(created.body.failed).to.deep.equal([]);
 
       // by_tags correlation: the id-based create embeds the tag ids, so filtering the prompt list

--- a/test/support/serenity/handlers/markets-subworkspace.test.js
+++ b/test/support/serenity/handlers/markets-subworkspace.test.js
@@ -33,11 +33,12 @@ import { TAG_IDS, dimensionTreeLevels, makeListProjectTagsStub } from '../fixtur
 use(chaiAsPromised);
 use(sinonChai);
 
-// Every generated prompt carries the two standard values (origin=ai,
-// intent=Informational) plus the producing `source/semrush` value; the last tag
-// is the per-prompt computed `type`. Order matches the write site:
-// [...standardIds, sourceId, typeId].
-const STANDARD_IDS = [TAG_IDS.originAi, TAG_IDS.intentInformational];
+// Every generated prompt carries the seeded default intent (Informational —
+// `origin` is retired, tag-display-names.md §3: STANDARD_PROMPT_TAG_VALUES no
+// longer contributes an `origin/ai` id here) plus the producing
+// `source/semrush` value; the last tag is the per-prompt computed `type`.
+// Order matches the write site: [intentId, sourceId, typeId].
+const STANDARD_IDS = [TAG_IDS.intentInformational];
 const GENERATED_IDS = [...STANDARD_IDS, TAG_IDS.sourceSemrush];
 
 // Matches one v3 create item `{ name, metadata }` (LLMO-6289). These handlers
@@ -1748,7 +1749,6 @@ describe('markets-subworkspace — defensive branch coverage', () => {
   // the Informational default. Prompts are partitioned by their (type, intent)
   // id pair, one upstream call per distinct pair.
   it('generateAndAttachPrompts: applies the classified intent per prompt and defaults an unclassified one', async () => {
-    const SOURCE_AI_ID = TAG_IDS.originAi;
     const handler = await esmock(
       '../../../../src/support/serenity/handlers/markets-subworkspace.js',
       {
@@ -1777,8 +1777,8 @@ describe('markets-subworkspace — defensive branch coverage', () => {
     );
     expect(res.status).to.equal(201);
     // Both are non-branded ('Trail' not mentioned); intent differs, so two calls.
-    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('buy now')], [SOURCE_AI_ID, TAG_IDS.intentTransactional, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
-    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('about it')], [SOURCE_AI_ID, TAG_IDS.intentInformational, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
+    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('buy now')], [TAG_IDS.intentTransactional, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
+    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('about it')], [TAG_IDS.intentInformational, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
   });
 
   // Boundary: at exactly AI_GEN_CLASSIFY_MAX + 1 texts, only the first MAX are
@@ -1818,8 +1818,8 @@ describe('markets-subworkspace — defensive branch coverage', () => {
     expect(classifySpy).to.have.been.calledOnce;
     expect(classifySpy.firstCall.args[0]).to.deep.equal(['p1', 'p2']);
     // p1/p2 classified Transactional; p3 (beyond the cap) defaults Informational.
-    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('p1'), genItemMatch('p2')], [...STANDARD_IDS.slice(0, 1), TAG_IDS.intentTransactional, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
-    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('p3')], [...STANDARD_IDS.slice(0, 1), TAG_IDS.intentInformational, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
+    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('p1'), genItemMatch('p2')], [TAG_IDS.intentTransactional, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
+    expect(transport.createPromptsWithMetadata).to.have.been.calledWithExactly(WS, 'new-proj', [genItemMatch('p3')], [TAG_IDS.intentInformational, TAG_IDS.sourceSemrush, TAG_IDS.typeNonBranded]);
     // The cap-hit is observable, not silent.
     expect(capLog.info).to.have.been.calledWithMatch(
       'generateAndAttachPrompts: AI-gen classify cap hit — tail defaults to Informational',

--- a/test/support/serenity/handlers/prompts-subworkspace.test.js
+++ b/test/support/serenity/handlers/prompts-subworkspace.test.js
@@ -249,11 +249,12 @@ describe('prompts-subworkspace handlers', () => {
       }, log);
       expect(result.created).to.have.length(1);
       expect(result.created[0]).to.include({ semrushPromptId: 'new-prompt', geoTargetId: 2840 });
-      // A create is a user-authenticated write: the derived `origin` (`human`) and
-      // producing `source` (`config`) are stamped, and intent defaults to
-      // Informational (Azure unconfigured, serenity-docs#32), alongside the caller's
-      // tag (origin-dimension.md §3, source-dimension.md §1). The v3
-      // metadata-carrying write stamps created_*/updated_* (LLMO-6289).
+      // A create is a user-authenticated write: the producing `source`
+      // (`config`, derived from origin=`human` — tag-display-names.md §3,
+      // `origin` no longer gets its own tag) is stamped, and intent defaults
+      // to Informational (Azure unconfigured, serenity-docs#32), alongside
+      // the caller's tag. The v3 metadata-carrying write stamps
+      // created_*/updated_* (LLMO-6289).
       expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WS, 'p-us-en', [createItemMatch('p', undefined)], ['tag-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
       expect(transport.publishProject).to.have.been.calledOnceWith(WS, 'p-us-en');
       expect(result.published).to.equal(true);
@@ -289,8 +290,9 @@ describe('prompts-subworkspace handlers', () => {
           text: 'p', tagIds: ['tag-1'], geoTargetId: 2840, languageCode: 'en',
         }],
       }, log, undefined, undefined, undefined, 'caller-42');
-      // The create also injects the derived origin, producing-system source, and
-      // default intent alongside the caller's tag; the metadata carries the resolved
+      // The create also injects the derived producing-system source (`origin`
+      // no longer gets its own tag, tag-display-names.md §3) and default
+      // intent alongside the caller's tag; the metadata carries the resolved
       // caller id (LLMO-6289).
       expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WS, 'p-us-en', [createItemMatch('p', 'caller-42')], ['tag-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
     });

--- a/test/support/serenity/handlers/prompts-subworkspace.test.js
+++ b/test/support/serenity/handlers/prompts-subworkspace.test.js
@@ -254,7 +254,7 @@ describe('prompts-subworkspace handlers', () => {
       // Informational (Azure unconfigured, serenity-docs#32), alongside the caller's
       // tag (origin-dimension.md §3, source-dimension.md §1). The v3
       // metadata-carrying write stamps created_*/updated_* (LLMO-6289).
-      expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WS, 'p-us-en', [createItemMatch('p', undefined)], ['tag-1', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
+      expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WS, 'p-us-en', [createItemMatch('p', undefined)], ['tag-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
       expect(transport.publishProject).to.have.been.calledOnceWith(WS, 'p-us-en');
       expect(result.published).to.equal(true);
     });
@@ -292,7 +292,7 @@ describe('prompts-subworkspace handlers', () => {
       // The create also injects the derived origin, producing-system source, and
       // default intent alongside the caller's tag; the metadata carries the resolved
       // caller id (LLMO-6289).
-      expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WS, 'p-us-en', [createItemMatch('p', 'caller-42')], ['tag-1', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
+      expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WS, 'p-us-en', [createItemMatch('p', 'caller-42')], ['tag-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
     });
 
     // A tag NAME cannot address a nested tag, so a `tags` key is rejected
@@ -321,7 +321,7 @@ describe('prompts-subworkspace handlers', () => {
         }],
       }, log, classifyByBrandMention);
       expect(result.created[0].tagIds).to.deep.equal([
-        TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded, TAG_IDS.originHuman,
+        TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded,
         TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
       ]);
       expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(
@@ -329,7 +329,7 @@ describe('prompts-subworkspace handlers', () => {
         'p-us-en',
         [createItemMatch('is Acme good?', undefined)],
         [
-          TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded, TAG_IDS.originHuman,
+          TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded,
           TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
         ],
       );

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -40,7 +40,9 @@ import {
   makeListProjectTagsStub,
   makeProvisioningTransportStubs,
 } from '../fixtures/tag-tree.js';
-import { INTENT_ROOT_NAME } from '../../../../src/support/serenity/prompt-tags.js';
+import {
+  INTENT_ROOT_NAME, ORIGIN_VALUE, PROXY_CREATE_SOURCE_VALUE,
+} from '../../../../src/support/serenity/prompt-tags.js';
 import { parseAuditLine } from './audit-log-test-utils.js';
 
 use(chaiAsPromised);
@@ -617,22 +619,23 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
       }],
     }, fakeLog());
 
-    // A create is a user-authenticated write: the derived `origin` (`human`) is
-    // stamped alongside the caller's tags (origin-dimension.md §3). No classifier
-    // is supplied here, so `type` is left untouched.
+    // A create is a user-authenticated write: the derived `source` (`config`,
+    // the human-authored default) is stamped alongside the caller's tags
+    // (tag-display-names.md §3 — `origin` no longer gets its own tag). No
+    // classifier is supplied here, so `type` is left untouched.
     expect(result.created).to.have.lengthOf(1);
     expect(result.created[0]).to.deep.equal({
       semrushPromptId: 'new-sem-id',
       geoTargetId: 2840,
       languageCode: 'en',
       text: 'hello',
-      tagIds: ['tag-cat-1', 'tag-child-1', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational],
+      tagIds: ['tag-cat-1', 'tag-child-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational],
     });
     expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(
       WORKSPACE,
       'proj-us-en',
       [createItemMatch('hello', undefined)],
-      ['tag-cat-1', 'tag-child-1', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational],
+      ['tag-cat-1', 'tag-child-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational],
     );
     expect(transport.publishProject).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en');
   });
@@ -746,8 +749,8 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
     }, fakeLog());
 
     expect(result.created[0].semrushPromptId).to.equal('');
-    expect(result.created[0].tagIds).to.deep.equal(['keep', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
-    expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', [createItemMatch('hello', undefined)], ['keep', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
+    expect(result.created[0].tagIds).to.deep.equal(['keep', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
+    expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', [createItemMatch('hello', undefined)], ['keep', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
   });
 
   it('returns empty semrushPromptId (not the string "undefined") when createPromptsWithMetadata returns an item with no id', async () => {
@@ -795,8 +798,8 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
       }],
     }, fakeLog());
 
-    expect(result.created[0].tagIds).to.deep.equal(['keep', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
-    expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', [createItemMatch('hello', undefined)], ['keep', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
+    expect(result.created[0].tagIds).to.deep.equal(['keep', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
+    expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', [createItemMatch('hello', undefined)], ['keep', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
   });
 
   it('caps a bulk-create tagIds array at MAX_TAG_IDS (50), mirroring the list-read query cap', async () => {
@@ -820,14 +823,15 @@ describe('handlers/prompts.js — handleCreatePrompts', () => {
     }, fakeLog());
 
     // The MAX_TAG_IDS cap bounds the CALLER's tags (50); the server-derived
-    // `origin` (human), producing `source` (config), and classified `intent`
-    // (Informational) are injected on top, so the stored set is the 50 capped tags
-    // plus those three computed ids.
-    expect(result.created[0].tagIds).to.have.lengthOf(53);
+    // producing `source` (config) and classified `intent` (Informational) are
+    // injected on top (`origin` no longer gets its own tag,
+    // tag-display-names.md §3), so the stored set is the 50 capped tags plus
+    // those two computed ids.
+    expect(result.created[0].tagIds).to.have.lengthOf(52);
     expect(result.created[0].tagIds).to.deep.equal(
       [
         ...tooMany.slice(0, 50),
-        TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
+        TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
       ],
     );
   });
@@ -2345,7 +2349,7 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
       }, fakeLog(), classifyByBrandMention);
 
       expect(result.created[0].tagIds).to.deep.equal([
-        TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded, TAG_IDS.originHuman,
+        TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded,
         TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
       ]);
       expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(
@@ -2353,7 +2357,7 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
         'proj-us-en',
         [createItemMatch('is Acme good?', undefined)],
         [
-          TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded, TAG_IDS.originHuman,
+          TAG_IDS.categoryRunningShoes, TAG_IDS.typeBranded,
           TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
         ],
       );
@@ -2381,7 +2385,7 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
       }, fakeLog(), classifyByBrandMention);
 
       expect(result.created[0].tagIds).to.deep.equal([
-        TAG_IDS.categoryRunningShoes, TAG_IDS.typeNonBranded, TAG_IDS.originHuman,
+        TAG_IDS.categoryRunningShoes, TAG_IDS.typeNonBranded,
         TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
       ]);
     });
@@ -2421,7 +2425,7 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
       }, fakeLog(), classifyByBrandMention);
 
       expect(result.created[0].tagIds).to.deep.equal([
-        decoyCategoryId, TAG_IDS.typeBranded, TAG_IDS.originHuman,
+        decoyCategoryId, TAG_IDS.typeBranded,
         TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
       ]);
     });
@@ -2446,29 +2450,29 @@ describe('handlers/prompts.js — unified type classification (serenity-docs#31)
         }],
       }, fakeLog(), classifyByBrandMention);
 
-      // The five roots are created at the root level, then `branded` beneath the
-      // freshly-minted `type` root, then `human` beneath the `origin` root, then
-      // `config` beneath the `source` root — the create path stamps the derived
-      // origin AND source as well as the computed type.
+      // The five roots are created at the root level (`origin` is still
+      // provisioned as a root — its retirement is a later, per-project fleet
+      // pass, tag-display-names.md §3 — but nothing is ever minted beneath it
+      // by this write path any more), then `branded` beneath the
+      // freshly-minted `type` root, then `config` beneath the `source` root —
+      // the create path stamps the derived SOURCE (via `deriveSource`, not a
+      // separate `origin` tag) as well as the computed type.
       expect(createProjectTags.firstCall.args[2]).to.deep.equal([
         'category', INTENT_ROOT_NAME, 'origin', 'type', 'source',
       ]);
       expect(createProjectTags.firstCall.args[3]).to.deep.equal({});
       expect(createProjectTags.secondCall.args[2]).to.deep.equal(['branded']);
       expect(createProjectTags.secondCall.args[3]).to.deep.equal({ parentId: 'created::type' });
-      // origin injection (the second half of the unified type+origin injector) mints
-      // `human` beneath the freshly-created `origin` root...
-      expect(createProjectTags.thirdCall.args[2]).to.deep.equal(['human']);
-      expect(createProjectTags.thirdCall.args[3]).to.deep.equal({ parentId: 'created::origin' });
-      // ...then source injection mints the default `config` beneath `source`, and
-      // finally intent injection mints the default `Informational` beneath `intent`.
-      expect(createProjectTags.getCall(3).args[2]).to.deep.equal(['config']);
-      expect(createProjectTags.getCall(3).args[3]).to.deep.equal({ parentId: 'created::source' });
-      expect(createProjectTags.getCall(4).args[2]).to.deep.equal(['Informational']);
-      expect(createProjectTags.getCall(4).args[3])
+      // source injection mints the derived `config` beneath `source` next (no
+      // `origin`-root create in between any more)...
+      expect(createProjectTags.thirdCall.args[2]).to.deep.equal(['config']);
+      expect(createProjectTags.thirdCall.args[3]).to.deep.equal({ parentId: 'created::source' });
+      // ...then intent injection mints the default `Informational` beneath `intent`.
+      expect(createProjectTags.getCall(3).args[2]).to.deep.equal(['Informational']);
+      expect(createProjectTags.getCall(3).args[3])
         .to.deep.equal({ parentId: `created::${INTENT_ROOT_NAME}` });
       expect(result.created[0].tagIds).to.deep.equal([
-        'tag-cat-1', 'created:created::type:branded', 'created:created::origin:human',
+        'tag-cat-1', 'created:created::type:branded',
         'created:created::source:config', `created:created::${INTENT_ROOT_NAME}:Informational`,
       ]);
     });
@@ -2816,19 +2820,22 @@ describe('handlers/prompts.js — deferPublish (serenity-docs#32 CSV-chunking)',
   });
 });
 
-// origin-dimension.md §3 (LLMO-6275): `origin` is derived from the write path,
-// never asserted by the user, and carries a create/update asymmetry — CREATE
-// injects the derived value; UPDATE never re-derives, preserving the stored one.
-// These are spec gates 5 (create arm), 7 and 8 on the Serenity tag path.
-describe('handlers/prompts.js — origin derivation (origin-dimension.md §3)', () => {
+// tag-display-names.md §3: `origin` no longer gets its own tag — every writer
+// that used to stamp one has stopped, and the authorship fact it used to carry
+// now folds into `source` via `deriveSource(source, origin)`. `originValue`
+// survives ONLY as an input to that fold (the Serenity-proxy path has no
+// Postgres row to read `origin` back from), never as a tag id of its own.
+describe('handlers/prompts.js — origin retirement (tag-display-names.md §3)', () => {
   const project = () => makeProject({
     semrushProjectId: 'proj-us-en', geoTargetId: 2840, languageCode: 'en',
   });
 
-  // Gate 5 (create arm): a user-authenticated Serenity create derives origin =
-  // `human`, stripping any caller-supplied tag id beneath the origin root and
-  // injecting the resolved `human` id — a user may not assert who authored a prompt.
-  it('create strips a caller-supplied origin tag id and injects the derived human origin', async () => {
+  // The create/update asymmetry `origin` used to carry now lives entirely in
+  // `source`'s derivation: a user-authenticated create derives the human
+  // default (`config`, unfolded — the producer wins over a generic `human`
+  // origin), never touching whatever origin-dimension id a caller happens to
+  // pass in `tagIds` (the dimension is no longer server-managed on this path).
+  it('create no longer strips or injects an origin tag, and derives source=config for a human create', async () => {
     const dataAccess = makeDataAccess([project()]);
     const transport = {
       listProjectTags: makeListProjectTagsStub(),
@@ -2843,58 +2850,46 @@ describe('handlers/prompts.js — origin derivation (origin-dimension.md §3)', 
         text: 'best shoes',
         geoTargetId: 2840,
         languageCode: 'en',
-        // The caller tries to assert `ai`; the server ignores it and stamps `human`.
+        // A caller-supplied origin-root id rides through untouched — the
+        // injector no longer reasons about the `origin` dimension at all.
         tagIds: [TAG_IDS.categoryRunningShoes, TAG_IDS.originAi],
       }],
     }, fakeLog(), classifyByBrandMention);
 
     expect(result.created[0].tagIds).to.deep.equal([
-      TAG_IDS.categoryRunningShoes, TAG_IDS.typeNonBranded, TAG_IDS.originHuman,
+      TAG_IDS.categoryRunningShoes, TAG_IDS.originAi, TAG_IDS.typeNonBranded,
       TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
     ]);
-    expect(result.created[0].tagIds).to.not.include(TAG_IDS.originAi);
+    expect(result.created[0].tagIds).to.not.include(TAG_IDS.originHuman);
   });
 
-  // Gate 8: the strip is BY RESOLVED ROOT ID, never by name. A customer category
-  // legitimately named `ai` (a category-root descendant) must survive a create
-  // that also carries an origin-root id — a name-based strip would delete it.
-  it('leaves a customer category named "ai" alone while stripping the real origin value', async () => {
-    const dataAccess = makeDataAccess([project()]);
-    const decoyAiCategoryId = 'category-ai-decoy';
-    const levels = dimensionTreeLevels();
-    levels[TAG_IDS.categoryRoot] = [
-      ...levels[TAG_IDS.categoryRoot],
-      {
-        id: decoyAiCategoryId,
-        name: 'ai',
-        parent_id: TAG_IDS.categoryRoot,
-        children_count: 0,
-        path: [{ id: TAG_IDS.categoryRoot, name: 'category' }],
-      },
-    ];
+  // Exit-criteria test (SITES-50446): a service-principal Serenity create —
+  // no Postgres row, `originValue` derived from the principal as `ai` — lands
+  // under the `ai-onboarding` slug (today's identity-mapped equivalent of
+  // "AI Onboarding"), not `config`'s slug. This is real, structural wiring
+  // (deriveSource operates on slugs), independent of display strings.
+  it('a service-principal create (originValue=ai, sourceValue=config) derives ai-onboarding, not config', async () => {
+    const AI_ONBOARDING_TAG_ID = 'created:root-source:ai-onboarding';
     const transport = {
-      listProjectTags: makeListProjectTagsStub(levels),
-      createPromptsWithMetadata: sinon.stub().resolves({
-        page: 1, total: 1, items: [{ id: 'new-sem-id', name: 'is Acme good?' }],
-      }),
-      publishProject: sinon.stub().resolves(),
+      listProjectTags: makeListProjectTagsStub(),
+      createProjectTags: sinon.stub().callsFake((ws, pid, names, opts) => Promise.resolve(
+        names.map((name) => ({ id: `created:${opts.parentId}:${name}`, name })),
+      )),
     };
+    const inject = makePromptTagInjector(transport, WORKSPACE, undefined, fakeLog(), {
+      originValue: ORIGIN_VALUE.AI, sourceValue: PROXY_CREATE_SOURCE_VALUE,
+    });
 
-    const result = await handleCreatePrompts(transport, dataAccess, BRAND, WORKSPACE, {
-      prompts: [{
-        text: 'is Acme good?',
-        geoTargetId: 2840,
-        languageCode: 'en',
-        tagIds: [decoyAiCategoryId, TAG_IDS.originAi],
-      }],
-    }, fakeLog(), classifyByBrandMention);
+    const out = await inject('proj-us-en', {
+      text: 'best shoes', geoTargetId: 2840, tagIds: [TAG_IDS.categoryRunningShoes],
+    });
 
-    // The `ai` CATEGORY survives; only the origin-root id is stripped, and the
-    // derived origin and source are injected.
-    expect(result.created[0].tagIds).to.deep.equal([
-      decoyAiCategoryId, TAG_IDS.typeBranded, TAG_IDS.originHuman,
-      TAG_IDS.sourceConfig, TAG_IDS.intentInformational,
-    ]);
+    // `ai-onboarding` does not pre-exist on the fixture tree (it is a fresh
+    // slug), so resolving it proves the derivation actually ran rather than
+    // coincidentally matching a pre-seeded id.
+    expect(transport.createProjectTags).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', ['ai-onboarding'], { parentId: TAG_IDS.sourceRoot });
+    expect(out.tagIds).to.include(AI_ONBOARDING_TAG_ID);
+    expect(out.tagIds).to.not.include(TAG_IDS.sourceConfig);
   });
 
   // Defense-in-depth: on a MID-RENAME project the `source` root still means
@@ -2982,21 +2977,23 @@ describe('handlers/prompts.js — origin derivation (origin-dimension.md §3)', 
     );
   });
 
-  describe('makePromptTagInjector origin asymmetry', () => {
-    it('create (originValue set): strips caller origin ids and appends the derived origin', async () => {
+  describe('makePromptTagInjector no longer manages origin', () => {
+    it('create (originValue set): leaves a caller-supplied origin id untouched — only source is derived/appended', async () => {
       const transport = { listProjectTags: makeListProjectTagsStub() };
       const inject = makePromptTagInjector(transport, WORKSPACE, undefined, fakeLog(), {
-        originValue: 'human',
+        originValue: ORIGIN_VALUE.HUMAN, sourceValue: PROXY_CREATE_SOURCE_VALUE,
       });
 
       const out = await inject('proj-1', {
         text: 'x', geoTargetId: 2840, tagIds: [TAG_IDS.categoryRunningShoes, TAG_IDS.originAi],
       });
 
-      expect(out.tagIds).to.deep.equal([TAG_IDS.categoryRunningShoes, TAG_IDS.originHuman]);
+      expect(out.tagIds).to.deep.equal([
+        TAG_IDS.categoryRunningShoes, TAG_IDS.originAi, TAG_IDS.sourceConfig,
+      ]);
     });
 
-    it('update (no originValue): leaves origin ids untouched and reads nothing', async () => {
+    it('update (no originValue/sourceValue): leaves origin AND source ids untouched, reads nothing', async () => {
       const transport = { listProjectTags: makeListProjectTagsStub() };
       const inject = makePromptTagInjector(transport, WORKSPACE, undefined, fakeLog());
 
@@ -3008,20 +3005,20 @@ describe('handlers/prompts.js — origin derivation (origin-dimension.md §3)', 
       expect(transport.listProjectTags).to.not.have.been.called;
     });
 
-    it('memoizes origin resolution per project across a batch', async () => {
+    it('memoizes the derived-source resolution per (project, derived value) across a batch', async () => {
       const transport = {
         listProjectTags: makeListProjectTagsStub(),
         createProjectTags: sinon.stub(),
       };
       const inject = makePromptTagInjector(transport, WORKSPACE, undefined, fakeLog(), {
-        originValue: 'human',
+        originValue: ORIGIN_VALUE.HUMAN, sourceValue: PROXY_CREATE_SOURCE_VALUE,
       });
 
       await inject('proj-1', { text: 'a', geoTargetId: 2840, tagIds: ['x'] });
       const readsAfterFirst = transport.listProjectTags.callCount;
       await inject('proj-1', { text: 'b', geoTargetId: 2840, tagIds: ['y'] });
 
-      // Same project => served from the per-project origin cache, no new reads.
+      // Same project + same derived value => served from the source cache.
       expect(transport.listProjectTags.callCount).to.equal(readsAfterFirst);
       expect(transport.createProjectTags).to.not.have.been.called;
     });
@@ -3406,7 +3403,7 @@ describe('handlers/prompts.js — authorship metadata (LLMO-6289)', () => {
       // The create also injects the derived origin (`human`), producing-system
       // source (`config`), and the default intent (Informational) alongside the
       // caller's tag; the metadata carries the stamped caller id (LLMO-6289).
-      expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', [createItemMatch('hi', 'caller-42')], ['tag-1', TAG_IDS.originHuman, TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
+      expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', [createItemMatch('hi', 'caller-42')], ['tag-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
     });
 
     it('stamps updated_* = the caller id on an edit (created_* untouched)', async () => {

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -2210,8 +2210,9 @@ describe('handlers/prompts.js — tag cache invalidation (Important #6)', () => 
     } = setupCtx;
 
     // Mutation: handleCreatePrompts pushes a new prompt → invalidate. The create
-    // path resolves the tag tree to stamp the derived `origin`, so the tree read
-    // must be stubbed for the create to succeed and reach the invalidation.
+    // path resolves the tag tree to stamp the derived `source` (tag-display-names.md
+    // §3 — `origin` no longer gets its own tag), so the tree read must be stubbed
+    // for the create to succeed and reach the invalidation.
     transport.listProjectTags = makeListProjectTagsStub();
     transport.createPromptsWithMetadata = sinon.stub().resolves({
       page: 1, total: 1, items: [{ id: 'sem-new', name: 'fresh' }],
@@ -3400,8 +3401,9 @@ describe('handlers/prompts.js — authorship metadata (LLMO-6289)', () => {
         }],
       }, fakeLog(), undefined, undefined, undefined, 'caller-42');
 
-      // The create also injects the derived origin (`human`), producing-system
-      // source (`config`), and the default intent (Informational) alongside the
+      // The create also injects the producing-system source (`config`, derived
+      // from origin=`human` — tag-display-names.md §3, `origin` no longer gets
+      // its own tag) and the default intent (Informational) alongside the
       // caller's tag; the metadata carries the stamped caller id (LLMO-6289).
       expect(transport.createPromptsWithMetadata).to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-us-en', [createItemMatch('hi', 'caller-42')], ['tag-1', TAG_IDS.sourceConfig, TAG_IDS.intentInformational]);
     });

--- a/test/support/serenity/prompt-tags.test.js
+++ b/test/support/serenity/prompt-tags.test.js
@@ -17,11 +17,13 @@ import {
   DIMENSION_PROVISION_ORDER,
   RESERVED_ROOT_NAMES,
   INTENT_ROOT_NAME,
+  ROOT_DISPLAY_NAME,
   rootNameOfDimension,
   dimensionOfRootName,
   ORIGIN_VALUE,
   INTENT_VALUE,
   TYPE_VALUE,
+  TYPE_VALUE_DISPLAY,
   CLOSED_DIMENSION_VALUES,
   CLOSED_DIMENSIONS,
   OPEN_DIMENSIONS,
@@ -29,6 +31,7 @@ import {
   ALL_DIMENSIONS,
   SOURCE_VALUES,
   SOURCE_LABEL,
+  DERIVED_SOURCE_VALUES,
   MAX_TAG_NAME_LEN,
   STANDARD_PROMPT_TAG_VALUES,
   isDimensionRootName,
@@ -36,6 +39,10 @@ import {
   isServerOwnedDimension,
   canonicalizeSource,
   closedValuesOf,
+  displayToSlug,
+  displayNameOfValue,
+  valueSlugOfDisplayName,
+  deriveSource,
 } from '../../../src/support/serenity/prompt-tags.js';
 
 describe('serenity prompt-tags taxonomy', () => {
@@ -137,9 +144,10 @@ describe('serenity prompt-tags taxonomy', () => {
   });
 
   describe('STANDARD_PROMPT_TAG_VALUES', () => {
-    it('seeds source=ai + intent=Informational only (type is classified per prompt)', () => {
+    it('seeds intent=Informational only (type is classified per prompt, origin is retired)', () => {
+      // tag-display-names.md §3: the `origin/ai` entry this list used to carry
+      // is retired — every writer that stamped an `origin` tag has stopped.
       expect(STANDARD_PROMPT_TAG_VALUES.map((t) => [t.dimension, t.name])).to.deep.equal([
-        ['origin', 'ai'],
         ['intent', 'Informational'],
       ]);
     });
@@ -188,26 +196,184 @@ describe('serenity prompt-tags taxonomy', () => {
     });
   });
 
-  describe('SOURCE_LABEL', () => {
-    it('is frozen and has exactly one entry per canonical value (exhaustive, CI gate)', () => {
+  describe('SOURCE_LABEL (the tag-name map, tag-display-names.md §1 item 3)', () => {
+    it('is frozen', () => {
       expect(Object.isFrozen(SOURCE_LABEL)).to.equal(true);
-      // This assertion FAILS the moment a canonical value is added to SOURCE_VALUES
-      // without a label — the exhaustiveness gate (source-dimension.md §7). No
+    });
+
+    it('every SOURCE_VALUES entry either has its own label, or is `llm-generated` (covered by the fold into ai-onboarding) — CI gate', () => {
+      // This assertion FAILS the moment a canonical value is added to
+      // SOURCE_VALUES without a label AND without being the one deliberate
+      // fold exemption (tag-display-names.md §6 item 1, §1 item 3). No
       // pass-through slug default is permitted.
-      expect(Object.keys(SOURCE_LABEL).sort()).to.deep.equal([...SOURCE_VALUES].sort());
       SOURCE_VALUES.forEach((slug) => {
-        expect(SOURCE_LABEL[slug], `missing SOURCE_LABEL for ${slug}`).to.be.a('string').and.not.equal('');
+        if (slug === 'llm-generated') {
+          expect(SOURCE_LABEL).to.not.have.property(slug);
+          expect(deriveSource(slug, undefined)).to.equal('ai-onboarding');
+        } else {
+          expect(SOURCE_LABEL[slug], `missing SOURCE_LABEL for ${slug}`)
+            .to.be.a('string').and.not.equal('');
+        }
       });
     });
 
-    it('every canonical value canonicalizes to itself (already folded)', () => {
-      SOURCE_VALUES.forEach((slug) => {
+    it('also labels every DERIVED_SOURCE_VALUES entry (the fold target)', () => {
+      DERIVED_SOURCE_VALUES.forEach((slug) => {
+        expect(SOURCE_LABEL[slug], `missing SOURCE_LABEL for derived value ${slug}`)
+          .to.be.a('string').and.not.equal('');
+      });
+    });
+
+    it('every display name in the tag-name map is unique (bijective, never two slugs sharing one name)', () => {
+      const names = Object.values(SOURCE_LABEL);
+      expect(new Set(names).size, 'SOURCE_LABEL has a duplicate display name').to.equal(names.length);
+    });
+
+    it('no display name folds back into a DIFFERENT slug than the one it labels', () => {
+      // tag-display-names.md §1 item 7: canonicalizeSource is never applied to
+      // a display name as if it were a slug; this pins that a folded display
+      // name, if it folds to anything at all, is exactly its own slug — never
+      // silently a different SOURCE_VALUES member. Holds trivially today
+      // (identity placeholders: folded === slug) and starts doing real
+      // disambiguation work the moment SOURCE_LABEL's values diverge.
+      Object.entries(SOURCE_LABEL).forEach(([slug, displayName]) => {
+        const folded = canonicalizeSource(displayName);
+        if (folded !== null) {
+          expect(folded).to.equal(slug);
+        }
+      });
+    });
+
+    it('displayToSlug is the true inverse of SOURCE_LABEL', () => {
+      Object.entries(SOURCE_LABEL).forEach(([slug, displayName]) => {
+        expect(displayToSlug(displayName)).to.equal(slug);
+      });
+      expect(displayToSlug('not-a-known-display-name')).to.equal(undefined);
+    });
+
+    it('every canonical value that keeps its own tag name canonicalizes to itself (already folded)', () => {
+      SOURCE_VALUES.filter((slug) => slug !== 'llm-generated').forEach((slug) => {
         expect(canonicalizeSource(slug)).to.equal(slug);
       });
     });
 
     it('is frozen for SOURCE_VALUES too', () => {
       expect(Object.isFrozen(SOURCE_VALUES)).to.equal(true);
+    });
+  });
+
+  describe('DERIVED_SOURCE_VALUES (tag-display-names.md §6 item 3)', () => {
+    it('is frozen and contains ai-onboarding', () => {
+      expect(Object.isFrozen(DERIVED_SOURCE_VALUES)).to.equal(true);
+      expect([...DERIVED_SOURCE_VALUES]).to.include('ai-onboarding');
+    });
+
+    it('is disjoint from the create-accepted enum (SOURCE_VALUES) — never a legal stored value', () => {
+      DERIVED_SOURCE_VALUES.forEach((value) => {
+        expect(SOURCE_VALUES).to.not.include(value);
+      });
+    });
+  });
+
+  describe('deriveSource (tag-display-names.md §3)', () => {
+    it('folds `config` + origin `ai` into ai-onboarding', () => {
+      expect(deriveSource('config', ORIGIN_VALUE.AI)).to.equal('ai-onboarding');
+    });
+
+    it('leaves `config` + origin `human` as config (the producer wins)', () => {
+      expect(deriveSource('config', ORIGIN_VALUE.HUMAN)).to.equal('config');
+    });
+
+    it('folds llm-generated into ai-onboarding regardless of origin', () => {
+      expect(deriveSource('llm-generated', ORIGIN_VALUE.HUMAN)).to.equal('ai-onboarding');
+      expect(deriveSource('llm-generated', ORIGIN_VALUE.AI)).to.equal('ai-onboarding');
+      expect(deriveSource('llm-generated', undefined)).to.equal('ai-onboarding');
+    });
+
+    it('leaves a specific producer untouched — origin carries no information for it', () => {
+      expect(deriveSource('gsc', ORIGIN_VALUE.HUMAN)).to.equal('gsc');
+      expect(deriveSource('drs', ORIGIN_VALUE.AI)).to.equal('drs');
+    });
+
+    it('canonicalizes before folding (case/underscore variants)', () => {
+      expect(deriveSource('CONFIG', ORIGIN_VALUE.AI)).to.equal('ai-onboarding');
+      expect(deriveSource('LLM_GENERATED', ORIGIN_VALUE.HUMAN)).to.equal('ai-onboarding');
+    });
+
+    it('propagates canonicalizeSource\'s null (do-not-tag) rather than substituting a default', () => {
+      expect(deriveSource('', ORIGIN_VALUE.AI)).to.equal(null);
+      expect(deriveSource(undefined, ORIGIN_VALUE.AI)).to.equal(null);
+    });
+  });
+
+  describe('ROOT_DISPLAY_NAME / rootNameOfDimension (tag-display-names.md §1 item 4)', () => {
+    it('is frozen and IDENTITY today for category/type/source', () => {
+      expect(Object.isFrozen(ROOT_DISPLAY_NAME)).to.equal(true);
+      expect(ROOT_DISPLAY_NAME[DIMENSION.CATEGORY]).to.equal(DIMENSION.CATEGORY);
+      expect(ROOT_DISPLAY_NAME[DIMENSION.TYPE]).to.equal(DIMENSION.TYPE);
+      expect(ROOT_DISPLAY_NAME[DIMENSION.SOURCE]).to.equal(DIMENSION.SOURCE);
+    });
+
+    it('does NOT cover intent or origin — intent stays hidden, origin retires rather than renames', () => {
+      expect(ROOT_DISPLAY_NAME).to.not.have.property(DIMENSION.INTENT);
+      expect(ROOT_DISPLAY_NAME).to.not.have.property(DIMENSION.ORIGIN);
+      expect(rootNameOfDimension(DIMENSION.INTENT)).to.equal(INTENT_ROOT_NAME);
+      expect(rootNameOfDimension(DIMENSION.ORIGIN)).to.equal(DIMENSION.ORIGIN);
+    });
+
+    it('RESERVED_ROOT_NAMES grows with the display root names without double-listing under identity', () => {
+      DIMENSION_PROVISION_ORDER.forEach((d) => {
+        expect(RESERVED_ROOT_NAMES).to.include(rootNameOfDimension(d));
+      });
+      // Deduped: today display === slug for category/type/source, so the set
+      // is still exactly 6 entries (5 dimensions + the one intent divergence).
+      expect(RESERVED_ROOT_NAMES.length).to.equal(6);
+    });
+  });
+
+  describe('dimensionOfRootName (resolves display names, slug names, and $abv_tags$intent)', () => {
+    it('resolves every dimension key to itself', () => {
+      DIMENSION_PROVISION_ORDER.forEach((d) => {
+        expect(dimensionOfRootName(d)).to.equal(d);
+      });
+    });
+
+    it('resolves every CURRENT root-name spelling (rootNameOfDimension) to its dimension', () => {
+      DIMENSION_PROVISION_ORDER.forEach((d) => {
+        expect(dimensionOfRootName(rootNameOfDimension(d))).to.equal(d);
+      });
+    });
+
+    it('resolves $abv_tags$intent to intent explicitly', () => {
+      expect(dimensionOfRootName(INTENT_ROOT_NAME)).to.equal(DIMENSION.INTENT);
+    });
+
+    it('is identity for anything outside the taxonomy', () => {
+      expect(dimensionOfRootName('Running Shoes')).to.equal('Running Shoes');
+    });
+  });
+
+  describe('TYPE_VALUE_DISPLAY / displayNameOfValue / valueSlugOfDisplayName', () => {
+    it('TYPE_VALUE_DISPLAY is frozen and identity today', () => {
+      expect(Object.isFrozen(TYPE_VALUE_DISPLAY)).to.equal(true);
+      expect(TYPE_VALUE_DISPLAY[TYPE_VALUE.BRANDED]).to.equal(TYPE_VALUE.BRANDED);
+      expect(TYPE_VALUE_DISPLAY[TYPE_VALUE.NON_BRANDED]).to.equal(TYPE_VALUE.NON_BRANDED);
+    });
+
+    it('displayNameOfValue routes source/type through their maps and leaves intent/origin untouched', () => {
+      expect(displayNameOfValue(DIMENSION.SOURCE, 'config')).to.equal(SOURCE_LABEL.config);
+      expect(displayNameOfValue(DIMENSION.TYPE, TYPE_VALUE.BRANDED))
+        .to.equal(TYPE_VALUE_DISPLAY[TYPE_VALUE.BRANDED]);
+      expect(displayNameOfValue(DIMENSION.INTENT, INTENT_VALUE.TASK)).to.equal(INTENT_VALUE.TASK);
+      expect(displayNameOfValue(DIMENSION.ORIGIN, ORIGIN_VALUE.AI)).to.equal(ORIGIN_VALUE.AI);
+    });
+
+    it('valueSlugOfDisplayName is the inverse for source/type, undefined for intent/origin', () => {
+      expect(valueSlugOfDisplayName(DIMENSION.SOURCE, SOURCE_LABEL.config)).to.equal('config');
+      expect(valueSlugOfDisplayName(DIMENSION.TYPE, TYPE_VALUE_DISPLAY[TYPE_VALUE.BRANDED]))
+        .to.equal(TYPE_VALUE.BRANDED);
+      expect(valueSlugOfDisplayName(DIMENSION.INTENT, INTENT_VALUE.TASK)).to.equal(undefined);
+      expect(valueSlugOfDisplayName(DIMENSION.ORIGIN, ORIGIN_VALUE.AI)).to.equal(undefined);
     });
   });
 });

--- a/test/support/serenity/tag-tree.test.js
+++ b/test/support/serenity/tag-tree.test.js
@@ -687,77 +687,102 @@ describe('serenity tag-tree', () => {
   // diverge, which is exactly what happens the moment serenity-docs#407 merges and
   // the orchestrator swaps the placeholder values in — this pins that the guardrail
   // will fire correctly on that day, not just today's no-op shape.
+  //
+  // Parameterized across all three DISPLAY_RENAMING_DIMENSIONS (category, type,
+  // source — MysticatBot review, WP-D2): the guardrail loop body is generic over
+  // the dimension, so a bug specific to one dimension's branch (e.g. an
+  // off-by-one in which array position feeds the log message) would not
+  // necessarily show up if only `category` were ever exercised.
   describe('ensureDimensionRoots — generalized display-rename split-root guardrail', () => {
-    it('warns when a slug root and its (post-freeze) display root exist as distinct tags', async () => {
-      const realPromptTags = await import('../../../src/support/serenity/prompt-tags.js');
-      const { ensureDimensionRoots: ensureDimensionRootsWithRename } = await esmock(
-        '../../../src/support/serenity/tag-tree.js',
-        {
-          '../../../src/support/serenity/prompt-tags.js': {
-            rootNameOfDimension: (dimension) => (
-              dimension === DIMENSION.CATEGORY ? 'Category' : realPromptTags.rootNameOfDimension(dimension)
-            ),
-          },
-        },
-      );
-      const listProjectTags = makeListProjectTagsStub({
-        '': [
-          { id: 'root-category-slug', name: 'category', children_count: 0 },
-          { id: 'root-category-display', name: 'Category', children_count: 0 },
-          { id: 'root-intent', name: INTENT_ROOT_NAME, children_count: 5 },
-          { id: 'root-origin', name: 'origin', children_count: 2 },
-          { id: 'root-type', name: 'type', children_count: 2 },
-          { id: 'root-source', name: 'source', children_count: 0 },
-        ],
-      });
-      const createProjectTags = sinon.stub();
-      const log = fakeLog();
-      const roots = await ensureDimensionRootsWithRename(
-        { listProjectTags, createProjectTags },
-        WS,
-        PROJECT,
-        log,
-      );
-      // Both spellings already existed — nothing to create.
-      expect(createProjectTags).to.not.have.been.called;
-      // The split is real (two different ids under the same dimension) and loud.
-      expect(log.warn).to.have.been.calledWithMatch(
-        /both the slug root "category" and its display root "Category" exist as distinct tags/,
-      );
-      // The canonical (display) spelling wins in the returned map.
-      expect(roots.get('category')).to.equal('root-category-display');
-    });
+    const CASES = [
+      { dimension: DIMENSION.CATEGORY, slug: 'category', display: 'Category' },
+      { dimension: DIMENSION.TYPE, slug: 'type', display: 'Type' },
+      { dimension: DIMENSION.SOURCE, slug: 'source', display: 'Source' },
+    ];
 
-    it('stays quiet when only the display spelling exists (the migrated, common case)', async () => {
+    /** Every OTHER root at its normal, un-renamed spelling. */
+    const OTHER_DEFAULT_ROOTS = [
+      { id: 'root-intent', name: INTENT_ROOT_NAME, children_count: 5 },
+      { id: 'root-origin', name: 'origin', children_count: 2 },
+      { id: 'root-category', name: 'category', children_count: 0 },
+      { id: 'root-type', name: 'type', children_count: 2 },
+      { id: 'root-source', name: 'source', children_count: 0 },
+    ];
+
+    /**
+     * Mocks `rootNameOfDimension` so ONLY `targetDimension` diverges to
+     * `fakeDisplayName` — every other dimension keeps resolving through the
+     * real implementation, so a test for one dimension can't accidentally
+     * exercise (or mask) another's branch of the guardrail loop.
+     */
+    async function ensureDimensionRootsRenaming(targetDimension, fakeDisplayName) {
       const realPromptTags = await import('../../../src/support/serenity/prompt-tags.js');
-      const { ensureDimensionRoots: ensureDimensionRootsWithRename } = await esmock(
+      const { ensureDimensionRoots: renamed } = await esmock(
         '../../../src/support/serenity/tag-tree.js',
         {
           '../../../src/support/serenity/prompt-tags.js': {
             rootNameOfDimension: (dimension) => (
-              dimension === DIMENSION.CATEGORY ? 'Category' : realPromptTags.rootNameOfDimension(dimension)
+              dimension === targetDimension
+                ? fakeDisplayName
+                : realPromptTags.rootNameOfDimension(dimension)
             ),
           },
         },
       );
-      const listProjectTags = makeListProjectTagsStub({
-        '': [
-          { id: 'root-category-display', name: 'Category', children_count: 0 },
-          { id: 'root-intent', name: INTENT_ROOT_NAME, children_count: 5 },
-          { id: 'root-origin', name: 'origin', children_count: 2 },
-          { id: 'root-type', name: 'type', children_count: 2 },
-          { id: 'root-source', name: 'source', children_count: 0 },
-        ],
+      return renamed;
+    }
+
+    /** Root-level fixture: every other dimension default, plus `slug`/`display` rows. */
+    function rootsFixture(slug, display, { includeSlug, includeDisplay }) {
+      const others = OTHER_DEFAULT_ROOTS.filter((r) => r.name !== slug);
+      const target = [
+        ...(includeSlug ? [{ id: `root-${slug}-slug`, name: slug, children_count: 0 }] : []),
+        ...(includeDisplay ? [{ id: `root-${slug}-display`, name: display, children_count: 0 }] : []),
+      ];
+      return { '': [...others, ...target] };
+    }
+
+    CASES.forEach(({ dimension, slug, display }) => {
+      describe(`${slug} dimension`, () => {
+        it(`warns when "${slug}" and "${display}" exist as distinct root tags`, async () => {
+          const renamed = await ensureDimensionRootsRenaming(dimension, display);
+          const listProjectTags = makeListProjectTagsStub(
+            rootsFixture(slug, display, { includeSlug: true, includeDisplay: true }),
+          );
+          const createProjectTags = sinon.stub();
+          const log = fakeLog();
+          const roots = await renamed(
+            { listProjectTags, createProjectTags },
+            WS,
+            PROJECT,
+            log,
+          );
+          // Both spellings already existed — nothing to create.
+          expect(createProjectTags).to.not.have.been.called;
+          // The split is real (two different ids under the same dimension) and loud.
+          expect(log.warn).to.have.been.calledWithMatch(
+            new RegExp(`both the slug root "${slug}" and its display root "${display}" exist as distinct tags`),
+          );
+          // The canonical (display) spelling wins in the returned map.
+          expect(roots.get(slug)).to.equal(`root-${slug}-display`);
+        });
+
+        it(`stays quiet when only "${display}" exists (the migrated, common case)`, async () => {
+          const renamed = await ensureDimensionRootsRenaming(dimension, display);
+          const listProjectTags = makeListProjectTagsStub(
+            rootsFixture(slug, display, { includeSlug: false, includeDisplay: true }),
+          );
+          const createProjectTags = sinon.stub();
+          const log = fakeLog();
+          await renamed(
+            { listProjectTags, createProjectTags },
+            WS,
+            PROJECT,
+            log,
+          );
+          expect(log.warn).to.not.have.been.calledWithMatch(/display-name migration may/);
+        });
       });
-      const createProjectTags = sinon.stub();
-      const log = fakeLog();
-      await ensureDimensionRootsWithRename(
-        { listProjectTags, createProjectTags },
-        WS,
-        PROJECT,
-        log,
-      );
-      expect(log.warn).to.not.have.been.calledWithMatch(/display-name migration may/);
     });
   });
 

--- a/test/support/serenity/tag-tree.test.js
+++ b/test/support/serenity/tag-tree.test.js
@@ -14,6 +14,7 @@ import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
 
 import {
   indexLevelByName,
@@ -675,6 +676,88 @@ describe('serenity tag-tree', () => {
       const log = fakeLog();
       await ensureDimensionRoots({ listProjectTags, createProjectTags }, WS, PROJECT, log);
       expect(log.warn).to.not.have.been.calledWithMatch(/intent dimension is split/);
+    });
+  });
+
+  // The generalized display-rename split-root guardrail (tag-display-names.md §3
+  // step 4, §5 phase 1) is dormant today — ROOT_DISPLAY_NAME is an IDENTITY
+  // PLACEHOLDER, so `rootNameOfDimension(dimension) === dimension` for all three
+  // display-renaming dimensions and the loop body in `ensureDimensionRoots` never
+  // runs. Exercising it for real means mocking `rootNameOfDimension` to actually
+  // diverge, which is exactly what happens the moment serenity-docs#407 merges and
+  // the orchestrator swaps the placeholder values in — this pins that the guardrail
+  // will fire correctly on that day, not just today's no-op shape.
+  describe('ensureDimensionRoots — generalized display-rename split-root guardrail', () => {
+    it('warns when a slug root and its (post-freeze) display root exist as distinct tags', async () => {
+      const realPromptTags = await import('../../../src/support/serenity/prompt-tags.js');
+      const { ensureDimensionRoots: ensureDimensionRootsWithRename } = await esmock(
+        '../../../src/support/serenity/tag-tree.js',
+        {
+          '../../../src/support/serenity/prompt-tags.js': {
+            rootNameOfDimension: (dimension) => (
+              dimension === DIMENSION.CATEGORY ? 'Category' : realPromptTags.rootNameOfDimension(dimension)
+            ),
+          },
+        },
+      );
+      const listProjectTags = makeListProjectTagsStub({
+        '': [
+          { id: 'root-category-slug', name: 'category', children_count: 0 },
+          { id: 'root-category-display', name: 'Category', children_count: 0 },
+          { id: 'root-intent', name: INTENT_ROOT_NAME, children_count: 5 },
+          { id: 'root-origin', name: 'origin', children_count: 2 },
+          { id: 'root-type', name: 'type', children_count: 2 },
+          { id: 'root-source', name: 'source', children_count: 0 },
+        ],
+      });
+      const createProjectTags = sinon.stub();
+      const log = fakeLog();
+      const roots = await ensureDimensionRootsWithRename(
+        { listProjectTags, createProjectTags },
+        WS,
+        PROJECT,
+        log,
+      );
+      // Both spellings already existed — nothing to create.
+      expect(createProjectTags).to.not.have.been.called;
+      // The split is real (two different ids under the same dimension) and loud.
+      expect(log.warn).to.have.been.calledWithMatch(
+        /both the slug root "category" and its display root "Category" exist as distinct tags/,
+      );
+      // The canonical (display) spelling wins in the returned map.
+      expect(roots.get('category')).to.equal('root-category-display');
+    });
+
+    it('stays quiet when only the display spelling exists (the migrated, common case)', async () => {
+      const realPromptTags = await import('../../../src/support/serenity/prompt-tags.js');
+      const { ensureDimensionRoots: ensureDimensionRootsWithRename } = await esmock(
+        '../../../src/support/serenity/tag-tree.js',
+        {
+          '../../../src/support/serenity/prompt-tags.js': {
+            rootNameOfDimension: (dimension) => (
+              dimension === DIMENSION.CATEGORY ? 'Category' : realPromptTags.rootNameOfDimension(dimension)
+            ),
+          },
+        },
+      );
+      const listProjectTags = makeListProjectTagsStub({
+        '': [
+          { id: 'root-category-display', name: 'Category', children_count: 0 },
+          { id: 'root-intent', name: INTENT_ROOT_NAME, children_count: 5 },
+          { id: 'root-origin', name: 'origin', children_count: 2 },
+          { id: 'root-type', name: 'type', children_count: 2 },
+          { id: 'root-source', name: 'source', children_count: 0 },
+        ],
+      });
+      const createProjectTags = sinon.stub();
+      const log = fakeLog();
+      await ensureDimensionRootsWithRename(
+        { listProjectTags, createProjectTags },
+        WS,
+        PROJECT,
+        log,
+      );
+      expect(log.warn).to.not.have.been.calledWithMatch(/display-name migration may/);
     });
   });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Builds the WP-D2 slug↔display mapping seam for spacecat-api-service ahead of the Serenity customer-facing-tag-names program: the map/inverse pair in `prompt-tags.js`, alias-tolerant tag-tree resolvers, and the retirement of the `origin` dimension's tag writers — with every display-name map landing as a frozen identity placeholder pending vocabulary sign-off.

## 2. Reasoning
The wave migrations shipped every customer's Brand Presence Tags filter populated with internal slugs (`config`, `source`, `gsc`, …), which product has ruled must be renamed to customer-facing strings, with `origin` retired by remapping into `source`. serenity-docs#407 (the vocabulary sign-off PR) is not yet merged, so this PR builds the entire mapping/resolution machinery now — behavior-neutral today — so that landing the real vocabulary later is a small, low-risk, values-only diff.

## 3. High-level overview of the changes
- `prompt-tags.js`: `SOURCE_LABEL` becomes a real, exhaustive slug→tag-name map (identity-valued today); `displayToSlug` is its true inverse; `ROOT_DISPLAY_NAME`/`rootNameOfDimension`/`dimensionOfRootName` generalize to tolerate both a dimension's slug and its (currently identical) display root name; `TYPE_VALUE_DISPLAY` mirrors the same pattern for `type` values; a new `DERIVED_SOURCE_VALUES` set (`ai-onboarding`) is added, disjoint from the create-accepted `SOURCE_VALUES` enum; `deriveSource(source, origin)` is new, real logic that folds `config`+`ai` and `llm-generated` into `ai-onboarding`.
- `tag-tree.js`: `ensureChildren` gains alias-aware resolution (a wanted name resolves via its own spelling or an alias, and only the canonical spelling is ever created); `ensureDimensionRoots` and the server-owned-value resolvers (`ensureServerOwnedValue`, `resolveServerOwnedValueInjection`) route through the new display/alias maps; a generalized split-root guardrail warns if a slug root and a display root ever coexist (dormant under today's identity placeholders).
- `handlers/prompts.js`: `makePromptTagInjector` no longer stamps a standalone `origin` tag on create. `originValue` survives purely as an input to `deriveSource`, since the Serenity-proxy write path has no Postgres row to read authorship back from otherwise.
- `STANDARD_PROMPT_TAG_VALUES` drops its `origin/ai` entry; `classify-prompts-job.js` and `markets-subworkspace.js` needed no code change beyond that (verified — neither stamps `origin` outside the removed entry point).
- `elements/definitions/topics.js`: the `category` root prefix and the dynamic tag-group keys built from raw wire prefixes now resolve through the same alias map, so a future display rename won't churn the stable API response keys.
- OpenAPI: the `category`/`categoryId` filter-parameter descriptions now document that both the slug and (future) display spelling of the tag-root prefix are recognized.

Behaviorally this PR is a no-op today (every map value is identity) — the only functional change is that `origin` no longer gets its own tag on any write path; authorship now folds into `source` via `deriveSource`.

## 4. Required information
- Jira / issue: SITES-50446
- Spec: https://github.com/adobe/serenity-docs/blob/feat/tag-display-names/docs/prompt-management/tag-display-names.md
- Implementation plan: https://github.com/adobe/serenity-docs/blob/feat/tag-display-names/docs/prompt-management/tag-display-names-implementation-plan.md (WP-D2 section)

## 5. Spec deviations
- Changed: WP-D2 item 9 (Elements boundary) is only partially built. The dimension-prefix alias fold landed in the filter-dimensions response path (`topics.js`'s group-key normalization and category-prefix extraction), but the client-supplied `tag`/`category` query-parameter resolution against a project's live tag tree (in `controllers/elements.js` / `elements-service.js`, with fail-loud on an unresolvable value) was not built.
  Why: the plan names the existing per-project tag cache (`listTagsForProject`) as the resolution source, but that cache holds bare tag names from the PE `by_tags` read, not the `__`-joined path strings the Elements `CBF_tags` filter matches on. Building correct value-level resolution would need either a live tree walk (which contradicts the plan's "cache read, not an upstream call" cost assumption) or a new joined-path cache, and this endpoint is a live, customer-facing Brand Presence filter — I judged shipping a guessed implementation riskier than leaving it for the orchestrator's call.
  Intentional: yes
- Changed: `handlers/tags.js` (`parseCreateTagBody`, `buildUpdatePayload`) has no diff, though the plan's WP-D2 item 5 mentions it.
  Why: `ensureServerOwnedValue` already resolves through the new display/alias maps internally, so the handler needed no change to inherit the tolerant behavior — confirmed by reading the call path and by the existing handler test suite staying green unmodified.
  Intentional: yes

## 6. Affected / used mysticat-workspace projects
- mysticat-data-service: has a Python twin of this map (`scripts/serenity_migration/tags.py`, `DERIVED_PROMPT_SOURCES`) being built concurrently under the same identity-placeholder pattern — the two must stay shape-identical (same slug keys, same `DERIVED_SOURCE_VALUES`/`DERIVED_PROMPT_SOURCES` contents) for the orchestrator's cross-repo drift check.
- spacecat-shared: this PR does not bump the Serenity PE-client dependency — that's blocked on WP-D1's GHCR mock release, tracked separately.
- project-elmo-ui: consumes the Serenity tag `name`/`path[].name` fields this PR's maps ultimately feed; unaffected today since every value is still identity-valued, but is the WP-D3 consumer once the vocabulary freezes.

## 8. Test plan
(a) Ran the full unit suite, lint, and type-check locally, plus the Lambda-bundle build/healthcheck gate (this PR touches `src/support/serenity/*`). Specifically verified: no write path (human create, subworkspace create, CSV import, AI-generation) attaches a standalone `origin` tag any more; a hypothetical service-principal create (`originValue: 'ai'`, no Postgres row) derives the `ai-onboarding` slug rather than `config`'s, exercising the new `deriveSource` wiring end-to-end through the injector. Could not run the `it-postgres` mock-backed `serenity.test.js` suite in this session — Docker was unavailable in the sandbox — so that regression check is still owed against the current (pre-WP-D1) PE-client mock before merge.
(b) No environment-specific verification steps apply — this PR is behavior-neutral in every environment until the vocabulary freezes and the display-name map values change in a follow-up PR.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```