### PR TITLE
feat(backfill-llmo): add force=true to bypass cdn-logs-analysis wait

### DIFF
--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -303,7 +303,7 @@ async function triggerBackfill(
               day: targetDate.getUTCDate(),
               hour: 23,
               processFullDay: true,
-              ...(force ? { forceReprocess: true, isSubAudit: true } : {}),
+              ...forceFields,
             },
           };
           // eslint-disable-next-line no-await-in-loop
@@ -389,7 +389,7 @@ function BackfillLlmoCommand(context) {
     name: 'Backfill LLMO',
     description: 'Backfills LLMO audits.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} baseurl={baseURL} audit={auditType} [days={days}|weeks={weeks}|date={YYYY-MM-DD}] [force=true]`,
+    usageText: `${PHRASES[0]} baseurl={baseURL} audit={auditType} [days={days}|weeks={weeks}|date={YYYY-MM-DD}] [force=true] (force=true is cdn-logs-analysis only)`,
   });
 
   const { dataAccess, log } = context;
@@ -432,6 +432,13 @@ function BackfillLlmoCommand(context) {
       const auditType = isWeeklyDbRefreshMode(parsed)
         ? (parsed.audit || AUDIT_TYPES.CDN_LOGS_REPORT)
         : parsed.audit;
+
+      const force = parsed.force === 'true';
+      if (force && auditType !== AUDIT_TYPES.CDN_LOGS_ANALYSIS) {
+        await say(`:warning: force=true is only supported for audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS}.`);
+        return;
+      }
+
       const isAllSites = parsed.baseurl?.toLowerCase() === 'all';
       const baseURL = isAllSites ? 'all' : extractURLFromSlackInput(parsed.baseurl);
 
@@ -584,7 +591,6 @@ function BackfillLlmoCommand(context) {
       const target = isAllSites ? `${sites.length} sites` : baseURL;
       await say(`:rocket: Triggering ${auditType} for ${target} (${timeDesc})...`);
 
-      const force = parsed.force === 'true';
       const configuration = await Configuration.findLatest();
       for (const s of sites) {
         // eslint-disable-next-line no-await-in-loop

--- a/src/support/slack/commands/backfill-llmo.js
+++ b/src/support/slack/commands/backfill-llmo.js
@@ -257,11 +257,21 @@ async function triggerBackfill(
   auditType,
   timeValue,
   specificDate,
+  force,
 ) {
   const { sqs } = context;
 
   switch (auditType) {
     case AUDIT_TYPES.CDN_LOGS_ANALYSIS: {
+      // force=true reproduces the exact auditContext shape the worker's own
+      // triggerSubAudits sends (processFullDay + forceReprocess + isSubAudit),
+      // skipping the S3-scan indirection and the "already aggregated" skip.
+      // forceReprocess makes the worker delete and rebuild existing S3
+      // aggregate partitions for that hour before reprocessing.
+      const forceFields = force
+        ? { processFullDay: true, forceReprocess: true, isSubAudit: true }
+        : {};
+
       // If specific date/hour provided, run for that hour only
       if (specificDate) {
         const message = {
@@ -272,6 +282,7 @@ async function triggerBackfill(
             month: specificDate.month,
             day: specificDate.day,
             hour: specificDate.hour,
+            ...forceFields,
           },
         };
         await sqs.sendMessage(configuration.getQueues().audits, message);
@@ -292,6 +303,7 @@ async function triggerBackfill(
               day: targetDate.getUTCDate(),
               hour: 23,
               processFullDay: true,
+              ...(force ? { forceReprocess: true, isSubAudit: true } : {}),
             },
           };
           // eslint-disable-next-line no-await-in-loop
@@ -377,7 +389,7 @@ function BackfillLlmoCommand(context) {
     name: 'Backfill LLMO',
     description: 'Backfills LLMO audits.',
     phrases: PHRASES,
-    usageText: `${PHRASES[0]} baseurl={baseURL} audit={auditType} [days={days}|weeks={weeks}|date={YYYY-MM-DD}]`,
+    usageText: `${PHRASES[0]} baseurl={baseURL} audit={auditType} [days={days}|weeks={weeks}|date={YYYY-MM-DD}] [force=true]`,
   });
 
   const { dataAccess, log } = context;
@@ -407,6 +419,7 @@ function BackfillLlmoCommand(context) {
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS} days=3\` (last 3 days)`);
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS} year=2024 month=11 day=15 hour=14\` (specific hour)`);
         await say(`• \`backfill-llmo baseurl=all audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS} year=2024 month=11 day=15 hour=14\` (all enabled sites)`);
+        await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS} year=2024 month=11 day=15 hour=23 force=true\` (force immediate processing, skip wait + reprocess if already run)`);
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} weeks=2\` (last 2 completed ISO weeks → DB)`);
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} days=10\` (last 10 days → DB)`);
         await say(`• \`backfill-llmo baseurl=https://example.com audit=${AUDIT_TYPES.CDN_LOGS_REPORT} date=2026-04-27\` (single traffic day → DB)`);
@@ -571,6 +584,7 @@ function BackfillLlmoCommand(context) {
       const target = isAllSites ? `${sites.length} sites` : baseURL;
       await say(`:rocket: Triggering ${auditType} for ${target} (${timeDesc})...`);
 
+      const force = parsed.force === 'true';
       const configuration = await Configuration.findLatest();
       for (const s of sites) {
         // eslint-disable-next-line no-await-in-loop
@@ -581,6 +595,7 @@ function BackfillLlmoCommand(context) {
           auditType,
           timeValue,
           specificDate,
+          force,
         );
       }
 

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -793,6 +793,22 @@ describe('BackfillLlmoCommand', () => {
       expect(slackContext.say.calledWith(`:warning: Supported audits: ${AUDIT_TYPES.CDN_LOGS_ANALYSIS}, ${AUDIT_TYPES.CDN_LOGS_REPORT}, ${AUDIT_TYPES.LLM_ERROR_PAGES}, ${AUDIT_TYPES.LLMO_REFERRAL_TRAFFIC}`)).to.be.true;
     });
 
+    it('rejects force=true for audit types other than cdn-logs-analysis', async () => {
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_REPORT}`,
+        'days=1',
+        'force=true',
+      ], slackContext);
+
+      expect(slackContext.say.calledWith(
+        `:warning: force=true is only supported for audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS}.`,
+      )).to.be.true;
+      expect(sqsStub.sendMessage).not.to.have.been.called;
+    });
+
     it('logs errors when they occur', async () => {
       const error = new Error('Test Error');
       dataAccessStub.Site.findByBaseURL.rejects(error);
@@ -853,6 +869,7 @@ describe('BackfillLlmoCommand', () => {
       for (const call of sqsStub.sendMessage.getCalls()) {
         const [, message] = call.args;
         expect(message.auditContext).to.have.all.keys('year', 'month', 'day', 'hour', 'processFullDay', 'forceReprocess', 'isSubAudit');
+        expect(message.auditContext.processFullDay).to.be.true;
         expect(message.auditContext.forceReprocess).to.be.true;
         expect(message.auditContext.isSubAudit).to.be.true;
       }

--- a/test/support/slack/commands/backfill-llmo.test.js
+++ b/test/support/slack/commands/backfill-llmo.test.js
@@ -811,10 +811,51 @@ describe('BackfillLlmoCommand', () => {
 
       expect(sqsStub.sendMessage.callCount).to.equal(1);
       const [, message] = sqsStub.sendMessage.firstCall.args;
+      expect(message.auditContext).to.have.all.keys('year', 'month', 'day', 'hour');
       expect(message.auditContext.year).to.equal(2024);
       expect(message.auditContext.month).to.equal(11);
       expect(message.auditContext.day).to.equal(15);
       expect(message.auditContext.hour).to.equal(14);
+    });
+
+    it('adds processFullDay/forceReprocess/isSubAudit for a specific date and hour when force=true', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(siteStub);
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS}`,
+        'year=2024', 'month=11', 'day=15', 'hour=23',
+        'force=true',
+      ], slackContext);
+
+      expect(sqsStub.sendMessage.callCount).to.equal(1);
+      const [, message] = sqsStub.sendMessage.firstCall.args;
+      expect(message.auditContext).to.have.all.keys('year', 'month', 'day', 'hour', 'processFullDay', 'forceReprocess', 'isSubAudit');
+      expect(message.auditContext.hour).to.equal(23);
+      expect(message.auditContext.processFullDay).to.be.true;
+      expect(message.auditContext.forceReprocess).to.be.true;
+      expect(message.auditContext.isSubAudit).to.be.true;
+    });
+
+    it('adds forceReprocess/isSubAudit to the days-loop backfill when force=true', async () => {
+      dataAccessStub.Site.findByBaseURL.resolves(siteStub);
+      const command = BackfillLlmoCommand(context);
+
+      await command.handleExecution([
+        'baseurl=https://example.com',
+        `audit=${AUDIT_TYPES.CDN_LOGS_ANALYSIS}`,
+        'days=2',
+        'force=true',
+      ], slackContext);
+
+      expect(sqsStub.sendMessage.callCount).to.equal(2);
+      for (const call of sqsStub.sendMessage.getCalls()) {
+        const [, message] = call.args;
+        expect(message.auditContext).to.have.all.keys('year', 'month', 'day', 'hour', 'processFullDay', 'forceReprocess', 'isSubAudit');
+        expect(message.auditContext.forceReprocess).to.be.true;
+        expect(message.auditContext.isSubAudit).to.be.true;
+      }
     });
 
     it('rejects days parameter greater than 14 for cdn-logs-analysis', async () => {


### PR DESCRIPTION
## Summary
- `backfill-llmo` now accepts `force=true` for `audit=cdn-logs-analysis`, on both the specific-date and days-loop branches.
- When set, it adds `processFullDay: true, forceReprocess: true, isSubAudit: true` to the outgoing `auditContext` — the exact shape the audit-worker's own `triggerSubAudits` sends internally (`spacecat-audit-worker/src/cdn-analysis/handler.js:227-239`). This skips the S3-scan indirection (only entered when `!isSubAudit && hour==='23'`) and the "already aggregated, skip" check (bypassed only when `forceReprocess` is set), so processing happens immediately instead of waiting for the next daily hour-23 UTC dispatcher run.
- No changes needed in `spacecat-audit-worker` — it already honors these flags regardless of producer.
- No new permission gating added, consistent with `run-audit`/`backfill-llmo` today (neither has any).

### Correct SpaceCat Slack command
```
backfill-llmo baseurl=https://nba.com audit=cdn-logs-analysis year=2026 month=8 day=31 hour=23 force=true
```
`hour` must be `23` for `byocdn-other`/`cloudflare`/`imperva` sites — those providers only have daily S3 partitions, so there's nothing to process for any other hour regardless of `force`. `force=true` only removes the *code-level* wait (the indirection + already-processed skip); it can't produce data for a day that hasn't completed yet.

## Test plan
- [x] `npx mocha test/support/slack/commands/backfill-llmo.test.js` — 57/57 passing, including 2 new cases (`force=true` on both branches) plus a tightened regression assertion on the existing specific-date test
- [x] `npx eslint` clean on both touched files
- [x] Coverage: no new gaps introduced (verified against baseline via `git stash` diff — pre-existing uncovered branches on lines 64/162/323 are untouched by this change)
- [x] Full `test/support/slack/commands/*.test.js` suite (931 tests) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)