### PR TITLE
feat(llmo): stop producing v1 onboarding orgs (resolver never returns v1)

### DIFF
--- a/docs/llmo-brandalf-apis/v1-v2-onboarding-consistency-safeguard.md
+++ b/docs/llmo-brandalf-apis/v1-v2-onboarding-consistency-safeguard.md
@@ -3,9 +3,10 @@
 **Jira:** [LLMO-4176](https://jira.corp.adobe.com/browse/LLMO-4176)
 **Epic:** [LLMO-4054 — Brandalf GA (Brandalf v1 fast follows)](https://jira.corp.adobe.com/browse/LLMO-4054)
 **Status:** Superseded in part by [LLMO-7108](https://jira.corp.adobe.com/browse/LLMO-7108)
-— the legacy-site cutoff has been removed (see the update note below). The
-`LLMO_ONBOARDING_DEFAULT_VERSION` kill switch is retained; the
-`LLMO_BRANDALF_GA_CUTOFF_MS` cutoff and its helpers are gone.
+— the legacy-site cutoff has been removed (see the update notes below) — and by the
+brandalf-migration cleanup §2 (api-service #3156), which **retired** the
+`LLMO_ONBOARDING_DEFAULT_VERSION === 'v1'` kill switch so `resolveLlmoOnboardingMode`
+can only return v2. The `LLMO_BRANDALF_GA_CUTOFF_MS` cutoff and its helpers are gone.
 **PRs:**
 - api-service: [adobe/spacecat-api-service#2171](https://github.com/adobe/spacecat-api-service/pull/2171)
 - audit-worker: [adobe/spacecat-audit-worker#2380](https://github.com/adobe/spacecat-audit-worker/pull/2380) *(companion fix — required for v1 onboarding to complete successfully)*
@@ -32,15 +33,17 @@ defaults to v2. Concretely:
   function has no side effects, so callers (e.g. the `(org, site) → brand`
   resolver GET in `brands.js`) no longer pass it.
 
-**Current decision order** in `resolveLlmoOnboardingMode`:
+**Current decision order** in `resolveLlmoOnboardingMode` (updated — the v1 kill
+switch has been retired; see the cleanup §2 note below):
 
 1. `brandalf=true` → **v2**
 2. `brandalf_migration=true` → **v2**
-3. `LLMO_ONBOARDING_DEFAULT_VERSION === 'v1'` (global kill switch) → **v1**
-4. otherwise → **v2**
+3. otherwise → **v2**
 
-The `LLMO_ONBOARDING_DEFAULT_VERSION` kill switch is **retained** as a global
-"hold not-yet-migrated orgs on v1" switch.
+`LLMO_ONBOARDING_DEFAULT_VERSION` is no longer a v1 kill switch: the resolver can
+never return v1. A non-v2 value (including a stale `'v1'`) is treated as invalid,
+logged as a warning, and resolves **v2**. The env var is read only to surface a
+lingering pin, and is deleted in the §1 follow-up.
 
 **Where the resolver runs.** `resolveLlmoOnboardingMode` is consumed on two
 paths, not just onboarding:
@@ -64,6 +67,25 @@ owning v2 brand rows — for those, this endpoint now serves the v2 brand.)
 The sections below describe the original cutoff-based design (rows referencing
 `LLMO_BRANDALF_GA_CUTOFF_MS` / "pre-cutoff sites") and are retained for
 historical context only — they no longer reflect the shipped code.
+
+## Update — brandalf-migration cleanup §2 (#3156): v1 kill switch retired
+
+The `LLMO_ONBOARDING_DEFAULT_VERSION === 'v1'` **global kill switch has been
+retired** (api-service
+[#3156](https://github.com/adobe/spacecat-api-service/pull/3156), the upstream gate
+for DRS [#2807](https://github.com/adobe-rnd/llmo-data-retrieval-service/issues/2807)
+Phase 2). `resolveLlmoOnboardingMode` can no longer return `v1`:
+
+- The `'v1'` arm was removed from `src/support/llmo-onboarding-mode.js`. Every path
+  now converges on **v2** (`brandalf=true` → v2, `brandalf_migration=true` → v2,
+  otherwise → v2), as reflected in the corrected "Current decision order" above.
+- `LLMO_ONBOARDING_DEFAULT_VERSION` is still read, but **only to warn** on a
+  lingering non-v2 pin — a stale `'v1'` now logs "invalid" and resolves v2. The env
+  var (and this whole flag-reading module) are deleted in the sequenced §1 follow-up
+  once no v1 customers remain.
+- On the read-only `(org, site) → brand` resolver in `brands.js`, a flagless org now
+  always resolves the v2 brand instead of 404'ing — the intended "stop producing v1
+  orgs" effect DRS #2807 depends on.
 
 ## Problem
 

--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -1213,27 +1213,17 @@ llmo-onboard:
                     brandalfTriggered:
                       type: boolean
                       description: True if the Brandalf brand-identification job was
-                        successfully submitted (v2 onboarding mode only; always false in v1).
+                        successfully submitted.
                     brandalfError:
                       type:
                         - string
                         - 'null'
                       description: Reason the Brandalf submission failed or was skipped, if any.
-                    promptGenerationJobId:
-                      type:
-                        - string
-                        - 'null'
-                      description: The v1-mode direct prompt-generation DRS job id, if submitted.
-                    promptGenerationError:
-                      type:
-                        - string
-                        - 'null'
-                      description: Reason the v1-mode prompt-generation submission failed, if any.
                     promptSuggestionSchedules:
                       type:
                         - array
                         - 'null'
-                      description: Per-pipeline registration result (v2 mode only); null when
+                      description: Per-pipeline registration result; null when
                         registration timed out rather than completed.
                       items:
                         type: object
@@ -1254,12 +1244,12 @@ llmo-onboard:
                     promptSuggestionSchedulesTimedOut:
                       type: boolean
                       description: True if prompt-suggestion schedule registration timed out
-                        before completing (v2 mode only).
+                        before completing.
                     requiredWorkFailed:
                       type: boolean
-                      description: True if any required submission for the resolved onboarding
-                        mode failed. When true, `message` reports a degraded outcome instead of
-                        unconditional success.
+                      description: True if any required submission (Brandalf or prompt-suggestion
+                        schedule registration) failed. When true, `message` reports a degraded
+                        outcome instead of unconditional success.
               required:
                 - message
                 - domain

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -1089,12 +1089,13 @@ function BrandsController(ctx, log, env) {
   /**
    * Resolves the active brand for a (organization, site) pair.
    *
-   * Gated by `resolveLlmoOnboardingMode` — returns 404 when the org is in v1
-   * mode (neither brandalf nor brandalf_migration set, or kill-switch
-   * downgrade). When v2 and an active brand row exists with
+   * `resolveLlmoOnboardingMode` always resolves v2 now — the service no longer
+   * produces v1 orgs (brandalf-migration cleanup §2) — so the former v1-mode 404
+   * (neither brandalf nor brandalf_migration set, or a kill-switch downgrade) can
+   * no longer occur. When an active brand row exists with
    * `brands.site_id === siteId` (the authoritative site mapping per
    * LLMO-4592), returns the full V2 brand object so callers can pick `id`
-   * (or any other field).
+   * (or any other field); otherwise 404.
    *
    * @returns {Promise<Response>} The active brand, or 404.
    */

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -31,8 +31,6 @@ import {
 } from '../../support/customer-config-mapper.js';
 import {
   resolveLlmoOnboardingMode,
-  LLMO_ONBOARDING_MODE_V1,
-  LLMO_ONBOARDING_MODE_V2,
   LLMO_FEATURE_FLAG_PRODUCT,
   LLMO_BRANDALF_FLAG,
 } from '../../support/llmo-onboarding-mode.js';
@@ -1348,14 +1346,15 @@ export async function enqueueLlmoOnboardingPublish(context, site, dataFolder) {
  * Activates the brand and kicks off prompt generation for an onboarded site.
  *
  * This is the brand/prompt-generation half of onboarding, owned by Piece 2
- * (LLMO-5605). For v2 it writes the initial brand to the normalized brands table
- * and triggers the Brandalf DRS job; for v1 it submits the legacy DRS
- * prompt-generation job directly. Site-only onboarding (LLMO-5606) does NOT call
- * this — it stands up the site with no brand entity, no Brandalf job, and no
- * prompt-generation job.
+ * (LLMO-5605). Always v2: it writes the initial brand to the normalized brands
+ * table and triggers the Brandalf DRS job. The legacy v1 direct
+ * prompt-generation path was retired (brandalf-migration cleanup §2). Site-only
+ * onboarding (LLMO-5606) does NOT call this — it stands up the site with no
+ * brand entity, no Brandalf job, and no prompt-generation job.
  *
  * @param {object} params
- * @param {string} params.onboardingMode - Resolved LLMO onboarding mode (v1/v2).
+ * @param {string} params.onboardingMode - Resolved LLMO onboarding mode (always
+ *   'v2'); forwarded to the DRS Brandalf job metadata.
  * @param {object} params.organization - The organization model.
  * @param {object} params.site - The site model.
  * @param {object} params.siteConfig - The (already-saved) site config object.
@@ -1368,8 +1367,6 @@ export async function enqueueLlmoOnboardingPublish(context, site, dataFolder) {
  * @returns {Promise<{
  *   brandalfTriggered: boolean,
  *   brandalfError: string|null,
- *   promptGenerationJobId: string|null,
- *   promptGenerationError: string|null,
  *   promptSuggestionSchedules: Array<object>|null,
  *   promptSuggestionSchedulesTimedOut: boolean,
  *   requiredWorkFailed: boolean,
@@ -1402,232 +1399,180 @@ export async function activateBrandAndGeneratePrompts({
   // gave no way to contradict.
   let brandalfTriggered = false;
   let brandalfError = null;
-  let promptGenerationJobId = null;
-  let promptGenerationError = null;
   let promptSuggestionSchedules = null;
   let promptSuggestionSchedulesTimedOut = false;
 
-  if (onboardingMode === LLMO_ONBOARDING_MODE_V2) {
-    const postgrestClient = context.dataAccess?.services?.postgrestClient;
+  const postgrestClient = context.dataAccess?.services?.postgrestClient;
 
-    // Write initial brand to normalized brands table so DRS prompt sync can
-    // find it via GET /v2/orgs/{orgId}/brands before the Brandalf job finishes.
-    // Brandalf will upsert over this with LLM-identified sub-brands later.
-    // Use baseURL (matches sites.base_url) so syncBrandSites can link the brand
-    // to the site. overrideBaseURL may differ (e.g., www.blick.ch vs blick.ch)
-    // and would fail the exact-match lookup against the sites table.
-    // LLMO-5556: a second site onboarded under an existing brand name must not
-    // re-point that brand's primary site, nor clobber its URLs/aliases via the
-    // full-replace syncs inside upsertBrand. Detect the collision and skip the
-    // initial-brand write — the brand already exists so DRS sync still resolves
-    // it; a human then decides whether the new site is a sub-brand or a URL.
-    try {
-      const { data: existingBrand, error: lookupError } = await postgrestClient
-        .from('brands')
-        .select('id, site_id')
-        .eq('organization_id', organization.getId())
-        .eq('name', brandName.trim())
-        .maybeSingle();
+  // Write initial brand to normalized brands table so DRS prompt sync can
+  // find it via GET /v2/orgs/{orgId}/brands before the Brandalf job finishes.
+  // Brandalf will upsert over this with LLM-identified sub-brands later.
+  // Use baseURL (matches sites.base_url) so syncBrandSites can link the brand
+  // to the site. overrideBaseURL may differ (e.g., www.blick.ch vs blick.ch)
+  // and would fail the exact-match lookup against the sites table.
+  // LLMO-5556: a second site onboarded under an existing brand name must not
+  // re-point that brand's primary site, nor clobber its URLs/aliases via the
+  // full-replace syncs inside upsertBrand. Detect the collision and skip the
+  // initial-brand write — the brand already exists so DRS sync still resolves
+  // it; a human then decides whether the new site is a sub-brand or a URL.
+  try {
+    const { data: existingBrand, error: lookupError } = await postgrestClient
+      .from('brands')
+      .select('id, site_id')
+      .eq('organization_id', organization.getId())
+      .eq('name', brandName.trim())
+      .maybeSingle();
 
-      if (lookupError) {
-        // Fail closed (LLMO-5556): PostgREST returns { data: null, error } on a
-        // query failure rather than throwing, so without this check a transient
-        // failure would fall through to upsertBrand and could re-point an
-        // existing brand's primary site. Skip the write as a precaution.
-        log.warn(`Skipping initial brand write: failed to look up existing brand "${brandName.trim()}" `
-          + `(org ${organization.getId()}): ${lookupError.message}`);
-      } else if (existingBrand?.site_id && existingBrand.site_id !== site.getId()) {
-        log.warn(`Skipping initial brand write: brand "${brandName.trim()}" `
-          + `(org ${organization.getId()}) already exists with a different primary site `
-          + `(existing=${existingBrand.site_id}, onboarding=${site.getId()}). `
-          + `Add ${baseURL} as a brand URL or onboard under a distinct brand name.`);
-      } else {
-        // No collision: proceed with upsert (new brand, existing brand with a
-        // null primary site, or a re-onboard of the same site). upsertBrand's
-        // own guard keeps an already-set site_id immutable on the last case.
-        // LLMO-5645: seed operator market when supplied; else the
-        // DEFAULT_BRAND_REGION placeholder (consistent with the V2 config +
-        // brandAliases, both overwritten by Brandalf's async result).
-        const stubRegions = onboardingStubRegions(region);
-        await upsertBrand({
-          organizationId: organization.getId(),
-          brand: {
-            name: brandName.trim(),
-            status: 'active',
-            baseSiteId: site.getId(),
-            region: stubRegions,
-            urls: [{ value: baseURL, type: 'base' }],
-            brandAliases: [{ name: brandName.trim(), regions: stubRegions }],
-          },
-          postgrestClient,
-          updatedBy: 'llmo-onboarding',
-          log,
-        });
-        log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
-      }
-    } catch (brandError) {
-      log.warn(`Failed to create initial brand in normalized table: ${brandError.message}`);
+    if (lookupError) {
+      // Fail closed (LLMO-5556): PostgREST returns { data: null, error } on a
+      // query failure rather than throwing, so without this check a transient
+      // failure would fall through to upsertBrand and could re-point an
+      // existing brand's primary site. Skip the write as a precaution.
+      log.warn(`Skipping initial brand write: failed to look up existing brand "${brandName.trim()}" `
+        + `(org ${organization.getId()}): ${lookupError.message}`);
+    } else if (existingBrand?.site_id && existingBrand.site_id !== site.getId()) {
+      log.warn(`Skipping initial brand write: brand "${brandName.trim()}" `
+        + `(org ${organization.getId()}) already exists with a different primary site `
+        + `(existing=${existingBrand.site_id}, onboarding=${site.getId()}). `
+        + `Add ${baseURL} as a brand URL or onboard under a distinct brand name.`);
+    } else {
+      // No collision: proceed with upsert (new brand, existing brand with a
+      // null primary site, or a re-onboard of the same site). upsertBrand's
+      // own guard keeps an already-set site_id immutable on the last case.
+      // LLMO-5645: seed operator market when supplied; else the
+      // DEFAULT_BRAND_REGION placeholder (consistent with the V2 config +
+      // brandAliases, both overwritten by Brandalf's async result).
+      const stubRegions = onboardingStubRegions(region);
+      await upsertBrand({
+        organizationId: organization.getId(),
+        brand: {
+          name: brandName.trim(),
+          status: 'active',
+          baseSiteId: site.getId(),
+          region: stubRegions,
+          urls: [{ value: baseURL, type: 'base' }],
+          brandAliases: [{ name: brandName.trim(), regions: stubRegions }],
+        },
+        postgrestClient,
+        updatedBy: 'llmo-onboarding',
+        log,
+      });
+      log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
     }
+  } catch (brandError) {
+    log.warn(`Failed to create initial brand in normalized table: ${brandError.message}`);
+  }
 
-    // One DRS client, shared by the Brandalf trigger and the recurring
-    // prompt-suggestion schedule registration below. createFrom can throw on a
-    // malformed context or SDK regression; treat that as "DRS unavailable" and
-    // skip both best-effort side-effects rather than 500 the whole onboarding
-    // (the Brandalf trigger and schedule registration are both best-effort).
-    let drsClient;
+  // One DRS client, shared by the Brandalf trigger and the recurring
+  // prompt-suggestion schedule registration below. createFrom can throw on a
+  // malformed context or SDK regression; treat that as "DRS unavailable" and
+  // skip both best-effort side-effects rather than 500 the whole onboarding
+  // (the Brandalf trigger and schedule registration are both best-effort).
+  let drsClient;
+  try {
+    drsClient = DrsClient.createFrom(context);
+  } catch (drsClientError) {
+    log.error(`DRS client creation failed, skipping Brandalf + schedules: ${drsClientError.message}`);
+    say(':warning: DRS client unavailable (will need manual trigger)');
+    // LLMO-7218 AC4: without this, brandalfError stays null and the returned summary says
+    // requiredWorkFailed=true with no captured reason anywhere in it — exactly the "reconstruct
+    // from logs" outcome AC4 exists to prevent.
+    brandalfError = drsClientError.message;
+  }
+
+  if (drsClient) {
+    // Trigger Brandalf immediately after the v2 config exists so downstream
+    // brand sync can attach results to the newly created organization.
     try {
-      drsClient = DrsClient.createFrom(context);
-    } catch (drsClientError) {
-      log.error(`DRS client creation failed, skipping Brandalf + schedules: ${drsClientError.message}`);
-      say(':warning: DRS client unavailable (will need manual trigger)');
-      // LLMO-7218 AC4: without this, brandalfError stays null and the returned summary says
-      // requiredWorkFailed=true with no captured reason anywhere in it — exactly the "reconstruct
-      // from logs" outcome AC4 exists to prevent. Mirrors the v1 branch below, which already
-      // records drsError.message from its own DrsClient.createFrom call.
-      brandalfError = drsClientError.message;
-    }
-
-    if (drsClient) {
-      // Trigger Brandalf immediately after the v2 config exists so downstream
-      // brand sync can attach results to the newly created organization.
-      try {
-        if (drsClient.isConfigured()) {
-          const companyWebsite = siteConfig.getFetchConfig?.()?.overrideBaseURL || baseURL;
-          await triggerBrandalfOnboardingJob({
-            drsClient,
-            organizationId: organization.getId(),
-            siteId: site.getId(),
-            imsOrgId,
-            brandName: brandName.trim(),
-            companyWebsite,
-            onboardingMode,
-            region,
-            log,
-            say,
-          });
-          brandalfTriggered = true;
-        } else {
-          log.debug('DRS client not configured, skipping Brandalf flow');
-          brandalfError = 'DRS client not configured';
-        }
-      } catch (drsError) {
-        log.error(`Failed to start DRS Brandalf flow: ${drsError.message}`);
-        say(':warning: Failed to start DRS Brandalf flow (will need manual trigger)');
-        brandalfError = drsError.message;
-      }
-
-      // Run the "prompt suggestion" pipelines, tier-gated (LLMO prompt-suggestion
-      // tier gate): PAYING sites get a recurring schedule with an immediate first
-      // run; TRIAL / non-paying (or an indeterminate tier — isPayingLlmoSite fails
-      // safe to trial) get a single on-demand run per pipeline, no recurring
-      // schedule. These fire right after we SUBMIT the async Brandalf job above
-      // (submit, not completion), so they race Brandalf: for a genuinely new site
-      // the immediate first run typically no-ops because base-prompt/brand data
-      // does not exist yet. For a paying site that is acceptable — the durable
-      // outcome is the recurring schedule row, and the next scheduled run
-      // self-heals once brand data exists. Cold-start latency is worst for
-      // synthetic_personas (quarterly): if its immediate run no-ops, the first real
-      // output can be up to a quarter out. Chaining registration off
-      // base-prompt-generation completion is cross-repo (DRS owns the
-      // Brandalf→prompt-gen chain) and out of scope here.
-      // TODO(LLMO-4258 follow-up): have DRS trigger these once base prompt
-      // generation completes, instead of racing the Brandalf submit.
-      // Bound by settleWithin: isPayingLlmoSite hits the tier service and is
-      // awaited on the synchronous response path. Its own try/catch handles
-      // rejections but NOT a hang, so cap it and fall back to `false` (trial) on
-      // timeout — same fail-safe-to-trial intent as isPayingLlmoSite itself, so an
-      // indeterminate tier never gets a recurring, fleet-wide schedule.
-      const isPaying = await settleWithin(
-        isPayingLlmoSite(site, context),
-        TIER_LOOKUP_TIMEOUT_MS,
-        false,
-      );
-
-      // Bound by settleWithin: the per-pipeline createSchedule/submitJob calls are
-      // awaited on the synchronous response path, so a slow/hung DRS could
-      // otherwise stall onboarding. On timeout we stop waiting — createSchedule is
-      // idempotent, the durable outcome is the server-side schedule row (paying)
-      // or a submitted job (trial), and per-pipeline ERROR logging inside
-      // ensurePromptSuggestionSchedules stays deterministic.
-      const scheduleResult = await settleWithin(
-        ensurePromptSuggestionSchedules({
-          drsClient,
-          siteId: site.getId(),
-          isPaying,
-          log,
-          say,
-        }),
-        SCHEDULE_REGISTRATION_TIMEOUT_MS,
-        null,
-      );
-      // null fallback === timed out with calls still pending: the per-pipeline
-      // catch blocks never fired, so this is the only place a hung DRS is visible.
-      // Schedules may still land server-side (createSchedule is idempotent), but
-      // the operator needs a signal that registration was abandoned mid-flight.
-      if (scheduleResult === null) {
-        log.warn('DRS prompt-suggestion schedule registration timed out after '
-          + `${SCHEDULE_REGISTRATION_TIMEOUT_MS}ms for site ${site.getId()} `
-          + '(schedules may still have been created server-side; may need manual verification)');
-        say(':warning: DRS schedule registration timed out (may need manual verification)');
-        promptSuggestionSchedulesTimedOut = true;
-      } else {
-        promptSuggestionSchedules = scheduleResult.results;
-      }
-    }
-  } else {
-    // V1 has no Brandalf trigger, so DRS will not submit prompt generation
-    // automatically. Submit it directly here so v1 onboardings still get
-    // prompts written to the legacy LLMO config (LLMO-4534).
-    try {
-      const drsClient = DrsClient.createFrom(context);
       if (drsClient.isConfigured()) {
-        const trimmedBrand = brandName.trim();
-        const brandProfile = siteConfig.getBrandProfile?.();
-        // LLMO-4534: v1 fallback audience is English-only. v2 onboardings get a
-        // locale-aware audience from brand_profile.main_profile.target_audience.
-        const audience = brandProfile?.main_profile?.target_audience
-          || `General consumers interested in ${trimmedBrand} products and services`;
-
-        // The audit-worker `drs-prompt-generation` handler takes the legacy LLMO
-        // config write path when `onboarding_mode` is absent from the DRS job
-        // metadata. Do NOT pass `onboarding_mode` here — adding it would route v1
-        // prompts to the v2 customer-config storage and break v1 onboardings.
-        //
-        // LLMO-4683: forward operator-supplied `region` so the GPT prompt-generation
-        // job conditions on the brand's market. Omitted → DRS client default ('US')
-        // applies, preserving prior behavior.
-        if (region) {
-          log.info(`Using operator-supplied region "${region}" for v1 DRS prompt generation`);
-        }
-        const drsJob = await drsClient.submitPromptGenerationJob({
-          baseUrl: siteConfig.getFetchConfig?.()?.overrideBaseURL || baseURL,
-          brandName: trimmedBrand,
-          audience,
+        const companyWebsite = siteConfig.getFetchConfig?.()?.overrideBaseURL || baseURL;
+        await triggerBrandalfOnboardingJob({
+          drsClient,
+          organizationId: organization.getId(),
           siteId: site.getId(),
           imsOrgId,
-          ...(region ? { region } : {}),
+          brandName: brandName.trim(),
+          companyWebsite,
+          onboardingMode,
+          region,
+          log,
+          say,
         });
-        if (!drsJob?.job_id) {
-          throw new Error('DRS submitPromptGenerationJob returned no job_id');
-        }
-        log.info(`Started DRS prompt generation: job=${drsJob.job_id}`);
-        say(`:robot_face: Started DRS prompt generation job: ${drsJob.job_id}`);
-        promptGenerationJobId = drsJob.job_id;
+        brandalfTriggered = true;
       } else {
-        log.debug('DRS client not configured, skipping prompt generation');
-        promptGenerationError = 'DRS client not configured';
+        log.debug('DRS client not configured, skipping Brandalf flow');
+        brandalfError = 'DRS client not configured';
       }
     } catch (drsError) {
-      log.error(`Failed to start DRS prompt generation: ${drsError.message}`);
-      say(`:warning: Failed to start DRS prompt generation for site ${site.getId()} (will need manual trigger)`);
-      promptGenerationError = drsError.message;
+      log.error(`Failed to start DRS Brandalf flow: ${drsError.message}`);
+      say(':warning: Failed to start DRS Brandalf flow (will need manual trigger)');
+      brandalfError = drsError.message;
+    }
+
+    // Run the "prompt suggestion" pipelines, tier-gated (LLMO prompt-suggestion
+    // tier gate): PAYING sites get a recurring schedule with an immediate first
+    // run; TRIAL / non-paying (or an indeterminate tier — isPayingLlmoSite fails
+    // safe to trial) get a single on-demand run per pipeline, no recurring
+    // schedule. These fire right after we SUBMIT the async Brandalf job above
+    // (submit, not completion), so they race Brandalf: for a genuinely new site
+    // the immediate first run typically no-ops because base-prompt/brand data
+    // does not exist yet. For a paying site that is acceptable — the durable
+    // outcome is the recurring schedule row, and the next scheduled run
+    // self-heals once brand data exists. Cold-start latency is worst for
+    // synthetic_personas (quarterly): if its immediate run no-ops, the first real
+    // output can be up to a quarter out. Chaining registration off
+    // base-prompt-generation completion is cross-repo (DRS owns the
+    // Brandalf→prompt-gen chain) and out of scope here.
+    // TODO(LLMO-4258 follow-up): have DRS trigger these once base prompt
+    // generation completes, instead of racing the Brandalf submit.
+    // Bound by settleWithin: isPayingLlmoSite hits the tier service and is
+    // awaited on the synchronous response path. Its own try/catch handles
+    // rejections but NOT a hang, so cap it and fall back to `false` (trial) on
+    // timeout — same fail-safe-to-trial intent as isPayingLlmoSite itself, so an
+    // indeterminate tier never gets a recurring, fleet-wide schedule.
+    const isPaying = await settleWithin(
+      isPayingLlmoSite(site, context),
+      TIER_LOOKUP_TIMEOUT_MS,
+      false,
+    );
+
+    // Bound by settleWithin: the per-pipeline createSchedule/submitJob calls are
+    // awaited on the synchronous response path, so a slow/hung DRS could
+    // otherwise stall onboarding. On timeout we stop waiting — createSchedule is
+    // idempotent, the durable outcome is the server-side schedule row (paying)
+    // or a submitted job (trial), and per-pipeline ERROR logging inside
+    // ensurePromptSuggestionSchedules stays deterministic.
+    const scheduleResult = await settleWithin(
+      ensurePromptSuggestionSchedules({
+        drsClient,
+        siteId: site.getId(),
+        isPaying,
+        log,
+        say,
+      }),
+      SCHEDULE_REGISTRATION_TIMEOUT_MS,
+      null,
+    );
+    // null fallback === timed out with calls still pending: the per-pipeline
+    // catch blocks never fired, so this is the only place a hung DRS is visible.
+    // Schedules may still land server-side (createSchedule is idempotent), but
+    // the operator needs a signal that registration was abandoned mid-flight.
+    if (scheduleResult === null) {
+      log.warn('DRS prompt-suggestion schedule registration timed out after '
+        + `${SCHEDULE_REGISTRATION_TIMEOUT_MS}ms for site ${site.getId()} `
+        + '(schedules may still have been created server-side; may need manual verification)');
+      say(':warning: DRS schedule registration timed out (may need manual verification)');
+      promptSuggestionSchedulesTimedOut = true;
+    } else {
+      promptSuggestionSchedules = scheduleResult.results;
     }
   }
 
-  // Required-work gate (LLMO-7218 AC3): what counts as "required" differs by mode, since v1 has
-  // no Brandalf step at all. A schedule-registration timeout counts as failed, not merely
-  // unknown — the caller needs an actionable signal, and "unknown" would let this collapse back
-  // into the same silent-success outcome AC3 exists to prevent.
+  // Required-work gate (LLMO-7218 AC3): onboarding is always v2, so required work is the
+  // Brandalf submission plus prompt-suggestion schedule registration. A schedule-registration
+  // timeout counts as failed, not merely unknown — the caller needs an actionable signal, and
+  // "unknown" would let this collapse back into the same silent-success outcome AC3 exists to
+  // prevent.
   //
   // "DRS client not configured" deliberately counts as failed here too, same as a genuine submit
   // error: either way the customer ends this onboarding with zero prompts, which is exactly the
@@ -1638,16 +1583,12 @@ export async function activateBrandAndGeneratePrompts({
   // trial sites never get the durable recurring schedule PAID sites do (LLMO-7218's schedule
   // reconciliation scope is PAID-only) — a trial customer whose one-time job failed to submit
   // also ends this onboarding with zero prompts, so the same signal applies.
-  const requiredWorkFailed = onboardingMode === LLMO_ONBOARDING_MODE_V2
-    ? !brandalfTriggered || promptSuggestionSchedulesTimedOut
-      || Boolean(promptSuggestionSchedules?.some((r) => r.status === 'failed'))
-    : promptGenerationJobId === null;
+  const requiredWorkFailed = !brandalfTriggered || promptSuggestionSchedulesTimedOut
+    || Boolean(promptSuggestionSchedules?.some((r) => r.status === 'failed'));
 
   return {
     brandalfTriggered,
     brandalfError,
-    promptGenerationJobId,
-    promptGenerationError,
     promptSuggestionSchedules,
     promptSuggestionSchedulesTimedOut,
     requiredWorkFailed,
@@ -1662,12 +1603,12 @@ export async function activateBrandAndGeneratePrompts({
  * @param {string} params.brandName - The brand name
  * @param {string} params.imsOrgId - The IMS Organization ID
  * @param {string} [params.deliveryType] - The delivery type for site creation
- * @param {string} [params.region] - Optional ISO 3166-1 alpha-2 region code forwarded to V1 DRS
- *   prompt generation. Omitted → DRS client default ('US') applies.
+ * @param {string} [params.region] - Optional ISO 3166-1 alpha-2 region code forwarded to the DRS
+ *   Brandalf onboarding job. Omitted → DRS client default ('US') applies.
  * @param {boolean} [params.siteOnly=false] - Site-only onboarding (LLMO-5606). When true, stands
  *   up the site, entitlement/enrollment, config, and site-analysis audits, but skips the entire
- *   brand activation + prompt-generation block (no brand entity, no Brandalf job, no v1
- *   prompt-generation job) and never enables/triggers llmo-customer-analysis.
+ *   brand activation + prompt-generation block (no brand entity, no Brandalf job) and never
+ *   enables/triggers llmo-customer-analysis.
  * @param {object} context - The request context
  * @param {Function} [say] - Optional function to send progress messages
  * @returns {Promise<object>} Onboarding result
@@ -1790,32 +1731,31 @@ export async function performLlmoOnboarding(params, context, say = () => {}) {
     site.setConfig(Config.toDynamoItem(siteConfig));
     await site.save();
 
-    if (onboardingMode === LLMO_ONBOARDING_MODE_V2) {
-      await ensureInitialCustomerConfigV2({
-        organizationId: organization.getId(),
-        brandName,
-        imsOrgId,
-        siteId: site.getId(),
-        baseURL,
-        overrideBaseURL: siteConfig.getFetchConfig?.()?.overrideBaseURL,
-        region,
-        context,
-      });
+    // Onboarding is always v2 — the v1 path was retired (brandalf-migration
+    // cleanup §2). Initialize the v2 customer config and enable the brandalf
+    // flag org-wide so the DRS scheduler uses v2 prompts for this org.
+    await ensureInitialCustomerConfigV2({
+      organizationId: organization.getId(),
+      brandName,
+      imsOrgId,
+      siteId: site.getId(),
+      baseURL,
+      overrideBaseURL: siteConfig.getFetchConfig?.()?.overrideBaseURL,
+      region,
+      context,
+    });
 
-      // Enable brandalf flag so DRS scheduler uses v2 prompts for this org
-      const postgrestClient = context.dataAccess?.services?.postgrestClient;
-      await upsertFeatureFlag({
-        organizationId: organization.getId(),
-        product: LLMO_FEATURE_FLAG_PRODUCT,
-        flagName: LLMO_BRANDALF_FLAG,
-        value: true,
-        updatedBy: 'llmo-onboarding',
-        postgrestClient,
-      });
-      log.info(`Enabled brandalf feature flag for organization ${organization.getId()}`);
-    } else {
-      log.info(`Skipping v2 customer config initialization for site ${site.getId()} in ${LLMO_ONBOARDING_MODE_V1} mode`);
-    }
+    // Enable brandalf flag so DRS scheduler uses v2 prompts for this org
+    const postgrestClient = context.dataAccess?.services?.postgrestClient;
+    await upsertFeatureFlag({
+      organizationId: organization.getId(),
+      product: LLMO_FEATURE_FLAG_PRODUCT,
+      flagName: LLMO_BRANDALF_FLAG,
+      value: true,
+      updatedBy: 'llmo-onboarding',
+      postgrestClient,
+    });
+    log.info(`Enabled brandalf feature flag for organization ${organization.getId()}`);
 
     // Brand activation + prompt generation. This block is owned by Piece 2
     // (LLMO-5605). Site-only onboarding (LLMO-5606) skips it entirely — no brand

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -33,6 +33,7 @@ import {
   resolveLlmoOnboardingMode,
   LLMO_FEATURE_FLAG_PRODUCT,
   LLMO_BRANDALF_FLAG,
+  LLMO_ONBOARDING_MODE_V2,
 } from '../../support/llmo-onboarding-mode.js';
 import { upsertFeatureFlag } from '../../support/feature-flags-storage.js';
 import { detectCdnForDomain } from '../../support/cdn-detection.js';
@@ -1390,6 +1391,16 @@ export async function activateBrandAndGeneratePrompts({
   context,
   say = () => {},
 }) {
+  // Contract guard (brandalf-migration cleanup §2): the resolver can no longer
+  // produce a non-v2 mode, and this value is stamped into DRS Brandalf job
+  // metadata. Fail closed so a future caller can never regress a stale 'v1' into
+  // DRS rather than silently handing off a v1-tagged job.
+  if (onboardingMode !== LLMO_ONBOARDING_MODE_V2) {
+    throw new Error(
+      `activateBrandAndGeneratePrompts requires onboardingMode '${LLMO_ONBOARDING_MODE_V2}'; got '${onboardingMode}'`,
+    );
+  }
+
   const { log } = context;
 
   // LLMO-7218 AC3/AC4: tracked here (not thrown) because every DRS side-effect below stays

--- a/src/support/llmo-onboarding-mode.js
+++ b/src/support/llmo-onboarding-mode.js
@@ -15,6 +15,11 @@ import { readFeatureFlag } from './feature-flags-storage.js';
 export const LLMO_FEATURE_FLAG_PRODUCT = 'LLMO';
 export const LLMO_BRANDALF_FLAG = 'brandalf';
 export const LLMO_BRANDALF_MIGRATION_FLAG = 'brandalf_migration';
+/**
+ * @deprecated The resolver can no longer return v1 (brandalf-migration cleanup §2),
+ * so this constant now has zero production importers. Retained only for the §1
+ * follow-up that deletes the remaining v1 plumbing; remove it there.
+ */
 export const LLMO_ONBOARDING_MODE_V1 = 'v1';
 export const LLMO_ONBOARDING_MODE_V2 = 'v2';
 

--- a/src/support/llmo-onboarding-mode.js
+++ b/src/support/llmo-onboarding-mode.js
@@ -56,38 +56,33 @@ export async function readBrandalfMigrationFlagOverride(organizationId, postgres
 }
 
 /**
- * Resolves the LLMO onboarding mode (v1 or v2) for the given organization.
+ * Resolves the LLMO onboarding mode for the given organization. Always resolves
+ * v2 — the service no longer produces v1 orgs (brandalf-migration cleanup §2;
+ * upstream gate for DRS #2807 Phase 2).
  *
- * Decision order:
- *  1. If brandalf=true on the org → return v2 (explicit v2 migration).
- *  2. If brandalf_migration=true on the org → return v2. brandalf_migration
- *     marks an existing v1 customer that's mid-migration to v2: v2 brand
- *     entities exist and the org reads v2 config. Runs before the kill switch
- *     so ops can't accidentally pin a brandalf_migration org back to v1.
- *  3. If LLMO_ONBOARDING_DEFAULT_VERSION is 'v1' → return v1 (global kill
- *     switch for orgs that have not been migrated to v2).
- *  4. Otherwise → return v2 (default for everyone else).
+ * Decision order (all paths now converge on v2):
+ *  1. If brandalf=true on the org → v2 (explicit v2 migration).
+ *  2. If brandalf_migration=true on the org → v2. brandalf_migration marks an
+ *     existing customer mid-migration to v2: v2 brand entities exist and the org
+ *     reads v2 config.
+ *  3. Otherwise → v2 (default for everyone else).
  *
- * The legacy-site cutoff that previously forced pre-GA customers onto v1
- * (createdAt before LLMO_BRANDALF_GA_CUTOFF_MS) was removed in LLMO-7108 so every
- * new onboarding defaults to v2 unless the kill switch holds the org back.
+ * The LLMO_ONBOARDING_DEFAULT_VERSION==='v1' kill switch was removed here so the
+ * resolver can never return v1. The env var read is retained only to warn on a
+ * lingering non-v2 pin — a stale 'v1' now logs "invalid" and resolves v2. The
+ * env var and this whole flag-reading module are deleted in the sequenced
+ * follow-ups (§1) once all v1 customers are gone.
  *
  * This is consumed on two paths, not just onboarding: performLlmoOnboarding
- * (which upserts brandalf=true org-wide on a v2 result) and the read-only
- * (org, site) -> brand resolver in brands.js (hit by BP refresh and the DRS
- * scheduler). Removing the cutoff flips a flagless pre-cutoff org to v2 on both
- * — the brand resolver now returns the v2 brand where it used to 404. It does
- * not by itself flip an already-onboarded org's brandalf flag (only an
- * onboarding does that, org-wide), and DRS gates on the flag independently, so a
- * still-flagless org keeps running v1 downstream until it is onboarded/flagged.
- *
- * TEMPORARY — the LLMO_ONBOARDING_DEFAULT_VERSION kill switch and the v1 branch
- * should be removed once all v1 customers have been migrated to v2, at which
- * point this collapses to "always v2".
+ * (which upserts brandalf=true org-wide) and the read-only (org, site) -> brand
+ * resolver in brands.js (hit by BP refresh and the DRS scheduler). Because the
+ * resolver can no longer return v1, the brand resolver now always resolves the
+ * v2 brand for a flagless org where a v1 result previously produced a 404 — this
+ * is the intended "stops producing v1 orgs" behavior on both paths.
  *
  * @param {string} organizationId
  * @param {object} context - Request context
- * @returns {Promise<'v1'|'v2'>}
+ * @returns {Promise<'v2'>}
  */
 export async function resolveLlmoOnboardingMode(organizationId, context) {
   const { log = console } = context || {};
@@ -137,11 +132,10 @@ export async function resolveLlmoOnboardingMode(organizationId, context) {
   }
 
   // 2. Environment-level default (brandalf is false/missing from here on).
-  //    'v1' is the global kill switch; anything else defaults to v2.
+  //    The 'v1' kill switch was removed — the resolver can never return v1.
+  //    Any non-v2 value (including a stale 'v1' pin) is treated as invalid and
+  //    resolves v2, surfacing the lingering pin in the logs.
   const configuredDefault = context?.env?.LLMO_ONBOARDING_DEFAULT_VERSION;
-  if (configuredDefault === LLMO_ONBOARDING_MODE_V1) {
-    return LLMO_ONBOARDING_MODE_V1;
-  }
   if (configuredDefault && configuredDefault !== LLMO_ONBOARDING_MODE_V2) {
     log.warn(
       `Invalid LLMO_ONBOARDING_DEFAULT_VERSION "${configuredDefault}", falling back to ${LLMO_ONBOARDING_MODE_V2}`,

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -2127,6 +2127,11 @@ describe('LLMO Onboarding Functions', () => {
       expect(result.message).to.equal('LLMO onboarding completed successfully');
       expect(mockLog.info).to.have.been.calledWith('Created site site123 for https://example.com using LLMO onboarding mode v2');
 
+      // Stale 'v1' pin does not degrade the run: all required DRS submissions
+      // still succeed, so the brand-activation summary reports no failure
+      // (matches the other brand-activation happy-path tests).
+      expect(result.brandActivation?.requiredWorkFailed).to.be.false;
+
       // v2 path taken: customer config + brandalf flag + Brandalf DRS job.
       expect(mockCustomerConfigV2Storage.writeCustomerConfigV2ToPostgres).to.have.been.calledOnce;
       expect(upsertStub).to.have.been.calledOnce;
@@ -5913,6 +5918,25 @@ describe('LLMO Onboarding Functions', () => {
       baseURL: 'https://example.com',
       context,
       say: sandbox.stub(),
+    });
+
+    it('throws when called with a non-v2 onboardingMode (contract guard, fails closed)', async () => {
+      const mockDrsClient = createMockDrsClient(sandbox);
+      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockDrsClient,
+          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
+        }),
+      );
+
+      const context = buildV2Context();
+      await expect(
+        activateBrandAndGeneratePrompts({ ...buildV2Params(context), onboardingMode: 'v1' }),
+      ).to.be.rejectedWith("activateBrandAndGeneratePrompts requires onboardingMode 'v2'; got 'v1'");
+
+      // Guard fires before any DRS hand-off, so a stale 'v1' can never leak into
+      // Brandalf job metadata.
+      expect(mockDrsClient.createFrom().submitJob).to.not.have.been.called;
     });
 
     it('registers all three prompt-suggestion schedules after the Brandalf trigger', async () => {

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -37,8 +37,9 @@ describe('LLMO Onboarding Functions', () => {
       Site: {
         findByBaseURL: sinon.stub(),
         create: sinon.stub(),
-        // Mode resolution defaults to v2. Tests that need v1 mode set
-        // LLMO_ONBOARDING_DEFAULT_VERSION='v1' in context.env (global kill switch).
+        // Mode resolution always yields v2 — the v1 kill switch was removed
+        // (brandalf-migration cleanup §2; upstream gate for DRS #2807), so a
+        // stale LLMO_ONBOARDING_DEFAULT_VERSION='v1' pin no longer forces v1.
         // allByOrganizationId is no longer read by resolveLlmoOnboardingMode
         // (the legacy-site cutoff was removed in LLMO-7108) — kept as a harmless
         // default for other code paths.
@@ -1655,68 +1656,6 @@ describe('LLMO Onboarding Functions', () => {
       expect(context.sqs.sendMessage).to.not.have.been.calledWith('audit-queue', sinon.match({ type: 'llmo-customer-analysis' }));
     });
 
-    it('v1: skips the DRS prompt-generation job and the v2 customer config', async () => {
-      const {
-        mockOrganization, mockSite, mockConfiguration,
-      } = buildSiteMocks();
-
-      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
-      mockDataAccess.Site.findByBaseURL.resolves(null);
-      mockDataAccess.Site.create.resolves(mockSite);
-      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
-
-      const mockConfig = createMockConfig();
-      const mockTierClient = createMockTierClient();
-      const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
-      const mockComposeBaseURL = createMockComposeBaseURL();
-      const { mockClient: sharePointClient } = createMockSharePointClient(
-        sinon,
-        { folderExists: false },
-      );
-      const mockOctokit = createMockOctokit();
-      const {
-        mockDrsClient, createFrom, submitPromptGenerationJob,
-      } = buildTrackableDrsClient();
-      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
-      const mockUpsertBrand = sinon.stub().resolves({ id: 'brand-x' });
-
-      const { performLlmoOnboarding: onboard } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockTierClient,
-          mockTracingFetch,
-          mockConfig,
-          mockComposeBaseURL,
-          mockSharePointClient: sharePointClient,
-          mockOctokit,
-          mockDrsClient,
-          mockCustomerConfigV2Storage,
-          mockUpsertBrand,
-        }),
-      );
-
-      const context = {
-        dataAccess: mockDataAccess,
-        log: mockLog,
-        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-        sqs: { sendMessage: sinon.stub().resolves() },
-      };
-
-      await onboard({
-        domain: 'example.com',
-        brandName: 'Test Brand',
-        imsOrgId: 'ABC123@AdobeOrg',
-        siteOnly: true,
-      }, context);
-
-      // v1 mode: no v2 customer config; site-only: no DRS prompt generation
-      expect(mockCustomerConfigV2Storage.writeCustomerConfigV2ToPostgres).to.not.have.been.called;
-      expect(createFrom).to.not.have.been.called;
-      expect(submitPromptGenerationJob).to.not.have.been.called;
-      expect(mockUpsertBrand).to.not.have.been.called;
-      expect(mockLog.info).to.have.been.calledWithMatch('skipping brand activation and prompt generation');
-    });
-
     it('rolls back SharePoint folder + enrollment when a step fails mid-flight (siteOnly)', async () => {
       const { mockOrganization, mockSite } = buildSiteMocks();
 
@@ -2077,6 +2016,129 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockLog.info).to.have.been.calledWith('Starting LLMO onboarding for IMS org ABC123@AdobeOrg, baseURL https://example.com, brand Test Brand');
       expect(mockLog.info).to.have.been.calledWith('Created site site123 for https://example.com using LLMO onboarding mode v2');
     });
+
+    // Regression pin (brandalf-migration cleanup §2; upstream gate for DRS
+    // #2807): onboarding is always v2 and NEVER takes a v1 branch. Even with a
+    // stale LLMO_ONBOARDING_DEFAULT_VERSION='v1' pin still set in the env, the
+    // resolver can no longer return v1, so onboarding must take the v2 path
+    // (v2 customer config + brandalf flag + Brandalf DRS job) and must NOT
+    // submit the retired legacy v1 direct prompt-generation job.
+    it('takes the v2 path (never the retired v1 branch) even with a stale LLMO_ONBOARDING_DEFAULT_VERSION=v1 pin', async () => {
+      const mockOrganization = {
+        getId: sinon.stub().returns('org123'),
+        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
+      };
+
+      const mockSite = {
+        getId: sinon.stub().returns('site123'),
+        getConfig: sinon.stub().returns({
+          updateLlmoBrand: sinon.stub(),
+          updateLlmoDataFolder: sinon.stub(),
+          getImports: sinon.stub().returns([]),
+          enableImport: sinon.stub(),
+          getFetchConfig: sinon.stub().returns({}),
+          updateFetchConfig: sinon.stub(),
+          getBrandProfile: sinon.stub().returns({
+            main_profile: { target_audience: 'Tech-savvy professionals' },
+          }),
+        }),
+        setConfig: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      const mockConfiguration = {
+        enableHandlerForSite: sinon.stub(),
+        disableHandlerForSite: sinon.stub(),
+        isHandlerEnabledForSite: sinon.stub().returns(false),
+        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
+        save: sinon.stub().resolves(),
+        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
+      };
+
+      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
+      mockDataAccess.Site.findByBaseURL.resolves(null);
+      mockDataAccess.Site.create.resolves(mockSite);
+      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
+
+      // feature_flags: read (mode resolution) returns no row → without the
+      // retired kill switch this must still resolve v2; upsert enables brandalf.
+      const eqFlag = sinon.stub().resolves({ data: [], error: null });
+      const eqProduct = sinon.stub().returns({ eq: eqFlag });
+      const eqOrg = sinon.stub().returns({ eq: eqProduct });
+      const selectRead = sinon.stub().returns({ eq: eqOrg });
+      const upsertSingle = sinon.stub().resolves({ data: { flag_value: true }, error: null });
+      const upsertSelect = sinon.stub().returns({ single: upsertSingle });
+      const upsertStub = sinon.stub().returns({ select: upsertSelect });
+      mockDataAccess.services.postgrestClient.from.withArgs('feature_flags').returns({
+        select: selectRead,
+        insert: upsertStub,
+      });
+
+      const mockConfig = createMockConfig();
+      const mockTierClient = createMockTierClient();
+      const mockTracingFetch = createMockTracingFetch();
+      const clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      const mockComposeBaseURL = createMockComposeBaseURL();
+      const { mockClient: sharePointClient } = createMockSharePointClient(
+        sinon,
+        { folderExists: false },
+      );
+      const mockOctokit = createMockOctokit();
+      const mockDrsClient = createMockDrsClient();
+      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
+      const mockUpsertBrand = sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
+
+      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockTierClient,
+          mockTracingFetch,
+          mockConfig,
+          mockComposeBaseURL,
+          mockSharePointClient: sharePointClient,
+          mockOctokit,
+          mockDrsClient,
+          mockCustomerConfigV2Storage,
+          mockUpsertBrand,
+        }),
+      );
+
+      const context = {
+        dataAccess: mockDataAccess,
+        log: mockLog,
+        // Stale kill-switch pin that used to force v1 — must now be ignored.
+        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
+        sqs: { sendMessage: sinon.stub().resolves() },
+      };
+
+      let result;
+      try {
+        const pending = performLlmoOnboardingWithMocks({
+          domain: 'example.com',
+          brandName: 'Test Brand',
+          imsOrgId: 'ABC123@AdobeOrg',
+        }, context);
+        await clock.tickAsync(60000);
+        result = await pending;
+      } finally {
+        clock.restore();
+      }
+
+      // Resolved v2 despite the stale 'v1' pin.
+      expect(result.message).to.equal('LLMO onboarding completed successfully');
+      expect(mockLog.info).to.have.been.calledWith('Created site site123 for https://example.com using LLMO onboarding mode v2');
+
+      // v2 path taken: customer config + brandalf flag + Brandalf DRS job.
+      expect(mockCustomerConfigV2Storage.writeCustomerConfigV2ToPostgres).to.have.been.calledOnce;
+      expect(upsertStub).to.have.been.calledOnce;
+      expect(mockLog.info).to.have.been.calledWith('Enabled brandalf feature flag for organization org123');
+      expect(mockUpsertBrand).to.have.been.calledOnce;
+      expect(mockDrsClient.createFrom().submitJob).to.have.been.calledWith(
+        sinon.match({ parameters: sinon.match({ metadata: sinon.match({ onboarding_mode: 'v2' }) }) }),
+      );
+
+      // Retired v1 branch NOT taken: no legacy direct prompt-generation job.
+      expect(mockDrsClient.createFrom().submitPromptGenerationJob).to.not.have.been.called;
+    }).timeout(10000);
 
     it('should continue onboarding when upsertBrand fails', async () => {
       const mockOrganization = {
@@ -2966,530 +3028,6 @@ describe('LLMO Onboarding Functions', () => {
       expect(mockSiteConfig.updateLlmoDetectedCdn).to.not.have.been.called;
       expect(mockLog.warn).to.have.been.calledWithMatch('CDN detection failed');
     });
-
-    it('should skip v2 initialization and Brandalf in v1 onboarding mode', async () => {
-      const mockOrganization = {
-        getId: sinon.stub().returns('org123'),
-        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
-      };
-
-      const mockSite = {
-        getId: sinon.stub().returns('site123'),
-        getConfig: sinon.stub().returns({
-          updateLlmoBrand: sinon.stub(),
-          updateLlmoDataFolder: sinon.stub(),
-          getImports: sinon.stub().returns([]),
-          enableImport: sinon.stub(),
-          getFetchConfig: sinon.stub().returns({}),
-          updateFetchConfig: sinon.stub(),
-          getBrandProfile: sinon.stub().returns({ main_profile: { target_audience: 'Tech-savvy professionals' } }),
-        }),
-        setConfig: sinon.stub(),
-        save: sinon.stub().resolves(),
-      };
-
-      const mockConfiguration = {
-        enableHandlerForSite: sinon.stub(),
-        disableHandlerForSite: sinon.stub(),
-        isHandlerEnabledForSite: sinon.stub().returns(false),
-        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
-        save: sinon.stub().resolves(),
-        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
-      };
-
-      // Force v1 mode via the global kill switch — no brandalf flag lookup needed.
-      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
-      mockDataAccess.Site.findByBaseURL.resolves(null);
-      mockDataAccess.Site.create.resolves(mockSite);
-      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
-
-      const mockConfig = createMockConfig();
-      const mockTierClient = createMockTierClient();
-      const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
-      const mockComposeBaseURL = createMockComposeBaseURL();
-      const { mockClient: sharePointClient } = createMockSharePointClient(
-        sinon,
-        { folderExists: false },
-      );
-      const mockOctokit = createMockOctokit();
-      const mockDrsClient = createMockDrsClient();
-      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
-
-      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockTierClient,
-          mockTracingFetch,
-          mockConfig,
-          mockComposeBaseURL,
-          mockSharePointClient: sharePointClient,
-          mockOctokit,
-          mockDrsClient,
-          mockCustomerConfigV2Storage,
-        }),
-      );
-
-      const context = {
-        dataAccess: mockDataAccess,
-        log: mockLog,
-        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-        sqs: {
-          sendMessage: sinon.stub().resolves(),
-        },
-      };
-
-      await performLlmoOnboardingWithMocks({
-        domain: 'example.com',
-        brandName: 'Test Brand',
-        imsOrgId: 'ABC123@AdobeOrg',
-      }, context);
-
-      expect(mockCustomerConfigV2Storage.writeCustomerConfigV2ToPostgres).to.not.have.been.called;
-      // V1 mode does not trigger Brandalf, but it MUST trigger DRS prompt generation
-      // directly so the legacy LLMO config still gets prompts written (LLMO-4534).
-      expect(mockDrsClient.createFrom().submitJob).to.not.have.been.called;
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob).to.have.been.calledOnce;
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob.firstCall.args[0]).to.include({
-        brandName: 'Test Brand',
-        siteId: 'site123',
-        imsOrgId: 'ABC123@AdobeOrg',
-        audience: 'Tech-savvy professionals',
-      });
-      // LLMO-4683: when the caller does not supply a region, the V1 path must NOT
-      // pass `region` so the DRS client's existing default ('US') applies. This
-      // locks in additive behavior — non-US callers must opt in.
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob.firstCall.args[0])
-        .to.not.have.property('region');
-    }).timeout(10000);
-
-    it('should forward operator-supplied region to DRS prompt generation in v1 mode (LLMO-4683)', async () => {
-      const mockOrganization = {
-        getId: sinon.stub().returns('org123'),
-        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
-      };
-
-      const mockSite = {
-        getId: sinon.stub().returns('site123'),
-        getConfig: sinon.stub().returns({
-          updateLlmoBrand: sinon.stub(),
-          updateLlmoDataFolder: sinon.stub(),
-          getImports: sinon.stub().returns([]),
-          enableImport: sinon.stub(),
-          getFetchConfig: sinon.stub().returns({}),
-          updateFetchConfig: sinon.stub(),
-          getBrandProfile: sinon.stub().returns({ main_profile: { target_audience: 'General consumers in India' } }),
-        }),
-        setConfig: sinon.stub(),
-        save: sinon.stub().resolves(),
-      };
-
-      const mockConfiguration = {
-        enableHandlerForSite: sinon.stub(),
-        disableHandlerForSite: sinon.stub(),
-        isHandlerEnabledForSite: sinon.stub().returns(false),
-        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
-        save: sinon.stub().resolves(),
-        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
-      };
-
-      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
-      mockDataAccess.Site.findByBaseURL.resolves(null);
-      mockDataAccess.Site.create.resolves(mockSite);
-      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
-
-      const mockConfig = createMockConfig();
-      const mockTierClient = createMockTierClient();
-      const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
-      const mockComposeBaseURL = createMockComposeBaseURL();
-      const { mockClient: sharePointClient } = createMockSharePointClient(
-        sinon,
-        { folderExists: false },
-      );
-      const mockOctokit = createMockOctokit();
-      const mockDrsClient = createMockDrsClient();
-      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
-
-      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockTierClient,
-          mockTracingFetch,
-          mockConfig,
-          mockComposeBaseURL,
-          mockSharePointClient: sharePointClient,
-          mockOctokit,
-          mockDrsClient,
-          mockCustomerConfigV2Storage,
-        }),
-      );
-
-      const context = {
-        dataAccess: mockDataAccess,
-        log: mockLog,
-        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-        sqs: {
-          sendMessage: sinon.stub().resolves(),
-        },
-      };
-
-      await performLlmoOnboardingWithMocks({
-        domain: 'example.com',
-        brandName: 'Test Brand IN',
-        imsOrgId: 'ABC123@AdobeOrg',
-        region: 'IN',
-      }, context);
-
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob).to.have.been.calledOnce;
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob.firstCall.args[0]).to.include({
-        brandName: 'Test Brand IN',
-        siteId: 'site123',
-        imsOrgId: 'ABC123@AdobeOrg',
-        region: 'IN',
-      });
-      expect(mockLog.info).to.have.been.calledWithMatch(
-        /Using operator-supplied region "IN" for v1 DRS prompt generation/,
-      );
-    }).timeout(10000);
-
-    it('should skip DRS prompt generation in v1 mode when DRS client is not configured', async () => {
-      const mockOrganization = {
-        getId: sinon.stub().returns('org123'),
-        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
-      };
-
-      const mockSite = {
-        getId: sinon.stub().returns('site123'),
-        getConfig: sinon.stub().returns({
-          updateLlmoBrand: sinon.stub(),
-          updateLlmoDataFolder: sinon.stub(),
-          getImports: sinon.stub().returns([]),
-          enableImport: sinon.stub(),
-          getFetchConfig: sinon.stub().returns({}),
-          updateFetchConfig: sinon.stub(),
-          getBrandProfile: sinon.stub().returns(null),
-        }),
-        setConfig: sinon.stub(),
-        save: sinon.stub().resolves(),
-      };
-
-      const mockConfiguration = {
-        enableHandlerForSite: sinon.stub(),
-        disableHandlerForSite: sinon.stub(),
-        isHandlerEnabledForSite: sinon.stub().returns(false),
-        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
-        save: sinon.stub().resolves(),
-        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
-      };
-
-      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
-      mockDataAccess.Site.findByBaseURL.resolves(null);
-      mockDataAccess.Site.create.resolves(mockSite);
-      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
-
-      const mockConfig = createMockConfig();
-      const mockTierClient = createMockTierClient();
-      const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
-      const mockComposeBaseURL = createMockComposeBaseURL();
-      const { mockClient: sharePointClient } = createMockSharePointClient(
-        sinon,
-        { folderExists: false },
-      );
-      const mockOctokit = createMockOctokit();
-      // DRS client not configured — v1 path should fall through the else branch and skip
-      // submitPromptGenerationJob, emitting a debug log instead.
-      const mockDrsClient = createMockDrsClient(sinon, { isConfigured: false });
-      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
-
-      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockTierClient,
-          mockTracingFetch,
-          mockConfig,
-          mockComposeBaseURL,
-          mockSharePointClient: sharePointClient,
-          mockOctokit,
-          mockDrsClient,
-          mockCustomerConfigV2Storage,
-        }),
-      );
-
-      const context = {
-        dataAccess: mockDataAccess,
-        log: mockLog,
-        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-        sqs: { sendMessage: sinon.stub().resolves() },
-      };
-
-      await performLlmoOnboardingWithMocks({
-        domain: 'example.com',
-        brandName: 'Test Brand',
-        imsOrgId: 'ABC123@AdobeOrg',
-      }, context);
-
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob).to.not.have.been.called;
-      expect(mockLog.debug).to.have.been.calledWith('DRS client not configured, skipping prompt generation');
-    }).timeout(10000);
-
-    it('should handle DRS prompt generation failure gracefully in v1 mode', async () => {
-      const mockOrganization = {
-        getId: sinon.stub().returns('org123'),
-        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
-      };
-
-      const mockSite = {
-        getId: sinon.stub().returns('site123'),
-        getConfig: sinon.stub().returns({
-          updateLlmoBrand: sinon.stub(),
-          updateLlmoDataFolder: sinon.stub(),
-          getImports: sinon.stub().returns([]),
-          enableImport: sinon.stub(),
-          getFetchConfig: sinon.stub().returns({}),
-          updateFetchConfig: sinon.stub(),
-          getBrandProfile: sinon.stub().returns(null),
-        }),
-        setConfig: sinon.stub(),
-        save: sinon.stub().resolves(),
-      };
-
-      const mockConfiguration = {
-        enableHandlerForSite: sinon.stub(),
-        disableHandlerForSite: sinon.stub(),
-        isHandlerEnabledForSite: sinon.stub().returns(false),
-        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
-        save: sinon.stub().resolves(),
-        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
-      };
-
-      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
-      mockDataAccess.Site.findByBaseURL.resolves(null);
-      mockDataAccess.Site.create.resolves(mockSite);
-      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
-
-      const mockConfig = createMockConfig();
-      const mockTierClient = createMockTierClient();
-      const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
-      const mockComposeBaseURL = createMockComposeBaseURL();
-      const { mockClient: sharePointClient } = createMockSharePointClient(
-        sinon,
-        { folderExists: false },
-      );
-      const mockOctokit = createMockOctokit();
-      // DRS prompt generation throws — onboarding should swallow the error, log it,
-      // and warn via say() that a manual trigger is required (LLMO-4534).
-      const submitPromptGenerationJob = sinon.stub().rejects(new Error('drs unavailable'));
-      const mockDrsClient = createMockDrsClient(sinon, { submitPromptGenerationJob });
-      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
-
-      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockTierClient,
-          mockTracingFetch,
-          mockConfig,
-          mockComposeBaseURL,
-          mockSharePointClient: sharePointClient,
-          mockOctokit,
-          mockDrsClient,
-          mockCustomerConfigV2Storage,
-        }),
-      );
-
-      const context = {
-        dataAccess: mockDataAccess,
-        log: mockLog,
-        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-        sqs: { sendMessage: sinon.stub().resolves() },
-      };
-
-      const sayStub = sinon.stub();
-
-      const result = await performLlmoOnboardingWithMocks({
-        domain: 'example.com',
-        brandName: 'Test Brand',
-        imsOrgId: 'ABC123@AdobeOrg',
-      }, context, sayStub);
-
-      // Onboarding still completes despite DRS failure
-      expect(result.siteId).to.equal('site123');
-      expect(submitPromptGenerationJob).to.have.been.calledOnce;
-      expect(mockLog.error).to.have.been.calledWith('Failed to start DRS prompt generation: drs unavailable');
-      expect(sayStub).to.have.been.calledWith(':warning: Failed to start DRS prompt generation for site site123 (will need manual trigger)');
-    }).timeout(10000);
-
-    it('should use the English fallback audience when brand profile is missing in v1 mode', async () => {
-      const mockOrganization = {
-        getId: sinon.stub().returns('org123'),
-        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
-      };
-
-      const mockSite = {
-        getId: sinon.stub().returns('site123'),
-        getConfig: sinon.stub().returns({
-          updateLlmoBrand: sinon.stub(),
-          updateLlmoDataFolder: sinon.stub(),
-          getImports: sinon.stub().returns([]),
-          enableImport: sinon.stub(),
-          getFetchConfig: sinon.stub().returns({}),
-          updateFetchConfig: sinon.stub(),
-          // Brand profile missing entirely — exercises the `||` fallback at the audience line.
-          getBrandProfile: sinon.stub().returns(null),
-        }),
-        setConfig: sinon.stub(),
-        save: sinon.stub().resolves(),
-      };
-
-      const mockConfiguration = {
-        enableHandlerForSite: sinon.stub(),
-        disableHandlerForSite: sinon.stub(),
-        isHandlerEnabledForSite: sinon.stub().returns(false),
-        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
-        save: sinon.stub().resolves(),
-        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
-      };
-
-      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
-      mockDataAccess.Site.findByBaseURL.resolves(null);
-      mockDataAccess.Site.create.resolves(mockSite);
-      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
-
-      const mockConfig = createMockConfig();
-      const mockTierClient = createMockTierClient();
-      const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
-      const mockComposeBaseURL = createMockComposeBaseURL();
-      const { mockClient: sharePointClient } = createMockSharePointClient(
-        sinon,
-        { folderExists: false },
-      );
-      const mockOctokit = createMockOctokit();
-      const mockDrsClient = createMockDrsClient();
-      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
-
-      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockTierClient,
-          mockTracingFetch,
-          mockConfig,
-          mockComposeBaseURL,
-          mockSharePointClient: sharePointClient,
-          mockOctokit,
-          mockDrsClient,
-          mockCustomerConfigV2Storage,
-        }),
-      );
-
-      const context = {
-        dataAccess: mockDataAccess,
-        log: mockLog,
-        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-        sqs: { sendMessage: sinon.stub().resolves() },
-      };
-
-      // Caller passes brandName with whitespace to confirm trim is applied to BOTH the
-      // audience template and the DRS payload (consistency).
-      await performLlmoOnboardingWithMocks({
-        domain: 'example.com',
-        brandName: '  Test Brand  ',
-        imsOrgId: 'ABC123@AdobeOrg',
-      }, context);
-
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob).to.have.been.calledOnce;
-      expect(mockDrsClient.createFrom().submitPromptGenerationJob.firstCall.args[0]).to.include({
-        brandName: 'Test Brand',
-        audience: 'General consumers interested in Test Brand products and services',
-        siteId: 'site123',
-        imsOrgId: 'ABC123@AdobeOrg',
-      });
-    }).timeout(10000);
-
-    it('should treat a DRS response missing job_id as a failure in v1 mode', async () => {
-      const mockOrganization = {
-        getId: sinon.stub().returns('org123'),
-        getImsOrgId: sinon.stub().returns('ABC123@AdobeOrg'),
-      };
-
-      const mockSite = {
-        getId: sinon.stub().returns('site123'),
-        getConfig: sinon.stub().returns({
-          updateLlmoBrand: sinon.stub(),
-          updateLlmoDataFolder: sinon.stub(),
-          getImports: sinon.stub().returns([]),
-          enableImport: sinon.stub(),
-          getFetchConfig: sinon.stub().returns({}),
-          updateFetchConfig: sinon.stub(),
-          getBrandProfile: sinon.stub().returns(null),
-        }),
-        setConfig: sinon.stub(),
-        save: sinon.stub().resolves(),
-      };
-
-      const mockConfiguration = {
-        enableHandlerForSite: sinon.stub(),
-        disableHandlerForSite: sinon.stub(),
-        isHandlerEnabledForSite: sinon.stub().returns(false),
-        getEnabledSiteIdsForHandler: sinon.stub().returns([]),
-        save: sinon.stub().resolves(),
-        getQueues: sinon.stub().returns({ audits: 'audit-queue' }),
-      };
-
-      mockDataAccess.Organization.findByImsOrgId.resolves(mockOrganization);
-      mockDataAccess.Site.findByBaseURL.resolves(null);
-      mockDataAccess.Site.create.resolves(mockSite);
-      mockDataAccess.Configuration.findLatest.resolves(mockConfiguration);
-
-      const mockConfig = createMockConfig();
-      const mockTierClient = createMockTierClient();
-      const mockTracingFetch = createMockTracingFetch();
-      originalSetTimeout = mockSetTimeoutImmediate();
-      const mockComposeBaseURL = createMockComposeBaseURL();
-      const { mockClient: sharePointClient } = createMockSharePointClient(
-        sinon,
-        { folderExists: false },
-      );
-      const mockOctokit = createMockOctokit();
-      // DRS resolves without a job_id — onboarding must NOT log/say a fake success;
-      // it must throw into the catch and emit the `:warning:` instead.
-      const submitPromptGenerationJob = sinon.stub().resolves({});
-      const mockDrsClient = createMockDrsClient(sinon, { submitPromptGenerationJob });
-      const mockCustomerConfigV2Storage = createMockCustomerConfigV2Storage();
-
-      const { performLlmoOnboarding: performLlmoOnboardingWithMocks } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockTierClient,
-          mockTracingFetch,
-          mockConfig,
-          mockComposeBaseURL,
-          mockSharePointClient: sharePointClient,
-          mockOctokit,
-          mockDrsClient,
-          mockCustomerConfigV2Storage,
-        }),
-      );
-
-      const context = {
-        dataAccess: mockDataAccess,
-        log: mockLog,
-        env: { ...mockEnv, LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
-        sqs: { sendMessage: sinon.stub().resolves() },
-      };
-
-      const sayStub = sinon.stub();
-
-      const result = await performLlmoOnboardingWithMocks({
-        domain: 'example.com',
-        brandName: 'Test Brand',
-        imsOrgId: 'ABC123@AdobeOrg',
-      }, context, sayStub);
-
-      expect(result.siteId).to.equal('site123');
-      expect(submitPromptGenerationJob).to.have.been.calledOnce;
-      expect(mockLog.error).to.have.been.calledWith('Failed to start DRS prompt generation: DRS submitPromptGenerationJob returned no job_id');
-      expect(sayStub).to.have.been.calledWith(':warning: Failed to start DRS prompt generation for site site123 (will need manual trigger)');
-      // The success log/say must NOT have been emitted with `undefined`
-      expect(mockLog.info).to.not.have.been.calledWith('Started DRS prompt generation: job=undefined');
-      expect(sayStub).to.not.have.been.calledWith(':robot_face: Started DRS prompt generation job: undefined');
-    }).timeout(10000);
 
     it('should skip DRS prompt generation when DRS client is not configured', async () => {
       // Mock organization
@@ -6725,9 +6263,6 @@ describe('LLMO Onboarding Functions', () => {
         .to.deep.equal(['created', 'created', 'created']);
       expect(result.promptSuggestionSchedulesTimedOut).to.be.false;
       expect(result.requiredWorkFailed).to.be.false;
-      // v2 has no direct prompt-generation submit (deferred to DRS post-Brandalf).
-      expect(result.promptGenerationJobId).to.equal(null);
-      expect(result.promptGenerationError).to.equal(null);
     });
 
     it('v2: a per-pipeline failed schedule result flags requiredWorkFailed (not a timeout)', async () => {
@@ -6760,54 +6295,6 @@ describe('LLMO Onboarding Functions', () => {
       expect(failed[0].providerId).to.equal('prompt_generation_agentic_traffic');
       expect(failed[0].error).to.equal('DRS POST /schedules failed');
       // requiredWorkFailed is driven by the `.some(r => r.status === 'failed')` branch.
-      expect(result.requiredWorkFailed).to.be.true;
-    });
-
-    it('v1 success: returns promptGenerationJobId, no Brandalf, requiredWorkFailed false', async () => {
-      const mockDrsClient = createMockDrsClient(sandbox);
-      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockDrsClient,
-          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
-        }),
-      );
-
-      const context = buildV2Context();
-      const result = await activateBrandAndGeneratePrompts({
-        ...buildV2Params(context),
-        onboardingMode: 'v1',
-      });
-
-      const instance = mockDrsClient.createFrom();
-      expect(instance.submitPromptGenerationJob).to.have.been.calledOnce;
-      // v1 never triggers Brandalf or registers recurring schedules.
-      expect(instance.submitJob).to.not.have.been.called;
-      expect(instance.createSchedule).to.not.have.been.called;
-      expect(result.promptGenerationJobId).to.equal('test-drs-job-123');
-      expect(result.promptGenerationError).to.equal(null);
-      expect(result.brandalfTriggered).to.be.false;
-      expect(result.requiredWorkFailed).to.be.false;
-    });
-
-    it('v1 failure: submitPromptGenerationJob with no job_id sets promptGenerationError + requiredWorkFailed', async () => {
-      const mockDrsClient = createMockDrsClient(sandbox, {
-        submitPromptGenerationJob: sandbox.stub().resolves({}), // no job_id
-      });
-      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
-        createCommonEsmockDependencies({
-          mockDrsClient,
-          mockUpsertBrand: sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
-        }),
-      );
-
-      const context = buildV2Context();
-      const result = await activateBrandAndGeneratePrompts({
-        ...buildV2Params(context),
-        onboardingMode: 'v1',
-      });
-
-      expect(result.promptGenerationJobId).to.equal(null);
-      expect(result.promptGenerationError).to.equal('DRS submitPromptGenerationJob returned no job_id');
       expect(result.requiredWorkFailed).to.be.true;
     });
   });

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -3595,8 +3595,6 @@ describe('LlmoController', () => {
       const brandActivation = {
         brandalfTriggered: true,
         brandalfError: null,
-        promptGenerationJobId: null,
-        promptGenerationError: null,
         promptSuggestionSchedules: [
           { providerId: 'prompt_generation_semrush', status: 'created' },
         ],

--- a/test/it/shared/tests/brand-for-org-site.js
+++ b/test/it/shared/tests/brand-for-org-site.js
@@ -34,11 +34,12 @@ import { upsertFeatureFlag } from '../../../../src/support/feature-flags-storage
  *  - 404 on missing org / site
  *  - 403 on cross-org user access
  *
- * The resolver's v1 → 404 gate is covered by controller unit tests
- * (test/controllers/brands.test.js). It is not exercised here: since LLMO-7108
- * removed the legacy-site cutoff, the only remaining v1 path is the
- * LLMO_ONBOARDING_DEFAULT_VERSION kill switch, which is fixed at IT-harness
- * startup and cannot be toggled per-test over HTTP.
+ * The resolver can no longer return v1 (the LLMO_ONBOARDING_DEFAULT_VERSION
+ * kill switch was removed — brandalf-migration cleanup §2; upstream gate for
+ * DRS #2807), so there is no v1 → 404 path to exercise here: every org resolves
+ * v2. The brands controller retains a defensive v1 → 404 branch that the real
+ * resolver never triggers; it is covered by controller unit tests
+ * (test/controllers/brands.test.js).
  *
  * Each describe block calls `resetData()` to start from baseline, then uses
  * the postgrestClient directly to set up the brandalf flag and brand→site

--- a/test/support/llmo-onboarding-mode.test.js
+++ b/test/support/llmo-onboarding-mode.test.js
@@ -165,11 +165,12 @@ describe('llmo-onboarding-mode', () => {
   });
 
   // ── resolveLlmoOnboardingMode ─────────────────────────────────────────────
-  // The legacy-site cutoff was removed in LLMO-7108. The resolver now decides:
+  // Always resolves v2 — the v1 kill switch was removed (brandalf-migration
+  // cleanup §2; upstream gate for DRS #2807). The resolver now decides:
   //   1. brandalf=true            → v2
   //   2. brandalf_migration=true  → v2
-  //   3. LLMO_ONBOARDING_DEFAULT_VERSION==='v1' (kill switch) → v1
-  //   4. otherwise                → v2
+  //   3. otherwise                → v2 (a stale LLMO_ONBOARDING_DEFAULT_VERSION
+  //      ='v1' pin is treated as invalid and resolves v2)
 
   describe('resolveLlmoOnboardingMode', () => {
     // ── Brandalf flag → v2 ─────────────────────────────────────────────────
@@ -207,24 +208,30 @@ describe('llmo-onboarding-mode', () => {
       });
     });
 
-    // ── Kill switch — no brandalf flag ─────────────────────────────────────
+    // ── Retired v1 kill switch — never returns v1 ──────────────────────────
+    // The LLMO_ONBOARDING_DEFAULT_VERSION==='v1' kill switch was removed
+    // (brandalf-migration cleanup §2; upstream gate for DRS #2807). A stale
+    // 'v1' pin must resolve v2, and the resolver must never return v1.
 
-    describe('kill switch — no brandalf flag', () => {
-      it('returns v1 when the kill switch is active and the flag row is missing', async () => {
+    describe('retired v1 kill switch — never returns v1', () => {
+      it('resolves v2 (not v1) with a stale LLMO_ONBOARDING_DEFAULT_VERSION=v1 pin and a missing flag row', async () => {
         const ctx = makeContext({
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
           brandalfValue: null,
         });
-        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
+        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v2');
+        // The stale pin is surfaced as invalid rather than honored.
+        expect(ctx.log.warn).to.have.been.calledWith(
+          'Invalid LLMO_ONBOARDING_DEFAULT_VERSION "v1", falling back to v2',
+        );
       });
 
-      it('returns v1 when the kill switch is active and brandalf=false', async () => {
+      it('resolves v2 (not v1) with a stale v1 pin and brandalf=false', async () => {
         const ctx = makeContext({
           env: { LLMO_ONBOARDING_DEFAULT_VERSION: 'v1' },
           brandalfValue: false,
         });
-        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v1');
-        // brandalf=false → kill switch → v1 without any site lookup.
+        expect(await resolveLlmoOnboardingMode('org-1', ctx)).to.equal('v2');
         expect(ctx.dataAccess.Site.allByOrganizationId).to.not.have.been.called;
       });
     });

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -470,8 +470,6 @@ describe('onboard-llmo-modal', () => {
         brandActivation: {
           brandalfTriggered: true,
           brandalfError: null,
-          promptGenerationJobId: null,
-          promptGenerationError: null,
           promptSuggestionSchedules: [
             { providerId: 'prompt_generation_semrush', status: 'created' },
           ],


### PR DESCRIPTION
## What

`resolveLlmoOnboardingMode` can no longer return `v1` — api-service now always onboards **v2**.

- `src/support/llmo-onboarding-mode.js`: drop the `LLMO_ONBOARDING_DEFAULT_VERSION==='v1'` kill-switch arm (a stale `'v1'` pin now warns and resolves v2).
- `src/controllers/llmo/llmo-onboarding.js`: collapse the dead v1 branches in `performLlmoOnboarding` + `activateBrandAndGeneratePrompts` to unconditional v2.
- Tests updated; `brandActivation` OpenAPI schema trimmed of its v1-only fields.

## Why

Upstream gate for **DRS #2807 Phase 2**: DRS can delete its legacy v1 LLMO-config read arms only once api-service stops producing v1 orgs (per `serenity-docs` `brandalf-migration-cleanup.md` §1/§2/§5). The DRS-side v1 drain has been **zero since 2026-08-28**, and a sweep of all 5025 prod orgs found only 2 on `brandalf_migration` (both already resolve v2) — so removing the v1 arm is safe.

## Related issues & spec

- **Design / spec:** serenity-docs [`brandalf-migration-cleanup.md`](https://github.com/adobe/serenity-docs/blob/main/docs/cleanup/brandalf-migration-cleanup.md) §1/§2/§5 (owner: Rainer Friederich) — the agreed inventory this implements.
- **Downstream:** DRS [#2807](https://github.com/adobe-rnd/llmo-data-retrieval-service/issues/2807) Phase 2; this PR is its upstream "stop producing v1 orgs" gate.

## Pre-merge prereq — CLEARED

- [x] **Confirmed 2026-09-01:** `LLMO_ONBOARDING_DEFAULT_VERSION` = `v2` in prod Vault (`dx_mysticat/prod/api-service`), **not** pinned `'v1'`. Prod is not relying on the kill switch, so removing the v1 arm is a behavioral no-op in prod.

## Cross-caller — owner sign-off please

`resolveLlmoOnboardingMode` also feeds the read-only (org, site)→brand resolver in `brands.js` (BP refresh + the DRS scheduler). With v1 gone, that resolver now always resolves the v2 brand for a flagless org instead of returning 404 — the intended "stop producing v1" effect DRS #2807 depends on, and a no-op while the checkbox above holds. `brands.js` is unchanged; its defensive v1→404 branch simply never triggers now.

## Rebased over #3155

Composed on top of #3155 (honest-reporting), which rewrote the same `activateBrandAndGeneratePrompts`: kept all of #3155's v2 outcome-summary work; removed only its v1 arm (the v1 `else`, the v1-only tracking vars, the v1 side of `requiredWorkFailed`) and its two v1-only tests.

## Follow-ups (not here)

- §5: remove `brandalf_migration` plumbing (gated on no mid-migration orgs).
- §1: delete `llmo-onboarding-mode.js` + the `LLMO_ONBOARDING_DEFAULT_VERSION` env var once no v1 customers remain.

The flag reads and `llmo-onboarding-mode.js` are deliberately kept so these stay separable.

## Validation

`lint` + `type-check` (base+strict) clean; touched mocha suites pass (run per-file); `docs:lint` valid.

Reviewers: api-service / LLMO owners (Rainer owns the cleanup doc).

`Introduced by: N/A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Docs Spec-Sync exception (review item 4)

`docs/openapi/llmo-api.yaml` has a real content change (removed `promptGenerationJobId` / `promptGenerationError` from the `brandActivation` schema). Per CLAUDE.md's documented exception for `docs/index.html` hash non-determinism across toolchains, `docs/index.html` is intentionally **not** regenerated here (regenerating on a non-canonical toolchain produces pure hash-noise churn). The OpenAPI spec file is the source of truth and `npm run docs:lint` passes ("API description is valid"). This invokes the documented opt-out rather than committing a hash-noise `docs/index.html` diff.
