### PR TITLE
fix(deps): bump spacecat-shared-scrape-client to 2.7.2 for PRE_ONBOARD tier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@adobe/spacecat-shared-launchdarkly-client": "1.3.1",
         "@adobe/spacecat-shared-project-engine-client": "1.21.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.1",
-        "@adobe/spacecat-shared-scrape-client": "2.7.1",
+        "@adobe/spacecat-shared-scrape-client": "2.7.2",
         "@adobe/spacecat-shared-slack-client": "1.7.2",
         "@adobe/spacecat-shared-ticket-client": "^1.0.4",
         "@adobe/spacecat-shared-tier-client": "1.6.3",
@@ -7475,14 +7475,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-scrape-client": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.7.1.tgz",
-      "integrity": "sha512-O1wsqtfX2owSe6P9kxu565QXEwkO8daMIBYbmy95JzO8Ss3dTrOVPniVmc/5yA16q1BcnaDHdOYqnRpRPbAIvg==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-scrape-client/-/spacecat-shared-scrape-client-2.7.2.tgz",
+      "integrity": "sha512-HGC/tBlTXeJNayVm8uBSlyye6GOFh7lEd0bKN0/pdo/CyZHVGqFK9fKgCm2fdwX6f4KHXd2oV4qQJLYmxjLB2A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.2",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@mysticat/data-service-types": "git+https://github.com/adobe/mysticat-data-service.git#types-ts-v1.42.0"
+        "@mysticat/data-service-types": "git+https://github.com/adobe/mysticat-data-service.git#types-ts-v1.53.0"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -14344,8 +14344,8 @@
       }
     },
     "node_modules/@mysticat/data-service-types": {
-      "version": "1.42.0",
-      "resolved": "git+ssh://git@github.com/adobe/mysticat-data-service.git#cf2149bd886be3ba5c3a5d7acc5b27b8aeab7fee",
+      "version": "1.53.0",
+      "resolved": "git+ssh://git@github.com/adobe/mysticat-data-service.git#f8423fd45c1c0e0287542030b69a25c09f110466",
       "license": "Apache-2.0"
     },
     "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@adobe/spacecat-shared-launchdarkly-client": "1.3.1",
     "@adobe/spacecat-shared-project-engine-client": "1.21.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.1",
-    "@adobe/spacecat-shared-scrape-client": "2.7.1",
+    "@adobe/spacecat-shared-scrape-client": "2.7.2",
     "@adobe/spacecat-shared-slack-client": "1.7.2",
     "@adobe/spacecat-shared-ticket-client": "^1.0.4",
     "@adobe/spacecat-shared-tier-client": "1.6.3",


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Bumps `@adobe/spacecat-shared-scrape-client` from `2.7.1` to `2.7.2` so that api-service's transitive `@mysticat/data-service-types` resolves to `1.53.0`, whose `ENTITLEMENT_TIER` enum includes the `PRE_ONBOARD` tier.

## 2. Reasoning
`TierClient.createEntitlement(tier)` validates its `tier` argument against `MYSTICAT_ENUMS_BY_TYPE.ENTITLEMENT_TIER` from `@mysticat/data-service-types`. `scrape-client` 2.7.1 pinned that package to `types-ts-v1.42.0` (pre-`PRE_ONBOARD`); `tier-client` pinned `types-ts-v1.53.0`. In api-service, which depends on both, npm **deduped the transitive `@mysticat/data-service-types` down to the stale `1.42.0`** — so `TierClient` ran against an enum missing `PRE_ONBOARD` and `createEntitlement('PRE_ONBOARD')` threw `Invalid tier: PRE_ONBOARD. Valid tiers: FREE_TRIAL, PAID, PLG`, breaking PRE_ONBOARD onboarding and the move-plg flow. `spacecat-shared` PR #1904 aligned `scrape-client`'s pin to `types-ts-v1.53.0` and released it as `2.7.2`; this PR consumes that release.

## 3. High-level overview of the changes
- **Before:** `scrape-client` (2.7.1) → `types-ts-v1.42.0`; `tier-client` → `v1.53.0`. npm deduped both to `1.42.0`. The resolved `ENTITLEMENT_TIER` enum was `FREE_TRIAL, PAID, PLG` — no `PRE_ONBOARD` — so `createEntitlement('PRE_ONBOARD')` threw before writing anything.
- **After:** `scrape-client` (2.7.2) → `types-ts-v1.53.0`, matching `tier-client`. Both dedup to `@mysticat/data-service-types` `1.53.0`; the resolved `ENTITLEMENT_TIER` enum is `FREE_TRIAL, PAID, PLG, PRE_ONBOARD`, so `createEntitlement('PRE_ONBOARD')` is accepted.
- No source changes — package.json + package-lock.json only. This is the consumer-side completion of the shared-package fix; it unblocks the onboarding "preserve PRE_ONBOARD tier" path and `move-plg-site`'s `createEntitlement(PRE_ONBOARD)` call in production.

## 4. Required information
- Jira / issue: SITES-50702 — https://jira.corp.adobe.com/browse/SITES-50702 (root cause of SITES-49886)

## 6. Affected / used mysticat-workspace projects
- `spacecat-shared` (`spacecat-shared-scrape-client`) — **consumed**; the fix originates there (PR #1904, released as `scrape-client` 2.7.2). This PR pulls that release.
- `spacecat-shared-tier-client` — **beneficiary**; unchanged, but stops being deduped to the stale types once `scrape-client` aligns, so its `createEntitlement` runs against a `PRE_ONBOARD`-aware enum.

## 7. Additional information outside the code
- Confirmed the dedup before the bump: `npm ls @mysticat/data-service-types` resolved both `scrape-client` and `tier-client` to the stale `1.42.0`.
- After bumping and forcing a re-resolve of the transitive git dep, `npm ls @mysticat/data-service-types` resolves both to `1.53.0`; runtime check of the resolved package shows `ENTITLEMENT_TIER` = `FREE_TRIAL, PAID, PLG, PRE_ONBOARD` (`includes('PRE_ONBOARD') === true`).

## 8. Test plan
(a) **Local:** ran the onboarding protected-tier guard suite (`test/support/utils-protected-tier-guard.test.js`) against the bumped dependency — passes. Note: unit tests stub `TierClient`, so they don't exercise the real enum; the enum fix is proven separately by the runtime resolution check in section 7.

(b) **Post-deploy (dev → prod):** after this deploys, run `onboard site <url>` in Slack against an org already on the `PRE_ONBOARD` tier and confirm it no longer errors with `Invalid tier: PRE_ONBOARD`; the org's ASO tier stays `PRE_ONBOARD` and a `SiteEnrollment` is bound. Also verify `move-plg-site` no longer throws when re-asserting `PRE_ONBOARD`.

## 9. Deployment & merge order
- Depends-on: adobe/spacecat-shared PR #1904 (already merged and released as `@adobe/spacecat-shared-scrape-client` 2.7.2) — this PR consumes that release, so no pending upstream.
- Sequence: merge this PR → api-service releases and deploys → `createEntitlement('PRE_ONBOARD')` is unblocked in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Small dependency version bump fixing PRE_ONBOARD tier behavior; trivial and reversible."
```