### PR TITLE
fix(dto): back-fill legacy top-level documentPath from v2 changeDetails.target (SITES-49140)

### DIFF
--- a/src/dto/fix.js
+++ b/src/dto/fix.js
@@ -17,6 +17,32 @@
 import { SuggestionDto } from './suggestion.js';
 
 /**
+ * Back-fills the legacy top-level `changeDetails.documentPath` from the v2
+ * canonical shape's `changeDetails.target.documentPath` (SITES-49140, ADR
+ * mysticat-architecture#200) when a writer has migrated to `schemaVersion: 2`
+ * but the top-level field a client already reads (e.g. the "Open in AEM
+ * Editor" UI action, added in #1835) is absent.
+ *
+ * The v2 Joi schema is `additionalProperties: false` at the top level, so a
+ * v2 writer cannot itself emit both `documentPath` and `schemaVersion: 2` —
+ * this normalization has to happen at the read/DTO boundary instead.
+ *
+ * @param {object} [changeDetails]
+ * @returns {object|undefined} changeDetails, with `documentPath` present at
+ *   the top level when resolvable from either shape.
+ */
+export function withLegacyDocumentPath(changeDetails) {
+  if (!changeDetails || changeDetails.documentPath !== undefined) {
+    return changeDetails;
+  }
+  const targetDocumentPath = changeDetails.target?.documentPath;
+  if (targetDocumentPath === undefined) {
+    return changeDetails;
+  }
+  return { ...changeDetails, documentPath: targetDocumentPath };
+}
+
+/**
  * Data transfer object for Fix.
  */
 export const FixDto = {
@@ -51,7 +77,7 @@ export const FixDto = {
       executedAt: fix.getExecutedAt(),
       deployedAt: fix.getDeployedAt(),
       publishedAt: fix.getPublishedAt(),
-      changeDetails: fix.getChangeDetails(),
+      changeDetails: withLegacyDocumentPath(fix.getChangeDetails()),
       status: fix.getStatus(),
       origin: fix.getOrigin(),
     };

--- a/test/dto/fix.test.js
+++ b/test/dto/fix.test.js
@@ -14,7 +14,7 @@ import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 
-import { FixDto } from '../../src/dto/fix.js';
+import { FixDto, withLegacyDocumentPath } from '../../src/dto/fix.js';
 import { SuggestionDto } from '../../src/dto/suggestion.js';
 
 use(chaiAsPromised);
@@ -247,6 +247,68 @@ describe('Fix DTO', () => {
 
       expect(json.suggestions).to.deep.equal([expectedSuggestionJson]);
       expect(SuggestionDto.toJSON).to.have.been.calledOnceWith(suggestion, 'full', null, null);
+    });
+
+    it('back-fills top-level documentPath from a v2 changeDetails.target.documentPath', () => {
+      const fix = createMockFix({
+        getChangeDetails: () => ({
+          schemaVersion: 2,
+          surface: 'ASO',
+          actorType: 'IMS_USER',
+          target: {
+            changeType: 'link-replace',
+            documentPath: 'https://author.example.com/mnt/overlay/.../redirects.xlsx',
+            changes: [],
+          },
+        }),
+      });
+
+      const json = FixDto.toJSON(fix);
+
+      expect(json.changeDetails.documentPath).to.equal(
+        'https://author.example.com/mnt/overlay/.../redirects.xlsx',
+      );
+      // original v2 record is preserved, not replaced
+      expect(json.changeDetails.target.documentPath).to.equal(
+        'https://author.example.com/mnt/overlay/.../redirects.xlsx',
+      );
+    });
+
+    it('does not overwrite an existing top-level documentPath', () => {
+      const fix = createMockFix({
+        getChangeDetails: () => ({
+          documentPath: 'https://legacy.example.com/edit.html',
+          target: { documentPath: 'https://v2.example.com/edit.html' },
+        }),
+      });
+
+      const json = FixDto.toJSON(fix);
+
+      expect(json.changeDetails.documentPath).to.equal('https://legacy.example.com/edit.html');
+    });
+
+    it('leaves changeDetails untouched when neither documentPath location is set', () => {
+      const fix = createMockFix({ getChangeDetails: () => ({ schemaVersion: 2, target: {} }) });
+
+      const json = FixDto.toJSON(fix);
+
+      expect(json.changeDetails).to.deep.equal({ schemaVersion: 2, target: {} });
+    });
+
+    it('handles a null/undefined changeDetails without throwing', () => {
+      const fix = createMockFix({ getChangeDetails: () => null });
+
+      const json = FixDto.toJSON(fix);
+
+      expect(json.changeDetails).to.equal(null);
+    });
+  });
+
+  describe('withLegacyDocumentPath', () => {
+    it('returns the input unchanged when there is nothing to back-fill', () => {
+      expect(withLegacyDocumentPath(undefined)).to.equal(undefined);
+      expect(withLegacyDocumentPath(null)).to.equal(null);
+      expect(withLegacyDocumentPath({ foo: 'bar' })).to.deep.equal({ foo: 'bar' });
     });
   });
 });


### PR DESCRIPTION
## Summary
- `FixEntity.changeDetails` writers are migrating to the canonical v2 shape (ADR [`adobe/mysticat-architecture#200`](https://github.com/adobe/mysticat-architecture/blob/main/platform/decisions/deploy-action-provenance-and-verify.md)), which nests `documentPath` under `target.documentPath` and forbids extra top-level keys on the v2 record.
- The ASO UI's "Open in AEM Editor" action reads `changeDetails.documentPath` at the top level (verified directly against the live UI source: `BrokenBacklinksDeployedViewTable.tsx` / `getFixDocumentPath.ts`) — without this fix, any v2-shaped fix (e.g. `adobe/spacecat-autofix-worker#723`) would silently lose that link.
- `FixDto.toJSON()` now back-fills the top-level `documentPath` from `target.documentPath` at the read/response boundary when it's absent, so existing consumers keep working regardless of which `changeDetails` schema version a given writer produced. Never overwrites an existing top-level value, and is a no-op for legacy freeform records.

## Test plan
- [x] `npm test` — full suite passing, lint clean
- [x] New unit tests cover: back-filling from `target.documentPath`, not overwriting an existing top-level value, no-op when neither location is set, and null/undefined `changeDetails` handled without throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["James Fong", "Dominique Jäggi"]
rationale: "Response-boundary DTO back-fill that never overwrites an existing value and no-ops for legacy records; purely additive fix, fully reversible."
```