### PR TITLE
fix: Restore Chinese language selection for Brand Markets | LLMO-7309

### DIFF
--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -78,16 +78,21 @@ export function clearLanguageCache() {
 const ENGLISH_LANGUAGE_NAMES = new Intl.DisplayNames(['en'], { type: 'language' });
 
 /**
- * Collapse a catalog language name to its base by dropping a trailing
- * parenthetical qualifier: `Chinese (Simplified)` → `chinese`. Semrush lists
- * some languages only under a script/region-qualified name (Chinese is the
- * known case — LLMO-7309), but the app models them by primary subtag alone
- * (`zh`), whose English name is the unqualified `Chinese`. Indexing both the
- * raw and base names lets an unqualified code resolve a qualified catalog row.
+ * Collapse a catalog language name to its base by dropping a trailing script
+ * qualifier: `Chinese Simplified` → `chinese`. Semrush lists Chinese only under
+ * script-qualified names — verified live (LLMO-7309), the `GET /v1/languages`
+ * catalog returns `Chinese Simplified` / `Chinese Traditional` (a trailing
+ * space-separated word, NOT a parenthetical) — but the app models Chinese by
+ * primary subtag alone (`zh`), whose English name is the unqualified `Chinese`.
+ * Indexing both the raw and base names lets an unqualified code resolve a
+ * qualified catalog row. Also tolerates a parenthetical form defensively.
  * @param {string} name
  */
 function baseLanguageName(name) {
-  return name.replace(/\s*\([^)]*\)\s*$/, '').trim();
+  return name
+    .replace(/\s*\([^)]*\)\s*$/, '')
+    .replace(/\s+(?:simplified|traditional)\s*$/i, '')
+    .trim();
 }
 
 function isoToEnglishName(languageTag) {
@@ -107,8 +112,8 @@ export async function resolveLanguageId(transport, languageTag, log) {
     const items = Array.isArray(resp?.items) ? resp.items : [];
     languageCache.byTag.clear();
     // Sort by name so a base-name alias resolves deterministically to the
-    // alphabetically-first qualified row (e.g. `zh` → `Chinese (Simplified)`
-    // before `Chinese (Traditional)`), independent of upstream ordering.
+    // alphabetically-first qualified row (e.g. `zh` → `Chinese Simplified`
+    // before `Chinese Traditional`), independent of upstream ordering.
     const sortedItems = [...items].sort(
       (a, b) => String(a?.name ?? '').localeCompare(String(b?.name ?? '')),
     );

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -61,45 +61,77 @@ export function validateParentIdQuery(raw) {
 export { resolveLocation };
 
 /**
+ * @typedef {object} LanguageCache
+ * @property {number} expiresAt
+ * @property {Map<string,string>} byTag
+ * @property {Map<string,string>} byNorm
+ * @property {{norm: string, id: string}[]} sorted
+ */
+
+/**
  * Module-scoped Semrush language UUID cache. 1h TTL — the catalog is stable
  * but languages do get added occasionally, so we don't pin it for the
  * lifetime of the warm Lambda container.
+ *
+ * `byTag` keys the exact lowercased catalog name → id (kept for the
+ * empty-catalog guard). `byNorm` keys the normalized name (see
+ * {@link normalizeLanguageName}) → id for word-order-independent lookup, and
+ * `sorted` holds `{ norm, id }` in catalog-name order so a token-subset
+ * fallback (legacy bare `zh` → Simplified) is deterministic.
+ *
+ * @type {LanguageCache}
  */
 const languageCache = {
   expiresAt: 0,
   byTag: new Map(),
+  byNorm: new Map(),
+  sorted: [],
 };
 
 export function clearLanguageCache() {
   languageCache.expiresAt = 0;
   languageCache.byTag.clear();
+  languageCache.byNorm.clear();
+  languageCache.sorted = [];
 }
 
 const ENGLISH_LANGUAGE_NAMES = new Intl.DisplayNames(['en'], { type: 'language' });
 
 /**
- * Collapse a catalog language name to its base by dropping a trailing script
- * qualifier: `Chinese Simplified` → `chinese`. Semrush lists Chinese only under
- * script-qualified names — verified live (LLMO-7309), the `GET /v1/languages`
- * catalog returns `Chinese Simplified` / `Chinese Traditional` (a trailing
- * space-separated word, NOT a parenthetical) — but the app models Chinese by
- * primary subtag alone (`zh`), whose English name is the unqualified `Chinese`.
- * Indexing both the raw and base names lets an unqualified code resolve a
- * qualified catalog row. Also tolerates a parenthetical form defensively.
+ * Normalize a language name to a word-order- and punctuation-independent key.
+ * Lowercases, splits on any non-alphanumeric run, sorts the tokens, and
+ * rejoins. The app's `Intl.DisplayNames` yields `"Simplified Chinese"` for
+ * `zh-Hans` while the live Semrush catalog returns `"Chinese Simplified"` —
+ * same tokens, reversed order (LLMO-7309); normalizing both to
+ * `"chinese simplified"` lets each script variant match its own catalog row
+ * (and tolerates a parenthetical form like `"Chinese (Simplified)"`).
  * @param {string} name
  */
-function baseLanguageName(name) {
-  return name
-    .replace(/\s*\([^)]*\)\s*$/, '')
-    .replace(/\s+(?:simplified|traditional)\s*$/i, '')
-    .trim();
+function normalizeLanguageName(name) {
+  return String(name)
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .sort()
+    .join(' ');
 }
 
+/**
+ * Resolve a BCP-47 language tag to its English catalog name. The full tag is
+ * resolved first so a script variant keeps its qualifier (`zh-hans` →
+ * `"Simplified Chinese"`); `Intl.DisplayNames` echoes an unknown tag verbatim,
+ * so a result equal to the tag means "unresolved" and we fall back to the
+ * primary subtag (bare `zh` → `"Chinese"`).
+ * @param {string} languageTag
+ * @returns {string|null}
+ */
 function isoToEnglishName(languageTag) {
-  // Strip region/script subtag — the catalog is keyed by primary language
-  // only (no `en-US` / `pt-BR` rows). Caller already enforces
-  // LANGUAGE_TAG_REGEX, so `primary` is always a 2–3 letter string here.
-  const primary = String(languageTag).toLowerCase().split('-')[0];
+  const tag = String(languageTag).toLowerCase();
+  const primary = tag.split('-')[0];
+  const full = ENGLISH_LANGUAGE_NAMES.of(tag);
+  if (full && full.toLowerCase() !== tag) {
+    return full;
+  }
   const name = ENGLISH_LANGUAGE_NAMES.of(primary);
   return name && name.toLowerCase() !== primary ? name : null;
 }
@@ -111,9 +143,11 @@ export async function resolveLanguageId(transport, languageTag, log) {
     const resp = await transport.listLanguages();
     const items = Array.isArray(resp?.items) ? resp.items : [];
     languageCache.byTag.clear();
-    // Sort by name so a base-name alias resolves deterministically to the
-    // alphabetically-first qualified row (e.g. `zh` → `Chinese Simplified`
-    // before `Chinese Traditional`), independent of upstream ordering.
+    languageCache.byNorm.clear();
+    languageCache.sorted = [];
+    // Sort by name so the token-subset fallback resolves deterministically to
+    // the alphabetically-first matching row (e.g. legacy bare `zh` →
+    // `Chinese Simplified` before `Chinese Traditional`).
     const sortedItems = [...items].sort(
       (a, b) => String(a?.name ?? '').localeCompare(String(b?.name ?? '')),
     );
@@ -121,15 +155,16 @@ export async function resolveLanguageId(transport, languageTag, log) {
       if (hasText(item?.name) && hasText(item?.id)) {
         const name = String(item.name).toLowerCase();
         const id = String(item.id);
-        // Exact name wins; register a base-name alias only if no row already
-        // claims it (an exact `Chinese` row must not be shadowed by an alias).
+        const norm = normalizeLanguageName(name);
+        // First writer wins (catalog is name-sorted) so exact/normalized keys
+        // are stable across upstream reordering.
         if (!languageCache.byTag.has(name)) {
           languageCache.byTag.set(name, id);
         }
-        const base = baseLanguageName(name);
-        if (base && base !== name && !languageCache.byTag.has(base)) {
-          languageCache.byTag.set(base, id);
+        if (norm && !languageCache.byNorm.has(norm)) {
+          languageCache.byNorm.set(norm, id);
         }
+        languageCache.sorted.push({ norm, id });
       }
     }
     if (languageCache.byTag.size === 0 && items.length > 0) {
@@ -149,7 +184,25 @@ export async function resolveLanguageId(transport, languageTag, log) {
   if (!englishName) {
     return null;
   }
-  return languageCache.byTag.get(englishName.toLowerCase()) || null;
+  const query = normalizeLanguageName(englishName);
+  // Exact normalized match: `zh-hans` "Simplified Chinese" ↔ "Chinese Simplified".
+  const exact = languageCache.byNorm.get(query);
+  if (exact) {
+    return exact;
+  }
+  // Token-subset fallback: a bare/base name (legacy `zh` → "chinese") resolves
+  // to the alphabetically-first catalog row whose tokens are a superset —
+  // i.e. `Chinese Simplified`. Exact matches above always win first.
+  const queryTokens = query.split(' ').filter(Boolean);
+  if (queryTokens.length > 0) {
+    for (const entry of languageCache.sorted) {
+      const tokens = new Set(entry.norm.split(' '));
+      if (queryTokens.every((t) => tokens.has(t))) {
+        return entry.id;
+      }
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/support/serenity/handlers/markets.js
+++ b/src/support/serenity/handlers/markets.js
@@ -77,6 +77,19 @@ export function clearLanguageCache() {
 
 const ENGLISH_LANGUAGE_NAMES = new Intl.DisplayNames(['en'], { type: 'language' });
 
+/**
+ * Collapse a catalog language name to its base by dropping a trailing
+ * parenthetical qualifier: `Chinese (Simplified)` → `chinese`. Semrush lists
+ * some languages only under a script/region-qualified name (Chinese is the
+ * known case — LLMO-7309), but the app models them by primary subtag alone
+ * (`zh`), whose English name is the unqualified `Chinese`. Indexing both the
+ * raw and base names lets an unqualified code resolve a qualified catalog row.
+ * @param {string} name
+ */
+function baseLanguageName(name) {
+  return name.replace(/\s*\([^)]*\)\s*$/, '').trim();
+}
+
 function isoToEnglishName(languageTag) {
   // Strip region/script subtag — the catalog is keyed by primary language
   // only (no `en-US` / `pt-BR` rows). Caller already enforces
@@ -93,9 +106,25 @@ export async function resolveLanguageId(transport, languageTag, log) {
     const resp = await transport.listLanguages();
     const items = Array.isArray(resp?.items) ? resp.items : [];
     languageCache.byTag.clear();
-    for (const item of items) {
+    // Sort by name so a base-name alias resolves deterministically to the
+    // alphabetically-first qualified row (e.g. `zh` → `Chinese (Simplified)`
+    // before `Chinese (Traditional)`), independent of upstream ordering.
+    const sortedItems = [...items].sort(
+      (a, b) => String(a?.name ?? '').localeCompare(String(b?.name ?? '')),
+    );
+    for (const item of sortedItems) {
       if (hasText(item?.name) && hasText(item?.id)) {
-        languageCache.byTag.set(String(item.name).toLowerCase(), String(item.id));
+        const name = String(item.name).toLowerCase();
+        const id = String(item.id);
+        // Exact name wins; register a base-name alias only if no row already
+        // claims it (an exact `Chinese` row must not be shadowed by an alias).
+        if (!languageCache.byTag.has(name)) {
+          languageCache.byTag.set(name, id);
+        }
+        const base = baseLanguageName(name);
+        if (base && base !== name && !languageCache.byTag.has(base)) {
+          languageCache.byTag.set(base, id);
+        }
       }
     }
     if (languageCache.byTag.size === 0 && items.length > 0) {

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -608,14 +608,69 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     expect(result.body.error).to.equal('unknownLanguage');
   });
 
-  // LLMO-7309: Semrush lists Chinese only under script-qualified names. The
-  // real `GET /v1/languages` catalog was captured live against the Add-market
-  // flow and returns `Chinese Simplified` / `Chinese Traditional` — a trailing
-  // space-separated word, NOT a parenthetical. The app models it by the bare
-  // primary subtag `zh` whose English name is `Chinese`, so the base-name
-  // aliasing must resolve `zh` to a qualified catalog row — deterministically
-  // the alphabetically-first one (Simplified).
-  it('resolves a bare `zh` to the alphabetically-first qualified Chinese catalog row', async () => {
+  // LLMO-7309: Semrush tracks Chinese as two script catalogs, returned live as
+  // `Chinese Simplified` / `Chinese Traditional` (space-separated). The app
+  // offers them as `zh-Hans` / `zh-Hant`, whose Intl English names are
+  // `Simplified Chinese` / `Traditional Chinese` (reversed word order) — so
+  // resolution matches on a word-order-independent normalized key.
+  it('resolves `zh-Hans` to the Chinese Simplified catalog row', async () => {
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(null);
+    dataAccess.BrandSemrushProject.create.resolves();
+    dataAccess.Site.findById.resolves({ getBaseURL: () => 'https://cuhk.edu.hk' });
+    const transport = {
+      listLanguages: sinon.stub().resolves({
+        items: [
+          { id: 'lang-zh-hant', name: 'Chinese Traditional' },
+          { id: 'lang-zh-hans', name: 'Chinese Simplified' },
+        ],
+      }),
+      createProject: sinon.stub().resolves({ id: 'proj-hk-zh' }),
+      updateProject: sinon.stub().resolves(),
+      publishProject: sinon.stub().resolves(),
+    };
+    clearLanguageCache();
+
+    const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'HK', languageCode: 'zh-Hans', siteId: '00000000-0000-4000-8000-0000000000cc', brandNames: ['CUHK'],
+    }, fakeLog());
+
+    expect(result.status).to.equal(201);
+    expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hans');
+    expect(result.body.languageCode).to.equal('zh-hans');
+  });
+
+  it('resolves `zh-Hant` to the Chinese Traditional catalog row', async () => {
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(null);
+    dataAccess.BrandSemrushProject.create.resolves();
+    dataAccess.Site.findById.resolves({ getBaseURL: () => 'https://cuhk.edu.hk' });
+    const transport = {
+      listLanguages: sinon.stub().resolves({
+        items: [
+          { id: 'lang-zh-hant', name: 'Chinese Traditional' },
+          { id: 'lang-zh-hans', name: 'Chinese Simplified' },
+        ],
+      }),
+      createProject: sinon.stub().resolves({ id: 'proj-hk-zh' }),
+      updateProject: sinon.stub().resolves(),
+      publishProject: sinon.stub().resolves(),
+    };
+    clearLanguageCache();
+
+    const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'HK', languageCode: 'zh-Hant', siteId: '00000000-0000-4000-8000-0000000000cc', brandNames: ['CUHK'],
+    }, fakeLog());
+
+    expect(result.status).to.equal(201);
+    expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hant');
+    expect(result.body.languageCode).to.equal('zh-hant');
+  });
+
+  // Back-compat: a market persisted as bare `zh` (before the split) still
+  // resolves — the token-subset fallback maps "chinese" to the alphabetically
+  // -first superset row, i.e. Simplified.
+  it('resolves a legacy bare `zh` to Chinese Simplified (token-subset fallback)', async () => {
     const dataAccess = makeDataAccess([]);
     dataAccess.BrandSemrushProject.findBySlice.resolves(null);
     dataAccess.BrandSemrushProject.create.resolves();
@@ -638,16 +693,12 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     }, fakeLog());
 
     expect(result.status).to.equal(201);
-    // Alphabetical: 'Chinese Simplified' < 'Chinese Traditional'.
     expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hans');
-    expect(result.body.languageCode).to.equal('zh');
   });
 
-  // A parenthetical qualifier form (`Chinese (Simplified)`) must also resolve —
-  // the base-name helper strips both a trailing parenthetical and a trailing
-  // space-separated script word, so the fix is robust if Semrush ever changes
-  // the catalog formatting.
-  it('resolves a bare `zh` when the catalog uses a parenthetical qualifier', async () => {
+  // A parenthetical catalog form must also resolve — the normalizer strips
+  // punctuation, so `zh-Hant` "Traditional Chinese" matches "Chinese (Traditional)".
+  it('resolves `zh-Hant` when the catalog uses a parenthetical qualifier', async () => {
     const dataAccess = makeDataAccess([]);
     dataAccess.BrandSemrushProject.findBySlice.resolves(null);
     dataAccess.BrandSemrushProject.create.resolves();
@@ -666,16 +717,16 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     clearLanguageCache();
 
     const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
-      market: 'HK', languageCode: 'zh', siteId: '00000000-0000-4000-8000-0000000000cc', brandNames: ['CUHK'],
+      market: 'HK', languageCode: 'zh-Hant', siteId: '00000000-0000-4000-8000-0000000000cc', brandNames: ['CUHK'],
     }, fakeLog());
 
     expect(result.status).to.equal(201);
-    expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hans');
+    expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hant');
   });
 
-  // An EXACT catalog name must never be shadowed by another row's base-name
-  // alias: a real `Chinese` row wins over the qualified aliases.
-  it('prefers an exact `Chinese` catalog row over qualified aliases for `zh`', async () => {
+  // An EXACT catalog name must win over the token-subset fallback: a real bare
+  // `Chinese` row resolves legacy `zh` directly rather than via the superset scan.
+  it('prefers an exact `Chinese` catalog row for legacy `zh`', async () => {
     const dataAccess = makeDataAccess([]);
     dataAccess.BrandSemrushProject.findBySlice.resolves(null);
     dataAccess.BrandSemrushProject.create.resolves();

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -608,7 +608,66 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     expect(result.body.error).to.equal('unknownLanguage');
   });
 
-  // Branch coverage: ICU DisplayNames returns the input verbatim for unknown
+  // LLMO-7309: Semrush lists Chinese only under script-qualified names
+  // (`Chinese (Simplified)` / `Chinese (Traditional)`), but the app models it
+  // by the bare primary subtag `zh` whose English name is `Chinese`. The
+  // base-name aliasing must resolve `zh` to a qualified catalog row —
+  // deterministically the alphabetically-first one (Simplified).
+  it('resolves a bare `zh` to the alphabetically-first qualified Chinese catalog row', async () => {
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(null);
+    dataAccess.BrandSemrushProject.create.resolves();
+    dataAccess.Site.findById.resolves({ getBaseURL: () => 'https://cuhk.edu.hk' });
+    const transport = {
+      listLanguages: sinon.stub().resolves({
+        items: [
+          { id: 'lang-zh-hant', name: 'Chinese (Traditional)' },
+          { id: 'lang-zh-hans', name: 'Chinese (Simplified)' },
+        ],
+      }),
+      createProject: sinon.stub().resolves({ id: 'proj-hk-zh' }),
+      updateProject: sinon.stub().resolves(),
+      publishProject: sinon.stub().resolves(),
+    };
+    clearLanguageCache();
+
+    const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'HK', languageCode: 'zh', siteId: '00000000-0000-4000-8000-0000000000cc', brandNames: ['CUHK'],
+    }, fakeLog());
+
+    expect(result.status).to.equal(201);
+    // Alphabetical: 'Chinese (Simplified)' < 'Chinese (Traditional)'.
+    expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hans');
+    expect(result.body.languageCode).to.equal('zh');
+  });
+
+  // An EXACT catalog name must never be shadowed by another row's base-name
+  // alias: a real `Chinese` row wins over the `Chinese (…)` aliases.
+  it('prefers an exact `Chinese` catalog row over qualified aliases for `zh`', async () => {
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(null);
+    dataAccess.BrandSemrushProject.create.resolves();
+    dataAccess.Site.findById.resolves({ getBaseURL: () => 'https://cuhk.edu.hk' });
+    const transport = {
+      listLanguages: sinon.stub().resolves({
+        items: [
+          { id: 'lang-zh-hans', name: 'Chinese (Simplified)' },
+          { id: 'lang-zh', name: 'Chinese' },
+        ],
+      }),
+      createProject: sinon.stub().resolves({ id: 'proj-hk-zh' }),
+      updateProject: sinon.stub().resolves(),
+      publishProject: sinon.stub().resolves(),
+    };
+    clearLanguageCache();
+
+    const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'HK', languageCode: 'zh', siteId: '00000000-0000-4000-8000-0000000000cc', brandNames: ['CUHK'],
+    }, fakeLog());
+
+    expect(result.status).to.equal(201);
+    expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh');
+  });
   // tags. The handler guards against that and returns null from
   // isoToEnglishName, which surfaces as 400 unknownLanguage.
   it('400s when the language tag is not a real language (ICU returns it unchanged)', async () => {

--- a/test/support/serenity/handlers/markets.test.js
+++ b/test/support/serenity/handlers/markets.test.js
@@ -608,12 +608,46 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     expect(result.body.error).to.equal('unknownLanguage');
   });
 
-  // LLMO-7309: Semrush lists Chinese only under script-qualified names
-  // (`Chinese (Simplified)` / `Chinese (Traditional)`), but the app models it
-  // by the bare primary subtag `zh` whose English name is `Chinese`. The
-  // base-name aliasing must resolve `zh` to a qualified catalog row —
-  // deterministically the alphabetically-first one (Simplified).
+  // LLMO-7309: Semrush lists Chinese only under script-qualified names. The
+  // real `GET /v1/languages` catalog was captured live against the Add-market
+  // flow and returns `Chinese Simplified` / `Chinese Traditional` — a trailing
+  // space-separated word, NOT a parenthetical. The app models it by the bare
+  // primary subtag `zh` whose English name is `Chinese`, so the base-name
+  // aliasing must resolve `zh` to a qualified catalog row — deterministically
+  // the alphabetically-first one (Simplified).
   it('resolves a bare `zh` to the alphabetically-first qualified Chinese catalog row', async () => {
+    const dataAccess = makeDataAccess([]);
+    dataAccess.BrandSemrushProject.findBySlice.resolves(null);
+    dataAccess.BrandSemrushProject.create.resolves();
+    dataAccess.Site.findById.resolves({ getBaseURL: () => 'https://cuhk.edu.hk' });
+    const transport = {
+      listLanguages: sinon.stub().resolves({
+        items: [
+          { id: 'lang-zh-hant', name: 'Chinese Traditional' },
+          { id: 'lang-zh-hans', name: 'Chinese Simplified' },
+        ],
+      }),
+      createProject: sinon.stub().resolves({ id: 'proj-hk-zh' }),
+      updateProject: sinon.stub().resolves(),
+      publishProject: sinon.stub().resolves(),
+    };
+    clearLanguageCache();
+
+    const result = await handleCreateMarket(transport, dataAccess, BRAND, WORKSPACE, {
+      market: 'HK', languageCode: 'zh', siteId: '00000000-0000-4000-8000-0000000000cc', brandNames: ['CUHK'],
+    }, fakeLog());
+
+    expect(result.status).to.equal(201);
+    // Alphabetical: 'Chinese Simplified' < 'Chinese Traditional'.
+    expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hans');
+    expect(result.body.languageCode).to.equal('zh');
+  });
+
+  // A parenthetical qualifier form (`Chinese (Simplified)`) must also resolve —
+  // the base-name helper strips both a trailing parenthetical and a trailing
+  // space-separated script word, so the fix is robust if Semrush ever changes
+  // the catalog formatting.
+  it('resolves a bare `zh` when the catalog uses a parenthetical qualifier', async () => {
     const dataAccess = makeDataAccess([]);
     dataAccess.BrandSemrushProject.findBySlice.resolves(null);
     dataAccess.BrandSemrushProject.create.resolves();
@@ -636,13 +670,11 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     }, fakeLog());
 
     expect(result.status).to.equal(201);
-    // Alphabetical: 'Chinese (Simplified)' < 'Chinese (Traditional)'.
     expect(transport.createProject.firstCall.args[1].language_id).to.equal('lang-zh-hans');
-    expect(result.body.languageCode).to.equal('zh');
   });
 
   // An EXACT catalog name must never be shadowed by another row's base-name
-  // alias: a real `Chinese` row wins over the `Chinese (…)` aliases.
+  // alias: a real `Chinese` row wins over the qualified aliases.
   it('prefers an exact `Chinese` catalog row over qualified aliases for `zh`', async () => {
     const dataAccess = makeDataAccess([]);
     dataAccess.BrandSemrushProject.findBySlice.resolves(null);
@@ -651,7 +683,7 @@ describe('handlers/markets.js — handleCreateMarket', () => {
     const transport = {
       listLanguages: sinon.stub().resolves({
         items: [
-          { id: 'lang-zh-hans', name: 'Chinese (Simplified)' },
+          { id: 'lang-zh-hans', name: 'Chinese Simplified' },
           { id: 'lang-zh', name: 'Chinese' },
         ],
       }),


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
This restores Chinese as a selectable language for Brand Markets add-market flows by tolerating Semrush catalog names that qualify Chinese with a parenthetical script or variant.

## 2. Reasoning
Chinese markets are valid in the product, but the Hong Kong Add market dialog no longer offered Chinese when filtering languages. The option source compared local language names to the Semrush catalog by exact English name, which dropped the Chinese option when Semrush names Chinese as a qualified variant such as Chinese (Simplified).

## 3. High-level overview of the changes
Before this change, both the UI picker and the API language-id resolver required exact catalog-name matches, so an unqualified local Chinese option could be filtered out or fail to resolve. After this change:
- exact catalog names still take precedence;
- catalog names are also matched by their base name after stripping a trailing parenthetical qualifier;
- Chinese can match a qualified Semrush Chinese catalog row while existing Chinese markets continue to render from their stored language label.

## 4. Required information
- Jira / issue: <https://jira.corp.adobe.com/browse/LLMO-7309|LLMO-7309>
- Other: <https://cq-dev.slack.com/archives/C091CRHN961/p1788351535374919|Slack report>

## 6. Affected / used mysticat-workspace projects
- spacecat-api-service: changed API-side Serenity market language resolution so selected Chinese markets can resolve against qualified Semrush catalog names.
- project-elmo-ui: changed the Brand Markets language option source to include local language options whose base English name is present in the Semrush catalog.

## 8. Test plan
- Verify in dev or stage: open Brand Markets for a Hong Kong brand, add a market, set Country/Market to Hong Kong, filter the Language field by `Ch`, and confirm Chinese is selectable.
- Verify that an existing Chinese market still renders with the expected language label in the Markets tab.
- Verify creation/publish of a Hong Kong Chinese market against a live Semrush-backed environment, paying attention to whether Simplified vs Traditional Chinese needs follow-up product modeling.

## 9. Deployment & merge order
- https://github.com/adobe/project-elmo-ui/pull/3061: related picker-side change that consumes this API behavior.
- Ordered sequence: merge/deploy spacecat-api-service first, then merge/deploy project-elmo-ui so the UI picker and backend resolver agree.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)
