### PR TITLE
fix(onboard): bind PRE_ONBOARD enrollment directly instead of via createEntitlement

### DIFF
--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -2062,7 +2062,7 @@ export const onboardSingleSite = async (
     const isPreOnboardOrg = existingTier === EntitlementModel.TIERS.PRE_ONBOARD;
     // preservePlgTier: PLG is fully preserved — skip the entitlement/enrollment write AND the
     // audit-config change below. preservePreOnboardTier: preserve only the tier — the enrollment
-    // is still bound and audit config still runs normally. `forced` overrides both.
+    // is still bound (see below) and audit config still runs normally. `forced` overrides both.
     const preservePlgTier = isPlgOrg && !forced;
     const preservePreOnboardTier = isPreOnboardOrg && !forced;
 
@@ -2075,22 +2075,43 @@ export const onboardSingleSite = async (
     if (preservePlgTier) {
       log.info(`Preserving ${existingTier} tier for org ${organizationId} - skipping entitlement/enrollment write during onboard of ${baseURL}`);
       await say(`:lock: Org for \`${baseURL}\` is on the *${existingTier}* tier — onboarding will NOT change the tier, entitlement, or enrollment. Running audits and opportunities only. (Use *Force Tier Update* to override.)`);
-    } else {
-      // Preserve a PRE_ONBOARD staging tier by re-asserting it (createEntitlement then only
-      // binds the missing enrollment); promote everything else — and PRE_ONBOARD too when
-      // forceTierUpdate is set — to the requested tier.
-      if (preservePreOnboardTier) {
-        log.info(`Preserving ${existingTier} tier for org ${organizationId} while binding the site enrollment during onboard of ${baseURL}`);
-        await say(`:lock: Org for \`${baseURL}\` is on the internal *${existingTier}* tier — onboarding will keep that tier and only ensure the site enrollment. (Use *Force Tier Update* to promote it.)`);
+    } else if (preservePreOnboardTier) {
+      // Preserve the PRE_ONBOARD staging tier and bind the site enrollment WITHOUT going through
+      // TierClient.createEntitlement: that call validates its tier argument against the mysticat
+      // ENTITLEMENT_TIER enum (FREE_TRIAL | PAID | PLG) and throws `Invalid tier: PRE_ONBOARD`
+      // before it can create anything (SITES-49886 follow-up). Create the SiteEnrollment directly
+      // against the org's existing entitlement instead — the same direct bind move-plg-site uses —
+      // so the entitlement/tier is never touched. Idempotent: only bind if not already enrolled.
+      log.info(`Preserving ${existingTier} tier for org ${organizationId} while binding the site enrollment during onboard of ${baseURL}`);
+      await say(`:lock: Org for \`${baseURL}\` is on the internal *${existingTier}* tier — onboarding will keep that tier and only ensure the site enrollment. (Use *Force Tier Update* to promote it.)`);
+      try {
+        const entitlementId = existingAso.getId();
+        const siteId = site.getId();
+        const existingEnrollments = await site.getSiteEnrollments();
+        const alreadyEnrolled = existingEnrollments
+          ?.some((se) => se.getEntitlementId() === entitlementId);
+        if (alreadyEnrolled) {
+          log.info(`Site ${siteId} already enrolled in ${existingTier} entitlement ${entitlementId} - nothing to bind`);
+        } else {
+          const siteEnrollment = await dataAccess.SiteEnrollment.create({ siteId, entitlementId });
+          log.info(`Bound ASO enrollment ${siteEnrollment.getId()} for site ${siteId} to existing ${existingTier} entitlement ${entitlementId}`);
+          await say(`:white_check_mark: Bound ASO enrollment ${siteEnrollment.getId()} to the existing ${existingTier} entitlement for site ${siteId}`);
+        }
+      } catch (error) {
+        log.error(`Binding ASO site enrollment for ${baseURL} failed: ${error.message}`);
+        await say(':x: Binding ASO site enrollment failed');
+        reportLine.errors = 'Binding ASO site enrollment failed';
+        reportLine.status = 'Failed';
+        throw error;
       }
-      const effectiveTier = preservePreOnboardTier ? existingTier : tier;
+    } else {
       const { entitlement } = await createEntitlementAndEnrollment(
         site,
         context,
         slackContext,
         reportLine,
         EntitlementModel.PRODUCT_CODES.ASO,
-        effectiveTier,
+        tier,
       );
 
       // SITES-50179: the Force Tier Update escape hatch was exercised on a PLG org (isPlgOrg is

--- a/test/support/utils-protected-tier-guard.test.js
+++ b/test/support/utils-protected-tier-guard.test.js
@@ -144,6 +144,7 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
       disableHandlerForSite: sandbox.stub(),
       save: sandbox.stub().resolves(),
     });
+    const siteEnrollmentCreate = sandbox.stub().resolves({ getId: () => 'enr-new' });
     const context = {
       log: {
         info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
@@ -165,11 +166,14 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
         Entitlement: {
           findByOrganizationIdAndProductCode: sandbox.stub().resolves(existingEntitlement),
         },
+        SiteEnrollment: {
+          create: siteEnrollmentCreate,
+        },
       },
       imsClient: { getImsOrganizationDetails: sandbox.stub() },
       sqs: { sendMessage: sandbox.stub().resolves() },
     };
-    return { context, configurationFindLatest };
+    return { context, configurationFindLatest, siteEnrollmentCreate };
   };
 
   const profile = { audits: { cwv: {} }, imports: {}, config: {} };
@@ -215,20 +219,26 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
     );
   });
 
-  it('preserves an existing PRE_ONBOARD tier but still binds the enrollment: re-asserts the staging tier (not the requested FREE_TRIAL) so createEntitlement only creates the enrollment, and audits run normally', async () => {
+  it('preserves an existing PRE_ONBOARD tier and binds the enrollment DIRECTLY — never calls TierClient.createEntitlement (which rejects PRE_ONBOARD), audits run normally', async () => {
     const { onboardSingleSite, tierCreateForSiteStub } = await loadOnboard();
     const site = makeHappyPathSite();
-    const { context, configurationFindLatest } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
+    // Site has no ASO enrollment yet — the direct-bind path reads this to stay idempotent.
+    site.getSiteEnrollments = sandbox.stub().resolves([]);
+    const { context, configurationFindLatest, siteEnrollmentCreate } = makeContext(
+      site,
+      { getTier: () => 'PRE_ONBOARD', getId: () => 'ent-test' },
+    );
 
     const result = await run(onboardSingleSite, context);
 
-    // Enrollment path still runs — TierClient is engaged ...
-    expect(tierCreateForSiteStub).to.have.been.calledOnce;
-    const createEntitlement = await tierCreateForSiteStub.firstCall.returnValue;
-    // ... but with the EXISTING PRE_ONBOARD tier, not the requested FREE_TRIAL, so the real
-    // TierClient leaves the tier untouched (currentTier === tier) and only binds the enrollment.
-    expect(createEntitlement.createEntitlement).to.have.been.calledWith('PRE_ONBOARD');
-    expect(createEntitlement.createEntitlement).to.not.have.been.calledWith('FREE_TRIAL');
+    // TierClient is never engaged: createEntitlement('PRE_ONBOARD') throws `Invalid tier` in
+    // prod, so the preserve path must bypass the entitlement API entirely.
+    expect(tierCreateForSiteStub).to.not.have.been.called;
+    // The enrollment is bound directly against the org's existing entitlement.
+    expect(siteEnrollmentCreate).to.have.been.calledOnceWith({
+      siteId: 'site-happy',
+      entitlementId: 'ent-test',
+    });
     // PRE_ONBOARD is not in the PLG skip branch — audit-config path still runs.
     expect(configurationFindLatest).to.have.been.calledOnce;
     // The report reflects the true, preserved tier.
@@ -240,16 +250,38 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
     );
   });
 
-  it('promotes a PRE_ONBOARD tier when forceTierUpdate=true (escape hatch): createEntitlement gets the requested FREE_TRIAL', async () => {
+  it('does not double-bind a PRE_ONBOARD enrollment when the site is already enrolled (idempotent)', async () => {
+    const { onboardSingleSite } = await loadOnboard();
+    const site = makeHappyPathSite();
+    // Site already holds an enrollment for the existing entitlement.
+    site.getSiteEnrollments = sandbox.stub().resolves([{ getEntitlementId: () => 'ent-test' }]);
+    const { context, siteEnrollmentCreate } = makeContext(
+      site,
+      { getTier: () => 'PRE_ONBOARD', getId: () => 'ent-test' },
+    );
+
+    const result = await run(onboardSingleSite, context);
+
+    expect(siteEnrollmentCreate).to.not.have.been.called;
+    expect(result.tier).to.equal('PRE_ONBOARD');
+    expect(result.status).to.equal('Success');
+  });
+
+  it('promotes a PRE_ONBOARD tier when forceTierUpdate=true (escape hatch): goes through TierClient with the requested FREE_TRIAL, not the direct bind', async () => {
     const { onboardSingleSite, tierCreateForSiteStub } = await loadOnboard();
     const site = makeHappyPathSite();
-    const { context, configurationFindLatest } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
+    const { context, configurationFindLatest, siteEnrollmentCreate } = makeContext(
+      site,
+      { getTier: () => 'PRE_ONBOARD', getId: () => 'ent-test' },
+    );
 
     const result = await run(onboardSingleSite, context, { forceTierUpdate: true });
 
     expect(tierCreateForSiteStub).to.have.been.calledOnce;
     const createEntitlement = await tierCreateForSiteStub.firstCall.returnValue;
     expect(createEntitlement.createEntitlement).to.have.been.calledWith('FREE_TRIAL');
+    // Forced promotion uses TierClient, not the direct-bind path.
+    expect(siteEnrollmentCreate).to.not.have.been.called;
     expect(configurationFindLatest).to.have.been.calledOnce;
     expect(result.status).to.equal('Success');
   });
@@ -323,17 +355,23 @@ describe('onboardSingleSite — protected-tier preservation (SITES-49886)', func
       expect(env).to.equal(context.env);
     });
 
-    it('does NOT alert when onboarding a PRE_ONBOARD org (tier preserved, enrollment bound — no downgrade)', async () => {
+    it('does NOT alert when onboarding a PRE_ONBOARD org (tier preserved, enrollment bound directly — no downgrade)', async () => {
       const {
         onboardSingleSite, notifyForcedTierDowngradeStub, tierCreateForSiteStub,
       } = await loadOnboard();
       const site = makeHappyPathSite();
-      const { context } = makeContext(site, { getTier: () => 'PRE_ONBOARD' });
+      site.getSiteEnrollments = sandbox.stub().resolves([]);
+      const { context, siteEnrollmentCreate } = makeContext(
+        site,
+        { getTier: () => 'PRE_ONBOARD', getId: () => 'ent-test' },
+      );
 
       // Default onboard preserves PRE_ONBOARD — the tier is never downgraded, so no alert.
       await run(onboardSingleSite, context);
 
-      expect(tierCreateForSiteStub).to.have.been.calledOnce;
+      // Enrollment is bound directly; TierClient is never engaged for the preserve path.
+      expect(tierCreateForSiteStub).to.not.have.been.called;
+      expect(siteEnrollmentCreate).to.have.been.calledOnce;
       expect(notifyForcedTierDowngradeStub).to.not.have.been.called;
     });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Fixes a regression in the PRE_ONBOARD onboarding path: bind the site enrollment directly against the org's existing entitlement instead of routing through `TierClient.createEntitlement`, which rejects the `PRE_ONBOARD` tier.

## 2. Reasoning
The previous change (merged + released as 1.780.2 — https://github.com/adobe/spacecat-api-service/pull/3163) tried to "preserve" a PRE_ONBOARD org's tier by re-passing the existing `PRE_ONBOARD` tier to `TierClient.createEntitlement`, relying on it to no-op the tier and only create the enrollment.

That fails in production. `createEntitlement` validates its `tier` argument against the mysticat `ENTITLEMENT_TIER` enum (`FREE_TRIAL | PAID | PLG`) and throws `Invalid tier: PRE_ONBOARD` **before** creating anything. `PRE_ONBOARD` exists only in `@adobe/spacecat-shared-data-access`'s `EntitlementModel.TIERS`, not in the enum `TierClient` validates against — so onboarding a PRE_ONBOARD org aborts. This was observed on dev.

The unit tests missed it because they stub `TierClient` entirely, so the real validation never ran — the old test even asserted `createEntitlement` was called with `'PRE_ONBOARD'`, which is exactly the call that throws in prod.

## 3. High-level overview of the changes
For an org whose existing ASO tier is `PRE_ONBOARD` (and `forceTierUpdate` is not set):

- **Before:** onboarding called `createEntitlement('PRE_ONBOARD')` → `Invalid tier` → onboarding failed.
- **After:** onboarding does **not** touch the entitlement API. It binds the `SiteEnrollment` directly against the org's existing entitlement (`dataAccess.SiteEnrollment.create({ siteId, entitlementId })`) when the site isn't already enrolled — the same direct bind `move-plg-site` uses. The tier is left untouched; audits/opportunities still run.

Unchanged:
- **PLG** is still fully preserved (entitlement + enrollment + audit-config skipped).
- **`forceTierUpdate`** still promotes either protected tier through `TierClient` with a valid requested tier (`FREE_TRIAL`/`PAID`).
- The SITES-50179 forced-downgrade alert stays PLG-only.
- Requesting `tier=PRE_ONBOARD` via onboard remains blocked (`RESTRICTED_TIERS`).
- A bound PRE_ONBOARD enrollment grants no customer access — access control gates on tier (`CUSTOMER_VISIBLE_TIERS`) before the enrollment check.

## 4. Required information
- Jira / issue: SITES-49886 — https://jira.corp.adobe.com/browse/SITES-49886 (alert scoping relates to SITES-50179 — https://jira.corp.adobe.com/browse/SITES-50179)

## 6. Additional information outside the code
Reproduced on **dev** before this fix: onboarding a PRE_ONBOARD org via the `onboard site` Slack command reached the preserve path and then failed with `Invalid tier: PRE_ONBOARD. Valid tiers: FREE_TRIAL, PAID, PLG` (raised by `TierClient.createEntitlement`). This PR removes that call from the preserve path, so the enrollment is bound without hitting the tier validation.

## 7. Test plan
(a) **Local:** the onboard protected-tier guard suite now asserts the corrected behavior — for a PRE_ONBOARD org, `TierClient` is **not** engaged and the enrollment is bound directly; an idempotent already-enrolled case makes no second bind; `forceTierUpdate` still promotes through `TierClient` to `FREE_TRIAL`; PLG stays fully preserved.

(b) **Dev verification:**
1. Find/create an org on `PRE_ONBOARD` with no ASO site enrollment.
2. Run `onboard site <url>` in Slack.
3. Confirm: no `Invalid tier` error; the org's ASO entitlement tier is still `PRE_ONBOARD`; a `SiteEnrollment` is now bound to it (`get entitlement imsorg …` shows an active enrollment); audits are triggered.
4. Re-run with **Force Tier Update** and confirm the tier is promoted to `FREE_TRIAL` and the enrollment remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
