### PR TITLE
fix: honor admin organizationId override on FACS access-mapping reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l tarunsingh --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "build:worker": "hedy -v --test-bundle --entryFile=src/serenity-prompt-classification/index.js --name=spacecat-services/serenity-job-runner",
     "deploy:worker": "hedy -v --deploy --entryFile=src/serenity-prompt-classification/index.js --name=spacecat-services/serenity-job-runner --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest -p AWS_ENV=prod",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l tarunsingh --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=latest$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "build:worker": "hedy -v --test-bundle --entryFile=src/serenity-prompt-classification/index.js --name=spacecat-services/serenity-job-runner",
     "deploy:worker": "hedy -v --deploy --entryFile=src/serenity-prompt-classification/index.js --name=spacecat-services/serenity-job-runner --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest -p AWS_ENV=prod",

--- a/src/controllers/state-access-mappings.js
+++ b/src/controllers/state-access-mappings.js
@@ -388,6 +388,54 @@ function StateAccessMappingsController(context) {
   }
 
   /**
+   * Admin-only tenant-scope override for read endpoints.
+   *
+   * FACS reads are scoped to the caller's own IMS org (`preamble` resolves it
+   * from the JWT tenant claim), so an internal admin previewing the customer
+   * ASO UI with `?organizationId=<uuid>` would otherwise query their OWN org's
+   * bindings and see nothing — unlike every other resource-addressed endpoint,
+   * which honours the preview org. This lets an admin (and only an admin) point
+   * the scope at the previewed org, mirroring the org-resolution already used by
+   * `adminCreateMapping` (org from input) and `getAuditLogs` (org from param).
+   *
+   * Non-admins always stay caller-scoped: the `organizationId` param is ignored
+   * for them, preserving tenant isolation.
+   *
+   * @param {object} ctx
+   * @param {string} callerImsOrgId Canonical caller org id from `preamble`.
+   * @returns {Promise<{ imsOrgId: string } | { error: Response }>}
+   */
+  async function resolveScopeImsOrgId(ctx, callerImsOrgId) {
+    if (!ctx.attributes?.authInfo?.isAdmin?.()) {
+      return { imsOrgId: callerImsOrgId };
+    }
+    const { organizationId } = getQueryParams(ctx);
+    if (!hasText(organizationId)) {
+      return { imsOrgId: callerImsOrgId };
+    }
+    if (!isValidUUID(organizationId)) {
+      return { error: badRequest('organizationId must be a valid UUID') };
+    }
+    try {
+      const org = await ctx.dataAccess.Organization.findById(organizationId);
+      if (!org) {
+        return { error: notFound('Organization not found') };
+      }
+      const orgImsOrgId = normalizeImsOrgId(org.getImsOrgId?.());
+      if (!orgImsOrgId) {
+        return { error: notFound('Organization has no IMS org') };
+      }
+      return { imsOrgId: orgImsOrgId };
+    } catch (error) {
+      log.error(
+        { tag: 'state-access-mappings', err: error.message, organizationId },
+        'Failed to resolve organization for scope override',
+      );
+      return { error: internalServerError('Failed to resolve organization') };
+    }
+  }
+
+  /**
    * True when the caller holds `<product>/can_manage_users` at the **FACS (JWT)**
    * layer (or is admin). This is the *strong* form of management authority: only
    * a FACS-layer manager may grant `can_manage_users` itself (hybrid-model §8.3 —
@@ -772,7 +820,12 @@ function StateAccessMappingsController(context) {
     if (pre.error) {
       return pre.error;
     }
-    const { product, imsOrgId } = pre;
+    const { product } = pre;
+    const scoped = await resolveScopeImsOrgId(ctx, pre.imsOrgId);
+    if (scoped.error) {
+      return scoped.error;
+    }
+    const { imsOrgId } = scoped;
     const { error: gateErr, authority } = await gateManager(ctx, product, imsOrgId);
     if (gateErr) {
       return gateErr;
@@ -828,7 +881,12 @@ function StateAccessMappingsController(context) {
     if (pre.error) {
       return pre.error;
     }
-    const { product, imsOrgId } = pre;
+    const { product } = pre;
+    const scoped = await resolveScopeImsOrgId(ctx, pre.imsOrgId);
+    if (scoped.error) {
+      return scoped.error;
+    }
+    const { imsOrgId } = scoped;
     const { error: gateErr, authority } = await gateManager(ctx, product, imsOrgId);
     if (gateErr) {
       return gateErr;

--- a/src/controllers/state-access-mappings.js
+++ b/src/controllers/state-access-mappings.js
@@ -425,6 +425,19 @@ function StateAccessMappingsController(context) {
       if (!orgImsOrgId) {
         return { error: notFound('Organization has no IMS org') };
       }
+      // Cross-tenant admin read: no emitAuditEvent equivalent exists for reads
+      // (only mutations are audited), so log it explicitly — otherwise an
+      // admin browsing another org's FACS bindings leaves no trace at all.
+      log.info(
+        {
+          tag: 'state-access-mappings',
+          actorId: resolveCallerUserIdent(ctx),
+          callerImsOrgId,
+          targetImsOrgId: orgImsOrgId,
+          organizationId,
+        },
+        'Admin cross-org scope override for FACS access-mapping read',
+      );
       return { imsOrgId: orgImsOrgId };
     } catch (error) {
       log.error(
@@ -1395,6 +1408,12 @@ function StateAccessMappingsController(context) {
    *
    * Provenance is reported per capability with tags from
    * {`jwt`, `state:user`, `state:org`}.
+   *
+   * No `?organizationId` admin-preview override here (unlike `listMappings` /
+   * `listHistory`): this endpoint reports the CALLER's own effective grants,
+   * not a preview of someone else's. An admin's real identity holds no
+   * personal state binding on a customer's resource regardless of preview
+   * context, so there is nothing to override.
    */
   async function getUserCapabilities(ctx) {
     const guard = requirePostgrestForFacsMappings(ctx);

--- a/test/controllers/state-access-mappings.test.js
+++ b/test/controllers/state-access-mappings.test.js
@@ -345,6 +345,88 @@ describe('StateAccessMappingsController', () => {
     });
   });
 
+  describe('GET /state/access-mappings — admin org-scope override (preview)', () => {
+    const PREVIEW_ORG_BARE = 'PREVIEW-ORG-999';
+    const PREVIEW_ORG_CANONICAL = 'PREVIEW-ORG-999@AdobeOrg';
+    const previewOrg = { getImsOrgId: () => PREVIEW_ORG_BARE };
+    const listQuery = {
+      resourceType: 'brand', resourceId: VALID_UUID_RES, organizationId: VALID_UUID_RES,
+    };
+
+    it('admin: scopes the read to the previewed org from ?organizationId', async () => {
+      const listStub = sinon.stub().resolves([makeRow({ ims_org_id: PREVIEW_ORG_CANONICAL })]);
+      const { Controller } = await loadController({ listFacsAccessMappings: listStub });
+      const ctx = makeContext({ isAdmin: true, organization: previewOrg, queryParams: listQuery });
+      const res = await Controller(ctx).listMappings(ctx);
+      expect(res.status).to.equal(200);
+      expect(listStub.firstCall.args[1].imsOrgId).to.equal(PREVIEW_ORG_CANONICAL);
+    });
+
+    it('non-admin: ignores ?organizationId and stays caller-scoped', async () => {
+      const listStub = sinon.stub().resolves([]);
+      const { Controller } = await loadController({ listFacsAccessMappings: listStub });
+      const ctx = makeContext({ isAdmin: false, organization: previewOrg, queryParams: listQuery });
+      const res = await Controller(ctx).listMappings(ctx);
+      expect(res.status).to.equal(200);
+      expect(listStub.firstCall.args[1].imsOrgId).to.equal(CALLER_ORG_CANONICAL);
+    });
+
+    it('admin: without ?organizationId stays caller-scoped', async () => {
+      const listStub = sinon.stub().resolves([]);
+      const { Controller } = await loadController({ listFacsAccessMappings: listStub });
+      const ctx = makeContext({
+        isAdmin: true,
+        queryParams: { resourceType: 'brand', resourceId: VALID_UUID_RES },
+      });
+      const res = await Controller(ctx).listMappings(ctx);
+      expect(res.status).to.equal(200);
+      expect(listStub.firstCall.args[1].imsOrgId).to.equal(CALLER_ORG_CANONICAL);
+    });
+
+    it('admin: returns 400 for an invalid organizationId', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({
+        isAdmin: true,
+        queryParams: { resourceType: 'brand', resourceId: VALID_UUID_RES, organizationId: 'not-a-uuid' },
+      });
+      const res = await Controller(ctx).listMappings(ctx);
+      expect(res.status).to.equal(400);
+    });
+
+    it('admin: returns 404 when the previewed org is not found', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, organization: null, queryParams: listQuery });
+      const res = await Controller(ctx).listMappings(ctx);
+      expect(res.status).to.equal(404);
+    });
+
+    it('admin: returns 404 when the previewed org has no IMS org', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({
+        isAdmin: true, organization: { getImsOrgId: () => null }, queryParams: listQuery,
+      });
+      const res = await Controller(ctx).listMappings(ctx);
+      expect(res.status).to.equal(404);
+    });
+
+    it('admin: returns 500 when the org lookup throws', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({ isAdmin: true, queryParams: listQuery });
+      ctx.dataAccess.Organization.findById = sinon.stub().rejects(new Error('db down'));
+      const res = await Controller(ctx).listMappings(ctx);
+      expect(res.status).to.equal(500);
+    });
+
+    it('listHistory honours the admin org-scope override too', async () => {
+      const histStub = sinon.stub().resolves([]);
+      const { Controller } = await loadController({ listFacsAccessMappingHistory: histStub });
+      const ctx = makeContext({ isAdmin: true, organization: previewOrg, queryParams: listQuery });
+      const res = await Controller(ctx).listHistory(ctx);
+      expect(res.status).to.equal(200);
+      expect(histStub.firstCall.args[1].imsOrgId).to.equal(PREVIEW_ORG_CANONICAL);
+    });
+  });
+
   describe('GET /state/access-mappings/history (listHistory)', () => {
     it('returns 400 when neither subject nor resource filter is supplied', async () => {
       const { Controller } = await loadController();

--- a/test/controllers/state-access-mappings.test.js
+++ b/test/controllers/state-access-mappings.test.js
@@ -425,6 +425,16 @@ describe('StateAccessMappingsController', () => {
       expect(res.status).to.equal(200);
       expect(histStub.firstCall.args[1].imsOrgId).to.equal(PREVIEW_ORG_CANONICAL);
     });
+
+    it('listHistory returns 400 for an invalid organizationId (error-guard wiring)', async () => {
+      const { Controller } = await loadController();
+      const ctx = makeContext({
+        isAdmin: true,
+        queryParams: { resourceType: 'brand', resourceId: VALID_UUID_RES, organizationId: 'not-a-uuid' },
+      });
+      const res = await Controller(ctx).listHistory(ctx);
+      expect(res.status).to.equal(400);
+    });
   });
 
   describe('GET /state/access-mappings/history (listHistory)', () => {


### PR DESCRIPTION
## Summary

Internal admins (Sites Internal org) preview the ASO customer UI via `?organizationId=<uuid>`. This works for every resource-addressed feature, but **not** the Permissions tab: the FACS read endpoints `GET /state/access-mappings` and `GET /state/access-mappings/history` derive the tenant scope **only** from the caller's JWT IMS-org tenant claim (`getTenantIds()[0]`) and ignore `organizationId`. So an admin previewing a customer's Permissions tab queries `facs_access_mappings` filtered by the **admin's own** org and sees zero rows — even though the customer's grants exist under the customer's IMS org.

This is the concrete cause of the Dover report (user visible in the customer Permissions tab, invisible via Sites Internal preview): not data loss — a scoping gap in these two read endpoints.

## Change

- New admin-only helper `resolveScopeImsOrgId(ctx, callerImsOrgId)`: when the caller `isAdmin()` **and** supplies `?organizationId=<uuid>`, resolve that org's canonical IMS org id and scope the read to it. Non-admins always stay caller-scoped (param ignored) — tenant isolation preserved.
- Wired into `listMappings` and `listHistory`.
- Mirrors org-resolution already used by `adminCreateMapping` (org from body) and `getAuditLogs` (org from path param).

Requires a matching UI change to forward `organizationId` on the Permissions requests (separate PR in `experience-success-studio-ui`). Backend is backwards-compatible: without the param, behavior is unchanged.

## Test plan

- [x] 8 new unit tests (admin override applied; non-admin ignored; no-param caller-scoped; 400 invalid uuid; 404 not-found; 404 no-ims-org; 500 lookup throws; listHistory parity)
- [x] `npx mocha test/controllers/state-access-mappings.test.js` → 162 passing
- [x] `eslint` clean on changed files
- [ ] CI type-check / docs-lint (local pre-commit failed only on **pre-existing, unrelated** errors in `brands.js`/`serenity/*` from stale local `node_modules` — `siteIdentityFromUrlString` not exported; not touched by this PR)

> [!NOTE]
> Security-sensitive: this is a customer authz endpoint. The guard is that the override is strictly `isAdmin()`-gated. Please review that boundary. A Jira ticket should be linked (relates to the ASO ReBAC/FACS work, SITES-47075).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: normal
impact: degradation
risk: major
changeApprovedBy: ["Dominique Jäggi", "Tarun Singh"]
rationale: "Changes tenant-scoping logic on a customer authz endpoint (FACS permissions reads) to let an admin-supplied param override the tenant scope; author flags it security-sensitive and asks for explicit review of the isAdmin() boundary, so it warrants gated human review despite being read-only and unit-tested."
```