### PR TITLE
feat: add CloudFront connector template download endpoint | LLMO-7074

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -764,6 +764,8 @@ paths:
     $ref: './llmo-api.yaml#/site-llmo-cloudfront-plan'
   /sites/{siteId}/llmo/cdn-onboard/cloudfront/permissions:
     $ref: './llmo-api.yaml#/site-llmo-cloudfront-permissions'
+  /sites/{siteId}/llmo/cdn-onboard/cloudfront/template:
+    $ref: './llmo-api.yaml#/site-llmo-cloudfront-template'
   /sites/{siteId}/llmo/cdn-onboard/cloudfront/log-delivery:
     $ref: './llmo-api.yaml#/site-llmo-cloudfront-log-delivery'
   /sites/{siteId}/llmo/cdn-onboard/cloudfront/log-rescan:

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -3503,6 +3503,39 @@ site-llmo-cloudfront-permissions:
     security:
       - api_key: [ ]
 
+site-llmo-cloudfront-template:
+  get:
+    tags:
+      - llmo
+    summary: Download the CloudFront connector role CloudFormation template
+    description: |
+      Returns the raw CloudFormation connector-role template as a YAML file download. It is the
+      same template the AWS quick-create link uses, for customers who create the stack manually
+      (expired quick-create presign, or no AWS console admin access). Read-only — no cross-account
+      customer AWS calls.
+    operationId: getLlmoCloudFrontTemplate
+    parameters:
+      - $ref: './parameters.yaml#/siteId'
+    responses:
+      '200':
+        description: The CloudFront connector role CloudFormation template YAML.
+        content:
+          text/yaml:
+            schema:
+              type: string
+      '400':
+        $ref: './responses.yaml#/400'
+      '401':
+        $ref: './responses.yaml#/401'
+      '403':
+        $ref: './responses.yaml#/403'
+      '404':
+        $ref: './responses.yaml#/404'
+      '500':
+        $ref: './responses.yaml#/500'
+    security:
+      - api_key: [ ]
+
 site-llmo-cloudfront-log-delivery:
   post:
     tags:

--- a/src/controllers/llmo/llmo-cloudfront.js
+++ b/src/controllers/llmo/llmo-cloudfront.js
@@ -1221,6 +1221,57 @@ function LlmoCloudFrontController(ctx) {
     }
   };
 
+  /**
+   * GET /sites/{siteId}/llmo/cdn-onboard/cloudfront/template
+   * Returns the raw CloudFormation connector-role template YAML as a file download, so a customer
+   * who can't use the quick-create link (expired presign, not an AWS console admin) can create the
+   * stack by hand. Serves the SAME S3 object the quick-create URL presigns and the permissions
+   * endpoint reads (env.EDGE_OPTIMIZE_TEMPLATE_KEY), so the download can't drift from the wizard.
+   * Read-only — gated on site access + LLMO admin (like getPermissions). No cross-account calls.
+   * @param {object} context - Request context
+   * @returns {Promise<Response>} 200 text/yaml attachment, or a 400/500 on a config/read failure.
+   */
+  const getTemplate = async (context) => {
+    const {
+      log, dataAccess, env, s3,
+    } = context;
+    const { siteId } = context.params;
+    const { Site } = dataAccess;
+
+    try {
+      const { error } = await gateEdgeOptimizeWizard(siteId, Site, 'download the CloudFront connector template');
+      if (error) {
+        return error;
+      }
+
+      const bucket = env.SPACECAT_CDN_CLOUDFRONT_TEMPLATE_BUCKET;
+      if (!hasText(bucket) || !s3?.s3Client || !s3?.GetObjectCommand) {
+        return badRequest('CloudFront template hosting is not configured for this environment');
+      }
+      // Same object the quick-create URL presigns and getPermissions reads — one source of truth.
+      const key = env.EDGE_OPTIMIZE_TEMPLATE_KEY || 'customer-bootstrap-role.yaml';
+
+      const response = await s3.s3Client.send(new s3.GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }));
+      const body = await response.Body.transformToString();
+
+      log.info(auditLine(context, 'template', 'downloaded', { siteId }));
+      // Raw YAML file download (not JSON). cleanupHeaderValue guards the filename header.
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'content-type': 'text/yaml; charset=utf-8',
+          'content-disposition': `attachment; filename="${cleanupHeaderValue(key)}"`,
+        },
+      });
+    } catch (error) {
+      log.error(`Failed to read the CloudFront connector template for site ${siteId}:`, error);
+      return internalServerError('Failed to read the CloudFront connector template, please try again');
+    }
+  };
+
   // Enable CDN access-log forwarding for a SINGLE CloudFront distribution to Adobe's cross-account
   // cdn-logs destination (mutation, idempotent). The assume-role externalId is the per-session UUID
   // from bootstrap (client-supplied, must match the connector role's trust policy); the delivery
@@ -1424,6 +1475,7 @@ function LlmoCloudFrontController(ctx) {
     deploy,
     plan,
     getPermissions,
+    getTemplate,
     enableCdnLogDelivery,
     rescanCdnLogDelivery,
   };

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -516,6 +516,7 @@ const routeFacsCapabilities = {
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/deploy': 'llmo/can_configure',
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/plan': 'llmo/can_configure',
       'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/permissions': 'llmo/can_configure',
+      'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/template': 'llmo/can_configure',
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-delivery': 'llmo/can_configure',
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-rescan': 'llmo/can_configure',
       'GET /sites/:siteId/llmo/cdn-onboard/cloudflare/config': 'llmo/can_configure',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -621,6 +621,7 @@ export default function getRouteHandlers(
     'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/deploy': llmoCloudFrontController.deploy,
     'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/plan': llmoCloudFrontController.plan,
     'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/permissions': llmoCloudFrontController.getPermissions,
+    'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/template': llmoCloudFrontController.getTemplate,
     'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-delivery': llmoCloudFrontController.enableCdnLogDelivery,
     'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-rescan': llmoCloudFrontController.rescanCdnLogDelivery,
     'GET /sites/:siteId/llmo/strategy': llmoController.getStrategy,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -97,6 +97,7 @@ export const INTERNAL_ROUTES = [
   'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/deploy',
   'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/plan',
   'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/permissions',
+  'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/template',
   'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-delivery',
   'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-rescan',
   'PUT /sites/:siteId/llmo/opportunities-reviewed',

--- a/test/controllers/llmo/llmo-cloudfront.test.js
+++ b/test/controllers/llmo/llmo-cloudfront.test.js
@@ -2286,6 +2286,94 @@ describe('LlmoCloudFrontController', () => {
     });
   });
 
+  describe('getTemplate', () => {
+    let templateContext;
+    let s3SendStub;
+    const sampleTemplate = "AWSTemplateFormatVersion: '2010-09-09'\nResources:\n  ConnectorRole:\n    Type: AWS::IAM::Role\n";
+
+    beforeEach(() => {
+      s3SendStub = sinon.stub().resolves({
+        Body: { transformToString: async () => sampleTemplate },
+      });
+      templateContext = {
+        ...mockContext,
+        params: { siteId: TEST_SITE_ID },
+        env: { SPACECAT_CDN_CLOUDFRONT_TEMPLATE_BUCKET: 'llmo-edgeoptimize-cf-template' },
+        s3: {
+          s3Client: { send: s3SendStub },
+          GetObjectCommand: function MockGetObjectCommand(params) {
+            Object.assign(this, params);
+          },
+        },
+      };
+    });
+
+    it('returns the raw template YAML as a file download', async () => {
+      const result = await controller.getTemplate(templateContext);
+
+      expect(result.status).to.equal(200);
+      expect(result.headers.get('content-type')).to.include('text/yaml');
+      expect(result.headers.get('content-disposition')).to.include('attachment');
+      expect(result.headers.get('content-disposition')).to.include('customer-bootstrap-role.yaml');
+      const body = await result.text();
+      expect(body).to.equal(sampleTemplate);
+      expect(s3SendStub.calledOnce).to.equal(true);
+      const [cmd] = s3SendStub.firstCall.args;
+      expect(cmd.Key).to.equal('customer-bootstrap-role.yaml');
+      expect(cmd.Bucket).to.equal('llmo-edgeoptimize-cf-template');
+    });
+
+    it('reads the env-configured template key', async () => {
+      const result = await controller.getTemplate({
+        ...templateContext,
+        env: {
+          SPACECAT_CDN_CLOUDFRONT_TEMPLATE_BUCKET: 'custom-bucket',
+          EDGE_OPTIMIZE_TEMPLATE_KEY: 'customer-bootstrap-role-log-only.yaml',
+        },
+      });
+      expect(result.status).to.equal(200);
+      const [cmd] = s3SendStub.firstCall.args;
+      expect(cmd.Bucket).to.equal('custom-bucket');
+      expect(cmd.Key).to.equal('customer-bootstrap-role-log-only.yaml');
+      expect(result.headers.get('content-disposition')).to.include('customer-bootstrap-role-log-only.yaml');
+    });
+
+    it('returns 400 when template hosting is not configured (no S3 client)', async () => {
+      const result = await controller.getTemplate({ ...templateContext, s3: {} });
+      expect(result.status).to.equal(400);
+      const body = await result.json();
+      expect(body.message).to.include('not configured');
+    });
+
+    it('returns 500 with a generic message when the S3 read fails', async () => {
+      s3SendStub.rejects(new Error('NoSuchKey'));
+      const result = await controller.getTemplate(templateContext);
+      expect(result.status).to.equal(500);
+      const body = await result.json();
+      expect(body.message).to.not.include('NoSuchKey');
+      expect(body.message).to.include('Failed to read the CloudFront connector template');
+    });
+
+    it('returns 404 when the site is not found', async () => {
+      mockDataAccess.Site.findById.resolves(null);
+      const result = await controller.getTemplate(templateContext);
+      expect(result.status).to.equal(404);
+    });
+
+    it('returns 403 when the user lacks access to the site', async () => {
+      const deniedController = controllerWithAccessDenied(mockContext);
+      const result = await deniedController.getTemplate(templateContext);
+      expect(result.status).to.equal(403);
+    });
+
+    it('returns 403 when the user is not an LLMO administrator', async () => {
+      const LlmoControllerNoAdmin = await esmock('../../../src/controllers/llmo/llmo-cloudfront.js', cfClientMocks(createMockAccessControlUtil(true, true, false)));
+      const result = await LlmoControllerNoAdmin(mockContext)
+        .getTemplate(templateContext);
+      expect(result.status).to.equal(403);
+    });
+  });
+
   describe('enableCdnLogDelivery', () => {
     let logDeliveryContext;
 

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -374,6 +374,7 @@ describe('getRouteHandlers', () => {
     deploy: () => null,
     plan: () => null,
     getPermissions: () => null,
+    getTemplate: () => null,
   };
 
   const mockLlmoAkamaiController = {
@@ -1323,6 +1324,7 @@ describe('getRouteHandlers', () => {
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/deploy',
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/plan',
       'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/permissions',
+      'GET /sites/:siteId/llmo/cdn-onboard/cloudfront/template',
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-delivery',
       'POST /sites/:siteId/llmo/cdn-onboard/cloudfront/log-rescan',
       'GET /sites/:siteId/llmo/edge-optimize-status',


### PR DESCRIPTION
## Related Issues

LLMO-7074 — CloudFront wizard improvements. Enables the UI to offer a "Download template (YAML)" action in the wizard's manual-setup fallback.

## What

Adds `GET /sites/:siteId/llmo/cdn-onboard/cloudfront/template` — returns the raw CloudFormation connector-role template as a YAML file download (`text/yaml`, `Content-Disposition: attachment`).

For customers who can't use the AWS quick-create link (expired presign, or not an AWS console admin) and need to create the connector-role stack by hand.

## How

- New `getTemplate` handler in `src/controllers/llmo/llmo-cloudfront.js`, mirroring `getPermissions`: same `gateEdgeOptimizeWizard` gate (site access + LLMO admin), same S3 object and key (`EDGE_OPTIMIZE_TEMPLATE_KEY`, default `customer-bootstrap-role.yaml`).
- Serves the **same** S3 template the quick-create URL presigns and the permissions endpoint reads — single source of truth, so the download can't drift from what the wizard uses.
- Read-only; no cross-account customer AWS calls.

## API spec

- Updated `docs/openapi/api.yaml` + `docs/openapi/llmo-api.yaml` with the new path (`getLlmoCloudFrontTemplate`), incl. response shape. `npm run docs:lint` passes (pre-existing warnings only).
- `docs/index.html` intentionally left as-is on main — per the repo's CLAUDE.md note, `docs:build` produces non-deterministic hash-noise off the canonical CI toolchain; the spec YAML is the source of truth.

## Tests

- 7 unit tests in `test/controllers/llmo/llmo-cloudfront.test.js` (download success, env-configured key, not-configured 400, S3-failure 500, 404, 403 access, 403 non-admin).
- `test/routes/index.test.js` updated (route enumeration + controller stub).
- No IT added — matches the direct sibling precedent: the S3-backed reads `getPermissions` and `bootstrap-url` have no IT coverage (the Postgres harness has no S3); auth/validation paths are unit-covered.
- Full run: `202 passing`; lint + type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: no-impact
risk: minor
changeApprovedBy: ["Akash Bhardwaj", "Dominique Jäggi"]
rationale: "New read-only GET endpoint serving a static S3 template file behind existing access gates; no data mutation."
```