### PR TITLE
feat(llmo): read-only org/identity integrity reconciliation report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ admin-idp-p*.json
 scripts/*
 !scripts/backfill-rum-config.mjs
 !scripts/generate-insomnia-collection.mjs
+!scripts/reconcile-org-identity-integrity.mjs
 !scripts/reconcile-prompt-suggestion-schedules.mjs
 !scripts/serenity-job-runner-ops.mjs
 !scripts/serenity-retype-backfill.mjs

--- a/scripts/reconcile-org-identity-integrity.mjs
+++ b/scripts/reconcile-org-identity-integrity.mjs
@@ -148,13 +148,13 @@ async function fetchAllRows(table, select, applyFilter = (q) => q) {
     if (error) {
       throw new Error(`Failed to fetch ${table} rows ${from}-${to}: ${error.message}`);
     }
-    rows.push(...(data ?? []));
-    if (rows.length > MAX_ROWS_PER_FETCH) {
+    if (rows.length + (data?.length ?? 0) > MAX_ROWS_PER_FETCH) {
       throw new Error(
-        `Aborting fetch of ${table}: exceeded ${MAX_ROWS_PER_FETCH} rows, which is far beyond `
+        `Aborting fetch of ${table}: would exceed ${MAX_ROWS_PER_FETCH} rows, which is far beyond `
         + 'this table\'s expected size and likely indicates a filter or pagination bug.',
       );
     }
+    rows.push(...(data ?? []));
     if (!data || data.length < pageSize) {
       log.info(`Fetched ${rows.length} rows from ${table}`);
       return rows;
@@ -172,6 +172,11 @@ function normalizeBrandName(name) {
 // Check 1: foreign LLMO enrollments
 // ---------------------------------------------------------------------------
 async function findForeignLlmoEnrollments() {
+  // `entitlements!inner`/`sites!inner` (here and in findActiveBrandIntegrityIssues below) make
+  // the nested-field access below null-safe, but as a side effect they silently drop any row
+  // with a dangling reference (a site_enrollment pointing at a deleted entitlement, an active
+  // brand whose site_id doesn't resolve) rather than surfacing it. Assumed prevented by FK
+  // constraints today; not verified by this script.
   const rows = await fetchAllRows(
     'site_enrollments',
     'id,site_id,entitlement_id,entitlements!inner(organization_id,product_code),sites!inner(organization_id,base_url)',
@@ -247,7 +252,7 @@ try {
   }
 } catch (error) {
   failed = true;
-  log.error(`FAILED to check foreign LLMO enrollments: ${error.message}`, error);
+  log.error(`FAILED to check foreign LLMO enrollments: ${error.message}`);
 }
 
 try {
@@ -266,7 +271,7 @@ try {
   }
 } catch (error) {
   failed = true;
-  log.error(`FAILED to check active brand integrity: ${error.message}`, error);
+  log.error(`FAILED to check active brand integrity: ${error.message}`);
 }
 
 exit(failed ? 1 : 0);

--- a/scripts/reconcile-org-identity-integrity.mjs
+++ b/scripts/reconcile-org-identity-integrity.mjs
@@ -111,6 +111,9 @@ const log = console;
 // mysticat-data-service), and createDataAccess simply omits the apikey/Authorization headers
 // when it's absent, falling back to the unauthenticated postgrest_anon role — the same pattern
 // scripts/reconcile-prompt-suggestion-schedules.mjs already documents for its own PostgREST reads.
+if (!env.POSTGREST_API_KEY) {
+  log.warn('POSTGREST_API_KEY not set; running as postgrest_anon');
+}
 const dataAccess = createDataAccess({
   postgrestUrl: env.POSTGREST_URL,
   postgrestSchema: env.POSTGREST_SCHEMA,
@@ -125,14 +128,13 @@ const MAX_ROWS_PER_FETCH = 200_000;
 
 /**
  * Fetches every row of a PostgREST table/select via keyset pagination on the immutable primary
- * key `id` (not a mutable timestamp, and not offset pagination — see below). Termination is
- * driven by an exact server-side row count (`{ count: 'exact' }`), not by "this page came back
- * short": PostgREST's own `db-max-rows` config can silently cap the rows a single page returns
- * below the requested limit, so a short page does NOT reliably mean "no more data" — relying on
- * it would let a `db-max-rows` cap at or below `pageSize` silently truncate the sweep into a
- * clean-looking but wrong "0 drift" report. `count: 'exact'` is unaffected by that per-page cap
- * (PostgREST computes it against the full filtered result set), so `rows.length >= totalCount`
- * is the only safe stop condition.
+ * key `id` (not a mutable timestamp, and not offset pagination — see below). Termination is on
+ * an EMPTY page (`data.length === 0`), not a SHORT one (`data.length < pageSize`): PostgREST's
+ * own `db-max-rows` config can silently cap the rows a single page returns below the requested
+ * limit, so a short-but-non-empty page does not reliably mean "no more data" under offset
+ * pagination. Keyset pagination removes the need to special-case that: asking for "up to
+ * `pageSize` rows with `id` greater than the last one seen" and getting zero back always means
+ * there is nothing left, cap or no cap, so an exact server-side row count isn't needed either.
  *
  * Keyset (`.gt('id', lastId)`) rather than offset (`.range(from, to)`) for the cursor itself: an
  * offset cursor advances by a fixed amount per page, so if a page were ever short for any reason
@@ -149,21 +151,17 @@ const MAX_ROWS_PER_FETCH = 200_000;
 async function fetchAllRows(table, select, applyFilter = (q) => q) {
   const rows = [];
   let lastId = null;
-  let totalCount = null;
   for (;;) {
     let query = applyFilter(
-      postgrestClient.from(table).select(select, { count: 'exact' }).order('id', { ascending: true }),
+      postgrestClient.from(table).select(select).order('id', { ascending: true }),
     );
     if (lastId !== null) {
       query = query.gt('id', lastId);
     }
     // eslint-disable-next-line no-await-in-loop
-    const { data, error, count } = await query.limit(pageSize);
+    const { data, error } = await query.limit(pageSize);
     if (error) {
       throw new Error(`Failed to fetch ${table} rows after id=${lastId ?? '(start)'}: ${error.message}`);
-    }
-    if (totalCount === null) {
-      totalCount = count;
     }
     if (rows.length + (data?.length ?? 0) > MAX_ROWS_PER_FETCH) {
       throw new Error(
@@ -172,8 +170,8 @@ async function fetchAllRows(table, select, applyFilter = (q) => q) {
       );
     }
     rows.push(...(data ?? []));
-    if (!data || data.length === 0 || rows.length >= totalCount) {
-      log.info(`Fetched ${rows.length}/${totalCount ?? '?'} rows from ${table}`);
+    if (!data || data.length === 0) {
+      log.info(`Fetched ${rows.length} rows from ${table}`);
       return rows;
     }
     lastId = data[data.length - 1].id;

--- a/scripts/reconcile-org-identity-integrity.mjs
+++ b/scripts/reconcile-org-identity-integrity.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+/**
+ * LLMO-7218 (AC8, AC9, AC12 + the "Monitoring" scope's foreign-enrollment / duplicate-brand
+ * items): a read-only, always-dry-run reconciliation report over three org/identity integrity
+ * signals. This script NEVER writes anything — per AC12 ("a production-safe dry-run command or
+ * report identifies existing records requiring remediation without mutating them") and because
+ * no code path anywhere in this codebase reassigns a site's organization today (confirmed by
+ * repo-wide search), so there is nothing safe to auto-fix yet; a fix requires a human decision
+ * about which side (the enrollment, the brand, or the site) is actually wrong for a given row.
+ *
+ * Three checks, run independently and reported separately:
+ *
+ * 1. Foreign LLMO enrollments (AC8's detection half): a `site_enrollments` row whose
+ *    entitlement's `organization_id` differs from the site's CURRENT `organization_id`. This is
+ *    the exact drift the ticket describes — "LLMO enrollments tied to an entitlement from
+ *    another organization" — and confirmed structurally possible because `site_enrollments` has
+ *    no `organization_id` column of its own; it only reaches an org indirectly via
+ *    `entitlement_id`, so nothing re-links it when a site's own `organization_id` changes.
+ * 2. Duplicate active normalized brand identities (AC9's detection half, the part NOT already
+ *    covered by the DB): `brands` already has an exact-match unique constraint
+ *    (`uq_brand_name_per_org`, `UNIQUE (organization_id, name)`), so this only surfaces
+ *    *normalized* variants that constraint can't catch — different whitespace or casing within
+ *    the same organization (e.g. "Acme Inc" vs "acme  inc"). Normalization here is
+ *    whitespace-collapse + case-fold, the same shape as the established
+ *    `transformer.py::_normalize_org_name()` / `book.py::_inline()` pattern from LLMO-7117,
+ *    reimplemented in JS since there's no shared cross-language normalization helper.
+ * 3. Brand/site organization mismatch: an active brand's own `organization_id` differs from its
+ *    anchor site's CURRENT `organization_id` (via `brands.site_id`). Every active brand has a
+ *    non-null `site_id` (enforced by `chk_active_brand_has_site_id`), so this join is always
+ *    resolvable for the rows this check considers.
+ *
+ * None of these three needs a database migration, RPC function, or raw SQL: PostgREST can't
+ * compare two columns to each other directly in a filter, so all three fetch the relevant rows
+ * (paginated, via the standard REST embed pattern already used elsewhere in this codebase) and
+ * do the cross-referencing in JS.
+ *
+ * Usage:
+ *   POSTGREST_URL=<url> node scripts/reconcile-org-identity-integrity.mjs [--page-size N]
+ *
+ * Exit status:
+ *   0  Report completed (regardless of whether any drift was found — finding drift is the
+ *      expected, useful outcome of a report, not a failure).
+ *   1  The report itself could not complete (a page fetch failed).
+ *
+ * Get POSTGREST_URL from the target env's Lambda configuration, same as the other scripts in
+ * this directory:
+ *   aws lambda get-function-configuration --function-name spacecat-api-service-<env> \
+ *     --query 'Environment.Variables.POSTGREST_URL'
+ */
+
+import { createDataAccess } from '@adobe/spacecat-shared-data-access';
+import { parseArgs } from 'node:util';
+import { env, exit } from 'node:process';
+
+const DEFAULT_PAGE_SIZE = 500;
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    'page-size': { type: 'string' },
+  },
+});
+
+function parsePageSize(raw) {
+  if (raw === undefined) {
+    return DEFAULT_PAGE_SIZE;
+  }
+  const n = Number(raw);
+  if (Number.isNaN(n) || !Number.isInteger(n) || n < 1) {
+    console.error(`ERROR: --page-size must be a positive integer, got "${raw}"`);
+    exit(1);
+  }
+  return n;
+}
+
+const pageSize = parsePageSize(values['page-size']);
+
+if (!env.POSTGREST_URL) {
+  console.error('ERROR: POSTGREST_URL is required');
+  exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+const log = console;
+const dataAccess = createDataAccess({
+  postgrestUrl: env.POSTGREST_URL,
+  postgrestSchema: env.POSTGREST_SCHEMA,
+  postgrestApiKey: env.POSTGREST_API_KEY,
+}, log);
+const { postgrestClient } = dataAccess.services;
+
+/**
+ * Fetches every row of a PostgREST table/select via offset pagination, sorted by the immutable
+ * primary key `id` (not a mutable timestamp) so a concurrent write elsewhere in the fleet can't
+ * shift row order across a page boundary and cause a row to be silently skipped or duplicated —
+ * the same class of bug fixed in scripts/reconcile-prompt-suggestion-schedules.mjs's own
+ * fleet-wide sweep.
+ * @param {string} table
+ * @param {string} select
+ * @param {(query: object) => object} [applyFilter] - optional filter chain applied to the query.
+ * @returns {Promise<object[]>}
+ */
+async function fetchAllRows(table, select, applyFilter = (q) => q) {
+  const rows = [];
+  let from = 0;
+  for (;;) {
+    const to = from + pageSize - 1;
+    // eslint-disable-next-line no-await-in-loop
+    const { data, error } = await applyFilter(
+      postgrestClient.from(table).select(select).order('id', { ascending: true }),
+    ).range(from, to);
+    if (error) {
+      throw new Error(`Failed to fetch ${table} rows ${from}-${to}: ${error.message}`);
+    }
+    rows.push(...(data ?? []));
+    if (!data || data.length < pageSize) {
+      return rows;
+    }
+    from += pageSize;
+  }
+}
+
+/** Whitespace-collapse + case-fold, matching the established LLMO-7117 normalization shape. */
+function normalizeBrandName(name) {
+  return String(name ?? '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Check 1: foreign LLMO enrollments
+// ---------------------------------------------------------------------------
+async function findForeignLlmoEnrollments() {
+  const rows = await fetchAllRows(
+    'site_enrollments',
+    'id,site_id,entitlement_id,entitlements!inner(organization_id,product_code),sites!inner(organization_id,base_url)',
+    (q) => q.eq('entitlements.product_code', 'LLMO'),
+  );
+  return rows
+    .filter((row) => row.entitlements.organization_id !== row.sites.organization_id)
+    .map((row) => ({
+      enrollmentId: row.id,
+      siteId: row.site_id,
+      siteBaseUrl: row.sites.base_url,
+      siteOrganizationId: row.sites.organization_id,
+      entitlementId: row.entitlement_id,
+      entitlementOrganizationId: row.entitlements.organization_id,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Checks 2 and 3: duplicate normalized active brands, and brand/site org mismatch
+// (share one fetch — both only ever consider active brands)
+// ---------------------------------------------------------------------------
+async function findActiveBrandIntegrityIssues() {
+  const brands = await fetchAllRows(
+    'brands',
+    'id,name,organization_id,site_id,sites!inner(organization_id,base_url)',
+    (q) => q.eq('status', 'active'),
+  );
+
+  const byOrgAndNormalizedName = new Map();
+  const orgMismatches = [];
+  for (const brand of brands) {
+    const key = `${brand.organization_id}::${normalizeBrandName(brand.name)}`;
+    const group = byOrgAndNormalizedName.get(key) ?? [];
+    group.push(brand);
+    byOrgAndNormalizedName.set(key, group);
+
+    if (brand.organization_id !== brand.sites.organization_id) {
+      orgMismatches.push({
+        brandId: brand.id,
+        brandName: brand.name,
+        brandOrganizationId: brand.organization_id,
+        siteId: brand.site_id,
+        siteBaseUrl: brand.sites.base_url,
+        siteOrganizationId: brand.sites.organization_id,
+      });
+    }
+  }
+
+  const duplicateNormalizedNames = [...byOrgAndNormalizedName.values()]
+    .filter((group) => group.length > 1)
+    .map((group) => ({
+      organizationId: group[0].organization_id,
+      normalizedName: normalizeBrandName(group[0].name),
+      brands: group.map((b) => ({ id: b.id, name: b.name })),
+    }));
+
+  return { duplicateNormalizedNames, orgMismatches };
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+log.info('Reconciliation report: org/identity integrity (read-only, no writes)');
+
+let failed = false;
+
+try {
+  const foreignEnrollments = await findForeignLlmoEnrollments();
+  log.info('---');
+  log.info(`Foreign LLMO enrollments: ${foreignEnrollments.length}`);
+  for (const row of foreignEnrollments) {
+    log.warn(`  enrollment=${row.enrollmentId} site=${row.siteId} (${row.siteBaseUrl}, org=${row.siteOrganizationId}) entitlement=${row.entitlementId} (org=${row.entitlementOrganizationId})`);
+  }
+} catch (error) {
+  failed = true;
+  log.error(`FAILED to check foreign LLMO enrollments: ${error.message}`, error);
+}
+
+try {
+  const { duplicateNormalizedNames, orgMismatches } = await findActiveBrandIntegrityIssues();
+
+  log.info('---');
+  log.info(`Duplicate active normalized brand identities: ${duplicateNormalizedNames.length}`);
+  for (const group of duplicateNormalizedNames) {
+    log.warn(`  org=${group.organizationId} normalized="${group.normalizedName}" brands=[${group.brands.map((b) => `${b.id} (${JSON.stringify(b.name)})`).join(', ')}]`);
+  }
+
+  log.info('---');
+  log.info(`Active brand / site organization mismatches: ${orgMismatches.length}`);
+  for (const row of orgMismatches) {
+    log.warn(`  brand=${row.brandId} (${row.brandName}, org=${row.brandOrganizationId}) site=${row.siteId} (${row.siteBaseUrl}, org=${row.siteOrganizationId})`);
+  }
+} catch (error) {
+  failed = true;
+  log.error(`FAILED to check active brand integrity: ${error.message}`, error);
+}
+
+exit(failed ? 1 : 0);

--- a/scripts/reconcile-org-identity-integrity.mjs
+++ b/scripts/reconcile-org-identity-integrity.mjs
@@ -125,8 +125,12 @@ const MAX_ROWS_PER_FETCH = 200_000;
  * concurrent DELETE of an earlier-sorting row still shifts every later offset by one, which can
  * skip the row that slides into the just-fetched range. Deletes of the rows this script cares
  * about (entitlements, site_enrollments, brands) are rare enough that this is an accepted gap,
- * not a solved one — same offset-pagination shape as
- * scripts/reconcile-prompt-suggestion-schedules.mjs's own fleet-wide sweep.
+ * not a solved one. scripts/reconcile-prompt-suggestion-schedules.mjs's own fleet-wide sweep
+ * avoids this class of bug entirely by using cursor pagination
+ * (`Site.allByEnrollmentFiltered({ cursor, returnCursor, orderBy: { attribute: 'siteId' } })`)
+ * through the data-access model layer rather than PostgREST offset pagination; this script
+ * stays on `.range()` for simplicity, since the three tables it reads are not expected to see
+ * deletes during a run.
  * @param {string} table
  * @param {string} select
  * @param {(query: object) => object} [applyFilter] - optional filter chain applied to the query.
@@ -239,7 +243,7 @@ try {
   log.info('---');
   log.info(`Foreign LLMO enrollments: ${foreignEnrollments.length}`);
   for (const row of foreignEnrollments) {
-    log.warn(`  enrollment=${row.enrollmentId} site=${row.siteId} (${row.siteBaseUrl}, org=${row.siteOrganizationId}) entitlement=${row.entitlementId} (org=${row.entitlementOrganizationId})`);
+    log.warn(`  enrollment=${row.enrollmentId} site=${row.siteId} (${JSON.stringify(row.siteBaseUrl)}, org=${row.siteOrganizationId}) entitlement=${row.entitlementId} (org=${row.entitlementOrganizationId})`);
   }
 } catch (error) {
   failed = true;
@@ -258,7 +262,7 @@ try {
   log.info('---');
   log.info(`Active brand / site organization mismatches: ${orgMismatches.length}`);
   for (const row of orgMismatches) {
-    log.warn(`  brand=${row.brandId} (${row.brandName}, org=${row.brandOrganizationId}) site=${row.siteId} (${row.siteBaseUrl}, org=${row.siteOrganizationId})`);
+    log.warn(`  brand=${row.brandId} (${JSON.stringify(row.brandName)}, org=${row.brandOrganizationId}) site=${row.siteId} (${JSON.stringify(row.siteBaseUrl)}, org=${row.siteOrganizationId})`);
   }
 } catch (error) {
   failed = true;

--- a/scripts/reconcile-org-identity-integrity.mjs
+++ b/scripts/reconcile-org-identity-integrity.mjs
@@ -78,13 +78,18 @@ const { values } = parseArgs({
   },
 });
 
+// Upper bound on --page-size: PostgREST's own db-max-rows config is a server-side backstop,
+// but a large operator-supplied value still asks for a single huge range unnecessarily -
+// capping here gives a clear error instead of relying on that backstop.
+const MAX_PAGE_SIZE = 10_000;
+
 function parsePageSize(raw) {
   if (raw === undefined) {
     return DEFAULT_PAGE_SIZE;
   }
   const n = Number(raw);
-  if (Number.isNaN(n) || !Number.isInteger(n) || n < 1) {
-    console.error(`ERROR: --page-size must be a positive integer, got "${raw}"`);
+  if (Number.isNaN(n) || !Number.isInteger(n) || n < 1 || n > MAX_PAGE_SIZE) {
+    console.error(`ERROR: --page-size must be a positive integer no greater than ${MAX_PAGE_SIZE}, got "${raw}"`);
     exit(1);
   }
   return n;
@@ -119,18 +124,23 @@ const { postgrestClient } = dataAccess.services;
 const MAX_ROWS_PER_FETCH = 200_000;
 
 /**
- * Fetches every row of a PostgREST table/select via offset pagination, sorted by the immutable
- * primary key `id` (not a mutable timestamp) so a concurrent UPDATE elsewhere in the fleet can't
- * reorder rows across a page boundary. This does NOT make the sweep fully concurrency-safe: a
- * concurrent DELETE of an earlier-sorting row still shifts every later offset by one, which can
- * skip the row that slides into the just-fetched range. Deletes of the rows this script cares
- * about (entitlements, site_enrollments, brands) are rare enough that this is an accepted gap,
- * not a solved one. scripts/reconcile-prompt-suggestion-schedules.mjs's own fleet-wide sweep
- * avoids this class of bug entirely by using cursor pagination
- * (`Site.allByEnrollmentFiltered({ cursor, returnCursor, orderBy: { attribute: 'siteId' } })`)
- * through the data-access model layer rather than PostgREST offset pagination; this script
- * stays on `.range()` for simplicity, since the three tables it reads are not expected to see
- * deletes during a run.
+ * Fetches every row of a PostgREST table/select via keyset pagination on the immutable primary
+ * key `id` (not a mutable timestamp, and not offset pagination — see below). Termination is
+ * driven by an exact server-side row count (`{ count: 'exact' }`), not by "this page came back
+ * short": PostgREST's own `db-max-rows` config can silently cap the rows a single page returns
+ * below the requested limit, so a short page does NOT reliably mean "no more data" — relying on
+ * it would let a `db-max-rows` cap at or below `pageSize` silently truncate the sweep into a
+ * clean-looking but wrong "0 drift" report. `count: 'exact'` is unaffected by that per-page cap
+ * (PostgREST computes it against the full filtered result set), so `rows.length >= totalCount`
+ * is the only safe stop condition.
+ *
+ * Keyset (`.gt('id', lastId)`) rather than offset (`.range(from, to)`) for the cursor itself: an
+ * offset cursor advances by a fixed amount per page, so if a page were ever short for any reason
+ * (including the `db-max-rows` cap above), advancing by the full `pageSize` would skip the rows
+ * that page never returned. A keyset cursor always resumes exactly after the last row actually
+ * seen, so nothing is skippable regardless of how many rows any single page returns. It also
+ * incidentally closes the gap the offset approach had with concurrent deletes (a deleted
+ * earlier-sorting row can no longer shift a later page's boundary).
  * @param {string} table
  * @param {string} select
  * @param {(query: object) => object} [applyFilter] - optional filter chain applied to the query.
@@ -138,15 +148,22 @@ const MAX_ROWS_PER_FETCH = 200_000;
  */
 async function fetchAllRows(table, select, applyFilter = (q) => q) {
   const rows = [];
-  let from = 0;
+  let lastId = null;
+  let totalCount = null;
   for (;;) {
-    const to = from + pageSize - 1;
+    let query = applyFilter(
+      postgrestClient.from(table).select(select, { count: 'exact' }).order('id', { ascending: true }),
+    );
+    if (lastId !== null) {
+      query = query.gt('id', lastId);
+    }
     // eslint-disable-next-line no-await-in-loop
-    const { data, error } = await applyFilter(
-      postgrestClient.from(table).select(select).order('id', { ascending: true }),
-    ).range(from, to);
+    const { data, error, count } = await query.limit(pageSize);
     if (error) {
-      throw new Error(`Failed to fetch ${table} rows ${from}-${to}: ${error.message}`);
+      throw new Error(`Failed to fetch ${table} rows after id=${lastId ?? '(start)'}: ${error.message}`);
+    }
+    if (totalCount === null) {
+      totalCount = count;
     }
     if (rows.length + (data?.length ?? 0) > MAX_ROWS_PER_FETCH) {
       throw new Error(
@@ -155,11 +172,11 @@ async function fetchAllRows(table, select, applyFilter = (q) => q) {
       );
     }
     rows.push(...(data ?? []));
-    if (!data || data.length < pageSize) {
-      log.info(`Fetched ${rows.length} rows from ${table}`);
+    if (!data || data.length === 0 || rows.length >= totalCount) {
+      log.info(`Fetched ${rows.length}/${totalCount ?? '?'} rows from ${table}`);
       return rows;
     }
-    from += pageSize;
+    lastId = data[data.length - 1].id;
   }
 }
 
@@ -261,7 +278,7 @@ try {
   log.info('---');
   log.info(`Duplicate active normalized brand identities: ${duplicateNormalizedNames.length}`);
   for (const group of duplicateNormalizedNames) {
-    log.warn(`  org=${group.organizationId} normalized="${group.normalizedName}" brands=[${group.brands.map((b) => `${b.id} (${JSON.stringify(b.name)})`).join(', ')}]`);
+    log.warn(`  org=${group.organizationId} normalized=${JSON.stringify(group.normalizedName)} brands=[${group.brands.map((b) => `${b.id} (${JSON.stringify(b.name)})`).join(', ')}]`);
   }
 
   log.info('---');

--- a/scripts/reconcile-org-identity-integrity.mjs
+++ b/scripts/reconcile-org-identity-integrity.mjs
@@ -101,6 +101,11 @@ if (!env.POSTGREST_URL) {
 // Init
 // ---------------------------------------------------------------------------
 const log = console;
+// POSTGREST_API_KEY is deliberately NOT required: this script only ever reads (entitlements,
+// site_enrollments, brands are all `GRANT SELECT ... TO postgrest_anon` with no RLS policy in
+// mysticat-data-service), and createDataAccess simply omits the apikey/Authorization headers
+// when it's absent, falling back to the unauthenticated postgrest_anon role — the same pattern
+// scripts/reconcile-prompt-suggestion-schedules.mjs already documents for its own PostgREST reads.
 const dataAccess = createDataAccess({
   postgrestUrl: env.POSTGREST_URL,
   postgrestSchema: env.POSTGREST_SCHEMA,
@@ -108,12 +113,20 @@ const dataAccess = createDataAccess({
 }, log);
 const { postgrestClient } = dataAccess.services;
 
+// Hard ceiling on rows accumulated by a single fetchAllRows() call — not a realistic size for
+// any of this script's three tables today, but a safety valve against unbounded memory growth
+// if a filter regresses to matching far more rows than expected, or a pagination bug loops.
+const MAX_ROWS_PER_FETCH = 200_000;
+
 /**
  * Fetches every row of a PostgREST table/select via offset pagination, sorted by the immutable
- * primary key `id` (not a mutable timestamp) so a concurrent write elsewhere in the fleet can't
- * shift row order across a page boundary and cause a row to be silently skipped or duplicated —
- * the same class of bug fixed in scripts/reconcile-prompt-suggestion-schedules.mjs's own
- * fleet-wide sweep.
+ * primary key `id` (not a mutable timestamp) so a concurrent UPDATE elsewhere in the fleet can't
+ * reorder rows across a page boundary. This does NOT make the sweep fully concurrency-safe: a
+ * concurrent DELETE of an earlier-sorting row still shifts every later offset by one, which can
+ * skip the row that slides into the just-fetched range. Deletes of the rows this script cares
+ * about (entitlements, site_enrollments, brands) are rare enough that this is an accepted gap,
+ * not a solved one — same offset-pagination shape as
+ * scripts/reconcile-prompt-suggestion-schedules.mjs's own fleet-wide sweep.
  * @param {string} table
  * @param {string} select
  * @param {(query: object) => object} [applyFilter] - optional filter chain applied to the query.
@@ -132,7 +145,14 @@ async function fetchAllRows(table, select, applyFilter = (q) => q) {
       throw new Error(`Failed to fetch ${table} rows ${from}-${to}: ${error.message}`);
     }
     rows.push(...(data ?? []));
+    if (rows.length > MAX_ROWS_PER_FETCH) {
+      throw new Error(
+        `Aborting fetch of ${table}: exceeded ${MAX_ROWS_PER_FETCH} rows, which is far beyond `
+        + 'this table\'s expected size and likely indicates a filter or pagination bug.',
+      );
+    }
     if (!data || data.length < pageSize) {
+      log.info(`Fetched ${rows.length} rows from ${table}`);
       return rows;
     }
     from += pageSize;


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a read-only, always-dry-run reconciliation report over three org/identity integrity signals: foreign LLMO enrollments, duplicate active normalized brand identities, and active brand/site organization mismatches.

## 2. Reasoning
LLMO-7218 Phase 4 ("Organization and identity integrity") asks for canonical active-brand enforcement, duplicate-identity prevention, and detection of site organization drift, plus an explicit AC12 requirement: "a production-safe dry-run command or report identifies existing records requiring remediation without mutating them." Investigation this session found the schema-level duplicate-brand gap is narrower than the ticket implies — `brands` already has an exact-match `UNIQUE(organization_id, name)` constraint, so only normalized (whitespace/case) variants slip through — and, more significantly, that no code path anywhere in this codebase reassigns a site's organization today, so there is no live write path actively creating enrollment/brand drift to hook a fix into. Building a speculative reassignment endpoint with no current caller would be premature; the safe, valuable first deliverable is the detection report the ticket itself calls for.

## 3. High-level overview of the changes
Before: no tooling existed to detect foreign LLMO enrollments, normalized-duplicate active brands, or brand/site organization mismatches anywhere in the fleet.

After: `scripts/reconcile-org-identity-integrity.mjs` (new, standalone ops script, no request-serving behaviour changes) runs three independent checks and reports each separately:
- Foreign LLMO enrollments: a `site_enrollments` row whose entitlement's `organization_id` differs from its site's current `organization_id` — possible because `site_enrollments` only reaches an org indirectly via `entitlement_id`, with no `organization_id` column of its own.
- Duplicate active normalized brand identities: groups active brands by `(organization_id, normalized name)`, surfacing only the variants the existing exact-match DB constraint can't catch. Normalization is whitespace-collapse + case-fold, the same shape as LLMO-7117's established `transformer.py::_normalize_org_name()` pattern.
- Active brand / site organization mismatch: an active brand's own `organization_id` versus its anchor site's current `organization_id` (every active brand has a non-null `site_id` per the `chk_active_brand_has_site_id` constraint, so this join always resolves).

No migration or RPC function is added — PostgREST can't compare two columns to each other in a filter, so all three fetch the relevant rows (paginated by the immutable `id`, not a volatile timestamp, for the same reason Phase 1's reconciler sorts that way) and cross-reference in JS. The script never writes anything and has no `--execute` mode at all.

## 4. Required information
- Jira / issue: [LLMO-7218](https://jira.corp.adobe.com/browse/LLMO-7218)

## 6. Affected / used mysticat-workspace projects
- `mysticat-data-service` (consumed): reads `sites` / `site_enrollments` / `entitlements` / `brands` via PostgREST; no schema or code there changes.

## 8. Test plan
(a) Local: `node --check` and `eslint` clean; ran the script directly against an intentionally unreachable `POSTGREST_URL` to confirm both checks correctly build their PostgREST query — the same nested-embed-then-dot-path-filter idiom already used in this codebase's own `Site.allByEnrollmentFiltered` — and fail with a controlled, reported error (exit 1) rather than an uncaught crash. Could not verify against live data this session — no dev/stage credentials were available.
(b) Per-environment verification:
  - **dev/stage**: run once and manually inspect a sample of any reported rows against the actual DB to confirm the query's join semantics match intent before trusting the report at scale.
  - **prod**: run as a read-only report; each of the three sections needs a human decision (which side of a mismatched row is authoritative) before any fix is written — this PR intentionally does not include a fix path.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: no-impact
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Standalone script, always dry-run with no execute mode at all — pure detection report, cannot mutate data."
```