### PR TITLE
fix(serenity): gate async prompt-classification on an explicit async flag, not deferPublish

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12032,7 +12032,20 @@ SerenityCreatePromptsRequest:
         carries `published: false`). Used for chunked CSV imports, where the
         client posts several chunks and issues a single publish after the last
         one (serenity-docs#32). Omitted/false publishes once at the end of the
-        call as usual.
+        call as usual. This is a SYNCHRONOUS-path hint only and does NOT trigger
+        async processing — use `async` for that.
+    async:
+      type: boolean
+      default: false
+      description: >
+        When true, the request is processed ASYNCHRONOUSLY: instead of
+        classifying + creating + publishing inline, the whole write is enqueued
+        to a background job and the endpoint returns 202 with a job id to poll
+        via `GET .../serenity/prompts/jobs/{jobId}` (serenity-docs#33).
+        Deliberately distinct from `deferPublish` (a synchronous publish-batching
+        hint) so that the synchronous CSV-chunking client — which sets
+        `deferPublish` on every non-final chunk — is never routed to async
+        unexpectedly. Omitted/false processes synchronously as usual.
 
 SerenityCreatePromptsResponse:
   type: object
@@ -12071,7 +12084,7 @@ SerenityCreatePromptsResponse:
 SerenityPromptsJobAccepted:
   type: object
   description: |
-    202 body for a CSV-import create (`deferPublish: true`). The write runs
+    202 body for an async prompt-create (`async: true`). The write runs
     asynchronously on the job runner; poll `jobId` at
     `GET .../serenity/prompts/jobs/{jobId}`.
   required: [jobId, status]

--- a/src/controllers/serenity.js
+++ b/src/controllers/serenity.js
@@ -31,7 +31,7 @@ import {
   handleCreatePrompts,
   handleUpdatePrompt,
   handleBulkDeletePrompts,
-  validateDeferPublish,
+  validateAsync,
   BULK_PROMPTS_MAX_ITEMS,
   resolveCallerId,
 } from '../support/serenity/handlers/prompts.js';
@@ -564,20 +564,20 @@ function SerenityController(context, log, env) {
       if (auth.error) {
         return auth.error;
       }
-      // serenity-docs#33 (Layer 1, #2920): CSV import is the ONLY bulk write path
-      // that routes to the async job runner — every other write path (single
-      // create, single edit, UI multi-add) stays synchronous. Routing is by
-      // SOURCE, not array length: `deferPublish` is the exact flag CSV-chunking
-      // already sets (see handleCreatePrompts' docstring) precisely because a UI
-      // multi-add never sets it, so a three-prompt UI add never pays
-      // queue+worker+publish latency. BOTH modes enqueue: subworkspace is the only
-      // mode that exists in practice (flat brands are effectively extinct), so
-      // gating the async path on flat-only meant it never fired. The worker
-      // reconstructs the write from the metadata below — `authMode` picks the
-      // subworkspace-vs-flat create branch, `workspaceId`/`parentWorkspaceId` give
-      // it the sub-workspace and org parent it needs.
+      // serenity-docs#33 (Layer 1, #2920): async routing is keyed off a DEDICATED
+      // `async: true` flag, NOT `deferPublish`. `deferPublish` is a publish-
+      // batching hint on the SYNCHRONOUS CSV-chunking path (set on every non-final
+      // chunk); conflating the two made that sync client silently receive 202s it
+      // never handled (a multi-chunk import broke). Keying async off its own
+      // explicit opt-in keeps every existing write path — single create/edit, UI
+      // multi-add, and the sync CSV-chunking client — synchronous and untouched,
+      // and makes the async job runner strictly opt-in for callers that will poll
+      // the job. BOTH modes enqueue: the worker reconstructs the write from the
+      // metadata below — `authMode` picks the subworkspace-vs-flat create branch,
+      // `workspaceId`/`parentWorkspaceId` give it the sub-workspace and org parent
+      // it needs.
       const body = ctx.data || {};
-      if (validateDeferPublish(body)) {
+      if (validateAsync(body)) {
         const prompts = Array.isArray(body.prompts) ? body.prompts : [];
         if (prompts.length === 0) {
           return createResponse(

--- a/src/support/serenity/handlers/prompts.js
+++ b/src/support/serenity/handlers/prompts.js
@@ -194,6 +194,33 @@ export function validateDeferPublish(body) {
 }
 
 /**
+ * Whether a bulk-create request opts into the ASYNC job runner (serenity-docs#33).
+ *
+ * This is a DEDICATED trigger, deliberately separate from `deferPublish`. The
+ * two are unrelated concerns and must not be conflated: `deferPublish` is a
+ * publish-batching hint on the synchronous path (defer the upstream publish
+ * until the last chunk), whereas `async` routes the whole write off the request
+ * path onto the SQS worker and returns 202 + a job id to poll. Overloading
+ * `deferPublish` for both meant the sync CSV-chunking client (which sets
+ * `deferPublish: true` on every non-final chunk) silently got 202s it did not
+ * expect. Keying async off its own explicit flag lets that client keep working
+ * synchronously untouched, and makes async strictly opt-in.
+ *
+ * Present-but-non-boolean is a hard 400 (mirrors validateDeferPublish); absent,
+ * `false`, or `true` are all accepted.
+ *
+ * @param {object} body - request body.
+ * @returns {boolean} true when `async === true`.
+ */
+export function validateAsync(body) {
+  const asyncFlag = body?.async;
+  if (asyncFlag !== undefined && typeof asyncFlag !== 'boolean') {
+    throw new ErrorWithStatusCode('async must be a boolean', 400);
+  }
+  return asyncFlag === true;
+}
+
+/**
  * Builds the prompt's tag list from the upstream item: one entry per tag,
  * carrying its id, bare name, parent id and root-first ancestry breadcrumb.
  *

--- a/test/controllers/serenity.test.js
+++ b/test/controllers/serenity.test.js
@@ -2770,18 +2770,19 @@ describe('SerenityController', () => {
       expect(handlers.handleCreatePromptsSubworkspace).not.to.have.been.called;
     });
 
-    // serenity-docs#33: CSV import routes to the async job runner instead of the
-    // synchronous classify/create/publish path. `deferPublish: true` is the exact
-    // flag CSV-chunking already sets (a UI multi-add never sets it), so routing
-    // is by source, not array length.
-    describe('CSV import async routing (serenity-docs#33)', () => {
-      it('enqueues a serenity-classify-prompts job and returns 202 when deferPublish is true (flat mode)', async () => {
+    // serenity-docs#33 (+#2/#3): bulk import routes to the async job runner via a
+    // DEDICATED `async: true` flag — NOT `deferPublish`. `deferPublish` stays a
+    // synchronous publish-batching hint; keying async off its own flag keeps the
+    // sync CSV-chunking client (which sets deferPublish on non-final chunks)
+    // working synchronously and untouched.
+    describe('async bulk routing (serenity-docs#33)', () => {
+      it('enqueues a serenity-classify-prompts job and returns 202 when async is true (flat mode)', async () => {
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const prompts = [{
           text: 'What is your return policy?', geoTargetId: 2840, languageCode: 'en', tagIds: ['tag-1'],
         }];
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts },
+          data: { async: true, prompts },
         }));
 
         expect(response.status).to.equal(202);
@@ -2808,7 +2809,7 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePrompts).to.not.have.been.called;
       });
 
-      it('enqueues a serenity-classify-prompts job and returns 202 for subworkspace-mode CSV import, carrying authMode + parentWorkspaceId', async () => {
+      it('enqueues a serenity-classify-prompts job and returns 202 for subworkspace-mode async import, carrying authMode + parentWorkspaceId', async () => {
         resolveBrandWorkspaceStub.resolves({
           mode: 'subworkspace', workspaceId: SUBWS, parentWorkspaceId: WORKSPACE,
         });
@@ -2817,7 +2818,7 @@ describe('SerenityController', () => {
           text: 'What is your return policy?', geoTargetId: 2840, languageCode: 'en', tagIds: ['tag-1'],
         }];
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts },
+          data: { async: true, prompts },
         }));
 
         expect(response.status).to.equal(202);
@@ -2845,7 +2846,23 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePrompts).to.not.have.been.called;
       });
 
-      it('stays synchronous (no enqueue) when deferPublish is absent, even for a large batch', async () => {
+      // Regression guard for the #2 collision (the whole point of this fix):
+      // deferPublish alone MUST stay synchronous now that it no longer triggers
+      // async — the sync CSV-chunking client sets it on every non-final chunk and
+      // must never receive a 202 it does not handle.
+      it('stays synchronous when deferPublish is true but async is absent (collision guard)', async () => {
+        handlers.handleCreatePrompts.resolves({ created: 1, failed: [] });
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const response = await controller.createPrompts(fakeContext({
+          data: { deferPublish: true, prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
+        }));
+
+        expect(response.status).to.equal(200);
+        expect(createAndEnqueueJobStub).to.not.have.been.called;
+        expect(handlers.handleCreatePrompts).to.have.been.calledOnce;
+      });
+
+      it('stays synchronous (no enqueue) when async is absent, even for a large batch', async () => {
         handlers.handleCreatePrompts.resolves({ created: 1, failed: [] });
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const response = await controller.createPrompts(fakeContext({
@@ -2857,7 +2874,7 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePrompts).to.have.been.calledOnce;
       });
 
-      it('stays synchronous for subworkspace-mode brands when deferPublish is absent', async () => {
+      it('stays synchronous for subworkspace-mode brands when async is absent', async () => {
         resolveBrandWorkspaceStub.resolves({
           mode: 'subworkspace', workspaceId: SUBWS, parentWorkspaceId: WORKSPACE,
         });
@@ -2872,23 +2889,33 @@ describe('SerenityController', () => {
         expect(handlers.handleCreatePromptsSubworkspace).to.have.been.calledOnce;
       });
 
-      it('400s without enqueueing when deferPublish is true but prompts is empty', async () => {
+      it('400s when async is not a boolean', async () => {
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts: [] },
+          data: { async: 'yes', prompts: [{ text: 'x', geoTargetId: 2840, languageCode: 'en' }] },
         }));
 
         expect(response.status).to.equal(400);
         expect(createAndEnqueueJobStub).to.not.have.been.called;
       });
 
-      it('400s without enqueueing when deferPublish is true and prompts exceeds the max item cap', async () => {
+      it('400s without enqueueing when async is true but prompts is empty', async () => {
+        const controller = SerenityController({ env: {} }, fakeLog(), {});
+        const response = await controller.createPrompts(fakeContext({
+          data: { async: true, prompts: [] },
+        }));
+
+        expect(response.status).to.equal(400);
+        expect(createAndEnqueueJobStub).to.not.have.been.called;
+      });
+
+      it('400s without enqueueing when async is true and prompts exceeds the max item cap', async () => {
         const controller = SerenityController({ env: {} }, fakeLog(), {});
         const tooMany = Array.from({ length: 501 }, (_, i) => ({
           text: `p${i}`, geoTargetId: 2840, languageCode: 'en',
         }));
         const response = await controller.createPrompts(fakeContext({
-          data: { deferPublish: true, prompts: tooMany },
+          data: { async: true, prompts: tooMany },
         }));
 
         expect(response.status).to.equal(400);

--- a/test/support/serenity/handlers/prompts.test.js
+++ b/test/support/serenity/handlers/prompts.test.js
@@ -25,6 +25,7 @@ import {
   normalizePromptInput,
   makeIntentInjector,
   validateDeferPublish,
+  validateAsync,
   reconcilePublishErrors,
   resolveCallerId,
   buildCreateMetadata,
@@ -2727,6 +2728,17 @@ describe('handlers/prompts.js — deferPublish (serenity-docs#32 CSV-chunking)',
     expect(validateDeferPublish({ deferPublish: true })).to.equal(true);
     expect(() => validateDeferPublish({ deferPublish: 'yes' }))
       .to.throw(ErrorWithStatusCode, /deferPublish must be a boolean/);
+  });
+
+  it('validateAsync resolves absent/false/true and rejects a non-boolean (serenity-docs#33)', () => {
+    expect(validateAsync({})).to.equal(false);
+    expect(validateAsync({ async: false })).to.equal(false);
+    expect(validateAsync({ async: true })).to.equal(true);
+    expect(() => validateAsync({ async: 'yes' }))
+      .to.throw(ErrorWithStatusCode, /async must be a boolean/);
+    // async and deferPublish are independent flags: neither implies the other.
+    expect(validateAsync({ deferPublish: true })).to.equal(false);
+    expect(validateDeferPublish({ async: true })).to.equal(false);
   });
 
   it('skips the trailing publish and reports published:false when deferPublish is true', async () => {


### PR DESCRIPTION
## What & why

serenity-docs#33's async prompt-classification routing (merged in **#3138**) was gated on `deferPublish`: in `src/controllers/serenity.js`, `createPrompts` did `if (validateDeferPublish(body)) { …createAndEnqueueJob…; return accepted(202) }`.

The problem: **`deferPublish` is overloaded.** It is also set by the existing **synchronous** CSV-chunking client — the UI's `createSerenityPrompts` / `useSerenityCsvImport` sends `deferPublish: !isLast` on every non-final chunk to batch the upstream publish. So after #3138, a multi-chunk Serenity CSV import silently started receiving `202 { jobId }` responses that the sync client does not handle → **broken import**.

### The fix — decouple async from `deferPublish` (explicit opt-in)

- New `validateAsync(body)` helper in `src/support/serenity/handlers/prompts.js` (returns `body.async === true`; present-but-non-boolean → 400), sitting next to `validateDeferPublish`, which is unchanged and stays a **synchronous** publish-batching hint.
- `createPrompts` now routes to the async job runner on `validateAsync(body)` instead of `validateDeferPublish(body)`.
- OpenAPI: added an `async` boolean (default `false`) to `SerenityCreatePromptsRequest`, clarified that `deferPublish` is a sync-path hint that does **not** trigger async, and corrected the 202-body (`SerenityPromptsJobAccepted`) description.

**Net effect:** async fires **only** when the caller sends `async: true`. Every existing caller (which sends only `deferPublish`, or neither) stays synchronous — exactly as before #3138.

### Preserves #3138

Everything #3138 added **inside** the async branch is untouched: the `authMode` / `workspaceId` / `parentWorkspaceId` reconstruction metadata and full subworkspace support. No `auth.mode !== 'subworkspace'` guard is reintroduced — both flat and subworkspace modes still enqueue when `async: true`.

### Empirical finding — latent fix, no active incident

**0 async jobs were enqueued in prod over the last 7 days**, so the async path, though live, has never actually fired. This is a latent-fix: async is now **dormant until a client opts in** with `async: true`, which safely reverts prod to all-synchronous behaviour.

### Credit

Approach mirrors the now-closed **#3071**, which implemented exactly this decoupling. This PR re-applies it on current `main` (which, unlike #3071, already carries #3138's subworkspace support — preserved here).

## Tests

- `test/controllers/serenity.test.js`: async-routing tests now drive the async path with `async: true`; **added a regression guard** asserting `deferPublish: true` **without** `async` stays synchronous (200, no enqueue); subworkspace-async coverage retained (driven by `async: true` + subworkspace mode); added a `400s when async is not a boolean` case.
- `test/support/serenity/handlers/prompts.test.js`: added `validateAsync` coverage (incl. that `async` and `deferPublish` are independent).
- `test/openapi-contract/serenity-api.test.js`: unchanged — `createSerenityPrompts` remains the documented 200 sync path; operationId↔FIXTURES parity intact.

## Gates (run manually — worktree)

- `npx mocha test/controllers/serenity.test.js test/support/serenity/handlers/prompts.test.js test/routes/index.test.js test/openapi-contract/serenity-api.test.js` → **409 passing, 0 failing**
- `npm run type-check` (base + strict) → **pass**
- `npm run lint` → **pass** (changed files clean)
- `npm run docs:lint` → **valid**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```