### PR TITLE
feat(slack): enrich-brand-claims command for off-site opportunity refresh (LLMO-7312)

### DIFF
--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -63,6 +63,7 @@ import addOaeStageDomain from './commands/add-oae-stage-domain.js';
 import togglePathSuggestions from './commands/toggle-path-suggestions.js';
 import getPathSuggestionsStatus from './commands/get-path-suggestions-status.js';
 import brandClaims from './commands/toggle-brand-claims.js';
+import enrichBrandClaims from './commands/enrich-brand-claims.js';
 
 /**
  * Returns all commands.
@@ -124,4 +125,5 @@ export default (context) => [
   togglePathSuggestions(context),
   getPathSuggestionsStatus(context),
   brandClaims(context),
+  enrichBrandClaims(context),
 ];

--- a/src/support/slack/commands/enrich-brand-claims.js
+++ b/src/support/slack/commands/enrich-brand-claims.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { isValidUrl } from '@adobe/spacecat-shared-utils';
+import BaseCommand from './base.js';
+import {
+  extractURLFromSlackInput,
+  postErrorMessage,
+  postSiteNotFoundMessage,
+} from '../../../utils/slack/base.js';
+import { triggerBrandClaimsEnrich } from '../../utils.js';
+
+const PHRASE = 'enrich-brand-claims';
+
+/**
+ * `enrich-brand-claims {site}` — triggers a cache-safe off-site opportunity link
+ * refresh for a site's existing Brand Claims (LLMO-7312). It fires the `brand-claims`
+ * audit with `mode: 'enrich'`; the audit worker forwards that onto its ready-signal
+ * and mystique's BP consumer force-recomputes only the citation matcher + delivery,
+ * leaving every expensive claims/LLM fact cached. Unlike `run audit ... brand-claims`
+ * (a full recompute), this is the cheap "pick up newly-available off-site
+ * opportunities" path — no LLM cost.
+ *
+ * @param {Object} context - The context object.
+ * @returns {Object} The command object.
+ */
+function EnrichBrandClaimsCommand(context) {
+  const baseCommand = BaseCommand({
+    id: 'enrich-brand-claims',
+    name: 'Enrich Brand Claims',
+    description: 'Refreshes off-site opportunity links for a site\'s existing Brand Claims (cache-safe; no full recompute).',
+    phrases: [PHRASE],
+    usageText: `${PHRASE} {site}`,
+  });
+
+  const { dataAccess, log } = context;
+  const { Site } = dataAccess;
+
+  const execute = async (message, slackContext) => {
+    const { say } = slackContext;
+
+    try {
+      const target = message.trim().slice(PHRASE.length).trim().split(/\s+/)[0];
+      const baseURL = extractURLFromSlackInput(target);
+
+      if (!baseURL || !isValidUrl(baseURL)) {
+        await say(`:warning: Please provide a valid site URL. ${baseCommand.usage()}`);
+        return;
+      }
+
+      const site = await Site.findByBaseURL(baseURL);
+      if (!site) {
+        await postSiteNotFoundMessage(say, baseURL);
+        return;
+      }
+
+      await triggerBrandClaimsEnrich(site, slackContext, context);
+      log.info(`enrich-brand-claims: triggered off-site opportunity enrich for site ${site.getId()} (${baseURL})`);
+      await say(`:adobe-run: Triggering Brand Claims off-site opportunity *enrich* for ${baseURL} (cache-safe link refresh).`);
+    } catch (error) {
+      log.error(error);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    execute,
+  };
+}
+
+export default EnrichBrandClaimsCommand;

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -116,6 +116,35 @@ export const sendAuditMessage = async (
   data: auditData,
 });
 
+/**
+ * Triggers a Brand Claims off-site opportunity ENRICHMENT run for a site (LLMO-7312).
+ *
+ * Sends the `brand-claims` audit message with a top-level `mode: 'enrich'` field
+ * (mirrors `onDemand`), which the audit worker forwards onto its ready-signal so
+ * mystique's BP consumer runs the cache-safe link refresh (force only the matcher +
+ * delivery) instead of a full claims recompute.
+ *
+ * @param {Site} site - The site object.
+ * @param {Object} slackContext - The Slack context object.
+ * @param {Object} lambdaContext - The Lambda context object.
+ * @returns {Promise} A promise representing the trigger operation.
+ */
+export const triggerBrandClaimsEnrich = async (
+  site,
+  slackContext,
+  lambdaContext,
+) => lambdaContext.sqs.sendMessage(lambdaContext.env.AUDIT_JOBS_QUEUE_URL, {
+  type: 'brand-claims',
+  siteId: site.getId(),
+  mode: 'enrich',
+  auditContext: {
+    slackContext: {
+      channelId: slackContext.channelId,
+      threadTs: slackContext.threadTs,
+    },
+  },
+});
+
 // todo: prototype - untested
 /* c8 ignore start */
 export const sendExperimentationCandidatesMessage = async (

--- a/test/support/slack/commands/enrich-brand-claims.test.js
+++ b/test/support/slack/commands/enrich-brand-claims.test.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('EnrichBrandClaimsCommand', () => {
+  let context;
+  let slackContext;
+  let triggerBrandClaimsEnrichStub;
+  let findByBaseURLStub;
+  let mockSite;
+  let EnrichBrandClaimsCommand;
+
+  const SITE_ID = '11111111-1111-4111-8111-111111111111';
+
+  before(async () => {
+    triggerBrandClaimsEnrichStub = sinon.stub();
+    EnrichBrandClaimsCommand = await esmock(
+      '../../../../src/support/slack/commands/enrich-brand-claims.js',
+      {
+        '../../../../src/support/utils.js': {
+          triggerBrandClaimsEnrich: triggerBrandClaimsEnrichStub,
+        },
+      },
+    );
+  });
+
+  beforeEach(() => {
+    triggerBrandClaimsEnrichStub.reset();
+    triggerBrandClaimsEnrichStub.resolves();
+    mockSite = {
+      getId: () => SITE_ID,
+      getBaseURL: () => 'https://example.com',
+    };
+    findByBaseURLStub = sinon.stub().resolves(mockSite);
+    context = {
+      dataAccess: { Site: { findByBaseURL: findByBaseURLStub } },
+      log: { info: sinon.spy(), error: sinon.spy(), warn: sinon.spy() },
+    };
+    slackContext = { say: sinon.spy(), channelId: 'C1', threadTs: 'T1' };
+  });
+
+  it('registers the enrich-brand-claims phrase', () => {
+    const command = EnrichBrandClaimsCommand(context);
+    expect(command.phrases).to.include('enrich-brand-claims');
+  });
+
+  it('triggers the enrich run for a valid site URL', async () => {
+    const command = EnrichBrandClaimsCommand(context);
+    await command.execute('enrich-brand-claims https://example.com', slackContext);
+
+    expect(findByBaseURLStub).to.have.been.calledWith('https://example.com');
+    expect(triggerBrandClaimsEnrichStub).to.have.been.calledOnce;
+    expect(triggerBrandClaimsEnrichStub.firstCall.args[0]).to.equal(mockSite);
+    expect(triggerBrandClaimsEnrichStub.firstCall.args[1]).to.equal(slackContext);
+    expect(triggerBrandClaimsEnrichStub.firstCall.args[2]).to.equal(context);
+    expect(slackContext.say.firstCall.args[0]).to.include('off-site opportunity');
+  });
+
+  it('warns and does not trigger for a missing/invalid URL', async () => {
+    const command = EnrichBrandClaimsCommand(context);
+    await command.execute('enrich-brand-claims', slackContext);
+
+    expect(triggerBrandClaimsEnrichStub).to.not.have.been.called;
+    expect(slackContext.say.firstCall.args[0]).to.include(':warning:');
+  });
+
+  it('reports site-not-found and does not trigger', async () => {
+    findByBaseURLStub.resolves(null);
+    const command = EnrichBrandClaimsCommand(context);
+    await command.execute('enrich-brand-claims https://unknown.com', slackContext);
+
+    expect(triggerBrandClaimsEnrichStub).to.not.have.been.called;
+    expect(slackContext.say).to.have.been.called;
+  });
+
+  it('surfaces an error if the trigger throws', async () => {
+    triggerBrandClaimsEnrichStub.rejects(new Error('sqs down'));
+    const command = EnrichBrandClaimsCommand(context);
+    await command.execute('enrich-brand-claims https://example.com', slackContext);
+
+    expect(context.log.error).to.have.been.called;
+    expect(slackContext.say).to.have.been.called;
+  });
+});

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -43,6 +43,7 @@ import {
   sendGlobalImportRunMessage,
   triggerGlobalImportRun,
   triggerGeoExperimentImpactMeasurement,
+  triggerBrandClaimsEnrich,
 } from '../../src/support/utils.js';
 
 use(chaiAsPromised);
@@ -1294,6 +1295,40 @@ describe('utils', () => {
       expect(result.validForRedirects).to.be.false;
       expect(result.programId).to.be.undefined;
       expect(result.environmentId).to.be.undefined;
+    });
+  });
+
+  describe('triggerBrandClaimsEnrich', () => {
+    let sandbox;
+    let sqsStub;
+    let context;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sqsStub = { sendMessage: sandbox.stub().resolves() };
+      context = {
+        env: { AUDIT_JOBS_QUEUE_URL: 'https://sqs.example.com/queue' },
+        sqs: sqsStub,
+      };
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it('publishes a brand-claims audit message with top-level mode=enrich', async () => {
+      const site = { getId: () => 'site-123' };
+      const slackContext = { channelId: 'C1', threadTs: 'T1' };
+
+      await triggerBrandClaimsEnrich(site, slackContext, context);
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const [queueUrl, message] = sqsStub.sendMessage.firstCall.args;
+      expect(queueUrl).to.equal('https://sqs.example.com/queue');
+      expect(message).to.deep.equal({
+        type: 'brand-claims',
+        siteId: 'site-123',
+        mode: 'enrich',
+        auditContext: { slackContext: { channelId: 'C1', threadTs: 'T1' } },
+      });
     });
   });
 


### PR DESCRIPTION
## What

Adds a dedicated Slack command **`enrich-brand-claims {site}`** that triggers the cache-safe Brand Claims **off-site opportunity link refresh** — the cheap "pick up newly-available off-site opportunities" path, with no full recompute and no LLM cost.

Final leg of a 3-repo change for [LLMO-7312](https://jira.corp.adobe.com/browse/LLMO-7312):
- experience-platform/mystique#4804 — BP consumer runs the enrichment (`opportunity_enrichment=True`)
- adobe/spacecat-audit-worker#2937 — `brand-claims` handler forwards top-level `mode` onto the ready-signal
- **this PR** — api-service: the operator-facing Slack command

## How

- New command `enrich-brand-claims {site}` (parallel to the existing `enable-brand-claims` / `disable-brand-claims` family — deliberately **not** overloading the shared `run audit`).
- New sender `triggerBrandClaimsEnrich(site, slackContext, context)` in `utils.js` that publishes the `brand-claims` audit message with a **top-level** `mode: 'enrich'` field, mirroring how `onDemand` is emitted. The audit worker reads that top-level field and forwards it; mystique's BP consumer then force-recomputes only the citation matcher + delivery, leaving every claims/LLM fact cached.
- Registered in `commands.js`.

## Flow

```
@spacecat enrich-brand-claims <url>
  → brand-claims audit message { type, siteId, mode: 'enrich', auditContext }
    → audit-worker stamps mode=enrich on BRAND_PRESENCE_SHEET_WRITTEN
      → mystique BP consumer → trigger_claims_scan(opportunity_enrichment=True)
```

## Testing

```
5 passing
```

- registers the phrase; triggers the enrich sender with `(site, slackContext, context)` for a valid URL; warns on missing/invalid URL (no trigger); site-not-found (no trigger); surfaces sender errors.
- `eslint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: no-impact
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "New operator-triggered Slack command that publishes an existing audit message shape with an extra mode field; purely additive, no change to existing behavior."
```