### PR TITLE
feat(referral-traffic): thread urlPathPrefix through referral endpoints (LLMO-7315)

### DIFF
--- a/docs/openapi/llmo-api.yaml
+++ b/docs/openapi/llmo-api.yaml
@@ -5429,6 +5429,7 @@ llmo-referral-traffic-filter-dimensions:
       range. Queries `rpc_referral_traffic_filter_dimensions`.
     operationId: getReferralTrafficFilterDimensions
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5464,6 +5465,7 @@ llmo-referral-traffic-kpis:
       sources; meaningful for `optel` / `ga4`.
     operationId: getReferralTrafficKpis
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5504,6 +5506,7 @@ llmo-referral-traffic-trend:
       `cja` sources; null for `optel` / `cdn`.
     operationId: getReferralTrafficTrend
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5543,6 +5546,7 @@ llmo-referral-traffic-by-platform:
       and `orders` are null for `optel` / `cdn` sources.
     operationId: getReferralTrafficByPlatform
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5579,6 +5583,7 @@ llmo-referral-traffic-by-region:
     description: Queries `rpc_referral_traffic_by_region`. Returns rows ordered by pageviews descending.
     operationId: getReferralTrafficByRegion
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5615,6 +5620,7 @@ llmo-referral-traffic-by-page-intent:
     description: Queries `rpc_referral_traffic_by_page_intent`. Returns rows ordered by pageviews descending.
     operationId: getReferralTrafficByPageIntent
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5659,6 +5665,7 @@ llmo-referral-traffic-by-url:
       28-day window.
     operationId: getReferralTrafficByUrl
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5785,6 +5792,7 @@ llmo-referral-traffic-by-device:
       sources.
     operationId: getReferralTrafficByDevice
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficSource' }
@@ -5831,6 +5839,7 @@ llmo-referral-traffic-business-impact:
       28-day window.
     operationId: getReferralTrafficBusinessImpact
     parameters:
+      - $ref: './parameters.yaml#/referralUrlPathPrefix'
       - name: source
         in: query
         schema: { $ref: './schemas.yaml#/ReferralTrafficBusinessImpactSource' }

--- a/docs/openapi/parameters.yaml
+++ b/docs/openapi/parameters.yaml
@@ -563,3 +563,19 @@ fields:
   schema:
     type: string
     example: 'id,baseURL,name'
+referralUrlPathPrefix:
+  name: urlPathPrefix
+  in: query
+  required: false
+  description: >-
+    Optional URL-path prefix that scopes a domain's referral data to a single
+    sub-path (e.g. `/knicks` returns the `/knicks` page and everything beneath
+    it). Used to show referral insights for a sub-path site that inherits its
+    domain-root site's configuration. A leading slash is added if missing and
+    trailing slashes are stripped; an empty value or `/` means no filter (whole
+    site). Snake-case alias: `url_path_prefix`. Not accepted by `has-data`,
+    `by-url-trend`, or `weeks`.
+  schema:
+    type: string
+    maxLength: 512
+    example: '/knicks'

--- a/src/controllers/llmo/llmo-referral-traffic.js
+++ b/src/controllers/llmo/llmo-referral-traffic.js
@@ -99,6 +99,46 @@ function defaultDateRange() {
   };
 }
 
+// Upper bound for a url-path-prefix filter value; longer input is treated as no
+// filter (defense-in-depth, mirrored by `maxLength` on the OpenAPI parameter).
+const MAX_URL_PATH_PREFIX_LENGTH = 512;
+
+/**
+ * Normalize the optional url-path-prefix filter (LLMO-7315).
+ *
+ * A prefix scopes a domain's referral data to a sub-path (e.g. '/knicks').
+ * Empty string, '/', or absent means NO filter (unchanged behavior).
+ * Otherwise the value is trimmed, forced to start with '/', and has all
+ * trailing '/' stripped so '/knicks', '/knicks/' and '/knicks///' resolve
+ * identically. A value that is only slashes (e.g. '/' or '//') collapses to
+ * empty and means "no filter".
+ *
+ * A repeated query param (parsed into an array) is ignored (treated as no
+ * filter) rather than coerced into a nonsense comma-joined value.
+ *
+ * @param {string|null|undefined} raw - Raw query value.
+ * @returns {string|null} Normalized prefix, or null when no filter applies.
+ */
+function normalizeUrlPathPrefix(raw) {
+  if (raw == null || Array.isArray(raw)) {
+    return null;
+  }
+  let prefix = String(raw).trim().replace(/\/+$/, '');
+  if (prefix === '') {
+    return null;
+  }
+  if (!prefix.startsWith('/')) {
+    prefix = `/${prefix}`;
+  }
+  // Defense-in-depth: ignore absurdly long values (not an injection risk — the value
+  // is only ever a bound RPC/PostgREST param — but caps memory abuse). A real path
+  // prefix is short; anything over the cap is treated as no filter.
+  if (prefix.length > MAX_URL_PATH_PREFIX_LENGTH) {
+    return null;
+  }
+  return prefix;
+}
+
 /**
  * Parse common referral-traffic query params from context.data.
  * Supports camelCase and snake_case aliases.
@@ -117,6 +157,7 @@ function parseParams(context) {
     pageIntent: q.pageIntent || q.page_intent || null,
     deviceType: q.deviceType || q.device_type || q.device || null,
     category: q.categoryName || q.category_name || null,
+    urlPathPrefix: normalizeUrlPathPrefix(q.urlPathPrefix || q.url_path_prefix || null),
   };
 }
 
@@ -134,6 +175,8 @@ function commonRpcParams(siteId, parsed) {
     p_device: parsed.deviceType,
     p_page_intent: parsed.pageIntent,
     p_category_name: parsed.category,
+    // LLMO-7315: optional url-path-prefix scope; null = no filter (unchanged).
+    p_url_path_prefix: parsed.urlPathPrefix,
   };
 }
 
@@ -208,6 +251,8 @@ export function createReferralTrafficFilterDimensionsHandler(getSiteAndValidateA
           p_source: parsed.source,
           p_start_date: parsed.startDate,
           p_end_date: parsed.endDate,
+          // LLMO-7315: optional url-path-prefix scope; null = no filter.
+          p_url_path_prefix: parsed.urlPathPrefix,
         });
 
         if (error) {
@@ -589,6 +634,11 @@ export function createReferralTrafficWeeksHandler(getSiteAndValidateAccess) {
         const source = VALID_SOURCES.has(rawSource) ? rawSource : DEFAULT_SOURCE;
         const tableName = SOURCE_TO_TABLE[source];
 
+        // LLMO-7315: /weeks is intentionally NOT url-path-prefix scoped. The week
+        // picker reflects the domain's data availability; the dashboard scopes it
+        // to a sub-path by querying the domain-root siteId (which owns the ingested
+        // rows), so a plain site_id read is correct here and avoids per-source
+        // PostgREST filter-string escaping.
         const rot = rotationCtx(siteId);
         if (rot.rotate) {
           // Rotation: the window is a pure function of now(); we only need to
@@ -705,8 +755,14 @@ export function createReferralTrafficUrlTrendHandler(getSiteAndValidateAccess) {
 
         const parsed = parseParams(ctx);
 
+        // LLMO-7315: rpc_referral_traffic_url_trend does an EXACT url_path match and is
+        // intentionally NOT given p_url_path_prefix. PostgREST resolves an RPC by its
+        // exact argument-name set, so passing an unknown p_url_path_prefix key would
+        // fail to match the function (PGRST202). Omit it via destructuring so the
+        // exclusion is visible at the call site.
+        const { p_url_path_prefix: _, ...urlTrendParams } = commonRpcParams(siteId, parsed);
         const { data, error } = await client.rpc('rpc_referral_traffic_url_trend', {
-          ...commonRpcParams(siteId, parsed),
+          ...urlTrendParams,
           p_url_path: urlPath,
         });
 
@@ -824,6 +880,10 @@ export function createReferralTrafficHasDataHandler(getSiteAndValidateAccess) {
           const lookback = new Date(Date.now() - HAS_DATA_LOOKBACK_DAYS * 86400000)
             .toISOString()
             .slice(0, 10);
+          // LLMO-7315: has-data is deliberately NOT scoped by urlPathPrefix. The
+          // UI calls has-data on the domain-ROOT siteId (no prefix) so a sub-path
+          // view inherits the domain's "configured" verdict; keying this probe on
+          // site_id only keeps that inheritance intact.
           results = await Promise.all(
             REFERRAL_HAS_DATA_TABLES.map((table) => client
               .from(table)

--- a/test/controllers/llmo/llmo-referral-traffic.test.js
+++ b/test/controllers/llmo/llmo-referral-traffic.test.js
@@ -51,6 +51,7 @@ function makeWeeksChainClient(
   const chain = {
     select: sinon.stub().returnsThis(),
     eq: sinon.stub().returnsThis(),
+    or: sinon.stub().returnsThis(),
     order: sinon.stub().returnsThis(),
     limit: sinon.stub()
       .onFirstCall().resolves(minResult)
@@ -249,6 +250,68 @@ describe('llmo-referral-traffic', () => {
     });
   });
 
+  // ── urlPathPrefix parsing / normalization (LLMO-7315) ─────────────────────
+  // Exercised through the kpis handler because parseParams + commonRpcParams are
+  // shared by every RPC endpoint, so p_url_path_prefix threading is proven once.
+
+  describe('urlPathPrefix (LLMO-7315)', () => {
+    const kpisPrefix = async (data) => {
+      const client = makeRpcClient({ data: [] });
+      await createReferralTrafficKpisHandler(stubbedValidateAccess)(makeContext({ client, data }));
+      return client.rpc.getCall(0).args[1].p_url_path_prefix;
+    };
+
+    it('threads a normalized prefix into commonRpcParams as p_url_path_prefix', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: '/knicks' })).to.equal('/knicks');
+    });
+
+    it('prepends a missing leading slash', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: 'knicks' })).to.equal('/knicks');
+    });
+
+    it('strips all trailing slashes', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: '/knicks/' })).to.equal('/knicks');
+      expect(await kpisPrefix({ urlPathPrefix: '/knicks///' })).to.equal('/knicks');
+    });
+
+    it('trims surrounding whitespace', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: '  /knicks  ' })).to.equal('/knicks');
+    });
+
+    it('treats an empty string as no filter (null)', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: '' })).to.equal(null);
+    });
+
+    it('treats "/" as no filter (null)', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: '/' })).to.equal(null);
+    });
+
+    it('treats a slashes-only value ("//") as no filter (null)', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: '//' })).to.equal(null);
+    });
+
+    it('ignores a repeated (array) param as no filter (null)', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: ['/knicks', '/nets'] })).to.equal(null);
+    });
+
+    it('ignores an over-long value as no filter (null)', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: `/${'a'.repeat(600)}` })).to.equal(null);
+    });
+
+    it('defaults to null when the param is absent', async () => {
+      expect(await kpisPrefix({})).to.equal(null);
+    });
+
+    it('accepts the url_path_prefix snake_case alias', async () => {
+      expect(await kpisPrefix({ url_path_prefix: '/knicks' })).to.equal('/knicks');
+    });
+
+    it('prefers urlPathPrefix over the snake_case alias', async () => {
+      expect(await kpisPrefix({ urlPathPrefix: '/nets', url_path_prefix: '/knicks' }))
+        .to.equal('/nets');
+    });
+  });
+
   // ── /filter-dimensions ────────────────────────────────────────────────────
 
   describe('filter-dimensions', () => {
@@ -283,6 +346,20 @@ describe('llmo-referral-traffic', () => {
       expect(body.platforms).to.deep.equal([]);
       expect(body.availableSources).to.deep.equal([]);
       expect(body.categories).to.deep.equal([]);
+    });
+
+    it('forwards p_url_path_prefix to the filter-dimensions RPC (LLMO-7315)', async () => {
+      const client = makeRpcClient({ data: [], error: null });
+      const handler = createReferralTrafficFilterDimensionsHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { urlPathPrefix: '/knicks' } }));
+      expect(client.rpc.getCall(0).args[1].p_url_path_prefix).to.equal('/knicks');
+    });
+
+    it('passes p_url_path_prefix=null when no prefix is given (LLMO-7315)', async () => {
+      const client = makeRpcClient({ data: [], error: null });
+      const handler = createReferralTrafficFilterDimensionsHandler(stubbedValidateAccess);
+      await handler(makeContext({ client }));
+      expect(client.rpc.getCall(0).args[1].p_url_path_prefix).to.equal(null);
     });
 
     it('returns 500 on PostgREST error', async () => {
@@ -665,6 +742,19 @@ describe('llmo-referral-traffic', () => {
       expect(client.rpc.getCall(0).args[1].p_url_search).to.equal('blog');
     });
 
+    it('forwards p_url_path_prefix alongside p_url_search (LLMO-7315)', async () => {
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficByUrlHandler(stubbedValidateAccess);
+      await handler(makeContext({
+        client,
+        data: { urlPathSearch: 'blog', urlPathPrefix: '/knicks' },
+      }));
+      const rpcArgs = client.rpc.getCall(0).args[1];
+      // Both filters can be set at once; neither clobbers the other.
+      expect(rpcArgs.p_url_search).to.equal('blog');
+      expect(rpcArgs.p_url_path_prefix).to.equal('/knicks');
+    });
+
     it('clamps pageSize above the max', async () => {
       const client = makeRpcClient({ data: [] });
       const handler = createReferralTrafficByUrlHandler(stubbedValidateAccess);
@@ -859,6 +949,15 @@ describe('llmo-referral-traffic', () => {
       expect(rpcArgs.p_start_date).to.equal('2026-01-01');
       expect(rpcArgs.p_end_date).to.equal('2026-01-28');
       expect(rpcArgs.p_platform).to.equal('openai');
+    });
+
+    it('does NOT forward p_url_path_prefix to rpc_referral_traffic_url_trend (LLMO-7315)', async () => {
+      // url_trend does an exact url_path match; the RPC has no p_url_path_prefix
+      // param, so passing one would fail PostgREST overload resolution (PGRST202).
+      const client = makeRpcClient({ data: [] });
+      const handler = createReferralTrafficUrlTrendHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { urlPath: '/blog', urlPathPrefix: '/knicks' } }));
+      expect(client.rpc.getCall(0).args[1]).to.not.have.property('p_url_path_prefix');
     });
 
     it('uses {} when context.data is null', async () => {
@@ -1090,6 +1189,19 @@ describe('llmo-referral-traffic', () => {
       const handler = createReferralTrafficWeeksHandler(stubbedValidateAccess);
       await handler(makeContext({ client }));
       expect(client.from.calledWith('referral_traffic_optel')).to.be.true;
+    });
+
+    it('does not url-path-prefix scope the weeks read even when a prefix is given (LLMO-7315)', async () => {
+      // /weeks is intentionally domain-level: the dashboard scopes the picker to a
+      // sub-path by passing the domain-root siteId, so no PostgREST .or() filter is
+      // applied here (avoids per-source filter-string escaping).
+      const client = makeWeeksChainClient(
+        { data: [{ traffic_date: '2026-01-05' }], error: null },
+        { data: [{ traffic_date: '2026-01-12' }], error: null },
+      );
+      const handler = createReferralTrafficWeeksHandler(stubbedValidateAccess);
+      await handler(makeContext({ client, data: { urlPathPrefix: '/knicks' } }));
+      expect(client.chain.or).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Threads an optional `urlPathPrefix` query parameter through the site-scoped referral-traffic endpoints down to the mysticat PostgREST RPCs, so a domain's referral data can be scoped to a single sub-path.

## 2. Reasoning
A sub-path site (e.g. `nba.com/knicks`) is its own SpaceCat Site whose referral data lives under the domain-root site, so selecting it surfaces the "configure CDN logs / connect analytics" onboarding prompt. This PR is the API layer of the cross-repo fix: it lets the UI query the domain-root site and scope the aggregates to the sub-path. Reported by Meryll Blanchet (Slack, 2026-09-01).

## 3. High-level overview of the changes
In `src/controllers/llmo/llmo-referral-traffic.js`:

- Parses a new `urlPathPrefix` query param (snake-case alias `url_path_prefix`), normalized: trimmed, leading slash enforced, all trailing slashes stripped; empty / `/` / a slashes-only value / a repeated (array) param all resolve to "no filter".
- Threads it into the shared RPC params as `p_url_path_prefix`, so it reaches `kpis`, `trend`, `by-platform`, `by-device`, `by-region`, `by-page-intent`, `by-url`, `business-impact`, and `filter-dimensions`.
- **`has-data` intentionally does NOT receive the prefix** — the UI calls `has-data` on the domain-root site id so a sub-path inherits the domain's "configured" verdict (and does not re-prompt for onboarding).
- **`by-url-trend` intentionally strips the prefix** — that RPC does an exact `url_path` match and has no such parameter; passing it would fail PostgREST overload resolution and break the endpoint.
- `weeks` stays domain-level (no prefix filter); the UI scopes the week picker by querying the domain-root site id.
- OpenAPI: adds a shared `urlPathPrefix` query parameter to the nine affected referral path definitions.

## 4. Required information
- Jira / issue: [LLMO-7315](https://jira.corp.adobe.com/browse/LLMO-7315) (Referral Traffic epic LLMO-649; relates to LLMO-7138 and LLMO-7247)
- Other: [mysticat-data-service PR (RPC parameter)](https://github.com/adobe/mysticat-data-service/pull/1008); reported on Slack by Meryll Blanchet (2026-09-01)

## 5. Affected / used mysticat-workspace projects
- mysticat-data-service — provides the `p_url_path_prefix` RPC parameter this PR sends; must ship first (contract).
- project-elmo-ui — sends the `url_path_prefix` query param and resolves the sub-path to its domain-root site (contract).

## 7. Test plan
- Unit coverage added for prefix normalization (empty / `/` / slashes-only / missing leading slash / multiple trailing slashes / repeated array param), for threading `p_url_path_prefix` into the RPC calls and the filter-dimensions call, for the deliberate exclusion from the `by-url-trend` RPC call, and for `weeks` staying unscoped.
- dev / stage / prod (after the mysticat-data-service migration is deployed): `GET /sites/<domain-root siteId>/referral-traffic/kpis?urlPathPrefix=/<subpath>` returns metrics scoped to the sub-path; the same call without `urlPathPrefix` is unchanged; `GET .../referral-traffic/by-url-trend?urlPath=/<page>` still returns 200 (regression guard for the exact-match RPC).

## 8. Deployment & merge order
Part of a coordinated three-PR change on branch `cwisse/LLMO-7315-referral-subpath-scoping`:
- [mysticat-data-service PR](https://github.com/adobe/mysticat-data-service/pull/1008) — depends-on; must deploy first (adds `p_url_path_prefix` to the RPCs). Deploying this API PR first would break the referral endpoints, since PostgREST cannot resolve the extra RPC argument until the migration lands.
- project-elmo-ui PR — related; consumes this endpoint contract and deploys after this PR.

Order to merge and deploy: mysticat-data-service → spacecat-api-service (this PR) → project-elmo-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "New optional query param threaded to RPCs with normalization and unit coverage; calls without the param are unchanged, fully backward compatible."
```