### PR TITLE
fix(onboard): preserve PRE_ONBOARD tier but bind enrollment during onboard

### DIFF
--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -2057,26 +2057,33 @@ export const onboardSingleSite = async (
     // promote either tier to the requested FREE_TRIAL/PAID.
     const existingAso = await getAsoEntitlement(organizationId, context);
     const existingTier = existingAso?.getTier() ?? null;
+    const forced = !!additionalParams.forceTierUpdate;
     const isPlgOrg = existingTier === EntitlementModel.TIERS.PLG;
     const isPreOnboardOrg = existingTier === EntitlementModel.TIERS.PRE_ONBOARD;
-    const preserveProtectedTier = isPlgOrg && !additionalParams.forceTierUpdate;
-    const preservePreOnboardTier = isPreOnboardOrg && !additionalParams.forceTierUpdate;
+    // preservePlgTier: PLG is fully preserved — skip the entitlement/enrollment write AND the
+    // audit-config change below. preservePreOnboardTier: preserve only the tier — the enrollment
+    // is still bound and audit config still runs normally. `forced` overrides both.
+    const preservePlgTier = isPlgOrg && !forced;
+    const preservePreOnboardTier = isPreOnboardOrg && !forced;
+
+    // Both preserve paths report the org's true, unchanged tier rather than the requested one.
+    if (preservePlgTier || preservePreOnboardTier) {
+      reportLine.tier = existingTier;
+    }
 
     // Create entitlement and enrollment
-    if (preserveProtectedTier) {
-      reportLine.tier = existingTier; // report the true, unchanged tier
+    if (preservePlgTier) {
       log.info(`Preserving ${existingTier} tier for org ${organizationId} - skipping entitlement/enrollment write during onboard of ${baseURL}`);
       await say(`:lock: Org for \`${baseURL}\` is on the *${existingTier}* tier — onboarding will NOT change the tier, entitlement, or enrollment. Running audits and opportunities only. (Use *Force Tier Update* to override.)`);
     } else {
       // Preserve a PRE_ONBOARD staging tier by re-asserting it (createEntitlement then only
       // binds the missing enrollment); promote everything else — and PRE_ONBOARD too when
       // forceTierUpdate is set — to the requested tier.
-      const effectiveTier = preservePreOnboardTier ? existingTier : tier;
       if (preservePreOnboardTier) {
-        reportLine.tier = existingTier; // report the true, preserved tier — not the requested one
         log.info(`Preserving ${existingTier} tier for org ${organizationId} while binding the site enrollment during onboard of ${baseURL}`);
         await say(`:lock: Org for \`${baseURL}\` is on the internal *${existingTier}* tier — onboarding will keep that tier and only ensure the site enrollment. (Use *Force Tier Update* to promote it.)`);
       }
+      const effectiveTier = preservePreOnboardTier ? existingTier : tier;
       const { entitlement } = await createEntitlementAndEnrollment(
         site,
         context,
@@ -2287,7 +2294,7 @@ export const onboardSingleSite = async (
     // Protected-tier orgs (SITES-49886): leave the existing audit scheduling config exactly
     // as-is. Enabling/disabling handlers here would alter a PLG customer's recurring-audit
     // setup; we only run audits once (below). Skipped unless forceTierUpdate.
-    if (preserveProtectedTier) {
+    if (preservePlgTier) {
       log.debug(`Preserving existing audit configuration for ${existingTier}-tier site ${siteID}`);
     } else {
       const latestConfiguration = await Configuration.findLatest();
@@ -2330,7 +2337,7 @@ export const onboardSingleSite = async (
     const auditsMessage = reportLine.audits || 'None';
     const importsMessage = reportLine.imports || 'None';
     let statusMessage;
-    if (preserveProtectedTier) {
+    if (preservePlgTier) {
       statusMessage = `:white_check_mark: *For site ${baseURL}*: Audit scheduling config preserved (${existingTier} tier); triggered audits once: ${auditsMessage}`;
     } else if (scheduledRun) {
       statusMessage = `:white_check_mark: *For site ${baseURL}*: Adding imports: ${importsMessage} and audits: ${auditsMessage} to scheduled run`;

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -1807,9 +1807,10 @@ export async function queueDeliveryConfigWriter(
  * @param {Object} additionalParams - Additional parameters
  * @param {string} additionalParams.tier - Entitlement tier
  * @param {boolean} [additionalParams.forceTierUpdate] - When true, allows the onboard
- *   command to change a PLG org's tier/entitlement and audit config. By default the PLG
- *   tier is preserved (SITES-49886). Separate from `force`, which only overrides the
- *   paid-profile downgrade guard.
+ *   command to promote a protected tier to the requested one. By default a PLG org's
+ *   tier/entitlement/enrollment and audit config are fully preserved, and a PRE_ONBOARD org's
+ *   tier is preserved while its enrollment is still bound (SITES-49886). Separate from
+ *   `force`, which only overrides the paid-profile downgrade guard.
  * @param {Object} options - Additional options
  * @param {Function} options.urlProcessor - Function to process the URL
  *                                          (e.g., extractURLFromSlackInput)
@@ -2035,21 +2036,31 @@ export const onboardSingleSite = async (
       prefetchedSite,
     );
 
-    // Protected-tier guard (SITES-49886): ASO entitlements are org-level. If the org
-    // already holds a PLG ASO entitlement, the onboard command must NOT touch the
-    // tier/entitlement/enrollment — TierClient.createEntitlement(FREE_TRIAL) would
-    // otherwise overwrite (downgrade) the existing PLG tier, exposing all opportunities
-    // instead of the limited PLG set. Onboarding is unsupported for PLG; we only run
-    // audits/opportunities once (below) and leave the earlier config untouched.
-    // An explicit additionalParams.forceTierUpdate is the sole escape hatch (kept separate
-    // from `force`, which only overrides the paid-profile downgrade guard).
-    // PRE_ONBOARD is deliberately NOT protected here: it's an internal staging tier meant
-    // to be promoted to a real tier (FREE_TRIAL/PAID) during onboarding, so the onboard
-    // command may create/update its entitlement normally.
+    // Protected-tier guard (SITES-49886): ASO entitlements are org-level.
+    //
+    // PLG: the onboard command must NOT touch the tier/entitlement/enrollment —
+    // TierClient.createEntitlement(FREE_TRIAL) would otherwise overwrite (downgrade) the
+    // existing PLG tier, exposing all opportunities instead of the limited PLG set.
+    // Onboarding is unsupported for PLG; we only run audits/opportunities once (below) and
+    // leave the earlier config untouched.
+    //
+    // PRE_ONBOARD: an internal staging tier (set by the move-plg-site flow) that must be
+    // promoted deliberately, never silently downgraded. We preserve the TIER but still bind
+    // the site enrollment — passing the org's existing PRE_ONBOARD tier to createEntitlement
+    // leaves the tier as-is (currentTier === tier, so no setTier) while still creating the
+    // enrollment when the site has none. Audits/opportunities run normally (PRE_ONBOARD is not
+    // in the PLG skip branch). This is not a RESTRICTED_TIERS violation: that guard blocks
+    // *requesting* tier=PRE_ONBOARD; here we only re-assert the org's already-existing tier.
+    //
+    // additionalParams.forceTierUpdate is the sole escape hatch for both tiers (kept separate
+    // from `force`, which only overrides the paid-profile downgrade guard): it lets onboarding
+    // promote either tier to the requested FREE_TRIAL/PAID.
     const existingAso = await getAsoEntitlement(organizationId, context);
     const existingTier = existingAso?.getTier() ?? null;
-    const isProtectedOrg = existingTier === EntitlementModel.TIERS.PLG;
-    const preserveProtectedTier = isProtectedOrg && !additionalParams.forceTierUpdate;
+    const isPlgOrg = existingTier === EntitlementModel.TIERS.PLG;
+    const isPreOnboardOrg = existingTier === EntitlementModel.TIERS.PRE_ONBOARD;
+    const preserveProtectedTier = isPlgOrg && !additionalParams.forceTierUpdate;
+    const preservePreOnboardTier = isPreOnboardOrg && !additionalParams.forceTierUpdate;
 
     // Create entitlement and enrollment
     if (preserveProtectedTier) {
@@ -2057,21 +2068,31 @@ export const onboardSingleSite = async (
       log.info(`Preserving ${existingTier} tier for org ${organizationId} - skipping entitlement/enrollment write during onboard of ${baseURL}`);
       await say(`:lock: Org for \`${baseURL}\` is on the *${existingTier}* tier — onboarding will NOT change the tier, entitlement, or enrollment. Running audits and opportunities only. (Use *Force Tier Update* to override.)`);
     } else {
+      // Preserve a PRE_ONBOARD staging tier by re-asserting it (createEntitlement then only
+      // binds the missing enrollment); promote everything else — and PRE_ONBOARD too when
+      // forceTierUpdate is set — to the requested tier.
+      const effectiveTier = preservePreOnboardTier ? existingTier : tier;
+      if (preservePreOnboardTier) {
+        reportLine.tier = existingTier; // report the true, preserved tier — not the requested one
+        log.info(`Preserving ${existingTier} tier for org ${organizationId} while binding the site enrollment during onboard of ${baseURL}`);
+        await say(`:lock: Org for \`${baseURL}\` is on the internal *${existingTier}* tier — onboarding will keep that tier and only ensure the site enrollment. (Use *Force Tier Update* to promote it.)`);
+      }
       const { entitlement } = await createEntitlementAndEnrollment(
         site,
         context,
         slackContext,
         reportLine,
         EntitlementModel.PRODUCT_CODES.ASO,
-        tier,
+        effectiveTier,
       );
 
-      // SITES-50179: the Force Tier Update escape hatch was exercised on a protected org
-      // (isProtectedOrg is only true here when forceTierUpdate bypassed the guard above). If it
-      // downgraded a PLG org to FREE_TRIAL — the exact transition that silently exposed the full
-      // opportunity set in the original incident — alert the team so every deliberate override is
-      // visible without manual auditing. Best-effort: never blocks onboarding.
-      if (isProtectedOrg && tier === EntitlementModel.TIERS.FREE_TRIAL) {
+      // SITES-50179: the Force Tier Update escape hatch was exercised on a PLG org (isPlgOrg is
+      // only true in this branch when forceTierUpdate bypassed the guard above). If it downgraded
+      // PLG to FREE_TRIAL — the exact transition that silently exposed the full opportunity set in
+      // the original incident — alert the team so every deliberate override is visible without
+      // manual auditing. A PRE_ONBOARD promotion is an expected admin action and is deliberately
+      // not alerted. Best-effort: never blocks onboarding.
+      if (isPlgOrg && tier === EntitlementModel.TIERS.FREE_TRIAL) {
         await notifyForcedTierDowngrade(
           {
             baseURL,

--- a/test/support/utils-protected-tier-guard.test.js
+++ b/test/support/utils-protected-tier-guard.test.js
@@ -21,10 +21,14 @@ use(sinonChai);
  * Unit tests for the protected-tier preservation guard in onboardSingleSite (utils.js),
  * added for SITES-49886.
  *
- * ASO entitlements are org-level. When an org already holds a PLG or PRE_ONBOARD ASO
- * entitlement, the onboard command must NOT change the tier/entitlement/enrollment and
- * must NOT alter audit scheduling config — it should only run audits/opportunities once.
- * An explicit additionalParams.forceTierUpdate is the sole escape hatch.
+ * ASO entitlements are org-level. The guard treats the two protected tiers differently:
+ *   - PLG: the onboard command must NOT change the tier/entitlement/enrollment and must NOT
+ *     alter audit scheduling config — it only runs audits/opportunities once.
+ *   - PRE_ONBOARD: an internal staging tier. The onboard command preserves the TIER but still
+ *     binds the site enrollment (re-asserting the existing tier, so createEntitlement leaves it
+ *     unchanged and only creates the missing enrollment); audits/opportunities run normally.
+ * An explicit additionalParams.forceTierUpdate is the sole escape hatch for both — it lets
+ * onboarding promote either tier to the requested FREE_TRIAL/PAID.
  */
 describe('onboardSingleSite — protected-tier preservation (SITES-49886)', function protectedTierSuite() {
   // Each test esmocks utils.js fresh; the cold load can exceed the 2s default.
@@ -211,17 +215,40 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
     );
   });
 
-  it('does NOT preserve an existing PRE_ONBOARD tier: creates/updates the entitlement normally (internal staging tier, promoted during onboarding)', async () => {
+  it('preserves an existing PRE_ONBOARD tier but still binds the enrollment: re-asserts the staging tier (not the requested FREE_TRIAL) so createEntitlement only creates the enrollment, and audits run normally', async () => {
     const { onboardSingleSite, tierCreateForSiteStub } = await loadOnboard();
     const site = makeHappyPathSite();
     const { context, configurationFindLatest } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
 
     const result = await run(onboardSingleSite, context);
 
-    // PRE_ONBOARD is no longer protected — the normal entitlement write + audit-config path run.
+    // Enrollment path still runs — TierClient is engaged ...
     expect(tierCreateForSiteStub).to.have.been.calledOnce;
     const createEntitlement = await tierCreateForSiteStub.firstCall.returnValue;
-    // Default requested tier is FREE_TRIAL — the staging tier is promoted.
+    // ... but with the EXISTING PRE_ONBOARD tier, not the requested FREE_TRIAL, so the real
+    // TierClient leaves the tier untouched (currentTier === tier) and only binds the enrollment.
+    expect(createEntitlement.createEntitlement).to.have.been.calledWith('PRE_ONBOARD');
+    expect(createEntitlement.createEntitlement).to.not.have.been.calledWith('FREE_TRIAL');
+    // PRE_ONBOARD is not in the PLG skip branch — audit-config path still runs.
+    expect(configurationFindLatest).to.have.been.calledOnce;
+    // The report reflects the true, preserved tier.
+    expect(result.tier).to.equal('PRE_ONBOARD');
+    expect(result.status).to.equal('Success');
+    // Operator is told the tier was preserved.
+    expect(sayStub).to.have.been.calledWith(
+      sinon.match(/on the internal \*PRE_ONBOARD\* tier/),
+    );
+  });
+
+  it('promotes a PRE_ONBOARD tier when forceTierUpdate=true (escape hatch): createEntitlement gets the requested FREE_TRIAL', async () => {
+    const { onboardSingleSite, tierCreateForSiteStub } = await loadOnboard();
+    const site = makeHappyPathSite();
+    const { context, configurationFindLatest } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
+
+    const result = await run(onboardSingleSite, context, { forceTierUpdate: true });
+
+    expect(tierCreateForSiteStub).to.have.been.calledOnce;
+    const createEntitlement = await tierCreateForSiteStub.firstCall.returnValue;
     expect(createEntitlement.createEntitlement).to.have.been.calledWith('FREE_TRIAL');
     expect(configurationFindLatest).to.have.been.calledOnce;
     expect(result.status).to.equal('Success');
@@ -266,10 +293,11 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
   });
 
   /**
-   * SITES-50179: whenever the Force Tier Update escape hatch actually downgrades a PLG/PRE_ONBOARD
-   * org to FREE_TRIAL, the team must get a Slack alert so every deliberate override is visible
-   * without manual auditing. The alert is fire-and-forget (see tier-change-alert.js) — these tests
-   * only assert the wiring: it fires on that exact transition and stays silent otherwise.
+   * SITES-50179: whenever the Force Tier Update escape hatch actually downgrades a PLG org to
+   * FREE_TRIAL, the team must get a Slack alert so every deliberate override is visible without
+   * manual auditing. A PRE_ONBOARD promotion is an expected admin action and is deliberately not
+   * alerted. The alert is fire-and-forget (see tier-change-alert.js) — these tests only assert the
+   * wiring: it fires on that exact transition and stays silent otherwise.
    */
   describe('force-downgrade alert (SITES-50179)', () => {
     it('alerts the team when forceTierUpdate downgrades PLG → FREE_TRIAL', async () => {
@@ -295,17 +323,31 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
       expect(env).to.equal(context.env);
     });
 
-    it('does NOT alert when onboarding a PRE_ONBOARD org to FREE_TRIAL (no longer a protected tier)', async () => {
+    it('does NOT alert when onboarding a PRE_ONBOARD org (tier preserved, enrollment bound — no downgrade)', async () => {
       const {
         onboardSingleSite, notifyForcedTierDowngradeStub, tierCreateForSiteStub,
       } = await loadOnboard();
       const site = makeHappyPathSite();
       const { context } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
 
-      // No forceTierUpdate needed — PRE_ONBOARD is promoted through the normal path.
+      // Default onboard preserves PRE_ONBOARD — the tier is never downgraded, so no alert.
       await run(onboardSingleSite, context);
 
       expect(tierCreateForSiteStub).to.have.been.calledOnce;
+      expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
+    });
+
+    it('does NOT alert when forceTierUpdate promotes PRE_ONBOARD → FREE_TRIAL (expected admin promotion, not the PLG incident)', async () => {
+      const {
+        onboardSingleSite, notifyForcedTierDowngradeStub, tierCreateForSiteStub,
+      } = await loadOnboard();
+      const site = makeHappyPathSite();
+      const { context } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
+
+      await run(onboardSingleSite, context, { forceTierUpdate: true });
+
+      const createEntitlement = await tierCreateForSiteStub.firstCall.returnValue;
+      expect(createEntitlement.createEntitlement).to.have.been.calledWith('FREE_TRIAL');
       expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
     });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Onboarding an organization that is already on the internal `PRE_ONBOARD` staging tier now preserves that tier while still binding the site's ASO enrollment, instead of promoting it to `FREE_TRIAL`.

## 2. Reasoning
Follow-up to the already-merged SITES-49886 change (https://github.com/adobe/spacecat-api-service/pull/3158), which removed `PRE_ONBOARD` from the onboard command's protected-tier guard so that onboarding an org on `PRE_ONBOARD` created/updated its entitlement normally — promoting `PRE_ONBOARD` → `FREE_TRIAL`.

`PRE_ONBOARD` is an internal staging tier set by the `move-plg-site` flow and is meant to be promoted deliberately, not silently downgraded during a routine onboard. At the same time, a site sitting on `PRE_ONBOARD` still needs its ASO enrollment bound so it is set up correctly and so a later promotion to a customer-visible tier succeeds (access control requires a site enrollment once the tier is customer-visible). This change keeps the staging tier intact but guarantees the enrollment.

## 3. High-level overview of the changes
Behaviour delta for an org whose existing ASO tier is `PRE_ONBOARD`:

- **Before (post-SITES-49886):** onboarding promoted the org to the requested tier (default `FREE_TRIAL`) and created the enrollment.
- **After:** onboarding preserves the `PRE_ONBOARD` tier and only ensures the site enrollment. Audits/opportunities still run normally.

How it works and what else is affected:

- The org's existing `PRE_ONBOARD` tier is re-asserted to `TierClient.createEntitlement`, which leaves the tier unchanged (`currentTier === tier`, so no tier write) and creates the enrollment only when the site has none. This is the same idempotent end-state the `move-plg-site` flow already produces.
- **PLG unchanged:** a PLG org is still fully preserved (entitlement + enrollment skipped; audits run once).
- **Escape hatch unchanged:** `forceTierUpdate` still promotes either protected tier to the requested `FREE_TRIAL`/`PAID`.
- **Alert scoping:** the SITES-50179 forced-downgrade Slack alert is now scoped to PLG only; a `PRE_ONBOARD` promotion is an expected admin action and no longer fires the alert.
- **No customer-visibility impact:** `PRE_ONBOARD` is not in `CUSTOMER_VISIBLE_TIERS`, and access control gates on tier before enrollment, so a bound `PRE_ONBOARD` enrollment cannot grant customer-facing product access. Requesting `tier=PRE_ONBOARD` via the onboard command remains blocked.

## 4. Required information
- Jira / issue: SITES-49886 — https://jira.corp.adobe.com/browse/SITES-49886 (alert scoping relates to SITES-50179 — https://jira.corp.adobe.com/browse/SITES-50179)

## 7. Test plan
(a) **Local:** covered by the onboard protected-tier guard unit suite, which exercises the new paths — `PRE_ONBOARD` tier preserved with enrollment bound (`createEntitlement` called with `PRE_ONBOARD`, not `FREE_TRIAL`), `forceTierUpdate` promotion to `FREE_TRIAL`, PLG full preservation, and the PLG-only downgrade alert — plus the full unit suite.

(b) **Dev verification:**
1. Put an org on `PRE_ONBOARD` (e.g. run the `move-plg-site` flow for a site into a target org).
2. Run the `onboard` Slack command for that site.
3. Confirm the org's ASO entitlement tier is still `PRE_ONBOARD` and a `SiteEnrollment` is now bound to that entitlement (query via PostgREST / the query-sites tooling), and that no forced-downgrade Slack alert fired.
4. Re-run onboard with **Force Tier Update** and confirm the tier is promoted to `FREE_TRIAL` and the enrollment remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Refines an existing entitlement/tier guard (prior incident SITES-49886/50179) to also bind enrollment; recoverable via redeploy, has an explicit override escape hatch."
```