### PR TITLE
fix(plg-onboarding): re-parent site project into customer org on reassignment

### DIFF
--- a/src/controllers/plg/plg-onboarding/onboarding-flow.js
+++ b/src/controllers/plg/plg-onboarding/onboarding-flow.js
@@ -37,7 +37,7 @@ import {
   revokePreviousAsoEnrollmentsForOrg,
 } from './entitlement.js';
 import { updateLaunchDarklyFlags } from './launchdarkly.js';
-import { createOrFindProject, enrollPlgConfigHandlers } from './site-setup.js';
+import { createOrFindProject, enrollPlgConfigHandlers, reparentSiteProjectToOrg } from './site-setup.js';
 import { STATUSES, REVIEW_DECISIONS } from './constants.js';
 
 const PLG_PROFILE_KEY = 'aso_plg';
@@ -376,6 +376,18 @@ async function handlePreonboardedFastPath({
     if (needsOrgReassignment) {
       site = await reassignSiteOrganization(site, customerOrgId);
       log.info(`Reassigned preonboarded site ${site.getId()} from internal org to customer org ${customerOrgId}`);
+    }
+
+    // Re-parent the preonboarding project (created under an internal/demo org) into
+    // the customer org so the site doesn't show as "Unassigned" in the Studio UI.
+    // No-op when the project already lives in the target org. Best-effort: a cosmetic
+    // re-parent must not fail onboarding. Only persists the site on a projectId change.
+    try {
+      if (await reparentSiteProjectToOrg(site, customerOrgId, context)) {
+        await site.save();
+      }
+    } catch (error) {
+      log.warn(`Failed to re-parent project for preonboarded site ${site.getId()}: ${error.message}`);
     }
 
     const { entitlement } = await ensureAsoEntitlement(site, organization, context);
@@ -802,8 +814,12 @@ export async function performAsoPlgOnboarding({
       }
     }
 
-    const project = await createOrFindProject(baseURL, organizationId, context);
+    // Only create/link a project when the site has none. A site that already
+    // carries a project (typically a preonboarding project stranded in an
+    // internal/demo org) is re-parented into the customer org after org
+    // reassignment below (Step 9), so creating one here would orphan it.
     if (!site.getProjectId()) {
+      const project = await createOrFindProject(baseURL, organizationId, context);
       site.setProjectId(project.getId());
     }
 
@@ -848,6 +864,19 @@ export async function performAsoPlgOnboarding({
       site = await reassignSiteOrganization(site, organizationId);
       onboarding.setOrganizationId(organizationId);
       steps.siteOrgReassigned = true;
+    }
+
+    // Re-parent the site's project into the resolved customer org so it doesn't
+    // render as "Unassigned" in the org-scoped Studio UI. No-op when the project
+    // already lives in the target org. Best-effort like the other post-reassignment
+    // enrichment steps — a cosmetic re-parent must not fail an otherwise-good
+    // onboarding. Only persists the site when the split branch changed its projectId.
+    try {
+      if (await reparentSiteProjectToOrg(site, organizationId, context)) {
+        await site.save();
+      }
+    } catch (error) {
+      log.warn(`Failed to re-parent project for site ${site.getId()}: ${error.message}`);
     }
 
     // Step 10: Add ASO entitlement, revoke any previous ASO enrollments for this org, update FF.

--- a/src/controllers/plg/plg-onboarding/site-setup.js
+++ b/src/controllers/plg/plg-onboarding/site-setup.js
@@ -48,6 +48,70 @@ export async function createOrFindProject(baseURL, organizationId, context) {
   return newProject;
 }
 
+/**
+ * Re-parents a site's project so it ends up in the same org as the site.
+ *
+ * Onboarding reassigns only `site.organizationId` (see `reassignSiteOrganization`),
+ * which leaves the site's project stranded in the org it was created under during
+ * preonboarding (typically an internal/demo org). The org-scoped Studio UI groups
+ * sites under `/organizations/{orgId}/projects`, so a site whose project lives in a
+ * different org can't be resolved in the customer's scope and renders as
+ * "Unassigned" — even though `site.organizationId` is correct. This is the
+ * automated-onboarding twin of the manual Slack fix in SITES-46200
+ * (`support/slack/actions/set-ims-org-modal.js` `reparentSiteProject`).
+ *
+ * Mutates `site` in place only in the split branch (where it sets a new projectId).
+ * Returns `true` when the site was mutated so the caller can persist it; the solo
+ * branch persists the project itself and the no-op branches return `false`.
+ *
+ * - No project on the site: nothing to do.
+ * - Project already in the target org: nothing to do.
+ * - Site is the only member of its project: move the whole project to the target
+ *   org (the site keeps its projectId).
+ * - Other sites still share the project: split — repoint this site to a project in
+ *   the target org (find-or-create by name) so the siblings keep their project.
+ *
+ * @param {object} site - The site being re-parented (already has its new orgId set).
+ * @param {string} targetOrgId - The Spacecat org id the site is moving to.
+ * @param {object} context - Lambda context (provides dataAccess + log).
+ * @returns {Promise<boolean>} `true` if `site` was mutated and needs a `save()`.
+ */
+export async function reparentSiteProjectToOrg(site, targetOrgId, context) {
+  const { dataAccess, log } = context;
+  const { Project, Site } = dataAccess;
+
+  const projectId = site.getProjectId();
+  if (!projectId) {
+    return false;
+  }
+
+  const project = await Project.findById(projectId);
+  if (!project) {
+    log.warn(`plg-onboarding: site ${site.getId()} references missing project ${projectId}; skipping project re-parent`);
+    return false;
+  }
+
+  if (project.getOrganizationId() === targetOrgId) {
+    return false;
+  }
+
+  const sitesOnProject = await Site.allByProjectId(projectId);
+  if (sitesOnProject.length <= 1) {
+    // Solo site on the project — move the whole project to the target org.
+    project.setOrganizationId(targetOrgId);
+    await project.save();
+    log.info(`plg-onboarding: moved project ${project.getId()} to org ${targetOrgId} so site ${site.getId()} stays resolvable in the site picker`);
+    return false;
+  }
+
+  // Project is shared with sites staying behind — split it so the moved site
+  // gets a project in the target org and the siblings keep theirs.
+  const newProject = await createOrFindProject(site.getBaseURL(), targetOrgId, context);
+  site.setProjectId(newProject.getId());
+  log.info(`plg-onboarding: split site ${site.getId()} onto project ${newProject.getId()} in org ${targetOrgId}`);
+  return true;
+}
+
 export async function enrollPlgConfigHandlers(site, context) {
   const { dataAccess, log } = context;
   try {

--- a/test/controllers/plg/plg-onboarding/displacement.test.js
+++ b/test/controllers/plg/plg-onboarding/displacement.test.js
@@ -478,5 +478,124 @@ describe('PlgOnboardingController', function describePlgOnboarding() {
         sinon.match({ entitlementId: 'ent-1' }),
       );
     });
+
+    it('re-parents the stranded project into the customer org during full onboarding reassignment', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-999';
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(null);
+
+      const existingSite = createMockSite({
+        id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID, projectId: 'stranded-project-id',
+      });
+      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
+      mockDataAccess.Site.findById.resolves(createMockSite({ orgId: TEST_ORG_ID }));
+
+      // The site's project currently lives in the internal org and is solo → move it.
+      mockProject.getOrganizationId.returns(INTERNAL_ORG_ID);
+      mockDataAccess.Project.findById.resolves(mockProject);
+      mockDataAccess.Site.allByProjectId.resolves([existingSite]);
+
+      stubs.mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      stubs.mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(mockProject.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(mockProject.save).to.have.been.called;
+      // Solo move keeps the site's projectId — no split.
+      expect(existingSite.setProjectId).to.not.have.been.called;
+    });
+
+    it('splits a shared project so the reassigned site gets its own customer-org project', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-999';
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(null);
+
+      const existingSite = createMockSite({
+        id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID, projectId: 'shared-project-id',
+      });
+      mockDataAccess.Site.findByBaseURL.resolves(existingSite);
+      mockDataAccess.Site.findById.resolves(createMockSite({ orgId: TEST_ORG_ID }));
+
+      mockProject.getOrganizationId.returns(INTERNAL_ORG_ID);
+      mockDataAccess.Project.findById.resolves(mockProject);
+      // A sibling site stays behind on the shared project → split instead of move.
+      mockDataAccess.Site.allByProjectId.resolves([existingSite, createMockSite({ id: 'sibling-site' })]);
+      // No project in the customer org yet → createOrFindProject creates a new one.
+      mockDataAccess.Project.allByOrganizationId.resolves([]);
+      mockDataAccess.Project.create.resolves({
+        getId: () => 'new-customer-project', getProjectName: () => TEST_DOMAIN,
+      });
+
+      stubs.mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      stubs.mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      // Shared project is left in place; the moved site is repointed to a new one.
+      expect(mockProject.setOrganizationId).to.not.have.been.called;
+      expect(existingSite.setProjectId).to.have.been.calledWith('new-customer-project');
+    });
+
+    it('re-parents the preonboarded project into the customer org on the fast path', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-123';
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING', siteId: TEST_SITE_ID, organizationId: INTERNAL_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+
+      const siteInInternalOrg = createMockSite({
+        id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID, projectId: 'stranded-project-id',
+      });
+      mockDataAccess.Site.findById.resolves(siteInInternalOrg);
+
+      mockProject.getOrganizationId.returns(INTERNAL_ORG_ID);
+      mockDataAccess.Project.findById.resolves(mockProject);
+      mockDataAccess.Site.allByProjectId.resolves([siteInInternalOrg]);
+
+      stubs.mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      stubs.mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(mockProject.setOrganizationId).to.have.been.calledWith(TEST_ORG_ID);
+      expect(mockProject.save).to.have.been.called;
+    });
+
+    it('splits a shared preonboarded project on the fast path', async () => {
+      const INTERNAL_ORG_ID = 'internal-org-123';
+      const preonboardedOnboarding = createMockOnboarding({
+        status: 'PRE_ONBOARDING', siteId: TEST_SITE_ID, organizationId: INTERNAL_ORG_ID,
+      });
+      mockDataAccess.PlgOnboarding.findByImsOrgIdAndDomain.resolves(preonboardedOnboarding);
+
+      const siteInInternalOrg = createMockSite({
+        id: TEST_SITE_ID, orgId: INTERNAL_ORG_ID, projectId: 'shared-project-id',
+      });
+      mockDataAccess.Site.findById.resolves(siteInInternalOrg);
+
+      mockProject.getOrganizationId.returns(INTERNAL_ORG_ID);
+      mockDataAccess.Project.findById.resolves(mockProject);
+      // Sibling stays behind on the shared project → split.
+      mockDataAccess.Site.allByProjectId.resolves([siteInInternalOrg, createMockSite({ id: 'sibling' })]);
+      mockDataAccess.Project.allByOrganizationId.resolves([]);
+      mockDataAccess.Project.create.resolves({
+        getId: () => 'new-customer-project', getProjectName: () => TEST_DOMAIN,
+      });
+
+      stubs.mockEnv.ASO_PLG_EXCLUDED_ORGS = INTERNAL_ORG_ID;
+      stubs.mockEnv.ASO_PLG_INTERNAL_ORG_DEMO_SITE_IDS = '';
+
+      const context = buildContext({ domain: TEST_DOMAIN });
+      const response = await controller.onboard(context);
+
+      expect(response.status).to.equal(200);
+      expect(mockProject.setOrganizationId).to.not.have.been.called;
+      expect(siteInInternalOrg.setProjectId).to.have.been.calledWith('new-customer-project');
+    });
   });
 });

--- a/test/controllers/plg/plg-onboarding/reparent-project.test.js
+++ b/test/controllers/plg/plg-onboarding/reparent-project.test.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { reparentSiteProjectToOrg } from '../../../../src/controllers/plg/plg-onboarding/site-setup.js';
+
+use(sinonChai);
+
+const TARGET_ORG = 'customer-org';
+const SOURCE_ORG = 'internal-demo-org';
+
+describe('reparentSiteProjectToOrg', () => {
+  let sandbox;
+  let log;
+  let Project;
+  let Site;
+  let context;
+
+  const makeSite = (overrides = {}) => ({
+    getId: sandbox.stub().returns(overrides.id || 'site-1'),
+    getBaseURL: sandbox.stub().returns(overrides.baseURL || 'https://example.com'),
+    getProjectId: sandbox.stub().returns(overrides.projectId ?? null),
+    setProjectId: sandbox.stub(),
+  });
+
+  const makeProject = (orgId) => ({
+    getId: sandbox.stub().returns('project-1'),
+    getProjectName: sandbox.stub().returns('example.com'),
+    getOrganizationId: sandbox.stub().returns(orgId),
+    setOrganizationId: sandbox.stub(),
+    save: sandbox.stub().resolves(),
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    };
+    Project = {
+      findById: sandbox.stub(),
+      allByOrganizationId: sandbox.stub().resolves([]),
+      create: sandbox.stub(),
+    };
+    Site = { allByProjectId: sandbox.stub() };
+    context = { dataAccess: { Project, Site }, log };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('does nothing and returns false when the site has no project', async () => {
+    const site = makeSite({ projectId: null });
+    const mutated = await reparentSiteProjectToOrg(site, TARGET_ORG, context);
+    expect(mutated).to.be.false;
+    expect(Project.findById).to.not.have.been.called;
+    expect(site.setProjectId).to.not.have.been.called;
+  });
+
+  it('warns and returns false when the referenced project is missing', async () => {
+    Project.findById.resolves(null);
+    const site = makeSite({ projectId: 'gone' });
+    const mutated = await reparentSiteProjectToOrg(site, TARGET_ORG, context);
+    expect(mutated).to.be.false;
+    expect(log.warn).to.have.been.calledWithMatch(/missing project/);
+    expect(Site.allByProjectId).to.not.have.been.called;
+  });
+
+  it('returns false when the project already lives in the target org', async () => {
+    const project = makeProject(TARGET_ORG);
+    Project.findById.resolves(project);
+    const site = makeSite({ projectId: 'project-1' });
+    const mutated = await reparentSiteProjectToOrg(site, TARGET_ORG, context);
+    expect(mutated).to.be.false;
+    expect(Site.allByProjectId).to.not.have.been.called;
+    expect(project.setOrganizationId).to.not.have.been.called;
+    expect(site.setProjectId).to.not.have.been.called;
+  });
+
+  it('moves the whole project (returns false) when the site is its only member', async () => {
+    const project = makeProject(SOURCE_ORG);
+    Project.findById.resolves(project);
+    const site = makeSite({ projectId: 'project-1' });
+    Site.allByProjectId.resolves([site]);
+
+    const mutated = await reparentSiteProjectToOrg(site, TARGET_ORG, context);
+
+    // Solo move persists the project itself, not the site.
+    expect(mutated).to.be.false;
+    expect(project.setOrganizationId).to.have.been.calledWith(TARGET_ORG);
+    expect(project.save).to.have.been.called;
+    expect(site.setProjectId).to.not.have.been.called;
+    expect(Project.create).to.not.have.been.called;
+  });
+
+  it('splits into a new target-org project (returns true) when the project is shared', async () => {
+    const project = makeProject(SOURCE_ORG);
+    Project.findById.resolves(project);
+    const site = makeSite({ projectId: 'project-1' });
+    const sibling = makeSite({ id: 'sibling' });
+    Site.allByProjectId.resolves([site, sibling]);
+    Project.create.resolves({ getId: () => 'new-project', getProjectName: () => 'example.com' });
+
+    const mutated = await reparentSiteProjectToOrg(site, TARGET_ORG, context);
+
+    // Split repoints the site, so the caller must persist it.
+    expect(mutated).to.be.true;
+    expect(project.setOrganizationId).to.not.have.been.called;
+    expect(Project.create).to.have.been.calledWithMatch({ organizationId: TARGET_ORG });
+    expect(site.setProjectId).to.have.been.calledWith('new-project');
+  });
+});

--- a/test/controllers/plg/plg-onboarding/shared-fixtures.js
+++ b/test/controllers/plg/plg-onboarding/shared-fixtures.js
@@ -218,11 +218,16 @@ export function createSharedMocks(sandbox) {
     enableImport: sandbox.stub(),
   };
 
-  // Project
+  // Project. getOrganizationId defaults to the resolved customer org so
+  // reparentSiteProjectToOrg is a no-op unless a test overrides it to a
+  // different (internal/demo) org.
   const mockProject = {
     getId: sandbox.stub().returns(TEST_PROJECT_ID),
     getProjectName: sandbox.stub().returns('example.com'),
+    getOrganizationId: sandbox.stub().returns(TEST_ORG_ID),
+    setOrganizationId: sandbox.stub(),
   };
+  mockProject.save = sandbox.stub().resolves(mockProject);
 
   const mockLog = {
     info: sandbox.stub(),
@@ -285,6 +290,9 @@ export function createMockDataAccess(sandbox, {
       findByBaseURL: sandbox.stub().resolves(null),
       findById: sandbox.stub().resolves(null),
       create: sandbox.stub().resolves(mockSite),
+      // Solo-on-project by default, so reparentSiteProjectToOrg takes the
+      // "move project" branch rather than the split branch.
+      allByProjectId: sandbox.stub().resolves([mockSite]),
     },
     Organization: {
       findByImsOrgId: sandbox.stub().resolves(mockOrganization),
@@ -292,6 +300,7 @@ export function createMockDataAccess(sandbox, {
     },
     Project: {
       allByOrganizationId: sandbox.stub().resolves([]),
+      findById: sandbox.stub().resolves(mockProject),
       create: sandbox.stub().resolves(mockProject),
     },
     Configuration: {
@@ -430,6 +439,8 @@ export function resetStubDefaults(stubs) {
   mockOrganization.getName.returns('Test Org');
   mockProject.getId.returns(TEST_PROJECT_ID);
   mockProject.getProjectName.returns(TEST_DOMAIN);
+  mockProject.getOrganizationId.returns(TEST_ORG_ID);
+  mockProject.save.resolves(mockProject);
   mockSiteConfig.getFetchConfig.returns({});
   mockSiteConfig.getImports.returns([]);
 }


### PR DESCRIPTION
## Problem

When PLG onboarding reassigns a site from an internal/demo org to the customer org, it updated only `site.organizationId` — the site's **project** was left behind in the original org. The org-scoped Studio UI groups sites by their project's org, so the site rendered under the generic **"Unassigned"** folder (visible to customers and ESEs) even though `site.organizationId` was correct.

This is the automated-onboarding twin of the manual Slack fix already shipped in **SITES-46200** (`set-ims-org-modal.js` `reparentSiteProject`).

### Root cause
`reassignSiteOrganization` (`plg-onboarding/entitlement.js`) only moves `site.organizationId`; it never touches the project. Two paths reassign the site but strand the project:
- **Full flow** (`performAsoPlgOnboarding`): the `if (!site.getProjectId())` guard kept the pre-existing (stranded) project.
- **Preonboard fast-path** (`handlePreonboardedFastPath`): no project handling at all.

## Fix

New `reparentSiteProjectToOrg` helper, called **best-effort** after site reassignment in **both** paths:
- **Solo** project → move the whole project to the target org.
- **Shared** project → split: repoint the moved site to a customer-org project (find-or-create), siblings keep theirs.
- Scoped project creation to the no-project case so a stranded project is no longer orphaned.

Best-effort (try/catch + conditional save) so a transient failure of this cosmetic re-parent never fails an otherwise-good onboarding, matching the surrounding enrichment steps.

## Tests
- 5 helper unit tests (`reparent-project.test.js`) covering no-project / missing-project / already-in-org / solo-move / split.
- 4 flow tests (`displacement.test.js`): solo + split × full-flow + fast-path.
- Full PLG onboarding suite green; lint clean.

## Notes
- Kept intentionally separate from the Slack `reparentSiteProject` helper — they use different project-creation dependencies (Slack `createProject` with a `say` callback vs PLG `createOrFindProject`); unifying would pull Slack coupling into the onboarding path. Behaviour is cross-referenced in the docstring.
- The re-parent runs after reassignment, consistent with the existing site-reassign-before-entitlement ordering.

SITES-50831

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Best-effort project re-parenting on org reassignment, wrapped in try/catch so a failure here never fails the onboarding; fully reversible by another re-parent move."
```