### PR TITLE
feat(ai-visibility): scope remaining v1 brand endpoints to subdomains

### DIFF
--- a/docs/openapi/ai-visibility-api.yaml
+++ b/docs/openapi/ai-visibility-api.yaml
@@ -1495,12 +1495,17 @@ ai-visibility-v1-brand-competitors:
 ai-visibility-v1-brand-competitors-stats:
   get:
     tags: [ai-visibility]
-    summary: Get competitor statistics (CompetitorsMetrics v1 JSON)
+    summary: Get competitor statistics (CompetitorService v2 JSON)
     description: |
       Returns time-series statistics for the target brand and its competitors using Semrush
-      `CompetitorsMetrics.Stats`. The response is native protobuf JSON (camelCase) without
+      `CompetitorService.Stats` (v2). The response is native protobuf JSON (camelCase) without
       additional field mapping.
       Optional `engine` selects one LLM.
+      Results are scoped by `search_type`, resolved from `domain`: a non-`www` subdomain is
+      scoped to that subdomain, while an apex domain or a bare `www` host is scoped to the
+      registrable domain.
+      Each `byDate` row carries an additive `isoDate` field that the previous v1
+      `CompetitorsMetrics.Stats` response did not return.
     operationId: getAiVisibilityV1BrandCompetitorsStats
     parameters:
       - *domainParam

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -10464,11 +10464,17 @@ AiVisibilityV1BrandStatsByLLMResponse:
 AiVisibilityV1BrandCompetitorsStatsByDate:
   type: object
   description: |
-    One row from `CompetitorsMetrics.StatsResponse.ByDate` as native protobuf JSON.
+    One row from `CompetitorService.StatsResponse.ByDate` (v2) as native protobuf JSON.
     UInt64 fields are serialized as JSON strings.
   properties:
     date:
       $ref: '#/AiVisibilitySemrushDate'
+    isoDate:
+      type: string
+      description: |
+        The row's date as an ISO-8601 string. Added by the v2 `CompetitorService`
+        message; the v1 `CompetitorsMetrics` message did not carry it. Always
+        present in the response.
     visibility:
       type: integer
       description: AI Visibility score for the brand on this date
@@ -10504,7 +10510,7 @@ AiVisibilityV1BrandCompetitorsStatsByBrand:
 AiVisibilityV1BrandCompetitorsStatsResponse:
   type: object
   description: |
-    Native Semrush `CompetitorsMetrics.StatsResponse` protobuf JSON from
+    Native Semrush `CompetitorService.StatsResponse` (v2) protobuf JSON from
     `GET /llmo/ai-visibility/v1/brand/competitors-stats`, plus `srFilters`
     from the API layer.
   properties:

--- a/src/support/ai-visibility/handlers/v1/brand/competitors-stats.js
+++ b/src/support/ai-visibility/handlers/v1/brand/competitors-stats.js
@@ -17,12 +17,13 @@ import { COUNTRY_ENUM, LLM_ENUM } from '@quazar/ai-seo-ts/common/types_pb.js';
 import {
   StatsRequestSchema,
   StatsResponseSchema,
-} from '@quazar/ai-seo-ts/ai-cr/messages_pb.js';
+} from '@quazar/ai-seo-ts/v2/competitor/messages_pb.js';
 import {
   engineToLlm,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
   resolveCountry,
+  resolveSearchType,
   responseFromGrpcError,
 } from '../../../grpc-utils.js';
 
@@ -31,6 +32,7 @@ export async function handleCompetitorsStats(sp, clients) {
   const country = resolveCountry(sp) || COUNTRY_ENUM.US;
   const engine = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const competitors = sp.get('competitors')?.split(',') || [];
+  const searchType = resolveSearchType(domain);
 
   let statsRequest;
   try {
@@ -44,6 +46,7 @@ export async function handleCompetitorsStats(sp, clients) {
           domain: competitor,
           name: competitor,
         })),
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );
@@ -58,7 +61,7 @@ export async function handleCompetitorsStats(sp, clients) {
   }
 
   try {
-    const statsMessage = await clients.crMetricsClient.stats(statsRequest);
+    const statsMessage = await clients.competitorClient.stats(statsRequest);
     const statsJson = toJson(
       StatsResponseSchema,
       statsMessage,

--- a/src/support/ai-visibility/handlers/v1/brand/stats-by-llm.js
+++ b/src/support/ai-visibility/handlers/v1/brand/stats-by-llm.js
@@ -20,6 +20,7 @@ import {
 } from '@quazar/ai-seo-ts/v2/brand/messages_pb.js';
 import {
   resolveCountry,
+  resolveSearchType,
   responseFromGrpcError,
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
@@ -30,6 +31,7 @@ export async function handleStatsByLLM(sp, clients) {
   const country = resolveCountry(sp) || COUNTRY_ENUM.US;
   const dateFrom = sp.get('dateFrom');
   const dateTo = sp.get('dateTo');
+  const searchType = resolveSearchType(domain);
 
   let statsRequest;
   try {
@@ -40,6 +42,7 @@ export async function handleStatsByLLM(sp, clients) {
         target: { domain, name: domain },
         date_from: dateFrom,
         date_to: dateTo,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/src/support/ai-visibility/handlers/v1/brand/top-brands.js
+++ b/src/support/ai-visibility/handlers/v1/brand/top-brands.js
@@ -21,6 +21,7 @@ import {
   PROTO_FROM_JSON,
   PROTO_TO_JSON,
   resolveCountry,
+  resolveSearchType,
   responseFromGrpcError,
 } from '../../../grpc-utils.js';
 
@@ -36,6 +37,7 @@ export async function handleTopBrands(sp, clients) {
   const country = resolveCountry(sp) || COUNTRY_ENUM.US;
   const llm = engineToLlm(sp.get('engine')) || LLM_ENUM.ALL;
   const limit = sp.get('limit') || '10';
+  const searchType = resolveSearchType(domain);
 
   let request;
   try {
@@ -46,6 +48,7 @@ export async function handleTopBrands(sp, clients) {
         brand_domain: domain,
         llm,
         limit,
+        search_type: searchType,
       },
       PROTO_FROM_JSON,
     );

--- a/test/support/ai-visibility/handlers/v1/brand/competitors-stats.test.js
+++ b/test/support/ai-visibility/handlers/v1/brand/competitors-stats.test.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import { StatsResponseSchema } from '@quazar/ai-seo-ts/v2/competitor/messages_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { handleCompetitorsStats } from '../../../../../../src/support/ai-visibility/handlers/v1/brand/competitors-stats.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+describe('AI Visibility – v1 brand/competitors-stats search_type (LLMO-7101)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      competitorClient: {
+        stats: sandbox.stub().resolves(
+          create(StatsResponseSchema, { byBrand: [] }),
+        ),
+      },
+      // The legacy v1 client stays wired for handlers/competitors.js; this handler
+      // must no longer reach for it.
+      crMetricsClient: {
+        stats: sandbox.stub(),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleCompetitorsStats', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleCompetitorsStats(sp('domain=intuit.com&competitors=hrblock.com'), clients);
+      expect(clients.competitorClient.stats.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleCompetitorsStats(sp('domain=turbotax.intuit.com&competitors=hrblock.com'), clients);
+      expect(clients.competitorClient.stats.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+
+    it('resolves search_type DOMAIN for a bare www subdomain', async () => {
+      await handleCompetitorsStats(sp('domain=www.intuit.com&competitors=hrblock.com'), clients);
+      expect(clients.competitorClient.stats.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('calls the v2 competitor service and not the legacy v1 metrics client', async () => {
+      await handleCompetitorsStats(sp('domain=intuit.com&competitors=hrblock.com'), clients);
+      expect(clients.competitorClient.stats).to.have.property('callCount', 1);
+      expect(clients.crMetricsClient.stats).to.have.property('callCount', 0);
+    });
+  });
+});

--- a/test/support/ai-visibility/handlers/v1/brand/stats-by-llm.test.js
+++ b/test/support/ai-visibility/handlers/v1/brand/stats-by-llm.test.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import { StatsByLLMResponseSchema } from '@quazar/ai-seo-ts/v2/brand/messages_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { handleStatsByLLM } from '../../../../../../src/support/ai-visibility/handlers/v1/brand/stats-by-llm.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+describe('AI Visibility – v1 brand/stats-by-llm search_type (LLMO-7288)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      brandClient: {
+        statsByLLM: sandbox.stub().resolves(
+          create(StatsByLLMResponseSchema, { byLlm: [] }),
+        ),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleStatsByLLM', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleStatsByLLM(sp('domain=intuit.com'), clients);
+      expect(clients.brandClient.statsByLLM.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleStatsByLLM(sp('domain=quickbooks.intuit.com'), clients);
+      expect(clients.brandClient.statsByLLM.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+
+    it('resolves search_type DOMAIN for a bare www subdomain', async () => {
+      await handleStatsByLLM(sp('domain=www.intuit.com'), clients);
+      expect(clients.brandClient.statsByLLM.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+  });
+});

--- a/test/support/ai-visibility/handlers/v1/brand/top-brands.test.js
+++ b/test/support/ai-visibility/handlers/v1/brand/top-brands.test.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { create } from '@bufbuild/protobuf';
+import { TopBrandsByDomainResponseSchema } from '@quazar/ai-seo-ts/v2/brand/messages_pb.js';
+import { SEARCH_TYPE_ENUM } from '@quazar/ai-seo-ts/v2/source/enums_pb.js';
+import { handleTopBrands } from '../../../../../../src/support/ai-visibility/handlers/v1/brand/top-brands.js';
+
+function sp(query) {
+  return new URLSearchParams(query);
+}
+
+describe('AI Visibility – v1 brand/top-brands search_type (LLMO-7261)', () => {
+  let sandbox;
+  let clients;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clients = {
+      brandClient: {
+        topBrandsByDomain: sandbox.stub().resolves(
+          create(TopBrandsByDomainResponseSchema, { brands: [] }),
+        ),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('handleTopBrands', () => {
+    it('resolves search_type DOMAIN for an apex domain', async () => {
+      await handleTopBrands(sp('domain=intuit.com'), clients);
+      expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('resolves search_type SUBDOMAIN for a non-www subdomain', async () => {
+      await handleTopBrands(sp('domain=quickbooks.intuit.com'), clients);
+      expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.SUBDOMAIN);
+    });
+
+    it('resolves search_type DOMAIN for a bare www subdomain', async () => {
+      await handleTopBrands(sp('domain=www.intuit.com'), clients);
+      expect(clients.brandClient.topBrandsByDomain.firstCall.args[0].searchType)
+        .to.equal(SEARCH_TYPE_ENUM.DOMAIN);
+    });
+
+    it('returns 400 and issues no gRPC call when domain is missing', async () => {
+      const result = await handleTopBrands(sp(''), clients);
+      expect(result.status).to.equal(400);
+      expect(clients.brandClient.topBrandsByDomain).to.have.property('callCount', 0);
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Sends `search_type` on the three `/llmo/ai-visibility/v1/brand/*` endpoints that still queried the registrable domain, and migrates `competitors-stats` onto the v2 competitor service so it can carry that field.

## 2. Reasoning
Semrush collapses every `*.intuit.com` host to the registrable domain unless the request states a `search_type`. A brand tracked at `quickbooks.intuit.com` therefore received `intuit.com`'s rollup: identical visibility, mentions and competitor numbers across every sibling subdomain, which is wrong for the customer and masks subdomain-sized gaps.

`search_type` has been wired handler-by-handler as each gRPC message gained the field. Three endpoints were still outstanding:

- `top-brands` and `stats-by-llm` were blocked on the field not existing upstream. It arrived in the Semrush AI-SEO SDK `v0.105.5-gen2.7.0` bump (https://github.com/adobe/spacecat-api-service/pull/3173), which merged recently.
- `competitors-stats` was blocked differently: the legacy `cr.v1 CompetitorsMetrics/Stats` message has no `search_type` in any SDK version, so the endpoint had to move to the v2 service that does.

## 3. High-level overview of the changes
Each of the three handlers now resolves `search_type` from the requested domain with the shared `resolveSearchType` helper and sets it on the outbound gRPC request. That helper already backs `stats-by-country` and the gap handlers, so this extends an established pattern rather than introducing one.

Behaviour delta, per endpoint:

- **`top-brands`** — before: a request for `quickbooks.intuit.com` returned the top brands computed across all of `intuit.com`. After: it returns the top brands for that subdomain alone.
- **`stats-by-llm`** — same delta for the per-model visibility and mention figures.
- **`competitors-stats`** — same delta for the competitor comparison series, and the call moves from `CompetitorsMetrics/Stats` to `CompetitorService/Stats`.

Apex and bare-`www` hosts resolve to `DOMAIN`, which is what the upstream already assumes when the field is unset, so no existing caller changes behaviour.

Two consequences worth reviewer attention:

- The v2 `StatsRequest` is a strict superset of the v1 message — fields 1 to 5 (`date_range`, `country`, `llm`, `target`, `competitors`) are identical in name, tag and type, and v2 only adds `date_from`, `date_to` and `search_type`. The request body and the response mapping are unchanged as a result.
- The v2 `StatsResponse.ByDate` adds an `iso_date` field that v1 did not have. Because the proto-to-JSON conversion sets `alwaysEmitImplicit`, `isoDate` now appears on every `byDate` entry in the API response. This is purely additive; no existing field is renamed, removed or retyped.

`crMetricsClient` stays wired in the transport because the older `handlers/competitors.js` endpoint still calls it. Only the v1 brand handler moved.

## 4. Required information
- Jira / issue: [LLMO-7261](https://jira.corp.adobe.com/browse/LLMO-7261) (top-brands), [LLMO-7288](https://jira.corp.adobe.com/browse/LLMO-7288) (stats-by-llm), [LLMO-7101](https://jira.corp.adobe.com/browse/LLMO-7101) (competitors-stats)
- Spec: [Subdomain-Scoped AI-Visibility for Prompt Generation](https://github.com/adobe/mysticat-architecture/blob/main/products/llmo/subdomain-aivisibility-e2e-fix.md) (`mysticat-architecture`, status: proposed)
- Other: SDK bump that added `search_type` upstream — https://github.com/adobe/spacecat-api-service/pull/3173

## 5. Spec deviations
- Changed: wired `v1/brand/{top-brands,stats-by-llm,competitors-stats}` rather than the `handlers/brands.js` trio the spec names.
  Why: the SDK bump landed `search_type` on these messages and they back the SR dashboard. The `handlers/brands.js` handlers the spec targets are DRS's endpoints and remain a separate follow-up; they are still unwired after this PR.
  Intentional: yes
- Changed: `competitors-stats` migrates from `cr.v1 CompetitorsMetrics/Stats` to `v2 CompetitorService/Stats`. The spec does not mention this migration.
  Why: v2 is the only variant carrying `search_type`. Fields 1 to 5 match exactly in name, tag and type, so request and response mapping are unchanged.
  Intentional: yes
- Changed: the spec said to confirm or defer `statsByLLM`. It was confirmed to carry `search_type` (field 6) and wired.
  Why: the confirmation succeeded, so the defer branch did not apply.
  Intentional: yes

## 6. Affected / used mysticat-workspace projects
- **project-elmo-ui** — consumer. The SR AI Visibility and Competitor Research dashboards call all three endpoints. The companion PR https://github.com/adobe/project-elmo-ui/pull/3063 fixes a brand-label bug that only becomes visible once these endpoints return subdomain-scoped data (see section 9).
- **llmo-data-retrieval-service** — unaffected by this PR, noted to scope the change. DRS calls the separate `/llmo/ai-visibility/brands/*` handlers, which are still not subdomain-scoped and remain a follow-up.

## 7. Additional information outside the code
- Resolved `search_type` against the real SDK schemas rather than trusting the generated typings: `quickbooks.intuit.com` resolves to `SUBDOMAIN` (2), while `intuit.com` and `www.intuit.com` both resolve to `DOMAIN` (1).
- Decoded the SDK's protobuf descriptors to confirm the field is genuinely present on each message before wiring it: `TopBrandsByDomainRequest` field 7, `StatsByLLMRequest` field 6, `v2 competitor StatsRequest` field 8.
- Compared the v1 and v2 competitor `StatsRequest` descriptors field by field to establish the superset relationship described in section 3, and diffed `StatsResponse` to find the added `iso_date`.
- Audited all 52 ai-visibility handlers for unwired `search_type`. Two gaps remain and are **not** addressed here because they are blocked upstream, not by this repo: the cited-sources handlers (`SourceDomainsRequest` and `SourceDomainsTotalsRequest` carry no `search_type` in any SDK version — a Semrush-side gap), and the cited-pages totals fallback in `handlers/brands.js`, which would need its own migration to `v2.source.SourcesTotalsRequest`.

## 8. Test plan

**Done locally.** Exercised `resolveSearchType` through the real generated schemas for apex, `www` and subdomain hosts, confirming the enum values above. Verified the three handlers construct valid requests against the v2 message definitions.

**Verified against the live Semrush gRPC service.** I probed `grpc-api.semrush.com` directly, calling the three real handlers with production credentials. Target `intuit.com` (apex) vs `quickbooks.intuit.com` (subdomain), competitors `hrblock.com,xero.com`, country US.

`CompetitorService/Stats` **is deployed and served** — HTTP 200, no `Unimplemented`. The earlier `grpc-status 12` result predated the SDK drop and no longer reproduces. That was this PR's main open risk and it is now closed.

**The v1 to v2 migration is value-identical.** Same request through the legacy `CompetitorsMetrics/Stats` and the new `CompetitorService/Stats` returns the same six monthly buckets with byte-identical metrics:

| Bucket | v1 mentions | v2 mentions | v1 audience | v2 audience | v1 owned | v2 owned |
|---|---|---|---|---|---|---|
| 2026-04 | 134973 | 134973 | 922595276 | 922595276 | 49244 | 49244 |
| 2026-05 | 125207 | 125207 | 862291849 | 862291849 | 46460 | 46460 |
| 2026-09 | 91638 | 91638 | 548249085 | 548249085 | 25747 | 25747 |

Two response deltas, both benign:
- `isoDate` is present on every `byDate` row (`2026-04`, ...), as documented in `schemas.yaml`. Additive.
- `date.day` moves from `15` to `1` on monthly buckets. Not user-visible in Elmo: the trend chart builds its label with `new Date(year, month - 1, 1)` and formats month plus year only, and the "latest point" comparator orders by year/month first, so the relative order is unchanged.

**`search_type` demonstrably drives the scoping.** Holding the target host fixed at `quickbooks.intuit.com` and varying only `search_type` isolates the field from the hostname:

| Request | 2026-06 mentions | 2026-06 ownedSources |
|---|---|---|
| target `intuit.com`, `DOMAIN` | 111545 | 34401 |
| target `quickbooks.intuit.com`, `DOMAIN` (control) | 111545 | 34401 |
| target `quickbooks.intuit.com`, `SUBDOMAIN` | 68407 | 16876 |

The control row returns the apex numbers exactly, so the change comes from `search_type` and not from the host string. `audience` and `visibility` stay root-domain in all three, matching the proto comment: *"Only the target is scoped ... audience and visibility stay root-domain."* Competitor entries are untouched by scoping — `hrblock.com` returns identical figures under both.

**Confirms the companion UI fix.** Under a subdomain request the target echoes back as `brand.domain = intuit.com`, `brand.name = quickbooks.intuit.com` — exactly the shape the Elmo PR now renders by preferring `name`.

**One data-availability note for testers, not a bug.** On `quickbooks.intuit.com` the `mentions` series is `0` for 2026-04 and 2026-05, then real from 2026-06 on. Subdomain-level mentions were backfilled from June; the apex series is populated for all six buckets. A subdomain trend chart that starts at zero for the first two months is expected.

`top-brands` and `stats-by-llm` were probed the same way and both return visibly different, correctly scoped results — for example `top-brands` on the apex leads with `quickbooks / turbotax / intuit`, while the subdomain returns `quickbooks / quickbooks online / quickbooks time`.

**dev.** Against a real customer brand that has a tracked subdomain (a `frescopa*` domain will not work — those are intercepted client-side and served from static fixtures, so the API is never called):

1. `GET /llmo/ai-visibility/v1/brand/competitors-stats?domain=<subdomain>` — first confirm it returns 200 rather than an `Unimplemented` error, then confirm the numbers differ from the same call with the apex domain.
2. `GET /llmo/ai-visibility/v1/brand/top-brands?domain=<subdomain>` and `.../stats-by-llm?domain=<subdomain>` — same apex-versus-subdomain comparison. Before this change the two responses were byte-identical.
3. Confirm the apex call itself is unchanged from production, since apex resolves to the same `search_type` the server already assumed.
4. Check that `byDate` entries in the `competitors-stats` response now carry `isoDate`, and that the UI tolerates the extra field.

**Integration tests.** The repo rule asks for integration tests on new or modified endpoints, but the standard pattern here provisions database state and these three handlers hold none: each is a pure gRPC proxy that maps query parameters to an upstream request and returns the response. The behaviour worth pinning is which `search_type` a host resolves to and which client is called, which the unit tests assert directly against the real generated schemas. The remaining risk is upstream availability, which no integration test in this repo could cover; it is called out above as a dev check.

**stage / prod.** Same three comparisons through the AI Visibility Results and Competitor Research dashboards for a customer with subdomain brands. The regression to watch for is an apex-domain brand whose figures shift, which would indicate `resolveSearchType` misclassifying a host.

## 9. Deployment & merge order
- Companion PR in `project-elmo-ui` — https://github.com/adobe/project-elmo-ui/pull/3063 — related. It fixes the competitor comparison table showing the registrable domain where the response now carries the subdomain as the brand name. That bug is only observable once this PR is deployed, but the UI fix is harmless before then.

Order: merge and deploy this PR first, then the `project-elmo-ui` PR. The reverse order is safe but leaves the UI fix with nothing to display.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)


## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: multi-repo
relatedPRs: ["adobe/spacecat-api-service#3187", "adobe/project-elmo-ui#3063"]
rationale: "Aggregate rating for a coordinated two-repo change. The backend sets an additive search_type field on three AI-visibility gRPC requests and moves competitors-stats from the v1 competitor-metrics method to the v2 method that carries the field; the v2 request is a verified strict superset of the v1 message. The UI relabels competitor rows by brand name. No schema change, no data migration, no auth or access-control change, and no backward-incompatible break: the response only gains an additive isoDate field. Any failure is fully reversible by redeploying the previous release, so it stays standard despite touching a customer-facing dashboard. Deploy the api-service PR before the elmo PR; either order is safe, but the reverse leaves the UI fix with nothing to display."
recommendations: "The main pre-merge unknown is now closed: CompetitorService/Stats was probed directly against the live Semrush gRPC service and returns 200, and the v1-to-v2 migration was verified value-identical on the same inputs, so the Unimplemented risk no longer applies. Residual checks are routine: confirm a 200 from /llmo/ai-visibility/v1/brand/competitors-stats on dev after deploy, and confirm the Competitor Research Market Comparison view renders. The response gains an additive isoDate field on byDate rows; no consumer depends on its absence. Back out by redeploying the previous revision."
backout: "Redeploy the previous release of the affected service; both changes are code-only with no migration or state to unwind."
```


