### PR TITLE
fix(onboard): allow onboarding to update entitlement for PRE_ONBOARD orgs

### DIFF
--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -1807,9 +1807,9 @@ export async function queueDeliveryConfigWriter(
  * @param {Object} additionalParams - Additional parameters
  * @param {string} additionalParams.tier - Entitlement tier
  * @param {boolean} [additionalParams.forceTierUpdate] - When true, allows the onboard
- *   command to change a PLG/PRE_ONBOARD org's tier/entitlement and audit config. By
- *   default these tiers are preserved (SITES-49886). Separate from `force`, which only
- *   overrides the paid-profile downgrade guard.
+ *   command to change a PLG org's tier/entitlement and audit config. By default the PLG
+ *   tier is preserved (SITES-49886). Separate from `force`, which only overrides the
+ *   paid-profile downgrade guard.
  * @param {Object} options - Additional options
  * @param {Function} options.urlProcessor - Function to process the URL
  *                                          (e.g., extractURLFromSlackInput)
@@ -2036,20 +2036,19 @@ export const onboardSingleSite = async (
     );
 
     // Protected-tier guard (SITES-49886): ASO entitlements are org-level. If the org
-    // already holds a PLG or PRE_ONBOARD ASO entitlement, the onboard command must NOT
-    // touch the tier/entitlement/enrollment — TierClient.createEntitlement(FREE_TRIAL)
-    // would otherwise overwrite (downgrade) the existing tier, exposing all opportunities
-    // instead of the limited PLG set. Onboarding is unsupported for these tiers; we only
-    // run audits/opportunities once (below) and leave the earlier config untouched.
+    // already holds a PLG ASO entitlement, the onboard command must NOT touch the
+    // tier/entitlement/enrollment — TierClient.createEntitlement(FREE_TRIAL) would
+    // otherwise overwrite (downgrade) the existing PLG tier, exposing all opportunities
+    // instead of the limited PLG set. Onboarding is unsupported for PLG; we only run
+    // audits/opportunities once (below) and leave the earlier config untouched.
     // An explicit additionalParams.forceTierUpdate is the sole escape hatch (kept separate
     // from `force`, which only overrides the paid-profile downgrade guard).
+    // PRE_ONBOARD is deliberately NOT protected here: it's an internal staging tier meant
+    // to be promoted to a real tier (FREE_TRIAL/PAID) during onboarding, so the onboard
+    // command may create/update its entitlement normally.
     const existingAso = await getAsoEntitlement(organizationId, context);
     const existingTier = existingAso?.getTier() ?? null;
-    const PROTECTED_EXISTING_TIERS = [
-      EntitlementModel.TIERS.PLG,
-      EntitlementModel.TIERS.PRE_ONBOARD,
-    ];
-    const isProtectedOrg = existingTier != null && PROTECTED_EXISTING_TIERS.includes(existingTier);
+    const isProtectedOrg = existingTier === EntitlementModel.TIERS.PLG;
     const preserveProtectedTier = isProtectedOrg && !additionalParams.forceTierUpdate;
 
     // Create entitlement and enrollment
@@ -2069,9 +2068,9 @@ export const onboardSingleSite = async (
 
       // SITES-50179: the Force Tier Update escape hatch was exercised on a protected org
       // (isProtectedOrg is only true here when forceTierUpdate bypassed the guard above). If it
-      // downgraded a PLG/PRE_ONBOARD org to FREE_TRIAL — the exact transition that silently exposed
-      // the full opportunity set in the original incident — alert the team so every deliberate
-      // override is visible without manual auditing. Best-effort: never blocks onboarding.
+      // downgraded a PLG org to FREE_TRIAL — the exact transition that silently exposed the full
+      // opportunity set in the original incident — alert the team so every deliberate override is
+      // visible without manual auditing. Best-effort: never blocks onboarding.
       if (isProtectedOrg && tier === EntitlementModel.TIERS.FREE_TRIAL) {
         await notifyForcedTierDowngrade(
           {
@@ -2265,8 +2264,8 @@ export const onboardSingleSite = async (
     //     fire once — enable status only gates scheduling, not triggering.
     const wantEnabled = scheduledRun || profile.protected;
     // Protected-tier orgs (SITES-49886): leave the existing audit scheduling config exactly
-    // as-is. Enabling/disabling handlers here would alter a PLG/PRE_ONBOARD customer's
-    // recurring-audit setup; we only run audits once (below). Skipped unless forceTierUpdate.
+    // as-is. Enabling/disabling handlers here would alter a PLG customer's recurring-audit
+    // setup; we only run audits once (below). Skipped unless forceTierUpdate.
     if (preserveProtectedTier) {
       log.debug(`Preserving existing audit configuration for ${existingTier}-tier site ${siteID}`);
     } else {

--- a/test/support/utils-protected-tier-guard.test.js
+++ b/test/support/utils-protected-tier-guard.test.js
@@ -183,34 +183,48 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
     { profileName: 'demo' },
   );
 
-  ['PLG', 'PRE_ONBOARD'].forEach((protectedTier) => {
-    it(`preserves an existing ${protectedTier} tier: no entitlement/enrollment write, no audit-config change, still runs audits + opportunities once`, async () => {
-      const { onboardSingleSite, sfnSendStub, tierCreateForSiteStub } = await loadOnboard();
-      const site = makeHappyPathSite();
-      const existingEntitlement = { getTier: () => protectedTier };
-      const { context, configurationFindLatest } = makeContext(site, existingEntitlement);
+  it('preserves an existing PLG tier: no entitlement/enrollment write, no audit-config change, still runs audits + opportunities once', async () => {
+    const { onboardSingleSite, sfnSendStub, tierCreateForSiteStub } = await loadOnboard();
+    const site = makeHappyPathSite();
+    const existingEntitlement = { getTier: () => 'PLG' };
+    const { context, configurationFindLatest } = makeContext(site, existingEntitlement);
 
-      const result = await run(onboardSingleSite, context);
+    const result = await run(onboardSingleSite, context);
 
-      // Tier / entitlement / enrollment untouched — TierClient never engaged.
-      expect(tierCreateForSiteStub).to.not.have.been.called;
-      // Audit scheduling config left as-is — findLatest lives inside the skipped branch.
-      expect(configurationFindLatest).to.not.have.been.called;
-      // Audits still triggered once ...
-      expect(context.sqs.sendMessage).to.have.been.calledWith(
-        context.env.AUDIT_JOBS_QUEUE_URL,
-        sinon.match({ type: 'cwv', siteId: 'site-happy' }),
-      );
-      // ... and the opportunity workflow still starts once.
-      expect(sfnSendStub).to.have.been.calledOnce;
-      // The report reflects the true, unchanged tier and the run succeeds.
-      expect(result.tier).to.equal(protectedTier);
-      expect(result.status).to.equal('Success');
-      // Operator is told the tier was preserved.
-      expect(sayStub).to.have.been.calledWith(
-        sinon.match(new RegExp(`on the \\*${protectedTier}\\* tier`)),
-      );
-    });
+    // Tier / entitlement / enrollment untouched — TierClient never engaged.
+    expect(tierCreateForSiteStub).to.not.have.been.called;
+    // Audit scheduling config left as-is — findLatest lives inside the skipped branch.
+    expect(configurationFindLatest).to.not.have.been.called;
+    // Audits still triggered once ...
+    expect(context.sqs.sendMessage).to.have.been.calledWith(
+      context.env.AUDIT_JOBS_QUEUE_URL,
+      sinon.match({ type: 'cwv', siteId: 'site-happy' }),
+    );
+    // ... and the opportunity workflow still starts once.
+    expect(sfnSendStub).to.have.been.calledOnce;
+    // The report reflects the true, unchanged tier and the run succeeds.
+    expect(result.tier).to.equal('PLG');
+    expect(result.status).to.equal('Success');
+    // Operator is told the tier was preserved.
+    expect(sayStub).to.have.been.calledWith(
+      sinon.match(/on the \*PLG\* tier/),
+    );
+  });
+
+  it('does NOT preserve an existing PRE_ONBOARD tier: creates/updates the entitlement normally (internal staging tier, promoted during onboarding)', async () => {
+    const { onboardSingleSite, tierCreateForSiteStub } = await loadOnboard();
+    const site = makeHappyPathSite();
+    const { context, configurationFindLatest } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
+
+    const result = await run(onboardSingleSite, context);
+
+    // PRE_ONBOARD is no longer protected — the normal entitlement write + audit-config path run.
+    expect(tierCreateForSiteStub).to.have.been.calledOnce;
+    const createEntitlement = await tierCreateForSiteStub.firstCall.returnValue;
+    // Default requested tier is FREE_TRIAL — the staging tier is promoted.
+    expect(createEntitlement.createEntitlement).to.have.been.calledWith('FREE_TRIAL');
+    expect(configurationFindLatest).to.have.been.calledOnce;
+    expect(result.status).to.equal('Success');
   });
 
   it('creates an entitlement normally when the org has NO existing ASO entitlement (ims2 → s3 happy path)', async () => {
@@ -258,29 +272,41 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
    * only assert the wiring: it fires on that exact transition and stays silent otherwise.
    */
   describe('force-downgrade alert (SITES-50179)', () => {
-    ['PLG', 'PRE_ONBOARD'].forEach((protectedTier) => {
-      it(`alerts the team when forceTierUpdate downgrades ${protectedTier} → FREE_TRIAL`, async () => {
-        const { onboardSingleSite, notifyForcedTierDowngradeStub } = await loadOnboard();
-        const site = makeHappyPathSite();
-        const { context } = makeContext(site, { getTier: () => protectedTier });
+    it('alerts the team when forceTierUpdate downgrades PLG → FREE_TRIAL', async () => {
+      const { onboardSingleSite, notifyForcedTierDowngradeStub } = await loadOnboard();
+      const site = makeHappyPathSite();
+      const { context } = makeContext(site, { getTier: () => 'PLG' });
 
-        await run(onboardSingleSite, context, { forceTierUpdate: true });
+      await run(onboardSingleSite, context, { forceTierUpdate: true });
 
-        expect(notifyForcedTierDowngradeStub).to.have.been.calledOnce;
-        const [payload, env] = notifyForcedTierDowngradeStub.firstCall.args;
-        expect(payload).to.include({
-          fromTier: protectedTier,
-          toTier: 'FREE_TRIAL',
-          baseURL: SITE_URL,
-          siteId: 'site-happy',
-          entitlementId: 'ent-test',
-        });
-        // Source thread is threaded through so the team can see who forced it.
-        expect(payload.sourceChannelId).to.equal('C1');
-        expect(payload.sourceThreadTs).to.equal('1.0');
-        // env is forwarded so the helper can resolve the PLG channel + bot token.
-        expect(env).to.equal(context.env);
+      expect(notifyForcedTierDowngradeStub).to.have.been.calledOnce;
+      const [payload, env] = notifyForcedTierDowngradeStub.firstCall.args;
+      expect(payload).to.include({
+        fromTier: 'PLG',
+        toTier: 'FREE_TRIAL',
+        baseURL: SITE_URL,
+        siteId: 'site-happy',
+        entitlementId: 'ent-test',
       });
+      // Source thread is threaded through so the team can see who forced it.
+      expect(payload.sourceChannelId).to.equal('C1');
+      expect(payload.sourceThreadTs).to.equal('1.0');
+      // env is forwarded so the helper can resolve the PLG channel + bot token.
+      expect(env).to.equal(context.env);
+    });
+
+    it('does NOT alert when onboarding a PRE_ONBOARD org to FREE_TRIAL (no longer a protected tier)', async () => {
+      const {
+        onboardSingleSite, notifyForcedTierDowngradeStub, tierCreateForSiteStub,
+      } = await loadOnboard();
+      const site = makeHappyPathSite();
+      const { context } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
+
+      // No forceTierUpdate needed — PRE_ONBOARD is promoted through the normal path.
+      await run(onboardSingleSite, context);
+
+      expect(tierCreateForSiteStub).to.have.been.calledOnce;
+      expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
     });
 
     it('does NOT alert when the protected tier is preserved (no forceTierUpdate)', async () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Removes the `PRE_ONBOARD` tier from the onboard command's protected-tier preservation guard in `onboardSingleSite`, so an org that already holds a `PRE_ONBOARD` ASO entitlement is onboarded through the normal path. `PLG` remains the only protected tier.

## 2. Reasoning
`PRE_ONBOARD` is an internal staging tier — set on a target org by the `move-plg-site` flow — that is meant to be promoted to a real tier (`FREE_TRIAL`/`PAID`) when a site is onboarded. SITES-49886 hardened the onboard command to preserve an existing `PLG` **or** `PRE_ONBOARD` entitlement (to stop a silent downgrade that exposed the full opportunity set). Bundling `PRE_ONBOARD` into that guard had an unwanted side effect: the onboard command could no longer create or update the entitlement for a `PRE_ONBOARD` org without the Force Tier Update escape hatch, blocking the intended promotion. This PR narrows the guard to `PLG` only.

## 3. High-level overview of the changes
Behaviour delta in the Slack `onboard` command (`onboardSingleSite`):

- **Before:** onboarding an org whose ASO entitlement was `PRE_ONBOARD` skipped the entitlement/enrollment write and the audit-scheduling-config write, posted a `:lock:` "tier preserved" message, and only ran audits/opportunities once. Changing the tier required `Force Tier Update`.
- **After:** a `PRE_ONBOARD` org is onboarded normally — the entitlement is created/updated to the requested tier (default `FREE_TRIAL`), audit scheduling config is synced, and no `:lock:` message is shown. No escape hatch needed.
- **`PLG` is unchanged:** still preserved unless `forceTierUpdate` is set, and the SITES-50179 forced-downgrade Slack alert still fires when a `PLG → FREE_TRIAL` downgrade is forced.
- **Consequence:** onboarding a `PRE_ONBOARD` org to `FREE_TRIAL` no longer triggers the SITES-50179 forced-downgrade alert, because that transition is now the expected promotion path rather than a deliberate override.

The separate `RESTRICTED_TIERS` guard — which blocks an operator from *requesting* `tier=PRE_ONBOARD` as the onboard target — is intentionally left unchanged.

## 4. Required information
- Other: SITES-49886 (origin of the protected-tier guard) https://jira.corp.adobe.com/browse/SITES-49886 · SITES-50179 (forced-downgrade alert) https://jira.corp.adobe.com/browse/SITES-50179

## 7. Test plan
(a) The behaviour change is covered by unit tests in the onboard protected-tier guard suite, updated to assert that a `PRE_ONBOARD` org is promoted through the normal entitlement/enrollment + audit-config path, that a `PLG` org is still preserved with the `:lock:` message, and that the forced-downgrade alert fires only for a forced `PLG → FREE_TRIAL` transition. No separate local-stack or through-API e2e was run this session.

(b) Per-environment verification (dev / stage / prod) via the Slack `onboard` command:
- Pick (or create via `move-plg-site`) an org whose ASO entitlement is `PRE_ONBOARD`, then run `onboard` for a site in that org. Expect: entitlement updated to the requested tier (default `FREE_TRIAL`), no `:lock:` "tier preserved" message, audits/opportunities run.
- Regression: run `onboard` for a site whose org holds a `PLG` entitlement. Expect: the `:lock:` "on the *PLG* tier" message, tier/entitlement/enrollment unchanged; and only when `Force Tier Update` is selected and it downgrades `PLG → FREE_TRIAL`, the forced-downgrade alert posts to the PLG channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Narrows a protected-tier guard so PRE_ONBOARD orgs promote normally; reversible business-logic fix with no data destruction."
```