### PR TITLE
fix(llmo): prevent GL from being stored as a brand region

### DIFF
--- a/docs/openapi/examples.yaml
+++ b/docs/openapi/examples.yaml
@@ -541,24 +541,24 @@ CustomerConfigAdobe:
           name: "Adobe Photoshop"
           status: "active"
           origin: "ai"
-          region: ["GL", "US", "GB", "DE", "FR", "JP", "CN"]
+          region: ["US", "GB", "DE", "FR", "JP", "CN"]
           description: "Adobe's flagship image editing and compositing software used for photography, digital art, and visual design across desktop, web, and mobile."
           updatedAt: "2026-01-03T09:15:22.000Z"
           updatedBy: "system"
           vertical: "Software & Technology"
           urls:
             - value: "https://www.adobe.com/products/photoshop.html"
-              regions: ["GL", "US", "GB", "DE", "FR", "JP", "CN"]
+              regions: ["US", "GB", "DE", "FR", "JP", "CN"]
           socialAccounts:
             - platform: "twitter"
               url: "https://x.com/Photoshop"
-              regions: ["GL"]
+              regions: ["US"]
             - platform: "facebook"
               url: "https://www.facebook.com/Photoshop/"
               regions: ["US", "GB"]
           brandAliases:
             - name: "Photoshop"
-              regions: ["GL"]
+              regions: ["US"]
             - name: "PS"
               regions: ["US", "GB", "DE", "FR"]
           competitors:
@@ -567,17 +567,17 @@ CustomerConfigAdobe:
               regions: ["US", "GB"]
             - name: "GIMP"
               url: "https://www.gimp.org"
-              regions: ["GL"]
+              regions: ["US"]
           relatedBrands:
             - name: "Wacom"
               url: "https://www.wacom.com"
-              regions: ["GL"]
+              regions: ["US"]
           earnedContent:
             - name: "Wikipedia"
               type: "encyclopedia"
               coverage_scope: "product history and feature overview"
               url: "https://en.wikipedia.org/wiki/Adobe_Photoshop"
-              regions: ["GL"]
+              regions: ["US"]
           prompts:
             - id: "photoshop-prompt-1"
               prompt: "What is the best photo editing software for portraits?"

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -6956,7 +6956,7 @@ CustomerConfigUrl:
       items:
         type: string
       description: Regions where this URL is applicable
-      example: ["GL", "US", "GB"]
+      example: ["US", "GB"]
 CustomerConfigSocialAccount:
   type: object
   description: A social media account for a brand
@@ -6979,7 +6979,7 @@ CustomerConfigSocialAccount:
       items:
         type: string
       description: Regions where this account is relevant
-      example: ["GL"]
+      example: ["US"]
 CustomerConfigBrandAlias:
   type: object
   description: An alternative name for a brand
@@ -7042,7 +7042,7 @@ CustomerConfigRelatedBrand:
       items:
         type: string
       description: Regions where this relationship is relevant
-      example: ["GL"]
+      example: ["US"]
 CustomerConfigEarnedContent:
   type: object
   description: Earned media content source
@@ -7075,7 +7075,7 @@ CustomerConfigEarnedContent:
       items:
         type: string
       description: Regions where this source is relevant
-      example: ["GL"]
+      example: ["US"]
 CustomerConfigBrand:
   type: object
   description: A brand configuration with all associated metadata
@@ -7110,7 +7110,7 @@ CustomerConfigBrand:
       items:
         type: string
       description: Regions where this brand operates
-      example: ["GL", "US", "GB"]
+      example: ["US", "GB"]
     description:
       type: string
       description: Detailed description of the brand

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -220,7 +220,7 @@ export async function triggerBrandalfOnboardingJob({
 // selected a market we seed it directly so the brand record is correct
 // immediately and stays correct even if Brandalf never completes. `region`
 // is a validated ISO 3166-1 alpha-2 code (e.g. 'US'); absent → keep the
-// DEFAULT_BRAND_REGION placeholder that Brandalf overwrites. SITES-3168: the
+// DEFAULT_BRAND_REGION placeholder that Brandalf overwrites. #3168: the
 // previous 'gl' placeholder collided with Greenland's real ISO code.
 export function onboardingStubRegions(region) {
   return region ? [region] : [DEFAULT_BRAND_REGION];

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -24,7 +24,11 @@ import {
   readCustomerConfigV2FromPostgres,
   writeCustomerConfigV2ToPostgres,
 } from '../../support/customer-config-v2-storage.js';
-import { convertV1ToV2, generateBrandId } from '../../support/customer-config-mapper.js';
+import {
+  convertV1ToV2,
+  generateBrandId,
+  DEFAULT_BRAND_REGION,
+} from '../../support/customer-config-mapper.js';
 import {
   resolveLlmoOnboardingMode,
   LLMO_ONBOARDING_MODE_V1,
@@ -211,13 +215,15 @@ export async function triggerBrandalfOnboardingJob({
 // submitOnboardingPromptGenerationJob removed — prompt generation is now
 // triggered by DRS after Brandalf completes (LLMO-4258, option b).
 
-// LLMO-5645: the initial stub brand uses 'gl' (worldwide) as a placeholder until
-// Brandalf returns the real region. When the operator selected a market we seed
-// it directly so the brand record is correct immediately and stays correct even
-// if Brandalf never completes. `region` is a validated ISO 3166-1 alpha-2 code
-// (e.g. 'US'); absent → keep the 'gl' placeholder that Brandalf overwrites.
+// LLMO-5645: the initial stub brand uses DEFAULT_BRAND_REGION ('US') as a
+// placeholder until Brandalf returns the real region. When the operator
+// selected a market we seed it directly so the brand record is correct
+// immediately and stays correct even if Brandalf never completes. `region`
+// is a validated ISO 3166-1 alpha-2 code (e.g. 'US'); absent → keep the
+// DEFAULT_BRAND_REGION placeholder that Brandalf overwrites. SITES-3168: the
+// previous 'gl' placeholder collided with Greenland's real ISO code.
 export function onboardingStubRegions(region) {
-  return region ? [region] : ['gl'];
+  return region ? [region] : [DEFAULT_BRAND_REGION];
 }
 
 export function buildInitialCustomerConfigV2({
@@ -1439,9 +1445,9 @@ export async function activateBrandAndGeneratePrompts({
         // No collision: proceed with upsert (new brand, existing brand with a
         // null primary site, or a re-onboard of the same site). upsertBrand's
         // own guard keeps an already-set site_id immutable on the last case.
-        // LLMO-5645: seed operator market when supplied; else the 'gl'
-        // placeholder (consistent with the V2 config + brandAliases, both
-        // overwritten by Brandalf's async result).
+        // LLMO-5645: seed operator market when supplied; else the
+        // DEFAULT_BRAND_REGION placeholder (consistent with the V2 config +
+        // brandAliases, both overwritten by Brandalf's async result).
         const stubRegions = onboardingStubRegions(region);
         await upsertBrand({
           organizationId: organization.getId(),

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -18,6 +18,7 @@ import {
   SERENITY_FEATURE_FLAG_NAME,
   SERENITY_FEATURE_FLAG_PRODUCT,
 } from './serenity/serenity-active.js';
+import { normalizeGlRegionSentinel, sanitizeRegions } from './customer-config-mapper.js';
 
 /**
  * PostgREST select string — joins all normalized child tables.
@@ -546,7 +547,7 @@ async function syncSocialAccounts(brandId, organizationId, socialAccounts, postg
       organization_id: organizationId,
       brand_id: brandId,
       url: s.url,
-      regions: s.regions || [],
+      regions: (s.regions || []).map(normalizeGlRegionSentinel),
       updated_by: updatedBy,
     }));
   await replaceChildRows('brand_social_accounts', brandId, rows, 'brand_id,url', postgrestClient);
@@ -570,7 +571,7 @@ async function syncEarnedSources(brandId, organizationId, earnedContent, postgre
       brand_id: brandId,
       name: e.name,
       url: e.url,
-      regions: e.regions || [],
+      regions: (e.regions || []).map(normalizeGlRegionSentinel),
       updated_by: updatedBy,
     }));
   await replaceChildRows('brand_earned_sources', brandId, rows, 'brand_id,url', postgrestClient);
@@ -588,7 +589,10 @@ async function syncAliases(brandId, organizationId, brandAliases, postgrestClien
   }
   const seen = new Set();
   const rows = (brandAliases || [])
-    .map((a) => ({ alias: typeof a === 'string' ? a : a?.name, regions: a?.regions || [] }))
+    .map((a) => ({
+      alias: typeof a === 'string' ? a : a?.name,
+      regions: (a?.regions || []).map(normalizeGlRegionSentinel),
+    }))
     .filter((a) => hasText(a.alias) && !seen.has(a.alias) && seen.add(a.alias))
     .map((a) => ({
       organization_id: organizationId,
@@ -616,7 +620,7 @@ async function syncCompetitors(brandId, organizationId, competitors, postgrestCl
       name: typeof c === 'string' ? c : c?.name,
       url: c?.url || null,
       aliases: Array.isArray(c?.aliases) ? c.aliases : [],
-      regions: c?.regions || [],
+      regions: (c?.regions || []).map(normalizeGlRegionSentinel),
     }))
     .filter((c) => hasText(c.name) && !seen.has(c.name) && seen.add(c.name))
     .map((c) => ({
@@ -1149,8 +1153,7 @@ export async function upsertBrand({
     throw new Error('Brand name is required');
   }
 
-  const regions = (brand.region || [])
-    .map((r) => (typeof r === 'string' ? r : String(r))).filter(hasText);
+  const regions = sanitizeRegions(brand.region);
 
   // Check if a non-deleted brand already exists with this name. Soft-deleted
   // brands are excluded (.neq('status', 'deleted')) so that creating a brand
@@ -1495,8 +1498,7 @@ export async function updateBrand({
   }
 
   if (updates.region !== undefined) {
-    patch.regions = (updates.region || [])
-      .map((r) => (typeof r === 'string' ? r : String(r))).filter(hasText);
+    patch.regions = sanitizeRegions(updates.region);
   }
 
   // Clear legacy columns on any brand update so old data doesn't linger.

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -18,7 +18,7 @@ import {
   SERENITY_FEATURE_FLAG_NAME,
   SERENITY_FEATURE_FLAG_PRODUCT,
 } from './serenity/serenity-active.js';
-import { normalizeGlRegionSentinel, sanitizeRegions } from './customer-config-mapper.js';
+import { sanitizeRegions } from './customer-config-mapper.js';
 
 /**
  * PostgREST select string — joins all normalized child tables.
@@ -547,7 +547,7 @@ async function syncSocialAccounts(brandId, organizationId, socialAccounts, postg
       organization_id: organizationId,
       brand_id: brandId,
       url: s.url,
-      regions: (s.regions || []).map(normalizeGlRegionSentinel),
+      regions: sanitizeRegions(s.regions),
       updated_by: updatedBy,
     }));
   await replaceChildRows('brand_social_accounts', brandId, rows, 'brand_id,url', postgrestClient);
@@ -571,7 +571,7 @@ async function syncEarnedSources(brandId, organizationId, earnedContent, postgre
       brand_id: brandId,
       name: e.name,
       url: e.url,
-      regions: (e.regions || []).map(normalizeGlRegionSentinel),
+      regions: sanitizeRegions(e.regions),
       updated_by: updatedBy,
     }));
   await replaceChildRows('brand_earned_sources', brandId, rows, 'brand_id,url', postgrestClient);
@@ -591,7 +591,7 @@ async function syncAliases(brandId, organizationId, brandAliases, postgrestClien
   const rows = (brandAliases || [])
     .map((a) => ({
       alias: typeof a === 'string' ? a : a?.name,
-      regions: (a?.regions || []).map(normalizeGlRegionSentinel),
+      regions: sanitizeRegions(a?.regions),
     }))
     .filter((a) => hasText(a.alias) && !seen.has(a.alias) && seen.add(a.alias))
     .map((a) => ({
@@ -620,7 +620,7 @@ async function syncCompetitors(brandId, organizationId, competitors, postgrestCl
       name: typeof c === 'string' ? c : c?.name,
       url: c?.url || null,
       aliases: Array.isArray(c?.aliases) ? c.aliases : [],
-      regions: (c?.regions || []).map(normalizeGlRegionSentinel),
+      regions: sanitizeRegions(c?.regions),
     }))
     .filter((c) => hasText(c.name) && !seen.has(c.name) && seen.add(c.name))
     .map((c) => ({

--- a/src/support/customer-config-mapper.js
+++ b/src/support/customer-config-mapper.js
@@ -98,7 +98,7 @@ const DEFAULT_BRAND_REGION = 'US';
 
 /**
  * Maps the legacy `GL` "worldwide" sentinel (Greenland's real ISO 3166-1
- * alpha-2 code, historically misused as a global placeholder — SITES-3168)
+ * alpha-2 code, historically misused as a global placeholder — #3168)
  * onto DEFAULT_BRAND_REGION. Case-insensitive, whitespace-trim-aware; any
  * other value passes through unchanged.
  * @param {*} region
@@ -114,7 +114,7 @@ function normalizeGlRegionSentinel(region) {
 /**
  * Coerces a raw region array to strings, normalizes the GL sentinel, and
  * drops blanks. Shared by every write path that persists a raw,
- * client-supplied regions array directly (SITES-3168).
+ * client-supplied regions array directly (#3168).
  * @param {Array<*>} regions
  * @returns {string[]}
  */
@@ -145,7 +145,7 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
 
   // Collect all unique regions from V1 config. Normalizes the legacy GL
   // sentinel to DEFAULT_BRAND_REGION before lowercasing so an explicit
-  // (not just missing) GL/gl value can never reach allRegions (SITES-3168).
+  // (not just missing) GL/gl value can never reach allRegions (#3168).
   const allRegions = new Set();
   const allUrls = new Set();
   const collectRegion = (r) => allRegions.add(normalizeGlRegionSentinel(r).toLowerCase());

--- a/src/support/customer-config-mapper.js
+++ b/src/support/customer-config-mapper.js
@@ -93,6 +93,38 @@ function generatePromptId(brandName, promptText) {
   return `${brandSlug}-${hash}`;
 }
 
+/** Fallback region when a caller has no market/region information at all. */
+const DEFAULT_BRAND_REGION = 'US';
+
+/**
+ * Maps the legacy `GL` "worldwide" sentinel (Greenland's real ISO 3166-1
+ * alpha-2 code, historically misused as a global placeholder — SITES-3168)
+ * onto DEFAULT_BRAND_REGION. Case-insensitive, whitespace-trim-aware; any
+ * other value passes through unchanged.
+ * @param {*} region
+ * @returns {*}
+ */
+function normalizeGlRegionSentinel(region) {
+  if (typeof region !== 'string') {
+    return region;
+  }
+  return region.trim().toLowerCase() === 'gl' ? DEFAULT_BRAND_REGION : region;
+}
+
+/**
+ * Coerces a raw region array to strings, normalizes the GL sentinel, and
+ * drops blanks. Shared by every write path that persists a raw,
+ * client-supplied regions array directly (SITES-3168).
+ * @param {Array<*>} regions
+ * @returns {string[]}
+ */
+function sanitizeRegions(regions) {
+  return (regions || [])
+    .map((r) => (typeof r === 'string' ? r : String(r)))
+    .map(normalizeGlRegionSentinel)
+    .filter(hasText);
+}
+
 /**
  * Converts LLMO config (V1) to Customer Config (V2)
  * @param {object} llmoConfig - V1 LLMO configuration
@@ -111,20 +143,23 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
 
   const brands = [];
 
-  // Collect all unique regions from V1 config
+  // Collect all unique regions from V1 config. Normalizes the legacy GL
+  // sentinel to DEFAULT_BRAND_REGION before lowercasing so an explicit
+  // (not just missing) GL/gl value can never reach allRegions (SITES-3168).
   const allRegions = new Set();
   const allUrls = new Set();
+  const collectRegion = (r) => allRegions.add(normalizeGlRegionSentinel(r).toLowerCase());
 
   // From brand aliases
   const brandAliases = llmoConfig.brands?.aliases || [];
   brandAliases.forEach((alias) => {
     const regions = alias.region || alias.regions || [];
-    regions.forEach((r) => allRegions.add(r.toLowerCase()));
+    regions.forEach(collectRegion);
   });
 
   // From competitors
   (llmoConfig.competitors?.competitors || []).forEach((comp) => {
-    (comp.regions || []).forEach((r) => allRegions.add(r.toLowerCase()));
+    (comp.regions || []).forEach(collectRegion);
   });
 
   // From categories
@@ -136,7 +171,7 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
     } else if (category.region) {
       regions = [category.region];
     }
-    regions.forEach((r) => allRegions.add(r.toLowerCase()));
+    regions.forEach(collectRegion);
 
     // Collect URLs from categories
     (category.urls || []).forEach((urlObj) => {
@@ -150,11 +185,11 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
   const topics = llmoConfig.topics || {};
   Object.values(topics).forEach((topic) => {
     (topic.prompts || []).forEach((prompt) => {
-      (prompt.regions || []).forEach((r) => allRegions.add(r.toLowerCase()));
+      (prompt.regions || []).forEach(collectRegion);
     });
   });
 
-  const brandRegions = allRegions.size > 0 ? Array.from(allRegions) : ['gl'];
+  const brandRegions = allRegions.size > 0 ? Array.from(allRegions) : [DEFAULT_BRAND_REGION];
   const brandUrls = Array.from(allUrls).map((url) => ({ value: url, type: 'base' }));
 
   // Only create a brand if we have brand aliases
@@ -196,12 +231,13 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
     socialAccounts: [],
     brandAliases: brandAliases.map((alias) => ({
       name: alias.name || (alias.aliases && alias.aliases[0]) || brandName,
-      regions: alias.region || alias.regions || ['gl'],
+      regions: (alias.region || alias.regions || [DEFAULT_BRAND_REGION])
+        .map(normalizeGlRegionSentinel),
     })),
     competitors: (llmoConfig.competitors?.competitors || []).map((comp) => ({
       name: comp.name,
       url: comp.url || '',
-      regions: comp.regions || ['gl'],
+      regions: (comp.regions || [DEFAULT_BRAND_REGION]).map(normalizeGlRegionSentinel),
     })),
     relatedBrands: [],
     earnedContent: [],
@@ -245,7 +281,7 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
             id: prompt.id || generatePromptId(brandName, prompt.prompt),
             prompt: prompt.prompt,
             status: prompt.status || 'active',
-            regions: prompt.regions || ['gl'],
+            regions: (prompt.regions || [DEFAULT_BRAND_REGION]).map(normalizeGlRegionSentinel),
             origin: prompt.origin || 'human',
             source: prompt.source || 'config',
             updatedBy: prompt.updatedBy || 'system',
@@ -277,7 +313,7 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
             id: prompt.id || generatePromptId(brandName, prompt.prompt),
             prompt: prompt.prompt,
             status: prompt.status || 'active',
-            regions: prompt.regions || ['gl'],
+            regions: (prompt.regions || [DEFAULT_BRAND_REGION]).map(normalizeGlRegionSentinel),
             origin: 'ai',
             source: prompt.source || 'flow',
             updatedBy: prompt.updatedBy || 'system',
@@ -330,7 +366,7 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
       id: promptId,
       prompt: prompt.prompt,
       status: 'deleted',
-      regions: prompt.regions || ['gl'],
+      regions: (prompt.regions || [DEFAULT_BRAND_REGION]).map(normalizeGlRegionSentinel),
       origin: prompt.origin || 'human',
       source: prompt.source || 'config',
       updatedBy: prompt.updatedBy || 'system',
@@ -355,7 +391,12 @@ export function convertV1ToV2(llmoConfig, brandName, imsOrgId) {
   };
 }
 
-export { generateBrandId };
+export {
+  generateBrandId,
+  DEFAULT_BRAND_REGION,
+  normalizeGlRegionSentinel,
+  sanitizeRegions,
+};
 
 export default {
   convertV1ToV2,

--- a/src/support/customer-config-mapper.js
+++ b/src/support/customer-config-mapper.js
@@ -112,17 +112,20 @@ function normalizeGlRegionSentinel(region) {
 }
 
 /**
- * Coerces a raw region array to strings, normalizes the GL sentinel, and
- * drops blanks. Shared by every write path that persists a raw,
- * client-supplied regions array directly (#3168).
+ * Coerces a raw region array to strings, normalizes the GL sentinel, drops
+ * blanks, and deduplicates (normalizing GL can otherwise collapse two
+ * distinct input values onto the same US region). Shared by every write path
+ * that persists a raw, client-supplied regions array directly (#3168).
  * @param {Array<*>} regions
  * @returns {string[]}
  */
 function sanitizeRegions(regions) {
-  return (regions || [])
-    .map((r) => (typeof r === 'string' ? r : String(r)))
-    .map(normalizeGlRegionSentinel)
-    .filter(hasText);
+  return [...new Set(
+    (regions || [])
+      .map((r) => (typeof r === 'string' ? r : String(r)))
+      .map(normalizeGlRegionSentinel)
+      .filter(hasText),
+  )];
 }
 
 /**

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -4470,12 +4470,12 @@ describe('LLMO Onboarding Functions', () => {
       expect(brand.v1SiteId).to.equal('site-123');
       expect(brand.baseUrl).to.equal('https://www.example.com');
       expect(brand.urls).to.deep.equal([{ value: 'https://www.example.com', type: 'base' }]);
-      expect(brand.brandAliases).to.deep.equal([{ name: 'Test Brand', regions: ['gl'] }]);
+      expect(brand.brandAliases).to.deep.equal([{ name: 'Test Brand', regions: ['US'] }]);
       expect(brand.updatedBy).to.equal('tester@example.com');
       expect(brand.prompts).to.deep.equal([]);
     });
 
-    it('seeds the operator-selected market in place of the gl placeholder (LLMO-5645)', async () => {
+    it('seeds the operator-selected market in place of the default US placeholder (LLMO-5645)', async () => {
       const { buildInitialCustomerConfigV2 } = await esmock('../../../src/controllers/llmo/llmo-onboarding.js', {});
 
       const result = buildInitialCustomerConfigV2({
@@ -4672,9 +4672,9 @@ describe('LLMO Onboarding Functions', () => {
       expect(newBrand.baseUrl).to.equal('https://www.example.com');
       expect(newBrand.status).to.equal('active');
       expect(newBrand.origin).to.equal('system');
-      expect(newBrand.regions).to.deep.equal(['gl']);
+      expect(newBrand.regions).to.deep.equal(['US']);
       expect(newBrand.urls).to.deep.equal([{ value: 'https://www.example.com', type: 'base' }]);
-      expect(newBrand.brandAliases).to.deep.equal([{ name: 'New Brand', regions: ['gl'] }]);
+      expect(newBrand.brandAliases).to.deep.equal([{ name: 'New Brand', regions: ['US'] }]);
 
       expect(mockCustomerConfigV2Storage.writeCustomerConfigV2ToPostgres).to.have.been.calledOnce;
       expect(mockCustomerConfigV2Storage.writeCustomerConfigV2ToPostgres.firstCall.args[0])

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -2394,6 +2394,43 @@ describe('brands-storage', () => {
       expect(earnedUpsert.row[0].regions).to.deep.equal(['US']);
     });
 
+    it('dedupes GL alongside an explicit US in aliases, competitors, social '
+      + 'accounts, and earned content on create', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          brandAliases: [{ name: 'Alias', regions: ['GL', 'US'] }],
+          competitors: [{ name: 'Rival', url: 'https://rival.com', regions: ['GL', 'US'] }],
+          socialAccounts: [{ url: 'https://x.com/test', regions: ['GL', 'US'] }],
+          earnedContent: [{ name: 'Blog', url: 'https://blog.com', regions: ['GL', 'US'] }],
+        },
+        postgrestClient: client,
+      });
+
+      const aliasesUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brand_aliases');
+      expect(aliasesUpsert.row[0].regions).to.deep.equal(['US']);
+
+      const competitorsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'competitors');
+      expect(competitorsUpsert.row[0].regions).to.deep.equal(['US']);
+
+      const socialUpsert = client.capturedCalls.upsert
+        .find((c) => c.table === 'brand_social_accounts');
+      expect(socialUpsert.row[0].regions).to.deep.equal(['US']);
+
+      const earnedUpsert = client.capturedCalls.upsert
+        .find((c) => c.table === 'brand_earned_sources');
+      expect(earnedUpsert.row[0].regions).to.deep.equal(['US']);
+    });
+
     it('accepts string aliases (not objects) in brandAliases', async () => {
       const fullBrandRow = makeBrandRow({
         brand_aliases: [{ alias: 'StringAlias', regions: [] }],

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -2319,7 +2319,7 @@ describe('brands-storage', () => {
       expect(result.region).to.deep.equal(['42']);
     });
 
-    it('normalizes GL to US on create, case-insensitively and whitespace-trimmed (SITES-3168)', async () => {
+    it('normalizes GL to US on create, case-insensitively and whitespace-trimmed (#3168)', async () => {
       const client = createCapturingClient({
         brands: [
           { data: null, error: null }, // no existing brand
@@ -2358,7 +2358,7 @@ describe('brands-storage', () => {
     });
 
     it('normalizes GL to US in aliases, competitors, social accounts, and earned '
-      + 'content on create (SITES-3168)', async () => {
+      + 'content on create (#3168)', async () => {
       const client = createCapturingClient({
         brands: [
           { data: null, error: null },
@@ -3239,7 +3239,7 @@ describe('brands-storage', () => {
       expect(result.region).to.deep.equal(['42']);
     });
 
-    it('normalizes GL to US on update, case-insensitively and whitespace-trimmed (SITES-3168)', async () => {
+    it('normalizes GL to US on update, case-insensitively and whitespace-trimmed (#3168)', async () => {
       const client = createCapturingClient({
         brands: [
           { data: makeBrandRow({ regions: ['US', 'US', 'DE'] }), error: null },

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -2319,6 +2319,81 @@ describe('brands-storage', () => {
       expect(result.region).to.deep.equal(['42']);
     });
 
+    it('normalizes GL to US on create, case-insensitively and whitespace-trimmed (SITES-3168)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null }, // no existing brand
+          { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
+          { data: makeBrandRow({ regions: ['US', 'US', 'DE'] }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', region: ['GL', ' gl ', 'DE'] },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.regions).to.deep.equal(['US', 'US', 'DE']);
+    });
+
+    it('leaves non-GL region values untouched on create', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ regions: ['FR'] }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', region: ['FR'] },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      expect(brandsUpsert.row.regions).to.deep.equal(['FR']);
+    });
+
+    it('normalizes GL to US in aliases, competitors, social accounts, and earned '
+      + 'content on create (SITES-3168)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          { data: makeBrandRow({ name: 'Test' }), error: null },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: {
+          name: 'Test',
+          brandAliases: [{ name: 'Alias', regions: ['GL'] }],
+          competitors: [{ name: 'Rival', url: 'https://rival.com', regions: ['GL'] }],
+          socialAccounts: [{ url: 'https://x.com/test', regions: ['GL'] }],
+          earnedContent: [{ name: 'Blog', url: 'https://blog.com', regions: ['GL'] }],
+        },
+        postgrestClient: client,
+      });
+
+      const aliasesUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brand_aliases');
+      expect(aliasesUpsert.row[0].regions).to.deep.equal(['US']);
+
+      const competitorsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'competitors');
+      expect(competitorsUpsert.row[0].regions).to.deep.equal(['US']);
+
+      const socialUpsert = client.capturedCalls.upsert
+        .find((c) => c.table === 'brand_social_accounts');
+      expect(socialUpsert.row[0].regions).to.deep.equal(['US']);
+
+      const earnedUpsert = client.capturedCalls.upsert
+        .find((c) => c.table === 'brand_earned_sources');
+      expect(earnedUpsert.row[0].regions).to.deep.equal(['US']);
+    });
+
     it('accepts string aliases (not objects) in brandAliases', async () => {
       const fullBrandRow = makeBrandRow({
         brand_aliases: [{ alias: 'StringAlias', regions: [] }],
@@ -3162,6 +3237,42 @@ describe('brands-storage', () => {
         postgrestClient,
       });
       expect(result.region).to.deep.equal(['42']);
+    });
+
+    it('normalizes GL to US on update, case-insensitively and whitespace-trimmed (SITES-3168)', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: makeBrandRow({ regions: ['US', 'US', 'DE'] }), error: null },
+        ],
+      });
+
+      await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { region: ['GL', ' gl ', 'DE'] },
+        postgrestClient: client,
+      });
+
+      const brandsUpdate = client.capturedCalls.update.find((c) => c.table === 'brands');
+      expect(brandsUpdate.row.regions).to.deep.equal(['US', 'US', 'DE']);
+    });
+
+    it('leaves non-GL region values untouched on update', async () => {
+      const client = createCapturingClient({
+        brands: [
+          { data: makeBrandRow({ regions: ['FR'] }), error: null },
+        ],
+      });
+
+      await updateBrand({
+        organizationId: ORG_ID,
+        brandId: BRAND_ID,
+        updates: { region: ['FR'] },
+        postgrestClient: client,
+      });
+
+      const brandsUpdate = client.capturedCalls.update.find((c) => c.table === 'brands');
+      expect(brandsUpdate.row.regions).to.deep.equal(['FR']);
     });
 
     it('handles null values for array update fields', async () => {

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -2324,7 +2324,7 @@ describe('brands-storage', () => {
         brands: [
           { data: null, error: null }, // no existing brand
           { data: { id: BRAND_ID, name: 'Test' }, error: null }, // upsert result
-          { data: makeBrandRow({ regions: ['US', 'US', 'DE'] }), error: null },
+          { data: makeBrandRow({ regions: ['US', 'DE'] }), error: null },
         ],
       });
 
@@ -2335,7 +2335,7 @@ describe('brands-storage', () => {
       });
 
       const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
-      expect(brandsUpsert.row.regions).to.deep.equal(['US', 'US', 'DE']);
+      expect(brandsUpsert.row.regions).to.deep.equal(['US', 'DE']);
     });
 
     it('leaves non-GL region values untouched on create', async () => {
@@ -3242,7 +3242,7 @@ describe('brands-storage', () => {
     it('normalizes GL to US on update, case-insensitively and whitespace-trimmed (#3168)', async () => {
       const client = createCapturingClient({
         brands: [
-          { data: makeBrandRow({ regions: ['US', 'US', 'DE'] }), error: null },
+          { data: makeBrandRow({ regions: ['US', 'DE'] }), error: null },
         ],
       });
 
@@ -3254,7 +3254,7 @@ describe('brands-storage', () => {
       });
 
       const brandsUpdate = client.capturedCalls.update.find((c) => c.table === 'brands');
-      expect(brandsUpdate.row.regions).to.deep.equal(['US', 'US', 'DE']);
+      expect(brandsUpdate.row.regions).to.deep.equal(['US', 'DE']);
     });
 
     it('leaves non-GL region values untouched on update', async () => {

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -75,7 +75,7 @@ describe('Customer Config Mapper', () => {
       expect(brand.competitors).to.have.lengthOf(1);
       expect(brand.prompts).to.have.lengthOf(1);
 
-      // SITES-3168: an explicit 'GL' input value (not just a missing region)
+      // #3168: an explicit 'GL' input value (not just a missing region)
       // must never survive into the persisted config — normalized to US.
       expect(brand.region).to.deep.equal(['us', 'gb']);
       expect(brand.brandAliases[1].regions).to.deep.equal(['US']);

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -11,7 +11,12 @@
  */
 
 import { expect } from 'chai';
-import { convertV1ToV2 } from '../../src/support/customer-config-mapper.js';
+import {
+  convertV1ToV2,
+  DEFAULT_BRAND_REGION,
+  normalizeGlRegionSentinel,
+  sanitizeRegions,
+} from '../../src/support/customer-config-mapper.js';
 
 describe('Customer Config Mapper', () => {
   describe('convertV1ToV2', () => {
@@ -69,6 +74,12 @@ describe('Customer Config Mapper', () => {
       expect(brand.brandAliases).to.have.lengthOf(2);
       expect(brand.competitors).to.have.lengthOf(1);
       expect(brand.prompts).to.have.lengthOf(1);
+
+      // SITES-3168: an explicit 'GL' input value (not just a missing region)
+      // must never survive into the persisted config — normalized to US.
+      expect(brand.region).to.deep.equal(['us', 'gb']);
+      expect(brand.brandAliases[1].regions).to.deep.equal(['US']);
+      expect(brand.competitors[0].regions).to.deep.equal(['US']);
       expect(brand.brandContext).to.equal('Photoshop is Adobe creative software.');
       expect(brand.mentionSentimentGuidance).to.equal('Treat factual price mentions as neutral.');
 
@@ -207,7 +218,7 @@ describe('Customer Config Mapper', () => {
       };
 
       const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
-      expect(result.customer.brands[0].competitors[0].regions).to.deep.equal(['gl']);
+      expect(result.customer.brands[0].competitors[0].regions).to.deep.equal(['US']);
     });
 
     it('handles category with array region', () => {
@@ -310,7 +321,7 @@ describe('Customer Config Mapper', () => {
       expect(result.customer.brands[0].region).to.include('jp');
     });
 
-    it('uses default region "gl" when no regions are specified', () => {
+    it('uses default region "US" when no regions are specified', () => {
       const llmoConfig = {
         brands: {
           aliases: [{ name: 'Test Brand' }],
@@ -320,7 +331,7 @@ describe('Customer Config Mapper', () => {
       };
 
       const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
-      expect(result.customer.brands[0].region).to.deep.equal(['gl']);
+      expect(result.customer.brands[0].region).to.deep.equal(['US']);
     });
 
     it('uses alias name from primaryAlias.name', () => {
@@ -418,7 +429,7 @@ describe('Customer Config Mapper', () => {
       };
 
       const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
-      expect(result.customer.brands[0].region).to.deep.equal(['gl']);
+      expect(result.customer.brands[0].region).to.deep.equal(['US']);
     });
 
     it('handles topics without prompts array', () => {
@@ -492,7 +503,7 @@ describe('Customer Config Mapper', () => {
       };
 
       const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
-      expect(result.customer.brands[0].prompts[0].regions).to.deep.equal(['gl']);
+      expect(result.customer.brands[0].prompts[0].regions).to.deep.equal(['US']);
     });
 
     it('preserves brand alias status from V1', () => {
@@ -755,6 +766,41 @@ describe('Customer Config Mapper', () => {
 
       const result = convertV1ToV2(llmoConfig, 'Fallback', 'test@org');
       expect(result.customer.brands[0].brandAliases[1].name).to.equal('Fallback');
+    });
+  });
+
+  describe('normalizeGlRegionSentinel', () => {
+    it('normalizes GL (any case, whitespace-trimmed) to DEFAULT_BRAND_REGION', () => {
+      expect(normalizeGlRegionSentinel('GL')).to.equal(DEFAULT_BRAND_REGION);
+      expect(normalizeGlRegionSentinel('gl')).to.equal(DEFAULT_BRAND_REGION);
+      expect(normalizeGlRegionSentinel('Gl')).to.equal(DEFAULT_BRAND_REGION);
+      expect(normalizeGlRegionSentinel(' gl ')).to.equal(DEFAULT_BRAND_REGION);
+    });
+
+    it('leaves other region values unchanged', () => {
+      expect(normalizeGlRegionSentinel('US')).to.equal('US');
+      expect(normalizeGlRegionSentinel('FR')).to.equal('FR');
+      expect(normalizeGlRegionSentinel('')).to.equal('');
+    });
+
+    it('passes through non-string values unchanged', () => {
+      expect(normalizeGlRegionSentinel(null)).to.equal(null);
+      expect(normalizeGlRegionSentinel(undefined)).to.equal(undefined);
+      expect(normalizeGlRegionSentinel(42)).to.equal(42);
+    });
+  });
+
+  describe('sanitizeRegions', () => {
+    it('coerces, normalizes GL, and drops blanks', () => {
+      expect(sanitizeRegions(['GL', ' gl ', 'DE', 42, ''])).to.deep.equal([
+        'US', 'US', 'DE', '42',
+      ]);
+    });
+
+    it('returns an empty array for null/undefined/empty input', () => {
+      expect(sanitizeRegions(null)).to.deep.equal([]);
+      expect(sanitizeRegions(undefined)).to.deep.equal([]);
+      expect(sanitizeRegions([])).to.deep.equal([]);
     });
   });
 });

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -791,10 +791,14 @@ describe('Customer Config Mapper', () => {
   });
 
   describe('sanitizeRegions', () => {
-    it('coerces, normalizes GL, and drops blanks', () => {
+    it('coerces, normalizes GL, drops blanks, and dedupes', () => {
       expect(sanitizeRegions(['GL', ' gl ', 'DE', 42, ''])).to.deep.equal([
-        'US', 'US', 'DE', '42',
+        'US', 'DE', '42',
       ]);
+    });
+
+    it('dedupes an explicit GL alongside an explicit US', () => {
+      expect(sanitizeRegions(['GL', 'US', 'DE'])).to.deep.equal(['US', 'DE']);
     });
 
     it('returns an empty array for null/undefined/empty input', () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Normalizes the legacy `GL` "worldwide" region sentinel to `US` at every write boundary for LLMO brand regions, so `GL` can never be persisted as a brand's market.

## 2. Reasoning
`GL` is a real ISO 3166-1 alpha-2 code (Greenland), but several write paths used it as a placeholder meaning "no region yet" or "worldwide." A Costa Cruises onboarding stored `GL` on its SpaceCat brand record; DRS then interpreted it as an actual Greenland market, asked for clarification about Danish/Greenlandic prompts, parsed zero prompts, and permanently failed a prompt-generation job. The downstream DRS defensive change for that failure mode is tracked separately (see Other, below) — this PR is the SpaceCat-side fix: `GL` must never be written as a brand region in the first place.

## 3. High-level overview of the changes
Before: a missing region defaulted to `gl` in several places, and an explicitly-supplied `GL`/`gl` value (from a client request or a V1 config import) was written through unmodified in others.

After: every region write for a brand — the top-level region, brand aliases, competitors, social accounts, earned content, and LLMO prompts — normalizes `GL`/`gl` (case-insensitive, whitespace-trimmed) to `US`, both for the missing-region default and for an explicitly-supplied `GL` value. No other region value's behavior changes; this is a single-sentinel fix, not a region allow-list.

- `src/support/customer-config-mapper.js`: adds `normalizeGlRegionSentinel()` and `sanitizeRegions()`, the two functions every other change below calls into. `convertV1ToV2()`'s region-aggregation and its brand-alias/competitor/prompt region fields now route through them.
- `src/controllers/llmo/llmo-onboarding.js`: `onboardingStubRegions()` now defaults to `US` instead of `gl` when no region is supplied.
- `src/support/brands-storage.js`: `upsertBrand`/`updateBrand`'s top-level region write, and the four child-table sync helpers (aliases, competitors, social accounts, earned content) they call, all normalize `GL` to `US` before writing.
- `docs/openapi/examples.yaml` / `schemas.yaml`: removed `GL` from the documented region examples.

Explicitly out of scope: migrating already-persisted `GL` records in production, including the Costa Cruises record named in the issue — tracked as separate follow-up work, not part of this change.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/3168
- Other: https://github.com/adobe-rnd/llmo-data-retrieval-service/issues/3103 (the downstream DRS defensive change for the same incident, tracked separately)

## 6. Affected / used mysticat-workspace projects
- llmo-data-retrieval-service (consumed): reads `brand.region`/prompt `regions` for collection scheduling; once a brand is onboarded or updated after this fix, it sees `US` instead of the `GL` sentinel for a missing/global market. No contract change — same ISO-code field, different value.

## 7. Additional information outside the code
Ran the real (unmocked) exported functions directly with `node`, outside the test harness, against explicit `GL` and missing-region inputs:
- `normalizeGlRegionSentinel('GL')`, `('gl')`, `(' Gl ')`, `('US')` — confirmed only the GL sentinel normalizes, case-insensitively and whitespace-trimmed.
- `sanitizeRegions(['GL', 'DE', 42])` — confirmed coercion, normalization, and blank-filtering compose correctly.
- `convertV1ToV2()` with an explicit `regions: ['GL']` on a brand alias and a competitor — confirmed both normalize to `US` in the resulting brand.
- `onboardingStubRegions(undefined)` / `('US')` — confirmed the onboarding stub default.
- Loaded `brands-storage.js` directly to confirm its new import from `customer-config-mapper.js` introduces no circular-import failure.

## 8. Test plan
(a) Locally: the direct real-function execution above (section 7), plus the scoped unit suites for every changed file, which now cover both the missing-region default and an explicitly-supplied `GL` value at every write site (top-level brand region, aliases, competitors, social accounts, earned content, and LLMO prompts).

(b) Per environment:
- **dev**: exercise the LLMO onboarding endpoint with no region and confirm the persisted brand record shows `region: ['US']`; separately `PATCH`/`POST` a brand with an explicit `region: ['GL']` (and nested `brandAliases[].regions`/`competitors[].regions`) and confirm the persisted row normalizes to `US`.
- **stage/prod**: same check on a real onboarding or brand update once deployed; no data migration runs as part of this change, so existing `GL` records (including the Costa Cruises one) are unaffected until the separate backfill work referenced above.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "Normalizes one legacy sentinel value (GL -> US) at existing brand-region write paths; no schema, auth, or public API-contract change, fully covered by tests, reversible via redeploy."
recommendations: "Validate on dev per the test plan above (missing-region default and explicit GL input) before promoting."
backout: "Redeploy the previous release."
```
