### PR TITLE
feat(slack): report check-impact-measurement outcome and add get-experiment command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,7 +541,7 @@ Commands for operations (see `src/support/slack/commands.js` for the full, curre
 - Organization setup: `/add-slack-channel`, `/configure-slack`
 - Debugging: `/site-info`, `/audit-info`
 - LLMO: `/brand-profile`, `/llmo-onboard`, `enable-brand-claims`, `disable-brand-claims`
-- Geo-experiments: `/trigger-impact-measurement`, `/check-impact-measurement`
+- Geo-experiments: `/trigger-impact-measurement`, `/check-impact-measurement`, `/get-experiment`
 
 ## Common Utilities
 

--- a/src/support/geo-experiment-helper.js
+++ b/src/support/geo-experiment-helper.js
@@ -65,6 +65,43 @@ export function isImpactMeasurementCheckEligible(geoExperiment) {
 }
 
 /**
+ * Observable outcomes of a geo-experiment's impact measurement, so the check command can report
+ * success/failure based on whether data actually got filled, instead of blindly refusing once no
+ * task is in flight.
+ */
+export const IMPACT_MEASUREMENT_OUTCOME = {
+  IN_FLIGHT: 'in_flight',
+  SUCCEEDED: 'succeeded',
+  COMPLETED_WITHOUT_INSIGHTS: 'completed_without_insights',
+  NOT_APPLICABLE: 'not_applicable',
+};
+
+/**
+ * Classifies a geo-experiment's impact-measurement outcome from its current persisted state:
+ * - IN_FLIGHT: a Mystique task is running (phase IMPACT_MEASUREMENT_STARTED) — a check is useful.
+ * - SUCCEEDED: phase IMPACT_MEASUREMENT_DONE with an insightsLocation — insights were written.
+ * - COMPLETED_WITHOUT_INSIGHTS: COMPLETED with no insightsLocation — measurement finished but
+ *   produced no data (llmo-experimentation-engine's `#completeWithoutInsights` path).
+ * - NOT_APPLICABLE: any earlier/other state — nothing has been measured, so nothing to report.
+ *
+ * @param {Object} geoExperiment
+ * @returns {string} one of IMPACT_MEASUREMENT_OUTCOME
+ */
+export function getImpactMeasurementOutcome(geoExperiment) {
+  if (isImpactMeasurementCheckEligible(geoExperiment)) {
+    return IMPACT_MEASUREMENT_OUTCOME.IN_FLIGHT;
+  }
+  if (geoExperiment.getPhase() === PHASES.IMPACT_MEASUREMENT_DONE
+    && geoExperiment.getInsightsLocation()) {
+    return IMPACT_MEASUREMENT_OUTCOME.SUCCEEDED;
+  }
+  if (geoExperiment.getStatus() === STATUSES.COMPLETED && !geoExperiment.getInsightsLocation()) {
+    return IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS;
+  }
+  return IMPACT_MEASUREMENT_OUTCOME.NOT_APPLICABLE;
+}
+
+/**
  * Validates a single phase config block.
  * All fields are optional — only present fields are validated.
  *

--- a/src/support/geo-experiment-helper.js
+++ b/src/support/geo-experiment-helper.js
@@ -91,10 +91,15 @@ export function getImpactMeasurementOutcome(geoExperiment) {
   if (isImpactMeasurementCheckEligible(geoExperiment)) {
     return IMPACT_MEASUREMENT_OUTCOME.IN_FLIGHT;
   }
-  if (geoExperiment.getPhase() === PHASES.IMPACT_MEASUREMENT_DONE
-    && geoExperiment.getInsightsLocation()) {
-    return IMPACT_MEASUREMENT_OUTCOME.SUCCEEDED;
+  // Measurement has reached its terminal phase: success iff insights were written. Keyed on phase
+  // (not status) so a transient non-COMPLETED status mid engine-update still reports the outcome
+  // rather than misleadingly claiming nothing is in flight.
+  if (geoExperiment.getPhase() === PHASES.IMPACT_MEASUREMENT_DONE) {
+    return geoExperiment.getInsightsLocation()
+      ? IMPACT_MEASUREMENT_OUTCOME.SUCCEEDED
+      : IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS;
   }
+  // Completed at an earlier phase with no insights — the engine's `#completeWithoutInsights` path.
   if (geoExperiment.getStatus() === STATUSES.COMPLETED && !geoExperiment.getInsightsLocation()) {
     return IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS;
   }

--- a/src/support/slack/commands.js
+++ b/src/support/slack/commands.js
@@ -65,6 +65,7 @@ import getPathSuggestionsStatus from './commands/get-path-suggestions-status.js'
 import brandClaims from './commands/toggle-brand-claims.js';
 import triggerImpactMeasurement from './commands/trigger-impact-measurement.js';
 import checkImpactMeasurement from './commands/check-impact-measurement.js';
+import getExperiment from './commands/get-experiment.js';
 import enrichBrandClaims from './commands/enrich-brand-claims.js';
 
 /**
@@ -129,5 +130,6 @@ export default (context) => [
   brandClaims(context),
   triggerImpactMeasurement(context),
   checkImpactMeasurement(context),
+  getExperiment(context),
   enrichBrandClaims(context),
 ];

--- a/src/support/slack/commands/check-impact-measurement.js
+++ b/src/support/slack/commands/check-impact-measurement.js
@@ -11,7 +11,7 @@
  */
 
 import { checkGeoExperimentImpactMeasurement } from '../../utils.js';
-import { isImpactMeasurementCheckEligible } from '../../geo-experiment-helper.js';
+import { getImpactMeasurementOutcome, IMPACT_MEASUREMENT_OUTCOME } from '../../geo-experiment-helper.js';
 import { resolveGeoExperiment } from './impact-measurement-helper.js';
 import BaseCommand from './base.js';
 import { extractURLFromSlackInput, postErrorMessage, postSiteNotFoundMessage } from '../../../utils/slack/base.js';
@@ -62,15 +62,33 @@ export default function CheckImpactMeasurementCommand(context) {
       }
 
       const geoExperimentId = geoExperiment.getId();
+      const outcome = getImpactMeasurementOutcome(geoExperiment);
 
-      if (!isImpactMeasurementCheckEligible(geoExperiment)) {
-        await say(`:warning: GeoExperiment ${geoExperimentId} for '${baseURL}' is at phase `
-          + `'${geoExperiment.getPhase()}' / status '${geoExperiment.getStatus()}' — a check `
-          + 'only makes sense at phase \'impact_measurement_started\' (an impact-measurement task '
-          + 'must be in flight). Use trigger-impact-measurement first if none is running.');
+      // Already terminal: report success/failure based on whether insights actually got filled,
+      // rather than refusing because no task is in flight.
+      if (outcome === IMPACT_MEASUREMENT_OUTCOME.SUCCEEDED) {
+        await say(`:white_check_mark: GeoExperiment ${geoExperimentId} for '${baseURL}' has `
+          + 'completed impact measurement — insights are available at '
+          + `\`${geoExperiment.getInsightsLocation()}\`.`);
         return;
       }
 
+      if (outcome === IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS) {
+        await say(`:x: GeoExperiment ${geoExperimentId} for '${baseURL}' completed without insights `
+          + `(phase '${geoExperiment.getPhase()}') — the impact measurement produced no data. `
+          + 'Use trigger-impact-measurement to re-run it.');
+        return;
+      }
+
+      if (outcome === IMPACT_MEASUREMENT_OUTCOME.NOT_APPLICABLE) {
+        await say(`:warning: GeoExperiment ${geoExperimentId} for '${baseURL}' is at phase `
+          + `'${geoExperiment.getPhase()}' / status '${geoExperiment.getStatus()}' — no `
+          + 'impact-measurement task is in flight to check. Use trigger-impact-measurement first '
+          + 'if none is running.');
+        return;
+      }
+
+      // IN_FLIGHT: a task is running — fire the async check and let the engine update the record.
       if (!sqs) {
         await say(':x: Cannot check impact measurement — missing SQS client.');
         return;
@@ -85,7 +103,7 @@ export default function CheckImpactMeasurementCommand(context) {
 
       await say(`:mag: Requested a check of GeoExperiment ${geoExperimentId}'s impact measurement `
         + `('${baseURL}'). If Mystique has finished, the experimentation engine will update it `
-        + 'shortly; otherwise it stays as-is until checked again.');
+        + 'shortly; re-run check-impact-measurement to see the result.');
     } catch (error) {
       log.error(error);
       await postErrorMessage(say, error);

--- a/src/support/slack/commands/get-experiment.js
+++ b/src/support/slack/commands/get-experiment.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveGeoExperiment } from './impact-measurement-helper.js';
+import BaseCommand from './base.js';
+import { extractURLFromSlackInput, postErrorMessage, postSiteNotFoundMessage } from '../../../utils/slack/base.js';
+
+const PHRASES = ['get-experiment'];
+
+const DASH = '—';
+
+// Short value or an em-dash placeholder when absent, so every row stays aligned and readable.
+const orDash = (value) => (value === undefined || value === null || value === '' ? DASH : value);
+
+// One concise, emoji-led summary line per meaningful facet of the experiment.
+function formatExperimentSummary(geoExperiment, baseURL) {
+  const metadata = geoExperiment.getMetadata() || {};
+  const metadataKeys = Object.keys(metadata);
+  const suggestionIds = geoExperiment.getSuggestionIds() || [];
+  const error = geoExperiment.getError();
+
+  const lines = [
+    `:test_tube: *GeoExperiment* \`${geoExperiment.getId()}\` — ${orDash(geoExperiment.getName())}`,
+    `:globe_with_meridians: *Site:* ${baseURL}`,
+    `:label: *Type:* ${orDash(geoExperiment.getType())}`,
+    `:round_pushpin: *Phase:* \`${geoExperiment.getPhase()}\`   :vertical_traffic_light: *Status:* \`${geoExperiment.getStatus()}\``,
+    `:dart: *Opportunity:* ${orDash(geoExperiment.getOpportunityId())}`,
+    `:bar_chart: *Prompts:* ${geoExperiment.getPromptsCount()} · :jigsaw: *Suggestions:* ${suggestionIds.length}`,
+    `:bulb: *Insights:* ${orDash(geoExperiment.getInsightsLocation())}`,
+    `:hourglass: *Window:* ${orDash(geoExperiment.getStartTime())} → ${orDash(geoExperiment.getEndTime())}`,
+    `:calendar: *Created:* ${orDash(geoExperiment.getCreatedAt())} · *Updated:* ${orDash(geoExperiment.getUpdatedAt())} (by ${orDash(geoExperiment.getUpdatedBy())})`,
+    `:card_index_dividers: *Metadata:* ${metadataKeys.length ? metadataKeys.join(', ') : DASH}`,
+  ];
+
+  if (error) {
+    lines.push(`:rotating_light: *Error:* ${error.message || JSON.stringify(error)}`);
+  }
+
+  return lines.join('\n');
+}
+
+// Prints a concise, emoji-led summary of a site's geo-experiment (resolved by domain — most
+// recent — or an optional explicit geoExperimentId) so operators can eyeball its state at a glance.
+export default function GetExperimentCommand(context) {
+  const baseCommand = BaseCommand({
+    id: 'get-experiment',
+    name: 'Get Experiment',
+    description: 'Shows a concise summary of a site\'s geo-experiment and its metadata.',
+    phrases: PHRASES,
+    usageText: `${PHRASES[0]} {baseURL} [geoExperimentId]`,
+  });
+
+  const { dataAccess, log } = context;
+  const { Site, GeoExperiment } = dataAccess;
+
+  const handleExecution = async (args, slackContext) => {
+    const { say } = slackContext;
+
+    try {
+      const [baseURLInput, geoExperimentIdInput] = args;
+      const baseURL = extractURLFromSlackInput(baseURLInput);
+
+      if (!baseURL) {
+        await say(baseCommand.usage());
+        return;
+      }
+
+      const site = await Site.findByBaseURL(baseURL);
+      if (!site) {
+        await postSiteNotFoundMessage(say, baseURL);
+        return;
+      }
+
+      const { geoExperiment, errorMessage } = await resolveGeoExperiment({
+        GeoExperiment, site, baseURL, geoExperimentIdInput,
+      });
+      if (errorMessage) {
+        await say(errorMessage);
+        return;
+      }
+
+      await say(formatExperimentSummary(geoExperiment, baseURL));
+    } catch (error) {
+      log.error(error);
+      await postErrorMessage(say, error);
+    }
+  };
+
+  baseCommand.init(context);
+
+  return {
+    ...baseCommand,
+    handleExecution,
+  };
+}

--- a/src/support/slack/commands/get-experiment.js
+++ b/src/support/slack/commands/get-experiment.js
@@ -34,7 +34,7 @@ function formatExperimentSummary(geoExperiment, baseURL) {
     `:label: *Type:* ${orDash(geoExperiment.getType())}`,
     `:round_pushpin: *Phase:* \`${geoExperiment.getPhase()}\`   :vertical_traffic_light: *Status:* \`${geoExperiment.getStatus()}\``,
     `:dart: *Opportunity:* ${orDash(geoExperiment.getOpportunityId())}`,
-    `:bar_chart: *Prompts:* ${geoExperiment.getPromptsCount()} · :jigsaw: *Suggestions:* ${suggestionIds.length}`,
+    `:bar_chart: *Prompts:* ${orDash(geoExperiment.getPromptsCount())} · :jigsaw: *Suggestions:* ${suggestionIds.length}`,
     `:bulb: *Insights:* ${orDash(geoExperiment.getInsightsLocation())}`,
     `:hourglass: *Window:* ${orDash(geoExperiment.getStartTime())} → ${orDash(geoExperiment.getEndTime())}`,
     `:calendar: *Created:* ${orDash(geoExperiment.getCreatedAt())} · *Updated:* ${orDash(geoExperiment.getUpdatedAt())} (by ${orDash(geoExperiment.getUpdatedBy())})`,
@@ -42,7 +42,10 @@ function formatExperimentSummary(geoExperiment, baseURL) {
   ];
 
   if (error) {
-    lines.push(`:rotating_light: *Error:* ${error.message || JSON.stringify(error)}`);
+    const errorText = typeof error === 'string'
+      ? error
+      : (error.message || JSON.stringify(error));
+    lines.push(`:rotating_light: *Error:* ${errorText}`);
   }
 
   return lines.join('\n');

--- a/test/support/geo-experiment-helper.test.js
+++ b/test/support/geo-experiment-helper.test.js
@@ -19,6 +19,8 @@ import {
   buildExperimentMetadata,
   isImpactMeasurementEligible,
   isImpactMeasurementCheckEligible,
+  getImpactMeasurementOutcome,
+  IMPACT_MEASUREMENT_OUTCOME,
 } from '../../src/support/geo-experiment-helper.js';
 
 const {
@@ -306,6 +308,50 @@ describe('geo-experiment-helper', () => {
         const geoExperiment = { getPhase: () => phase, getStatus: () => STATUSES.COMPLETED };
         expect(isImpactMeasurementCheckEligible(geoExperiment)).to.be.false;
       });
+    });
+  });
+
+  describe('getImpactMeasurementOutcome', () => {
+    const makeGeo = ({ phase, status, insightsLocation }) => ({
+      getPhase: () => phase,
+      getStatus: () => status,
+      getInsightsLocation: () => insightsLocation,
+    });
+
+    it('is IN_FLIGHT at impact_measurement_started', () => {
+      const geo = makeGeo({
+        phase: PHASES.IMPACT_MEASUREMENT_STARTED,
+        status: STATUSES.IN_PROGRESS,
+      });
+      expect(getImpactMeasurementOutcome(geo)).to.equal(IMPACT_MEASUREMENT_OUTCOME.IN_FLIGHT);
+    });
+
+    it('is SUCCEEDED at impact_measurement_done with an insightsLocation', () => {
+      const geo = makeGeo({
+        phase: PHASES.IMPACT_MEASUREMENT_DONE,
+        status: STATUSES.COMPLETED,
+        insightsLocation: 's3://bucket/insights.json',
+      });
+      expect(getImpactMeasurementOutcome(geo)).to.equal(IMPACT_MEASUREMENT_OUTCOME.SUCCEEDED);
+    });
+
+    it('is COMPLETED_WITHOUT_INSIGHTS when COMPLETED with no insightsLocation', () => {
+      const geo = makeGeo({ phase: PHASES.POST_ANALYSIS_DONE, status: STATUSES.COMPLETED });
+      expect(getImpactMeasurementOutcome(geo)).to.equal(
+        IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS,
+      );
+    });
+
+    it('treats impact_measurement_done without an insightsLocation as completed-without-insights', () => {
+      const geo = makeGeo({ phase: PHASES.IMPACT_MEASUREMENT_DONE, status: STATUSES.COMPLETED });
+      expect(getImpactMeasurementOutcome(geo)).to.equal(
+        IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS,
+      );
+    });
+
+    it('is NOT_APPLICABLE for an earlier, non-terminal phase', () => {
+      const geo = makeGeo({ phase: PHASES.PRE_ANALYSIS_STARTED, status: STATUSES.IN_PROGRESS });
+      expect(getImpactMeasurementOutcome(geo)).to.equal(IMPACT_MEASUREMENT_OUTCOME.NOT_APPLICABLE);
     });
   });
 });

--- a/test/support/geo-experiment-helper.test.js
+++ b/test/support/geo-experiment-helper.test.js
@@ -349,6 +349,15 @@ describe('geo-experiment-helper', () => {
       );
     });
 
+    it('reports the outcome by phase even if status is transiently non-COMPLETED at DONE', () => {
+      // Keyed on phase, not status: a mid-update IN_PROGRESS status at IMPACT_MEASUREMENT_DONE
+      // still reports completed-without-insights rather than falling through to NOT_APPLICABLE.
+      const geo = makeGeo({ phase: PHASES.IMPACT_MEASUREMENT_DONE, status: STATUSES.IN_PROGRESS });
+      expect(getImpactMeasurementOutcome(geo)).to.equal(
+        IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS,
+      );
+    });
+
     it('is NOT_APPLICABLE for an earlier, non-terminal phase', () => {
       const geo = makeGeo({ phase: PHASES.PRE_ANALYSIS_STARTED, status: STATUSES.IN_PROGRESS });
       expect(getImpactMeasurementOutcome(geo)).to.equal(IMPACT_MEASUREMENT_OUTCOME.NOT_APPLICABLE);

--- a/test/support/slack/commands/check-impact-measurement.test.js
+++ b/test/support/slack/commands/check-impact-measurement.test.js
@@ -14,6 +14,7 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import esmock from 'esmock';
+import { IMPACT_MEASUREMENT_OUTCOME } from '../../../../src/support/geo-experiment-helper.js';
 
 use(sinonChai);
 
@@ -24,12 +25,14 @@ function mockGeoExperiment({
   phase = 'impact_measurement_started',
   status = 'COMPLETED',
   siteId = 'site-1',
+  insightsLocation,
 } = {}) {
   return {
     getId: () => id,
     getPhase: () => phase,
     getStatus: () => status,
     getSiteId: () => siteId,
+    getInsightsLocation: () => insightsLocation,
   };
 }
 
@@ -43,14 +46,14 @@ describe('CheckImpactMeasurementCommand', () => {
   let postErrorMessageStub;
   let postSiteNotFoundMessageStub;
   let checkGeoExperimentImpactMeasurementStub;
-  let isImpactMeasurementCheckEligibleStub;
+  let getImpactMeasurementOutcomeStub;
 
   beforeEach(async () => {
     extractURLFromSlackInputStub = sinon.stub();
     postErrorMessageStub = sinon.stub().resolves();
     postSiteNotFoundMessageStub = sinon.stub().resolves();
     checkGeoExperimentImpactMeasurementStub = sinon.stub().resolves();
-    isImpactMeasurementCheckEligibleStub = sinon.stub().returns(true);
+    getImpactMeasurementOutcomeStub = sinon.stub().returns(IMPACT_MEASUREMENT_OUTCOME.IN_FLIGHT);
 
     CheckImpactMeasurementCommand = (await esmock(
       '../../../../src/support/slack/commands/check-impact-measurement.js',
@@ -64,7 +67,8 @@ describe('CheckImpactMeasurementCommand', () => {
           checkGeoExperimentImpactMeasurement: checkGeoExperimentImpactMeasurementStub,
         },
         '../../../../src/support/geo-experiment-helper.js': {
-          isImpactMeasurementCheckEligible: isImpactMeasurementCheckEligibleStub,
+          getImpactMeasurementOutcome: getImpactMeasurementOutcomeStub,
+          IMPACT_MEASUREMENT_OUTCOME,
         },
       },
     )).default;
@@ -133,18 +137,52 @@ describe('CheckImpactMeasurementCommand', () => {
     );
   });
 
-  it('warns and does not check when the experiment is not eligible', async () => {
+  it('reports success with the insights location when measurement has completed', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const geo = mockGeoExperiment({
+      phase: 'impact_measurement_done',
+      status: 'COMPLETED',
+      insightsLocation: 's3://bucket/geo-experiments/geo-exp-1/insights.json',
+    });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [geo] });
+    getImpactMeasurementOutcomeStub.returns(IMPACT_MEASUREMENT_OUTCOME.SUCCEEDED);
+    const command = CheckImpactMeasurementCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    expect(slackContext.say.firstCall.args[0]).to.include(':white_check_mark:');
+    expect(slackContext.say.firstCall.args[0]).to.include('s3://bucket/geo-experiments/geo-exp-1/insights.json');
+    expect(checkGeoExperimentImpactMeasurementStub).to.not.have.been.called;
+  });
+
+  it('reports a completed-without-insights failure and suggests re-triggering', async () => {
     extractURLFromSlackInputStub.returns('https://example.com');
     dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
     const geo = mockGeoExperiment({ phase: 'post_analysis_done', status: 'COMPLETED' });
     dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [geo] });
-    isImpactMeasurementCheckEligibleStub.returns(false);
+    getImpactMeasurementOutcomeStub.returns(IMPACT_MEASUREMENT_OUTCOME.COMPLETED_WITHOUT_INSIGHTS);
+    const command = CheckImpactMeasurementCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    expect(slackContext.say.firstCall.args[0]).to.include('without insights');
+    expect(slackContext.say.firstCall.args[0]).to.include('trigger-impact-measurement');
+    expect(checkGeoExperimentImpactMeasurementStub).to.not.have.been.called;
+  });
+
+  it('warns and does not check when no task is in flight and nothing has been measured', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const geo = mockGeoExperiment({ phase: 'pre_analysis_done', status: 'IN_PROGRESS' });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [geo] });
+    getImpactMeasurementOutcomeStub.returns(IMPACT_MEASUREMENT_OUTCOME.NOT_APPLICABLE);
     const command = CheckImpactMeasurementCommand(context);
 
     await command.handleExecution(['example.com'], slackContext);
 
     expect(slackContext.say.firstCall.args[0]).to.include('geo-exp-1');
-    expect(slackContext.say.firstCall.args[0]).to.include('post_analysis_done');
+    expect(slackContext.say.firstCall.args[0]).to.include('pre_analysis_done');
     expect(checkGeoExperimentImpactMeasurementStub).to.not.have.been.called;
   });
 

--- a/test/support/slack/commands/get-experiment.test.js
+++ b/test/support/slack/commands/get-experiment.test.js
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+const VALID_GEO_EXP_ID = '11111111-1111-4111-8111-111111111111';
+
+function mockGeoExperiment(overrides = {}) {
+  const base = {
+    id: 'geo-exp-1',
+    name: 'Recover content visibility',
+    type: 'onsite_opportunity_deployment',
+    phase: 'impact_measurement_done',
+    status: 'COMPLETED',
+    siteId: 'site-1',
+    opportunityId: 'opp-1',
+    promptsCount: 12,
+    suggestionIds: ['sug-1', 'sug-2'],
+    insightsLocation: 's3://bucket/geo-experiments/geo-exp-1/insights.json',
+    startTime: '2026-08-01T00:00:00.000Z',
+    endTime: '2026-08-15T00:00:00.000Z',
+    createdAt: '2026-07-31T00:00:00.000Z',
+    updatedAt: '2026-09-03T00:00:00.000Z',
+    updatedBy: 'U01USER',
+    metadata: { urls: ['https://example.com'], impactMeasurementTaskId: 'task-1' },
+    error: undefined,
+    ...overrides,
+  };
+  return {
+    getId: () => base.id,
+    getName: () => base.name,
+    getType: () => base.type,
+    getPhase: () => base.phase,
+    getStatus: () => base.status,
+    getSiteId: () => base.siteId,
+    getOpportunityId: () => base.opportunityId,
+    getPromptsCount: () => base.promptsCount,
+    getSuggestionIds: () => base.suggestionIds,
+    getInsightsLocation: () => base.insightsLocation,
+    getStartTime: () => base.startTime,
+    getEndTime: () => base.endTime,
+    getCreatedAt: () => base.createdAt,
+    getUpdatedAt: () => base.updatedAt,
+    getUpdatedBy: () => base.updatedBy,
+    getMetadata: () => base.metadata,
+    getError: () => base.error,
+  };
+}
+
+describe('GetExperimentCommand', () => {
+  let GetExperimentCommand;
+  let context;
+  let slackContext;
+  let dataAccessStub;
+  let extractURLFromSlackInputStub;
+  let postErrorMessageStub;
+  let postSiteNotFoundMessageStub;
+
+  beforeEach(async () => {
+    extractURLFromSlackInputStub = sinon.stub();
+    postErrorMessageStub = sinon.stub().resolves();
+    postSiteNotFoundMessageStub = sinon.stub().resolves();
+
+    GetExperimentCommand = (await esmock(
+      '../../../../src/support/slack/commands/get-experiment.js',
+      {
+        '../../../../src/utils/slack/base.js': {
+          extractURLFromSlackInput: extractURLFromSlackInputStub,
+          postErrorMessage: postErrorMessageStub,
+          postSiteNotFoundMessage: postSiteNotFoundMessageStub,
+        },
+      },
+    )).default;
+
+    dataAccessStub = {
+      Site: { findByBaseURL: sinon.stub() },
+      GeoExperiment: { allBySiteId: sinon.stub(), findById: sinon.stub() },
+    };
+
+    context = {
+      dataAccess: dataAccessStub,
+      env: {},
+      log: { error: sinon.spy() },
+    };
+
+    slackContext = {
+      say: sinon.stub().resolves(),
+      channelId: 'C123',
+      user: 'U01USER',
+    };
+  });
+
+  it('initializes with base command metadata', () => {
+    const command = GetExperimentCommand(context);
+    expect(command.id).to.equal('get-experiment');
+    expect(command.name).to.equal('Get Experiment');
+    expect(command.phrases).to.deep.equal(['get-experiment']);
+  });
+
+  it('shows usage when baseURL is missing/invalid', async () => {
+    extractURLFromSlackInputStub.returns(null);
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution([], slackContext);
+
+    expect(slackContext.say).to.have.been.calledOnceWith(command.usage());
+  });
+
+  it('notifies when site is not found', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves(null);
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    expect(postSiteNotFoundMessageStub).to.have.been.calledOnceWith(
+      slackContext.say,
+      'https://example.com',
+    );
+  });
+
+  it('notifies when the site has no geo-experiments', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [] });
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    expect(slackContext.say).to.have.been.calledOnceWith(
+      ":x: No geo-experiments found for 'https://example.com'.",
+    );
+  });
+
+  it('renders a concise emoji summary of the most recent experiment', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const latest = mockGeoExperiment({ id: 'geo-exp-latest' });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [latest, mockGeoExperiment()] });
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    const msg = slackContext.say.firstCall.args[0];
+    expect(msg).to.include(':test_tube:');
+    expect(msg).to.include('geo-exp-latest');
+    expect(msg).to.include('https://example.com');
+    expect(msg).to.include('onsite_opportunity_deployment');
+    expect(msg).to.include('impact_measurement_done');
+    expect(msg).to.include('COMPLETED');
+    expect(msg).to.include('insights.json');
+    expect(msg).to.include(':jigsaw:');
+    // metadata top-level keys are listed, not dumped
+    expect(msg).to.include('urls, impactMeasurementTaskId');
+  });
+
+  it('renders em-dash placeholders and an error line when fields are absent', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const geo = mockGeoExperiment({
+      name: undefined,
+      opportunityId: undefined,
+      insightsLocation: undefined,
+      startTime: undefined,
+      endTime: undefined,
+      updatedBy: undefined,
+      suggestionIds: undefined,
+      metadata: undefined,
+      error: { message: 'measurement failed' },
+    });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [geo] });
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    const msg = slackContext.say.firstCall.args[0];
+    expect(msg).to.include('—');
+    expect(msg).to.include(':rotating_light:');
+    expect(msg).to.include('measurement failed');
+    expect(msg).to.include(':jigsaw: *Suggestions:* 0');
+  });
+
+  it('stringifies a non-message error object on the error line', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const geo = mockGeoExperiment({ error: { code: 'E_MYSTIQUE' } });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [geo] });
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    expect(slackContext.say.firstCall.args[0]).to.include('E_MYSTIQUE');
+  });
+
+  it('resolves an explicitly supplied geoExperimentId', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    dataAccessStub.GeoExperiment.findById.resolves(
+      mockGeoExperiment({ id: VALID_GEO_EXP_ID, siteId: 'site-1' }),
+    );
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com', VALID_GEO_EXP_ID], slackContext);
+
+    expect(dataAccessStub.GeoExperiment.findById).to.have.been.calledOnceWith(VALID_GEO_EXP_ID);
+    expect(dataAccessStub.GeoExperiment.allBySiteId).to.not.have.been.called;
+    expect(slackContext.say.firstCall.args[0]).to.include(VALID_GEO_EXP_ID);
+  });
+
+  it('rejects an invalid geoExperimentId', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com', 'not-a-uuid'], slackContext);
+
+    expect(slackContext.say.firstCall.args[0]).to.include('not a valid geo-experiment id');
+    expect(dataAccessStub.GeoExperiment.findById).to.not.have.been.called;
+  });
+
+  it('logs and posts an error message when an exception occurs', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.rejects(new Error('boom'));
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    expect(context.log.error).to.have.been.calledOnce;
+    expect(postErrorMessageStub).to.have.been.calledOnce;
+  });
+});

--- a/test/support/slack/commands/get-experiment.test.js
+++ b/test/support/slack/commands/get-experiment.test.js
@@ -206,6 +206,33 @@ describe('GetExperimentCommand', () => {
     expect(slackContext.say.firstCall.args[0]).to.include('E_MYSTIQUE');
   });
 
+  it('renders a plain-string error without extra quoting', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const geo = mockGeoExperiment({ error: 'measurement failed' });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [geo] });
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    expect(slackContext.say.firstCall.args[0]).to.include(':rotating_light: *Error:* measurement failed');
+  });
+
+  it('renders an em-dash for a missing prompts count instead of "null"/"undefined"', async () => {
+    extractURLFromSlackInputStub.returns('https://example.com');
+    dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });
+    const geo = mockGeoExperiment({ promptsCount: undefined });
+    dataAccessStub.GeoExperiment.allBySiteId.resolves({ data: [geo] });
+    const command = GetExperimentCommand(context);
+
+    await command.handleExecution(['example.com'], slackContext);
+
+    const msg = slackContext.say.firstCall.args[0];
+    expect(msg).to.include(':bar_chart: *Prompts:* —');
+    expect(msg).to.not.include('*Prompts:* undefined');
+    expect(msg).to.not.include('*Prompts:* null');
+  });
+
   it('resolves an explicitly supplied geoExperimentId', async () => {
     extractURLFromSlackInputStub.returns('https://example.com');
     dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-1' });


### PR DESCRIPTION
## Summary
Two geo-experiment Slack UX improvements, both branched from latest `main` (after #3170 merged):

1. **`check-impact-measurement` now reports success/failure based on whether data got filled**, instead of blindly refusing once no Mystique task is in flight. New `getImpactMeasurementOutcome()` helper classifies the experiment's current state:
   - `IN_FLIGHT` (phase `impact_measurement_started`) → fires the async check as before.
   - `SUCCEEDED` (phase `impact_measurement_done` + `insightsLocation`) → :white_check_mark: reports the insights location.
   - `COMPLETED_WITHOUT_INSIGHTS` (COMPLETED, no `insightsLocation`) → :x: reports the failure and suggests re-triggering.
   - `NOT_APPLICABLE` (any earlier state) → :warning: nothing in flight to check.

   Motivation: an operator running `check` after a run got a fire-and-forget ":mag: requested…" then a ":warning: … a check only makes sense at impact_measurement_started" — never a clear "did it work?". Now the second check reports the actual outcome. (The command is still async over SQS — it reports the last-known persisted state, which is what the operator wants.)

2. **New `get-experiment` Slack command** — `get-experiment {baseURL} [geoExperimentId]` prints a concise, emoji-led summary of a site's geo-experiment (resolved by domain → most recent, or an explicit id): id/name, site, type, phase/status, opportunity, prompts/suggestions counts, insights location, window, created/updated, and metadata top-level keys (+ an error line when present).

## Test plan
- [x] `npm run lint` — clean
- [x] New/updated unit tests: `get-experiment.test.js` (new), `check-impact-measurement.test.js` (rewritten for the outcome branches), `geo-experiment-helper.test.js` (new `getImpactMeasurementOutcome` cases) — 59 passing
- [x] Coverage: `check-impact-measurement.js` and `get-experiment.js` at 100%; `getImpactMeasurementOutcome` 100% branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Internal Slack operator-tooling improvements (outcome reporting + a new read-only summary command); no data writes beyond existing behavior, fully reversible."
```