### PR TITLE
feat: add `move llmo org` slack command to relocate a site's full brand graph

### DIFF
--- a/src/support/slack/actions/index.js
+++ b/src/support/slack/actions/index.js
@@ -28,6 +28,7 @@ import { preflightConfigModal } from './preflight-config-modal.js';
 import openPreflightConfig from './open-preflight-config.js';
 import { openSetImsOrgModal, setImsOrgModal } from './set-ims-org-modal.js';
 import movePlgSiteModal from './move-plg-site.js';
+import moveLlmoOrgModal from './move-llmo-org.js';
 import { openAddSiteModal, addSiteModal } from './add-site-modal.js';
 import {
   openEnsureEntitlementSiteModal,
@@ -57,6 +58,7 @@ const actions = {
   open_preflight_config: openPreflightConfig,
   open_set_ims_org_modal: openSetImsOrgModal,
   open_move_plg_site_modal: movePlgSiteModal,
+  open_move_llmo_org_modal: moveLlmoOrgModal,
   open_add_site_modal: openAddSiteModal,
   add_entitlements_action: addEntitlementsAction,
   update_org_action: updateOrgAction,

--- a/src/support/slack/actions/move-llmo-org.js
+++ b/src/support/slack/actions/move-llmo-org.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createEntitlementAndEnrollment } from '../../../controllers/llmo/llmo-onboarding.js';
+import { reparentSiteProject } from './set-ims-org-modal.js';
+import { createSayFunction } from './entitlement-modal-utils.js';
+import {
+  buildResultMessage,
+  describePreviewError,
+  executeOrgMove,
+  formatBlockingConflicts,
+  previewOrgMove,
+} from '../llmo-org-move.js';
+
+/**
+ * Handles the "Confirm Move" button click from the `move llmo org` command.
+ *
+ * Re-validates the move (the preview the operator saw may be stale), relocates the whole
+ * LLMO entity graph via `wrpc_move_brandalf_org`, re-parents the site's project so the
+ * site stays visible in the destination org's site picker, and provisions LLMO
+ * entitlement/enrollment on the destination org.
+ *
+ * @param {object} lambdaContext - The Lambda context.
+ * @returns {Function} The Bolt action handler.
+ */
+export function openMoveLlmoOrgModal(lambdaContext) {
+  const { dataAccess, log } = lambdaContext;
+  const { Site, Organization } = dataAccess;
+
+  return async ({ ack, body, client }) => {
+    await ack();
+
+    const {
+      baseURL, siteId, sourceOrgId, destOrgId, imsOrgId, channelId, threadTs, messageTs,
+    } = JSON.parse(body.actions[0].value);
+    const say = createSayFunction(client, channelId, threadTs);
+    const userId = body?.user?.id || 'unknown';
+
+    const updateMessage = async (text) => client.chat.update({
+      channel: channelId,
+      ts: messageTs,
+      text,
+      blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }],
+    });
+
+    try {
+      const site = await Site.findById(siteId);
+      if (!site) {
+        await updateMessage(`:x: Site \`${baseURL}\` no longer exists.`);
+        return;
+      }
+
+      const destOrg = await Organization.findById(destOrgId);
+      if (!destOrg) {
+        await updateMessage(`:x: Destination organization \`${imsOrgId}\` no longer exists.`);
+        return;
+      }
+
+      // The site may have been moved by someone else between the preview and this click.
+      if (site.getOrganizationId() !== sourceOrgId) {
+        await updateMessage(
+          `:x: \`${baseURL}\` is no longer in the organization it was in when this preview `
+          + 'was generated. Re-run `move llmo org` to get a fresh preview.',
+        );
+        return;
+      }
+
+      // Re-preview so a conflict introduced since the button was posted surfaces as a
+      // readable message rather than a raw database exception from the write RPC.
+      const preview = await previewOrgMove(lambdaContext, sourceOrgId, destOrgId);
+      const previewError = describePreviewError(preview);
+      if (previewError) {
+        await updateMessage(previewError);
+        return;
+      }
+      if (preview.ok !== true) {
+        await updateMessage(
+          `:x: *This move is now blocked* — the destination org changed since the preview:\n\n${
+            formatBlockingConflicts(preview.blocking_conflicts)
+          }`,
+        );
+        return;
+      }
+
+      await updateMessage(`:hourglass_flowing_sand: Moving LLMO org for \`${baseURL}\`…`);
+
+      const result = await executeOrgMove(
+        lambdaContext,
+        sourceOrgId,
+        destOrgId,
+        `slack:move-llmo-org:${userId}`,
+      );
+
+      // Everything below runs outside the RPC's transaction. The entity move itself is
+      // already durable at this point; a failure here leaves the org move applied but the
+      // project re-parent and/or entitlement provisioning incomplete, which is recoverable
+      // by re-running `set imsorg`/onboarding rather than by re-running this command.
+      const movedSite = await Site.findById(siteId);
+      await reparentSiteProject({
+        site: movedSite,
+        targetOrgId: destOrgId,
+        baseURL,
+        lambdaContext,
+        say,
+      });
+      await movedSite.save();
+
+      await createEntitlementAndEnrollment(movedSite, lambdaContext, say);
+
+      await updateMessage(buildResultMessage(result, baseURL));
+
+      log.info(
+        `move llmo org: moved site ${siteId} (${baseURL}) from org ${sourceOrgId} to `
+        + `${destOrgId} (${imsOrgId}) for user ${userId}`,
+      );
+    } catch (error) {
+      log.error(`Error moving LLMO org for ${baseURL} to ${imsOrgId}:`, error);
+      await updateMessage(`:x: Failed to move LLMO org for \`${baseURL}\`: ${error.message}`);
+    }
+  };
+}
+
+export default openMoveLlmoOrgModal;

--- a/src/support/slack/actions/move-llmo-org.js
+++ b/src/support/slack/actions/move-llmo-org.js
@@ -25,9 +25,15 @@ import {
  * Handles the "Confirm Move" button click from the `move llmo org` command.
  *
  * Re-validates the move (the preview the operator saw may be stale), relocates the whole
- * LLMO entity graph via `wrpc_move_brandalf_org`, re-parents the site's project so the
- * site stays visible in the destination org's site picker, and provisions LLMO
- * entitlement/enrollment on the destination org.
+ * LLMO entity graph via `wrpc_move_brandalf_org`, then runs the per-site follow-up for
+ * *every* site the move covered: re-parenting each site's project so it stays visible in
+ * the destination org's site picker, and provisioning LLMO entitlement/enrollment on the
+ * destination org.
+ *
+ * The follow-up loops because the move is scoped to the transitive closure of brands and
+ * sites reachable from the named site, which is frequently wider than that one site.
+ * Re-parenting only the seed site would leave the other moved sites owned by a project in
+ * the source org - the same class of half-move this ticket exists to fix.
  *
  * @param {object} lambdaContext - The Lambda context.
  * @returns {Function} The Bolt action handler.
@@ -75,8 +81,10 @@ export function openMoveLlmoOrgModal(lambdaContext) {
       }
 
       // Re-preview so a conflict introduced since the button was posted surfaces as a
-      // readable message rather than a raw database exception from the write RPC.
-      const preview = await previewOrgMove(lambdaContext, sourceOrgId, destOrgId);
+      // readable message rather than a raw database exception from the write RPC. Its
+      // site list is also what drives the per-site follow-up below - it has to be read
+      // before the move, while the sites are still resolvable from the source org.
+      const preview = await previewOrgMove(lambdaContext, siteId, destOrgId);
       const previewError = describePreviewError(preview);
       if (previewError) {
         await updateMessage(previewError);
@@ -84,42 +92,76 @@ export function openMoveLlmoOrgModal(lambdaContext) {
       }
       if (preview.ok !== true) {
         await updateMessage(
-          `:x: *This move is now blocked* — the destination org changed since the preview:\n\n${
+          `:x: *This move is now blocked* — the data changed since the preview:\n\n${
             formatBlockingConflicts(preview.blocking_conflicts)
           }`,
         );
         return;
       }
 
-      await updateMessage(`:hourglass_flowing_sand: Moving LLMO org for \`${baseURL}\`…`);
+      const movedSites = preview.sites || [];
+
+      await updateMessage(
+        `:hourglass_flowing_sand: Moving LLMO org for \`${baseURL}\` `
+        + `(${movedSites.length} site${movedSites.length === 1 ? '' : 's'}, `
+        + `${(preview.brands || []).length} brand${(preview.brands || []).length === 1 ? '' : 's'})…`,
+      );
 
       const result = await executeOrgMove(
         lambdaContext,
-        sourceOrgId,
+        siteId,
         destOrgId,
         `slack:move-llmo-org:${userId}`,
       );
 
       // Everything below runs outside the RPC's transaction. The entity move itself is
       // already durable at this point; a failure here leaves the org move applied but the
-      // project re-parent and/or entitlement provisioning incomplete, which is recoverable
-      // by re-running `set imsorg`/onboarding rather than by re-running this command.
-      const movedSite = await Site.findById(siteId);
-      await reparentSiteProject({
-        site: movedSite,
-        targetOrgId: destOrgId,
-        baseURL,
-        lambdaContext,
-        say,
-      });
-      await movedSite.save();
+      // project re-parent and/or entitlement provisioning incomplete for that one site.
+      // That is recoverable by re-running `set imsorg`/onboarding for the affected site,
+      // so a single site's failure is collected and reported rather than aborting the
+      // remaining sites.
+      const followUpFailures = [];
+      for (const movedSiteRef of movedSites) {
+        try {
+          // Re-fetch: the RPC rewrote organization_id in the database, but the JS model
+          // held by this handler still carries the old value.
+          // eslint-disable-next-line no-await-in-loop -- sequential per site; each writes
+          const movedSite = await Site.findById(movedSiteRef.id);
+          if (!movedSite) {
+            followUpFailures.push(`\`${movedSiteRef.base_url}\`: site no longer exists`);
+          } else {
+            // eslint-disable-next-line no-await-in-loop -- sequential per site
+            await reparentSiteProject({
+              site: movedSite,
+              targetOrgId: destOrgId,
+              baseURL: movedSiteRef.base_url,
+              lambdaContext,
+              say,
+            });
+            // eslint-disable-next-line no-await-in-loop -- sequential per site
+            await movedSite.save();
+            // eslint-disable-next-line no-await-in-loop -- sequential per site
+            await createEntitlementAndEnrollment(movedSite, lambdaContext, say);
+          }
+        } catch (followUpError) {
+          log.error(
+            `move llmo org: follow-up failed for site ${movedSiteRef.id} `
+            + `(${movedSiteRef.base_url}): ${followUpError.message}`,
+          );
+          followUpFailures.push(`\`${movedSiteRef.base_url}\`: ${followUpError.message}`);
+        }
+      }
 
-      await createEntitlementAndEnrollment(movedSite, lambdaContext, say);
-
-      await updateMessage(buildResultMessage(result, baseURL));
+      const followUpNote = followUpFailures.length > 0
+        ? '\n\n:warning: *The entity move succeeded, but post-move setup failed for some '
+          + `sites.* Re-run \`set imsorg\` / onboarding for these:\n${
+            followUpFailures.map((f) => `• ${f}`).join('\n')}`
+        : '';
+      await updateMessage(`${buildResultMessage(result, baseURL, preview)}${followUpNote}`);
 
       log.info(
-        `move llmo org: moved site ${siteId} (${baseURL}) from org ${sourceOrgId} to `
+        `move llmo org: moved site ${siteId} (${baseURL}) and ${movedSites.length} site(s) / `
+        + `${result.brands_moved || 0} brand(s) from org ${sourceOrgId} to `
         + `${destOrgId} (${imsOrgId}) for user ${userId}`,
       );
     } catch (error) {

--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -33,6 +33,7 @@ import onboardStatus from './commands/onboard-status.js';
 import llmoOnboard from './commands/llmo-onboard.js';
 import setSiteOrganizationCommand from './commands/set-ims-org.js';
 import movePlgSite from './commands/move-plg-site.js';
+import moveLlmoOrg from './commands/move-llmo-org.js';
 import toggleSiteImport from './commands/toggle-site-import.js';
 import runTrafficAnalysisBackfill from './commands/run-traffic-analysis-backfill.js';
 import backfillLlmo from './commands/backfill-llmo.js';
@@ -95,6 +96,7 @@ export default (context) => [
   llmoOnboard(context),
   setSiteOrganizationCommand(context),
   movePlgSite(context),
+  moveLlmoOrg(context),
   toggleSiteImport(context),
   backfillLlmo(context),
   getPromptUsage(context),

--- a/src/support/slack/commands/move-llmo-org.js
+++ b/src/support/slack/commands/move-llmo-org.js
@@ -59,9 +59,14 @@ function buildConfirmBlocks(text, payload) {
 /**
  * Factory function to create the MoveLlmoOrgCommand object.
  *
- * Relocates a customer's whole LLMO entity graph - brands, prompts, topics, categories,
- * competitors, feature flags and the site itself - from the organization its site
- * currently sits in to another IMS org.
+ * Relocates a customer's whole LLMO entity graph - brands, prompts, competitors, feature
+ * flags and the sites themselves - from the organization the named site currently sits
+ * in to another IMS org.
+ *
+ * The move is scoped to the transitive closure of brands and sites reachable from the
+ * named site, not to the whole source organization: customers are routinely provisioned
+ * into a shared or DEMO org, and moving everything in that org would relocate unrelated
+ * tenants too.
  *
  * This command only ever previews. It reports what would move and what conflicts, then
  * posts a confirmation button; the write happens in the `open_move_llmo_org_modal`
@@ -75,9 +80,9 @@ function MoveLlmoOrgCommand(context) {
   const baseCommand = BaseCommand({
     id: 'move-llmo-org',
     name: 'Move LLMO Org',
-    description: 'Moves a site and its full LLMO entity graph (brands, prompts, topics, '
-      + 'categories, competitors, feature flags) to another IMS org. Shows a preview and '
-      + 'requires confirmation before writing.',
+    description: 'Moves a site and every brand transitively linked to it - along with their '
+      + 'prompts, competitors and feature flags - to another IMS org. Shows a preview of the '
+      + 'full blast radius and requires confirmation before writing.',
     phrases: PHRASES,
     usageText: `${PHRASES[0]} {site} {imsOrgId}`,
   });
@@ -122,7 +127,7 @@ function MoveLlmoOrgCommand(context) {
       const sourceOrgId = site.getOrganizationId();
       const destOrgId = destOrg.getId();
 
-      const preview = await previewOrgMove(context, sourceOrgId, destOrgId);
+      const preview = await previewOrgMove(context, site.getId(), destOrgId);
 
       const previewError = describePreviewError(preview);
       if (previewError) {
@@ -132,9 +137,12 @@ function MoveLlmoOrgCommand(context) {
 
       if (preview.ok !== true) {
         await say(
-          `:x: *This move is blocked.* The destination org already holds conflicting data:\n\n${
+          `:x: *This move is blocked.*\n\n${
             formatBlockingConflicts(preview.blocking_conflicts)
-          }\n\nResolve these in the destination org (rename or remove the conflicting brand) and re-run.`,
+          }\n\nA name or base-site clash is resolved by renaming or removing the conflicting `
+          + 'brand in the destination org. A *different org* appearing in the list means the '
+          + 'brand/site graph already straddles two organizations — that is pre-existing data '
+          + 'corruption and needs untangling by hand before this move can run.',
         );
         return;
       }

--- a/src/support/slack/commands/move-llmo-org.js
+++ b/src/support/slack/commands/move-llmo-org.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { isValidIMSOrgId } from '@adobe/spacecat-shared-utils';
+import BaseCommand from './base.js';
+import {
+  extractURLFromSlackInput,
+  postErrorMessage,
+  postSiteNotFoundMessage,
+} from '../../../utils/slack/base.js';
+import {
+  buildPreviewMessage,
+  describePreviewError,
+  formatBlockingConflicts,
+  previewOrgMove,
+} from '../llmo-org-move.js';
+
+const PHRASES = ['move llmo org'];
+
+/**
+ * Builds the confirmation message blocks. Kept in one place so the initial post and the
+ * follow-up update (which injects the message's own timestamp into the button payload)
+ * cannot drift apart.
+ *
+ * @param {string} text - The rendered preview.
+ * @param {object} payload - The button's JSON payload.
+ * @returns {Array<object>} Slack blocks.
+ */
+function buildConfirmBlocks(text, payload) {
+  return [
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Confirm Move' },
+          style: 'danger',
+          action_id: 'open_move_llmo_org_modal',
+          value: JSON.stringify(payload),
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Factory function to create the MoveLlmoOrgCommand object.
+ *
+ * Relocates a customer's whole LLMO entity graph - brands, prompts, topics, categories,
+ * competitors, feature flags and the site itself - from the organization its site
+ * currently sits in to another IMS org.
+ *
+ * This command only ever previews. It reports what would move and what conflicts, then
+ * posts a confirmation button; the write happens in the `open_move_llmo_org_modal`
+ * action so the operator sees the blast radius before anything changes.
+ *
+ * @param {Object} context - The context object.
+ * @returns {MoveLlmoOrgCommand} The MoveLlmoOrgCommand object.
+ * @constructor
+ */
+function MoveLlmoOrgCommand(context) {
+  const baseCommand = BaseCommand({
+    id: 'move-llmo-org',
+    name: 'Move LLMO Org',
+    description: 'Moves a site and its full LLMO entity graph (brands, prompts, topics, '
+      + 'categories, competitors, feature flags) to another IMS org. Shows a preview and '
+      + 'requires confirmation before writing.',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {site} {imsOrgId}`,
+  });
+
+  const { dataAccess, log } = context;
+  const { Site, Organization } = dataAccess;
+
+  const handleExecution = async (args, slackContext) => {
+    const {
+      say, channelId, threadTs, client,
+    } = slackContext;
+
+    try {
+      const [baseURLInput, imsOrgId] = args;
+
+      const baseURL = extractURLFromSlackInput(baseURLInput);
+      if (!baseURL) {
+        await say(':warning: Please provide a valid site base URL.');
+        return;
+      }
+
+      if (!imsOrgId || !isValidIMSOrgId(imsOrgId)) {
+        await say(':warning: Please provide a valid destination IMS Org ID.');
+        return;
+      }
+
+      const site = await Site.findByBaseURL(baseURL);
+      if (!site) {
+        await postSiteNotFoundMessage(say, baseURL);
+        return;
+      }
+
+      const destOrg = await Organization.findByImsOrgId(imsOrgId);
+      if (!destOrg) {
+        await say(
+          `:x: No Spacecat organization found for IMS Org ID \`${imsOrgId}\`. `
+          + 'Use `set imsorg` to create it first, then re-run this command.',
+        );
+        return;
+      }
+
+      const sourceOrgId = site.getOrganizationId();
+      const destOrgId = destOrg.getId();
+
+      const preview = await previewOrgMove(context, sourceOrgId, destOrgId);
+
+      const previewError = describePreviewError(preview);
+      if (previewError) {
+        await say(previewError);
+        return;
+      }
+
+      if (preview.ok !== true) {
+        await say(
+          `:x: *This move is blocked.* The destination org already holds conflicting data:\n\n${
+            formatBlockingConflicts(preview.blocking_conflicts)
+          }\n\nResolve these in the destination org (rename or remove the conflicting brand) and re-run.`,
+        );
+        return;
+      }
+
+      const text = buildPreviewMessage(preview, baseURL);
+      const basePayload = {
+        baseURL,
+        siteId: site.getId(),
+        sourceOrgId,
+        destOrgId,
+        imsOrgId,
+        channelId,
+        threadTs,
+      };
+
+      const posted = await client.chat.postMessage({
+        channel: channelId,
+        thread_ts: threadTs,
+        text: `Ready to move LLMO org for ${baseURL}`,
+        blocks: buildConfirmBlocks(text, { ...basePayload, messageTs: 'placeholder' }),
+      });
+
+      await client.chat.update({
+        channel: channelId,
+        ts: posted.ts,
+        text: `Ready to move LLMO org for ${baseURL}`,
+        blocks: buildConfirmBlocks(text, { ...basePayload, messageTs: posted.ts }),
+      });
+    } catch (error) {
+      log.error(error);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+}
+
+export default MoveLlmoOrgCommand;

--- a/src/support/slack/llmo-org-move.js
+++ b/src/support/slack/llmo-org-move.js
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Shared logic for relocating a full LLMO ("brandalf") entity graph from one
+ * organization to another.
+ *
+ * Historically the Slack "Update IMS Org" flow only reassigned `sites.organization_id`,
+ * which stranded every brand-centric entity (brands, prompts, topics, categories,
+ * competitors, feature flags) in the source org. Now that the product navigates by
+ * brand rather than by site, that left customers with an empty destination org and an
+ * orphaned source org (LLMO-7294).
+ *
+ * The relocation itself is delegated to two PostgREST functions in
+ * mysticat-data-service, NOT to the data-access models:
+ *
+ *  - `rpc_org_move_preview`  - read-only; reports what would move and what conflicts.
+ *  - `wrpc_move_brandalf_org` - performs the move in a single transaction.
+ *
+ * An RPC is required rather than a sequence of model writes because
+ * `feature_flags_organization_id_brand_id_fkey` is a composite foreign key
+ * `(organization_id, brand_id) -> brands(organization_id, id)`. Updating `brands` and
+ * `feature_flags` as two separate statements transiently violates that constraint in
+ * whichever order they are attempted, so the update must happen inside one
+ * data-modifying CTE. The `Brand` data-access model also deliberately does not expose
+ * a setter for `organization_id`.
+ */
+
+const PREVIEW_RPC = 'rpc_org_move_preview';
+const MOVE_RPC = 'wrpc_move_brandalf_org';
+
+/**
+ * Above these counts the move is flagged as unusually large in the preview. The move is
+ * still allowed - it runs in a single transaction, so a large move is not a corruption
+ * risk - but a source org holding this many sites or active brands is a strong hint the
+ * operator resolved the wrong org and is about to relocate an unrelated customer.
+ */
+export const LARGE_MOVE_SITE_THRESHOLD = 5;
+export const LARGE_MOVE_BRAND_THRESHOLD = 5;
+
+/**
+ * Entitlements and site enrollments are deliberately out of scope for the move
+ * (LLMO-7294). `site_enrollments` has no `organization_id` - it reaches the org only
+ * indirectly via `entitlement_id` - so entitlements cannot be re-pointed by the same
+ * org-id rewrite that moves everything else, and cloning them 1:1 across tenants is a
+ * billing decision this tooling should not make on its own.
+ *
+ * The caller re-runs the normal LLMO entitlement/enrollment provisioning against the
+ * destination org after the move, which grants correct access there but leaves the
+ * source org's now-unused enrollment in place. See the LLMO Troubleshooting wiki.
+ */
+export const ENTITLEMENT_GOTCHA = ':warning: *Entitlements are not moved.* A fresh LLMO '
+  + 'entitlement/enrollment is provisioned on the destination org, but the source org\'s '
+  + 'existing entitlement and its site enrollment are left untouched and must be revoked '
+  + 'manually if the customer should no longer be billed there.';
+
+/**
+ * Tables reported by the preview, in the order they are rendered. Keys match the
+ * `counts` object returned by `rpc_org_move_preview`.
+ */
+const COUNT_LABELS = [
+  ['brands', 'Brands'],
+  ['brand_aliases', 'Brand aliases'],
+  ['brand_sites', 'Brand sites'],
+  ['brand_urls', 'Brand URLs'],
+  ['brand_social_accounts', 'Social accounts'],
+  ['brand_earned_sources', 'Earned sources'],
+  ['categories', 'Categories'],
+  ['topics', 'Topics'],
+  ['prompts', 'Prompts'],
+  ['topic_prompts', 'Topic prompts'],
+  ['category_prompts', 'Category prompts'],
+  ['competitors', 'Competitors'],
+  ['feature_flags', 'Feature flags'],
+  ['sites', 'Sites'],
+];
+
+const BLOCKING_CONFLICT_LABELS = {
+  brand_name: 'A brand with this name already exists in the destination org',
+  brand_base_site: 'A brand in the destination org already uses this site',
+};
+
+/**
+ * PostgREST returns a scalar-returning function's payload either bare or wrapped in a
+ * single-element array depending on the negotiated representation. Normalise both.
+ *
+ * @param {*} data - Raw `data` from a postgrest-js `.rpc()` call.
+ * @returns {object|null} The unwrapped payload.
+ */
+function unwrap(data) {
+  if (Array.isArray(data)) {
+    return data.length > 0 ? data[0] : null;
+  }
+  return data ?? null;
+}
+
+/**
+ * @param {object} context - Lambda context.
+ * @returns {object} The PostgREST client.
+ * @throws {Error} If the client is unavailable.
+ */
+function resolvePostgrestClient(context) {
+  const postgrestClient = context?.dataAccess?.services?.postgrestClient;
+  if (!postgrestClient?.rpc) {
+    throw new Error('PostgREST client is unavailable; cannot move the organization.');
+  }
+  return postgrestClient;
+}
+
+/**
+ * Reports what a move from `sourceOrgId` to `destOrgId` would do. Read-only.
+ *
+ * Never throws on a business-level problem: an unevaluable request (unknown org, same
+ * org) comes back as `{ ok: false, error: <code> }`, and a genuine blocking conflict
+ * comes back as `{ ok: false, blocking_conflicts: [...] }` with no `error` key. Only
+ * transport/database failures throw.
+ *
+ * @param {object} context - Lambda context.
+ * @param {string} sourceOrgId - Source SpaceCat organization id.
+ * @param {string} destOrgId - Destination SpaceCat organization id.
+ * @returns {Promise<object>} The preview payload.
+ */
+export async function previewOrgMove(context, sourceOrgId, destOrgId) {
+  const postgrestClient = resolvePostgrestClient(context);
+
+  const { data, error } = await postgrestClient.rpc(PREVIEW_RPC, {
+    p_src: sourceOrgId,
+    p_dst: destOrgId,
+  });
+
+  if (error) {
+    throw new Error(`${PREVIEW_RPC}: ${error.message}`);
+  }
+
+  const preview = unwrap(data);
+  if (!preview) {
+    throw new Error(`${PREVIEW_RPC} returned no data.`);
+  }
+  return preview;
+}
+
+/**
+ * Performs the move. All fourteen tables are rewritten inside one transaction, so this
+ * either fully succeeds or fully rolls back.
+ *
+ * Raises (surfacing as a thrown error) when a blocking conflict is present, so callers
+ * should preview first to give the operator a readable message instead of a raw
+ * database error.
+ *
+ * @param {object} context - Lambda context.
+ * @param {string} sourceOrgId - Source SpaceCat organization id.
+ * @param {string} destOrgId - Destination SpaceCat organization id.
+ * @param {string} updatedBy - Audit stamp written to `updated_by`.
+ * @returns {Promise<object>} The move result payload.
+ */
+export async function executeOrgMove(context, sourceOrgId, destOrgId, updatedBy) {
+  const postgrestClient = resolvePostgrestClient(context);
+
+  const { data, error } = await postgrestClient.rpc(MOVE_RPC, {
+    p_src: sourceOrgId,
+    p_dst: destOrgId,
+    p_updated_by: updatedBy,
+  });
+
+  if (error) {
+    throw new Error(`${MOVE_RPC}: ${error.message}`);
+  }
+
+  const result = unwrap(data);
+  if (!result) {
+    throw new Error(`${MOVE_RPC} returned no data.`);
+  }
+  return result;
+}
+
+/**
+ * @param {object} preview - Payload from {@link previewOrgMove}.
+ * @returns {boolean} True when the preview reports an unusually large move.
+ */
+export function isLargeMove(preview) {
+  const siteCount = preview?.sites?.length || 0;
+  const activeBrandCount = (preview?.brands || []).filter((b) => b.status === 'active').length;
+  return siteCount > LARGE_MOVE_SITE_THRESHOLD
+    || activeBrandCount > LARGE_MOVE_BRAND_THRESHOLD;
+}
+
+/**
+ * Turns a preview's `error` code into an operator-readable sentence.
+ *
+ * @param {object} preview - Payload from {@link previewOrgMove}.
+ * @returns {string|null} The message, or null when the preview was evaluable.
+ */
+export function describePreviewError(preview) {
+  switch (preview?.error) {
+    case 'source_org_not_found':
+      return ':x: The site\'s current organization no longer exists.';
+    case 'destination_org_not_found':
+      return ':x: The destination organization could not be found.';
+    case 'same_org':
+      return ':information_source: The site is already in that organization - nothing to move.';
+    default:
+      return preview?.error ? `:x: Cannot evaluate the move: \`${preview.error}\`.` : null;
+  }
+}
+
+function formatOrg(org) {
+  if (!org) {
+    return '_unknown_';
+  }
+  const name = org.name || '_unnamed_';
+  return org.ims_org_id ? `*${name}* (\`${org.ims_org_id}\`)` : `*${name}*`;
+}
+
+function formatCounts(counts = {}) {
+  const lines = COUNT_LABELS
+    .filter(([key]) => Number(counts[key]) > 0)
+    .map(([key, label]) => `• ${label}: *${counts[key]}*`);
+  return lines.length > 0 ? lines.join('\n') : '_Nothing to move._';
+}
+
+function formatBrands(brands = []) {
+  if (brands.length === 0) {
+    return '_No brands._';
+  }
+  return brands
+    .map((b) => `• *${b.name}* (\`${b.status}\`)${b.site_id ? '' : ' — _no site_'}`)
+    .join('\n');
+}
+
+function formatSites(sites = []) {
+  if (sites.length === 0) {
+    return '_No sites._';
+  }
+  return sites.map((s) => `• \`${s.base_url}\``).join('\n');
+}
+
+function formatAutoResolved(autoResolved = {}) {
+  const notes = [];
+  if (autoResolved.categories_merged > 0) {
+    notes.push(`• *${autoResolved.categories_merged}* categor${autoResolved.categories_merged === 1 ? 'y' : 'ies'} already exist in the destination and will be *merged* (their prompts are re-pointed at the destination's copy).`);
+  }
+  if (autoResolved.topics_disambiguated > 0) {
+    notes.push(`• *${autoResolved.topics_disambiguated}* topic id${autoResolved.topics_disambiguated === 1 ? '' : 's'} clash with the destination and will be *renamed* with a \` (moved)\` suffix.`);
+  }
+  if (autoResolved.feature_flags_dropped > 0) {
+    notes.push(`• *${autoResolved.feature_flags_dropped}* duplicate feature flag${autoResolved.feature_flags_dropped === 1 ? '' : 's'} will be *dropped* — the destination org's existing value wins.`);
+  }
+  return notes;
+}
+
+/**
+ * Renders the blocking conflicts a preview reported.
+ *
+ * `blocking_conflicts` entries are `{ type, detail }` objects, not strings.
+ *
+ * @param {Array<object>} conflicts - The `blocking_conflicts` array.
+ * @returns {string} Markdown lines.
+ */
+export function formatBlockingConflicts(conflicts = []) {
+  return conflicts
+    .map((c) => {
+      const label = BLOCKING_CONFLICT_LABELS[c.type] || c.type;
+      return `• ${label}: \`${c.detail}\``;
+    })
+    .join('\n');
+}
+
+/**
+ * Builds the human-readable preview summary posted before the operator confirms.
+ *
+ * @param {object} preview - Payload from {@link previewOrgMove}.
+ * @param {string} baseURL - The site the operator asked about.
+ * @returns {string} Slack mrkdwn.
+ */
+export function buildPreviewMessage(preview, baseURL) {
+  const sections = [
+    '*Move LLMO organization*',
+    '',
+    `Triggered by site: \`${baseURL}\``,
+    `From: ${formatOrg(preview.source)}`,
+    `To: ${formatOrg(preview.destination)}`,
+    '',
+    '*What will move*',
+    formatCounts(preview.counts),
+    '',
+    '*Brands*',
+    formatBrands(preview.brands),
+    '',
+    '*Sites*',
+    formatSites(preview.sites),
+  ];
+
+  const autoResolved = formatAutoResolved(preview.auto_resolved);
+  if (autoResolved.length > 0) {
+    sections.push('', '*Automatically resolved conflicts*', ...autoResolved);
+  }
+
+  if (isLargeMove(preview)) {
+    sections.push(
+      '',
+      `:rotating_light: *This is an unusually large move* (${preview.sites?.length || 0} sites, `
+      + `${(preview.brands || []).filter((b) => b.status === 'active').length} active brands). `
+      + 'Confirm this is really the customer you meant to relocate before continuing.',
+    );
+  }
+
+  sections.push('', ENTITLEMENT_GOTCHA);
+
+  return sections.join('\n');
+}
+
+/**
+ * Builds the summary posted after a successful move.
+ *
+ * @param {object} result - Payload from {@link executeOrgMove}.
+ * @param {string} baseURL - The site the operator asked about.
+ * @returns {string} Slack mrkdwn.
+ */
+export function buildResultMessage(result, baseURL) {
+  const lines = [
+    `:white_check_mark: *Moved LLMO organization for* \`${baseURL}\``,
+    '',
+    `From: ${formatOrg(result.source)}`,
+    `To: ${formatOrg(result.destination)}`,
+    '',
+    `• Brands moved: *${result.brands_moved || 0}*`,
+    `• Feature flags moved: *${result.feature_flags_moved || 0}*`,
+  ];
+
+  if (result.categories_merged > 0) {
+    lines.push(`• Categories merged into existing destination rows: *${result.categories_merged}*`);
+  }
+  if (result.topics_disambiguated > 0) {
+    lines.push(`• Topics renamed to avoid a clash: *${result.topics_disambiguated}*`);
+  }
+  if (result.feature_flags_dropped > 0) {
+    lines.push(`• Duplicate feature flags dropped: *${result.feature_flags_dropped}*`);
+  }
+
+  lines.push('', ENTITLEMENT_GOTCHA);
+
+  return lines.join('\n');
+}

--- a/src/support/slack/llmo-org-move.js
+++ b/src/support/slack/llmo-org-move.js
@@ -11,7 +11,7 @@
  */
 
 /**
- * Shared logic for relocating a full LLMO ("brandalf") entity graph from one
+ * Shared logic for relocating a customer's LLMO ("brandalf") entity graph from one
  * organization to another.
  *
  * Historically the Slack "Update IMS Org" flow only reassigned `sites.organization_id`,
@@ -19,6 +19,14 @@
  * competitors, feature flags) in the source org. Now that the product navigates by
  * brand rather than by site, that left customers with an empty destination org and an
  * orphaned source org (LLMO-7294).
+ *
+ * The move is scoped to a SITE, not to an organization. Customers are routinely
+ * provisioned into a shared or DEMO org, so relocating everything matching
+ * `organization_id = <source>` would drag every other tenant in that org along too. The
+ * database resolves the transitive closure of brands and sites reachable from the given
+ * site instead - a site can carry many brands and a brand can span many sites, so the
+ * closure is frequently wider than the one site the operator names, and the preview
+ * spells out exactly what it pulled in.
  *
  * The relocation itself is delegated to two PostgREST functions in
  * mysticat-data-service, NOT to the data-access models:
@@ -41,8 +49,8 @@ const MOVE_RPC = 'wrpc_move_brandalf_org';
 /**
  * Above these counts the move is flagged as unusually large in the preview. The move is
  * still allowed - it runs in a single transaction, so a large move is not a corruption
- * risk - but a source org holding this many sites or active brands is a strong hint the
- * operator resolved the wrong org and is about to relocate an unrelated customer.
+ * risk - but a closure this wide is a strong hint the operator named a site that shares
+ * brands with an unrelated customer, and is about to relocate both.
  */
 export const LARGE_MOVE_SITE_THRESHOLD = 5;
 export const LARGE_MOVE_BRAND_THRESHOLD = 5;
@@ -56,37 +64,52 @@ export const LARGE_MOVE_BRAND_THRESHOLD = 5;
  *
  * The caller re-runs the normal LLMO entitlement/enrollment provisioning against the
  * destination org after the move, which grants correct access there but leaves the
- * source org's now-unused enrollment in place. See the LLMO Troubleshooting wiki.
+ * source org's now-unused entitlement in place.
+ *
+ * The ordering below is not advisory. `revoke entitlement site` deletes the enrollment
+ * for a site regardless of which org it currently belongs to, so running it *after* a
+ * move deletes the correct enrollment this command just created, silently leaving the
+ * customer without access in the destination org.
  */
-export const ENTITLEMENT_GOTCHA = ':warning: *Entitlements are not moved.* A fresh LLMO '
-  + 'entitlement/enrollment is provisioned on the destination org, but the source org\'s '
-  + 'existing entitlement and its site enrollment are left untouched and must be revoked '
-  + 'manually if the customer should no longer be billed there.';
+export const ENTITLEMENT_GOTCHA = ':warning: *Entitlements are not moved* — and the order '
+  + 'you clean them up in matters.\n'
+  + '• *Moving a whole tenant between IMS orgs:* run `revoke entitlement imsorg` against '
+  + 'the *source* IMS org *after* this move completes.\n'
+  + '• *Extracting a customer from a shared/DEMO org:* run `revoke entitlement site` '
+  + '*before* this move. Running it afterwards deletes the enrollment this command just '
+  + 'created on the destination org and leaves the customer with no access.\n'
+  + '• Neither command removes a `site_enrollments` row backed by a *paid* entitlement — '
+  + 'that still needs doing by hand.';
 
 /**
  * Tables reported by the preview, in the order they are rendered. Keys match the
  * `counts` object returned by `rpc_org_move_preview`.
+ *
+ * Categories and topics are absent by design: they are copied into the destination
+ * rather than moved, and are reported separately under the taxonomy plan. The two
+ * prompt junction tables are absent too - they follow their prompts automatically via
+ * the `sync_prompt_junction_tables` trigger.
  */
 const COUNT_LABELS = [
   ['brands', 'Brands'],
+  ['sites', 'Sites'],
+  ['prompts', 'Prompts'],
   ['brand_aliases', 'Brand aliases'],
-  ['brand_sites', 'Brand sites'],
+  ['brand_sites', 'Brand ↔ site links'],
   ['brand_urls', 'Brand URLs'],
   ['brand_social_accounts', 'Social accounts'],
   ['brand_earned_sources', 'Earned sources'],
-  ['categories', 'Categories'],
-  ['topics', 'Topics'],
-  ['prompts', 'Prompts'],
-  ['topic_prompts', 'Topic prompts'],
-  ['category_prompts', 'Category prompts'],
   ['competitors', 'Competitors'],
-  ['feature_flags', 'Feature flags'],
-  ['sites', 'Sites'],
+  ['brand_feature_flags', 'Brand feature flags'],
 ];
 
 const BLOCKING_CONFLICT_LABELS = {
   brand_name: 'A brand with this name already exists in the destination org',
   brand_base_site: 'A brand in the destination org already uses this site',
+  foreign_brand_in_scope: 'This brand is reachable from the site but belongs to a different org '
+    + '(pre-existing cross-org data; moving would drag an unrelated tenant along)',
+  foreign_site_in_scope: 'This site is reachable from the site but belongs to a different org '
+    + '(pre-existing cross-org data; moving would drag an unrelated tenant along)',
 };
 
 /**
@@ -117,24 +140,25 @@ function resolvePostgrestClient(context) {
 }
 
 /**
- * Reports what a move from `sourceOrgId` to `destOrgId` would do. Read-only.
+ * Reports what moving the closure rooted at `siteId` into `destOrgId` would do.
+ * Read-only.
  *
- * Never throws on a business-level problem: an unevaluable request (unknown org, same
- * org) comes back as `{ ok: false, error: <code> }`, and a genuine blocking conflict
- * comes back as `{ ok: false, blocking_conflicts: [...] }` with no `error` key. Only
- * transport/database failures throw.
+ * Never throws on a business-level problem: an unevaluable request (unknown site or org,
+ * site already in the destination) comes back as `{ ok: false, error: <code> }`, and a
+ * genuine blocking conflict comes back as `{ ok: false, blocking_conflicts: [...] }`
+ * with no `error` key. Only transport/database failures throw.
  *
  * @param {object} context - Lambda context.
- * @param {string} sourceOrgId - Source SpaceCat organization id.
+ * @param {string} siteId - The site the move is seeded from.
  * @param {string} destOrgId - Destination SpaceCat organization id.
  * @returns {Promise<object>} The preview payload.
  */
-export async function previewOrgMove(context, sourceOrgId, destOrgId) {
+export async function previewOrgMove(context, siteId, destOrgId) {
   const postgrestClient = resolvePostgrestClient(context);
 
   const { data, error } = await postgrestClient.rpc(PREVIEW_RPC, {
-    p_src: sourceOrgId,
-    p_dst: destOrgId,
+    p_site_id: siteId,
+    p_dst_org: destOrgId,
   });
 
   if (error) {
@@ -149,7 +173,7 @@ export async function previewOrgMove(context, sourceOrgId, destOrgId) {
 }
 
 /**
- * Performs the move. All fourteen tables are rewritten inside one transaction, so this
+ * Performs the move. Every affected table is rewritten inside one transaction, so this
  * either fully succeeds or fully rolls back.
  *
  * Raises (surfacing as a thrown error) when a blocking conflict is present, so callers
@@ -157,17 +181,17 @@ export async function previewOrgMove(context, sourceOrgId, destOrgId) {
  * database error.
  *
  * @param {object} context - Lambda context.
- * @param {string} sourceOrgId - Source SpaceCat organization id.
+ * @param {string} siteId - The site the move is seeded from.
  * @param {string} destOrgId - Destination SpaceCat organization id.
  * @param {string} updatedBy - Audit stamp written to `updated_by`.
  * @returns {Promise<object>} The move result payload.
  */
-export async function executeOrgMove(context, sourceOrgId, destOrgId, updatedBy) {
+export async function executeOrgMove(context, siteId, destOrgId, updatedBy) {
   const postgrestClient = resolvePostgrestClient(context);
 
   const { data, error } = await postgrestClient.rpc(MOVE_RPC, {
-    p_src: sourceOrgId,
-    p_dst: destOrgId,
+    p_site_id: siteId,
+    p_dst_org: destOrgId,
     p_updated_by: updatedBy,
   });
 
@@ -201,8 +225,10 @@ export function isLargeMove(preview) {
  */
 export function describePreviewError(preview) {
   switch (preview?.error) {
-    case 'source_org_not_found':
-      return ':x: The site\'s current organization no longer exists.';
+    case 'site_not_found':
+      return ':x: That site no longer exists.';
+    case 'site_and_destination_required':
+      return ':x: A site and a destination organization are both required.';
     case 'destination_org_not_found':
       return ':x: The destination organization could not be found.';
     case 'same_org':
@@ -240,19 +266,53 @@ function formatSites(sites = []) {
   if (sites.length === 0) {
     return '_No sites._';
   }
-  return sites.map((s) => `• \`${s.base_url}\``).join('\n');
+  return sites
+    .map((s) => `• \`${s.base_url}\`${s.is_seed ? ' ← _the site you named_' : ''}`)
+    .join('\n');
 }
 
-function formatAutoResolved(autoResolved = {}) {
+/**
+ * Describes what happens to the shared taxonomy.
+ *
+ * Categories and topics are copied into the destination rather than moved, because both
+ * are shared across brands: `categories` has no `brand_id` at all, and brand-owned
+ * topics are routinely referenced by other brands' prompts. Moving those rows would
+ * strip the taxonomy from whichever brands stay behind.
+ *
+ * @param {object} taxonomy - The preview's `taxonomy` object.
+ * @returns {Array<string>} Markdown lines.
+ */
+function formatTaxonomyPlan(taxonomy = {}) {
   const notes = [];
-  if (autoResolved.categories_merged > 0) {
-    notes.push(`• *${autoResolved.categories_merged}* categor${autoResolved.categories_merged === 1 ? 'y' : 'ies'} already exist in the destination and will be *merged* (their prompts are re-pointed at the destination's copy).`);
+  const reused = (taxonomy.categories_reused || 0) + (taxonomy.topics_reused || 0);
+  const copied = (taxonomy.categories_copied || 0) + (taxonomy.topics_copied || 0);
+
+  if (copied > 0) {
+    notes.push(
+      `• *${taxonomy.categories_copied || 0}* categor${taxonomy.categories_copied === 1 ? 'y' : 'ies'} `
+      + `and *${taxonomy.topics_copied || 0}* topic${taxonomy.topics_copied === 1 ? '' : 's'} `
+      + 'will be *copied* into the destination org.',
+    );
   }
-  if (autoResolved.topics_disambiguated > 0) {
-    notes.push(`• *${autoResolved.topics_disambiguated}* topic id${autoResolved.topics_disambiguated === 1 ? '' : 's'} clash with the destination and will be *renamed* with a \` (moved)\` suffix.`);
+  if (reused > 0) {
+    notes.push(
+      `• *${taxonomy.categories_reused || 0}* categor${taxonomy.categories_reused === 1 ? 'y' : 'ies'} `
+      + `and *${taxonomy.topics_reused || 0}* topic${taxonomy.topics_reused === 1 ? '' : 's'} `
+      + 'already exist in the destination and will be *reused*.',
+    );
   }
-  if (autoResolved.feature_flags_dropped > 0) {
-    notes.push(`• *${autoResolved.feature_flags_dropped}* duplicate feature flag${autoResolved.feature_flags_dropped === 1 ? '' : 's'} will be *dropped* — the destination org's existing value wins.`);
+  if (copied > 0 || reused > 0) {
+    notes.push(
+      '• The originals stay in the source org — they are shared with brands that are '
+      + '_not_ moving, so they are copied rather than relocated.',
+    );
+  }
+  if (taxonomy.org_feature_flags_copied > 0) {
+    notes.push(
+      `• *${taxonomy.org_feature_flags_copied}* org-level feature flag`
+      + `${taxonomy.org_feature_flags_copied === 1 ? '' : 's'} will be *copied* to the `
+      + 'destination (existing destination values are never overwritten).',
+    );
   }
   return notes;
 }
@@ -277,39 +337,52 @@ export function formatBlockingConflicts(conflicts = []) {
 /**
  * Builds the human-readable preview summary posted before the operator confirms.
  *
+ * The brand and site lists are the point of this message, not decoration: the move is
+ * seeded from one site but covers everything transitively connected to it, so the
+ * operator has to be able to see whether the closure pulled in more than they meant.
+ *
  * @param {object} preview - Payload from {@link previewOrgMove}.
  * @param {string} baseURL - The site the operator asked about.
  * @returns {string} Slack mrkdwn.
  */
 export function buildPreviewMessage(preview, baseURL) {
+  const brands = preview.brands || [];
+  const sites = preview.sites || [];
+
   const sections = [
     '*Move LLMO organization*',
     '',
-    `Triggered by site: \`${baseURL}\``,
+    `Seeded from site: \`${baseURL}\``,
     `From: ${formatOrg(preview.source)}`,
     `To: ${formatOrg(preview.destination)}`,
+    '',
+    `*Everything below moves together* — ${brands.length} brand${brands.length === 1 ? '' : 's'} `
+    + `across ${sites.length} site${sites.length === 1 ? '' : 's'}. Brands and sites are linked `
+    + 'many-to-many, so relocating one without the others would leave the link rows pointing '
+    + 'across an org boundary.',
     '',
     '*What will move*',
     formatCounts(preview.counts),
     '',
     '*Brands*',
-    formatBrands(preview.brands),
+    formatBrands(brands),
     '',
     '*Sites*',
-    formatSites(preview.sites),
+    formatSites(sites),
   ];
 
-  const autoResolved = formatAutoResolved(preview.auto_resolved);
-  if (autoResolved.length > 0) {
-    sections.push('', '*Automatically resolved conflicts*', ...autoResolved);
+  const taxonomy = formatTaxonomyPlan(preview.taxonomy);
+  if (taxonomy.length > 0) {
+    sections.push('', '*Shared taxonomy*', ...taxonomy);
   }
 
   if (isLargeMove(preview)) {
     sections.push(
       '',
-      `:rotating_light: *This is an unusually large move* (${preview.sites?.length || 0} sites, `
-      + `${(preview.brands || []).filter((b) => b.status === 'active').length} active brands). `
-      + 'Confirm this is really the customer you meant to relocate before continuing.',
+      `:rotating_light: *This is an unusually large move* (${sites.length} sites, `
+      + `${brands.filter((b) => b.status === 'active').length} active brands). `
+      + 'Check the lists above and confirm this is really the customer you meant to '
+      + 'relocate before continuing.',
     );
   }
 
@@ -321,29 +394,43 @@ export function buildPreviewMessage(preview, baseURL) {
 /**
  * Builds the summary posted after a successful move.
  *
+ * The org display names come from the preview, not the result: the write RPC returns
+ * bare organization ids.
+ *
  * @param {object} result - Payload from {@link executeOrgMove}.
  * @param {string} baseURL - The site the operator asked about.
+ * @param {object} [preview] - The preview the move was confirmed from, for org names.
  * @returns {string} Slack mrkdwn.
  */
-export function buildResultMessage(result, baseURL) {
+export function buildResultMessage(result, baseURL, preview = {}) {
   const lines = [
     `:white_check_mark: *Moved LLMO organization for* \`${baseURL}\``,
     '',
-    `From: ${formatOrg(result.source)}`,
-    `To: ${formatOrg(result.destination)}`,
+    `From: ${formatOrg(preview.source)}`,
+    `To: ${formatOrg(preview.destination)}`,
     '',
     `• Brands moved: *${result.brands_moved || 0}*`,
-    `• Feature flags moved: *${result.feature_flags_moved || 0}*`,
+    `• Sites moved: *${result.sites_moved || 0}*`,
+    `• Prompts moved: *${result.prompts_moved || 0}*`,
   ];
 
-  if (result.categories_merged > 0) {
-    lines.push(`• Categories merged into existing destination rows: *${result.categories_merged}*`);
+  if (result.brand_feature_flags_moved > 0) {
+    lines.push(`• Brand feature flags moved: *${result.brand_feature_flags_moved}*`);
   }
-  if (result.topics_disambiguated > 0) {
-    lines.push(`• Topics renamed to avoid a clash: *${result.topics_disambiguated}*`);
+  if (result.org_feature_flags_copied > 0) {
+    lines.push(`• Org feature flags copied: *${result.org_feature_flags_copied}*`);
   }
-  if (result.feature_flags_dropped > 0) {
-    lines.push(`• Duplicate feature flags dropped: *${result.feature_flags_dropped}*`);
+  if (result.categories_mapped > 0) {
+    lines.push(`• Categories resolved in the destination: *${result.categories_mapped}*`);
+  }
+  if (result.topics_mapped > 0) {
+    lines.push(`• Topics resolved in the destination: *${result.topics_mapped}*`);
+  }
+  if (result.source_topics_unowned > 0) {
+    lines.push(
+      '• Topics left in the source org and released from their moved brand: '
+      + `*${result.source_topics_unowned}*`,
+    );
   }
 
   lines.push('', ENTITLEMENT_GOTCHA);

--- a/test/support/slack/actions/move-llmo-org.test.js
+++ b/test/support/slack/actions/move-llmo-org.test.js
@@ -37,24 +37,31 @@ describe('move-llmo-org action', () => {
     ok: true,
     source: { id: 'src-1', name: 'Source Org', ims_org_id: '111111111111111111111111@AdobeOrg' },
     destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: IMS_ORG },
+    seed_site_id: 'site-1',
     blocking_conflicts: [],
-    auto_resolved: {
-      categories_merged: 0, topics_disambiguated: 0, feature_flags_dropped: 0,
+    taxonomy: {
+      categories_reused: 0,
+      categories_copied: 0,
+      topics_reused: 0,
+      topics_copied: 0,
+      org_feature_flags_copied: 0,
     },
     brands: [{
-      id: 'b1', name: 'Acme', status: 'active', site_id: 's1',
+      id: 'b1', name: 'Acme', status: 'active', site_id: 'site-1',
     }],
-    sites: [{ id: 's1', base_url: 'https://acme.com' }],
+    sites: [{ id: 'site-1', base_url: 'https://acme.com', is_seed: true }],
     counts: { brands: 1 },
     ...overrides,
   });
 
   const moveResult = {
     ok: true,
-    source: { id: 'src-1', name: 'Source Org', ims_org_id: '111111111111111111111111@AdobeOrg' },
-    destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: IMS_ORG },
+    source: 'src-1',
+    destination: 'dst-1',
     brands_moved: 1,
-    feature_flags_moved: 2,
+    sites_moved: 1,
+    prompts_moved: 9,
+    brand_feature_flags_moved: 2,
   };
 
   beforeEach(async () => {
@@ -139,8 +146,8 @@ describe('move-llmo-org action', () => {
     await run();
 
     expect(rpcStub).to.have.been.calledWith('wrpc_move_brandalf_org', {
-      p_src: 'src-1',
-      p_dst: 'dst-1',
+      p_site_id: 'site-1',
+      p_dst_org: 'dst-1',
       p_updated_by: 'slack:move-llmo-org:U123',
     });
     expect(reparentSiteProjectStub).to.have.been.calledOnce;
@@ -224,13 +231,113 @@ describe('move-llmo-org action', () => {
     expect(createEntitlementAndEnrollmentStub).to.not.have.been.called;
   });
 
-  it('reports a failure from entitlement provisioning after a successful move', async () => {
+  it('reports a per-site follow-up failure without losing the successful move', async () => {
     createEntitlementAndEnrollmentStub.rejects(new Error('tier unavailable'));
 
     await run();
 
+    expect(lastUpdateText()).to.contain('Moved LLMO organization');
+    expect(lastUpdateText()).to.contain('post-move setup failed');
     expect(lastUpdateText()).to.contain('tier unavailable');
     expect(lambdaContext.log.error).to.have.been.called;
+  });
+
+  it('runs the follow-up for every site the closure moved, not just the seed', async () => {
+    const siteB = {
+      getId: sandbox.stub().returns('site-2'),
+      getBaseURL: sandbox.stub().returns('https://acme.co.uk'),
+      save: sandbox.stub().resolves(),
+    };
+    rpcStub.callsFake((fn) => {
+      if (fn === 'rpc_org_move_preview') {
+        return Promise.resolve({
+          data: preview({
+            sites: [
+              { id: 'site-1', base_url: 'https://acme.com', is_seed: true },
+              { id: 'site-2', base_url: 'https://acme.co.uk', is_seed: false },
+            ],
+          }),
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: { ...moveResult, sites_moved: 2 }, error: null });
+    });
+    siteStub.findById.withArgs('site-2').resolves(siteB);
+
+    await run();
+
+    expect(reparentSiteProjectStub).to.have.been.calledTwice;
+    expect(createEntitlementAndEnrollmentStub).to.have.been.calledTwice;
+    expect(siteB.save).to.have.been.calledOnce;
+    expect(lastUpdateText()).to.not.contain('post-move setup failed');
+  });
+
+  it('continues with the remaining sites when one site fails its follow-up', async () => {
+    const siteB = {
+      getId: sandbox.stub().returns('site-2'),
+      getBaseURL: sandbox.stub().returns('https://acme.co.uk'),
+      save: sandbox.stub().resolves(),
+    };
+    rpcStub.callsFake((fn) => {
+      if (fn === 'rpc_org_move_preview') {
+        return Promise.resolve({
+          data: preview({
+            sites: [
+              { id: 'site-1', base_url: 'https://acme.com', is_seed: true },
+              { id: 'site-2', base_url: 'https://acme.co.uk', is_seed: false },
+            ],
+          }),
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: { ...moveResult, sites_moved: 2 }, error: null });
+    });
+    siteStub.findById.withArgs('site-2').resolves(siteB);
+    reparentSiteProjectStub.onFirstCall().rejects(new Error('project gone'));
+
+    await run();
+
+    expect(createEntitlementAndEnrollmentStub).to.have.been.calledOnce;
+    expect(siteB.save).to.have.been.calledOnce;
+    expect(lastUpdateText()).to.contain('post-move setup failed');
+    expect(lastUpdateText()).to.contain('https://acme.com');
+    expect(lastUpdateText()).to.contain('project gone');
+  });
+
+  it('reports a moved site that has since disappeared', async () => {
+    siteStub.findById.onSecondCall().resolves(null);
+
+    await run();
+
+    expect(lastUpdateText()).to.contain('post-move setup failed');
+    expect(lastUpdateText()).to.contain('site no longer exists');
+    expect(createEntitlementAndEnrollmentStub).to.not.have.been.called;
+  });
+
+  it('shows the org names from the preview rather than the result RPC uuids', async () => {
+    await run();
+
+    expect(lastUpdateText()).to.contain('Source Org');
+    expect(lastUpdateText()).to.contain('Dest Org');
+    expect(lastUpdateText()).to.not.contain('_unnamed_');
+  });
+
+  it('tolerates a preview with no site or brand lists', async () => {
+    rpcStub.callsFake((fn) => {
+      if (fn === 'rpc_org_move_preview') {
+        const p = preview();
+        delete p.sites;
+        delete p.brands;
+        return Promise.resolve({ data: p, error: null });
+      }
+      return Promise.resolve({ data: moveResult, error: null });
+    });
+
+    await run();
+
+    expect(client.chat.update).to.have.been.calledWithMatch({ text: sinon.match(/0 sites, 0 brands/) });
+    expect(createEntitlementAndEnrollmentStub).to.not.have.been.called;
+    expect(lastUpdateText()).to.contain('Moved LLMO organization');
   });
 
   it('falls back to an unknown user id when the body carries no user', async () => {

--- a/test/support/slack/actions/move-llmo-org.test.js
+++ b/test/support/slack/actions/move-llmo-org.test.js
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('move-llmo-org action', () => {
+  let sandbox;
+  let lambdaContext;
+  let siteStub;
+  let organizationStub;
+  let rpcStub;
+  let site;
+  let client;
+  let ack;
+  let body;
+  let createEntitlementAndEnrollmentStub;
+  let reparentSiteProjectStub;
+  let openMoveLlmoOrgModal;
+
+  const IMS_ORG = 'ABCDEF1234567890ABCDEF12@AdobeOrg';
+
+  const preview = (overrides = {}) => ({
+    ok: true,
+    source: { id: 'src-1', name: 'Source Org', ims_org_id: '111111111111111111111111@AdobeOrg' },
+    destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: IMS_ORG },
+    blocking_conflicts: [],
+    auto_resolved: {
+      categories_merged: 0, topics_disambiguated: 0, feature_flags_dropped: 0,
+    },
+    brands: [{
+      id: 'b1', name: 'Acme', status: 'active', site_id: 's1',
+    }],
+    sites: [{ id: 's1', base_url: 'https://acme.com' }],
+    counts: { brands: 1 },
+    ...overrides,
+  });
+
+  const moveResult = {
+    ok: true,
+    source: { id: 'src-1', name: 'Source Org', ims_org_id: '111111111111111111111111@AdobeOrg' },
+    destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: IMS_ORG },
+    brands_moved: 1,
+    feature_flags_moved: 2,
+  };
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    site = {
+      getId: sandbox.stub().returns('site-1'),
+      getOrganizationId: sandbox.stub().returns('src-1'),
+      getBaseURL: sandbox.stub().returns('https://acme.com'),
+      save: sandbox.stub().resolves(),
+    };
+
+    siteStub = { findById: sandbox.stub().resolves(site) };
+    organizationStub = { findById: sandbox.stub().resolves({ getId: () => 'dst-1' }) };
+
+    rpcStub = sandbox.stub().callsFake((fn) => {
+      if (fn === 'rpc_org_move_preview') {
+        return Promise.resolve({ data: preview(), error: null });
+      }
+      return Promise.resolve({ data: moveResult, error: null });
+    });
+
+    createEntitlementAndEnrollmentStub = sandbox.stub().resolves({});
+    reparentSiteProjectStub = sandbox.stub().resolves();
+
+    ({ openMoveLlmoOrgModal } = await esmock('../../../../src/support/slack/actions/move-llmo-org.js', {
+      '../../../../src/controllers/llmo/llmo-onboarding.js': {
+        createEntitlementAndEnrollment: createEntitlementAndEnrollmentStub,
+      },
+      '../../../../src/support/slack/actions/set-ims-org-modal.js': {
+        reparentSiteProject: reparentSiteProjectStub,
+      },
+    }));
+
+    lambdaContext = {
+      dataAccess: {
+        Site: siteStub,
+        Organization: organizationStub,
+        services: { postgrestClient: { rpc: rpcStub } },
+      },
+      log: { info: sandbox.spy(), warn: sandbox.spy(), error: sandbox.spy() },
+    };
+
+    ack = sandbox.stub().resolves();
+    client = {
+      chat: {
+        update: sandbox.stub().resolves(),
+        postMessage: sandbox.stub().resolves(),
+      },
+    };
+    body = {
+      user: { id: 'U123' },
+      actions: [{
+        value: JSON.stringify({
+          baseURL: 'https://acme.com',
+          siteId: 'site-1',
+          sourceOrgId: 'src-1',
+          destOrgId: 'dst-1',
+          imsOrgId: IMS_ORG,
+          channelId: 'C1',
+          threadTs: 'T1',
+          messageTs: 'M1',
+        }),
+      }],
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const run = () => openMoveLlmoOrgModal(lambdaContext)({ ack, body, client });
+
+  const lastUpdateText = () => client.chat.update.lastCall.args[0].text;
+
+  it('acknowledges the interaction immediately', async () => {
+    await run();
+    expect(ack).to.have.been.calledOnce;
+  });
+
+  it('performs the move and provisions entitlement on the destination org', async () => {
+    await run();
+
+    expect(rpcStub).to.have.been.calledWith('wrpc_move_brandalf_org', {
+      p_src: 'src-1',
+      p_dst: 'dst-1',
+      p_updated_by: 'slack:move-llmo-org:U123',
+    });
+    expect(reparentSiteProjectStub).to.have.been.calledOnce;
+    expect(createEntitlementAndEnrollmentStub).to.have.been.calledOnce;
+    expect(lastUpdateText()).to.contain('Moved LLMO organization');
+  });
+
+  it('re-reads the site after the move so entitlements target the new org', async () => {
+    await run();
+
+    // Once for the pre-flight check, once after the RPC rewrote sites.organization_id.
+    expect(siteStub.findById).to.have.been.calledTwice;
+    const entitlementSite = createEntitlementAndEnrollmentStub.firstCall.args[0];
+    expect(entitlementSite).to.equal(site);
+  });
+
+  it('re-previews before writing so a newly-introduced conflict is caught', async () => {
+    await run();
+    expect(rpcStub.firstCall.args[0]).to.equal('rpc_org_move_preview');
+  });
+
+  it('aborts when the site no longer exists', async () => {
+    siteStub.findById.resolves(null);
+    await run();
+
+    expect(lastUpdateText()).to.contain('no longer exists');
+    expect(rpcStub).to.not.have.been.called;
+  });
+
+  it('aborts when the destination org no longer exists', async () => {
+    organizationStub.findById.resolves(null);
+    await run();
+
+    expect(lastUpdateText()).to.contain('no longer exists');
+    expect(rpcStub).to.not.have.been.called;
+  });
+
+  it('aborts when the site was moved by someone else since the preview', async () => {
+    site.getOrganizationId.returns('somewhere-else');
+    await run();
+
+    expect(lastUpdateText()).to.contain('no longer in the organization');
+    expect(rpcStub).to.not.have.been.called;
+  });
+
+  it('aborts when the re-preview is unevaluable', async () => {
+    rpcStub.callsFake(() => Promise.resolve({ data: { error: 'same_org' }, error: null }));
+    await run();
+
+    expect(lastUpdateText()).to.contain('already in that organization');
+    expect(rpcStub).to.have.been.calledOnce;
+  });
+
+  it('aborts when a blocking conflict appeared after the preview', async () => {
+    rpcStub.callsFake(() => Promise.resolve({
+      data: preview({ ok: false, blocking_conflicts: [{ type: 'brand_name', detail: 'Acme' }] }),
+      error: null,
+    }));
+
+    await run();
+
+    expect(lastUpdateText()).to.contain('now blocked');
+    expect(lastUpdateText()).to.contain('Acme');
+    // Only the preview ran; the write RPC was never reached.
+    expect(rpcStub).to.have.been.calledOnce;
+  });
+
+  it('reports a failure from the write RPC', async () => {
+    rpcStub.callsFake((fn) => {
+      if (fn === 'rpc_org_move_preview') {
+        return Promise.resolve({ data: preview(), error: null });
+      }
+      return Promise.resolve({ data: null, error: { message: 'deadlock' } });
+    });
+
+    await run();
+
+    expect(lastUpdateText()).to.contain('Failed to move LLMO org');
+    expect(lastUpdateText()).to.contain('deadlock');
+    expect(lambdaContext.log.error).to.have.been.called;
+    expect(createEntitlementAndEnrollmentStub).to.not.have.been.called;
+  });
+
+  it('reports a failure from entitlement provisioning after a successful move', async () => {
+    createEntitlementAndEnrollmentStub.rejects(new Error('tier unavailable'));
+
+    await run();
+
+    expect(lastUpdateText()).to.contain('tier unavailable');
+    expect(lambdaContext.log.error).to.have.been.called;
+  });
+
+  it('falls back to an unknown user id when the body carries no user', async () => {
+    delete body.user;
+    await run();
+
+    expect(rpcStub).to.have.been.calledWith('wrpc_move_brandalf_org', sinon.match({
+      p_updated_by: 'slack:move-llmo-org:unknown',
+    }));
+  });
+
+  it('carries the entitlement gotcha into the result message', async () => {
+    await run();
+    expect(lastUpdateText()).to.contain('Entitlements are not moved');
+  });
+});

--- a/test/support/slack/commands/move-llmo-org.test.js
+++ b/test/support/slack/commands/move-llmo-org.test.js
@@ -31,14 +31,19 @@ describe('MoveLlmoOrgCommand', () => {
     ok: true,
     source: { id: 'src-1', name: 'Source Org', ims_org_id: '111111111111111111111111@AdobeOrg' },
     destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: 'ABCDEF1234567890ABCDEF12@AdobeOrg' },
+    seed_site_id: 'site-1',
     blocking_conflicts: [],
-    auto_resolved: {
-      categories_merged: 0, topics_disambiguated: 0, feature_flags_dropped: 0,
+    taxonomy: {
+      categories_reused: 0,
+      categories_copied: 0,
+      topics_reused: 0,
+      topics_copied: 0,
+      org_feature_flags_copied: 0,
     },
     brands: [{
-      id: 'b1', name: 'Acme', status: 'active', site_id: 's1',
+      id: 'b1', name: 'Acme', status: 'active', site_id: 'site-1',
     }],
-    sites: [{ id: 's1', base_url: 'https://acme.com' }],
+    sites: [{ id: 'site-1', base_url: 'https://acme.com', is_seed: true }],
     counts: { brands: 1, prompts: 4 },
     ...overrides,
   });
@@ -148,12 +153,27 @@ describe('MoveLlmoOrgCommand', () => {
     expect(slackContext.client.chat.postMessage).to.not.have.been.called;
   });
 
+  it('explains a cross-org closure as pre-existing corruption, not a rename fix', async () => {
+    rpcStub.resolves({
+      data: preview({
+        ok: false,
+        blocking_conflicts: [{ type: 'foreign_site_in_scope', detail: 'site-uuid-9' }],
+      }),
+      error: null,
+    });
+
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+
+    expect(slackContext.say).to.have.been.calledWithMatch(/straddles two organizations/);
+    expect(slackContext.client.chat.postMessage).to.not.have.been.called;
+  });
+
   it('posts a preview with a confirm button carrying the move payload', async () => {
     await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
 
     expect(rpcStub).to.have.been.calledOnceWith('rpc_org_move_preview', {
-      p_src: 'src-1',
-      p_dst: 'dst-1',
+      p_site_id: 'site-1',
+      p_dst_org: 'dst-1',
     });
     expect(slackContext.client.chat.postMessage).to.have.been.calledOnce;
 

--- a/test/support/slack/commands/move-llmo-org.test.js
+++ b/test/support/slack/commands/move-llmo-org.test.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import MoveLlmoOrgCommand from '../../../../src/support/slack/commands/move-llmo-org.js';
+
+use(sinonChai);
+
+describe('MoveLlmoOrgCommand', () => {
+  let sandbox;
+  let context;
+  let slackContext;
+  let siteStub;
+  let organizationStub;
+  let rpcStub;
+  let site;
+
+  const preview = (overrides = {}) => ({
+    ok: true,
+    source: { id: 'src-1', name: 'Source Org', ims_org_id: '111111111111111111111111@AdobeOrg' },
+    destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: 'ABCDEF1234567890ABCDEF12@AdobeOrg' },
+    blocking_conflicts: [],
+    auto_resolved: {
+      categories_merged: 0, topics_disambiguated: 0, feature_flags_dropped: 0,
+    },
+    brands: [{
+      id: 'b1', name: 'Acme', status: 'active', site_id: 's1',
+    }],
+    sites: [{ id: 's1', base_url: 'https://acme.com' }],
+    counts: { brands: 1, prompts: 4 },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    site = {
+      getId: sandbox.stub().returns('site-1'),
+      getOrganizationId: sandbox.stub().returns('src-1'),
+    };
+
+    siteStub = { findByBaseURL: sandbox.stub().resolves(site) };
+    organizationStub = {
+      findByImsOrgId: sandbox.stub().resolves({ getId: sandbox.stub().returns('dst-1') }),
+    };
+    rpcStub = sandbox.stub().resolves({ data: preview(), error: null });
+
+    context = {
+      dataAccess: {
+        Site: siteStub,
+        Organization: organizationStub,
+        services: { postgrestClient: { rpc: rpcStub } },
+      },
+      log: { error: sandbox.spy(), info: sandbox.spy() },
+      env: {},
+    };
+
+    slackContext = {
+      say: sandbox.spy(),
+      channelId: 'C123',
+      threadTs: '111.222',
+      client: {
+        chat: {
+          postMessage: sandbox.stub().resolves({ ts: '111.333' }),
+          update: sandbox.stub().resolves(),
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const run = (args) => MoveLlmoOrgCommand(context).handleExecution(args, slackContext);
+
+  it('is registered with the expected phrase and usage', () => {
+    const command = MoveLlmoOrgCommand(context);
+    expect(command.phrases).to.deep.equal(['move llmo org']);
+    expect(command.usage()).to.contain('move llmo org');
+  });
+
+  it('rejects a missing or malformed site url', async () => {
+    await run(['not-a-url', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+    expect(slackContext.say).to.have.been.calledWithMatch(/valid site base URL/);
+    expect(rpcStub).to.not.have.been.called;
+  });
+
+  it('rejects an invalid destination IMS org id', async () => {
+    await run(['https://acme.com', 'nonsense']);
+    expect(slackContext.say).to.have.been.calledWithMatch(/valid destination IMS Org ID/);
+    expect(rpcStub).to.not.have.been.called;
+  });
+
+  it('rejects a missing destination IMS org id', async () => {
+    await run(['https://acme.com']);
+    expect(slackContext.say).to.have.been.calledWithMatch(/valid destination IMS Org ID/);
+  });
+
+  it('reports when the site is unknown', async () => {
+    siteStub.findByBaseURL.resolves(null);
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+    expect(slackContext.say).to.have.been.called;
+    expect(rpcStub).to.not.have.been.called;
+  });
+
+  it('refuses when the destination org has no SpaceCat record', async () => {
+    organizationStub.findByImsOrgId.resolves(null);
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+    expect(slackContext.say).to.have.been.calledWithMatch(/set imsorg/);
+    expect(rpcStub).to.not.have.been.called;
+  });
+
+  it('surfaces an unevaluable preview without posting a confirm button', async () => {
+    rpcStub.resolves({ data: { error: 'same_org' }, error: null });
+
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+
+    expect(slackContext.say).to.have.been.calledWithMatch(/already in that organization/);
+    expect(slackContext.client.chat.postMessage).to.not.have.been.called;
+  });
+
+  it('refuses to offer a confirm button when the move is blocked', async () => {
+    rpcStub.resolves({
+      data: preview({
+        ok: false,
+        blocking_conflicts: [{ type: 'brand_name', detail: 'Acme' }],
+      }),
+      error: null,
+    });
+
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+
+    expect(slackContext.say).to.have.been.calledWithMatch(/This move is blocked/);
+    expect(slackContext.say).to.have.been.calledWithMatch(/Acme/);
+    expect(slackContext.client.chat.postMessage).to.not.have.been.called;
+  });
+
+  it('posts a preview with a confirm button carrying the move payload', async () => {
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+
+    expect(rpcStub).to.have.been.calledOnceWith('rpc_org_move_preview', {
+      p_src: 'src-1',
+      p_dst: 'dst-1',
+    });
+    expect(slackContext.client.chat.postMessage).to.have.been.calledOnce;
+
+    // The button payload is only complete after the update pass, which injects the
+    // posted message's own timestamp so the action can edit it in place.
+    const updateArgs = slackContext.client.chat.update.firstCall.args[0];
+    const button = updateArgs.blocks[1].elements[0];
+    expect(button.action_id).to.equal('open_move_llmo_org_modal');
+    expect(JSON.parse(button.value)).to.deep.include({
+      baseURL: 'https://acme.com',
+      siteId: 'site-1',
+      sourceOrgId: 'src-1',
+      destOrgId: 'dst-1',
+      imsOrgId: 'ABCDEF1234567890ABCDEF12@AdobeOrg',
+      messageTs: '111.333',
+    });
+  });
+
+  it('never writes: the command only ever calls the read-only preview RPC', async () => {
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+    expect(rpcStub).to.have.been.calledOnce;
+    expect(rpcStub).to.not.have.been.calledWith('wrpc_move_brandalf_org');
+  });
+
+  it('reports the entitlement gotcha in the preview', async () => {
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+    const updateArgs = slackContext.client.chat.update.firstCall.args[0];
+    expect(updateArgs.blocks[0].text.text).to.contain('Entitlements are not moved');
+  });
+
+  it('handles an unexpected failure gracefully', async () => {
+    siteStub.findByBaseURL.rejects(new Error('db down'));
+
+    await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
+
+    expect(context.log.error).to.have.been.called;
+    expect(slackContext.say).to.have.been.called;
+  });
+});

--- a/test/support/slack/llmo-org-move.test.js
+++ b/test/support/slack/llmo-org-move.test.js
@@ -42,16 +42,19 @@ describe('llmo-org-move', () => {
     ok: true,
     source: { id: 'src-1', name: 'Source Org', ims_org_id: 'SRC@AdobeOrg' },
     destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: 'DST@AdobeOrg' },
+    seed_site_id: 's1',
     blocking_conflicts: [],
-    auto_resolved: {
-      categories_merged: 0,
-      topics_disambiguated: 0,
-      feature_flags_dropped: 0,
+    taxonomy: {
+      categories_reused: 0,
+      categories_copied: 0,
+      topics_reused: 0,
+      topics_copied: 0,
+      org_feature_flags_copied: 0,
     },
     brands: [{
       id: 'b1', name: 'Acme', status: 'active', site_id: 's1',
     }],
-    sites: [{ id: 's1', base_url: 'https://acme.com' }],
+    sites: [{ id: 's1', base_url: 'https://acme.com', is_seed: true }],
     counts: { brands: 1, prompts: 12, sites: 1 },
     ...overrides,
   });
@@ -69,14 +72,14 @@ describe('llmo-org-move', () => {
   });
 
   describe('previewOrgMove', () => {
-    it('calls rpc_org_move_preview with the source and destination org ids', async () => {
+    it('calls rpc_org_move_preview with the seed site and destination org id', async () => {
       rpcStub.resolves({ data: basePreview(), error: null });
 
-      const preview = await previewOrgMove(context, 'src-1', 'dst-1');
+      const preview = await previewOrgMove(context, 's1', 'dst-1');
 
       expect(rpcStub).to.have.been.calledOnceWith('rpc_org_move_preview', {
-        p_src: 'src-1',
-        p_dst: 'dst-1',
+        p_site_id: 's1',
+        p_dst_org: 'dst-1',
       });
       expect(preview.ok).to.be.true;
     });
@@ -84,7 +87,7 @@ describe('llmo-org-move', () => {
     it('unwraps a single-element array payload', async () => {
       rpcStub.resolves({ data: [basePreview()], error: null });
 
-      const preview = await previewOrgMove(context, 'src-1', 'dst-1');
+      const preview = await previewOrgMove(context, 's1', 'dst-1');
 
       expect(preview.source.id).to.equal('src-1');
     });
@@ -110,14 +113,14 @@ describe('llmo-org-move', () => {
   });
 
   describe('executeOrgMove', () => {
-    it('calls wrpc_move_brandalf_org with the audit stamp', async () => {
+    it('calls wrpc_move_brandalf_org with the seed site and the audit stamp', async () => {
       rpcStub.resolves({ data: { ok: true, brands_moved: 3 }, error: null });
 
-      const result = await executeOrgMove(context, 'src-1', 'dst-1', 'slack:tester');
+      const result = await executeOrgMove(context, 's1', 'dst-1', 'slack:tester');
 
       expect(rpcStub).to.have.been.calledOnceWith('wrpc_move_brandalf_org', {
-        p_src: 'src-1',
-        p_dst: 'dst-1',
+        p_site_id: 's1',
+        p_dst_org: 'dst-1',
         p_updated_by: 'slack:tester',
       });
       expect(result.brands_moved).to.equal(3);
@@ -148,9 +151,14 @@ describe('llmo-org-move', () => {
       expect(describePreviewError(basePreview())).to.be.null;
     });
 
-    it('explains a missing source org', () => {
-      expect(describePreviewError({ error: 'source_org_not_found' }))
-        .to.contain('current organization no longer exists');
+    it('explains a missing site', () => {
+      expect(describePreviewError({ error: 'site_not_found' }))
+        .to.contain('site no longer exists');
+    });
+
+    it('explains missing arguments', () => {
+      expect(describePreviewError({ error: 'site_and_destination_required' }))
+        .to.contain('both required');
     });
 
     it('explains a missing destination org', () => {
@@ -212,6 +220,17 @@ describe('llmo-org-move', () => {
         .to.contain('future_kind');
     });
 
+    it('labels a cross-org brand or site pulled in by the closure', () => {
+      const rendered = formatBlockingConflicts([
+        { type: 'foreign_brand_in_scope', detail: 'brand-uuid-1' },
+        { type: 'foreign_site_in_scope', detail: 'site-uuid-2' },
+      ]);
+
+      expect(rendered).to.contain('belongs to a different org');
+      expect(rendered).to.contain('brand-uuid-1');
+      expect(rendered).to.contain('site-uuid-2');
+    });
+
     it('renders an empty string for no conflicts', () => {
       expect(formatBlockingConflicts()).to.equal('');
     });
@@ -227,6 +246,25 @@ describe('llmo-org-move', () => {
       expect(text).to.contain('Prompts: *12*');
       expect(text).to.contain('Acme');
       expect(text).to.contain('https://acme.com');
+    });
+
+    it('explains that the closure moves as one unit', () => {
+      const text = buildPreviewMessage(basePreview(), 'https://acme.com');
+
+      expect(text).to.contain('Everything below moves together');
+      expect(text).to.contain('Seeded from site');
+    });
+
+    it('marks the site the operator named', () => {
+      const text = buildPreviewMessage(basePreview({
+        sites: [
+          { id: 's1', base_url: 'https://acme.com', is_seed: true },
+          { id: 's2', base_url: 'https://acme.co.uk', is_seed: false },
+        ],
+      }), 'https://acme.com');
+
+      expect(text).to.contain('`https://acme.com` ← _the site you named_');
+      expect(text).to.contain('`https://acme.co.uk`\n');
     });
 
     it('always carries the entitlement gotcha', () => {
@@ -261,33 +299,59 @@ describe('llmo-org-move', () => {
       expect(text).to.contain('no site');
     });
 
-    it('lists auto-resolved conflicts, pluralised', () => {
+    it('describes the taxonomy copy/reuse plan, pluralised', () => {
       const text = buildPreviewMessage(basePreview({
-        auto_resolved: {
-          categories_merged: 1,
-          topics_disambiguated: 2,
-          feature_flags_dropped: 3,
+        taxonomy: {
+          categories_reused: 2,
+          categories_copied: 1,
+          topics_reused: 4,
+          topics_copied: 3,
+          org_feature_flags_copied: 2,
         },
       }), 'https://acme.com');
 
-      expect(text).to.contain('Automatically resolved conflicts');
+      expect(text).to.contain('Shared taxonomy');
       expect(text).to.contain('*1* category');
-      expect(text).to.contain('*2* topic ids');
-      expect(text).to.contain('*3* duplicate feature flags');
+      expect(text).to.contain('*3* topics');
+      expect(text).to.contain('*copied* into the destination org');
+      expect(text).to.contain('*2* categories');
+      expect(text).to.contain('*4* topics');
+      expect(text).to.contain('*reused*');
+      expect(text).to.contain('The originals stay in the source org');
+      expect(text).to.contain('*2* org-level feature flags');
     });
 
-    it('pluralises a single topic and flag correctly', () => {
+    it('pluralises a single reused topic and a single org flag correctly', () => {
       const text = buildPreviewMessage(basePreview({
-        auto_resolved: {
-          categories_merged: 2,
-          topics_disambiguated: 1,
-          feature_flags_dropped: 1,
+        taxonomy: {
+          categories_reused: 1,
+          categories_copied: 0,
+          topics_reused: 1,
+          topics_copied: 0,
+          org_feature_flags_copied: 1,
         },
       }), 'https://acme.com');
 
-      expect(text).to.contain('*2* categories');
-      expect(text).to.contain('*1* topic id ');
-      expect(text).to.contain('*1* duplicate feature flag ');
+      expect(text).to.contain('*1* category');
+      expect(text).to.contain('*1* topic ');
+      expect(text).to.contain('*1* org-level feature flag ');
+      expect(text).to.not.contain('*copied* into the destination org');
+    });
+
+    it('says nothing about taxonomy when there is none to resolve', () => {
+      expect(buildPreviewMessage(basePreview(), 'https://acme.com'))
+        .to.not.contain('Shared taxonomy');
+    });
+
+    it('tolerates a taxonomy block missing individual keys', () => {
+      const text = buildPreviewMessage(basePreview({
+        taxonomy: { topics_copied: 2, categories_reused: 3 },
+      }), 'https://acme.com');
+
+      expect(text).to.contain('*0* categories');
+      expect(text).to.contain('*2* topics');
+      expect(text).to.contain('*3* categories');
+      expect(text).to.contain('*0* topics');
     });
 
     it('shouts about an unusually large move', () => {
@@ -310,13 +374,13 @@ describe('llmo-org-move', () => {
       expect(text).to.contain('6 active brands');
     });
 
-    it('handles a preview with no auto_resolved block', () => {
+    it('handles a preview with no taxonomy block', () => {
       const preview = basePreview();
-      delete preview.auto_resolved;
+      delete preview.taxonomy;
 
       const text = buildPreviewMessage(preview, 'https://acme.com');
 
-      expect(text).to.not.contain('Automatically resolved conflicts');
+      expect(text).to.not.contain('Shared taxonomy');
     });
 
     it('reports a large site-driven move even when the brand list is absent', () => {
@@ -344,40 +408,63 @@ describe('llmo-org-move', () => {
   describe('buildResultMessage', () => {
     it('summarises a clean move', () => {
       const text = buildResultMessage({
-        source: { id: 'src-1', name: 'Source Org', ims_org_id: 'SRC@AdobeOrg' },
-        destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: 'DST@AdobeOrg' },
+        source: 'src-1',
+        destination: 'dst-1',
         brands_moved: 2,
-        feature_flags_moved: 5,
-      }, 'https://acme.com');
+        sites_moved: 3,
+        prompts_moved: 40,
+        brand_feature_flags_moved: 5,
+      }, 'https://acme.com', basePreview());
 
       expect(text).to.contain('Moved LLMO organization');
       expect(text).to.contain('Brands moved: *2*');
-      expect(text).to.contain('Feature flags moved: *5*');
+      expect(text).to.contain('Sites moved: *3*');
+      expect(text).to.contain('Prompts moved: *40*');
+      expect(text).to.contain('Brand feature flags moved: *5*');
       expect(text).to.contain(ENTITLEMENT_GOTCHA);
     });
 
-    it('omits conflict lines when nothing was auto-resolved', () => {
-      const text = buildResultMessage({}, 'https://acme.com');
+    it('takes the org display names from the preview, not the result', () => {
+      const text = buildResultMessage(
+        { source: 'src-1', destination: 'dst-1' },
+        'https://acme.com',
+        basePreview(),
+      );
 
-      expect(text).to.not.contain('merged');
-      expect(text).to.not.contain('renamed');
-      expect(text).to.not.contain('dropped');
-      expect(text).to.contain('Brands moved: *0*');
-      expect(text).to.contain('Feature flags moved: *0*');
+      expect(text).to.contain('Source Org');
+      expect(text).to.contain('SRC@AdobeOrg');
+      expect(text).to.contain('Dest Org');
+      expect(text).to.not.contain('_unnamed_');
     });
 
-    it('reports auto-resolved conflicts when present', () => {
+    it('renders unknown orgs when no preview is supplied', () => {
+      expect(buildResultMessage({}, 'https://acme.com')).to.contain('_unknown_');
+    });
+
+    it('omits the optional lines when nothing else happened', () => {
+      const text = buildResultMessage({}, 'https://acme.com', basePreview());
+
+      expect(text).to.not.contain('feature flags');
+      expect(text).to.not.contain('Categories resolved');
+      expect(text).to.not.contain('Topics');
+      expect(text).to.contain('Brands moved: *0*');
+      expect(text).to.contain('Sites moved: *0*');
+      expect(text).to.contain('Prompts moved: *0*');
+    });
+
+    it('reports copied org flags and the resolved taxonomy when present', () => {
       const text = buildResultMessage({
         brands_moved: 1,
-        feature_flags_moved: 1,
-        categories_merged: 4,
-        topics_disambiguated: 3,
-        feature_flags_dropped: 2,
-      }, 'https://acme.com');
+        org_feature_flags_copied: 2,
+        categories_mapped: 4,
+        topics_mapped: 3,
+        source_topics_unowned: 7,
+      }, 'https://acme.com', basePreview());
 
-      expect(text).to.contain('Categories merged into existing destination rows: *4*');
-      expect(text).to.contain('Topics renamed to avoid a clash: *3*');
-      expect(text).to.contain('Duplicate feature flags dropped: *2*');
+      expect(text).to.contain('Org feature flags copied: *2*');
+      expect(text).to.contain('Categories resolved in the destination: *4*');
+      expect(text).to.contain('Topics resolved in the destination: *3*');
+      expect(text).to.contain('released from their moved brand: *7*');
     });
   });
 });

--- a/test/support/slack/llmo-org-move.test.js
+++ b/test/support/slack/llmo-org-move.test.js
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import {
+  ENTITLEMENT_GOTCHA,
+  buildPreviewMessage,
+  buildResultMessage,
+  describePreviewError,
+  executeOrgMove,
+  formatBlockingConflicts,
+  isLargeMove,
+  previewOrgMove,
+} from '../../../src/support/slack/llmo-org-move.js';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+describe('llmo-org-move', () => {
+  let sandbox;
+  let rpcStub;
+  let context;
+
+  /**
+   * A minimal, conflict-free preview. Individual tests override just the field
+   * they exercise.
+   */
+  const basePreview = (overrides = {}) => ({
+    ok: true,
+    source: { id: 'src-1', name: 'Source Org', ims_org_id: 'SRC@AdobeOrg' },
+    destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: 'DST@AdobeOrg' },
+    blocking_conflicts: [],
+    auto_resolved: {
+      categories_merged: 0,
+      topics_disambiguated: 0,
+      feature_flags_dropped: 0,
+    },
+    brands: [{
+      id: 'b1', name: 'Acme', status: 'active', site_id: 's1',
+    }],
+    sites: [{ id: 's1', base_url: 'https://acme.com' }],
+    counts: { brands: 1, prompts: 12, sites: 1 },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    rpcStub = sandbox.stub();
+    context = {
+      dataAccess: { services: { postgrestClient: { rpc: rpcStub } } },
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('previewOrgMove', () => {
+    it('calls rpc_org_move_preview with the source and destination org ids', async () => {
+      rpcStub.resolves({ data: basePreview(), error: null });
+
+      const preview = await previewOrgMove(context, 'src-1', 'dst-1');
+
+      expect(rpcStub).to.have.been.calledOnceWith('rpc_org_move_preview', {
+        p_src: 'src-1',
+        p_dst: 'dst-1',
+      });
+      expect(preview.ok).to.be.true;
+    });
+
+    it('unwraps a single-element array payload', async () => {
+      rpcStub.resolves({ data: [basePreview()], error: null });
+
+      const preview = await previewOrgMove(context, 'src-1', 'dst-1');
+
+      expect(preview.source.id).to.equal('src-1');
+    });
+
+    it('throws when the PostgREST client is unavailable', async () => {
+      await expect(previewOrgMove({ dataAccess: {} }, 'a', 'b'))
+        .to.be.rejectedWith(/PostgREST client is unavailable/);
+    });
+
+    it('throws when the RPC reports an error', async () => {
+      rpcStub.resolves({ data: null, error: { message: 'boom' } });
+
+      await expect(previewOrgMove(context, 'a', 'b'))
+        .to.be.rejectedWith(/rpc_org_move_preview: boom/);
+    });
+
+    it('throws when the RPC returns no data', async () => {
+      rpcStub.resolves({ data: [], error: null });
+
+      await expect(previewOrgMove(context, 'a', 'b'))
+        .to.be.rejectedWith(/returned no data/);
+    });
+  });
+
+  describe('executeOrgMove', () => {
+    it('calls wrpc_move_brandalf_org with the audit stamp', async () => {
+      rpcStub.resolves({ data: { ok: true, brands_moved: 3 }, error: null });
+
+      const result = await executeOrgMove(context, 'src-1', 'dst-1', 'slack:tester');
+
+      expect(rpcStub).to.have.been.calledOnceWith('wrpc_move_brandalf_org', {
+        p_src: 'src-1',
+        p_dst: 'dst-1',
+        p_updated_by: 'slack:tester',
+      });
+      expect(result.brands_moved).to.equal(3);
+    });
+
+    it('throws when the PostgREST client is unavailable', async () => {
+      await expect(executeOrgMove({}, 'a', 'b', 'x'))
+        .to.be.rejectedWith(/PostgREST client is unavailable/);
+    });
+
+    it('throws when the RPC reports an error', async () => {
+      rpcStub.resolves({ data: null, error: { message: 'conflict' } });
+
+      await expect(executeOrgMove(context, 'a', 'b', 'x'))
+        .to.be.rejectedWith(/wrpc_move_brandalf_org: conflict/);
+    });
+
+    it('throws when the RPC returns no data', async () => {
+      rpcStub.resolves({ data: null, error: null });
+
+      await expect(executeOrgMove(context, 'a', 'b', 'x'))
+        .to.be.rejectedWith(/returned no data/);
+    });
+  });
+
+  describe('describePreviewError', () => {
+    it('returns null when the preview was evaluable', () => {
+      expect(describePreviewError(basePreview())).to.be.null;
+    });
+
+    it('explains a missing source org', () => {
+      expect(describePreviewError({ error: 'source_org_not_found' }))
+        .to.contain('current organization no longer exists');
+    });
+
+    it('explains a missing destination org', () => {
+      expect(describePreviewError({ error: 'destination_org_not_found' }))
+        .to.contain('destination organization could not be found');
+    });
+
+    it('explains a same-org no-op', () => {
+      expect(describePreviewError({ error: 'same_org' }))
+        .to.contain('already in that organization');
+    });
+
+    it('falls back to the raw code for an unrecognised error', () => {
+      expect(describePreviewError({ error: 'something_new' }))
+        .to.contain('something_new');
+    });
+  });
+
+  describe('isLargeMove', () => {
+    it('is false for a small move', () => {
+      expect(isLargeMove(basePreview())).to.be.false;
+    });
+
+    it('is true when the site count exceeds the threshold', () => {
+      const sites = Array.from({ length: 6 }, (_, i) => ({ id: `s${i}`, base_url: `https://s${i}.com` }));
+      expect(isLargeMove(basePreview({ sites }))).to.be.true;
+    });
+
+    it('is true when the active brand count exceeds the threshold', () => {
+      const brands = Array.from({ length: 6 }, (_, i) => ({ id: `b${i}`, name: `B${i}`, status: 'active' }));
+      expect(isLargeMove(basePreview({ brands }))).to.be.true;
+    });
+
+    it('ignores inactive brands when counting', () => {
+      const brands = Array.from({ length: 8 }, (_, i) => ({ id: `b${i}`, name: `B${i}`, status: 'archived' }));
+      expect(isLargeMove(basePreview({ brands }))).to.be.false;
+    });
+
+    it('handles a preview with no brands or sites', () => {
+      expect(isLargeMove({})).to.be.false;
+    });
+  });
+
+  describe('formatBlockingConflicts', () => {
+    it('renders the {type, detail} object shape with a friendly label', () => {
+      const rendered = formatBlockingConflicts([
+        { type: 'brand_name', detail: 'Acme' },
+        { type: 'brand_base_site', detail: 'site-uuid-1' },
+      ]);
+
+      expect(rendered).to.contain('already exists in the destination org');
+      expect(rendered).to.contain('Acme');
+      expect(rendered).to.contain('already uses this site');
+      expect(rendered).to.contain('site-uuid-1');
+    });
+
+    it('falls back to the raw type for an unknown conflict', () => {
+      expect(formatBlockingConflicts([{ type: 'future_kind', detail: 'x' }]))
+        .to.contain('future_kind');
+    });
+
+    it('renders an empty string for no conflicts', () => {
+      expect(formatBlockingConflicts()).to.equal('');
+    });
+  });
+
+  describe('buildPreviewMessage', () => {
+    it('reports the orgs, counts, brands and sites', () => {
+      const text = buildPreviewMessage(basePreview(), 'https://acme.com');
+
+      expect(text).to.contain('Source Org');
+      expect(text).to.contain('SRC@AdobeOrg');
+      expect(text).to.contain('Dest Org');
+      expect(text).to.contain('Prompts: *12*');
+      expect(text).to.contain('Acme');
+      expect(text).to.contain('https://acme.com');
+    });
+
+    it('always carries the entitlement gotcha', () => {
+      expect(buildPreviewMessage(basePreview(), 'https://acme.com'))
+        .to.contain(ENTITLEMENT_GOTCHA);
+    });
+
+    it('omits tables with a zero count', () => {
+      const text = buildPreviewMessage(basePreview({ counts: { brands: 1 } }), 'https://acme.com');
+      expect(text).to.not.contain('Prompts:');
+    });
+
+    it('reports when there is nothing to move', () => {
+      const text = buildPreviewMessage(
+        basePreview({ counts: {}, brands: [], sites: [] }),
+        'https://acme.com',
+      );
+      expect(text).to.contain('Nothing to move');
+      expect(text).to.contain('No brands');
+      expect(text).to.contain('No sites');
+    });
+
+    it('flags a brand with no site', () => {
+      const text = buildPreviewMessage(
+        basePreview({
+          brands: [{
+            id: 'b1', name: 'Acme', status: 'inactive', site_id: null,
+          }],
+        }),
+        'https://acme.com',
+      );
+      expect(text).to.contain('no site');
+    });
+
+    it('lists auto-resolved conflicts, pluralised', () => {
+      const text = buildPreviewMessage(basePreview({
+        auto_resolved: {
+          categories_merged: 1,
+          topics_disambiguated: 2,
+          feature_flags_dropped: 3,
+        },
+      }), 'https://acme.com');
+
+      expect(text).to.contain('Automatically resolved conflicts');
+      expect(text).to.contain('*1* category');
+      expect(text).to.contain('*2* topic ids');
+      expect(text).to.contain('*3* duplicate feature flags');
+    });
+
+    it('pluralises a single topic and flag correctly', () => {
+      const text = buildPreviewMessage(basePreview({
+        auto_resolved: {
+          categories_merged: 2,
+          topics_disambiguated: 1,
+          feature_flags_dropped: 1,
+        },
+      }), 'https://acme.com');
+
+      expect(text).to.contain('*2* categories');
+      expect(text).to.contain('*1* topic id ');
+      expect(text).to.contain('*1* duplicate feature flag ');
+    });
+
+    it('shouts about an unusually large move', () => {
+      const sites = Array.from({ length: 7 }, (_, i) => ({ id: `s${i}`, base_url: `https://s${i}.com` }));
+      const text = buildPreviewMessage(basePreview({ sites }), 'https://acme.com');
+
+      expect(text).to.contain('unusually large move');
+      expect(text).to.contain('7 sites');
+    });
+
+    it('reports a large brand-driven move even when the site list is absent', () => {
+      const brands = Array.from({ length: 6 }, (_, i) => ({ id: `b${i}`, name: `B${i}`, status: 'active' }));
+      const preview = basePreview({ brands });
+      delete preview.sites;
+
+      const text = buildPreviewMessage(preview, 'https://acme.com');
+
+      expect(text).to.contain('unusually large move');
+      expect(text).to.contain('0 sites');
+      expect(text).to.contain('6 active brands');
+    });
+
+    it('handles a preview with no auto_resolved block', () => {
+      const preview = basePreview();
+      delete preview.auto_resolved;
+
+      const text = buildPreviewMessage(preview, 'https://acme.com');
+
+      expect(text).to.not.contain('Automatically resolved conflicts');
+    });
+
+    it('reports a large site-driven move even when the brand list is absent', () => {
+      const sites = Array.from({ length: 6 }, (_, i) => ({ id: `s${i}`, base_url: `https://s${i}.com` }));
+      const preview = basePreview({ sites });
+      delete preview.brands;
+
+      const text = buildPreviewMessage(preview, 'https://acme.com');
+
+      expect(text).to.contain('unusually large move');
+      expect(text).to.contain('6 sites');
+      expect(text).to.contain('0 active brands');
+    });
+
+    it('renders an org with no ims org id or name', () => {
+      const text = buildPreviewMessage(
+        basePreview({ source: { id: 'x' }, destination: null }),
+        'https://acme.com',
+      );
+      expect(text).to.contain('_unnamed_');
+      expect(text).to.contain('_unknown_');
+    });
+  });
+
+  describe('buildResultMessage', () => {
+    it('summarises a clean move', () => {
+      const text = buildResultMessage({
+        source: { id: 'src-1', name: 'Source Org', ims_org_id: 'SRC@AdobeOrg' },
+        destination: { id: 'dst-1', name: 'Dest Org', ims_org_id: 'DST@AdobeOrg' },
+        brands_moved: 2,
+        feature_flags_moved: 5,
+      }, 'https://acme.com');
+
+      expect(text).to.contain('Moved LLMO organization');
+      expect(text).to.contain('Brands moved: *2*');
+      expect(text).to.contain('Feature flags moved: *5*');
+      expect(text).to.contain(ENTITLEMENT_GOTCHA);
+    });
+
+    it('omits conflict lines when nothing was auto-resolved', () => {
+      const text = buildResultMessage({}, 'https://acme.com');
+
+      expect(text).to.not.contain('merged');
+      expect(text).to.not.contain('renamed');
+      expect(text).to.not.contain('dropped');
+      expect(text).to.contain('Brands moved: *0*');
+      expect(text).to.contain('Feature flags moved: *0*');
+    });
+
+    it('reports auto-resolved conflicts when present', () => {
+      const text = buildResultMessage({
+        brands_moved: 1,
+        feature_flags_moved: 1,
+        categories_merged: 4,
+        topics_disambiguated: 3,
+        feature_flags_dropped: 2,
+      }, 'https://acme.com');
+
+      expect(text).to.contain('Categories merged into existing destination rows: *4*');
+      expect(text).to.contain('Topics renamed to avoid a clash: *3*');
+      expect(text).to.contain('Duplicate feature flags dropped: *2*');
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a `move llmo org {site} {imsOrgId}` Slack command that relocates a customer's LLMO/ABV footprint — every brand transitively linked to the named site, plus its prompts, competitors, feature flags and the sites themselves — from one IMS org to another, behind a preview-and-confirm gate.

> **Updated after peer review of the companion data-service PR.** The move is now scoped to the brand closure reachable from the named site, not to the whole source organization. Reviewers who saw the earlier version should re-read section 3 — the unit of work changed.

## 2. Reasoning
AOE agents move a customer's LLMO product between tenants using the *Update IMS Org* button in the onboarding modal. That flow reassigns `sites.organization_id` and nothing else, which was correct when the product navigated by site.

Navigation is now brand-centric, and brands are not reachable from the site row. The result is that a "successful" org move strands every brand, prompt, competitor and feature flag in the source org: the destination org shows the site but appears otherwise empty, and the customer's configuration is silently orphaned. Recovering from that today is a manual, per-table SQL exercise.

## 3. High-level overview of the changes
**Before:** the only way to move a customer between orgs moved one column on one row, with no visibility into what else was attached and no way to see the blast radius beforehand.

**After:** `move llmo org {site} {imsOrgId}` does the whole job, in two deliberate steps.

**Step 1 — preview (read-only, writes nothing).** Resolves the site and the destination IMS org, then reports back in-channel:
- source and destination org, each echoed with its IMS org id so the operator can confirm they typed the right tenant;
- **every brand and every site the move will carry**, with the seed site marked. This is the substance of the message, not decoration — see below;
- per-table row counts;
- what happens to the shared taxonomy: how many categories and topics will be *copied* into the destination and how many already exist there and will be *reused*, plus an explicit note that the originals stay behind;
- any *blocking* conflict — a brand name or base site already taken in the destination, or a closure that straddles two organizations — in which case the move is refused;
- a loud warning when the move is unusually large (more than five sites or five active brands), as a "did you mean this org?" check.

The preview ends in a **Confirm Move** button. Nothing is written until a human presses it.

**Why the brand and site lists matter.** The move is *seeded* from one site but covers the transitive closure of brands and sites connected to it, because brands and sites are many-to-many. That closure is frequently wider than the site the operator named — and it is deliberately narrower than the source organization, since customers are routinely provisioned into shared or DEMO orgs where an org-wide move would relocate unrelated tenants. The preview exists so the operator can see whether the closure reached further than they meant before anything is written.

**Step 2 — execute.** On confirm the handler re-validates (including that the site has not changed orgs since the preview was rendered), re-runs the preview so a conflict introduced in the meantime still blocks, then calls `wrpc_move_brandalf_org`, which rewrites everything in a single transaction. It then runs the per-site follow-up — project re-parent so each site stays visible in the destination org's site picker, and entitlement/enrollment provisioning — **for every site the closure moved**, and posts a result summary.

That follow-up loop is a fix in its own right: it previously ran for the seed site only, which under a brand-scoped closure would have left every other moved site holding a project in the source org and no enrollment in the destination — the same class of half-move this ticket exists to fix, reintroduced one layer up. Per-site failures are collected and reported rather than thrown, because the entity move is already committed by that point and aborting the loop would strand the remaining sites for no benefit. The result message names any site that needs a manual `set imsorg` / onboarding re-run.

Also fixed: `buildResultMessage` rendered the write RPC's `source`/`destination` fields, which are bare uuid strings rather than objects, so every successful move displayed "From: *_unnamed_*". Org names now come from the preview.

**Deliberately out of scope:**
- **Entitlements are not transferred.** `site_enrollments` reaches an org only via `entitlement_id`, so a 1:1 transfer is not something we can do safely here. Behaviour matches the existing flow: a fresh entitlement is provisioned on the destination and the source's stale one is left behind. The message spells out the *ordering* too, which is not advisory — `revoke entitlement site` deletes a site's enrollment regardless of which org it currently belongs to, so running it *after* a move deletes the enrollment this command just created and leaves the customer with no access. It must run *before* when extracting a customer from a shared org; `revoke entitlement imsorg` runs *after*, against the source IMS org, when moving a whole tenant.
- **The existing *Update IMS Org* button is untouched** and still moves only the site. Operators should be pointed at the new command; the wiki update covers this.

## 4. Required information
- Jira / issue: [LLMO-7294](https://jira.corp.adobe.com/browse/LLMO-7294)
- Other: [LLMO Troubleshooting Guide](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=MSTeam&title=LLMO+Troubleshooting+Guide) — to be updated with the entitlement caveat, the ordering rule, and a pointer to this command

## 6. Affected / used mysticat-workspace projects
- **mysticat-data-service** — contract. Provides `rpc_org_move_preview` and `wrpc_move_brandalf_org`, which this command calls via the PostgREST client. Both take a seed *site* plus a destination org. The RPCs must be merged and deployed before this command does anything in a live environment (see section 9).

## 7. Additional information outside the code
The two RPCs this command depends on were exercised end-to-end against the **dev** database in the companion PR, including the isolation property this command's preview is built around: a closure seeded from `adobe.com` resolved to 58 brands / 23 sites out of a source org holding 594 sites and 240 brands, and after the move the source org retained its other tenants. All cross-org integrity checks came back clean across the whole dev database.

Nothing in *this* repo has been run against a real database, because the RPCs do not yet exist in any deployed environment. The unit tests here mock the PostgREST client, so they pin the request/response contract and the Slack rendering, not the SQL. Every payload key the JS reads was cross-checked against the migration's `jsonb_build_object` calls by hand. First real exercise is the dev verification in section 8.

Prod scale of the pre-existing entitlement gap, for context on why it is documented rather than fixed here: 507 stale enrollments across 441 sites and 301 orgs.

## 8. Test plan
**Local.** Not verifiable end-to-end locally: the command's only side effects go through PostgREST RPCs that are not yet deployed, and the Slack surface needs a real workspace. Coverage is at the seams — RPC request shape, the `ok` / blocking-conflict / lookup-error branches of the preview contract, the multi-site follow-up loop including partial failure, and the rendered message blocks.

**dev** (after the data-service RPCs are deployed) — this is the first real exercise of the flow:
1. Pick a throwaway site in a dev org that has at least one brand with prompts attached, and that shares the org with unrelated tenants.
2. Run `@spacecat move llmo org <baseURL> <destination IMS org id>`.
3. **Check the closure first:** confirm the brand and site lists contain what you expect and, critically, that the org's *other* tenants are absent from them. Confirm the destination org echoed back is the one you intended.
4. Press **Confirm Move**.
5. Verify in the database that the brand rows, prompts, competitors and feature flags now carry the destination `organization_id`; that the moving prompts point at destination-org topics/categories; and that the source org still holds its other tenants.
6. Load the destination org in the UI and confirm **every** moved site appears in the site picker (this is what the per-site project re-parent is for) and the brands are navigable.
7. Confirm an entitlement exists on the destination org for each moved site, and note the stale ones still on the source — expected, and called out in the result message.

**Conflict paths on dev:** (a) create a brand in the destination with the same name as one in the source, run the command, confirm it refuses with the conflicting brand named and writes nothing; (b) find a site whose closure straddles two orgs and confirm the command refuses with the foreign-org message rather than dragging the second tenant along.

**stage:** repeat the happy path on a non-customer site before any production use.

**prod:** first use should be a real customer move done with a second person reading the preview, since the confirm step is the only gate. Pay particular attention to the brand and site lists. Verify the destination org in the UI afterwards, and follow the wiki's entitlement ordering.

## 9. Deployment & merge order
- https://github.com/adobe/mysticat-data-service/pull/1000 — **depends-on**. Adds the `rpc_org_move_preview` and `wrpc_move_brandalf_org` functions this command calls. Until it is deployed, the command fails at the RPC call.

Order: merge and deploy the data-service PR first, confirm the RPCs respond on the target environment, then merge and deploy this one. Merging this first is safe but the command is non-functional until the RPCs land.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "New internal Slack ops tool with preview, conflict detection, and confirm-before-write; cross-org move is guarded and recoverable, not a customer-facing or unrecoverable operation."
```