### PR TITLE
fix(llmo): report onboarding success honestly when required work fails

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -1200,6 +1200,52 @@ llmo-onboard:
                     the request body; omitted when the DRS default ('US')
                     applies.
                   example: "IN"
+                brandActivation:
+                  type: object
+                  description: |
+                    Submission-level outcome of the brand activation / prompt-generation
+                    side-effects (LLMO-7218). "Submission" because Brandalf and prompt
+                    generation both complete asynchronously via a DRS-side callback this
+                    endpoint has no visibility into — this reports whether the required
+                    work was successfully HANDED OFF to DRS, not whether it eventually
+                    succeeded. Omitted for site-only onboarding, which never runs this step.
+                  properties:
+                    brandalfTriggered:
+                      type: boolean
+                      description: True if the Brandalf brand-identification job was
+                        successfully submitted (v2 onboarding mode only; always false in v1).
+                    brandalfError:
+                      type:
+                        - string
+                        - 'null'
+                      description: Reason the Brandalf submission failed or was skipped, if any.
+                    promptGenerationJobId:
+                      type:
+                        - string
+                        - 'null'
+                      description: The v1-mode direct prompt-generation DRS job id, if submitted.
+                    promptGenerationError:
+                      type:
+                        - string
+                        - 'null'
+                      description: Reason the v1-mode prompt-generation submission failed, if any.
+                    promptSuggestionSchedules:
+                      type:
+                        - array
+                        - 'null'
+                      description: Per-pipeline registration result (v2 mode only); null when
+                        registration timed out rather than completed.
+                      items:
+                        type: object
+                    promptSuggestionSchedulesTimedOut:
+                      type: boolean
+                      description: True if prompt-suggestion schedule registration timed out
+                        before completing (v2 mode only).
+                    requiredWorkFailed:
+                      type: boolean
+                      description: True if any required submission for the resolved onboarding
+                        mode failed. When true, `message` reports a degraded outcome instead of
+                        unconditional success.
               required:
                 - message
                 - domain

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -1237,6 +1237,20 @@ llmo-onboard:
                         registration timed out rather than completed.
                       items:
                         type: object
+                        properties:
+                          providerId:
+                            type: string
+                            description: The prompt-suggestion pipeline's provider id.
+                          status:
+                            type: string
+                            enum: ["created", "already-existed", "submitted", "failed"]
+                            description: |
+                              "created"/"already-existed" for a paying site's recurring schedule;
+                              "submitted" for a trial site's one-shot run; "failed" if
+                              registration/submission itself failed.
+                          error:
+                            type: string
+                            description: Present only when status is "failed".
                     promptSuggestionSchedulesTimedOut:
                       type: boolean
                       description: True if prompt-suggestion schedule registration timed out

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1634,7 +1634,7 @@ export async function activateBrandAndGeneratePrompts({
   // also ends this onboarding with zero prompts, so the same signal applies.
   const requiredWorkFailed = onboardingMode === LLMO_ONBOARDING_MODE_V2
     ? !brandalfTriggered || promptSuggestionSchedulesTimedOut
-      || promptSuggestionSchedules?.some((r) => r.status === 'failed')
+      || Boolean(promptSuggestionSchedules?.some((r) => r.status === 'failed'))
     : promptGenerationJobId === null;
 
   return {

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1474,6 +1474,11 @@ export async function activateBrandAndGeneratePrompts({
     } catch (drsClientError) {
       log.error(`DRS client creation failed, skipping Brandalf + schedules: ${drsClientError.message}`);
       say(':warning: DRS client unavailable (will need manual trigger)');
+      // LLMO-7218 AC4: without this, brandalfError stays null and the returned summary says
+      // requiredWorkFailed=true with no captured reason anywhere in it — exactly the "reconstruct
+      // from logs" outcome AC4 exists to prevent. Mirrors the v1 branch below, which already
+      // records drsError.message from its own DrsClient.createFrom call.
+      brandalfError = drsClientError.message;
     }
 
     if (drsClient) {
@@ -1617,6 +1622,16 @@ export async function activateBrandAndGeneratePrompts({
   // no Brandalf step at all. A schedule-registration timeout counts as failed, not merely
   // unknown — the caller needs an actionable signal, and "unknown" would let this collapse back
   // into the same silent-success outcome AC3 exists to prevent.
+  //
+  // "DRS client not configured" deliberately counts as failed here too, same as a genuine submit
+  // error: either way the customer ends this onboarding with zero prompts, which is exactly the
+  // gap AC3 exists to surface. This is a real outcome in dev/local environments where DRS secrets
+  // are absent (not merely a test-fixture artifact) — see the two failure-scenario tests the PR
+  // author already treats as legitimate (DRS-not-configured, Brandalf-submission-failure).
+  // A trial-tier one-shot prompt-suggestion run failing counts the same way, even though
+  // trial sites never get the durable recurring schedule PAID sites do (LLMO-7218's schedule
+  // reconciliation scope is PAID-only) — a trial customer whose one-time job failed to submit
+  // also ends this onboarding with zero prompts, so the same signal applies.
   const requiredWorkFailed = onboardingMode === LLMO_ONBOARDING_MODE_V2
     ? !brandalfTriggered || promptSuggestionSchedulesTimedOut
       || promptSuggestionSchedules?.some((r) => r.status === 'failed')

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -1359,7 +1359,21 @@ export async function enqueueLlmoOnboardingPublish(context, site, dataFolder) {
  * @param {string} [params.region] - Optional ISO 3166-1 alpha-2 region.
  * @param {object} params.context - The request context.
  * @param {Function} [params.say] - Optional Slack say callback.
- * @returns {Promise<void>}
+ * @returns {Promise<{
+ *   brandalfTriggered: boolean,
+ *   brandalfError: string|null,
+ *   promptGenerationJobId: string|null,
+ *   promptGenerationError: string|null,
+ *   promptSuggestionSchedules: Array<object>|null,
+ *   promptSuggestionSchedulesTimedOut: boolean,
+ *   requiredWorkFailed: boolean,
+ * }>} A submission-level summary (LLMO-7218 AC3/AC4) of the best-effort DRS side-effects
+ *   this function runs. "Submission" because Brandalf and prompt generation both complete
+ *   asynchronously via a DRS-side callback this repo has no visibility into (LLMO-4258
+ *   option b) — this cannot report whether the async work eventually SUCCEEDED, only
+ *   whether it was successfully HANDED OFF to DRS. `requiredWorkFailed` is true when any
+ *   required submission for the resolved onboarding mode failed, so a caller can tell a
+ *   degraded onboarding apart from a fully successful one instead of always seeing success.
  */
 export async function activateBrandAndGeneratePrompts({
   onboardingMode,
@@ -1374,6 +1388,18 @@ export async function activateBrandAndGeneratePrompts({
   say = () => {},
 }) {
   const { log } = context;
+
+  // LLMO-7218 AC3/AC4: tracked here (not thrown) because every DRS side-effect below stays
+  // best-effort by design — a DRS outage must not fail the site/entitlement/config work this
+  // function's caller already committed. Returned instead so the caller can report an honest
+  // outcome rather than the unconditional "completed successfully" this function previously
+  // gave no way to contradict.
+  let brandalfTriggered = false;
+  let brandalfError = null;
+  let promptGenerationJobId = null;
+  let promptGenerationError = null;
+  let promptSuggestionSchedules = null;
+  let promptSuggestionSchedulesTimedOut = false;
 
   if (onboardingMode === LLMO_ONBOARDING_MODE_V2) {
     const postgrestClient = context.dataAccess?.services?.postgrestClient;
@@ -1468,12 +1494,15 @@ export async function activateBrandAndGeneratePrompts({
             log,
             say,
           });
+          brandalfTriggered = true;
         } else {
           log.debug('DRS client not configured, skipping Brandalf flow');
+          brandalfError = 'DRS client not configured';
         }
       } catch (drsError) {
         log.error(`Failed to start DRS Brandalf flow: ${drsError.message}`);
         say(':warning: Failed to start DRS Brandalf flow (will need manual trigger)');
+        brandalfError = drsError.message;
       }
 
       // Run the "prompt suggestion" pipelines, tier-gated (LLMO prompt-suggestion
@@ -1529,6 +1558,9 @@ export async function activateBrandAndGeneratePrompts({
           + `${SCHEDULE_REGISTRATION_TIMEOUT_MS}ms for site ${site.getId()} `
           + '(schedules may still have been created server-side; may need manual verification)');
         say(':warning: DRS schedule registration timed out (may need manual verification)');
+        promptSuggestionSchedulesTimedOut = true;
+      } else {
+        promptSuggestionSchedules = scheduleResult.results;
       }
     }
   } else {
@@ -1569,14 +1601,36 @@ export async function activateBrandAndGeneratePrompts({
         }
         log.info(`Started DRS prompt generation: job=${drsJob.job_id}`);
         say(`:robot_face: Started DRS prompt generation job: ${drsJob.job_id}`);
+        promptGenerationJobId = drsJob.job_id;
       } else {
         log.debug('DRS client not configured, skipping prompt generation');
+        promptGenerationError = 'DRS client not configured';
       }
     } catch (drsError) {
       log.error(`Failed to start DRS prompt generation: ${drsError.message}`);
       say(`:warning: Failed to start DRS prompt generation for site ${site.getId()} (will need manual trigger)`);
+      promptGenerationError = drsError.message;
     }
   }
+
+  // Required-work gate (LLMO-7218 AC3): what counts as "required" differs by mode, since v1 has
+  // no Brandalf step at all. A schedule-registration timeout counts as failed, not merely
+  // unknown — the caller needs an actionable signal, and "unknown" would let this collapse back
+  // into the same silent-success outcome AC3 exists to prevent.
+  const requiredWorkFailed = onboardingMode === LLMO_ONBOARDING_MODE_V2
+    ? !brandalfTriggered || promptSuggestionSchedulesTimedOut
+      || promptSuggestionSchedules?.some((r) => r.status === 'failed')
+    : promptGenerationJobId === null;
+
+  return {
+    brandalfTriggered,
+    brandalfError,
+    promptGenerationJobId,
+    promptGenerationError,
+    promptSuggestionSchedules,
+    promptSuggestionSchedulesTimedOut,
+    requiredWorkFailed,
+  };
 }
 
 /**
@@ -1747,8 +1801,9 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
     // entity (upsertBrand), no Brandalf job, and no v1 prompt-generation job.
     // ensureInitialCustomerConfigV2 + the brandalf feature flag deliberately stay
     // in the always-run path above.
+    let brandActivationResult = null;
     if (!siteOnly) {
-      await activateBrandAndGeneratePrompts({
+      brandActivationResult = await activateBrandAndGeneratePrompts({
         onboardingMode,
         organization,
         site,
@@ -1773,6 +1828,11 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       : [...BASIC_AUDITS, 'wikipedia-analysis'];
     await triggerAudits(auditsToTrigger, context, site);
 
+    // LLMO-7218 AC3: the response can no longer claim unconditional success when a required
+    // brand/prompt-generation submission failed - siteOnly onboarding has no brand-activation
+    // step at all, so it is unaffected by this gate.
+    const requiredWorkFailed = brandActivationResult?.requiredWorkFailed ?? false;
+
     return {
       site,
       siteId: site.getId(),
@@ -1780,7 +1840,10 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
       baseURL,
       dataFolder,
       detectedCdn,
-      message: 'LLMO onboarding completed successfully',
+      message: requiredWorkFailed
+        ? 'LLMO onboarding completed with warnings: required brand/prompt-generation work failed'
+        : 'LLMO onboarding completed successfully',
+      ...(brandActivationResult ? { brandActivation: brandActivationResult } : {}),
     };
   } catch (error) {
     log.error(`Error during LLMO onboarding: ${error.message}. Attempting cleanup.`);

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1038,7 +1038,7 @@ function LlmoController(ctx) {
         log.warn(`LLMO onboarding: failed to trigger brand-profile workflow for site ${result.siteId}`, hookError);
       }
 
-      log.info(`LLMO onboarding completed successfully for domain ${domain}`);
+      log.info(`LLMO onboarding ${result.brandActivation?.requiredWorkFailed ? 'completed with warnings' : 'completed successfully'} for domain ${domain}`);
 
       return ok({
         message: result.message,

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1053,6 +1053,10 @@ function LlmoController(ctx) {
         status: 'completed',
         createdAt: new Date().toISOString(),
         brandProfileExecutionName,
+        // LLMO-7218 AC4: structured submission-level context (which required step failed, if
+        // any) so a caller doesn't have to reconstruct it from logs. Absent for siteOnly
+        // onboarding, which never runs brand activation.
+        ...(result.brandActivation ? { brandActivation: result.brandActivation } : {}),
         ...(region ? { region } : {}),
       });
     } catch (error) {

--- a/src/controllers/llmo/llmo.js
+++ b/src/controllers/llmo/llmo.js
@@ -1050,6 +1050,11 @@ function LlmoController(ctx) {
         organizationId: result.organizationId,
         siteId: result.siteId,
         detectedCdn: result.detectedCdn,
+        // Intentionally always 'completed', never 'failed', even when
+        // brandActivation.requiredWorkFailed is true: the site/org/entitlement/config work this
+        // endpoint owns did succeed (hence the 200 response), and 'failed' would overclaim a
+        // total failure the enum has no room to qualify. requiredWorkFailed is the correct field
+        // for a caller to branch on for the "succeeded with a degraded step" case.
         status: 'completed',
         createdAt: new Date().toISOString(),
         brandProfileExecutionName,

--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -429,8 +429,15 @@ export async function onboardSite(input, lambdaCtx, slackCtx) {
 
     const { site, siteId } = result;
 
+    // LLMO-7218 AC3/AC4: the per-step :warning: messages from activateBrandAndGeneratePrompts
+    // already streamed to this thread in real time as they happened; this final banner must
+    // not override that with an unconditional checkmark when required work actually failed.
+    const requiredWorkFailed = result.brandActivation?.requiredWorkFailed ?? false;
     const regionLine = region ? `\n:globe_with_meridians: *Region:* ${region}` : '';
-    const message = `:white_check_mark: *LLMO onboarding completed successfully!*
+    const statusLine = requiredWorkFailed
+      ? ':warning: *LLMO onboarding completed with warnings* — see the messages above for what needs manual follow-up.'
+      : ':white_check_mark: *LLMO onboarding completed successfully!*';
+    const message = `${statusLine}
 
 :link: *Site:* ${baseURL}
 :identification_card: *Site ID:* ${siteId}

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -6507,12 +6507,17 @@ describe('LLMO Onboarding Functions', () => {
       const context = buildV2Context();
       const params = buildV2Params(context);
       // Resolves (does not reject) despite createFrom throwing.
-      await activateBrandAndGeneratePrompts(params);
+      const result = await activateBrandAndGeneratePrompts(params);
 
       expect(mockDrsClient.createFrom).to.have.been.calledOnce;
       const errorLogs = context.log.error.getCalls().map((c) => c.args[0]);
       expect(errorLogs.some((m) => m.includes('DRS client creation failed'))).to.be.true;
       expect(params.say).to.have.been.calledWithMatch(/DRS client unavailable/);
+      // LLMO-7218 AC4: the reason must be captured on the returned summary, not just logged,
+      // so a caller can recover it without reconstructing from logs.
+      expect(result.brandalfError).to.equal('DRS client init boom');
+      expect(result.brandalfTriggered).to.be.false;
+      expect(result.requiredWorkFailed).to.be.true;
     });
 
     it('warns when schedule registration times out (settleWithin fallback)', async () => {

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -2160,7 +2160,7 @@ describe('LLMO Onboarding Functions', () => {
 
       // Onboarding completes despite upsertBrand failure
       expect(result.message).to.equal(
-        'LLMO onboarding completed successfully',
+        'LLMO onboarding completed with warnings: required brand/prompt-generation work failed',
       );
       expect(failingUpsertBrand).to.have.been.calledOnce;
       expect(mockLog.warn).to.have.been.calledWith(
@@ -2271,7 +2271,7 @@ describe('LLMO Onboarding Functions', () => {
       );
 
       // Onboarding still completes
-      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
       // The existing brand's primary site is NOT touched
       expect(mockUpsertBrand).to.not.have.been.called;
       expect(mockLog.warn).to.have.been.calledWithMatch(
@@ -2376,7 +2376,7 @@ describe('LLMO Onboarding Functions', () => {
         context,
       );
 
-      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
       expect(mockUpsertBrand).to.not.have.been.called;
       expect(mockLog.warn).to.have.been.calledWithMatch(
         'failed to look up existing brand',
@@ -2481,7 +2481,7 @@ describe('LLMO Onboarding Functions', () => {
         context,
       );
 
-      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
       expect(mockUpsertBrand).to.have.been.calledOnce;
       expect(mockLog.info).to.have.been.calledWith('Created initial brand "Test Brand" in normalized table for site site123');
     });
@@ -2584,7 +2584,7 @@ describe('LLMO Onboarding Functions', () => {
         context,
       );
 
-      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
       expect(mockUpsertBrand).to.have.been.calledOnce;
       expect(mockLog.warn).to.not.have.been.calledWithMatch('already exists with a different primary site');
     });
@@ -3491,7 +3491,7 @@ describe('LLMO Onboarding Functions', () => {
 
       // Verify onboarding completed successfully
       expect(result.siteId).to.equal('site123');
-      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
 
       // Verify DRS was checked but not called (prompt gen is deferred, only Brandalf is checked)
       expect(mockLog.debug).to.have.been.calledWith('DRS client not configured, skipping Brandalf flow');
@@ -3582,7 +3582,7 @@ describe('LLMO Onboarding Functions', () => {
 
       // Verify onboarding completed successfully despite DRS failure
       expect(result.siteId).to.equal('site123');
-      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
 
       // Verify error was logged but didn't fail onboarding
       expect(mockLog.error).to.have.been.calledWith('Failed to start DRS Brandalf flow: Brandalf API connection failed');

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -161,6 +161,13 @@ describe('LLMO Onboarding Functions', () => {
     return sandbox.stub().resolves({ ok, status, statusText });
   };
 
+  // Safe only when the code under test never reaches a settleWithin-wrapped call (this fires
+  // ANY setTimeout synchronously, so it forces settleWithin's timeout branch to win every race).
+  // v1 onboarding has no settleWithin calls at all, so it's unaffected here. Any V2 test whose
+  // outcome depends on settleWithin actually resolving (tier lookup, schedule registration)
+  // must use `sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })` + `clock.tickAsync`
+  // instead - using this helper there previously caused 5 tests to assert a false
+  // schedule-registration-timeout outcome unrelated to what they were testing (LLMO-7218).
   const mockSetTimeoutImmediate = (sandbox = sinon) => {
     const original = global.setTimeout;
     global.setTimeout = sandbox.stub().callsFake((fn) => {
@@ -6615,11 +6622,15 @@ describe('LLMO Onboarding Functions', () => {
         // Advance past every pending timer (schedule-registration + any sibling
         // settleWithin), flushing microtasks between ticks.
         await clock.tickAsync(60000);
-        await pending;
+        const result = await pending;
 
         const warnLogs = context.log.warn.getCalls().map((c) => c.args[0]);
         expect(warnLogs.some((m) => m.includes('schedule registration timed out'))).to.be.true;
         expect(params.say).to.have.been.calledWithMatch(/schedule registration timed out/);
+        // The promptSuggestionSchedulesTimedOut disjunct of requiredWorkFailed, exercised
+        // directly (not via the .some(status==='failed') or !brandalfTriggered disjuncts).
+        expect(result.promptSuggestionSchedulesTimedOut).to.be.true;
+        expect(result.requiredWorkFailed).to.be.true;
       } finally {
         clock.restore();
       }

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -1623,6 +1623,10 @@ describe('LLMO Onboarding Functions', () => {
       expect(siteConfig.updateLlmoBrand).to.have.been.calledWith('Test Brand');
       expect(mockSite.save).to.have.been.called;
 
+      // LLMO-7218 AC3: siteOnly skips brand activation entirely, so the top-level
+      // result carries no brandActivation summary at all.
+      expect(result.brandActivation).to.be.undefined;
+
       // Always-run path preserved: v2 customer config + brandalf flag
       expect(mockCustomerConfigV2Storage.writeCustomerConfigV2ToPostgres).to.have.been.calledOnce;
       expect(upsertStub).to.have.been.calledOnce;
@@ -2118,7 +2122,11 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
       const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
+      // Real (fake) timers, not mockSetTimeoutImmediate: the latter fires settleWithin's
+      // timeout branch synchronously, forcing a false schedule-registration timeout that
+      // flips requiredWorkFailed — a fixture artifact unrelated to the brand-write branch
+      // under test. tickAsync fast-forwards the real caps once the fast stubs resolve.
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
       const mockComposeBaseURL = createMockComposeBaseURL();
       const { mockClient: sharePointClient } = createMockSharePointClient(
         sinon,
@@ -2149,19 +2157,27 @@ describe('LLMO Onboarding Functions', () => {
         sqs: { sendMessage: sinon.stub().resolves() },
       };
 
-      const result = await onboardWithMocks(
-        {
-          domain: 'example.com',
-          imsOrgId: 'ABC123@AdobeOrg',
-          brandName: 'Test Brand',
-        },
-        context,
-      );
+      let result;
+      try {
+        const pending = onboardWithMocks(
+          {
+            domain: 'example.com',
+            imsOrgId: 'ABC123@AdobeOrg',
+            brandName: 'Test Brand',
+          },
+          context,
+        );
+        await clock.tickAsync(60000);
+        result = await pending;
+      } finally {
+        clock.restore();
+      }
 
-      // Onboarding completes despite upsertBrand failure
-      expect(result.message).to.equal(
-        'LLMO onboarding completed with warnings: required brand/prompt-generation work failed',
-      );
+      // Onboarding completes successfully despite the upsertBrand failure: the initial
+      // brand write is best-effort, while the required Brandalf submission + schedule
+      // registration both succeed here, so requiredWorkFailed is false.
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.brandActivation?.requiredWorkFailed).to.be.false;
       expect(failingUpsertBrand).to.have.been.calledOnce;
       expect(mockLog.warn).to.have.been.calledWith(
         'Failed to create initial brand in normalized table: '
@@ -2234,7 +2250,11 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
       const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
+      // Real (fake) timers, not mockSetTimeoutImmediate: the latter fires settleWithin's
+      // timeout branch synchronously, forcing a false schedule-registration timeout that
+      // flips requiredWorkFailed — a fixture artifact unrelated to the brand-write branch
+      // under test. tickAsync fast-forwards the real caps once the fast stubs resolve.
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
       const mockComposeBaseURL = createMockComposeBaseURL();
       const { mockClient: sharePointClient } = createMockSharePointClient(
         sinon,
@@ -2265,13 +2285,23 @@ describe('LLMO Onboarding Functions', () => {
         sqs: { sendMessage: sinon.stub().resolves() },
       };
 
-      const result = await onboardWithMocks(
-        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
-        context,
-      );
+      let result;
+      try {
+        const pending = onboardWithMocks(
+          { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+          context,
+        );
+        await clock.tickAsync(60000);
+        result = await pending;
+      } finally {
+        clock.restore();
+      }
 
-      // Onboarding still completes
-      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
+      // Onboarding completes successfully: skipping the collision brand write does not
+      // affect the required Brandalf submission / schedule registration, both of which
+      // succeed here, so requiredWorkFailed is false.
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.brandActivation?.requiredWorkFailed).to.be.false;
       // The existing brand's primary site is NOT touched
       expect(mockUpsertBrand).to.not.have.been.called;
       expect(mockLog.warn).to.have.been.calledWithMatch(
@@ -2340,7 +2370,11 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
       const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
+      // Real (fake) timers, not mockSetTimeoutImmediate: the latter fires settleWithin's
+      // timeout branch synchronously, forcing a false schedule-registration timeout that
+      // flips requiredWorkFailed — a fixture artifact unrelated to the brand-write branch
+      // under test. tickAsync fast-forwards the real caps once the fast stubs resolve.
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
       const mockComposeBaseURL = createMockComposeBaseURL();
       const { mockClient: sharePointClient } = createMockSharePointClient(
         sinon,
@@ -2371,12 +2405,23 @@ describe('LLMO Onboarding Functions', () => {
         sqs: { sendMessage: sinon.stub().resolves() },
       };
 
-      const result = await onboardWithMocks(
-        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
-        context,
-      );
+      let result;
+      try {
+        const pending = onboardWithMocks(
+          { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+          context,
+        );
+        await clock.tickAsync(60000);
+        result = await pending;
+      } finally {
+        clock.restore();
+      }
 
-      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
+      // Onboarding completes successfully: failing closed on the lookup skips only the
+      // best-effort brand write; the required Brandalf submission / schedule registration
+      // both succeed here, so requiredWorkFailed is false.
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.brandActivation?.requiredWorkFailed).to.be.false;
       expect(mockUpsertBrand).to.not.have.been.called;
       expect(mockLog.warn).to.have.been.calledWithMatch(
         'failed to look up existing brand',
@@ -2445,7 +2490,11 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
       const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
+      // Real (fake) timers, not mockSetTimeoutImmediate: the latter fires settleWithin's
+      // timeout branch synchronously, forcing a false schedule-registration timeout that
+      // flips requiredWorkFailed — a fixture artifact unrelated to the brand-write branch
+      // under test. tickAsync fast-forwards the real caps once the fast stubs resolve.
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
       const mockComposeBaseURL = createMockComposeBaseURL();
       const { mockClient: sharePointClient } = createMockSharePointClient(
         sinon,
@@ -2476,12 +2525,23 @@ describe('LLMO Onboarding Functions', () => {
         sqs: { sendMessage: sinon.stub().resolves() },
       };
 
-      const result = await onboardWithMocks(
-        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
-        context,
-      );
+      let result;
+      try {
+        const pending = onboardWithMocks(
+          { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+          context,
+        );
+        await clock.tickAsync(60000);
+        result = await pending;
+      } finally {
+        clock.restore();
+      }
 
-      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
+      // Onboarding completes successfully: the brand write proceeds and the required
+      // Brandalf submission / schedule registration both succeed here, so
+      // requiredWorkFailed is false.
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.brandActivation?.requiredWorkFailed).to.be.false;
       expect(mockUpsertBrand).to.have.been.calledOnce;
       expect(mockLog.info).to.have.been.calledWith('Created initial brand "Test Brand" in normalized table for site site123');
     });
@@ -2548,7 +2608,11 @@ describe('LLMO Onboarding Functions', () => {
       const mockConfig = createMockConfig();
       const mockTierClient = createMockTierClient();
       const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
+      // Real (fake) timers, not mockSetTimeoutImmediate: the latter fires settleWithin's
+      // timeout branch synchronously, forcing a false schedule-registration timeout that
+      // flips requiredWorkFailed — a fixture artifact unrelated to the brand-write branch
+      // under test. tickAsync fast-forwards the real caps once the fast stubs resolve.
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
       const mockComposeBaseURL = createMockComposeBaseURL();
       const { mockClient: sharePointClient } = createMockSharePointClient(
         sinon,
@@ -2579,12 +2643,23 @@ describe('LLMO Onboarding Functions', () => {
         sqs: { sendMessage: sinon.stub().resolves() },
       };
 
-      const result = await onboardWithMocks(
-        { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
-        context,
-      );
+      let result;
+      try {
+        const pending = onboardWithMocks(
+          { domain: 'example.com', imsOrgId: 'ABC123@AdobeOrg', brandName: 'Test Brand' },
+          context,
+        );
+        await clock.tickAsync(60000);
+        result = await pending;
+      } finally {
+        clock.restore();
+      }
 
-      expect(result.message).to.equal('LLMO onboarding completed with warnings: required brand/prompt-generation work failed');
+      // Onboarding completes successfully: the same-site re-onboard is not a collision,
+      // so the brand write proceeds and the required Brandalf submission / schedule
+      // registration both succeed here, so requiredWorkFailed is false.
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(result.brandActivation?.requiredWorkFailed).to.be.false;
       expect(mockUpsertBrand).to.have.been.calledOnce;
       expect(mockLog.warn).to.not.have.been.calledWithMatch('already exists with a different primary site');
     });
@@ -6614,6 +6689,115 @@ describe('LLMO Onboarding Functions', () => {
       // All three trial pipelines surfaced the one-shot failure, none swallowed.
       expect(oneShotLogs).to.have.lengthOf(3);
       expect(params.say).to.have.been.calledWithMatch(/Failed to run\/register DRS .*\(one-shot run\)/);
+    });
+
+    // LLMO-7218 AC3/AC4: the returned submission-outcome summary is the contract
+    // performLlmoOnboarding / the HTTP + Slack layers use to report an honest
+    // outcome. These assert the SHAPE of that object directly (not just a message
+    // string), which nothing else in this suite covered.
+    it('v2 full success: returns brandalfTriggered + all-created schedules + requiredWorkFailed false', async () => {
+      const mockDrsClient = createMockDrsClient(sandbox);
+      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      const result = await activateBrandAndGeneratePrompts(buildV2Params(context));
+
+      expect(result.brandalfTriggered).to.be.true;
+      expect(result.brandalfError).to.equal(null);
+      expect(result.promptSuggestionSchedules).to.be.an('array').with.lengthOf(3);
+      expect(result.promptSuggestionSchedules.map((r) => r.status))
+        .to.deep.equal(['created', 'created', 'created']);
+      expect(result.promptSuggestionSchedulesTimedOut).to.be.false;
+      expect(result.requiredWorkFailed).to.be.false;
+      // v2 has no direct prompt-generation submit (deferred to DRS post-Brandalf).
+      expect(result.promptGenerationJobId).to.equal(null);
+      expect(result.promptGenerationError).to.equal(null);
+    });
+
+    it('v2: a per-pipeline failed schedule result flags requiredWorkFailed (not a timeout)', async () => {
+      const err = new Error('DRS POST /schedules failed');
+      err.status = 503;
+      // Only the agentic-traffic pipeline's registration fails; the other two succeed.
+      const createSchedule = sandbox.stub();
+      createSchedule
+        .withArgs(sinon.match((a) => a.providerIds[0] === 'prompt_generation_agentic_traffic'))
+        .rejects(err);
+      createSchedule.resolves({ scheduleId: 'sched-ok', alreadyExisted: false });
+
+      const mockDrsClient = createMockDrsClient(sandbox, { createSchedule });
+      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      const result = await activateBrandAndGeneratePrompts(buildV2Params(context));
+
+      // Brandalf succeeded and nothing timed out — the degradation is a genuine
+      // per-pipeline registration failure, surfaced with the documented shape.
+      expect(result.brandalfTriggered).to.be.true;
+      expect(result.promptSuggestionSchedulesTimedOut).to.be.false;
+      const failed = result.promptSuggestionSchedules.filter((r) => r.status === 'failed');
+      expect(failed).to.have.lengthOf(1);
+      expect(failed[0].providerId).to.equal('prompt_generation_agentic_traffic');
+      expect(failed[0].error).to.equal('DRS POST /schedules failed');
+      // requiredWorkFailed is driven by the `.some(r => r.status === 'failed')` branch.
+      expect(result.requiredWorkFailed).to.be.true;
+    });
+
+    it('v1 success: returns promptGenerationJobId, no Brandalf, requiredWorkFailed false', async () => {
+      const mockDrsClient = createMockDrsClient(sandbox);
+      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      const result = await activateBrandAndGeneratePrompts({
+        ...buildV2Params(context),
+        onboardingMode: 'v1',
+      });
+
+      const instance = mockDrsClient.createFrom();
+      expect(instance.submitPromptGenerationJob).to.have.been.calledOnce;
+      // v1 never triggers Brandalf or registers recurring schedules.
+      expect(instance.submitJob).to.not.have.been.called;
+      expect(instance.createSchedule).to.not.have.been.called;
+      expect(result.promptGenerationJobId).to.equal('test-drs-job-123');
+      expect(result.promptGenerationError).to.equal(null);
+      expect(result.brandalfTriggered).to.be.false;
+      expect(result.requiredWorkFailed).to.be.false;
+    });
+
+    it('v1 failure: submitPromptGenerationJob with no job_id sets promptGenerationError + requiredWorkFailed', async () => {
+      const mockDrsClient = createMockDrsClient(sandbox, {
+        submitPromptGenerationJob: sandbox.stub().resolves({}), // no job_id
+      });
+      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      const result = await activateBrandAndGeneratePrompts({
+        ...buildV2Params(context),
+        onboardingMode: 'v1',
+      });
+
+      expect(result.promptGenerationJobId).to.equal(null);
+      expect(result.promptGenerationError).to.equal('DRS submitPromptGenerationJob returned no job_id');
+      expect(result.requiredWorkFailed).to.be.true;
     });
   });
 });

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -3590,6 +3590,143 @@ describe('LlmoController', () => {
       const responseBody = await result.json();
       expect(responseBody.imsOrgId).to.equal(upperCaseImsOrgId);
     });
+
+    it('surfaces brandActivation in the ok() response when performLlmoOnboarding returns it (LLMO-7218 AC4)', async () => {
+      const brandActivation = {
+        brandalfTriggered: true,
+        brandalfError: null,
+        promptGenerationJobId: null,
+        promptGenerationError: null,
+        promptSuggestionSchedules: [
+          { providerId: 'prompt_generation_semrush', status: 'created' },
+        ],
+        promptSuggestionSchedulesTimedOut: false,
+        requiredWorkFailed: false,
+      };
+      const onboardWithBrandActivation = sinon.stub().resolves({
+        siteId: 'new-site-id',
+        organizationId: 'new-org-id',
+        baseURL: 'https://example.com',
+        dataFolder: 'dev/example-com',
+        message: 'LLMO onboarding completed successfully',
+        brandActivation,
+      });
+      const LlmoControllerOnboard = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-onboarding.js': {
+          validateSiteNotOnboarded: validateSiteNotOnboardedStub,
+          performLlmoOnboarding: onboardWithBrandActivation,
+          generateDataFolder: (baseURL, env) => {
+            const url = new URL(baseURL);
+            const dataFolderName = url.hostname.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+            return env === 'prod' ? dataFolderName : `dev/${dataFolderName}`;
+          },
+        },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
+          Config: { toDynamoItem: sinon.stub().returnsArg(0) },
+        },
+        '@adobe/spacecat-shared-utils': {
+          SPACECAT_USER_AGENT: TEST_USER_AGENT,
+          tracingFetch: tracingFetchStub,
+          hasText: (text) => text && text.trim().length > 0,
+          isObject: (obj) => obj !== null && typeof obj === 'object',
+          llmoConfig,
+          schemas: {},
+          composeBaseURL: (domain) => (domain.startsWith('http') ? domain : `https://${domain}`),
+        },
+        '../../../src/support/brand-profile-trigger.js': {
+          triggerBrandProfileAgent: (...args) => triggerBrandProfileAgentStub(...args),
+        },
+        ...getCommonMocks(),
+      });
+      const testController = LlmoControllerOnboard(mockContext);
+
+      const result = await testController.onboardCustomer(onboardingContext);
+
+      expect(result.status).to.equal(200);
+      const responseBody = await result.json();
+      // Admin onboarding surfaces the full submission-outcome summary so a caller can
+      // branch on the degraded-step case (requiredWorkFailed) without reading logs.
+      expect(responseBody.brandActivation).to.deep.equal(brandActivation);
+      expect(responseBody.status).to.equal('completed');
+    });
+  });
+
+  describe('onboardSiteOnly', () => {
+    it('response does NOT include a brandActivation field (siteOnly skips brand activation)', async () => {
+      const mockOrg = {
+        getId: sinon.stub().returns('paid-org-id'),
+        getImsOrgId: sinon.stub().returns('paid-ims-org@AdobeOrg'),
+      };
+      mockDataAccess.Organization = {
+        findById: sinon.stub().resolves(mockOrg),
+      };
+      // siteOnly onboarding returns NO brandActivation (brand activation never runs).
+      const siteOnlyPerformStub = sinon.stub().resolves({
+        siteId: 'so-site-id',
+        organizationId: 'paid-org-id',
+        baseURL: 'https://example.com',
+        dataFolder: 'dev/example-com',
+        message: 'LLMO onboarding completed successfully',
+      });
+      const LlmoControllerSiteOnly = await esmock('../../../src/controllers/llmo/llmo.js', {
+        '../../../src/controllers/llmo/llmo-onboarding.js': {
+          validateSiteNotOnboarded: sinon.stub().resolves({ isValid: true }),
+          performLlmoOnboarding: siteOnlyPerformStub,
+          postLlmoAlert: sinon.stub().resolves(),
+          generateDataFolder: (baseURL, env) => {
+            const url = new URL(baseURL);
+            const dataFolderName = url.hostname.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+            return env === 'prod' ? dataFolderName : `dev/${dataFolderName}`;
+          },
+        },
+        '../../../src/support/access-control-util.js': createMockAccessControlUtil(true),
+        '@adobe/spacecat-shared-tier-client': {
+          default: {
+            createForOrg: () => ({
+              checkValidEntitlement: sinon.stub().resolves({
+                entitlement: { getTier: () => 'PAID' },
+              }),
+            }),
+          },
+        },
+        '@adobe/spacecat-shared-utils': {
+          SPACECAT_USER_AGENT: TEST_USER_AGENT,
+          tracingFetch: tracingFetchStub,
+          hasText: (text) => text && text.trim().length > 0,
+          isObject: (obj) => obj !== null && typeof obj === 'object',
+          isValidUrl: (url) => {
+            try {
+              return Boolean(new URL(url));
+            } catch {
+              return false;
+            }
+          },
+          llmoConfig,
+          schemas: {},
+          composeBaseURL: (domain) => (domain.startsWith('http') ? domain : `https://${domain}`),
+        },
+        ...getCommonMocks(),
+      });
+      const testController = LlmoControllerSiteOnly(mockContext);
+
+      const context = {
+        ...mockContext,
+        params: { spaceCatId: 'paid-org-id' },
+        data: { domain: 'example.com', brandName: 'Test Brand' },
+      };
+
+      const result = await testController.onboardSiteOnly(context);
+
+      expect(result.status).to.equal(201);
+      const responseBody = await result.json();
+      // siteOnly onboarding never runs brand activation, so the response must not
+      // carry a brandActivation summary.
+      expect(responseBody).to.not.have.property('brandActivation');
+      expect(responseBody.status).to.equal('processing');
+      // Confirm the controller actually took the siteOnly orchestration path.
+      expect(siteOnlyPerformStub.firstCall.args[0].siteOnly).to.equal(true);
+    });
   });
 
   describe('offboardCustomer', () => {

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -387,7 +387,11 @@ describe('onboard-llmo-modal', () => {
       await onboardSite(input, lambdaCtx, slackCtx);
 
       expect(sayStub).to.have.been.calledWith(':gear: Test Brand onboarding started...');
-      expect(sayStub).to.have.been.calledWith(sinon.match(':white_check_mark: *LLMO onboarding completed successfully!*'));
+      // This test's context has no DRS client configured, so schedule registration inside
+      // activateBrandAndGeneratePrompts genuinely times out against a real (non-mocked)
+      // DrsClient - the banner honestly reports that (LLMO-7218 AC3) rather than the
+      // unconditional success message this test asserted on before that gate existed.
+      expect(sayStub).to.have.been.calledWith(sinon.match(':warning: *LLMO onboarding completed with warnings*'));
       expect(sayStub).to.have.been.calledWith(sinon.match(':link: *Site:* https://example.com'));
       expect(sayStub).to.have.been.calledWith(sinon.match(':identification_card: *Site ID:* site123'));
       expect(sayStub).to.have.been.calledWith(sinon.match(':file_folder: *Data Folder:* example-com'));
@@ -481,12 +485,15 @@ describe('onboard-llmo-modal', () => {
 
       await onboardSite(input, lambdaCtx, slackCtx);
 
-      const successCall = sayStub.getCalls().find(
+      // Matches either banner variant - this test's DRS-unconfigured context genuinely
+      // times out schedule registration (see the test above), so the banner is the
+      // "with warnings" variant here, not the plain success one (LLMO-7218 AC3).
+      const finalCall = sayStub.getCalls().find(
         (call) => typeof call.args[0] === 'string'
-          && call.args[0].includes('LLMO onboarding completed successfully'),
+          && call.args[0].includes('LLMO onboarding completed'),
       );
-      expect(successCall, 'success message was sent').to.exist;
-      expect(successCall.args[0]).to.not.include(':globe_with_meridians:');
+      expect(finalCall, 'final onboarding message was sent').to.exist;
+      expect(finalCall.args[0]).to.not.include(':globe_with_meridians:');
     });
 
     it('should always call GitHub to update helix-query.yaml, ignoring a stray tempOnboarding param (LLMO-7141)', async () => {

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -387,10 +387,13 @@ describe('onboard-llmo-modal', () => {
       await onboardSite(input, lambdaCtx, slackCtx);
 
       expect(sayStub).to.have.been.calledWith(':gear: Test Brand onboarding started...');
-      // This test's context has no DRS client configured, so schedule registration inside
-      // activateBrandAndGeneratePrompts genuinely times out against a real (non-mocked)
-      // DrsClient - the banner honestly reports that (LLMO-7218 AC3) rather than the
-      // unconditional success message this test asserted on before that gate existed.
+      // This test's context has no DRS client configured, so activateBrandAndGeneratePrompts
+      // skips the Brandalf submission entirely (brandalfTriggered stays false) and
+      // ensurePromptSuggestionSchedules short-circuits on !drsClient.isConfigured() — no
+      // timeout path is reached at all. requiredWorkFailed is therefore true for this v2
+      // onboarding because the required Brandalf work was never handed off (LLMO-7218 AC3),
+      // so the banner honestly reports that rather than the unconditional success message
+      // this test asserted on before that gate existed.
       expect(sayStub).to.have.been.calledWith(sinon.match(':warning: *LLMO onboarding completed with warnings*'));
       expect(sayStub).to.have.been.calledWith(sinon.match(':link: *Site:* https://example.com'));
       expect(sayStub).to.have.been.calledWith(sinon.match(':identification_card: *Site ID:* site123'));
@@ -447,6 +450,66 @@ describe('onboard-llmo-modal', () => {
       });
     });
 
+    it('posts the :white_check_mark: success banner when brand activation fully succeeds (LLMO-7218 AC3)', async () => {
+      // The other onboardSite tests run against an unconfigured DRS, so their banner is
+      // always the degraded :warning: variant. Here we stub performLlmoOnboarding to return
+      // a fully-successful brand activation (requiredWorkFailed:false) — the branch that
+      // drives the :white_check_mark: banner — which had no coverage otherwise.
+      const mockSite = createDefaultMockSite(sandbox);
+      const lambdaCtx = createDefaultMockLambdaCtx(sandbox, { mockSite });
+      const slackCtx = createDefaultMockSlackCtx(sandbox);
+      const sayStub = slackCtx.say;
+
+      const performLlmoOnboardingStub = sandbox.stub().resolves({
+        site: mockSite,
+        siteId: 'site123',
+        organizationId: 'org123',
+        baseURL: 'https://example.com',
+        dataFolder: 'example-com',
+        message: 'LLMO onboarding completed successfully',
+        brandActivation: {
+          brandalfTriggered: true,
+          brandalfError: null,
+          promptGenerationJobId: null,
+          promptGenerationError: null,
+          promptSuggestionSchedules: [
+            { providerId: 'prompt_generation_semrush', status: 'created' },
+          ],
+          promptSuggestionSchedulesTimedOut: false,
+          requiredWorkFailed: false,
+        },
+      });
+
+      const modalWithSuccess = await esmock('../../../../src/support/slack/actions/onboard-llmo-modal.js', {
+        '../../../../src/controllers/llmo/llmo-onboarding.js': {
+          performLlmoOnboarding: performLlmoOnboardingStub,
+          validateSiteNotOnboarded: sandbox.stub().resolves({ isValid: true }),
+          generateDataFolder: sandbox.stub().returns('example-com'),
+        },
+        '../../../../src/utils/slack/base.js': sharedSlackMock,
+        '../../../../src/support/brand-profile-trigger.js': {
+          triggerBrandProfileAgent: (...args) => triggerBrandProfileAgentStub(...args),
+        },
+      });
+
+      await modalWithSuccess.onboardSite(
+        {
+          baseURL: 'https://example.com',
+          brandName: 'Test Brand',
+          imsOrgId: 'ABC123@AdobeOrg',
+          deliveryType: 'aem_edge',
+        },
+        lambdaCtx,
+        slackCtx,
+      );
+
+      expect(performLlmoOnboardingStub).to.have.been.calledOnce;
+      // Success banner — NOT the degraded warning variant.
+      expect(sayStub).to.have.been.calledWith(sinon.match(':white_check_mark: *LLMO onboarding completed successfully!*'));
+      expect(sayStub).to.not.have.been.calledWith(sinon.match(':warning: *LLMO onboarding completed with warnings*'));
+      expect(triggerBrandProfileAgentStub).to.have.been.calledOnce;
+    });
+
     it('should surface region in the success message when supplied (LLMO-4683)', async () => {
       const input = {
         baseURL: 'https://example.com',
@@ -485,9 +548,11 @@ describe('onboard-llmo-modal', () => {
 
       await onboardSite(input, lambdaCtx, slackCtx);
 
-      // Matches either banner variant - this test's DRS-unconfigured context genuinely
-      // times out schedule registration (see the test above), so the banner is the
-      // "with warnings" variant here, not the plain success one (LLMO-7218 AC3).
+      // Matches either banner variant. This test's DRS-unconfigured context skips the
+      // Brandalf submission (brandalfTriggered stays false) and short-circuits schedule
+      // registration on !isConfigured() — no timeout occurs — so requiredWorkFailed is true
+      // and the banner is the "with warnings" variant here, not the plain success one
+      // (LLMO-7218 AC3).
       const finalCall = sayStub.getCalls().find(
         (call) => typeof call.args[0] === 'string'
           && call.args[0].includes('LLMO onboarding completed'),


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Fixes the LLMO onboarding response reporting unconditional "completed successfully" even when a required Brandalf or prompt-generation submission failed.

## 2. Reasoning
Every DRS side-effect inside `activateBrandAndGeneratePrompts` (Brandalf brand-identification, prompt-suggestion schedule registration, the v1 direct prompt-generation submission) is deliberately best-effort — a DRS outage must not fail the site/entitlement/config work onboarding already committed. But nothing captured whether those best-effort submissions actually succeeded, so the response always claimed full success even when, for example, the Brandalf job never got submitted or schedule registration timed out. LLMO-7218 asks that "the onboarding outcome cannot report success when required identity or base-prompt work failed" and that failure context be preserved without log reconstruction.

Scoped deliberately to *submission* outcomes, not true completion: Brandalf and prompt generation both complete asynchronously via a DRS-side callback this repo has no visibility into (no webhook/callback route exists here; DRS chains Brandalf → prompt-gen internally per LLMO-4258 option b). Tracking actual completion would need new callback infrastructure that doesn't exist today — out of scope for this change.

## 3. High-level overview of the changes
Before: `activateBrandAndGeneratePrompts` returned nothing; every DRS failure inside it was logged and swallowed with no way for the caller to see it, so `performLlmoOnboarding` always returned `message: "LLMO onboarding completed successfully"` regardless of outcome.

After:
- `activateBrandAndGeneratePrompts` returns a summary object (`brandalfTriggered`/`brandalfError`, `promptGenerationJobId`/`promptGenerationError`, `promptSuggestionSchedules`, `promptSuggestionSchedulesTimedOut`, `requiredWorkFailed`) instead of void. No DRS-call behavior changes — this only adds tracking around the existing try/catch blocks.
- `performLlmoOnboarding` threads that summary into its response: `message` becomes `"LLMO onboarding completed with warnings: required brand/prompt-generation work failed"` when `requiredWorkFailed` is true, and a new `brandActivation` field (also documented in the OpenAPI schema) carries the structured detail. `siteOnly` onboarding is unaffected — it never runs brand activation at all.
- The Slack onboarding modal's final banner gets the same fix: its per-step `:warning:` messages already streamed live as failures happened, but the final banner previously overrode that history with an unconditional green checkmark regardless.

## 4. Required information
- Jira / issue: [LLMO-7218](https://jira.corp.adobe.com/browse/LLMO-7218)

## 8. Test plan
(a) Local: updated 7 existing unit test assertions that hardcoded the old unconditional-success message. Two of those were genuinely testing failure scenarios (DRS not configured, Brandalf submission failure) that the old code was silently misreporting as success — those now correctly assert the "with warnings" message. The other five were a schedule-registration-timeout artifact in those fixtures' mock/timer setup (`mockSetTimeoutImmediate` forces `settleWithin`'s timeout branch to always win, unrelated to what those tests are actually about) - fixed by migrating them to `sinon.useFakeTimers` + `clock.tickAsync`, so they now assert the genuine success outcome. Added dedicated shape-level coverage for the new `brandActivation`/`requiredWorkFailed` return value (v2 success, v2 per-pipeline failure, v1 success, v1 failure), controller-level coverage confirming `brandActivation` surfaces in the HTTP response and is absent for `siteOnly`, and a Slack-modal test for the success (checkmark) banner, which previously had no coverage.
(b) Per-environment verification: exercise the full onboarding flow (both HTTP `POST /llmo/onboard` and the Slack modal) against dev/stage with a genuinely misconfigured or unreachable DRS client to confirm the new `brandActivation.requiredWorkFailed` signal and degraded message actually surface end to end, not just in mocks.

## 9. Notes
- `docs/index.html` was not regenerated for the new `brandActivation` OpenAPI schema addition - per CLAUDE.md's `docs/index.html` non-determinism note, `docs/openapi/llmo-api.yaml` is the source of truth reviewers should verify; the generated doc will pick up the field on its next canonical-toolchain regen.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Reporting-accuracy fix that only changes response messaging/fields; no change to underlying DRS calls or data writes."
```