### PR TITLE
feat(ai-visibility): scope Cited Pages tab to subdomains via search_type

### DIFF
--- a/src/support/ai-visibility/handlers/v1/source/cited-pages-export.js
+++ b/src/support/ai-visibility/handlers/v1/source/cited-pages-export.js
@@ -25,7 +25,6 @@ import {
   SourcesRequestSchema,
 } from '@quazar/ai-seo-ts/v2/source/messages_pb.js';
 import {
-  SEARCH_TYPE_ENUM,
   SOURCE_CATEGORY_ENUM,
   SOURCES_REQUEST_ORDER_BY_ENUM,
 } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
@@ -34,6 +33,7 @@ import {
   resolveCountry,
   engineToLlm,
   responseFromGrpcError,
+  resolveSearchType,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -48,6 +48,7 @@ export async function handleCitedPagesExport(sp, clients) {
   const sortDirection = sp.get('sortDirection') || ORDER_DIRECTION_ENUM.DESC;
   const date = sp.get('date');
   const { limit, offset } = parseLimitOffset(sp);
+  const searchType = resolveSearchType(domain);
 
   let exportRequest;
   try {
@@ -65,7 +66,7 @@ export async function handleCitedPagesExport(sp, clients) {
         },
         range: { limit, offset },
         target_date: date,
-        search_type: SEARCH_TYPE_ENUM.DOMAIN,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/source/cited-pages-totals.js
+++ b/src/support/ai-visibility/handlers/v1/source/cited-pages-totals.js
@@ -19,11 +19,11 @@ import {
   OwnedSourcesTotalRequestSchema,
   OwnedSourcesTotalResponseSchema,
 } from '@quazar/ai-seo-ts/v2/source/messages_pb.js';
-import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
 import {
   resolveCountry,
   engineToLlm,
   responseFromGrpcError,
+  resolveSearchType,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -35,6 +35,7 @@ export async function handleCitedPagesTotals(sp, clients) {
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const country = resolveCountry(sp) || COUNTRY_ENUM.WORLDWIDE;
   const date = sp.get('date');
+  const searchType = resolveSearchType(domain);
 
   let totalsRequest;
   try {
@@ -46,7 +47,7 @@ export async function handleCitedPagesTotals(sp, clients) {
         target: { domain, name: domain },
         filter_ql: buildCitedPagesFilterQl(sp),
         target_date: date,
-        search_type: SEARCH_TYPE_ENUM.DOMAIN,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/source/cited-pages.js
+++ b/src/support/ai-visibility/handlers/v1/source/cited-pages.js
@@ -21,7 +21,6 @@ import {
   SourcesResponseSchema,
 } from '@quazar/ai-seo-ts/v2/source/messages_pb.js';
 import {
-  SEARCH_TYPE_ENUM,
   SOURCE_CATEGORY_ENUM,
   SOURCES_REQUEST_ORDER_BY_ENUM,
 } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
@@ -31,6 +30,7 @@ import {
   engineToLlm,
   responseFromGrpcError,
   escapeQlString,
+  resolveSearchType,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
 } from '../../../grpc-utils.js';
@@ -52,6 +52,7 @@ export async function handleCitedPages(sp, clients) {
   const sortDirection = sp.get('sortDirection') || ORDER_DIRECTION_ENUM.DESC;
   const date = sp.get('date');
   const { limit, offset } = parseLimitOffset(sp);
+  const searchType = resolveSearchType(domain);
 
   let listRequest;
   try {
@@ -69,7 +70,7 @@ export async function handleCitedPages(sp, clients) {
         },
         range: { limit, offset },
         target_date: date,
-        search_type: SEARCH_TYPE_ENUM.DOMAIN,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/test/support/ai-visibility/handlers/v1/source/cited-pages.test.js
+++ b/test/support/ai-visibility/handlers/v1/source/cited-pages.test.js
@@ -31,6 +31,8 @@ function sp(query) {
 
 const APEX = 'domain=intuit.com';
 const SUBDOMAIN = 'domain=quickbooks.intuit.com';
+const WWW = 'domain=www.intuit.com';
+const MISSING = '';
 
 describe('AI Visibility – v1 cited-pages search_type (LLMO-7015)', () => {
   let sandbox;
@@ -59,6 +61,16 @@ describe('AI Visibility – v1 cited-pages search_type (LLMO-7015)', () => {
       await handleCitedPages(sp(SUBDOMAIN), clients);
       expect(clients.sourceClient.sources.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
     });
+
+    it('resolves search_type DOMAIN for a bare www subdomain', async () => {
+      await handleCitedPages(sp(WWW), clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type DOMAIN when the domain is missing', async () => {
+      await handleCitedPages(sp(MISSING), clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
   });
 
   describe('handleCitedPagesTotals', () => {
@@ -71,6 +83,16 @@ describe('AI Visibility – v1 cited-pages search_type (LLMO-7015)', () => {
       await handleCitedPagesTotals(sp(SUBDOMAIN), clients);
       expect(clients.sourceClient.ownedSourcesTotal.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
     });
+
+    it('resolves search_type DOMAIN for a bare www subdomain', async () => {
+      await handleCitedPagesTotals(sp(WWW), clients);
+      expect(clients.sourceClient.ownedSourcesTotal.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type DOMAIN when the domain is missing', async () => {
+      await handleCitedPagesTotals(sp(MISSING), clients);
+      expect(clients.sourceClient.ownedSourcesTotal.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
   });
 
   describe('handleCitedPagesExport', () => {
@@ -82,6 +104,16 @@ describe('AI Visibility – v1 cited-pages search_type (LLMO-7015)', () => {
     it('resolves search_type SUBDOMAIN for a non-www subdomain on the nested request', async () => {
       await handleCitedPagesExport(sp(SUBDOMAIN), clients);
       expect(clients.sourceClient.sourcesExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+
+    it('resolves search_type DOMAIN for a bare www subdomain on the nested request', async () => {
+      await handleCitedPagesExport(sp(WWW), clients);
+      expect(clients.sourceClient.sourcesExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type DOMAIN when the domain is missing on the nested request', async () => {
+      await handleCitedPagesExport(sp(MISSING), clients);
+      expect(clients.sourceClient.sourcesExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
     });
   });
 });

--- a/test/support/ai-visibility/handlers/v1/source/cited-pages.test.js
+++ b/test/support/ai-visibility/handlers/v1/source/cited-pages.test.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable max-len -- AI Visibility cited-pages search_type tests */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import {
+  SourcesResponseSchema,
+  OwnedSourcesTotalResponseSchema,
+} from '@quazar/ai-seo-ts/v2/source/messages_pb.js';
+import { ExportResponseSchema } from '@quazar/ai-seo-ts/v2/common/messages_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { handleCitedPages } from '../../../../../../src/support/ai-visibility/handlers/v1/source/cited-pages.js';
+import { handleCitedPagesTotals } from '../../../../../../src/support/ai-visibility/handlers/v1/source/cited-pages-totals.js';
+import { handleCitedPagesExport } from '../../../../../../src/support/ai-visibility/handlers/v1/source/cited-pages-export.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+const APEX = 'domain=intuit.com';
+const SUBDOMAIN = 'domain=quickbooks.intuit.com';
+
+describe('AI Visibility – v1 cited-pages search_type (LLMO-7015)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      sourceClient: {
+        sources: sandbox.stub().resolves(create(SourcesResponseSchema, { source: [] })),
+        ownedSourcesTotal: sandbox.stub().resolves(create(OwnedSourcesTotalResponseSchema, {})),
+        sourcesExport: sandbox.stub().resolves(create(ExportResponseSchema, {})),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleCitedPages', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleCitedPages(sp(APEX), clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleCitedPages(sp(SUBDOMAIN), clients);
+      expect(clients.sourceClient.sources.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+
+  describe('handleCitedPagesTotals', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleCitedPagesTotals(sp(APEX), clients);
+      expect(clients.sourceClient.ownedSourcesTotal.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleCitedPagesTotals(sp(SUBDOMAIN), clients);
+      expect(clients.sourceClient.ownedSourcesTotal.firstCall.args[0].searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+
+  describe('handleCitedPagesExport', () => {
+    it('resolves search_type DOMAIN for an apex domain on the nested request', async () => {
+      await handleCitedPagesExport(sp(APEX), clients);
+      expect(clients.sourceClient.sourcesExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain on the nested request', async () => {
+      await handleCitedPagesExport(sp(SUBDOMAIN), clients);
+      expect(clients.sourceClient.sourcesExport.firstCall.args[0].request.searchType).to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Scope the AI Visibility Cited Pages tab to subdomains. The three cited-pages gRPC handlers now derive `search_type` from the domain instead of hardcoding `DOMAIN`.

## 2. Reasoning
The Cited Pages tab collapses any subdomain to its registrable domain, so loading it for `quickbooks.intuit.com` returns the same cited pages as `intuit.com`. Same root cause as the Performing Prompts tab (LLMO-6992, merged in #3041): the handlers send `search_type` but hardcode `SEARCH_TYPE_ENUM.DOMAIN`, and Semrush defaults collapse subdomains to the apex.

## 3. High-level overview of the changes
Replace the hardcoded `search_type: SEARCH_TYPE_ENUM.DOMAIN` with `search_type: resolveSearchType(domain)` in the three handlers backing the tab:

- `cited-pages` (list, `sources()`)
- `cited-pages-totals` (`ownedSourcesTotal()`)
- `cited-pages-export` (`sourcesExport()`, on the nested `SourcesRequest`)

`resolveSearchType` (in `grpc-utils.js`, added by LLMO-6992) maps a non-`www` subdomain to `SUBDOMAIN` and apex / bare `www` / unparseable input to `DOMAIN`.

Behaviour delta:
- Before: selecting a subdomain in the AI Visibility domain filter returned the apex domain's cited pages.
- After: selecting a subdomain scopes Cited Pages (list, totals, export) to that subdomain; apex domains are unchanged.

The UI already sends the full subdomain as the `domain` param, so no UI change is needed. Request/response shapes are unchanged — only the derived `search_type` value changes. No new helper, no OpenAPI/route/DTO changes.

## 4. Required information
- Jira / issue: [LLMO-7015](https://jira.corp.adobe.com/browse/LLMO-7015)
- Exemption: trivial value swap mirroring merged LLMO-6992/#3041, verified live against the Semrush gRPC; grounded in LLMO-7015 - no spec required for this change.
- Other: sibling work — [#3041](https://github.com/adobe/spacecat-api-service/pull/3041) (Performing Prompts, LLMO-6992), [#3111](https://github.com/adobe/spacecat-api-service/pull/3111) (brands/*), [#3124](https://github.com/adobe/spacecat-api-service/pull/3124) (stats-by-country)

## 6. Affected / used mysticat-workspace projects
- project-elmo-ui — consumer (contract unchanged). The AI Visibility Cited Pages tab calls these endpoints; it already passes the selected subdomain as `domain`, so it picks up subdomain scoping with no change.

## 7. Additional information outside the code
Verified live against the Semrush gRPC (direct call, bypassing the REST layer) that these handlers' methods honor `search_type=SUBDOMAIN` and return distinct results — this is the request family LLMO-6992 did not cover. For target `quickbooks.intuit.com`, category `OWNED_BY_TARGET`:

- `sources()`: `DOMAIN` returned mixed `*.intuit.com` URLs (turbotax, quickbooks, …); `SUBDOMAIN` returned only `quickbooks.intuit.com/*`.
- `ownedSourcesTotal()`: `DOMAIN` total 62,629 vs `SUBDOMAIN` total 40,262.

## 8. Test plan
(a) Live gRPC A/B probe (above) confirmed subdomain vs apex return different cited pages and totals — satisfies the ticket's live-verification acceptance criterion. Added a unit test mirroring the sibling `gap-source-domains` test: asserts `DOMAIN` for apex (`intuit.com`) and `SUBDOMAIN` for `quickbooks.intuit.com` across all three handlers.

(b) dev: in the AI Visibility dashboard, select a non-`www` subdomain in the domain filter and open the Cited Pages tab — the list, totals, and CSV export should scope to that subdomain. Select the apex domain — results should be unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Josep López", "Dima", "Dominique Jäggi"]
rationale: "Read-only derived-parameter fix mirroring an already-merged sibling change; no write path or contract change."
```