### PR TITLE
feat(suggestions): gate suggestionKey write-on-create behind admin/S2S

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
         "@adobe/spacecat-shared-content-client": "1.10.0",
-        "@adobe/spacecat-shared-data-access": "4.21.0",
+        "@adobe/spacecat-shared-data-access": "^4.23.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
         "@adobe/spacecat-shared-http-utils": "1.36.0",
@@ -3863,9 +3863,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.21.0.tgz",
-      "integrity": "sha512-4nobD+tRfQnvxIXckdczvJvb/hER3f6c5VhYK1QTO1NmC44+fD14wAK4HjzIHLuAWGROLntQ3siExhyej8Ac8g==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.23.0.tgz",
+      "integrity": "sha512-HBJ+kikNB8hxW+ZSXJ3Cf3TgP9nIlIpETpCdggS+7GiH0VmfwdvYy2x+ac107e9QYOyGpalSjMjkINhnaz0doA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
     "@adobe/spacecat-shared-content-client": "1.10.0",
-    "@adobe/spacecat-shared-data-access": "4.21.0",
+    "@adobe/spacecat-shared-data-access": "^4.23.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
     "@adobe/spacecat-shared-http-utils": "1.36.0",

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -1022,10 +1022,35 @@ function SuggestionsController(ctx, sqs, env) {
       return forbidden('User does not belong to the organization');
     }
 
+    // suggestionKey is a protected identity field (readOnly on the ORM schema,
+    // collision-checked only via the internal rekey_bbl_suggestion RPC used by
+    // Mystique's in-process projector). Setting it on create via this public API
+    // is restricted to callers with an explicit grant — either a scoped S2S
+    // suggestion:write capability or plain admin access Any caller without that grant has
+    // suggestionKey silently dropped rather than erroring, so ordinary suggestion
+    // creation (the overwhelmingly common case) is unaffected.
+    const suggKeyS2SResult = await accessControlUtil.hasS2SCapability(CAP_SUGGESTION_WRITE);
+    const canSetSuggestionKey = suggKeyS2SResult.allowed || accessControlUtil.hasAdminAccess();
+
     const suggestionPromises = context.data.map(async (suggData, index) => {
       try {
         // eslint-disable-next-line no-param-reassign
         suggData.opportunityId = opptyId;
+
+        if (hasText(suggData.suggestionKey)) {
+          if (!canSetSuggestionKey) {
+            // eslint-disable-next-line no-param-reassign
+            delete suggData.suggestionKey;
+          } else if (!suggData.suggestionKey.startsWith(`site:${siteId}:`)) {
+            // Check to make sure the suggestionKey is scoped to the correct site
+            return {
+              index,
+              message: `suggestionKey must be scoped to site ${siteId}`,
+              statusCode: 400,
+            };
+          }
+        }
+
         const suggestionEntity = await Suggestion.create(suggData);
         return {
           index,

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -2942,6 +2942,89 @@ describe('Suggestions Controller', () => {
     expect(createResponse.suggestions[1]).to.have.property('message', 'Validation error');
   });
 
+  describe('createSuggestions suggestionKey gating', () => {
+    it('strips suggestionKey silently when caller is neither admin nor a granted S2S consumer', async () => {
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(false);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({ allowed: false, reason: 'not-s2s' });
+
+      suggs[0].suggestionKey = `site:${SITE_ID}:backlink:abc:referrer:def`;
+
+      const response = await suggestionsController.createSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: [suggs[0]],
+        ...context,
+      });
+
+      expect(response.status).to.equal(207);
+      const createResponse = await response.json();
+      expect(createResponse.suggestions[0]).to.have.property('statusCode', 201);
+      expect(mockSuggestion.create.calledOnce).to.be.true;
+      expect(mockSuggestion.create.firstCall.args[0].suggestionKey).to.be.undefined;
+    });
+
+    it('preserves a correctly site-scoped suggestionKey when caller is an admin', async () => {
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({ allowed: false, reason: 'not-s2s' });
+
+      const key = `site:${SITE_ID}:backlink:abc:referrer:def`;
+      suggs[0].suggestionKey = key;
+
+      const response = await suggestionsController.createSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: [suggs[0]],
+        ...context,
+      });
+
+      expect(response.status).to.equal(207);
+      const createResponse = await response.json();
+      expect(createResponse.suggestions[0]).to.have.property('statusCode', 201);
+      expect(mockSuggestion.create.calledOnce).to.be.true;
+      expect(mockSuggestion.create.firstCall.args[0].suggestionKey).to.equal(key);
+    });
+
+    it('preserves a correctly site-scoped suggestionKey when caller is a granted S2S consumer', async () => {
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(false);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability')
+        .resolves({ allowed: true, reason: 'granted', clientId: 'svc-suggestions', consumerId: 'consumer-1' });
+
+      const key = `site:${SITE_ID}:backlink:abc:referrer:def`;
+      suggs[0].suggestionKey = key;
+
+      const response = await suggestionsController.createSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: [suggs[0]],
+        ...context,
+      });
+
+      expect(response.status).to.equal(207);
+      const createResponse = await response.json();
+      expect(createResponse.suggestions[0]).to.have.property('statusCode', 201);
+      expect(mockSuggestion.create.calledOnce).to.be.true;
+      expect(mockSuggestion.create.firstCall.args[0].suggestionKey).to.equal(key);
+    });
+
+    it('rejects a suggestionKey scoped to a different site even for an admin caller', async () => {
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({ allowed: false, reason: 'not-s2s' });
+
+      suggs[0].suggestionKey = 'site:some-other-site-id:backlink:abc:referrer:def';
+
+      const response = await suggestionsController.createSuggestions({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+        data: [suggs[0]],
+        ...context,
+      });
+
+      expect(response.status).to.equal(207);
+      const createResponse = await response.json();
+      expect(createResponse.suggestions[0]).to.have.property('statusCode', 400);
+      expect(createResponse.suggestions[0]).to.have.property('message', `suggestionKey must be scoped to site ${SITE_ID}`);
+      expect(mockSuggestion.create.calledOnce).to.be.false;
+    });
+  });
+
   it('creates a suggestion returns bad request if no site ID is passed', async () => {
     const response = await suggestionsController.createSuggestions({
       params: { opportunityId: OPPORTUNITY_ID },


### PR DESCRIPTION
Allow admins (or S2S consumers with the suggestion:write capability) to set a suggestion's suggestionKey on creation. Mainly used for testing purposes on fancy clones. Mystique-sourced suggestions should already have their suggestionKey set via the in-process V2 projector's own RPC path, so this is not expected to be exercised in normal production traffic.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: normal
impact: degradation
risk: major
changeApprovedBy: ["@rpapani", "Dominique Jäggi"]
rationale: "Tightens access control on an existing public write path (suggestionKey), a security-boundary change to already-live behavior warranting human review."
```