### PR TITLE
fix(serenity): exclude org parent workspace from sub-workspace adoption candidates

### DIFF
--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -177,8 +177,13 @@ async function claimedBrandId(brandCollection, workspaceId) {
 async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log, claim) {
   const { brandCollection, selfBrandId } = claim;
   const family = await transport.listWorkspaceFamily(parentWorkspaceId);
-  const items = familyItems(family);
-  const sameTitle = items.filter((w) => w?.title === title && w?.status === 'created');
+  // The family listing includes the queried parent itself (live-verified against the
+  // gateway), so it must be excluded before any candidate logic runs — otherwise a brand
+  // whose name matches the parent workspace's own title reaches the adoption candidate
+  // set and assertNotParent() 409s AFTER the create attempt, instead of a fresh child
+  // ever being considered (LLMO-7349).
+  const children = familyItems(family).filter((w) => w?.id !== parentWorkspaceId);
+  const sameTitle = children.filter((w) => w?.title === title && w?.status === 'created');
 
   if (sameTitle.length > 0
     && typeof brandCollection?.findBySemrushSubWorkspaceId !== 'function') {
@@ -208,7 +213,7 @@ async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log
     // Surface filtered-out non-`created` same-title stubs (Semrush ack-then-fail
     // zombies) so their accumulation is visible in logs without a manual family
     // query — they are the exact failure mode this status filter absorbs (#2718).
-    const ignored = items.filter((w) => w?.title === title && w?.status !== 'created');
+    const ignored = children.filter((w) => w?.title === title && w?.status !== 'created');
     if (ignored.length > 0) {
       log?.info?.('ensureSubworkspace: ignoring non-created same-title family stub(s)', {
         parentWorkspaceId,

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -177,13 +177,12 @@ async function claimedBrandId(brandCollection, workspaceId) {
 async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log, claim) {
   const { brandCollection, selfBrandId } = claim;
   const family = await transport.listWorkspaceFamily(parentWorkspaceId);
-  // The family listing includes the queried parent itself (live-verified against the
-  // gateway), so it must be excluded before any candidate logic runs — otherwise a brand
-  // whose name matches the parent workspace's own title reaches the adoption candidate
-  // set and assertNotParent() 409s AFTER the create attempt, instead of a fresh child
-  // ever being considered (LLMO-7349). No hasText(w?.id) guard here (unlike
-  // enforceLinkedGuard's mirror-image filter below): an id-less entry still falls out of
-  // the title/status check right after, so the guard would be redundant, not protective.
+  // The family response includes the queried parent itself (live-verified against the
+  // gateway); exclude it before candidate selection, or a brand whose name matches the
+  // parent workspace's own title is returned as the match here and a fresh child is
+  // never even attempted (LLMO-7349). No hasText(w?.id) guard here (unlike
+  // enforceLinkedGuard's mirror-image filter below): keep ID-less entries so the
+  // existing missing-ID guard further down fails safely instead of silently dropping them.
   const children = familyItems(family).filter((w) => w?.id !== parentWorkspaceId);
   const sameTitle = children.filter((w) => w?.title === title && w?.status === 'created');
 

--- a/src/support/serenity/workspace-lifecycle.js
+++ b/src/support/serenity/workspace-lifecycle.js
@@ -181,7 +181,9 @@ async function findAdoptableFamilyMatch(transport, parentWorkspaceId, title, log
   // gateway), so it must be excluded before any candidate logic runs — otherwise a brand
   // whose name matches the parent workspace's own title reaches the adoption candidate
   // set and assertNotParent() 409s AFTER the create attempt, instead of a fresh child
-  // ever being considered (LLMO-7349).
+  // ever being considered (LLMO-7349). No hasText(w?.id) guard here (unlike
+  // enforceLinkedGuard's mirror-image filter below): an id-less entry still falls out of
+  // the title/status check right after, so the guard would be redundant, not protective.
   const children = familyItems(family).filter((w) => w?.id !== parentWorkspaceId);
   const sameTitle = children.filter((w) => w?.title === title && w?.status === 'created');
 

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -662,6 +662,63 @@ describe('workspace-lifecycle', () => {
       });
     });
 
+    describe('parent workspace title collision (LLMO-7349)', () => {
+      // The family endpoint returns the queried parent itself as one of its own family
+      // items (live-verified against the gateway). A brand named identically to the
+      // parent workspace's title must never let the parent reach the adoption
+      // candidate set — only a genuine child may ever be created or adopted.
+      it('proactive create-or-adopt: does not adopt a same-titled, created, empty PARENT; creates a fresh child instead', async () => {
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: PARENT_WS, title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureWithUnclaimedFamily(transport, brand);
+
+        expect(result).to.equal(SUB_WS);
+        expect(transport.createSubworkspace).to.have.been.calledOnceWith(PARENT_WS, EXPECTED_TITLE);
+        expect(transport.listProjects).to.not.have.been.calledWith(PARENT_WS);
+        expect(brand.setSemrushSubWorkspaceId).to.have.been.calledOnceWithExactly(SUB_WS);
+      });
+
+      it('adopts the real same-titled CHILD and ignores the same-titled parent sitting beside it', async () => {
+        const transport = makeTransport({
+          listWorkspaceFamily: sinon.stub().resolves([
+            { id: PARENT_WS, title: EXPECTED_TITLE, status: 'created' },
+            { id: 'real-child-ws', title: EXPECTED_TITLE, status: 'created' },
+          ]),
+        });
+        const brand = makeBrand();
+
+        const result = await ensureWithUnclaimedFamily(transport, brand);
+
+        expect(result).to.equal('real-child-ws');
+        expect(transport.createSubworkspace).to.not.have.been.called;
+        expect(transport.listProjects).to.have.been.calledOnceWith('real-child-ws');
+        expect(brand.setSemrushSubWorkspaceId).to.have.been.calledOnceWithExactly('real-child-ws');
+      });
+
+      it('504-recovery: reports no adoptable family match rather than adopting the parent', async () => {
+        const listWorkspaceFamily = sinon.stub();
+        listWorkspaceFamily.onFirstCall().resolves([]);
+        listWorkspaceFamily.onSecondCall().resolves([
+          { id: PARENT_WS, title: EXPECTED_TITLE, status: 'created' },
+        ]);
+        const transport = makeTransport({
+          createSubworkspace: sinon.stub().rejects(new SerenityTransportError(504, 'timeout')),
+          listWorkspaceFamily,
+        });
+        const brand = makeBrand();
+
+        await expect(ensureWithUnclaimedFamily(transport, brand))
+          .to.be.rejectedWith(/no family match to adopt/);
+        expect(transport.listProjects).to.not.have.been.called;
+        expect(brand.setSemrushSubWorkspaceId).to.not.have.been.called;
+      });
+    });
+
     it('502s when create returns no id', async () => {
       const transport = makeTransport({
         createSubworkspace: sinon.stub().resolves({ id: '' }),

--- a/test/support/serenity/workspace-lifecycle.test.js
+++ b/test/support/serenity/workspace-lifecycle.test.js
@@ -714,6 +714,7 @@ describe('workspace-lifecycle', () => {
 
         await expect(ensureWithUnclaimedFamily(transport, brand))
           .to.be.rejectedWith(/no family match to adopt/);
+        expect(listWorkspaceFamily).to.have.been.calledTwice;
         expect(transport.listProjects).to.not.have.been.called;
         expect(brand.setSemrushSubWorkspaceId).to.not.have.been.called;
       });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Fixes brand creation failing with HTTP 409 when the requested brand name exactly matches the Semrush organization's parent workspace title.

## 2. Reasoning
Blocks onboarding a valid customer brand whose real brand name matches its Semrush workspace name — currently blocking a real customer (Lundbeck, onboarding meeting scheduled for 2026-09-08).

## 3. High-level overview of the changes
`findAdoptableFamilyMatch()` in `src/support/serenity/workspace-lifecycle.js` queries the Semrush User Manager family endpoint for the org's parent workspace. That endpoint returns the queried parent itself as one of its own family items (live-verified against production). The same-title/created filter therefore selected the parent as an "adoptable" sub-workspace candidate whenever a brand's name matched the parent workspace's own title. The downstream `assertNotParent()` safety guard correctly rejected it with a 409 — but only after that candidate was already selected, and before any brand-row persistence is attempted (the guard fires ahead of `brand.setSemrushSubWorkspaceId()`/`brand.save()`, so no brand row is ever written in that path).

Before: a brand named identically to its org's parent workspace title could never be created — it always 409s.
After: the parent workspace is excluded from the family listing before any candidate matching runs, so a fresh child sub-workspace is created (or a genuine same-titled child is adopted, if one already exists). Timeout-recovery adoption is likewise unaffected — it still correctly reports "no adoptable match" rather than adopting the parent.

The fix mirrors an existing pattern already in the same file: `decommissionBrandWorkspace`'s `enforceLinkedGuard` already excludes the queried workspace's own id from its own family listing the same way. `assertNotParent()` is left unchanged as defense-in-depth — it still protects the `createSubworkspace` branch against a hypothetical gateway bug that echoes back the parent id.

### Pre-PR review decisions
- The new `children` filter (`w?.id !== parentWorkspaceId`) does not guard `hasText(w?.id)` before comparing, unlike the `enforceLinkedGuard` precedent it's modeled on. Declined: a malformed/id-less entry passes into `children` either way but is filtered out immediately after by the title/status checks, so there is no observable behavioral difference — the same tolerance the pre-existing code already had for malformed items.

## 4. Required information
- Jira / issue: [LLMO-7349](https://jira.corp.adobe.com/browse/LLMO-7349)

## 8. Test plan
No manual or live end-to-end verification was performed beyond the automated unit suite: neither the repo's IT suite (`test/it/shared/tests/serenity.js`) nor `review-kit:local-validate`'s assertion matrix (Serenity markets, Elements cited-domains, AI Visibility — all read routes) exercises brand creation or the family-listing/sub-workspace-adoption code path this PR changes. This fix is validated only at the unit level, with a mocked transport reproducing the exact live-verified production defect (family listing including the queried parent) described in the Jira issue.

Per-environment verification:
- **Prod**: once deployed, attempt brand creation for org `e3c8d312-8306-4b5d-ade1-f57aeef68fe3` (H. Lundbeck A/S) with brand name `Lundbeck`. Expect success with `brands.semrush_sub_workspace_id` set to a new child workspace id, never equal to the org's `semrush_workspace_id` (`2152792a-4405-4ef6-97bf-7849000399b4`). Tracked in the post-deploy validation ledger.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "Single-repo, single-function bug fix excluding the org's own Semrush parent workspace from adoption candidates in an internal sub-workspace-provisioning helper. No schema/infra/auth changes; the existing assertNotParent() defense-in-depth guard is untouched. The change only widens a previously-broken case (brand name matching the parent title) to now succeed; no existing successful path is altered. Fully covered by unit tests reproducing the live-verified production defect."
recommendations: "Verify brand creation for the Lundbeck org (see test plan) once deployed to prod; tracked in the post-deploy validation ledger."
backout: "Revert this commit and redeploy the previous release; no data migration or irreversible state change involved."
```
