### PR TITLE
feat: presign Google Ads placement-exclusion CSVs via a click-time endpoint (SITES-50551)

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -355,6 +355,8 @@ paths:
     $ref: './site-opportunities.yaml#/site-opportunity-suggestions-by-status-paged-with-cursor'
   /sites/{siteId}/opportunities/{opportunityId}/suggestions/{suggestionId}:
     $ref: './site-opportunities.yaml#/site-opportunity-suggestion'
+  /sites/{siteId}/opportunities/{opportunityId}/suggestions/{suggestionId}/guidance-csv/{refKey}:
+    $ref: './site-opportunities.yaml#/site-opportunity-suggestion-guidance-csv'
   /sites/{siteId}/opportunities/{opportunityId}/suggestions/{suggestionId}/fixes:
     $ref: './site-opportunities.yaml#/site-opportunity-suggestion-fixes'
   /sites/{siteId}/opportunities/{opportunityId}/suggestions/{suggestionId}/backoffice-reviews:

--- a/docs/openapi/site-opportunities.yaml
+++ b/docs/openapi/site-opportunities.yaml
@@ -1433,6 +1433,71 @@ site-opportunity-suggestion:
     security:
       - session_token: [ ]
 
+site-opportunity-suggestion-guidance-csv:
+  parameters:
+    - $ref: './parameters.yaml#/siteId'
+    - $ref: './parameters.yaml#/opportunityId'
+    - $ref: './parameters.yaml#/suggestionId'
+    - name: refKey
+      in: path
+      required: true
+      description: |
+        Which of the `gads-placement-exclusions` guidance CSV references to presign.
+      schema:
+        type: string
+        enum:
+          - account_auto_ref
+          - account_pmax_ref
+          - site_auto_ref
+          - site_pmax_ref
+  get:
+    operationId: getSiteOpportunitySuggestionGuidanceCsv
+    summary: |
+      Get a short-lived presigned download URL for a guidance CSV
+    description: |
+      Mints, on request, a short-lived (1-hour) presigned S3 URL for one of a
+      `gads-placement-exclusions` suggestion's guidance CSV references. The CSV's
+      key is resolved server-side from the suggestion's stored data and signed
+      against the pinned mystique-assets bucket; the caller supplies only the
+      constrained `refKey`.
+    tags:
+      - opportunity-suggestions
+    responses:
+      '200':
+        description: A short-lived presigned download URL for the requested guidance CSV.
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - presignedUrl
+                - expiresAt
+              properties:
+                presignedUrl:
+                  type: string
+                  format: uri
+                  description: Presigned S3 GetObject URL for the CSV (1-hour TTL).
+                expiresAt:
+                  type: string
+                  format: date-time
+                  description: ISO-8601 expiry of the presigned URL.
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '403':
+        $ref: './responses.yaml#/403'
+      '404':
+        $ref: './responses.yaml#/404'
+      '429':
+        $ref: './responses.yaml#/429'
+      '500':
+        $ref: './responses.yaml#/500'
+      '503':
+        $ref: './responses.yaml#/503'
+    security:
+      - session_token: [ ]
+
 site-opportunity-suggestion-backoffice-reviews:
   parameters:
     - $ref: './parameters.yaml#/siteId'

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -18,6 +18,7 @@ import {
   notFound,
   ok,
 } from '@adobe/spacecat-shared-http-utils';
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
 import {
   hasText,
   isArray, isNonEmptyArray,
@@ -89,8 +90,9 @@ const GADS_GUIDANCE_REF_KEYS = [
   'site_pmax_ref',
 ];
 
-// Presigned CSV download URLs are valid for 7 days.
-const GADS_PRESIGN_TTL_SECONDS = 60 * 60 * 24 * 7;
+// Click-time presigned guidance-CSV download URLs are short-lived (1 hour): the
+// URL is minted on the download request, so it only needs to outlive the click.
+const GADS_GUIDANCE_CSV_TTL_SECONDS = 60 * 60;
 
 /**
  * Parses an `s3://bucket/key` URI into its bucket and key parts.
@@ -115,75 +117,6 @@ const parseS3Uri = (uri) => {
   }
   return { bucket, key };
 };
-
-/**
- * Presigns the CSV references carried by a `gads-placement-exclusions` suggestion.
- *
- * The browser cannot presign S3 keys, so for suggestions whose `data.guidance`
- * carries the `*_ref` objects ({@link GADS_GUIDANCE_REF_KEYS}), each present ref's
- * `s3://bucket/key` `uri` is presigned on-serve and exposed as a sibling `*_url`
- * (e.g. `guidance.account_auto_url`) alongside a single `guidance.expiresAt` (ISO
- * string). Everything else in `data` is left verbatim.
- *
- * No-op (returns the input unchanged) when: the suggestion carries no guidance
- * refs (any non-gads suggestion, or a projected view without `data.guidance`), S3
- * is not configured on the request, or none of the refs resolve to a well-formed
- * S3 URI. A missing/null ref simply yields no corresponding `*_url`.
- *
- * @param {object} s3 - S3 context wrapper (`s3Client`, `getSignedUrl`, `GetObjectCommand`).
- * @param {object} suggestionJson - A serialized suggestion (output of `SuggestionDto.toJSON`).
- * @param {object} [log] - Optional logger for presign failures.
- * @returns {Promise<object>} The suggestion, with presigned `*_url`s injected when applicable.
- */
-const presignGadsGuidanceRefs = async (s3, suggestionJson, log) => {
-  const guidance = suggestionJson?.data?.guidance;
-  if (!isNonEmptyObject(guidance)) {
-    return suggestionJson;
-  }
-
-  const { s3Client, getSignedUrl, GetObjectCommand } = s3 ?? {};
-  if (!s3Client || !getSignedUrl || !GetObjectCommand) {
-    return suggestionJson;
-  }
-
-  const additions = {};
-  await Promise.all(GADS_GUIDANCE_REF_KEYS.map(async (refKey) => {
-    const parsed = parseS3Uri(guidance[refKey]?.uri);
-    if (!parsed) {
-      return;
-    }
-    try {
-      const command = new GetObjectCommand({ Bucket: parsed.bucket, Key: parsed.key });
-      const url = await getSignedUrl(s3Client, command, { expiresIn: GADS_PRESIGN_TTL_SECONDS });
-      additions[refKey.replace(/_ref$/, '_url')] = url;
-    } catch (err) {
-      log?.warn?.(`Failed to presign gads guidance ref ${refKey} for suggestion ${suggestionJson?.id}: ${err.message}`);
-    }
-  }));
-
-  if (Object.keys(additions).length === 0) {
-    return suggestionJson;
-  }
-  additions.expiresAt = new Date(Date.now() + GADS_PRESIGN_TTL_SECONDS * 1000).toISOString();
-  return {
-    ...suggestionJson,
-    data: {
-      ...suggestionJson.data,
-      guidance: { ...guidance, ...additions },
-    },
-  };
-};
-
-/**
- * Presigns the gads guidance refs for a list of serialized suggestions.
- * @param {object} s3 - S3 context wrapper.
- * @param {object[]} suggestions - Serialized suggestions.
- * @param {object} [log] - Optional logger.
- * @returns {Promise<object[]>} The suggestions, each presigned where applicable.
- */
-const presignGadsGuidanceRefsForList = (s3, suggestions, log) => Promise.all(
-  suggestions.map((suggestion) => presignGadsGuidanceRefs(s3, suggestion, log)),
-);
 
 // Allowed state_transition values on a backoffice review (SITES-43974). Validated
 // so the Learning Agent corpus never receives arbitrary free-text transitions.
@@ -622,13 +555,9 @@ function SuggestionsController(ctx, sqs, env) {
       );
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const serialized = grantedEntities.map(
+    const suggestions = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
-    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
-    // other opportunity types / absent refs). Done before field projection so a
-    // client selecting `data` still receives the presigned `*_url`s.
-    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
       return badRequest(error);
@@ -696,13 +625,9 @@ function SuggestionsController(ctx, sqs, env) {
       }
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const serialized = grantedEntities.map(
+    const suggestions = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
-    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
-    // other opportunity types / absent refs). Done before field projection so a
-    // client selecting `data` still receives the presigned `*_url`s.
-    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
 
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
@@ -767,13 +692,9 @@ function SuggestionsController(ctx, sqs, env) {
       }
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const serialized = grantedEntities.map(
+    const suggestions = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
-    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
-    // other opportunity types / absent refs). Done before field projection so a
-    // client selecting `data` still receives the presigned `*_url`s.
-    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
       return badRequest(error);
@@ -841,13 +762,9 @@ function SuggestionsController(ctx, sqs, env) {
       }
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const serialized = grantedEntities.map(
+    const suggestions = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
-    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
-    // other opportunity types / absent refs). Done before field projection so a
-    // client selecting `data` still receives the presigned `*_url`s.
-    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
       return badRequest(error);
@@ -917,13 +834,7 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Suggestion not found');
     }
 
-    // Presign the gads-placement-exclusions guidance CSV refs on-serve
-    // (no-op for other opportunity types / absent refs).
-    const json = await presignGadsGuidanceRefs(
-      ctx.s3,
-      SuggestionDto.toJSON(suggestion, view, opportunity, locale),
-      ctx.log,
-    );
+    const json = SuggestionDto.toJSON(suggestion, view, opportunity, locale);
 
     // ?include=reviews composes human-review feedback_event rows at read time
     // (no inline mirror on the suggestion). ?include=reviews,patches additionally
@@ -938,6 +849,102 @@ function SuggestionsController(ctx, sqs, env) {
     }
 
     return ok(json);
+  };
+
+  /**
+   * Returns a short-lived presigned download URL for one of a
+   * `gads-placement-exclusions` suggestion's guidance CSV references.
+   *
+   * The browser cannot presign S3 keys, so the URL is minted on the download
+   * request (mirroring `llmo/brand-claims.js`): the CSV's `s3://` uri is resolved
+   * from the suggestion's stored `data.guidance[refKey]`, the bucket is pinned
+   * server-side to `S3_MYSTIQUE_BUCKET` so a caller-tampered `uri` cannot turn
+   * this into a cross-bucket read (confused-deputy guard), existence is verified,
+   * and a 1-hour `GetObject` URL is signed. Minting per click needs no long TTL.
+   *
+   * @param {object} context of the request.
+   * @returns {Promise<Response>} `{ presignedUrl, expiresAt }`, or an error response.
+   */
+  const getPresignedGuidanceCsvUrl = async (context) => {
+    const siteId = context.params?.siteId;
+    const opptyId = context.params?.opportunityId || undefined;
+    const suggestionId = context.params?.suggestionId || undefined;
+    const refKey = context.params?.refKey;
+
+    if (!isValidUUID(siteId)) {
+      return badRequest('Site ID required');
+    }
+    if (!isValidUUID(opptyId)) {
+      return badRequest('Opportunity ID required');
+    }
+    if (!isValidUUID(suggestionId)) {
+      return badRequest('Suggestion ID required');
+    }
+    if (!GADS_GUIDANCE_REF_KEYS.includes(refKey)) {
+      return badRequest('Invalid guidance CSV reference');
+    }
+
+    const { s3 } = ctx;
+    const mystiqueBucket = env?.S3_MYSTIQUE_BUCKET;
+    if (!s3?.s3Client || !s3.getSignedUrl || !s3.GetObjectCommand || !hasText(mystiqueBucket)) {
+      return badRequest('S3 storage is not configured for this environment');
+    }
+
+    const site = await Site.findById(siteId);
+    if (!site) {
+      return notFound('Site not found');
+    }
+    if (!await accessControlUtil.hasAccess(site)) {
+      return forbidden('User does not belong to the organization');
+    }
+
+    const suggestion = await Suggestion.findById(suggestionId);
+    if (!suggestion || suggestion.getOpportunityId() !== opptyId) {
+      return notFound('Suggestion not found');
+    }
+    const opportunity = await suggestion.getOpportunity();
+    if (!opportunity || opportunity.getSiteId() !== siteId) {
+      return notFound();
+    }
+    if (await getIsSummitPlgEnabled(site, ctx, context, accessControlUtil)
+      && !(await SuggestionGrant.isSuggestionGranted(suggestion.getId()))) {
+      return notFound('Suggestion not found');
+    }
+
+    const parsed = parseS3Uri(suggestion.getData()?.guidance?.[refKey]?.uri);
+    if (!parsed) {
+      return notFound('Guidance CSV not available');
+    }
+    // `data` is caller-writable (PATCH/POST persist it verbatim), so the ref's
+    // bucket is never trusted: only objects in the pinned mystique-assets bucket
+    // are signable. A mismatch is a tampering/misconfiguration signal — warn.
+    if (parsed.bucket !== mystiqueBucket) {
+      ctx.log?.warn?.(`Refusing to presign guidance CSV for suggestion ${suggestionId}: ref ${refKey} names bucket ${parsed.bucket}, expected ${mystiqueBucket}`);
+      return notFound('Guidance CSV not available');
+    }
+
+    try {
+      // Presigning never verifies existence; HeadObject yields a clean 404 when
+      // the object is missing (e.g. a ref written ahead of its CSV).
+      await s3.s3Client.send(new HeadObjectCommand({ Bucket: mystiqueBucket, Key: parsed.key }));
+      const command = new s3.GetObjectCommand({ Bucket: mystiqueBucket, Key: parsed.key });
+      const presignedUrl = await s3.getSignedUrl(
+        s3.s3Client,
+        command,
+        { expiresIn: GADS_GUIDANCE_CSV_TTL_SECONDS },
+      );
+      return ok({
+        presignedUrl,
+        expiresAt: new Date(Date.now() + GADS_GUIDANCE_CSV_TTL_SECONDS * 1000).toISOString(),
+      });
+    } catch (err) {
+      if (err.name === 'NotFound' || err.$metadata?.httpStatusCode === 404) {
+        ctx.log?.warn?.(`Guidance CSV object missing for suggestion ${suggestionId} ref ${refKey}: ${parsed.key}`);
+        return notFound('Guidance CSV not available');
+      }
+      ctx.log?.error?.(`Failed to presign guidance CSV for suggestion ${suggestionId} ref ${refKey}: ${err.message}`);
+      return badRequest(`Error retrieving guidance CSV: ${err.message}`);
+    }
   };
 
   /**
@@ -3586,6 +3593,7 @@ function SuggestionsController(ctx, sqs, env) {
     getAllForOpportunity,
     getAllForOpportunityPaged,
     getByID,
+    getPresignedGuidanceCsvUrl,
     getByStatus,
     getByStatusPaged,
     getSuggestionFixes,

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -14,6 +14,7 @@ import {
   badRequest,
   createResponse,
   forbidden,
+  internalServerError,
   noContent,
   notFound,
   ok,
@@ -93,6 +94,15 @@ const GADS_GUIDANCE_REF_KEYS = [
 // Click-time presigned guidance-CSV download URLs are short-lived (1 hour): the
 // URL is minted on the download request, so it only needs to outlive the click.
 const GADS_GUIDANCE_CSV_TTL_SECONDS = 60 * 60;
+
+// Server-side key prefix that binds a guidance CSV to its site. Mystique writes
+// these CSVs to
+// `gads-placement-exclusions/csv/{site_id}/{customer_id}/{obs_version}/{scope}.{source}.csv`
+// (contract: experience-platform/mystique `s3_bodies.write_csv_body`). Because
+// `data.guidance` is caller-writable, we presign only keys under the AUTHORIZED
+// site's prefix, so a tampered `uri` cannot read another tenant's object within
+// the shared mystique-assets bucket.
+const GADS_GUIDANCE_CSV_KEY_ROOT = 'gads-placement-exclusions/csv';
 
 /**
  * Parses an `s3://bucket/key` URI into its bucket and key parts.
@@ -857,10 +867,12 @@ function SuggestionsController(ctx, sqs, env) {
    *
    * The browser cannot presign S3 keys, so the URL is minted on the download
    * request (mirroring `llmo/brand-claims.js`): the CSV's `s3://` uri is resolved
-   * from the suggestion's stored `data.guidance[refKey]`, the bucket is pinned
-   * server-side to `S3_MYSTIQUE_BUCKET` so a caller-tampered `uri` cannot turn
-   * this into a cross-bucket read (confused-deputy guard), existence is verified,
-   * and a 1-hour `GetObject` URL is signed. Minting per click needs no long TTL.
+   * from the suggestion's stored `data.guidance[refKey]`. Because that stored data
+   * is caller-writable, authorization does not trust it: the bucket is pinned
+   * server-side to `S3_MYSTIQUE_BUCKET` (no cross-bucket reads) and the key must
+   * sit under the authorized site's prefix `gads-placement-exclusions/csv/{siteId}/`
+   * (no cross-object/cross-tenant reads). Existence is verified, then a 1-hour
+   * `GetObject` URL is signed. Minting per click needs no long TTL.
    *
    * @param {object} context of the request.
    * @returns {Promise<Response>} `{ presignedUrl, expiresAt }`, or an error response.
@@ -884,18 +896,20 @@ function SuggestionsController(ctx, sqs, env) {
       return badRequest('Invalid guidance CSV reference');
     }
 
-    const { s3 } = ctx;
-    const mystiqueBucket = env?.S3_MYSTIQUE_BUCKET;
-    if (!s3?.s3Client || !s3.getSignedUrl || !s3.GetObjectCommand || !hasText(mystiqueBucket)) {
-      return badRequest('S3 storage is not configured for this environment');
-    }
-
     const site = await Site.findById(siteId);
     if (!site) {
       return notFound('Site not found');
     }
     if (!await accessControlUtil.hasAccess(site)) {
       return forbidden('User does not belong to the organization');
+    }
+
+    // S3 config is an environment-global signal, so this guard is placed after
+    // access control (consistent with the sibling handlers) rather than ahead of it.
+    const { s3 } = ctx;
+    const mystiqueBucket = env?.S3_MYSTIQUE_BUCKET;
+    if (!s3?.s3Client || !s3.getSignedUrl || !s3.GetObjectCommand || !hasText(mystiqueBucket)) {
+      return badRequest('S3 storage is not configured for this environment');
     }
 
     const suggestion = await Suggestion.findById(suggestionId);
@@ -915,11 +929,19 @@ function SuggestionsController(ctx, sqs, env) {
     if (!parsed) {
       return notFound('Guidance CSV not available');
     }
-    // `data` is caller-writable (PATCH/POST persist it verbatim), so the ref's
-    // bucket is never trusted: only objects in the pinned mystique-assets bucket
-    // are signable. A mismatch is a tampering/misconfiguration signal — warn.
+    // `data` is caller-writable (PATCH/POST persist it verbatim), so neither the
+    // ref's bucket nor its key is trusted for authorization. Bucket must be the
+    // pinned mystique-assets bucket (no cross-bucket reads)...
     if (parsed.bucket !== mystiqueBucket) {
-      ctx.log?.warn?.(`Refusing to presign guidance CSV for suggestion ${suggestionId}: ref ${refKey} names bucket ${parsed.bucket}, expected ${mystiqueBucket}`);
+      context.log.warn(`Refusing to presign guidance CSV for suggestion ${suggestionId}: ref ${refKey} names bucket ${parsed.bucket}, expected ${mystiqueBucket}`);
+      return notFound('Guidance CSV not available');
+    }
+    // ...and key must sit under the AUTHORIZED site's CSV prefix, binding the
+    // signed object to the site (closes cross-object/cross-tenant reads within
+    // the shared bucket). `siteId` is already access-checked above.
+    const expectedKeyPrefix = `${GADS_GUIDANCE_CSV_KEY_ROOT}/${siteId}/`;
+    if (!parsed.key.startsWith(expectedKeyPrefix)) {
+      context.log.warn(`Refusing to presign guidance CSV for suggestion ${suggestionId}: ref ${refKey} key is outside the site prefix ${expectedKeyPrefix}`);
       return notFound('Guidance CSV not available');
     }
 
@@ -939,11 +961,19 @@ function SuggestionsController(ctx, sqs, env) {
       });
     } catch (err) {
       if (err.name === 'NotFound' || err.$metadata?.httpStatusCode === 404) {
-        ctx.log?.warn?.(`Guidance CSV object missing for suggestion ${suggestionId} ref ${refKey}: ${parsed.key}`);
+        context.log.warn(`Guidance CSV object missing for suggestion ${suggestionId} ref ${refKey}: ${parsed.key}`);
         return notFound('Guidance CSV not available');
       }
-      ctx.log?.error?.(`Failed to presign guidance CSV for suggestion ${suggestionId} ref ${refKey}: ${err.message}`);
-      return badRequest(`Error retrieving guidance CSV: ${err.message}`);
+      // A server-side S3 failure is not the client's fault: return 5xx (503 for
+      // throttling/transient so clients retry, 500 otherwise) with a generic
+      // message — the internal error text stays in the log, not the response.
+      context.log.error(`Failed to presign guidance CSV for suggestion ${suggestionId} ref ${refKey}: ${err.message}`);
+      const status = err.$metadata?.httpStatusCode;
+      const transient = status === 429 || status === 503
+        || ['ThrottlingException', 'TooManyRequestsException', 'SlowDown', 'RequestLimitExceeded', 'ServiceUnavailable'].includes(err.name);
+      return transient
+        ? createResponse({ message: 'Guidance CSV service temporarily unavailable' }, 503)
+        : internalServerError('Error retrieving guidance CSV');
     }
   };
 

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -76,6 +76,115 @@ import { createAtomicStrategy, deleteAtomicStrategy } from '../support/atomic-st
 
 const VALIDATION_ERROR_NAME = 'ValidationError';
 
+/**
+ * Guidance CSV reference keys carried by `gads-placement-exclusions` suggestions.
+ * Each value is an object `{ uri, row_count, byte_size }` where `uri` is an
+ * `s3://bucket/key` pointer into the `spacecat-{env}-mystique-assets` bucket.
+ * @type {string[]}
+ */
+const GADS_GUIDANCE_REF_KEYS = [
+  'account_auto_ref',
+  'account_pmax_ref',
+  'site_auto_ref',
+  'site_pmax_ref',
+];
+
+// Presigned CSV download URLs are valid for 7 days.
+const GADS_PRESIGN_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+/**
+ * Parses an `s3://bucket/key` URI into its bucket and key parts.
+ * @param {string} uri - The S3 URI to parse.
+ * @returns {{ bucket: string, key: string }|null} Parsed parts, or null when the
+ *   input is not a well-formed `s3://bucket/key` URI.
+ */
+const parseS3Uri = (uri) => {
+  if (!hasText(uri) || !uri.startsWith('s3://')) {
+    return null;
+  }
+  const withoutScheme = uri.slice('s3://'.length);
+  const slashIndex = withoutScheme.indexOf('/');
+  if (slashIndex <= 0) {
+    return null;
+  }
+  const bucket = withoutScheme.slice(0, slashIndex);
+  const key = withoutScheme.slice(slashIndex + 1);
+  // `slashIndex > 0` guarantees a non-empty bucket segment; only the key can be empty.
+  if (!hasText(key)) {
+    return null;
+  }
+  return { bucket, key };
+};
+
+/**
+ * Presigns the CSV references carried by a `gads-placement-exclusions` suggestion.
+ *
+ * The browser cannot presign S3 keys, so for suggestions whose `data.guidance`
+ * carries the `*_ref` objects ({@link GADS_GUIDANCE_REF_KEYS}), each present ref's
+ * `s3://bucket/key` `uri` is presigned on-serve and exposed as a sibling `*_url`
+ * (e.g. `guidance.account_auto_url`) alongside a single `guidance.expiresAt` (ISO
+ * string). Everything else in `data` is left verbatim.
+ *
+ * No-op (returns the input unchanged) when: the suggestion carries no guidance
+ * refs (any non-gads suggestion, or a projected view without `data.guidance`), S3
+ * is not configured on the request, or none of the refs resolve to a well-formed
+ * S3 URI. A missing/null ref simply yields no corresponding `*_url`.
+ *
+ * @param {object} s3 - S3 context wrapper (`s3Client`, `getSignedUrl`, `GetObjectCommand`).
+ * @param {object} suggestionJson - A serialized suggestion (output of `SuggestionDto.toJSON`).
+ * @param {object} [log] - Optional logger for presign failures.
+ * @returns {Promise<object>} The suggestion, with presigned `*_url`s injected when applicable.
+ */
+const presignGadsGuidanceRefs = async (s3, suggestionJson, log) => {
+  const guidance = suggestionJson?.data?.guidance;
+  if (!isNonEmptyObject(guidance)) {
+    return suggestionJson;
+  }
+
+  const { s3Client, getSignedUrl, GetObjectCommand } = s3 ?? {};
+  if (!s3Client || !getSignedUrl || !GetObjectCommand) {
+    return suggestionJson;
+  }
+
+  const additions = {};
+  await Promise.all(GADS_GUIDANCE_REF_KEYS.map(async (refKey) => {
+    const parsed = parseS3Uri(guidance[refKey]?.uri);
+    if (!parsed) {
+      return;
+    }
+    try {
+      const command = new GetObjectCommand({ Bucket: parsed.bucket, Key: parsed.key });
+      const url = await getSignedUrl(s3Client, command, { expiresIn: GADS_PRESIGN_TTL_SECONDS });
+      additions[refKey.replace(/_ref$/, '_url')] = url;
+    } catch (err) {
+      log?.warn?.(`Failed to presign gads guidance ref ${refKey} for suggestion ${suggestionJson?.id}: ${err.message}`);
+    }
+  }));
+
+  if (Object.keys(additions).length === 0) {
+    return suggestionJson;
+  }
+  additions.expiresAt = new Date(Date.now() + GADS_PRESIGN_TTL_SECONDS * 1000).toISOString();
+  return {
+    ...suggestionJson,
+    data: {
+      ...suggestionJson.data,
+      guidance: { ...guidance, ...additions },
+    },
+  };
+};
+
+/**
+ * Presigns the gads guidance refs for a list of serialized suggestions.
+ * @param {object} s3 - S3 context wrapper.
+ * @param {object[]} suggestions - Serialized suggestions.
+ * @param {object} [log] - Optional logger.
+ * @returns {Promise<object[]>} The suggestions, each presigned where applicable.
+ */
+const presignGadsGuidanceRefsForList = (s3, suggestions, log) => Promise.all(
+  suggestions.map((suggestion) => presignGadsGuidanceRefs(s3, suggestion, log)),
+);
+
 // Allowed state_transition values on a backoffice review (SITES-43974). Validated
 // so the Learning Agent corpus never receives arbitrary free-text transitions.
 const FEEDBACK_STATE_TRANSITIONS = [
@@ -513,9 +622,13 @@ function SuggestionsController(ctx, sqs, env) {
       );
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const suggestions = grantedEntities.map(
+    const serialized = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
+    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
+    // other opportunity types / absent refs). Done before field projection so a
+    // client selecting `data` still receives the presigned `*_url`s.
+    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
       return badRequest(error);
@@ -583,9 +696,13 @@ function SuggestionsController(ctx, sqs, env) {
       }
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const suggestions = grantedEntities.map(
+    const serialized = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
+    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
+    // other opportunity types / absent refs). Done before field projection so a
+    // client selecting `data` still receives the presigned `*_url`s.
+    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
 
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
@@ -650,9 +767,13 @@ function SuggestionsController(ctx, sqs, env) {
       }
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const suggestions = grantedEntities.map(
+    const serialized = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
+    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
+    // other opportunity types / absent refs). Done before field projection so a
+    // client selecting `data` still receives the presigned `*_url`s.
+    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
       return badRequest(error);
@@ -720,9 +841,13 @@ function SuggestionsController(ctx, sqs, env) {
       }
     }
     const grantedEntities = await filterByGrantStatus(site, suggestionEntities, context);
-    const suggestions = grantedEntities.map(
+    const serialized = grantedEntities.map(
       (sugg) => SuggestionDto.toJSON(sugg, view, opportunity, locale),
     );
+    // Presign the gads-placement-exclusions guidance CSV refs on-serve (no-op for
+    // other opportunity types / absent refs). Done before field projection so a
+    // client selecting `data` still receives the presigned `*_url`s.
+    const suggestions = await presignGadsGuidanceRefsForList(ctx.s3, serialized, ctx.log);
     const { list, error } = applyFieldProjection(suggestions, context.data?.fields);
     if (error) {
       return badRequest(error);
@@ -792,7 +917,13 @@ function SuggestionsController(ctx, sqs, env) {
       return notFound('Suggestion not found');
     }
 
-    const json = SuggestionDto.toJSON(suggestion, view, opportunity, locale);
+    // Presign the gads-placement-exclusions guidance CSV refs on-serve
+    // (no-op for other opportunity types / absent refs).
+    const json = await presignGadsGuidanceRefs(
+      ctx.s3,
+      SuggestionDto.toJSON(suggestion, view, opportunity, locale),
+      ctx.log,
+    );
 
     // ?include=reviews composes human-review feedback_event rows at read time
     // (no inline mirror on the suggestion). ?include=reviews,patches additionally

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -763,6 +763,7 @@ const routeFacsCapabilities = {
       'GET /sites/:siteId/opportunities/:opportunityId/fixes/by-status/:status': 'llmo/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions': 'llmo/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'llmo/can_view',
+      'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey': 'llmo/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/fixes': 'llmo/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status': 'llmo/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit': 'llmo/can_view',
@@ -1087,6 +1088,7 @@ const routeFacsCapabilities = {
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit': 'aso/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit/:cursor': 'aso/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'aso/can_view',
+      'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey': 'aso/can_view',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/fixes': 'aso/can_view',
       'GET /sites/:siteId/edge-deployed-urls': 'aso/can_view',
       'GET /sites/:siteId/fixes': 'aso/can_view',
@@ -1358,6 +1360,9 @@ const routeFacsCapabilities = {
     // target / language / semrush prompt id / aio tag id), not SpaceCat
     // resources. The enclosing :brandId is the FACS resource for these routes.
     'semrushPromptId', 'geoTargetId', 'languageCode', 'tagId',
+    // gads guidance-CSV download selector (one of the four `*_ref` keys) — a
+    // label naming which stored CSV to presign, not a FACS resource.
+    'refKey',
     // Filter / pagination / format params (not entities):
     'base64PageUrl', 'base64Url', 'baseURL', 'channel', 'cursor',
     'dataSource', 'deliveryType', 'endDate', 'eventType',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -410,6 +410,7 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit/:cursor': suggestionsController.getByStatusPaged,
     'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit': suggestionsController.getByStatusPaged,
     'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': suggestionsController.getByID,
+    'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey': suggestionsController.getPresignedGuidanceCsvUrl,
     'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/fixes': suggestionsController.getSuggestionFixes,
     'POST /sites/:siteId/opportunities/:opportunityId/suggestions': suggestionsController.createSuggestions,
     'POST /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/backoffice-reviews': suggestionsController.createBackofficeReview,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -546,6 +546,7 @@ const routeRequiredCapabilities = {
   'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit/:cursor': 'suggestion:read',
   'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit': 'suggestion:read',
   'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId': 'suggestion:read',
+  'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey': 'suggestion:read',
   'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/fixes': 'fixEntity:read',
   'GET /sites/:siteId/edge-deployed-urls': 'suggestion:read',
   'POST /sites/:siteId/opportunities/:opportunityId/suggestions': CAP_SUGGESTION_WRITE,

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -816,6 +816,30 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(503);
     });
 
+    it('maps an S3 error carrying a 429 $metadata status to 503 (throttled)', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const throttled = Object.assign(new Error('too many requests'), { $metadata: { httpStatusCode: 429 } });
+      const s3 = buildS3(sandbox.stub().rejects(throttled));
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(503);
+      expect(presignLog.error.calledOnce).to.equal(true);
+    });
+
+    it('maps a getSignedUrl rejection (HeadObject ok, presign throws) to 500 and does not leak the error', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      getSignedUrl = sandbox.stub().rejects(new Error('presign boom secret detail'));
+      const s3 = buildS3(); // HeadObject (send) resolves; only the presign fails
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(500);
+      const body = await response.json();
+      expect(body.message).to.not.match(/presign boom/); // internal detail stays in the log
+      expect(s3.s3Client.send.callCount).to.equal(1); // HeadObject ran
+      expect(presignLog.error.calledOnce).to.equal(true);
+      expect(presignLog.error.firstCall.args[0]).to.match(/presign boom/);
+    });
+
     it('returns forbidden when the caller lacks access to the site', async () => {
       returnSuggestion(gadsSuggestion(fullGuidance()));
       sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -179,6 +179,7 @@ describe('Suggestions Controller', () => {
     'previewSuggestions',
     'fetchFromEdge',
     'getByID',
+    'getPresignedGuidanceCsvUrl',
     'getByStatus',
     'getByStatusPaged',
     'getSuggestionFixes',
@@ -560,11 +561,11 @@ describe('Suggestions Controller', () => {
     expect(() => SuggestionsController({ dataAccess: { Opportunity: {}, Suggestion: '' } })).to.throw('Data access required');
   });
 
-  describe('presign gads-placement-exclusions guidance CSV refs on-serve', () => {
+  describe('getPresignedGuidanceCsvUrl (click-time gads guidance CSV presign)', () => {
     const MYSTIQUE_BUCKET = 'spacecat-dev-mystique-assets';
 
-    // Minimal fake for @aws-sdk GetObjectCommand: records the { Bucket, Key } it was
-    // constructed with under `.input`, mirroring the real command shape.
+    // Minimal fake for the s3 wrapper's GetObjectCommand: records the { Bucket, Key }
+    // it was constructed with under `.input`, mirroring the real command shape.
     function FakeGetObjectCommand(params) {
       this.input = params;
     }
@@ -572,13 +573,13 @@ describe('Suggestions Controller', () => {
     let getSignedUrl;
     let presignLog;
 
-    const buildS3 = () => ({
-      s3Client: { send: sandbox.stub() },
+    const buildS3 = (send) => ({
+      s3Client: { send: send || sandbox.stub().resolves({}) },
       getSignedUrl,
       GetObjectCommand: FakeGetObjectCommand,
     });
 
-    const buildController = (s3) => SuggestionsController({
+    const buildController = (s3, envOverrides = {}) => SuggestionsController({
       dataAccess: mockSuggestionDataAccess,
       pathInfo: { headers: { 'x-product': 'llmo' } },
       s3,
@@ -587,6 +588,8 @@ describe('Suggestions Controller', () => {
     }, mockSqs, {
       AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
       LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+      S3_MYSTIQUE_BUCKET: MYSTIQUE_BUCKET,
+      ...envOverrides,
     });
 
     const gadsSuggestion = (guidance) => ({
@@ -601,16 +604,7 @@ describe('Suggestions Controller', () => {
       updatedAt: new Date(),
     });
 
-    // Wire every read path (list, paged, by-status, by-id) to return `suggData`.
     const returnSuggestion = (suggData) => {
-      mockSuggestion.allByOpportunityId.callsFake((opptyId, options) => {
-        const entities = [mockSuggestionEntity(suggData)];
-        return Promise.resolve(options ? { data: entities, cursor: undefined } : entities);
-      });
-      mockSuggestion.allByOpportunityIdAndStatus.callsFake((opptyId, status, options) => {
-        const entities = [mockSuggestionEntity(suggData)];
-        return Promise.resolve(options ? { data: entities, cursor: undefined } : entities);
-      });
       mockSuggestion.findById.callsFake((id) => Promise.resolve(
         id === suggData.id ? mockSuggestionEntity(suggData) : null,
       ));
@@ -623,7 +617,16 @@ describe('Suggestions Controller', () => {
       site_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/site/pmax.csv`, row_count: 2, byte_size: 20 },
     });
 
-    const listParams = () => ({ params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID }, ...context });
+    const csvParams = (refKey = 'account_auto_ref', overrides = {}) => ({
+      params: {
+        siteId: SITE_ID,
+        opportunityId: OPPORTUNITY_ID,
+        suggestionId: SUGGESTION_IDS[0],
+        refKey,
+        ...overrides,
+      },
+      ...context,
+    });
 
     beforeEach(() => {
       getSignedUrl = sandbox.stub().callsFake((client, command, opts) => Promise.resolve(
@@ -632,182 +635,165 @@ describe('Suggestions Controller', () => {
       presignLog = { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() };
     });
 
-    it('injects a presigned *_url for each present ref plus a single expiresAt (getAllForOpportunity)', async () => {
+    it('returns a presigned URL + expiresAt for a valid ref (pinned bucket, parsed key, 1h TTL)', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const s3 = buildS3();
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(200);
+      const body = await response.json();
+
+      expect(body.presignedUrl).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/auto.csv?exp=3600`);
+      expect(body.expiresAt).to.be.a('string');
+      expect(Number.isNaN(new Date(body.expiresAt).getTime())).to.equal(false);
+
+      // presign pins the server bucket (not the caller's uri) + parsed key + 1h TTL
+      expect(getSignedUrl.callCount).to.equal(1);
+      expect(getSignedUrl.firstCall.args[1].input).to.deep.equal({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/acct/auto.csv' });
+      expect(getSignedUrl.firstCall.args[2]).to.deep.equal({ expiresIn: 3600 });
+
+      // existence verified against the pinned bucket before signing
+      expect(s3.s3Client.send.callCount).to.equal(1);
+      expect(s3.s3Client.send.firstCall.args[0].input).to.deep.equal({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/acct/auto.csv' });
+    });
+
+    it('presigns the specific requested ref only', async () => {
       returnSuggestion(gadsSuggestion(fullGuidance()));
 
-      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('site_pmax_ref'));
       expect(response.status).to.equal(200);
-      const [suggestion] = await response.json();
-      const { guidance } = suggestion.data;
+      const body = await response.json();
+      expect(body.presignedUrl).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/pmax.csv?exp=3600`);
+      expect(getSignedUrl.callCount).to.equal(1);
+    });
 
-      expect(guidance.account_auto_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/auto.csv?exp=604800`);
-      expect(guidance.account_pmax_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/pmax.csv?exp=604800`);
-      expect(guidance.site_auto_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/auto.csv?exp=604800`);
-      expect(guidance.site_pmax_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/pmax.csv?exp=604800`);
+    it('refuses (404) and warns when the ref names a foreign bucket (confused-deputy guard)', async () => {
+      returnSuggestion(gadsSuggestion({
+        account_auto_ref: { uri: 's3://attacker-bucket/secrets/data.csv' },
+      }));
 
-      // one shared, valid ISO expiry
-      expect(guidance.expiresAt).to.be.a('string');
-      expect(Number.isNaN(new Date(guidance.expiresAt).getTime())).to.equal(false);
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+      expect(getSignedUrl.called).to.equal(false);
+      expect(presignLog.warn.calledOnce).to.equal(true);
+      expect(presignLog.warn.firstCall.args[0]).to.match(/attacker-bucket/);
+    });
 
-      // original refs preserved verbatim
-      expect(guidance.account_auto_ref).to.deep.equal(
-        { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv`, row_count: 10, byte_size: 100 },
+    it('returns 404 when the ref is absent, its uri is null, or the uri is not s3://', async () => {
+      returnSuggestion(gadsSuggestion({ site_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/x.csv` } }));
+      let response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+
+      returnSuggestion(gadsSuggestion({ account_auto_ref: { uri: null } }));
+      response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+
+      returnSuggestion(gadsSuggestion({ account_auto_ref: { uri: 'https://cdn.example/not-s3.csv' } }));
+      response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 400 for an unknown refKey', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('evil_ref'));
+      expect(response.status).to.equal(400);
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 400 when S3 is not configured on the request', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const response = await buildController(undefined).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(400);
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 400 when S3_MYSTIQUE_BUCKET is not configured', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const response = await buildController(buildS3(), { S3_MYSTIQUE_BUCKET: undefined })
+        .getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(400);
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 404 and warns when the object does not exist (HeadObject 404)', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const notFoundErr = Object.assign(new Error('missing'), { name: 'NotFound' });
+      const s3 = buildS3(sandbox.stub().rejects(notFoundErr));
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+      expect(getSignedUrl.called).to.equal(false);
+      expect(presignLog.warn.calledOnce).to.equal(true);
+    });
+
+    it('returns 404 when HeadObject reports a 404 via $metadata', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const metaErr = Object.assign(new Error('missing'), { $metadata: { httpStatusCode: 404 } });
+      const s3 = buildS3(sandbox.stub().rejects(metaErr));
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 400 and logs on a non-404 S3 error', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const s3 = buildS3(sandbox.stub().rejects(new Error('kaboom')));
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(400);
+      expect(presignLog.error.calledOnce).to.equal(true);
+    });
+
+    it('returns forbidden when the caller lacks access to the site', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(false);
+
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(403);
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 404 when the site is not found', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(
+        csvParams('account_auto_ref', { siteId: SITE_ID_NOT_FOUND }),
       );
-
-      // presign invoked once per ref with the bucket/key parsed from the s3:// uri
-      expect(getSignedUrl.callCount).to.equal(4);
-      const calledFor = getSignedUrl.getCalls().map((c) => ({
-        Bucket: c.args[1].input.Bucket,
-        Key: c.args[1].input.Key,
-        expiresIn: c.args[2].expiresIn,
-      }));
-      expect(calledFor).to.deep.include({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/acct/auto.csv', expiresIn: 604800 });
-      expect(calledFor).to.deep.include({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/site/pmax.csv', expiresIn: 604800 });
+      expect(response.status).to.equal(404);
     });
 
-    it('leaves a non-gads suggestion (no guidance refs) untouched', async () => {
-      // default allByOpportunityId returns suggs[0], which has no data.guidance
-      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
-      expect(response.status).to.equal(200);
-      const [suggestion] = await response.json();
+    it('returns 404 when the suggestion is missing or belongs to another opportunity', async () => {
+      mockSuggestion.findById.resolves(null);
+      let response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
 
-      expect(suggestion.data).to.not.have.property('guidance');
-      expect(suggestion.data).to.not.have.property('account_auto_url');
+      const sugg = gadsSuggestion(fullGuidance());
+      sugg.opportunityId = OPPORTUNITY_ID_NOT_FOUND;
+      returnSuggestion(sugg);
+      response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
       expect(getSignedUrl.called).to.equal(false);
     });
 
-    it('is a no-op when S3 is not configured on the request', async () => {
-      returnSuggestion(gadsSuggestion(fullGuidance()));
-
-      const response = await buildController(undefined).getAllForOpportunity(listParams());
-      expect(response.status).to.equal(200);
-      const [suggestion] = await response.json();
-      const { guidance } = suggestion.data;
-
-      expect(guidance).to.not.have.property('account_auto_url');
-      expect(guidance).to.not.have.property('expiresAt');
-      // refs still present, verbatim
-      expect(guidance.account_auto_ref.uri).to.equal(`s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv`);
+    it('returns 404 when the opportunity does not belong to the site', async () => {
+      mockSuggestion.findById.resolves({
+        getId: () => SUGGESTION_IDS[0],
+        getOpportunityId: () => OPPORTUNITY_ID,
+        getOpportunity: async () => ({ getSiteId: () => SITE_ID_NOT_FOUND }),
+        getData: () => ({ guidance: fullGuidance() }),
+      });
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
       expect(getSignedUrl.called).to.equal(false);
     });
 
-    it('presigns only present refs — a missing/null ref or non-s3 uri yields no *_url', async () => {
-      returnSuggestion(gadsSuggestion({
-        account_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv` }, // valid
-        account_pmax_ref: null, // missing ref object
-        site_auto_ref: { uri: null }, // null uri
-        site_pmax_ref: { uri: 'https://cdn.example/not-s3.csv' }, // non-s3 scheme
-      }));
-
-      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
-      expect(response.status).to.equal(200);
-      const [suggestion] = await response.json();
-      const { guidance } = suggestion.data;
-
-      expect(guidance.account_auto_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/auto.csv?exp=604800`);
-      expect(guidance).to.not.have.property('account_pmax_url');
-      expect(guidance).to.not.have.property('site_auto_url');
-      expect(guidance).to.not.have.property('site_pmax_url');
-      expect(guidance.expiresAt).to.be.a('string');
-      expect(getSignedUrl.callCount).to.equal(1);
-    });
-
-    it('skips malformed s3 uris (no key, no slash) and presigns the well-formed one', async () => {
-      returnSuggestion(gadsSuggestion({
-        account_auto_ref: { uri: 's3://bucket-no-slash' }, // no key separator
-        account_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/` }, // empty key
-        site_auto_ref: { uri: 's3:///leading-slash-key' }, // empty bucket segment
-        site_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/site/pmax.csv` }, // valid
-      }));
-
-      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
-      expect(response.status).to.equal(200);
-      const [suggestion] = await response.json();
-      const { guidance } = suggestion.data;
-
-      expect(guidance).to.not.have.property('account_auto_url');
-      expect(guidance).to.not.have.property('account_pmax_url');
-      expect(guidance).to.not.have.property('site_auto_url');
-      expect(guidance.site_pmax_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/pmax.csv?exp=604800`);
-      expect(getSignedUrl.callCount).to.equal(1);
-    });
-
-    it('logs a warning and injects no *_url when presigning fails', async () => {
-      getSignedUrl = sandbox.stub().rejects(new Error('presign boom'));
-      returnSuggestion(gadsSuggestion(fullGuidance()));
-
-      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
-      expect(response.status).to.equal(200);
-      const [suggestion] = await response.json();
-      const { guidance } = suggestion.data;
-
-      expect(guidance).to.not.have.property('account_auto_url');
-      expect(guidance).to.not.have.property('expiresAt');
-      expect(presignLog.warn.callCount).to.equal(4);
-    });
-
-    it('presigns refs for getAllForOpportunityPaged', async () => {
-      returnSuggestion(gadsSuggestion(fullGuidance()));
-
-      const response = await buildController(buildS3()).getAllForOpportunityPaged({
-        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, limit: 10 },
-        ...context,
-      });
-      expect(response.status).to.equal(200);
-      const { suggestions } = await response.json();
-      expect(suggestions[0].data.guidance.account_auto_url).to.match(/^https:\/\/signed\.example\//);
-      expect(suggestions[0].data.guidance.expiresAt).to.be.a('string');
-    });
-
-    it('presigns refs for getByStatus', async () => {
-      returnSuggestion(gadsSuggestion(fullGuidance()));
-
-      const response = await buildController(buildS3()).getByStatus({
-        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, status: 'NEW' },
-        ...context,
-      });
-      expect(response.status).to.equal(200);
-      const [suggestion] = await response.json();
-      expect(suggestion.data.guidance.site_pmax_url).to.match(/^https:\/\/signed\.example\//);
-    });
-
-    it('presigns refs for getByStatusPaged', async () => {
-      returnSuggestion(gadsSuggestion(fullGuidance()));
-
-      const response = await buildController(buildS3()).getByStatusPaged({
-        params: {
-          siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, status: 'NEW', limit: 10,
-        },
-        ...context,
-      });
-      expect(response.status).to.equal(200);
-      const { suggestions } = await response.json();
-      expect(suggestions[0].data.guidance.account_pmax_url).to.match(/^https:\/\/signed\.example\//);
-    });
-
-    it('presigns refs for getByID', async () => {
-      returnSuggestion(gadsSuggestion(fullGuidance()));
-
-      const response = await buildController(buildS3()).getByID({
-        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
-        ...context,
-      });
-      expect(response.status).to.equal(200);
-      const suggestion = await response.json();
-      expect(suggestion.data.guidance.account_auto_url).to.match(/^https:\/\/signed\.example\//);
-      expect(suggestion.data.guidance.expiresAt).to.be.a('string');
-      expect(getSignedUrl.callCount).to.equal(4);
-    });
-
-    it('leaves a non-gads suggestion untouched for getByID', async () => {
-      // suggs[0] has no data.guidance
-      const response = await buildController(buildS3()).getByID({
-        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
-        ...context,
-      });
-      expect(response.status).to.equal(200);
-      const suggestion = await response.json();
-      expect(suggestion.data).to.not.have.property('guidance');
+    it('returns 400 for an invalid siteId / opportunityId / suggestionId', async () => {
+      const c = buildController(buildS3());
+      expect((await c.getPresignedGuidanceCsvUrl(csvParams('account_auto_ref', { siteId: 'nope' }))).status).to.equal(400);
+      expect((await c.getPresignedGuidanceCsvUrl(csvParams('account_auto_ref', { opportunityId: 'nope' }))).status).to.equal(400);
+      expect((await c.getPresignedGuidanceCsvUrl(csvParams('account_auto_ref', { suggestionId: 'nope' }))).status).to.equal(400);
       expect(getSignedUrl.called).to.equal(false);
     });
   });

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -610,11 +610,17 @@ describe('Suggestions Controller', () => {
       ));
     };
 
+    // Mystique's real per-site CSV key layout (contract: s3_bodies.write_csv_body):
+    // gads-placement-exclusions/csv/{site_id}/{customer_id}/{obs_version}/{scope}.{source}.csv
+    const CUSTOMER_ID = '1234567890';
+    const OBS_VERSION = '2026-08-27_job-abc';
+    const keyFor = (scope, source, siteId = SITE_ID) => `gads-placement-exclusions/csv/${siteId}/${CUSTOMER_ID}/${OBS_VERSION}/${scope}.${source}.csv`;
+
     const fullGuidance = () => ({
-      account_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv`, row_count: 10, byte_size: 100 },
-      account_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/pmax.csv`, row_count: 5, byte_size: 50 },
-      site_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/site/auto.csv`, row_count: 3, byte_size: 30 },
-      site_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/site/pmax.csv`, row_count: 2, byte_size: 20 },
+      account_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/${keyFor('account', 'auto')}`, row_count: 10, byte_size: 100 },
+      account_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/${keyFor('account', 'pmax')}`, row_count: 5, byte_size: 50 },
+      site_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/${keyFor('site', 'auto')}`, row_count: 3, byte_size: 30 },
+      site_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/${keyFor('site', 'pmax')}`, row_count: 2, byte_size: 20 },
     });
 
     const csvParams = (refKey = 'account_auto_ref', overrides = {}) => ({
@@ -626,6 +632,7 @@ describe('Suggestions Controller', () => {
         ...overrides,
       },
       ...context,
+      log: presignLog,
     });
 
     beforeEach(() => {
@@ -643,18 +650,21 @@ describe('Suggestions Controller', () => {
       expect(response.status).to.equal(200);
       const body = await response.json();
 
-      expect(body.presignedUrl).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/auto.csv?exp=3600`);
+      expect(body.presignedUrl).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/${keyFor('account', 'auto')}?exp=3600`);
       expect(body.expiresAt).to.be.a('string');
       expect(Number.isNaN(new Date(body.expiresAt).getTime())).to.equal(false);
+      // expiresAt tracks the 1h TTL (not merely "a valid date"): within a small tolerance of now+3600s
+      const expiryMs = new Date(body.expiresAt).getTime() - Date.now();
+      expect(expiryMs).to.be.closeTo(3600 * 1000, 5000);
 
       // presign pins the server bucket (not the caller's uri) + parsed key + 1h TTL
       expect(getSignedUrl.callCount).to.equal(1);
-      expect(getSignedUrl.firstCall.args[1].input).to.deep.equal({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/acct/auto.csv' });
+      expect(getSignedUrl.firstCall.args[1].input).to.deep.equal({ Bucket: MYSTIQUE_BUCKET, Key: keyFor('account', 'auto') });
       expect(getSignedUrl.firstCall.args[2]).to.deep.equal({ expiresIn: 3600 });
 
       // existence verified against the pinned bucket before signing
       expect(s3.s3Client.send.callCount).to.equal(1);
-      expect(s3.s3Client.send.firstCall.args[0].input).to.deep.equal({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/acct/auto.csv' });
+      expect(s3.s3Client.send.firstCall.args[0].input).to.deep.equal({ Bucket: MYSTIQUE_BUCKET, Key: keyFor('account', 'auto') });
     });
 
     it('presigns the specific requested ref only', async () => {
@@ -663,8 +673,33 @@ describe('Suggestions Controller', () => {
       const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('site_pmax_ref'));
       expect(response.status).to.equal(200);
       const body = await response.json();
-      expect(body.presignedUrl).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/pmax.csv?exp=3600`);
+      expect(body.presignedUrl).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/${keyFor('site', 'pmax')}?exp=3600`);
       expect(getSignedUrl.callCount).to.equal(1);
+    });
+
+    it('refuses (404) and warns when the key is outside the authorized site prefix (BOLA guard)', async () => {
+      // Same pinned bucket, but the ref key points at ANOTHER site's CSV prefix.
+      // `data.guidance` is caller-writable, so this is the cross-tenant attack:
+      // the key must sit under `gads-placement-exclusions/csv/{thisSiteId}/`.
+      const otherSiteId = SITE_ID_NOT_FOUND;
+      returnSuggestion(gadsSuggestion({
+        account_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/${keyFor('account', 'auto', otherSiteId)}` },
+      }));
+
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+      expect(getSignedUrl.called).to.equal(false);
+      expect(presignLog.warn.calledOnce).to.equal(true);
+      expect(presignLog.warn.firstCall.args[0]).to.match(/outside the site prefix/);
+    });
+
+    it('refuses (404) a key in the pinned bucket but outside the gads csv root', async () => {
+      returnSuggestion(gadsSuggestion({
+        account_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/brand_claims/llmo/${SITE_ID}/data.json.gz` },
+      }));
+      const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(404);
+      expect(getSignedUrl.called).to.equal(false);
     });
 
     it('refuses (404) and warns when the ref names a foreign bucket (confused-deputy guard)', async () => {
@@ -692,6 +727,18 @@ describe('Suggestions Controller', () => {
       response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
       expect(response.status).to.equal(404);
 
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 404 (no sign) for malformed s3 uris — no slash, empty key, or empty bucket', async () => {
+      // Exercises parseS3Uri's three null-returning branches through the handler
+      // (this parser is the enforcement point for the bucket pin).
+      for (const uri of ['s3://bucket-no-slash', `s3://${MYSTIQUE_BUCKET}/`, 's3:///leading-slash-key']) {
+        returnSuggestion(gadsSuggestion({ account_auto_ref: { uri } }));
+        // eslint-disable-next-line no-await-in-loop
+        const response = await buildController(buildS3()).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+        expect(response.status, `uri=${uri}`).to.equal(404);
+      }
       expect(getSignedUrl.called).to.equal(false);
     });
 
@@ -738,13 +785,35 @@ describe('Suggestions Controller', () => {
       expect(getSignedUrl.called).to.equal(false);
     });
 
-    it('returns 400 and logs on a non-404 S3 error', async () => {
+    it('maps a non-404, non-transient S3 error to 500 with a generic message (no raw AWS text)', async () => {
       returnSuggestion(gadsSuggestion(fullGuidance()));
-      const s3 = buildS3(sandbox.stub().rejects(new Error('kaboom')));
+      const s3 = buildS3(sandbox.stub().rejects(new Error('kaboom internal detail')));
 
       const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
-      expect(response.status).to.equal(400);
+      expect(response.status).to.equal(500);
+      const body = await response.json();
+      expect(body.message).to.not.match(/kaboom/); // internal error text stays in the log, not the response
       expect(presignLog.error.calledOnce).to.equal(true);
+      expect(presignLog.error.firstCall.args[0]).to.match(/kaboom/); // ...but is logged
+    });
+
+    it('maps a throttling/transient S3 error to 503', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const throttled = Object.assign(new Error('slow down'), { name: 'ThrottlingException' });
+      const s3 = buildS3(sandbox.stub().rejects(throttled));
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(503);
+      expect(presignLog.error.calledOnce).to.equal(true);
+    });
+
+    it('maps an S3 error carrying a 503 $metadata status to 503', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      const unavailable = Object.assign(new Error('unavailable'), { $metadata: { httpStatusCode: 503 } });
+      const s3 = buildS3(sandbox.stub().rejects(unavailable));
+
+      const response = await buildController(s3).getPresignedGuidanceCsvUrl(csvParams('account_auto_ref'));
+      expect(response.status).to.equal(503);
     });
 
     it('returns forbidden when the caller lacks access to the site', async () => {
@@ -794,6 +863,43 @@ describe('Suggestions Controller', () => {
       expect((await c.getPresignedGuidanceCsvUrl(csvParams('account_auto_ref', { siteId: 'nope' }))).status).to.equal(400);
       expect((await c.getPresignedGuidanceCsvUrl(csvParams('account_auto_ref', { opportunityId: 'nope' }))).status).to.equal(400);
       expect((await c.getPresignedGuidanceCsvUrl(csvParams('account_auto_ref', { suggestionId: 'nope' }))).status).to.equal(400);
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('returns 404 (no sign) when summit-plg is enabled and the suggestion is not granted', async () => {
+      // Mirrors the getByID summit-plg gate: the only security-relevant branch
+      // unique to this handler must be exercised.
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+      mockSuggestionGrant.isSuggestionGranted.resolves(false);
+      const ControllerWithSummitPlg = await esmock('../../src/controllers/suggestions.js', {
+        '../../src/support/utils.js': {
+          getIsSummitPlgEnabled: async () => true,
+        },
+      });
+      const controller = ControllerWithSummitPlg({
+        dataAccess: mockSuggestionDataAccess,
+        pathInfo: { headers: { 'x-product': 'llmo' } },
+        s3: buildS3(),
+        log: presignLog,
+        ...authContext,
+      }, mockSqs, {
+        AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+        LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+        S3_MYSTIQUE_BUCKET: MYSTIQUE_BUCKET,
+      });
+
+      const response = await controller.getPresignedGuidanceCsvUrl({
+        params: {
+          siteId: SITE_ID,
+          opportunityId: OPPORTUNITY_ID,
+          suggestionId: SUGGESTION_IDS[0],
+          refKey: 'account_auto_ref',
+        },
+        pathInfo: { headers: { 'x-client-type': 'sites-optimizer-ui' } },
+        ...context,
+        log: presignLog,
+      });
+      expect(response.status).to.equal(404);
       expect(getSignedUrl.called).to.equal(false);
     });
   });

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -560,6 +560,258 @@ describe('Suggestions Controller', () => {
     expect(() => SuggestionsController({ dataAccess: { Opportunity: {}, Suggestion: '' } })).to.throw('Data access required');
   });
 
+  describe('presign gads-placement-exclusions guidance CSV refs on-serve', () => {
+    const MYSTIQUE_BUCKET = 'spacecat-dev-mystique-assets';
+
+    // Minimal fake for @aws-sdk GetObjectCommand: records the { Bucket, Key } it was
+    // constructed with under `.input`, mirroring the real command shape.
+    function FakeGetObjectCommand(params) {
+      this.input = params;
+    }
+
+    let getSignedUrl;
+    let presignLog;
+
+    const buildS3 = () => ({
+      s3Client: { send: sandbox.stub() },
+      getSignedUrl,
+      GetObjectCommand: FakeGetObjectCommand,
+    });
+
+    const buildController = (s3) => SuggestionsController({
+      dataAccess: mockSuggestionDataAccess,
+      pathInfo: { headers: { 'x-product': 'llmo' } },
+      s3,
+      log: presignLog,
+      ...authContext,
+    }, mockSqs, {
+      AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+      LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+    });
+
+    const gadsSuggestion = (guidance) => ({
+      id: SUGGESTION_IDS[0],
+      opportunityId: OPPORTUNITY_ID,
+      type: 'PLACEMENT_EXCLUSION',
+      status: 'NEW',
+      rank: 1,
+      data: { guidance },
+      kpiDeltas: {},
+      updatedBy: 'system',
+      updatedAt: new Date(),
+    });
+
+    // Wire every read path (list, paged, by-status, by-id) to return `suggData`.
+    const returnSuggestion = (suggData) => {
+      mockSuggestion.allByOpportunityId.callsFake((opptyId, options) => {
+        const entities = [mockSuggestionEntity(suggData)];
+        return Promise.resolve(options ? { data: entities, cursor: undefined } : entities);
+      });
+      mockSuggestion.allByOpportunityIdAndStatus.callsFake((opptyId, status, options) => {
+        const entities = [mockSuggestionEntity(suggData)];
+        return Promise.resolve(options ? { data: entities, cursor: undefined } : entities);
+      });
+      mockSuggestion.findById.callsFake((id) => Promise.resolve(
+        id === suggData.id ? mockSuggestionEntity(suggData) : null,
+      ));
+    };
+
+    const fullGuidance = () => ({
+      account_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv`, row_count: 10, byte_size: 100 },
+      account_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/pmax.csv`, row_count: 5, byte_size: 50 },
+      site_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/site/auto.csv`, row_count: 3, byte_size: 30 },
+      site_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/site/pmax.csv`, row_count: 2, byte_size: 20 },
+    });
+
+    const listParams = () => ({ params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID }, ...context });
+
+    beforeEach(() => {
+      getSignedUrl = sandbox.stub().callsFake((client, command, opts) => Promise.resolve(
+        `https://signed.example/${command.input.Bucket}/${command.input.Key}?exp=${opts.expiresIn}`,
+      ));
+      presignLog = { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() };
+    });
+
+    it('injects a presigned *_url for each present ref plus a single expiresAt (getAllForOpportunity)', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+
+      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
+      expect(response.status).to.equal(200);
+      const [suggestion] = await response.json();
+      const { guidance } = suggestion.data;
+
+      expect(guidance.account_auto_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/auto.csv?exp=604800`);
+      expect(guidance.account_pmax_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/pmax.csv?exp=604800`);
+      expect(guidance.site_auto_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/auto.csv?exp=604800`);
+      expect(guidance.site_pmax_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/pmax.csv?exp=604800`);
+
+      // one shared, valid ISO expiry
+      expect(guidance.expiresAt).to.be.a('string');
+      expect(Number.isNaN(new Date(guidance.expiresAt).getTime())).to.equal(false);
+
+      // original refs preserved verbatim
+      expect(guidance.account_auto_ref).to.deep.equal(
+        { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv`, row_count: 10, byte_size: 100 },
+      );
+
+      // presign invoked once per ref with the bucket/key parsed from the s3:// uri
+      expect(getSignedUrl.callCount).to.equal(4);
+      const calledFor = getSignedUrl.getCalls().map((c) => ({
+        Bucket: c.args[1].input.Bucket,
+        Key: c.args[1].input.Key,
+        expiresIn: c.args[2].expiresIn,
+      }));
+      expect(calledFor).to.deep.include({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/acct/auto.csv', expiresIn: 604800 });
+      expect(calledFor).to.deep.include({ Bucket: MYSTIQUE_BUCKET, Key: 'gads/site/pmax.csv', expiresIn: 604800 });
+    });
+
+    it('leaves a non-gads suggestion (no guidance refs) untouched', async () => {
+      // default allByOpportunityId returns suggs[0], which has no data.guidance
+      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
+      expect(response.status).to.equal(200);
+      const [suggestion] = await response.json();
+
+      expect(suggestion.data).to.not.have.property('guidance');
+      expect(suggestion.data).to.not.have.property('account_auto_url');
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('is a no-op when S3 is not configured on the request', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+
+      const response = await buildController(undefined).getAllForOpportunity(listParams());
+      expect(response.status).to.equal(200);
+      const [suggestion] = await response.json();
+      const { guidance } = suggestion.data;
+
+      expect(guidance).to.not.have.property('account_auto_url');
+      expect(guidance).to.not.have.property('expiresAt');
+      // refs still present, verbatim
+      expect(guidance.account_auto_ref.uri).to.equal(`s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv`);
+      expect(getSignedUrl.called).to.equal(false);
+    });
+
+    it('presigns only present refs — a missing/null ref or non-s3 uri yields no *_url', async () => {
+      returnSuggestion(gadsSuggestion({
+        account_auto_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/acct/auto.csv` }, // valid
+        account_pmax_ref: null, // missing ref object
+        site_auto_ref: { uri: null }, // null uri
+        site_pmax_ref: { uri: 'https://cdn.example/not-s3.csv' }, // non-s3 scheme
+      }));
+
+      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
+      expect(response.status).to.equal(200);
+      const [suggestion] = await response.json();
+      const { guidance } = suggestion.data;
+
+      expect(guidance.account_auto_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/acct/auto.csv?exp=604800`);
+      expect(guidance).to.not.have.property('account_pmax_url');
+      expect(guidance).to.not.have.property('site_auto_url');
+      expect(guidance).to.not.have.property('site_pmax_url');
+      expect(guidance.expiresAt).to.be.a('string');
+      expect(getSignedUrl.callCount).to.equal(1);
+    });
+
+    it('skips malformed s3 uris (no key, no slash) and presigns the well-formed one', async () => {
+      returnSuggestion(gadsSuggestion({
+        account_auto_ref: { uri: 's3://bucket-no-slash' }, // no key separator
+        account_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/` }, // empty key
+        site_auto_ref: { uri: 's3:///leading-slash-key' }, // empty bucket segment
+        site_pmax_ref: { uri: `s3://${MYSTIQUE_BUCKET}/gads/site/pmax.csv` }, // valid
+      }));
+
+      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
+      expect(response.status).to.equal(200);
+      const [suggestion] = await response.json();
+      const { guidance } = suggestion.data;
+
+      expect(guidance).to.not.have.property('account_auto_url');
+      expect(guidance).to.not.have.property('account_pmax_url');
+      expect(guidance).to.not.have.property('site_auto_url');
+      expect(guidance.site_pmax_url).to.equal(`https://signed.example/${MYSTIQUE_BUCKET}/gads/site/pmax.csv?exp=604800`);
+      expect(getSignedUrl.callCount).to.equal(1);
+    });
+
+    it('logs a warning and injects no *_url when presigning fails', async () => {
+      getSignedUrl = sandbox.stub().rejects(new Error('presign boom'));
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+
+      const response = await buildController(buildS3()).getAllForOpportunity(listParams());
+      expect(response.status).to.equal(200);
+      const [suggestion] = await response.json();
+      const { guidance } = suggestion.data;
+
+      expect(guidance).to.not.have.property('account_auto_url');
+      expect(guidance).to.not.have.property('expiresAt');
+      expect(presignLog.warn.callCount).to.equal(4);
+    });
+
+    it('presigns refs for getAllForOpportunityPaged', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+
+      const response = await buildController(buildS3()).getAllForOpportunityPaged({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, limit: 10 },
+        ...context,
+      });
+      expect(response.status).to.equal(200);
+      const { suggestions } = await response.json();
+      expect(suggestions[0].data.guidance.account_auto_url).to.match(/^https:\/\/signed\.example\//);
+      expect(suggestions[0].data.guidance.expiresAt).to.be.a('string');
+    });
+
+    it('presigns refs for getByStatus', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+
+      const response = await buildController(buildS3()).getByStatus({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, status: 'NEW' },
+        ...context,
+      });
+      expect(response.status).to.equal(200);
+      const [suggestion] = await response.json();
+      expect(suggestion.data.guidance.site_pmax_url).to.match(/^https:\/\/signed\.example\//);
+    });
+
+    it('presigns refs for getByStatusPaged', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+
+      const response = await buildController(buildS3()).getByStatusPaged({
+        params: {
+          siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, status: 'NEW', limit: 10,
+        },
+        ...context,
+      });
+      expect(response.status).to.equal(200);
+      const { suggestions } = await response.json();
+      expect(suggestions[0].data.guidance.account_pmax_url).to.match(/^https:\/\/signed\.example\//);
+    });
+
+    it('presigns refs for getByID', async () => {
+      returnSuggestion(gadsSuggestion(fullGuidance()));
+
+      const response = await buildController(buildS3()).getByID({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
+        ...context,
+      });
+      expect(response.status).to.equal(200);
+      const suggestion = await response.json();
+      expect(suggestion.data.guidance.account_auto_url).to.match(/^https:\/\/signed\.example\//);
+      expect(suggestion.data.guidance.expiresAt).to.be.a('string');
+      expect(getSignedUrl.callCount).to.equal(4);
+    });
+
+    it('leaves a non-gads suggestion untouched for getByID', async () => {
+      // suggs[0] has no data.guidance
+      const response = await buildController(buildS3()).getByID({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
+        ...context,
+      });
+      expect(response.status).to.equal(200);
+      const suggestion = await response.json();
+      expect(suggestion.data).to.not.have.property('guidance');
+      expect(getSignedUrl.called).to.equal(false);
+    });
+  });
+
   describe('getEdgeDeployedUrls', () => {
     const makeOppty = (id, type, tags) => ({
       getId: () => id,

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -151,6 +151,7 @@ describe('getRouteHandlers', () => {
     getPagedForOpportunity: sinon.stub(),
     getByStatus: sinon.stub(),
     getByID: sinon.stub(),
+    getPresignedGuidanceCsvUrl: sinon.stub(),
     createSuggestions: sinon.stub(),
     createBackofficeReview: sinon.stub(),
     patchSuggestion: sinon.stub(),
@@ -1153,6 +1154,7 @@ describe('getRouteHandlers', () => {
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit/:cursor',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId',
+      'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey',
       'GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/fixes',
       'POST /sites/:siteId/opportunities/:opportunityId/suggestions',
       'POST /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/backoffice-reviews',
@@ -1544,6 +1546,8 @@ describe('getRouteHandlers', () => {
     expect(dynamicRoutes['GET /sites/:siteId/opportunities/:opportunityId/suggestions/by-status/:status/paged/:limit'].paramNames).to.deep.equal(['siteId', 'opportunityId', 'status', 'limit']);
     expect(dynamicRoutes['GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId'].handler).to.equal(mockSuggestionsController.getByID);
     expect(dynamicRoutes['GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId'].paramNames).to.deep.equal(['siteId', 'opportunityId', 'suggestionId']);
+    expect(dynamicRoutes['GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey'].handler).to.equal(mockSuggestionsController.getPresignedGuidanceCsvUrl);
+    expect(dynamicRoutes['GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey'].paramNames).to.deep.equal(['siteId', 'opportunityId', 'suggestionId', 'refKey']);
     expect(dynamicRoutes['POST /sites/:siteId/opportunities/:opportunityId/suggestions'].handler).to.equal(mockSuggestionsController.createSuggestions);
     expect(dynamicRoutes['PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId'].handler).to.equal(mockSuggestionsController.patchSuggestion);
     expect(dynamicRoutes['PATCH /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId'].paramNames).to.deep.equal(['siteId', 'opportunityId', 'suggestionId']);


### PR DESCRIPTION
## What & why (D2)

The `gads-placement-exclusions` opportunity's suggestions carry four CSV references under `suggestion.data.guidance`:

- `account_auto_ref`
- `account_pmax_ref`
- `site_auto_ref`
- `site_pmax_ref`

Each is `{ uri, row_count, byte_size }` where `uri` is an `s3://bucket/key` pointer into `spacecat-{env}-mystique-assets`. The browser cannot presign S3 keys, so the API does it.

## Design: click-time presign endpoint

A dedicated, opportunity-scoped endpoint mints a short-lived presigned URL **on download**, mirroring `llmo/brand-claims.js`:

```
GET /sites/:siteId/opportunities/:opportunityId/suggestions/:suggestionId/guidance-csv/:refKey
→ 200 { presignedUrl, expiresAt }
```

- The caller passes only the constrained `refKey` (one of the four `*_ref` keys). The S3 key is resolved **server-side** from the stored suggestion's `data.guidance[refKey].uri`.
- The bucket is **pinned server-side** to `S3_MYSTIQUE_BUCKET`; the ref uri's bucket is never trusted (a mismatch is refused with 404 + a `warn`). This closes the confused-deputy.
- `HeadObject` verifies existence for a clean 404, then a **1-hour** `GetObject` URL is signed. Minting per click means no long-lived bearer link.
- Authorized with the end-user session token at the same tier as the suggestion reads (`suggestion:read` + `llmo|aso can_view` + `hasAccess(site)`), so studio-ui calls it directly.

The generic suggestion read paths (`getAllForOpportunity[/Paged]`, `getByStatus[/Paged]`, `getByID`) serve `data` verbatim — no gads-specific logic remains in them.

## Why this over eager on-read presigning

The first cut injected `*_url`s into every suggestion read (7-day TTL). Review flagged: (a) a **confused-deputy** — the presigned bucket came from caller-writable `data`; (b) gads-specifics in the **generic** controller; (c) a **7-day** bearer link minted on every read even if never downloaded. The click-time endpoint resolves all three: bucket pinned + key server-derived + short TTL + generic controller left clean.

## Consumer

studio-ui download-only v1 ([OneAdobe/experience-success-studio-ui#2236](https://github.com/OneAdobe/experience-success-studio-ui/pull/2236)) calls the endpoint per click and downloads `presignedUrl`. **Companion UI change required:** read the endpoint on click instead of embedded `*_url`s.

## Tests

Replaces the eager unit tests with endpoint tests: happy path (pinned bucket/key + 1h TTL), foreign-bucket refusal + `warn`, absent/null/non-s3 → 404, unknown `refKey` → 400, S3/bucket unconfigured → 400, HeadObject 404, non-404 S3 error → 400, and access control. Route/capability/OpenAPI coverage tests updated. Full `npm test` passes; coverage stays above the 90% gate.

Ref: [SITES-50551](https://jira.corp.adobe.com/browse/SITES-50551)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "New auth-gated read endpoint that pins the S3 bucket server-side and derives the key server-side, closing a confused-deputy risk rather than opening one."
```