### PR TITLE
fix: bump spacecat-shared-data-access to 4.28.0 for AsyncJob expiresAt (SITES-47947)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -546,7 +546,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.2.tgz",
       "integrity": "sha512-LIF6K7YQ78/Wxw2OQY+f5HxdIsoZnsJCcNWm9fnBQBRGHBIh3hQq+krD1yRWe/pkBVxAm7o4FJs8SmJkJjU0LQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -10899,6 +10898,7 @@
       "version": "3.973.13",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -12554,6 +12554,7 @@
       "version": "3.973.21",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.21",
         "@smithy/core": "^3.24.6",
@@ -12568,6 +12569,7 @@
       "version": "3.972.8",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -12623,6 +12625,7 @@
       "version": "3.972.19",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
         "@aws-sdk/types": "^3.973.13",
@@ -12638,6 +12641,7 @@
       "version": "3.973.13",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -13215,8 +13219,7 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.7.0",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -13234,7 +13237,6 @@
     "node_modules/@connectrpc/connect": {
       "version": "2.1.1",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -14118,7 +14120,6 @@
     "node_modules/@langchain/core": {
       "version": "0.3.80",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -14368,7 +14369,6 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -14543,7 +14543,6 @@
       "version": "1.9.0",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -14688,7 +14687,6 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -16423,7 +16421,6 @@
     "node_modules/@types/express": {
       "version": "5.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -16614,7 +16611,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16653,7 +16649,6 @@
       "version": "8.20.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17034,7 +17029,6 @@
     "node_modules/aws-xray-sdk-core": {
       "version": "3.12.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -17217,7 +17211,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -17807,7 +17800,6 @@
       "version": "6.2.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19700,7 +19692,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -23373,7 +23364,6 @@
       "version": "4.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -24306,6 +24296,7 @@
       "version": "0.38.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -24314,7 +24305,6 @@
       "version": "6.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -26774,7 +26764,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -27190,7 +27179,8 @@
     "node_modules/obliterator": {
       "version": "1.6.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -27234,7 +27224,6 @@
     "node_modules/openai": {
       "version": "5.12.2",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -28228,7 +28217,6 @@
       "version": "19.2.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28237,7 +28225,6 @@
       "version": "19.2.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -28878,7 +28865,6 @@
       "version": "25.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -30037,7 +30023,6 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -30812,7 +30797,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -30916,7 +30900,6 @@
     "node_modules/unified": {
       "version": "11.0.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -31585,7 +31568,6 @@
     "node_modules/ws": {
       "version": "8.18.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -31830,7 +31812,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -31838,7 +31819,6 @@
     "node_modules/zod-to-json-schema": {
       "version": "3.25.0",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@adobe/spacecat-shared-brand-client": "1.4.0",
         "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
         "@adobe/spacecat-shared-content-client": "1.10.0",
-        "@adobe/spacecat-shared-data-access": "4.24.0",
+        "@adobe/spacecat-shared-data-access": "4.28.0",
         "@adobe/spacecat-shared-drs-client": "1.14.0",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
         "@adobe/spacecat-shared-http-utils": "1.36.0",
@@ -546,6 +546,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.2.tgz",
       "integrity": "sha512-LIF6K7YQ78/Wxw2OQY+f5HxdIsoZnsJCcNWm9fnBQBRGHBIh3hQq+krD1yRWe/pkBVxAm7o4FJs8SmJkJjU0LQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "aws4": "1.13.2"
@@ -3863,9 +3864,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.24.0.tgz",
-      "integrity": "sha512-xSCA2WedkDTQHdXYFsmR0pLbb2TuVeRgU09tpC7XT45MH/hjE+U5/QxiNdS/E/kZxa4JpHhgkvr9GHKI8Kem2Q==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.28.0.tgz",
+      "integrity": "sha512-APOrVO1cNXRKzmOVIAmkZmLXVPbhQqa7m5qixi3CAwOhLPG8EGce/Uh2UfQmumgXKLkMvB2fG2XqQqiebZ0ADQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -10898,7 +10899,6 @@
       "version": "3.973.13",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -12554,7 +12554,6 @@
       "version": "3.973.21",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.21",
         "@smithy/core": "^3.24.6",
@@ -12569,7 +12568,6 @@
       "version": "3.972.8",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -12625,7 +12623,6 @@
       "version": "3.972.19",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.8",
         "@aws-sdk/types": "^3.973.13",
@@ -12641,7 +12638,6 @@
       "version": "3.973.13",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
@@ -13219,7 +13215,8 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.7.0",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -13237,6 +13234,7 @@
     "node_modules/@connectrpc/connect": {
       "version": "2.1.1",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -14120,6 +14118,7 @@
     "node_modules/@langchain/core": {
       "version": "0.3.80",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -14369,6 +14368,7 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -14543,6 +14543,7 @@
       "version": "1.9.0",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -14687,6 +14688,7 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -16421,6 +16423,7 @@
     "node_modules/@types/express": {
       "version": "5.0.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -16611,6 +16614,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16649,6 +16653,7 @@
       "version": "8.20.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17029,6 +17034,7 @@
     "node_modules/aws-xray-sdk-core": {
       "version": "3.12.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -17211,6 +17217,7 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -17800,6 +17807,7 @@
       "version": "6.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19692,6 +19700,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -23364,6 +23373,7 @@
       "version": "4.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -24296,7 +24306,6 @@
       "version": "0.38.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -24305,6 +24314,7 @@
       "version": "6.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -26764,6 +26774,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -27179,8 +27190,7 @@
     "node_modules/obliterator": {
       "version": "1.6.1",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -27224,6 +27234,7 @@
     "node_modules/openai": {
       "version": "5.12.2",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -28217,6 +28228,7 @@
       "version": "19.2.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28225,6 +28237,7 @@
       "version": "19.2.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -28865,6 +28878,7 @@
       "version": "25.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -30023,6 +30037,7 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -30797,6 +30812,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -30900,6 +30916,7 @@
     "node_modules/unified": {
       "version": "11.0.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -31568,6 +31585,7 @@
     "node_modules/ws": {
       "version": "8.18.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -31812,6 +31830,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -31819,6 +31838,7 @@
     "node_modules/zod-to-json-schema": {
       "version": "3.25.0",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@adobe/spacecat-shared-brand-client": "1.4.0",
     "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
     "@adobe/spacecat-shared-content-client": "1.10.0",
-    "@adobe/spacecat-shared-data-access": "4.24.0",
+    "@adobe/spacecat-shared-data-access": "4.28.0",
     "@adobe/spacecat-shared-drs-client": "1.14.0",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
     "@adobe/spacecat-shared-http-utils": "1.36.0",


### PR DESCRIPTION
## What

Bumps `@adobe/spacecat-shared-data-access` `4.24.0` → `4.28.0`.

## Why

4.28.0 adds the persisted `expiresAt` default on the AsyncJob model ([adobe/spacecat-shared#1909](https://github.com/adobe/spacecat-shared/pull/1909), SITES-47947), restoring the 7-day TTL contract lost in the DynamoDB→Postgres migration. With this, every `AsyncJob.create` stamps `expires_at = now() + 7 days` instead of writing `NULL`.

**api-service is the sole AsyncJob creator in the fleet** (org-wide code search): `preflight.js`, `site-detection.js`, and the serenity `async-job-runner.js`. So this one bump stops new NULL-TTL rows at the source for every AsyncJob type — no other consumer creates them.

Downstream, the mystique `AsyncJobReaper` (SITES-47948, live on Dev) purges expired rows 7 days on (preflights cascade via FK). Existing legacy NULL rows are handled by a separate one-time backfill, not this PR.

## Lockfile note

The only real dependency change is `spacecat-shared-data-access` 4.24.0 → 4.28.0. The remaining `package-lock.json` lines are npm re-computing `"peer": true` markers on unrelated transitive packages (aws-sdk, langchain, octokit, react, typescript, zod, …) — cosmetic normalization, no version/dependency changes.

## Validation

- `npm install` resolved 4.28.0; lockfile updated.
- Smoke: `test/controllers/preflight.test.js` (exercises `AsyncJob.create`) green (47 passing) on the new lib.
- Minor-version-only jump (4.24→4.28), backward-compatible; full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Minor-version, backward-compatible dependency bump that starts stamping a TTL default on new rows; existing rows handled by a separate backfill; reversible by pinning back."
```