### PR TITLE
feat(llmo): bounded PAPI active-version lookup in akamai getVersions

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -6367,8 +6367,8 @@ site-llmo-akamai-versions:
                 active:
                   type: object
                   description: >-
-                    The PAPI activation record currently ACTIVE on each network, keyed by network
-                    name. A network with no active version is absent.
+                    The version currently ACTIVE on each network, keyed by network name. A network
+                    the property was never activated on is absent.
                   properties:
                     STAGING:
                       $ref: '#/akamai-active-activation'
@@ -6963,11 +6963,16 @@ akamai-property-ref:
 akamai-active-activation:
   type: object
   additionalProperties: false
-  description: The version currently ACTIVE on a network (projected from the PAPI activation record).
+  description: >-
+    The version currently ACTIVE on a network, from PAPI's bounded
+    `/versions/latest?activatedOn=NETWORK` lookup.
   properties:
     activationId:
-      type: string
-      example: 'atv_20135679'
+      type: [string, 'null']
+      description: >-
+        Always null — a bounded version lookup carries no activation record. Retained for
+        response-shape stability.
+      example: null
     propertyVersion:
       type: integer
       example: 5

--- a/src/controllers/llmo/llmo-akamai.js
+++ b/src/controllers/llmo/llmo-akamai.js
@@ -1194,33 +1194,36 @@ function LlmoAkamaiController(ctx) {
     const siteId = site.getId();
 
     try {
-      // Independent reads — run concurrently to halve endpoint latency.
-      const [activations, latestVersion] = await Promise.all([
-        client.listActivations(propertyId, contractId, groupId),
+      // Independent, history-independent reads — run concurrently. Each active-per-network value
+      // comes from PAPI's bounded `/versions/latest?activatedOn=NETWORK` lookup rather than
+      // scanning the property's full activation history, so this endpoint's cost stays flat as the
+      // number of versions/activations grows.
+      const [latestVersion, staging, production] = await Promise.all([
         client.getLatestVersion(propertyId, contractId, groupId),
+        client.getLatestVersionActivatedOn(propertyId, contractId, groupId, 'STAGING'),
+        client.getLatestVersionActivatedOn(propertyId, contractId, groupId, 'PRODUCTION'),
       ]);
-      // Active-per-network from the full activation history: key the ACTIVE entries by network.
-      // (latestActivation is newest-*submitted* — could be a failed/aborted record — so it is
-      // deliberately not used here.)
-      const active = activations.reduce((acc, activation) => {
-        if (String(activation.status || '').toUpperCase() !== 'ACTIVE') {
-          return acc;
-        }
-        const network = String(activation.network || '').toUpperCase();
-        // Akamai keeps at most one ACTIVE activation per network; if PAPI ever returns more, keep
-        // the first seen rather than letting a later one silently overwrite it (deterministic).
-        if (!(network in acc)) {
-          // Project only the fields the UI needs — do NOT pass the raw PAPI record through, so a
-          // future upstream field (e.g. notifyEmails) can't leak into the response.
-          acc[network] = {
-            activationId: activation.activationId,
-            propertyVersion: activation.propertyVersion,
-            network: activation.network,
-            status: activation.status,
-          };
-        }
-        return acc;
-      }, {});
+      // A bounded lookup returns a *version* record (not an activation record), so activationId is
+      // always null here — the version is active on the network by definition. The key is kept for
+      // response-shape stability with the previous (history-scan) implementation. An absent
+      // (undefined) result means the property was never activated on that network.
+      const active = {};
+      if (staging) {
+        active.STAGING = {
+          activationId: null,
+          propertyVersion: staging.propertyVersion,
+          network: 'STAGING',
+          status: 'ACTIVE',
+        };
+      }
+      if (production) {
+        active.PRODUCTION = {
+          activationId: null,
+          propertyVersion: production.propertyVersion,
+          network: 'PRODUCTION',
+          status: 'ACTIVE',
+        };
+      }
       return ok({ propertyId, latestVersion, active });
     } catch (e) {
       return papiErrorResponse(e, 'version listing', context, { siteId, propertyId });

--- a/test/controllers/llmo/llmo-akamai.test.js
+++ b/test/controllers/llmo/llmo-akamai.test.js
@@ -90,6 +90,7 @@ describe('LlmoAkamaiController', () => {
         { propertyId: PROPERTY_ID, propertyName: 'example', matchedOn: ['hostname'] },
       ]),
       getLatestVersion: sandbox.stub().resolves(7),
+      getLatestVersionActivatedOn: sandbox.stub(),
       getRuleTree: sandbox.stub().resolves({ ruleTree: RULE_TREE, ruleFormat: 'v2024-01-01', etag: 'etag-7' }),
       createVersion: sandbox.stub().resolves(8),
       updateRuleTree: sandbox.stub().resolves({ errors: [], warnings: [] }),
@@ -113,6 +114,13 @@ describe('LlmoAkamaiController', () => {
     // the freshly-fetched version's etag, not a stale one from the latest-version (v7) lookup.
     mockAkamaiClient.getRuleTree.withArgs(PROPERTY_ID, 8)
       .resolves({ ruleTree: RULE_TREE, ruleFormat: 'v2024-01-01', etag: 'etag-8' });
+
+    // Bounded active-version lookup: STAGING active on v7, PRODUCTION active on v5 (matches the
+    // default listActivations fixture above). undefined => never activated on that network.
+    mockAkamaiClient.getLatestVersionActivatedOn
+      .withArgs(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING').resolves({ propertyVersion: 7 });
+    mockAkamaiClient.getLatestVersionActivatedOn
+      .withArgs(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'PRODUCTION').resolves({ propertyVersion: 5 });
 
     mockTokowakaClient = {
       fetchMetaconfig: sandbox.stub().resolves({ apiKeys: [LLMO_API_KEY] }),
@@ -945,62 +953,52 @@ describe('LlmoAkamaiController', () => {
   });
 
   describe('getVersions', () => {
-    it('returns the latest version and the ACTIVE activation per network', async () => {
+    it('returns the latest version and the active version per network', async () => {
       const res = await controller.getVersions(withData(propertyRef));
       const body = await res.json();
       expect(res.status).to.equal(200);
       expect(body.propertyId).to.equal(PROPERTY_ID);
       expect(body.latestVersion).to.equal(7);
-      expect(body.active.STAGING.propertyVersion).to.equal(7);
-      expect(body.active.PRODUCTION.propertyVersion).to.equal(5);
-      expect(mockAkamaiClient.listActivations)
-        .to.have.been.calledWith(PROPERTY_ID, CONTRACT_ID, GROUP_ID);
+      expect(body.active.STAGING).to.deep.equal({
+        activationId: null, propertyVersion: 7, network: 'STAGING', status: 'ACTIVE',
+      });
+      expect(body.active.PRODUCTION).to.deep.equal({
+        activationId: null, propertyVersion: 5, network: 'PRODUCTION', status: 'ACTIVE',
+      });
     });
 
-    it('omits a network that has no ACTIVE activation', async () => {
-      mockAkamaiClient.listActivations.resolves([
-        {
-          activationId: 'atv_s', status: 'ACTIVE', network: 'STAGING', propertyVersion: 7,
-        },
-        {
-          activationId: 'atv_p', status: 'PENDING', network: 'PRODUCTION', propertyVersion: 6,
-        },
-      ]);
+    it('uses the bounded active-version lookup and never loads the full activation history', async () => {
+      await controller.getVersions(withData(propertyRef));
+      expect(mockAkamaiClient.getLatestVersionActivatedOn)
+        .to.have.been.calledWith(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
+      expect(mockAkamaiClient.getLatestVersionActivatedOn)
+        .to.have.been.calledWith(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'PRODUCTION');
+      expect(mockAkamaiClient.listActivations).to.not.have.been.called;
+    });
+
+    it('omits a network that was never activated', async () => {
+      mockAkamaiClient.getLatestVersionActivatedOn
+        .withArgs(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'PRODUCTION').resolves(undefined);
       const res = await controller.getVersions(withData(propertyRef));
       const body = await res.json();
       expect(body.active.STAGING.propertyVersion).to.equal(7);
       expect(body.active.PRODUCTION).to.be.undefined;
     });
 
-    it('returns an empty active map when nothing is active', async () => {
-      mockAkamaiClient.listActivations.resolves([
-        {
-          activationId: 'atv_p', status: 'DEACTIVATED', network: 'PRODUCTION', propertyVersion: 4,
-        },
-      ]);
+    it('returns an empty active map when neither network has an active version', async () => {
+      mockAkamaiClient.getLatestVersionActivatedOn
+        .withArgs(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING').resolves(undefined);
+      mockAkamaiClient.getLatestVersionActivatedOn
+        .withArgs(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'PRODUCTION').resolves(undefined);
       const res = await controller.getVersions(withData(propertyRef));
       const body = await res.json();
       expect(body.active).to.deep.equal({});
     });
 
-    it('keeps the first ACTIVE activation per network (does not overwrite with a later one)', async () => {
-      // Two ACTIVE STAGING entries (should not happen per Akamai's one-active-per-network rule):
-      // the first seen wins; a later one must not silently overwrite it.
-      mockAkamaiClient.listActivations.resolves([
-        {
-          activationId: 'atv_first', status: 'ACTIVE', network: 'STAGING', propertyVersion: 9,
-        },
-        {
-          activationId: 'atv_second', status: 'ACTIVE', network: 'STAGING', propertyVersion: 6,
-        },
-      ]);
-      const res = await controller.getVersions(withData(propertyRef));
-      const body = await res.json();
-      expect(body.active.STAGING.propertyVersion).to.equal(9);
-    });
-
     it('maps a PAPI failure to 502', async () => {
-      mockAkamaiClient.listActivations.rejects(new Error('PAPI GET /activations -> 500: oops'));
+      mockAkamaiClient.getLatestVersionActivatedOn
+        .withArgs(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING')
+        .rejects(new Error('PAPI GET /versions/latest -> 500: oops'));
       const res = await controller.getVersions(withData(propertyRef));
       expect(res.status).to.equal(502);
     });


### PR DESCRIPTION
## Summary

`getVersions` derived the active staging/production versions by scanning `listActivations()` — the property's full activation history on both networks. That is one PAPI call, but its payload and processing grow with the property's activation history, adding latency to the Property step and exposing onboarding to PAPI/gateway timeouts on properties with hundreds of versions.

This replaces the history scan with three concurrent, **bounded** PAPI lookups whose cost is independent of activation history:

- `/versions/latest`
- `/versions/latest?activatedOn=STAGING`
- `/versions/latest?activatedOn=PRODUCTION`

A network the property was never activated on resolves to an **absent** `active` entry rather than failing the request.

## What changed

- **`src/controllers/llmo/llmo-akamai.js`** — `getVersions` now runs the three bounded lookups via `Promise.all` and builds `active` from the per-network results. No `listActivations()`.
  - A bounded lookup returns a *version* record (no activation record), so `activationId` is always `null`; the field is retained for response-shape stability.
- **`docs/openapi/llmo-api.yaml`** — `akamai-active-activation`: `activationId` is now `type: [string, 'null']` with an always-null note; `active` description updated.
- **`test/controllers/llmo/llmo-akamai.test.js`** — `getVersions` suite rewritten: per-network active version, **asserts `listActivations` is never called**, never-activated network omitted, empty `active` map, PAPI-failure → 502.

## Testing

- `npx mocha --timeout 10000 test/controllers/llmo/llmo-akamai.test.js` — **115 passing**.
- `npm run lint` clean; `npm run docs:lint` valid.
- `docs/index.html` intentionally **not** regenerated — `docs:build` produces hash-noise off the canonical CI toolchain (see repo CLAUDE.md). Spec files are the source of truth; regen on CI.

## Dependency

Requires the release of `@adobe/spacecat-shared-akamai-client` from adobe/spacecat-shared#1901 (adds `getLatestVersionActivatedOn`). **Merge/release that first, then bump the dep here** — CI will fail until the bump lands.

## Breaking changes

None. Same endpoint/shape; `active[network].activationId` is now always `null` (was populated from the activation record, unconsumed by the UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)