### PR TITLE
feat(elements): Brand Claims response-feed join (141adc88 x 404fb017)

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -200,6 +200,8 @@ paths:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-access'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/sentiment-overview:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-sentiment-overview'
+  /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/responses:
+    $ref: './serenity-api.yaml#/v2-serenity-brand-presence-responses'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/subreddits:
     $ref: './serenity-api.yaml#/v2-serenity-brand-presence-subreddits'
   /v2/orgs/{spaceCatId}/brands/{brandId}/serenity/brand-presence/reddit-threads:

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12809,6 +12809,123 @@ SerenityBrandPresenceSubredditRow:
       description: Semrush project the row belongs to.
       example: 'cb4f6443-e01f-4075-a586-85511f136e31'
 
+SerenityBrandPresenceResponseFeedSource:
+  type: object
+  description: |
+    One source cited by an AI answer.
+
+    Ordered within `sources` by `rank`, which is the element's AGGREGATE ranking for
+    that domain — NOT the position the citation occupied inline in the answer text.
+    True inline citation order is not available upstream; do not present this as
+    citation order.
+  required: [url, domain, rank, domainType]
+  properties:
+    url:
+      type: string
+      description: Cited URL.
+      example: 'https://www.runnersworld.com/gear/best-running-shoes'
+    domain:
+      type: string
+      description: Display/domain form of the source.
+      example: 'runnersworld.com'
+    rank:
+      type: integer
+      description: Aggregate ranking from the element (see the ordering caveat above).
+      example: 1
+    domainType:
+      type: string
+      description: Semrush domain classification.
+      example: 'Earned'
+
+SerenityBrandPresenceResponseFeedRecord:
+  type: object
+  description: |
+    One AI answer with the sources cited in that same execution, keyed by
+    `(projectId, prompt, model, date)`.
+
+    `model` and `date` are always present and are load-bearing: the downstream consumer
+    keys on `(prompt, region)` and carries neither dimension, so it cannot reconstruct
+    them. An empty `sources` array means that execution cited nothing — never that
+    sources were lost.
+  required: [projectId, prompt, model, date, response, sources, sourceCount]
+  properties:
+    projectId:
+      type: string
+      description: Semrush project (one per market).
+      example: '460e0a7b-b8db-44f4-8b16-0e1bd1241efa'
+    prompt:
+      type: string
+      example: 'best running shoes for flat feet'
+    model:
+      type: string
+      description: AI model that produced the answer.
+      example: 'chatgpt-paid'
+    date:
+      type: string
+      format: date
+      description: Calendar day of the execution (YYYY-MM-DD).
+      example: '2026-08-24'
+    response:
+      type: string
+      description: The answer text.
+    sources:
+      type: array
+      items:
+        $ref: '#/SerenityBrandPresenceResponseFeedSource'
+    sourceCount:
+      type: integer
+      description: |
+        Number of source rows joined to this answer. Exposed so a caller can spot an
+        implausible fan-out if the one-execution-per-tuple invariant were violated
+        upstream.
+      example: 3
+
+SerenityBrandPresenceResponseFeed:
+  type: object
+  description: |
+    Brand Claims response feed for the requested days: each AI answer paired with the
+    sources cited in the same execution.
+
+    `truncated` and `unmatchedSourceKeyCount` exist so a consumer can tell an incomplete
+    read from a genuinely quiet day — the distinction the feed depends on, since a
+    missing tuple is normally legitimate.
+  required: [records, totalCount, days, projectIds, pageSize, truncated, unmatchedSourceKeyCount]
+  properties:
+    records:
+      type: array
+      items:
+        $ref: '#/SerenityBrandPresenceResponseFeedRecord'
+    totalCount:
+      type: integer
+      example: 42
+    days:
+      type: array
+      description: Calendar days covered, oldest first.
+      items: { type: string, format: date }
+      example: ['2026-08-23', '2026-08-24']
+    projectIds:
+      type: array
+      description: Projects (markets) scoped to. Empty means workspace-wide.
+      items: { type: string }
+    pageSize:
+      type: integer
+      description: Upstream page size actually used, after clamping.
+      example: 5000
+    truncated:
+      type: boolean
+      description: |
+        True when at least one upstream page came back full, so the window may be
+        clipped and this day's set incomplete. A consumer seeing this should narrow the
+        range rather than treat the result as whole.
+      example: false
+    unmatchedSourceKeyCount:
+      type: integer
+      description: |
+        Source rows whose answer was not present in the same page. Normally 0; a
+        persistently high value means the two elements disagreed and the join is losing
+        citations.
+      example: 0
+
 SerenityBrandPresenceSubreddits:
   type: object
   description: |

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1500,6 +1500,138 @@ v2-serenity-brand-presence-sentiment-overview:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
       '500': { $ref: './responses.yaml#/500' }
 
+v2-serenity-brand-presence-responses:
+  parameters:
+    - name: spaceCatId
+      in: path
+      required: true
+      description: SpaceCat Organization ID (UUID)
+      schema:
+        type: string
+        format: uuid
+    - name: brandId
+      in: path
+      required: true
+      description: Brand ID (UUID-only on the /serenity/* surface)
+      schema:
+        type: string
+        format: uuid
+  get:
+    tags: [serenity]
+    summary: Brand Claims response feed — AI answers paired with the sources cited in the same execution
+    description: |
+      Returns one record per AI answer for each day in the range, carrying that
+      execution's own cited sources. Brand Claims sits under Brand Presence within the
+      ABV product.
+
+      Assembled from two Semrush elements that each hold half the record: `141adc88`
+      has the answer text but no date, `404fb017` has the date and the cited URLs but
+      no answer. They are joined on `(project_id, prompt, model, date)`, which is sound
+      because at most one execution exists per that tuple (measured: 2,553 tuples, each
+      mapping to exactly one execution id).
+
+      Brand-scoped via the brand's Semrush sub-workspace, resolved from `:brandId` — the
+      caller never supplies a workspace and never holds a Semrush credential.
+
+      **Range-based by design.** The upstream window is bounded above only, so a single
+      day is recovered as the difference between two pulls. Consecutive days share a
+      boundary, so an N-day range costs N+1 upstream pulls per element rather than 2N.
+
+      **Absence is meaningful.** A `(prompt, model)` tuple runs on roughly 61 of 74 days
+      in practice; some models far fewer. A missing tuple means that model did not run
+      that day — never an error, and never lost data. An answer that cited nothing is
+      returned with an empty `sources` array rather than omitted.
+
+      **Ordering caveat.** `sources` is ordered by the element's aggregate `rank`, which
+      is NOT the order the sources appeared inline in the answer. True inline citation
+      order is not available upstream; do not present this as citation order.
+    operationId: listSerenityBrandPresenceResponses
+    security:
+      - session_token: []
+    parameters:
+      - name: from
+        in: query
+        required: false
+        description: |
+          Inclusive range start (YYYY-MM-DD). Alias `startDate`. Defaults to 7 days
+          before `to`. The span must be under 74 days — the upstream window is rolling
+          and older executions are unrecoverable, so a wider request is rejected rather
+          than served as an empty result.
+        schema: { type: string, format: date }
+      - name: to
+        in: query
+        required: false
+        description: |
+          Inclusive range end (YYYY-MM-DD). Alias `endDate`. Defaults to yesterday —
+          today's executions are still landing, so ending on today would report a
+          partial day as though complete.
+        schema: { type: string, format: date }
+      - name: startDate
+        in: query
+        required: false
+        description: Alias for `from`; `from` takes precedence when both are given.
+        schema: { type: string, format: date }
+      - name: endDate
+        in: query
+        required: false
+        description: Alias for `to`; `to` takes precedence when both are given.
+        schema: { type: string, format: date }
+      - name: model
+        in: query
+        required: false
+        description: |
+          AI model to scope to. Accepts a Semrush Elements model name directly, or a
+          UI platform code which is translated server-side.
+        schema: { type: string }
+      - name: platform
+        in: query
+        required: false
+        description: Legacy alias for `model`; `model` takes precedence when both are given.
+        schema: { type: string }
+      - name: projectId
+        in: query
+        required: false
+        description: |
+          Comma-separated Semrush project UUIDs (one project per market). Alias
+          `project_id`. Omitted → all of the brand's markets. Each id must be a valid
+          UUID (400 otherwise) and must be owned by this brand (403 otherwise).
+        schema: { type: string, pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}){0,7}$' }
+      - name: project_id
+        in: query
+        required: false
+        description: Snake_case alias for `projectId`.
+        schema: { type: string }
+      - name: limit
+        in: query
+        required: false
+        description: |
+          Upstream page size, clamped to 1..20000 (default 5000). 20000 is the largest
+          page that works on both upstream routes. Raising this is preferable to paging,
+          because every upstream call re-scans the whole rolling window.
+        schema: { type: integer, minimum: 1, maximum: 20000, default: 5000 }
+    responses:
+      '200':
+        description: Response feed retrieved.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityBrandPresenceResponseFeed' }
+      '400': { $ref: './responses.yaml#/400' }
+      '403':
+        description: Caller lacks access to the organization, or a supplied projectId is not owned by the brand.
+      '404':
+        description: Organization not found, brand not found for this organization, serenity is not active for the brand, or the brand has no resolvable Semrush workspace.
+      '502':
+        description: Upstream returned a non-2xx response.
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '503':
+        description: PostgREST client not available (required to resolve the brand's Semrush workspace before the element call).
+        content:
+          application/json:
+            schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
+      '500': { $ref: './responses.yaml#/500' }
+
 v2-serenity-brand-presence-subreddits:
   parameters:
     - name: spaceCatId

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -30,6 +30,7 @@ import { createSerenityTransport } from '../support/serenity/rest-transport.js';
 import { SerenityTransportError } from '../support/serenity/serenity-transport-error.js';
 import { logUpstreamError } from '../support/serenity/upstream-log.js';
 import { cachedOk } from '../support/cached-response.js';
+import { ResponseFeedDto } from '../dto/response-feed.js';
 import AccessControlUtil from '../support/access-control-util.js';
 import { ErrorWithStatusCode, resolveSemrushImsToken } from '../support/utils.js';
 import { X_PROMISE_TOKEN_HEADER, PROMISE_TOKEN_REQUIRED_ERROR_CODE } from '../utils/constants.js';
@@ -39,6 +40,19 @@ const BEARER_PREFIX = 'Bearer ';
 // Caps concurrent DB queries / upstream POSTs when fanning out across brands or projects.
 // mapWithConcurrency itself lives in support/elements/concurrency.js (shared with the service).
 const FANOUT_CONCURRENCY = 8;
+
+/** Milliseconds in a day, for span arithmetic on `YYYY-MM-DD` bounds. */
+const MS_PER_DAY = 86400000;
+
+/**
+ * Maximum span the response feed will serve, in days.
+ *
+ * The upstream window is ROLLING and about 74 days wide (measured 2026-09-04). Beyond it a
+ * day is UNRECOVERABLE rather than expensive, and the failure is silent: the upstream
+ * returns nothing for an out-of-window day, which is indistinguishable from "no model ran".
+ * Rejecting at the edge keeps that ambiguity out of the response.
+ */
+const RESPONSE_FEED_MAX_SPAN_DAYS = 74;
 
 /**
  * Maps a BrandSemrushProject model instance to the plain object shape the
@@ -2173,12 +2187,98 @@ export default function ElementsController(context, log, env) {
   };
   /* c8 ignore stop */
 
+  /**
+   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/responses
+   *
+   * The Brand Claims RESPONSE FEED: each AI answer for the requested days, paired with the
+   * sources cited in that same execution. Brand Claims sits under Brand Presence within the
+   * ABV product, hence the path segment.
+   *
+   * Assembled from two elements that each hold half the record — 141adc88 has the answer but
+   * no date, 404fb017 has the date and citations but no answer — joined on
+   * `(project_id, prompt, model, date)`. See `elements-service.js#getResponseFeed`.
+   *
+   * RANGE-BASED BY DESIGN. Consecutive days share a window boundary, so N days cost N+1
+   * upstream pulls rather than 2N. A per-day endpoint would forfeit that and pay double.
+   */
+  const listResponseFeed = async (ctx) => {
+    try {
+      const auth = await authorizeOrg(ctx);
+      if (auth.error) {
+        return auth.error;
+      }
+      // authorizeOrg validated `:brandId`, confirmed the brand belongs to the org, and
+      // resolved the brand's Semrush sub-workspace. The caller never supplies a workspace
+      // id and never holds a Semrush credential (design of record §10).
+      const { workspaceId, brand } = auth;
+      const query = extractQuery(ctx);
+
+      // Default to the last 7 days ending yesterday. Yesterday, not today: the upstream
+      // window is bounded by `CBF_date__end` and today's executions are still landing, so
+      // ending on today would report a partial day as though it were complete. Seven days
+      // is a working week of context at 8 boundary pulls per market — small enough to stay
+      // responsive, wide enough to be useful without a caller computing dates.
+      const defaultEnd = addDaysToDate(new Date().toISOString().slice(0, 10), -1);
+      const startDate = query.from || query.startDate || addDaysToDate(defaultEnd, -6);
+      const endDate = query.to || query.endDate || defaultEnd;
+
+      if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
+        return badRequest('from and to must be valid YYYY-MM-DD dates');
+      }
+      if (startDate > endDate) {
+        return badRequest('from must not be after to');
+      }
+
+      // The upstream window is ROLLING and about 74 days wide (measured 2026-09-04). A day
+      // older than that is UNRECOVERABLE, not merely expensive — the data is gone upstream.
+      // Rejecting is essential: serving such a request would return an empty result that is
+      // indistinguishable from "nothing ran", i.e. silent data loss presented as fact.
+      const spanDays = (Date.parse(`${endDate}T00:00:00Z`)
+        - Date.parse(`${startDate}T00:00:00Z`)) / MS_PER_DAY;
+      if (spanDays >= RESPONSE_FEED_MAX_SPAN_DAYS) {
+        return badRequest(
+          `Date range must not exceed ${RESPONSE_FEED_MAX_SPAN_DAYS} days: the upstream window `
+          + 'is rolling and older executions are unrecoverable',
+        );
+      }
+
+      const service = await buildService(ctx);
+
+      // Project scoping: caller-supplied projectId(s) (CSV) scope to those Semrush projects;
+      // absent → all of the brand's markets. LOAD-BEARING: the technical account is broadly
+      // entitled, so a caller who guessed another brand's project UUID could otherwise read
+      // that tenant's answers. Ownership is checked against this brand's own rows.
+      const projectIds = extractProjectIds(query);
+      // `dataAccess` is guaranteed present here — `authorizeOrg` above already read
+      // `Organization` from it — so this is a plain destructure rather than the optional
+      // form the sibling handlers use, whose fallback branch is unreachable in practice.
+      const { BrandSemrushProject } = ctx.dataAccess;
+      const brandSemrushProjects = await fetchBrandSemrushProjects(BrandSemrushProject, [brand]);
+      const ownershipError = checkProjectIdsOwnership(projectIds, brandSemrushProjects);
+      if (ownershipError) {
+        return ownershipError;
+      }
+
+      const result = await service.getResponseFeed(workspaceId, {
+        projectIds,
+        startDate,
+        endDate,
+        model: query.model || query.platform,
+        limit: query.limit,
+      });
+      return ok(ResponseFeedDto.toEnvelopeJSON(result));
+    } catch (e) {
+      return mapError(e, log, reqCtxOf(ctx));
+    }
+  };
+
   return {
     listUrlInspectorFilterDimensions,
     listWeeks,
     checkAccess,
     listPrompts,
     listCitedDomains,
+    listResponseFeed,
     listSubreddits,
     listRedditThreads,
     listYoutubeVideos,

--- a/src/dto/response-feed.js
+++ b/src/dto/response-feed.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * DTO for the Brand Claims response feed.
+ *
+ * Shapes the joined `(answer + its cited sources)` records into the API contract. The
+ * upstream Semrush element rows are never exposed: `execution_id` (an opaque composite of
+ * the join tuple), `model_name_cbf_value`, and the raw `tags` blob all stay server-side.
+ */
+
+/**
+ * Maps one joined source row to its API form.
+ *
+ * ⚠️ `position` is the element's AGGREGATE ranking for that domain, NOT the position the
+ * citation occupied inline in the answer text. The array is ordered by it because that
+ * yields a stable, sensible sequence — but this is explicitly NOT a claim about inline
+ * citation order, which Semrush does not expose today. Consumers must not present it as
+ * "the order the model cited these".
+ *
+ * @param {object} source - Joined source row.
+ * @returns {object} API representation.
+ */
+const toSourceJSON = (source) => ({
+  url: source.url ?? '',
+  domain: source.source ?? '',
+  rank: source.position ?? 0,
+  domainType: source.domainType ?? '',
+});
+
+export const ResponseFeedDto = {
+  /**
+   * Maps one joined record to its API form.
+   *
+   * `model` and `date` are exposed EXPLICITLY and are not optional. The downstream Brand
+   * Claims consumer keys its own identity on `(prompt, region)` — it carries no model and
+   * no date dimension — so it cannot reconstruct either from anything else in the payload.
+   * Dropping them here would silently collapse distinct executions into one.
+   *
+   * @param {object} record - Record from `joinResponsesToSources`.
+   * @returns {object} camelCase API representation.
+   */
+  toJSON: (record) => ({
+    projectId: record.projectId ?? '',
+    prompt: record.prompt ?? '',
+    // Load-bearing for the consumer — see above.
+    model: record.model ?? '',
+    date: record.date ?? '',
+    response: record.response ?? '',
+    // Empty when that execution cited nothing. ABSENCE IS MEANINGFUL: an empty array means
+    // "this model cited no sources on this day", never "sources were lost".
+    sources: (record.sources ?? []).map(toSourceJSON),
+    sourceCount: record.sourceRowCount ?? 0,
+  }),
+
+  /**
+   * Wraps the feed in its response envelope.
+   *
+   * `truncated` and `unmatchedSourceKeyCount` exist so a consumer can tell an incomplete
+   * read from a genuinely quiet day — the distinction the whole feed depends on, since a
+   * missing tuple is normally legitimate (a model runs on a median 61 of 74 days).
+   *
+   * @param {object} feed - Result from `getResponseFeed`.
+   * @returns {object} API response body.
+   */
+  toEnvelopeJSON: (feed) => ({
+    records: (feed.records ?? []).map(ResponseFeedDto.toJSON),
+    totalCount: (feed.records ?? []).length,
+    days: feed.days ?? [],
+    projectIds: feed.projectIds ?? [],
+    pageSize: feed.pageSize ?? 0,
+    // True when at least one upstream page came back full, so this window may be clipped.
+    // A consumer seeing this should narrow the range rather than treat the result as whole.
+    truncated: feed.truncated ?? false,
+    // Source rows whose answer was not in the same page. Normally 0; a persistently high
+    // value means the two elements disagreed and the join is losing citations.
+    unmatchedSourceKeyCount: feed.unmatchedSourceKeyCount ?? 0,
+  }),
+};

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -895,6 +895,9 @@ const routeFacsCapabilities = {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/access': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'llmo/can_view',
+      // Brand Claims response feed. Sits under Brand Presence within the ABV product, and
+      // is a read of the brand's own answer corpus — same `can_view` gate as its siblings.
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/responses': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'llmo/can_view',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': 'llmo/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -269,6 +269,7 @@ export default function getRouteHandlers(
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': elementsController.listPrompts,
     // eslint-disable-next-line max-len
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': elementsController.listCitedDomains,
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/responses': elementsController.listResponseFeed,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': elementsController.listSentimentOverview,
     // Per-subreddit Reddit stats (Subreddits element faf56e29).
     // eslint-disable-next-line max-len

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -342,6 +342,7 @@ const routeRequiredCapabilities = {
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts': 'organization:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview': 'brand:read',
+  'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/responses': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads': 'brand:read',
   'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/youtube-videos': 'brand:read',

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -33,6 +33,16 @@ export {
 export {
   buildCitedDomainsPayload, transformCitedDomainsResponse, transformCitedDomainsResponses,
 } from './cited-domains.js';
+export {
+  buildPromptResponsesPayload,
+  transformPromptResponsesResponse,
+  DEFAULT_RESPONSE_PAGE_SIZE,
+  MAX_RESPONSE_PAGE_SIZE,
+} from './prompt-responses.js';
+export {
+  buildResponseSourcesPayload, transformResponseSourcesResponse,
+} from './response-sources.js';
+export { joinResponsesToSources, diffDayExecutions } from './response-feed.js';
 export { buildSubredditsPayload, transformSubredditsResponse } from './subreddits.js';
 export { buildRedditThreadsPayload, transformRedditThreadsResponse } from './reddit-threads.js';
 export { buildYoutubeVideosPayload, transformYoutubeVideosResponse } from './youtube-videos.js';

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -36,6 +36,7 @@ export {
 export {
   buildPromptResponsesPayload,
   transformPromptResponsesResponse,
+  clampLimit,
   DEFAULT_RESPONSE_PAGE_SIZE,
   MAX_RESPONSE_PAGE_SIZE,
 } from './prompt-responses.js';

--- a/src/support/elements/definitions/prompt-responses.js
+++ b/src/support/elements/definitions/prompt-responses.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { resolveElementModel } from '../constants.js';
+import { buildAdvancedFilters, resolveElementModel } from '../constants.js';
 
 /**
  * Default page size for a Prompt Responses call.
@@ -42,9 +42,13 @@ const RESPONSE_SORT_COLUMNS = Object.freeze(['prompt asc']);
  * {@link DEFAULT_RESPONSE_PAGE_SIZE} for absent/non-numeric input.
  *
  * @param {number|string} [limit] - Requested page size.
+ * Exported so {@link module:response-sources} shares one definition rather than duplicating
+ * it — both elements page under the same per-workspace request budget.
+ *
+ * @param {number|string} [limit] - Requested page size.
  * @returns {number} Clamped page size.
  */
-function clampLimit(limit) {
+export function clampLimit(limit) {
   const parsed = Number.parseInt(limit, 10);
   if (!Number.isFinite(parsed)) {
     return DEFAULT_RESPONSE_PAGE_SIZE;
@@ -58,7 +62,7 @@ function clampLimit(limit) {
  * @param {number|string} [offset] - Requested row offset.
  * @returns {number} Non-negative offset.
  */
-function clampOffset(offset) {
+export function clampOffset(offset) {
   const parsed = Number.parseInt(offset, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
@@ -132,12 +136,16 @@ export function buildPromptResponsesPayload({
     filters: {
       // Duplicated in simple AND advanced — see the grammar warning above.
       ...(end ? { simple: { CBF_date__start: start, CBF_date__end: end } } : {}),
-      advanced: { op: 'and', filters: advancedFilters },
+      ...buildAdvancedFilters(advancedFilters),
     },
     pagination: {
       limit: clampLimit(limit),
       offset: clampOffset(offset),
       // Required for deterministic pagination — see RESPONSE_SORT_COLUMNS.
+      // [unverified] wire format: no other definition in this repo sends `pagination`, so the
+      // field name and the `'<col> asc'` string form are encoded from live observation rather
+      // than from an in-repo precedent. Confirm against a real call before an endpoint depends
+      // on this shape.
       sort_columns: [...RESPONSE_SORT_COLUMNS],
     },
   };

--- a/src/support/elements/definitions/prompt-responses.js
+++ b/src/support/elements/definitions/prompt-responses.js
@@ -15,29 +15,39 @@ import { buildAdvancedFilters, resolveElementModel } from '../constants.js';
 /**
  * Default page size for a Prompt Responses call.
  *
- * Measured live 2026-09-04 against the external route (Repsol ES workspace), timing and
- * payload per page:
+ * This endpoint must run over BOTH upstream routes, so the bounds are calibrated to the
+ * more restrictive of the two:
  *
- *   |   limit | result                    |
- *   |--------:|---------------------------|
- *   |     400 | 200 —  6.8s,  1.3 MB      |
- *   |   1,500 | 200 —  8.3s,  4.9 MB      |
- *   |   5,000 | 200 — 12.4s, 14.7 MB      |
- *   |  20,000 | 200 — 44.6s, 60.6 MB      |
- *   |  50,000 | 504 Gateway Timeout       |
+ *  - INTERNAL  `/enterprise/pages/api/v3/...`, IMS bearer — today's transport, used for an
+ *    interactive caller whose own token drives the x-promise-token flow.
+ *  - EXTERNAL  `api.semrush.com/apis/v4-raw/...`, `Authorization: Apikey` — the technical
+ *    account, and the INTENDED PRODUCTION PATH for the Brand Claims feed, which is a
+ *    background job with no caller token to borrow. Binding it is the auth-seam work
+ *    (spec PR-B / LLMO-6836).
  *
- * 5,000 is the default: it is an order of magnitude fewer round trips than 400 while keeping
- * a page near ten seconds and well inside gateway timeouts. Raising `limit` is strongly
- * preferable to walking `offset`, because every call re-scans the whole rolling window.
+ * Measured live 2026-09-04, per page:
+ *
+ *   |   limit | internal (IMS)          | external (technical account) |
+ *   |--------:|-------------------------|------------------------------|
+ *   |   5,000 | 200 — 12.8s,  14.7 MB   | 200 — 12.4s, 14.7 MB         |
+ *   |  20,000 | 200 — 41.6s,  60.7 MB   | 200 — 44.6s, 60.6 MB         |
+ *   |  50,000 | 200 — 95.9s, 149.6 MB   | 504 Gateway Timeout          |
+ *
+ * 5,000 is the default: an order of magnitude fewer round trips than a 400-row page while
+ * keeping a page near ten seconds on both routes. Raising `limit` is strongly preferable to
+ * walking `offset`, because every call re-scans the whole rolling window.
  */
 export const DEFAULT_RESPONSE_PAGE_SIZE = 5000;
 
 /**
- * Hard ceiling on `limit`. 20,000 is the largest page observed to succeed; 50,000 returns a
- * `504` (see the table above). A caller asking for more is clamped rather than allowed to fail
- * upstream. An earlier revision of this file set the ceiling at 1,000 on the belief that the
- * element 504s above ~1,500 rows — that was wrong by more than a factor of ten, and it clamped
- * callers to twenty times below what the element actually serves.
+ * Hard ceiling on `limit`. 20,000 is the largest page that works on BOTH routes — which is
+ * the real reason it is the ceiling, and a stronger basis than either measurement alone.
+ *
+ * Two independent limits happen to agree here. On the external gateway 50,000 returns a
+ * `504`, so it is simply unavailable on the production path for this feed. On the internal
+ * route 50,000 does succeed, but at ~96s and ~150 MB per page it is hostile to Lambda
+ * execution time and memory. A caller asking for more is clamped rather than allowed to hit
+ * either wall.
  */
 export const MAX_RESPONSE_PAGE_SIZE = 20000;
 
@@ -55,9 +65,8 @@ const RESPONSE_SORT_COLUMNS = Object.freeze(['prompt asc']);
  * Clamps a caller-supplied page size into `[1, MAX_RESPONSE_PAGE_SIZE]`, falling back to
  * {@link DEFAULT_RESPONSE_PAGE_SIZE} for absent/non-numeric input.
  *
- * @param {number|string} [limit] - Requested page size.
  * Exported so {@link module:response-sources} shares one definition rather than duplicating
- * it — both elements page under the same per-workspace request budget.
+ * it — both elements page under the same request budget and the same page-size ceiling.
  *
  * @param {number|string} [limit] - Requested page size.
  * @returns {number} Clamped page size.

--- a/src/support/elements/definitions/prompt-responses.js
+++ b/src/support/elements/definitions/prompt-responses.js
@@ -15,17 +15,31 @@ import { buildAdvancedFilters, resolveElementModel } from '../constants.js';
 /**
  * Default page size for a Prompt Responses call.
  *
- * Kept well under the ~1500-row ceiling at which this element starts returning 504s
- * (measured live). Callers paginating a large project should walk `offset` rather than
- * raise `limit` past that ceiling.
+ * Measured live 2026-09-04 against the external route (Repsol ES workspace), timing and
+ * payload per page:
+ *
+ *   |   limit | result                    |
+ *   |--------:|---------------------------|
+ *   |     400 | 200 —  6.8s,  1.3 MB      |
+ *   |   1,500 | 200 —  8.3s,  4.9 MB      |
+ *   |   5,000 | 200 — 12.4s, 14.7 MB      |
+ *   |  20,000 | 200 — 44.6s, 60.6 MB      |
+ *   |  50,000 | 504 Gateway Timeout       |
+ *
+ * 5,000 is the default: it is an order of magnitude fewer round trips than 400 while keeping
+ * a page near ten seconds and well inside gateway timeouts. Raising `limit` is strongly
+ * preferable to walking `offset`, because every call re-scans the whole rolling window.
  */
-export const DEFAULT_RESPONSE_PAGE_SIZE = 400;
+export const DEFAULT_RESPONSE_PAGE_SIZE = 5000;
 
 /**
- * Hard ceiling on `limit`. Above roughly 1500 rows per page the element 504s instead of
- * paginating, so a caller asking for more is clamped rather than allowed to fail upstream.
+ * Hard ceiling on `limit`. 20,000 is the largest page observed to succeed; 50,000 returns a
+ * `504` (see the table above). A caller asking for more is clamped rather than allowed to fail
+ * upstream. An earlier revision of this file set the ceiling at 1,000 on the belief that the
+ * element 504s above ~1,500 rows — that was wrong by more than a factor of ten, and it clamped
+ * callers to twenty times below what the element actually serves.
  */
-export const MAX_RESPONSE_PAGE_SIZE = 1000;
+export const MAX_RESPONSE_PAGE_SIZE = 20000;
 
 /**
  * Sort applied to every Prompt Responses call.
@@ -142,10 +156,9 @@ export function buildPromptResponsesPayload({
       limit: clampLimit(limit),
       offset: clampOffset(offset),
       // Required for deterministic pagination — see RESPONSE_SORT_COLUMNS.
-      // [unverified] wire format: no other definition in this repo sends `pagination`, so the
-      // field name and the `'<col> asc'` string form are encoded from live observation rather
-      // than from an in-repo precedent. Confirm against a real call before an endpoint depends
-      // on this shape.
+      // Wire format VERIFIED live 2026-09-04: `["prompt asc"]` and `["prompt desc"]` return
+      // 200. A bare `["prompt"]` (no direction), the object form `[{col,dir}]`, and an unknown
+      // column all return 400. So the direction suffix is required and the column must exist.
       sort_columns: [...RESPONSE_SORT_COLUMNS],
     },
   };

--- a/src/support/elements/definitions/prompt-responses.js
+++ b/src/support/elements/definitions/prompt-responses.js
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+
+/**
+ * Default page size for a Prompt Responses call.
+ *
+ * Kept well under the ~1500-row ceiling at which this element starts returning 504s
+ * (measured live). Callers paginating a large project should walk `offset` rather than
+ * raise `limit` past that ceiling.
+ */
+export const DEFAULT_RESPONSE_PAGE_SIZE = 400;
+
+/**
+ * Hard ceiling on `limit`. Above roughly 1500 rows per page the element 504s instead of
+ * paginating, so a caller asking for more is clamped rather than allowed to fail upstream.
+ */
+export const MAX_RESPONSE_PAGE_SIZE = 1000;
+
+/**
+ * Sort applied to every Prompt Responses call.
+ *
+ * `sort_columns` is REQUIRED for deterministic pagination: without it the element does not
+ * guarantee a stable row order between calls, so a paginated walk can silently repeat or
+ * skip rows across pages. Sorting by `prompt` gives a total order that is stable across the
+ * two calls the day-difference in `response-feed.js` depends on.
+ */
+const RESPONSE_SORT_COLUMNS = Object.freeze(['prompt asc']);
+
+/**
+ * Clamps a caller-supplied page size into `[1, MAX_RESPONSE_PAGE_SIZE]`, falling back to
+ * {@link DEFAULT_RESPONSE_PAGE_SIZE} for absent/non-numeric input.
+ *
+ * @param {number|string} [limit] - Requested page size.
+ * @returns {number} Clamped page size.
+ */
+function clampLimit(limit) {
+  const parsed = Number.parseInt(limit, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_RESPONSE_PAGE_SIZE;
+  }
+  return Math.min(Math.max(1, parsed), MAX_RESPONSE_PAGE_SIZE);
+}
+
+/**
+ * Floors a caller-supplied offset at 0, falling back to 0 for absent/non-numeric input.
+ *
+ * @param {number|string} [offset] - Requested row offset.
+ * @returns {number} Non-negative offset.
+ */
+function clampOffset(offset) {
+  const parsed = Number.parseInt(offset, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+/**
+ * Builds the payload for the Prompt Responses element (141adc88, a shared UUID that also
+ * powers the Citations+Source Count and Executions rows — see `element-ids.js`). Returns
+ * one row per AI response with the columns:
+ *
+ *   `model`, `model_name_cbf_value`, `position`, `project_id`, `prompt`, `response`, `tags`
+ *
+ * ⚠️ This element carries NO `date` column. That is the whole reason the response feed needs
+ * a join: the answer text lives here, the date and the citation URLs live on SOURCES_DATES
+ * (404fb017), and the two are paired on `(project_id, prompt, model, date)` — see
+ * {@link module:response-feed}. The date for a row obtained here is therefore known only
+ * from the window the caller requested, never from the row itself.
+ *
+ * ⚠️ DATE FILTER GRAMMAR — this element rejects the obvious spellings SILENTLY:
+ *  - `CBF_date__start`/`CBF_date__end` must be duplicated in BOTH `filters.simple` AND
+ *    `filters.advanced`. The element expects the duplication; `definitions/cited-domains.js`
+ *    is the known-good precedent and this file follows it exactly.
+ *  - `start_date`/`end_date`, a flat placement directly under `filters`, and a placement at
+ *    the `render_data` top level are ALL SILENTLY IGNORED. An entirely invented key behaves
+ *    identically — measured. This means a date filter written the obvious way FAILS OPEN:
+ *    the call returns HTTP 200 with a full-width result that is indistinguishable from a
+ *    successful narrow query. There is no error to catch and nothing in the response says
+ *    the filter was dropped, so a wrong spelling here surfaces as silently wrong data
+ *    downstream, not as a failure.
+ *  - `CBF_date__start` is IGNORED by the element even in the correct position;
+ *    `CBF_date__end` acts as an UPPER BOUND only. The returned window is ROLLING
+ *    (~50 days observed), not cumulative, so as `end` advances rows both appear AND
+ *    disappear. It is still sent, both because the element expects the key to be present
+ *    and so that a future Semrush fix honouring it needs no change here.
+ *
+ * Because only the upper bound is honoured, a SINGLE day cannot be requested directly —
+ * recover it with the two-call set difference in {@link module:response-feed.diffDayExecutions}.
+ *
+ * @param {object} [params]
+ * @param {string} [params.projectId] - Semrush project id, sent as the top-level
+ *   `project_id` (NOT a `CBF_*` filter — this element ignores those for project scoping).
+ *   Omitted → every project in the workspace.
+ * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
+ *   code). Translated + validated via {@link resolveElementModel}.
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
+ * @param {string} [params.endDate] - ISO date (YYYY-MM-DD) upper bound. Required by the
+ *   caller in practice; absent means "whatever the element's default window is".
+ * @param {number} [params.limit] - Page size, clamped to [1, {@link MAX_RESPONSE_PAGE_SIZE}].
+ * @param {number} [params.offset] - Row offset, floored at 0.
+ * @returns {object} Elements API payload.
+ */
+export function buildPromptResponsesPayload({
+  projectId, model, platform, endDate, limit, offset,
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  // `CBF_date__start` is ignored by the element (upper bound only), so the start value is
+  // cosmetic — it is sent because the element expects the key, and mirrors `endDate` so the
+  // payload never claims a window wider than the caller asked for.
+  const start = endDate;
+  const end = endDate;
+
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+  ];
+  if (end) {
+    advancedFilters.push({ op: 'gte', val: start, col: 'CBF_date__start' });
+    advancedFilters.push({ op: 'lte', val: end, col: 'CBF_date__end' });
+  }
+
+  return {
+    ...(projectId && { project_id: projectId }),
+    filters: {
+      // Duplicated in simple AND advanced — see the grammar warning above.
+      ...(end ? { simple: { CBF_date__start: start, CBF_date__end: end } } : {}),
+      advanced: { op: 'and', filters: advancedFilters },
+    },
+    pagination: {
+      limit: clampLimit(limit),
+      offset: clampOffset(offset),
+      // Required for deterministic pagination — see RESPONSE_SORT_COLUMNS.
+      sort_columns: [...RESPONSE_SORT_COLUMNS],
+    },
+  };
+}
+
+/**
+ * Normalises a raw Prompt Responses element response into the row shape the join consumes.
+ *
+ * The element is a `table` (rows under `blocks.data`). Field mapping:
+ *   `projectId` ← `project_id`
+ *   `prompt`    ← `prompt`
+ *   `model`     ← `model`
+ *   `response`  ← `response`   (the answer text)
+ *   `position`  ← `position`
+ *   `tags`      ← `tags`
+ *
+ * Rows missing a `prompt` are dropped: `prompt` is one of the four join-key components, so a
+ * row without one can never pair with a source row and would only add an unjoinable record.
+ *
+ * `date` is deliberately NOT set here — this element has no date column (see
+ * {@link buildPromptResponsesPayload}). The join supplies it from the source side.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @returns {Array<object>} Normalised response rows.
+ */
+export function transformPromptResponsesResponse(raw) {
+  const rows = raw?.blocks?.data ?? [];
+  return rows
+    .filter((row) => row && row.prompt != null)
+    .map((row) => ({
+      projectId: row.project_id || '',
+      prompt: row.prompt,
+      model: row.model || '',
+      modelNameCbfValue: row.model_name_cbf_value || '',
+      response: row.response || '',
+      // `Number(x) || 0` (not `Number(x ?? 0)`) so a non-numeric value coerces to 0 rather
+      // than NaN, which would serialise as null and corrupt any ordering by this field.
+      position: Number(row.position) || 0,
+      tags: row.tags || '',
+    }));
+}

--- a/src/support/elements/definitions/response-feed.js
+++ b/src/support/elements/definitions/response-feed.js
@@ -17,7 +17,20 @@
  * free text: any printable choice (`|`, `::`, tab) could occur inside a prompt and let two
  * different tuples collide on one key. A control character cannot appear in these values.
  */
-const KEY_SEP = '\u001F';
+/**
+ * Composite keys are built with `JSON.stringify` over the component array rather than by
+ * joining on a separator.
+ *
+ * A separator — ANY separator, including a control character such as U+001F — is forgeable:
+ * `(project 'p', prompt 'a<SEP>b', model 'm')` and `(project 'p', prompt 'a', model 'b<SEP>m')`
+ * join to the identical string, so two distinct executions would share one key. `prompt` is
+ * free text supplied by the customer, so this is a data-dependent correctness bug rather than
+ * a theoretical one. JSON escaping removes the ambiguity: quotes and control characters inside
+ * a component are escaped, so no component can forge a boundary.
+ */
+function compositeKey(parts) {
+  return JSON.stringify(parts);
+}
 
 /**
  * Builds the composite join key `(project_id, prompt, model, date)`.
@@ -38,13 +51,30 @@ const KEY_SEP = '\u001F';
  *   carry it, response rows do not — see the module docs).
  * @returns {string} Composite key.
  */
+function identityKey(row) {
+  return compositeKey([row.projectId ?? '', row.prompt ?? '', row.model ?? '']);
+}
+
+/**
+ * Builds the dateless identity used by {@link diffDayExecutions}. Kept adjacent to
+ * {@link joinKey} and derived from the same {@link identityKey} prefix so the two cannot
+ * drift apart if the key tuple ever changes.
+ *
+ * @param {object} row - A normalised response row.
+ * @returns {string} Dateless composite key.
+ */
+function dayIdentity(row) {
+  return identityKey(row);
+}
+
 function joinKey(row, date) {
-  return [
+  // Derived from the same components as the dateless identity so the two cannot drift.
+  return compositeKey([
     row.projectId ?? '',
     row.prompt ?? '',
     row.model ?? '',
     date ?? row.date ?? '',
-  ].join(KEY_SEP);
+  ]);
 }
 
 /**
@@ -181,7 +211,7 @@ export function diffDayExecutions(rowsEndD, rowsEndDminus1) {
   const current = Array.isArray(rowsEndD) ? rowsEndD : [];
   const previous = Array.isArray(rowsEndDminus1) ? rowsEndDminus1 : [];
   // Date is constant across a single call pair, so compare on the other three components.
-  const identity = (row) => [row.projectId ?? '', row.prompt ?? '', row.model ?? ''].join(KEY_SEP);
+  const identity = dayIdentity;
   // Multiset difference: consume one prior occurrence per matching row. A distinct Set here
   // would return [] for any prompt that also ran earlier in the rolling window (see above).
   const remaining = new Map();

--- a/src/support/elements/definitions/response-feed.js
+++ b/src/support/elements/definitions/response-feed.js
@@ -11,13 +11,6 @@
  */
 
 /**
- * Field separator for the composite join key.
- *
- * U+001F (UNIT SEPARATOR) is used rather than a printable delimiter because `prompt` is
- * free text: any printable choice (`|`, `::`, tab) could occur inside a prompt and let two
- * different tuples collide on one key. A control character cannot appear in these values.
- */
-/**
  * Composite keys are built with `JSON.stringify` over the component array rather than by
  * joining on a separator.
  *
@@ -33,40 +26,39 @@ function compositeKey(parts) {
 }
 
 /**
- * Builds the composite join key `(project_id, prompt, model, date)`.
- *
- * This exact tuple is the join contract, and its soundness rests on a MEASURED invariant:
- * at most ONE execution exists per `(project_id, prompt, model, date)`. Advancing the window
- * end by one day added exactly 10 new responses for one prompt in a 10-model project — never
- * 11, never 20. A model may contribute ZERO on a given day (`deepseek` was observed at +0),
- * but never two. So the key cannot pair one answer with another execution's citations.
- *
- * ⚠️ This invariant is measured, not contractual — Semrush has not confirmed it as a
- * guarantee. If it were ever violated, the symptom would be an answer carrying a merged
- * source list from two executions rather than an error. {@link joinResponsesToSources}
- * therefore records `sourceRowCount` so a caller can spot an implausible fan-out.
+ * Builds the dateless identity `(project_id, prompt, model)` used by both
+ * {@link joinKey} and {@link diffDayExecutions}, so the two cannot drift apart if the key
+ * tuple ever changes.
  *
  * @param {object} row - A normalised response or source row.
- * @param {string} [date] - Date component; taken from `row.date` when omitted (source rows
- *   carry it, response rows do not — see the module docs).
- * @returns {string} Composite key.
+ * @returns {string} Dateless composite key.
  */
 function identityKey(row) {
   return compositeKey([row.projectId ?? '', row.prompt ?? '', row.model ?? '']);
 }
 
 /**
- * Builds the dateless identity used by {@link diffDayExecutions}. Kept adjacent to
- * {@link joinKey} and derived from the same {@link identityKey} prefix so the two cannot
- * drift apart if the key tuple ever changes.
+ * Builds the full composite join key `(project_id, prompt, model, date)`.
  *
- * @param {object} row - A normalised response row.
- * @returns {string} Dateless composite key.
+ * This exact tuple is the join contract, and its soundness rests on a MEASURED invariant:
+ * at most ONE execution exists per `(project_id, prompt, model, date)`. Verified directly
+ * against element 404fb017, which carries both `execution_id` and `date`: across 2,553
+ * tuples every one mapped to exactly one `execution_id`, with zero violations (2026-09-04).
+ * A model may contribute ZERO on a given day, but never two.
+ *
+ * ⚠️ This invariant is measured, not contractual — Semrush has not confirmed it as a
+ * guarantee. If it were ever violated, the symptom would be an answer carrying a merged
+ * source list from two executions rather than an error. {@link joinResponsesToSources}
+ * therefore records `sourceRowCount` so a caller can spot an implausible fan-out.
+ *
+ * Both sides must express `date` as a bare `YYYY-MM-DD`: the source transform truncates the
+ * element's full timestamp, and the answer side supplies the requested day.
+ *
+ * @param {object} row - A normalised response or source row.
+ * @param {string} [date] - Date component; taken from `row.date` when omitted (source rows
+ *   carry it, response rows do not — see the module docs).
+ * @returns {string} Composite key.
  */
-function dayIdentity(row) {
-  return identityKey(row);
-}
-
 function joinKey(row, date) {
   // Derived from the same components as the dateless identity so the two cannot drift.
   return compositeKey([
@@ -178,10 +170,11 @@ export function joinResponsesToSources(responseRows, sourceRows, { date } = {}) 
  *   executions(D) = responses(end = D) MINUS responses(end = D-1)
  *
  * This is necessary because the element ignores `CBF_date__start` and honours
- * `CBF_date__end` as an upper bound over a ROLLING (~50 day) window, so a single day cannot
- * be requested directly — see {@link module:prompt-responses}. Two calls are therefore the
- * documented cost of one day. A Semrush fix honouring `CBF_date__start` would halve it, and
- * this function would become unnecessary rather than merely cheaper.
+ * `CBF_date__end` as an upper bound over a ROLLING window (~74 days measured 2026-09-04), so
+ * a single day cannot be requested directly — see {@link module:prompt-responses}. Two calls
+ * are therefore the documented cost of ONE isolated day. Consecutive days share a boundary,
+ * so a caller recovering a RANGE should fetch each boundary once and reuse it for the two
+ * days it borders: N days cost N+1 pulls, not 2N.
  *
  * Rows are identified by `(project_id, prompt, model)`, and the difference is a MULTISET
  * (count-based) difference, NOT a distinct-set difference. This is load-bearing.
@@ -211,7 +204,7 @@ export function diffDayExecutions(rowsEndD, rowsEndDminus1) {
   const current = Array.isArray(rowsEndD) ? rowsEndD : [];
   const previous = Array.isArray(rowsEndDminus1) ? rowsEndDminus1 : [];
   // Date is constant across a single call pair, so compare on the other three components.
-  const identity = dayIdentity;
+  const identity = identityKey;
   // Multiset difference: consume one prior occurrence per matching row. A distinct Set here
   // would return [] for any prompt that also ran earlier in the rolling window (see above).
   const remaining = new Map();

--- a/src/support/elements/definitions/response-feed.js
+++ b/src/support/elements/definitions/response-feed.js
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Field separator for the composite join key.
+ *
+ * U+001F (UNIT SEPARATOR) is used rather than a printable delimiter because `prompt` is
+ * free text: any printable choice (`|`, `::`, tab) could occur inside a prompt and let two
+ * different tuples collide on one key. A control character cannot appear in these values.
+ */
+const KEY_SEP = '\u001F';
+
+/**
+ * Builds the composite join key `(project_id, prompt, model, date)`.
+ *
+ * This exact tuple is the join contract, and its soundness rests on a MEASURED invariant:
+ * at most ONE execution exists per `(project_id, prompt, model, date)`. Advancing the window
+ * end by one day added exactly 10 new responses for one prompt in a 10-model project — never
+ * 11, never 20. A model may contribute ZERO on a given day (`deepseek` was observed at +0),
+ * but never two. So the key cannot pair one answer with another execution's citations.
+ *
+ * ⚠️ This invariant is measured, not contractual — Semrush has not confirmed it as a
+ * guarantee. If it were ever violated, the symptom would be an answer carrying a merged
+ * source list from two executions rather than an error. {@link joinResponsesToSources}
+ * therefore records `sourceRowCount` so a caller can spot an implausible fan-out.
+ *
+ * @param {object} row - A normalised response or source row.
+ * @param {string} [date] - Date component; taken from `row.date` when omitted (source rows
+ *   carry it, response rows do not — see the module docs).
+ * @returns {string} Composite key.
+ */
+function joinKey(row, date) {
+  return [
+    row.projectId ?? '',
+    row.prompt ?? '',
+    row.model ?? '',
+    date ?? row.date ?? '',
+  ].join(KEY_SEP);
+}
+
+/**
+ * Groups normalised source rows by their `(project_id, prompt, model, date)` key, with each
+ * group ordered by the element's `position` column.
+ *
+ * ⚠️ `position` is an AGGREGATE ranking on element 404fb017, NOT the true inline citation
+ * order within the answer text. Ordering by it produces a stable, sensible sequence, but it
+ * is NOT a claim that this is the order the sources appeared in the response. Recovering
+ * true inline order is a known nice-to-have gap on the Semrush side, not something this
+ * function can or does establish.
+ *
+ * @param {Array<object>} sourceRows - Rows from `transformResponseSourcesResponse`.
+ * @returns {Map<string, Array<object>>} Key → position-ordered source rows.
+ */
+function groupSourcesByKey(sourceRows) {
+  const byKey = new Map();
+  for (const row of sourceRows) {
+    const key = joinKey(row);
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.push(row);
+    } else {
+      byKey.set(key, [row]);
+    }
+  }
+  for (const rows of byKey.values()) {
+    // Stable sort by aggregate position — see the ordering caveat above.
+    rows.sort((a, b) => a.position - b.position);
+  }
+  return byKey;
+}
+
+/**
+ * Joins answer rows (element 141adc88, which has the text but NO date) to their citation
+ * rows (element 404fb017, which has the date and URLs but NO text), producing one record per
+ * answer carrying its own ordered source list.
+ *
+ * The join key is `(project_id, prompt, model, date)`. Because the answer element carries no
+ * date, the date is supplied by the caller — it is the `endDate` the response page was
+ * fetched with, i.e. the day whose executions those answers belong to. Callers recovering a
+ * single day should pass the same `date` they passed to
+ * {@link module:response-feed.diffDayExecutions}.
+ *
+ * ABSENCE IS MEANINGFUL. An answer with no matching source rows is returned with an EMPTY
+ * `sources` array, not dropped: a missing tuple means that model did not cite anything (or
+ * did not run) that day, NOT that data was lost. Consumers must tolerate these gaps rather
+ * than treat them as an error. Symmetrically, source rows with no matching answer are
+ * reported via `unmatchedSourceKeys` instead of being silently discarded, so a caller can
+ * tell "no citations" apart from "the two pages disagreed".
+ *
+ * Pure function — no I/O, no clock, no network.
+ *
+ * @param {Array<object>} responseRows - Rows from `transformPromptResponsesResponse`.
+ * @param {Array<object>} sourceRows - Rows from `transformResponseSourcesResponse`.
+ * @param {object} [opts]
+ * @param {string} [opts.date] - ISO date (YYYY-MM-DD) the answer rows belong to. Required
+ *   for any row to match, since answer rows carry no date of their own.
+ * @returns {{records: Array<object>, unmatchedSourceKeys: Array<string>}}
+ */
+export function joinResponsesToSources(responseRows, sourceRows, { date } = {}) {
+  const responses = Array.isArray(responseRows) ? responseRows : [];
+  const sources = Array.isArray(sourceRows) ? sourceRows : [];
+  const sourcesByKey = groupSourcesByKey(sources);
+  const matchedKeys = new Set();
+
+  const records = responses.map((row) => {
+    const key = joinKey(row, date);
+    const matched = sourcesByKey.get(key) ?? [];
+    if (matched.length > 0) {
+      matchedKeys.add(key);
+    }
+    return {
+      projectId: row.projectId,
+      prompt: row.prompt,
+      model: row.model,
+      // Carried from the requested window, not from the answer row — see above.
+      date: date ?? '',
+      response: row.response,
+      tags: row.tags,
+      // Ordered by aggregate `position`, which is NOT true inline citation order.
+      sources: matched.map((s) => ({
+        url: s.url,
+        source: s.source,
+        position: s.position,
+        domainType: s.domainType,
+      })),
+      // Lets a caller detect an implausible fan-out if the one-execution-per-tuple
+      // invariant were ever violated upstream.
+      sourceRowCount: matched.length,
+    };
+  });
+
+  const unmatchedSourceKeys = [...sourcesByKey.keys()].filter((k) => !matchedKeys.has(k));
+  return { records, unmatchedSourceKeys };
+}
+
+/**
+ * Recovers the executions belonging to a SINGLE day D as an exact set difference:
+ *
+ *   executions(D) = responses(end = D) MINUS responses(end = D-1)
+ *
+ * This is necessary because the element ignores `CBF_date__start` and honours
+ * `CBF_date__end` as an upper bound over a ROLLING (~50 day) window, so a single day cannot
+ * be requested directly — see {@link module:prompt-responses}. Two calls are therefore the
+ * documented cost of one day. A Semrush fix honouring `CBF_date__start` would halve it, and
+ * this function would become unnecessary rather than merely cheaper.
+ *
+ * Rows are identified by `(project_id, prompt, model)`, and the difference is a MULTISET
+ * (count-based) difference, NOT a distinct-set difference. This is load-bearing.
+ *
+ * Element 141adc88 carries NO date column and returns one row PER EXECUTION, so a single page
+ * holds the whole rolling window: measured live, a 400-row page contained just 10 distinct
+ * `(prompt, model)` pairs, one of them repeated 54 times (~54 days of history). A prompt that
+ * runs daily therefore already appears in the D-1 page, so a distinct-set difference filters
+ * its day-D row out and returns NOTHING. Verified against two live adjacent-day captures:
+ * a set difference yielded 0 rows both times where the multiset difference yielded 4 and 5.
+ * Returning [] would be indistinguishable from "nothing ran", which is precisely the
+ * data-loss outcome the absence-is-meaningful rule forbids.
+ *
+ * ⚠️ Because the window ROLLS rather than accumulating, rows can also DROP OUT of the older
+ * end as `end` advances. Such a row is present in the D-1 page and absent from the D page;
+ * it is correctly NOT reported as new (it is not an execution on day D). This is why the
+ * difference is computed one-way — `rowsEndD` minus `rowsEndDminus1` — and never as a
+ * symmetric difference, which would misreport those expiries as day-D activity.
+ *
+ * Pure function — no I/O, no clock, no network.
+ *
+ * @param {Array<object>} rowsEndD - Normalised rows fetched with `endDate = D`.
+ * @param {Array<object>} rowsEndDminus1 - Normalised rows fetched with `endDate = D-1`.
+ * @returns {Array<object>} The subset of `rowsEndD` that is new on day D.
+ */
+export function diffDayExecutions(rowsEndD, rowsEndDminus1) {
+  const current = Array.isArray(rowsEndD) ? rowsEndD : [];
+  const previous = Array.isArray(rowsEndDminus1) ? rowsEndDminus1 : [];
+  // Date is constant across a single call pair, so compare on the other three components.
+  const identity = (row) => [row.projectId ?? '', row.prompt ?? '', row.model ?? ''].join(KEY_SEP);
+  // Multiset difference: consume one prior occurrence per matching row. A distinct Set here
+  // would return [] for any prompt that also ran earlier in the rolling window (see above).
+  const remaining = new Map();
+  previous.forEach((row) => {
+    const key = identity(row);
+    remaining.set(key, (remaining.get(key) ?? 0) + 1);
+  });
+  return current.filter((row) => {
+    const key = identity(row);
+    const count = remaining.get(key) ?? 0;
+    if (count > 0) {
+      remaining.set(key, count - 1);
+      return false;
+    }
+    return true;
+  });
+}

--- a/src/support/elements/definitions/response-sources.js
+++ b/src/support/elements/definitions/response-sources.js
@@ -14,6 +14,28 @@ import { buildAdvancedFilters, resolveElementModel } from '../constants.js';
 import { clampLimit, clampOffset } from './prompt-responses.js';
 
 /**
+ * Normalises the element's `date` column to a bare `YYYY-MM-DD` calendar day.
+ *
+ * ⚠️ LOAD-BEARING. The element returns a full timestamp (`2026-09-03T00:00:00Z` — measured
+ * live 2026-09-04), but `date` is one of the four join-key components and the answer side
+ * supplies it as a bare `YYYY-MM-DD` (element 141adc88 has no date column at all, so the
+ * caller passes the day it requested). Comparing the two raw forms never matches, and the
+ * failure is SILENT: every record would come back with an empty `sources` array, which is
+ * indistinguishable from the legitimate "that model cited nothing that day" case. Truncating
+ * here — at the boundary where the upstream shape is normalised — keeps both sides of the
+ * join in one vocabulary.
+ *
+ * Truncation is safe because the element is day-granular: the time component was `00:00:00Z`
+ * on every row observed, and `execution_id` itself is a day-granular composite.
+ *
+ * @param {string} value - Raw `date` cell.
+ * @returns {string} `YYYY-MM-DD`, or `''` when absent.
+ */
+function toCalendarDay(value) {
+  return typeof value === 'string' ? value.slice(0, 10) : '';
+}
+
+/**
  * Sort applied to every Response Sources call.
  *
  * `sort_columns` is REQUIRED for deterministic pagination (see the same note in
@@ -97,7 +119,8 @@ export function buildResponseSourcesPayload({
  *   `projectId`   ← `project_id`
  *   `prompt`      ← `prompt`
  *   `model`       ← `model`
- *   `date`        ← `date`         (the join component PROMPT_RESPONSES cannot supply)
+ *   `date`        ← `date`, TRUNCATED to `YYYY-MM-DD` (see {@link toCalendarDay} — the raw
+ *                  cell is a full timestamp and would never match the join key otherwise)
  *   `url`         ← `url_cbf`, falling back to `source`
  *   `source`      ← `source`
  *   `position`    ← `position`
@@ -118,7 +141,9 @@ export function transformResponseSourcesResponse(raw) {
       projectId: row.project_id || '',
       prompt: row.prompt,
       model: row.model || '',
-      date: row.date,
+      // Truncated to the calendar day: the raw cell is `YYYY-MM-DDTHH:mm:ssZ` and the join
+      // key's other side carries a bare `YYYY-MM-DD`. See {@link toCalendarDay}.
+      date: toCalendarDay(row.date),
       // `url_cbf` is the citation target; `source` is the display/domain form. Prefer the
       // former and fall back so a row with only one populated still yields a usable URL.
       url: row.url_cbf || row.source || '',

--- a/src/support/elements/definitions/response-sources.js
+++ b/src/support/elements/definitions/response-sources.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { resolveElementModel } from '../constants.js';
+import {
+  DEFAULT_RESPONSE_PAGE_SIZE,
+  MAX_RESPONSE_PAGE_SIZE,
+} from './prompt-responses.js';
+
+/**
+ * Sort applied to every Response Sources call.
+ *
+ * `sort_columns` is REQUIRED for deterministic pagination (see the same note in
+ * `prompt-responses.js`). `prompt asc` is the primary key of the walk; `position asc` keeps
+ * the citation rows of one answer contiguous and in the element's own ranking order, which
+ * is what {@link transformResponseSourcesResponse} preserves.
+ */
+const SOURCE_SORT_COLUMNS = Object.freeze(['prompt asc', 'position asc']);
+
+/**
+ * Clamps a caller-supplied page size into `[1, MAX_RESPONSE_PAGE_SIZE]`, falling back to
+ * {@link DEFAULT_RESPONSE_PAGE_SIZE} for absent/non-numeric input.
+ *
+ * @param {number|string} [limit] - Requested page size.
+ * @returns {number} Clamped page size.
+ */
+function clampLimit(limit) {
+  const parsed = Number.parseInt(limit, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_RESPONSE_PAGE_SIZE;
+  }
+  return Math.min(Math.max(1, parsed), MAX_RESPONSE_PAGE_SIZE);
+}
+
+/**
+ * Floors a caller-supplied offset at 0, falling back to 0 for absent/non-numeric input.
+ *
+ * @param {number|string} [offset] - Requested row offset.
+ * @returns {number} Non-negative offset.
+ */
+function clampOffset(offset) {
+  const parsed = Number.parseInt(offset, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+/**
+ * Builds the payload for the Response Sources element (404fb017, `SOURCES_DATES`). Returns
+ * one row per CITATION with the columns:
+ *
+ *   `execution_id`, `prompt`, `date`, `model`, `source`, `url_cbf`, `position`,
+ *   `domain_type`, `project_id`, `tags`
+ *
+ * ⚠️ This element carries NO answer text. It is the other half of the response feed: it
+ * supplies the `date` and the cited URLs that PROMPT_RESPONSES (141adc88) lacks, and the two
+ * are paired on `(project_id, prompt, model, date)` — see {@link module:response-feed}.
+ *
+ * `execution_id` is a COMPOSITE STRING (`project_id` + `date` + `model` + `prompt`), so it is
+ * day-granular and adds nothing beyond the join tuple already assembled from the individual
+ * columns. It is normalised through for traceability, not used as a key.
+ *
+ * ⚠️ The same silently-failing date grammar as `prompt-responses.js` applies here verbatim —
+ * `CBF_date__start`/`CBF_date__end` duplicated across `filters.simple` and `filters.advanced`;
+ * `start_date`/`end_date` and any flat or top-level placement IGNORED WITHOUT ERROR (the call
+ * FAILS OPEN, returning a full-width result that looks like a successful narrow query);
+ * `CBF_date__start` ignored even when correctly placed, `CBF_date__end` honoured as an upper
+ * bound only, over a ROLLING (~50 day) window. See {@link module:prompt-responses} for the
+ * full description and the measurements behind it.
+ *
+ * @param {object} [params]
+ * @param {string} [params.projectId] - Semrush project id, sent as the top-level
+ *   `project_id`. Omitted → every project in the workspace.
+ * @param {string} [params.model] - AI model filter (Semrush engine name or UI platform
+ *   code). Translated + validated via {@link resolveElementModel}.
+ * @param {string} [params.platform] - Legacy alias for `model`; `model` takes precedence.
+ * @param {string} [params.endDate] - ISO date (YYYY-MM-DD) upper bound.
+ * @param {number} [params.limit] - Page size, clamped to [1, {@link MAX_RESPONSE_PAGE_SIZE}].
+ * @param {number} [params.offset] - Row offset, floored at 0.
+ * @returns {object} Elements API payload.
+ */
+export function buildResponseSourcesPayload({
+  projectId, model, platform, endDate, limit, offset,
+} = {}) {
+  const resolvedModel = resolveElementModel(model || platform);
+  // `CBF_date__start` is ignored (upper bound only) — mirrored from `endDate` for the same
+  // reason as in `prompt-responses.js`.
+  const start = endDate;
+  const end = endDate;
+
+  const advancedFilters = [
+    { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
+  ];
+  if (end) {
+    advancedFilters.push({ op: 'gte', val: start, col: 'CBF_date__start' });
+    advancedFilters.push({ op: 'lte', val: end, col: 'CBF_date__end' });
+  }
+
+  return {
+    ...(projectId && { project_id: projectId }),
+    filters: {
+      // Duplicated in simple AND advanced — see the grammar warning above.
+      ...(end ? { simple: { CBF_date__start: start, CBF_date__end: end } } : {}),
+      advanced: { op: 'and', filters: advancedFilters },
+    },
+    pagination: {
+      limit: clampLimit(limit),
+      offset: clampOffset(offset),
+      // Required for deterministic pagination — see SOURCE_SORT_COLUMNS.
+      sort_columns: [...SOURCE_SORT_COLUMNS],
+    },
+  };
+}
+
+/**
+ * Normalises a raw Response Sources element response into the row shape the join consumes.
+ *
+ * The element is a `table` (rows under `blocks.data`). Field mapping:
+ *   `projectId`   ← `project_id`
+ *   `prompt`      ← `prompt`
+ *   `model`       ← `model`
+ *   `date`        ← `date`         (the join component PROMPT_RESPONSES cannot supply)
+ *   `url`         ← `url_cbf`, falling back to `source`
+ *   `source`      ← `source`
+ *   `position`    ← `position`
+ *   `domainType`  ← `domain_type`
+ *   `executionId` ← `execution_id` (composite; carried for traceability only)
+ *
+ * Rows missing a `prompt` or a `date` are dropped — both are join-key components, so such a
+ * row can never pair with an answer.
+ *
+ * @param {object} raw - Raw response from the Elements API.
+ * @returns {Array<object>} Normalised source rows.
+ */
+export function transformResponseSourcesResponse(raw) {
+  const rows = raw?.blocks?.data ?? [];
+  return rows
+    .filter((row) => row && row.prompt != null && row.date != null)
+    .map((row) => ({
+      projectId: row.project_id || '',
+      prompt: row.prompt,
+      model: row.model || '',
+      date: row.date,
+      // `url_cbf` is the citation target; `source` is the display/domain form. Prefer the
+      // former and fall back so a row with only one populated still yields a usable URL.
+      url: row.url_cbf || row.source || '',
+      source: row.source || '',
+      position: Number(row.position) || 0,
+      domainType: row.domain_type || '',
+      executionId: row.execution_id || '',
+      tags: row.tags || '',
+    }));
+}

--- a/src/support/elements/definitions/response-sources.js
+++ b/src/support/elements/definitions/response-sources.js
@@ -10,11 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { resolveElementModel } from '../constants.js';
-import {
-  DEFAULT_RESPONSE_PAGE_SIZE,
-  MAX_RESPONSE_PAGE_SIZE,
-} from './prompt-responses.js';
+import { buildAdvancedFilters, resolveElementModel } from '../constants.js';
+import { clampLimit, clampOffset } from './prompt-responses.js';
 
 /**
  * Sort applied to every Response Sources call.
@@ -25,32 +22,6 @@ import {
  * is what {@link transformResponseSourcesResponse} preserves.
  */
 const SOURCE_SORT_COLUMNS = Object.freeze(['prompt asc', 'position asc']);
-
-/**
- * Clamps a caller-supplied page size into `[1, MAX_RESPONSE_PAGE_SIZE]`, falling back to
- * {@link DEFAULT_RESPONSE_PAGE_SIZE} for absent/non-numeric input.
- *
- * @param {number|string} [limit] - Requested page size.
- * @returns {number} Clamped page size.
- */
-function clampLimit(limit) {
-  const parsed = Number.parseInt(limit, 10);
-  if (!Number.isFinite(parsed)) {
-    return DEFAULT_RESPONSE_PAGE_SIZE;
-  }
-  return Math.min(Math.max(1, parsed), MAX_RESPONSE_PAGE_SIZE);
-}
-
-/**
- * Floors a caller-supplied offset at 0, falling back to 0 for absent/non-numeric input.
- *
- * @param {number|string} [offset] - Requested row offset.
- * @returns {number} Non-negative offset.
- */
-function clampOffset(offset) {
-  const parsed = Number.parseInt(offset, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-}
 
 /**
  * Builds the payload for the Response Sources element (404fb017, `SOURCES_DATES`). Returns
@@ -108,7 +79,7 @@ export function buildResponseSourcesPayload({
     filters: {
       // Duplicated in simple AND advanced — see the grammar warning above.
       ...(end ? { simple: { CBF_date__start: start, CBF_date__end: end } } : {}),
-      advanced: { op: 'and', filters: advancedFilters },
+      ...buildAdvancedFilters(advancedFilters),
     },
     pagination: {
       limit: clampLimit(limit),

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -14,7 +14,7 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 import { ELEMENT_IDS } from './element-ids.js';
 import { SEP } from './constants.js';
 import { mapWithConcurrency } from './concurrency.js';
-import { splitDateRangeIntoWeeksBackward } from './week-utils.js';
+import { splitDateRangeIntoWeeksBackward, addDaysToDate } from './week-utils.js';
 import {
   DIMENSION,
   INTENT_VALUE,
@@ -41,6 +41,13 @@ import {
   buildCitedDomainsPayload,
   transformCitedDomainsResponse,
   transformCitedDomainsResponses,
+  buildPromptResponsesPayload,
+  transformPromptResponsesResponse,
+  clampLimit,
+  buildResponseSourcesPayload,
+  transformResponseSourcesResponse,
+  joinResponsesToSources,
+  diffDayExecutions,
   buildSubredditsPayload,
   transformSubredditsResponse,
   buildRedditThreadsPayload,
@@ -93,6 +100,45 @@ const SOURCE_VISIBILITY_CALL_MAX_RETRIES = 1;
 // TRENDS_MAX_WEEKS=8 weeks x 4 element calls each) so a wide date range can't
 // spawn an unbounded number of parallel Semrush requests.
 const STATS_TRENDS_WEEK_CONCURRENCY = 4;
+
+/**
+ * Bounds parallel per-project (per-market) fan-out for the response feed.
+ *
+ * Deliberately lower than {@link FANOUT_CONCURRENCY} elsewhere in this file. The production
+ * path for this feed is the technical account over the external gateway, whose rate limit is
+ * 100 requests per ~60s window and is PER CREDENTIAL, not per workspace (measured
+ * 2026-09-04: three different workspaces decremented one shared counter under one reset
+ * timestamp). The budget therefore does NOT scale with the number of brands — every
+ * consumer of that credential draws from one pool, so this feed contends fleet-wide and a
+ * large multi-market brand must not be able to spend the budget in a burst.
+ *
+ * The internal IMS route exposes no `x-ratelimit-*` headers, but that is absence of
+ * evidence, not a higher limit — the bound above is the one to design against.
+ *
+ * Each unit of concurrency costs 2 requests per boundary (one per element), so 4 markets
+ * over a 7-day range is already 4 x 8 x 2 = 64 requests against a 100-per-minute pool.
+ */
+const RESPONSE_FEED_CONCURRENCY = 4;
+
+/**
+ * Expands an inclusive `YYYY-MM-DD` range into its individual days, oldest first.
+ *
+ * The controller has already validated both ends and capped the span, so this does no
+ * validation of its own beyond guarding against a non-terminating loop.
+ *
+ * @param {string} startDate - First day, `YYYY-MM-DD`.
+ * @param {string} endDate - Last day, `YYYY-MM-DD`.
+ * @returns {string[]} Days from `startDate` to `endDate` inclusive.
+ */
+function enumerateDays(startDate, endDate) {
+  const days = [];
+  let cursor = startDate;
+  while (cursor <= endDate) {
+    days.push(cursor);
+    cursor = addDaysToDate(cursor, 1);
+  }
+  return days;
+}
 
 /**
  * Creates the Elements service that composes transport calls with per-element
@@ -290,6 +336,146 @@ export function createElementsService(transport, log) {
       return { count: base.count, prompts };
     },
 
+    /**
+     * Fetches the Brand Claims RESPONSE FEED for a date range: each AI answer paired with
+     * the sources cited in that same execution.
+     *
+     * Neither element can serve this alone. `CITATIONS_SOURCES` (141adc88) has the answer
+     * text but NO date; `SOURCES_DATES` (404fb017) has the date and the cited URLs but no
+     * answer. They are joined on `(project_id, prompt, model, date)` — sound because at most
+     * one execution exists per that tuple (measured 2026-09-04: 2,553 tuples, every one
+     * mapping to exactly one `execution_id`, zero violations).
+     *
+     * BOUNDARY AMORTISATION — the reason this is range-based rather than per-day. The
+     * element ignores `CBF_date__start` and honours `CBF_date__end` as an upper bound over a
+     * rolling window, so a single day is recovered as a difference of two pulls:
+     *
+     *     executions(D) = responses(end = D) MINUS responses(end = D-1)
+     *
+     * Consecutive days SHARE a boundary, so fetching each boundary exactly once and reusing
+     * it for the two days it borders costs N+1 pulls for N days rather than 2N — a ~43%
+     * saving at a week, approaching 2x for longer ranges. The boundary set below is built
+     * once and indexed; no day re-fetches a boundary its neighbour already pulled.
+     *
+     * BUDGET. The production path for this feed is the technical account over the external
+     * gateway, where the rate limit is 100 requests per ~60s window and is PER CREDENTIAL,
+     * not per workspace (measured 2026-09-04: three different workspaces decremented one
+     * shared counter under one reset timestamp). The budget does NOT scale with brands, so
+     * this endpoint contends fleet-wide with every other consumer of that credential. Hence
+     * the deliberately low {@link RESPONSE_FEED_CONCURRENCY}, no retry logic here (a retry
+     * storm would consume the shared pool), and a preference for fewer/larger pages: every
+     * call re-scans the whole rolling window, so raising `limit` is strictly better than
+     * walking `offset`. The internal IMS route publishes no rate-limit headers, which is
+     * absence of evidence rather than a higher ceiling.
+     *
+     * ABSENCE IS MEANINGFUL. A `(prompt, model)` tuple runs on a median 61 of 74 days
+     * (`google-ai-overview` on only 50), so gaps are ROUTINE. A missing tuple means that
+     * model did not run that day — never an error, never data loss. No branch here treats an
+     * empty page or an unmatched key as a failure.
+     *
+     * @param {string} workspaceId - Semrush workspace UUID (resolved from the brand; the
+     *   caller never supplies one).
+     * @param {object} params - Query params.
+     * @param {string[]} [params.projectIds] - Ownership-checked project ids (one per
+     *   market). Empty → a single workspace-wide call.
+     * @param {string} params.startDate - First day to report, `YYYY-MM-DD`.
+     * @param {string} params.endDate - Last day to report, `YYYY-MM-DD`.
+     * @param {string} [params.model] - Model/platform filter.
+     * @param {number} [params.limit] - Upstream page size (clamped by the payload builders).
+     * @returns {Promise<object>} `{ records, days, projectIds, pageSize, truncated,
+     *   unmatchedSourceKeyCount }`.
+     */
+    async getResponseFeed(workspaceId, params) {
+      const {
+        projectIds, startDate, endDate, model, limit,
+      } = params;
+      const ids = Array.isArray(projectIds)
+        // `.trim()` before the emptiness test: `hasText('  ')` is true, so a whitespace-only
+        // id would otherwise become a scope and be sent upstream as `project_id: '  '`.
+        // The controller's UUID validation makes that unreachable today, but the service
+        // must not depend on a caller-side check for its own correctness.
+        ? [...new Set(projectIds.map((id) => String(id ?? '').trim()).filter(hasText))]
+        : [];
+      // No project id → one workspace-wide read. `undefined` (not '') so the payload
+      // builders omit `project_id` entirely rather than sending an empty scope.
+      const scopes = ids.length > 0 ? ids : [undefined];
+
+      // Days to report, plus the extra D-1 boundary the first day needs. Each boundary is
+      // fetched ONCE below and reused by the (at most two) days that border it.
+      const days = enumerateDays(startDate, endDate);
+      const boundaries = [addDaysToDate(days[0], -1), ...days];
+
+      const perScope = await mapWithConcurrency(
+        scopes,
+        RESPONSE_FEED_CONCURRENCY,
+        async (projectId) => {
+          const answersByBoundary = new Map();
+          const sourcesByBoundary = new Map();
+          // Sequential across boundaries: the credential's budget is shared fleet-wide, so
+          // this trades wall-clock for a smaller instantaneous burst against the 100/min pool.
+          for (const boundary of boundaries) {
+            /* eslint-disable no-await-in-loop */
+            const [rawAnswers, rawSources] = await Promise.all([
+              transport.fetchElement(
+                workspaceId,
+                ELEMENT_IDS.CITATIONS_SOURCES,
+                buildPromptResponsesPayload({
+                  projectId, model, endDate: boundary, limit,
+                }),
+              ),
+              transport.fetchElement(
+                workspaceId,
+                ELEMENT_IDS.SOURCES_DATES,
+                buildResponseSourcesPayload({
+                  projectId, model, endDate: boundary, limit,
+                }),
+              ),
+            ]);
+            /* eslint-enable no-await-in-loop */
+            answersByBoundary.set(boundary, transformPromptResponsesResponse(rawAnswers));
+            sourcesByBoundary.set(boundary, transformResponseSourcesResponse(rawSources));
+          }
+          return { answersByBoundary, sourcesByBoundary };
+        },
+      );
+
+      const records = [];
+      let unmatchedSourceKeyCount = 0;
+      let truncated = false;
+      const pageSize = clampLimit(limit);
+
+      for (const { answersByBoundary, sourcesByBoundary } of perScope) {
+        for (const day of days) {
+          // Every `day` and its `D-1` predecessor are members of `boundaries`, which was
+          // fully populated above — so these lookups always hit. No `?? []` fallback: it
+          // would be unreachable, and would mask a genuine gap if the boundary set and the
+          // day list ever fell out of step.
+          const answersToday = answersByBoundary.get(day);
+          const answersYesterday = answersByBoundary.get(addDaysToDate(day, -1));
+          // A full page means the upstream window was cut off, so this day's difference may
+          // be incomplete. Reported rather than silently served as if it were whole.
+          if (answersToday.length >= pageSize) {
+            truncated = true;
+          }
+          const dayAnswers = diffDayExecutions(answersToday, answersYesterday);
+          // Source rows carry their own date, so the day's rows are selected directly
+          // rather than by difference — no second pull needed on this side.
+          const daySources = sourcesByBoundary.get(day).filter((row) => row.date === day);
+          const joined = joinResponsesToSources(dayAnswers, daySources, { date: day });
+          records.push(...joined.records);
+          unmatchedSourceKeyCount += joined.unmatchedSourceKeys.length;
+        }
+      }
+
+      return {
+        records,
+        days,
+        projectIds: ids,
+        pageSize,
+        truncated,
+        unmatchedSourceKeyCount,
+      };
+    },
     /**
      * Fetches domains most frequently cited alongside owned URLs (URL Inspector
      * Cited Domains panel), backed by element 98b91d00 ("Stats per Domain").

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -1972,6 +1972,232 @@ describe('ElementsController', () => {
 
   // ─── extractQuery edge cases ──────────────────────────────────────────────
 
+  // ─── listResponseFeed (Brand Claims response feed) ─────────────────────────
+
+  describe('listResponseFeed', () => {
+    const FEED_RESULT = {
+      records: [{
+        projectId: 'proj-1',
+        prompt: 'best running shoes',
+        model: 'chatgpt-paid',
+        date: '2026-08-24',
+        response: 'Some answer',
+        sources: [],
+        sourceRowCount: 0,
+      }],
+      days: ['2026-08-24'],
+      projectIds: ['proj-1'],
+      pageSize: 5000,
+      truncated: false,
+      unmatchedSourceKeyCount: 0,
+    };
+
+    const feedUrl = (qs = '') => `https://api.example.com/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`
+      + `/serenity/brand-presence/responses${qs}`;
+
+    beforeEach(() => {
+      serviceStub.getResponseFeed = sinon.stub().resolves(FEED_RESULT);
+    });
+
+    it('returns the DTO envelope for a valid range', async () => {
+      const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
+      const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+      expect(res.status).to.equal(200);
+      const body = await readBody(res);
+      expect(body.totalCount).to.equal(1);
+      expect(body.records[0].model).to.equal('chatgpt-paid');
+      expect(body.records[0].date).to.equal('2026-08-24');
+      expect(body.truncated).to.equal(false);
+    });
+
+    it('passes the resolved workspace, never a caller-supplied one', async () => {
+      const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24&workspaceId=evil') });
+      await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+      expect(serviceStub.getResponseFeed).to.have.been.calledWith(SUB_WORKSPACE_ID);
+    });
+
+    describe('date range', () => {
+      it('rejects a malformed from/to', async () => {
+        const ctx = fakeContext({ url: feedUrl('?from=24-08-2026&to=2026-08-24') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+        expect(res.status).to.equal(400);
+      });
+
+      it('rejects an impossible calendar date', async () => {
+        const ctx = fakeContext({ url: feedUrl('?from=2026-13-45&to=2026-08-24') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+        expect(res.status).to.equal(400);
+      });
+
+      it('rejects an inverted range', async () => {
+        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-20') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+        expect(res.status).to.equal(400);
+      });
+
+      // The upstream window is rolling and ~74 days. Beyond it a day is UNRECOVERABLE, and
+      // the upstream returns nothing rather than erroring — which would be served as an
+      // empty result indistinguishable from "no model ran". Rejecting keeps that
+      // ambiguity out of the response.
+      it('rejects a span beyond the rolling window rather than returning an empty result', async () => {
+        const ctx = fakeContext({ url: feedUrl('?from=2026-01-01&to=2026-08-24') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(400);
+        const body = await readBody(res);
+        expect(body.message).to.contain('unrecoverable');
+        expect(serviceStub.getResponseFeed).to.not.have.been.called;
+      });
+
+      it('accepts a span just inside the window', async () => {
+        const ctx = fakeContext({ url: feedUrl('?from=2026-06-13&to=2026-08-24') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+        expect(res.status).to.equal(200);
+      });
+
+      it('accepts the startDate/endDate aliases', async () => {
+        const ctx = fakeContext({ url: feedUrl('?startDate=2026-08-23&endDate=2026-08-24') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(200);
+        expect(serviceStub.getResponseFeed.firstCall.args[1]).to.include({
+          startDate: '2026-08-23', endDate: '2026-08-24',
+        });
+      });
+
+      // Ending yesterday, not today: today's executions are still landing, so ending on
+      // today would report a partial day as if it were complete.
+      it('defaults to the last 7 days ending yesterday', async () => {
+        const ctx = fakeContext({ url: feedUrl() });
+        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        const today = new Date().toISOString().slice(0, 10);
+        const { startDate, endDate } = serviceStub.getResponseFeed.firstCall.args[1];
+        expect(endDate).to.equal(addDaysToDate(today, -1));
+        expect(startDate).to.equal(addDaysToDate(today, -7));
+      });
+    });
+
+    describe('project ownership (tenant isolation)', () => {
+      // LOAD-BEARING: the technical account is broadly entitled, so a caller who guessed
+      // another brand's Semrush project UUID could otherwise read that tenant's answers.
+      it('forbids a projectId this brand does not own', async () => {
+        const ctx = fakeContext({
+          url: feedUrl('?from=2026-08-24&to=2026-08-24&projectId=11111111-1111-4111-8111-111111111111'),
+          withBrandSemrushProject: true,
+          brandSemrushProjects: brandSemrushProjectsFor(['22222222-2222-4222-8222-222222222222']),
+        });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(403);
+        expect(serviceStub.getResponseFeed).to.not.have.been.called;
+      });
+
+      it('allows a projectId the brand owns', async () => {
+        const owned = '22222222-2222-4222-8222-222222222222';
+        const ctx = fakeContext({
+          url: feedUrl(`?from=2026-08-24&to=2026-08-24&projectId=${owned}`),
+          withBrandSemrushProject: true,
+          brandSemrushProjects: brandSemrushProjectsFor([owned]),
+        });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(200);
+        expect(serviceStub.getResponseFeed.firstCall.args[1].projectIds).to.deep.equal([owned]);
+      });
+
+      it('rejects a non-UUID projectId before any upstream call', async () => {
+        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24&projectId=not-a-uuid') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(400);
+        expect(serviceStub.getResponseFeed).to.not.have.been.called;
+      });
+
+      it('scopes to all of the brand markets when no projectId is given', async () => {
+        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
+        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(serviceStub.getResponseFeed.firstCall.args[1].projectIds).to.deep.equal([]);
+      });
+
+      // The ownership check must fail CLOSED when the data-access layer yields no
+      // BrandSemrushProject: the owned set is empty, so any supplied id is unowned and the
+      // request is denied rather than passed upstream unchecked.
+      it('denies a supplied projectId when no brand projects are resolvable', async () => {
+        const ctx = fakeContext({
+          url: feedUrl('?from=2026-08-24&to=2026-08-24&projectId=22222222-2222-4222-8222-222222222222'),
+          withBrandSemrushProject: true,
+          brandSemrushProjects: [],
+        });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(403);
+        expect(serviceStub.getResponseFeed).to.not.have.been.called;
+      });
+    });
+
+    describe('auth guards', () => {
+      it('403s when the caller lacks access to the organization', async () => {
+        accessControlHasAccessStub.resolves(false);
+        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(403);
+        expect(serviceStub.getResponseFeed).to.not.have.been.called;
+      });
+
+      it('404s when serenity is not active for the brand', async () => {
+        isSerenityActiveForBrandStub.resolves(false);
+        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(404);
+      });
+
+      it('400s on a malformed brand id', async () => {
+        const ctx = fakeContext({
+          url: feedUrl('?from=2026-08-24&to=2026-08-24'),
+          params: { brandId: 'not-a-uuid' },
+        });
+        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(res.status).to.equal(400);
+      });
+    });
+
+    describe('query passthrough', () => {
+      it('forwards the model filter and page limit', async () => {
+        const ctx = fakeContext({
+          url: feedUrl('?from=2026-08-24&to=2026-08-24&model=perplexity&limit=100'),
+        });
+        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(serviceStub.getResponseFeed.firstCall.args[1]).to.include({
+          model: 'perplexity', limit: '100',
+        });
+      });
+
+      it('accepts platform as a legacy alias for model', async () => {
+        const ctx = fakeContext({
+          url: feedUrl('?from=2026-08-24&to=2026-08-24&platform=grok'),
+        });
+        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+        expect(serviceStub.getResponseFeed.firstCall.args[1].model).to.equal('grok');
+      });
+    });
+
+    it('maps an upstream transport failure to 502', async () => {
+      serviceStub.getResponseFeed.rejects(new MockElementsTransportError(500, 'boom'));
+      const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
+      const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+
+      expect(res.status).to.equal(502);
+    });
+  });
   describe('extractQuery', () => {
     it('returns empty params (plus an empty projectIds) when request URL is missing', async () => {
       const ctx = fakeContext({ url: null });

--- a/test/dto/response-feed.test.js
+++ b/test/dto/response-feed.test.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ResponseFeedDto } from '../../src/dto/response-feed.js';
+
+const record = (over = {}) => ({
+  projectId: 'proj-1',
+  prompt: 'best running shoes',
+  model: 'chatgpt-paid',
+  date: '2026-08-24',
+  response: 'Some answer text',
+  tags: '$abv_tags$type__branded',
+  sources: [{
+    url: 'https://runnersworld.com/best',
+    source: 'runnersworld.com',
+    position: 1,
+    domainType: 'Earned',
+  }],
+  sourceRowCount: 1,
+  ...over,
+});
+
+describe('ResponseFeedDto', () => {
+  describe('toJSON', () => {
+    it('maps a joined record onto the API contract', () => {
+      expect(ResponseFeedDto.toJSON(record())).to.deep.equal({
+        projectId: 'proj-1',
+        prompt: 'best running shoes',
+        model: 'chatgpt-paid',
+        date: '2026-08-24',
+        response: 'Some answer text',
+        sources: [{
+          url: 'https://runnersworld.com/best',
+          domain: 'runnersworld.com',
+          rank: 1,
+          domainType: 'Earned',
+        }],
+        sourceCount: 1,
+      });
+    });
+
+    // The downstream consumer keys on (prompt, region) and carries no model or date
+    // dimension, so it cannot reconstruct either. Dropping them would silently collapse
+    // distinct executions into one.
+    it('always exposes model and date, which the consumer cannot reconstruct', () => {
+      const json = ResponseFeedDto.toJSON(record());
+      expect(json).to.have.property('model', 'chatgpt-paid');
+      expect(json).to.have.property('date', '2026-08-24');
+    });
+
+    it('never leaks upstream-only fields', () => {
+      const json = ResponseFeedDto.toJSON(record({
+        executionId: 'proj-1|2026-08-24|chatgpt-paid|best running shoes',
+        modelNameCbfValue: 'ChatGPT (paid)',
+      }));
+      expect(json).to.not.have.property('executionId');
+      expect(json).to.not.have.property('modelNameCbfValue');
+      expect(json).to.not.have.property('tags');
+    });
+
+    // Empty sources mean "cited nothing that day", which is routine and not an error.
+    it('renders an empty source list rather than omitting the field', () => {
+      const json = ResponseFeedDto.toJSON(record({ sources: [], sourceRowCount: 0 }));
+      expect(json.sources).to.deep.equal([]);
+      expect(json.sourceCount).to.equal(0);
+    });
+
+    it('defaults every field on a sparse record instead of emitting undefined', () => {
+      expect(ResponseFeedDto.toJSON({})).to.deep.equal({
+        projectId: '',
+        prompt: '',
+        model: '',
+        date: '',
+        response: '',
+        sources: [],
+        sourceCount: 0,
+      });
+    });
+
+    it('defaults missing fields on a sparse source row', () => {
+      const json = ResponseFeedDto.toJSON(record({ sources: [{}] }));
+      expect(json.sources[0]).to.deep.equal({
+        url: '', domain: '', rank: 0, domainType: '',
+      });
+    });
+  });
+
+  describe('toEnvelopeJSON', () => {
+    it('wraps the records with the paging and integrity envelope', () => {
+      const envelope = ResponseFeedDto.toEnvelopeJSON({
+        records: [record()],
+        days: ['2026-08-24'],
+        projectIds: ['proj-1'],
+        pageSize: 5000,
+        truncated: false,
+        unmatchedSourceKeyCount: 0,
+      });
+
+      expect(envelope.totalCount).to.equal(1);
+      expect(envelope.days).to.deep.equal(['2026-08-24']);
+      expect(envelope.projectIds).to.deep.equal(['proj-1']);
+      expect(envelope.pageSize).to.equal(5000);
+      expect(envelope.truncated).to.equal(false);
+      expect(envelope.unmatchedSourceKeyCount).to.equal(0);
+      expect(envelope.records[0].prompt).to.equal('best running shoes');
+    });
+
+    // Truncation must be visible: it is what separates an incomplete read from a genuinely
+    // quiet day, and a missing tuple is normally legitimate.
+    it('surfaces truncation so a clipped window is not read as a quiet day', () => {
+      const envelope = ResponseFeedDto.toEnvelopeJSON({
+        records: [], days: ['2026-08-24'], truncated: true, unmatchedSourceKeyCount: 3,
+      });
+      expect(envelope.truncated).to.equal(true);
+      expect(envelope.unmatchedSourceKeyCount).to.equal(3);
+    });
+
+    it('renders an empty feed without throwing', () => {
+      expect(ResponseFeedDto.toEnvelopeJSON({})).to.deep.equal({
+        records: [],
+        totalCount: 0,
+        days: [],
+        projectIds: [],
+        pageSize: 0,
+        truncated: false,
+        unmatchedSourceKeyCount: 0,
+      });
+    });
+  });
+});

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -492,6 +492,38 @@ const FIXTURES = {
       }],
     },
   },
+  listSerenityBrandPresenceResponses: {
+    expectedStatus: 200,
+    usesElementsController: true,
+    controllerMethod: 'listResponseFeed',
+    serviceMethod: 'getResponseFeed',
+    // from/to are optional (they default to the last 7 days ending yesterday), but are
+    // supplied here so the fixture is deterministic rather than clock-dependent.
+    query: { from: '2026-08-23', to: '2026-08-24' },
+    // getResponseFeed returns the joined shape; the controller maps it through
+    // ResponseFeedDto.toEnvelopeJSON before ok().
+    handlerResult: {
+      records: [{
+        projectId: 'cb4f6443-e01f-4075-a586-85511f136e31',
+        prompt: 'best running shoes for flat feet',
+        model: 'chatgpt-paid',
+        date: '2026-08-24',
+        response: 'For flat feet, look for stability shoes with firm midsoles.',
+        sources: [{
+          url: 'https://www.runnersworld.com/gear/best-running-shoes',
+          source: 'runnersworld.com',
+          position: 1,
+          domainType: 'Earned',
+        }],
+        sourceRowCount: 1,
+      }],
+      days: ['2026-08-23', '2026-08-24'],
+      projectIds: ['cb4f6443-e01f-4075-a586-85511f136e31'],
+      pageSize: 5000,
+      truncated: false,
+      unmatchedSourceKeyCount: 0,
+    },
+  },
   listSerenityBrandPresenceSubreddits: {
     expectedStatus: 200,
     usesElementsController: true,

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -1028,6 +1028,7 @@ describe('getRouteHandlers', () => {
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/access',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/cited-domains',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/responses',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/sentiment-overview',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/subreddits',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/reddit-threads',

--- a/test/support/elements/definitions/prompt-responses.test.js
+++ b/test/support/elements/definitions/prompt-responses.test.js
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  buildPromptResponsesPayload,
+  transformPromptResponsesResponse,
+  DEFAULT_RESPONSE_PAGE_SIZE,
+  MAX_RESPONSE_PAGE_SIZE,
+} from '../../../../src/support/elements/definitions/prompt-responses.js';
+import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
+
+const responseRow = (overrides = {}) => ({
+  project_id: 'proj-1',
+  prompt: 'best running shoes',
+  model: 'chatgpt-paid',
+  model_name_cbf_value: 'ChatGPT Paid',
+  response: 'The best running shoes are ...',
+  position: 3,
+  tags: '$abv_tags$intent__Commercial',
+  ...overrides,
+});
+
+const rawWith = (...rows) => ({ blocks: { data: rows } });
+
+describe('prompt-responses definitions', () => {
+  describe('buildPromptResponsesPayload', () => {
+    it('falls back to the default model when no params are provided', () => {
+      const payload = buildPromptResponsesPayload();
+      expect(payload.filters.advanced.filters[0]).to.deep.equal({
+        op: 'or', filters: [{ op: 'eq', val: DEFAULT_ELEMENT_MODEL, col: 'CBF_model' }],
+      });
+    });
+
+    it('translates a UI platform code to its Semrush model name', () => {
+      const payload = buildPromptResponsesPayload({ platform: 'anthropic' });
+      expect(payload.filters.advanced.filters[0].filters[0].val).to.equal('claude-sonnet-4');
+    });
+
+    it('prefers model over platform when both are supplied', () => {
+      const payload = buildPromptResponsesPayload({ model: 'grok-3', platform: 'anthropic' });
+      expect(payload.filters.advanced.filters[0].filters[0].val).to.equal('grok-3');
+    });
+
+    it('sends the date bounds in BOTH the simple and advanced blocks', () => {
+      const payload = buildPromptResponsesPayload({ endDate: '2026-08-24' });
+      expect(payload.filters.simple).to.deep.equal({
+        CBF_date__start: '2026-08-24', CBF_date__end: '2026-08-24',
+      });
+      expect(payload.filters.advanced.filters).to.deep.include({
+        op: 'gte', val: '2026-08-24', col: 'CBF_date__start',
+      });
+      expect(payload.filters.advanced.filters).to.deep.include({
+        op: 'lte', val: '2026-08-24', col: 'CBF_date__end',
+      });
+    });
+
+    it('never emits the silently-ignored start_date/end_date spellings', () => {
+      const payload = buildPromptResponsesPayload({ endDate: '2026-08-24' });
+      expect(payload).to.not.have.property('start_date');
+      expect(payload).to.not.have.property('end_date');
+      expect(payload.filters).to.not.have.property('start_date');
+      expect(payload.filters).to.not.have.property('end_date');
+    });
+
+    it('omits the date blocks entirely when no endDate is given', () => {
+      const payload = buildPromptResponsesPayload();
+      expect(payload.filters).to.not.have.property('simple');
+      const cols = payload.filters.advanced.filters.map((f) => f.col);
+      expect(cols).to.not.include('CBF_date__start');
+      expect(cols).to.not.include('CBF_date__end');
+    });
+
+    it('includes a top-level project_id when provided', () => {
+      const payload = buildPromptResponsesPayload({ projectId: 'proj-42' });
+      expect(payload.project_id).to.equal('proj-42');
+    });
+
+    it('omits project_id when not provided', () => {
+      expect(buildPromptResponsesPayload()).to.not.have.property('project_id');
+    });
+
+    it('always sends sort_columns for deterministic pagination', () => {
+      expect(buildPromptResponsesPayload().pagination.sort_columns).to.deep.equal(['prompt asc']);
+    });
+
+    it('defaults the page size and offset', () => {
+      const { pagination } = buildPromptResponsesPayload();
+      expect(pagination.limit).to.equal(DEFAULT_RESPONSE_PAGE_SIZE);
+      expect(pagination.offset).to.equal(0);
+    });
+
+    it('honours an explicit limit and offset', () => {
+      const { pagination } = buildPromptResponsesPayload({ limit: 50, offset: 100 });
+      expect(pagination.limit).to.equal(50);
+      expect(pagination.offset).to.equal(100);
+    });
+
+    it('clamps a limit above the 504-inducing ceiling', () => {
+      expect(buildPromptResponsesPayload({ limit: 99999 }).pagination.limit)
+        .to.equal(MAX_RESPONSE_PAGE_SIZE);
+    });
+
+    it('clamps a zero or negative limit up to 1', () => {
+      expect(buildPromptResponsesPayload({ limit: 0 }).pagination.limit).to.equal(1);
+      expect(buildPromptResponsesPayload({ limit: -5 }).pagination.limit).to.equal(1);
+    });
+
+    it('falls back to the default limit for a non-numeric value', () => {
+      expect(buildPromptResponsesPayload({ limit: 'abc' }).pagination.limit)
+        .to.equal(DEFAULT_RESPONSE_PAGE_SIZE);
+    });
+
+    it('floors a negative or non-numeric offset at 0', () => {
+      expect(buildPromptResponsesPayload({ offset: -10 }).pagination.offset).to.equal(0);
+      expect(buildPromptResponsesPayload({ offset: 'abc' }).pagination.offset).to.equal(0);
+    });
+  });
+
+  describe('transformPromptResponsesResponse', () => {
+    it('maps the element columns onto the normalised row shape', () => {
+      const [row] = transformPromptResponsesResponse(rawWith(responseRow()));
+      expect(row).to.deep.equal({
+        projectId: 'proj-1',
+        prompt: 'best running shoes',
+        model: 'chatgpt-paid',
+        modelNameCbfValue: 'ChatGPT Paid',
+        response: 'The best running shoes are ...',
+        position: 3,
+        tags: '$abv_tags$intent__Commercial',
+      });
+    });
+
+    it('never sets a date — this element has no date column', () => {
+      const [row] = transformPromptResponsesResponse(rawWith(responseRow()));
+      expect(row).to.not.have.property('date');
+    });
+
+    it('drops rows without a prompt, which can never join', () => {
+      const rows = transformPromptResponsesResponse(
+        rawWith(responseRow(), responseRow({ prompt: null })),
+      );
+      expect(rows).to.have.lengthOf(1);
+    });
+
+    it('drops null rows', () => {
+      expect(transformPromptResponsesResponse(rawWith(null, responseRow()))).to.have.lengthOf(1);
+    });
+
+    it('coerces a non-numeric position to 0 rather than NaN', () => {
+      const [row] = transformPromptResponsesResponse(rawWith(responseRow({ position: 'x' })));
+      expect(row.position).to.equal(0);
+    });
+
+    it('defaults absent optional fields to empty strings', () => {
+      const [row] = transformPromptResponsesResponse(rawWith({ prompt: 'p' }));
+      expect(row.projectId).to.equal('');
+      expect(row.model).to.equal('');
+      expect(row.modelNameCbfValue).to.equal('');
+      expect(row.response).to.equal('');
+      expect(row.tags).to.equal('');
+    });
+
+    it('returns an empty array for absent, empty or malformed payloads', () => {
+      expect(transformPromptResponsesResponse(undefined)).to.deep.equal([]);
+      expect(transformPromptResponsesResponse({})).to.deep.equal([]);
+      expect(transformPromptResponsesResponse({ blocks: {} })).to.deep.equal([]);
+      expect(transformPromptResponsesResponse(rawWith())).to.deep.equal([]);
+    });
+  });
+});

--- a/test/support/elements/definitions/prompt-responses.test.js
+++ b/test/support/elements/definitions/prompt-responses.test.js
@@ -106,16 +106,22 @@ describe('prompt-responses definitions', () => {
     });
 
     it('pins the page bounds to the values measured against the live element', () => {
-      // These are evidence, not preferences (measured 2026-09-04, Repsol ES workspace):
-      //   20,000 -> 200 in 44.6s / 60.6 MB      50,000 -> 504 Gateway Timeout
-      //    5,000 -> 200 in 12.4s / 14.7 MB
-      // Asserted as literals so that changing the constant away from the measured ceiling
-      // fails here rather than silently tracking it. Re-measure before changing these.
+      // Evidence, not preference. Measured 2026-09-04 on BOTH routes this endpoint must
+      // run over (per page):
+      //            internal (IMS)          external (technical account)
+      //    5,000   200 - 12.8s /  14.7MB   200 - 12.4s / 14.7MB
+      //   20,000   200 - 41.6s /  60.7MB   200 - 44.6s / 60.6MB
+      //   50,000   200 - 95.9s / 149.6MB   504 Gateway Timeout
+      // 20,000 is the largest page that works on BOTH, which is why it is the ceiling:
+      // 50,000 is unavailable on the external gateway (the feed's production path) and
+      // ~96s/~150MB on the internal route, hostile to Lambda timeout and memory.
+      // Asserted as literals so changing a constant away from the measured basis fails
+      // here rather than silently tracking it. Re-measure before changing these.
       expect(MAX_RESPONSE_PAGE_SIZE).to.equal(20000);
       expect(DEFAULT_RESPONSE_PAGE_SIZE).to.equal(5000);
     });
 
-    it('clamps a limit above the 504-inducing ceiling', () => {
+    it('clamps a limit above the page-size ceiling', () => {
       expect(buildPromptResponsesPayload({ limit: 99999 }).pagination.limit)
         .to.equal(MAX_RESPONSE_PAGE_SIZE);
     });

--- a/test/support/elements/definitions/prompt-responses.test.js
+++ b/test/support/elements/definitions/prompt-responses.test.js
@@ -105,6 +105,16 @@ describe('prompt-responses definitions', () => {
       expect(pagination.offset).to.equal(100);
     });
 
+    it('pins the page bounds to the values measured against the live element', () => {
+      // These are evidence, not preferences (measured 2026-09-04, Repsol ES workspace):
+      //   20,000 -> 200 in 44.6s / 60.6 MB      50,000 -> 504 Gateway Timeout
+      //    5,000 -> 200 in 12.4s / 14.7 MB
+      // Asserted as literals so that changing the constant away from the measured ceiling
+      // fails here rather than silently tracking it. Re-measure before changing these.
+      expect(MAX_RESPONSE_PAGE_SIZE).to.equal(20000);
+      expect(DEFAULT_RESPONSE_PAGE_SIZE).to.equal(5000);
+    });
+
     it('clamps a limit above the 504-inducing ceiling', () => {
       expect(buildPromptResponsesPayload({ limit: 99999 }).pagination.limit)
         .to.equal(MAX_RESPONSE_PAGE_SIZE);

--- a/test/support/elements/definitions/response-feed.test.js
+++ b/test/support/elements/definitions/response-feed.test.js
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  joinResponsesToSources,
+  diffDayExecutions,
+} from '../../../../src/support/elements/definitions/response-feed.js';
+
+const DATE = '2026-08-24';
+
+const answer = (overrides = {}) => ({
+  projectId: 'proj-1',
+  prompt: 'best running shoes',
+  model: 'chatgpt-paid',
+  modelNameCbfValue: 'ChatGPT Paid',
+  response: 'The best running shoes are ...',
+  position: 1,
+  tags: 'type__branded',
+  ...overrides,
+});
+
+const cite = (overrides = {}) => ({
+  projectId: 'proj-1',
+  prompt: 'best running shoes',
+  model: 'chatgpt-paid',
+  date: DATE,
+  url: 'https://a.example/1',
+  source: 'a.example',
+  position: 1,
+  domainType: 'Earned',
+  executionId: 'e1',
+  tags: '',
+  ...overrides,
+});
+
+describe('response-feed join', () => {
+  describe('joinResponsesToSources', () => {
+    it('pairs an answer with its own sources on (project, prompt, model, date)', () => {
+      const { records } = joinResponsesToSources(
+        [answer()],
+        [cite(), cite({ url: 'https://b.example/2', source: 'b.example', position: 2 })],
+        { date: DATE },
+      );
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].response).to.equal('The best running shoes are ...');
+      expect(records[0].date).to.equal(DATE);
+      expect(records[0].sources.map((s) => s.url))
+        .to.deep.equal(['https://a.example/1', 'https://b.example/2']);
+      expect(records[0].sourceRowCount).to.equal(2);
+    });
+
+    it('orders sources by the aggregate position column', () => {
+      const { records } = joinResponsesToSources(
+        [answer()],
+        [
+          cite({ url: 'https://third', position: 30 }),
+          cite({ url: 'https://first', position: 1 }),
+          cite({ url: 'https://second', position: 7 }),
+        ],
+        { date: DATE },
+      );
+      expect(records[0].sources.map((s) => s.url))
+        .to.deep.equal(['https://first', 'https://second', 'https://third']);
+    });
+
+    it('does NOT pair sources from a different model', () => {
+      const { records } = joinResponsesToSources(
+        [answer({ model: 'chatgpt-paid' })],
+        [cite({ model: 'claude-sonnet-4' })],
+        { date: DATE },
+      );
+      expect(records[0].sources).to.deep.equal([]);
+      expect(records[0].sourceRowCount).to.equal(0);
+    });
+
+    it('does NOT pair sources from a different day', () => {
+      const { records } = joinResponsesToSources(
+        [answer()],
+        [cite({ date: '2026-08-23' })],
+        { date: DATE },
+      );
+      expect(records[0].sources).to.deep.equal([]);
+    });
+
+    it('does NOT pair sources from a different project', () => {
+      const { records } = joinResponsesToSources(
+        [answer({ projectId: 'proj-1' })],
+        [cite({ projectId: 'proj-2' })],
+        { date: DATE },
+      );
+      expect(records[0].sources).to.deep.equal([]);
+    });
+
+    it('does NOT pair sources from a different prompt', () => {
+      const { records } = joinResponsesToSources(
+        [answer({ prompt: 'a' })],
+        [cite({ prompt: 'b' })],
+        { date: DATE },
+      );
+      expect(records[0].sources).to.deep.equal([]);
+    });
+
+    it('keeps an answer with no sources rather than dropping it — absence is meaningful', () => {
+      const { records } = joinResponsesToSources([answer()], [], { date: DATE });
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].sources).to.deep.equal([]);
+      expect(records[0].sourceRowCount).to.equal(0);
+    });
+
+    it('reports source rows that matched no answer instead of discarding them', () => {
+      const { records, unmatchedSourceKeys } = joinResponsesToSources(
+        [answer()],
+        [cite(), cite({ prompt: 'an orphaned prompt' })],
+        { date: DATE },
+      );
+      expect(records).to.have.lengthOf(1);
+      expect(unmatchedSourceKeys).to.have.lengthOf(1);
+      expect(unmatchedSourceKeys[0]).to.contain('an orphaned prompt');
+    });
+
+    it('routes each answer to its own sources when models differ on one prompt', () => {
+      const { records, unmatchedSourceKeys } = joinResponsesToSources(
+        [answer({ model: 'chatgpt-paid' }), answer({ model: 'claude-sonnet-4' })],
+        [
+          cite({ model: 'chatgpt-paid', url: 'https://gpt-src' }),
+          cite({ model: 'claude-sonnet-4', url: 'https://claude-src' }),
+        ],
+        { date: DATE },
+      );
+      expect(records[0].sources.map((s) => s.url)).to.deep.equal(['https://gpt-src']);
+      expect(records[1].sources.map((s) => s.url)).to.deep.equal(['https://claude-src']);
+      expect(unmatchedSourceKeys).to.deep.equal([]);
+    });
+
+    it('does not let a prompt containing a delimiter collide with another tuple', () => {
+      // The composite key uses U+001F precisely so free-text prompts cannot forge a boundary.
+      const { records } = joinResponsesToSources(
+        [answer({ prompt: 'a|proj-1|x' })],
+        [cite({ prompt: 'a', projectId: 'proj-1|x' })],
+        { date: DATE },
+      );
+      expect(records[0].sources).to.deep.equal([]);
+    });
+
+    it('projects only the citation fields a consumer needs', () => {
+      const { records } = joinResponsesToSources([answer()], [cite()], { date: DATE });
+      expect(records[0].sources[0]).to.deep.equal({
+        url: 'https://a.example/1', source: 'a.example', position: 1, domainType: 'Earned',
+      });
+    });
+
+    it('matches nothing when no date is supplied, since answers carry none', () => {
+      const { records } = joinResponsesToSources([answer()], [cite()]);
+      expect(records[0].sources).to.deep.equal([]);
+      expect(records[0].date).to.equal('');
+    });
+
+    it('tolerates absent or non-array inputs', () => {
+      expect(joinResponsesToSources(undefined, undefined).records).to.deep.equal([]);
+      expect(joinResponsesToSources(null, null).unmatchedSourceKeys).to.deep.equal([]);
+      expect(joinResponsesToSources([answer()], 'nope', { date: DATE }).records)
+        .to.have.lengthOf(1);
+    });
+
+    it('treats missing key components as empty rather than throwing', () => {
+      // No projectId and no model on either side: both must normalise to '' and still pair.
+      const { records } = joinResponsesToSources(
+        [{ prompt: 'p', response: 'r' }],
+        [{
+          prompt: 'p', date: DATE, url: 'https://u', position: 1,
+        }],
+        { date: DATE },
+      );
+      expect(records[0].sources.map((s) => s.url)).to.deep.equal(['https://u']);
+    });
+
+    it('normalises a null prompt to the empty key component', () => {
+      // Both transforms drop prompt-less rows, so this is only reachable by calling the
+      // join directly — but the key builder must not throw or stringify null if they do.
+      const { records } = joinResponsesToSources(
+        [answer({ prompt: null })],
+        [cite({ prompt: null })],
+        { date: DATE },
+      );
+      expect(records[0].sources.map((s) => s.url)).to.deep.equal(['https://a.example/1']);
+    });
+
+    it('groups a source row that carries no date under the empty-date key', () => {
+      // Exercises the `row.date` fallback in the key builder: source rows are keyed from
+      // their own date, so one lacking it must still group rather than throw. Such a row
+      // cannot match a dated answer, so it surfaces as unmatched.
+      const { records, unmatchedSourceKeys } = joinResponsesToSources(
+        [answer()],
+        [{
+          projectId: 'proj-1', prompt: 'best running shoes', model: 'chatgpt-paid', position: 1,
+        }],
+        { date: DATE },
+      );
+      expect(records[0].sources).to.deep.equal([]);
+      expect(unmatchedSourceKeys).to.have.lengthOf(1);
+    });
+  });
+
+  describe('diffDayExecutions', () => {
+    // Regression: element 141adc88 has no date column and returns one row PER EXECUTION, so a
+    // page holds the entire ~50-day rolling window. Measured live: a 400-row page held only 10
+    // distinct (prompt, model) pairs, one repeated 54 times. A distinct-Set difference therefore
+    // returns [] for any prompt that also ran earlier in the window — verified against two live
+    // adjacent-day captures, where a set difference gave 0 rows and a multiset difference gave
+    // 4 and 5. [] is indistinguishable from "nothing ran", the data-loss outcome we forbid.
+    it('counts repeats: a daily prompt already in the D-1 page still reports its day-D row', () => {
+      // Same (project, prompt, model) 3x on D-1 and 4x on D: exactly one execution on day D.
+      const prev = [answer(), answer(), answer()];
+      const curr = [answer(), answer(), answer(), answer()];
+
+      const result = diffDayExecutions(curr, prev);
+
+      expect(result).to.have.lengthOf(1);
+    });
+
+    it('does not collapse repeated rows to a single identity', () => {
+      // 1 -> 3 is two new executions, not one, and not zero.
+      expect(diffDayExecutions([answer(), answer(), answer()], [answer()])).to.have.lengthOf(2);
+    });
+
+    it('reports every row when the prior page is empty', () => {
+      expect(diffDayExecutions([answer(), answer()], [])).to.have.lengthOf(2);
+    });
+
+    it('reports nothing when the counts are unchanged', () => {
+      const prev = [answer(), answer()];
+      expect(diffDayExecutions([answer(), answer()], prev)).to.deep.equal([]);
+    });
+
+    it('never returns negative rows when the window drops more than it gains', () => {
+      // Rows aging off the OLDER end of the rolling window: 4 -> 2 is an expiry, not activity.
+      expect(diffDayExecutions([answer(), answer()], [answer(), answer(), answer(), answer()]))
+        .to.deep.equal([]);
+    });
+
+    it('returns only the rows that are new on day D', () => {
+      const carried = answer({ prompt: 'carried over' });
+      const fresh = answer({ prompt: 'new today' });
+      expect(diffDayExecutions([carried, fresh], [carried]))
+        .to.deep.equal([fresh]);
+    });
+
+    it('returns everything when the previous day had no rows', () => {
+      const rows = [answer(), answer({ model: 'grok-3' })];
+      expect(diffDayExecutions(rows, [])).to.deep.equal(rows);
+    });
+
+    it('returns nothing when the day added no executions', () => {
+      const rows = [answer()];
+      expect(diffDayExecutions(rows, rows)).to.deep.equal([]);
+    });
+
+    it('distinguishes rows by model, so one model per prompt is counted separately', () => {
+      const gpt = answer({ model: 'chatgpt-paid' });
+      const claude = answer({ model: 'claude-sonnet-4' });
+      expect(diffDayExecutions([gpt, claude], [gpt])).to.deep.equal([claude]);
+    });
+
+    it('distinguishes rows by project', () => {
+      const p1 = answer({ projectId: 'proj-1' });
+      const p2 = answer({ projectId: 'proj-2' });
+      expect(diffDayExecutions([p1, p2], [p1])).to.deep.equal([p2]);
+    });
+
+    it('ignores rows that rolled OFF the older end of the window', () => {
+      // The window rolls rather than accumulating, so a row present at end=D-1 and absent at
+      // end=D is an expiry, not day-D activity — a symmetric difference would misreport it.
+      const expired = answer({ prompt: 'aged out' });
+      const fresh = answer({ prompt: 'new today' });
+      const result = diffDayExecutions([fresh], [expired]);
+      expect(result).to.deep.equal([fresh]);
+      expect(result).to.not.deep.include(expired);
+    });
+
+    it('measures the one-execution-per-tuple invariant: 10 models add exactly 10 rows', () => {
+      const models = [
+        'chatgpt-paid', 'claude-sonnet-4', 'grok-3', 'gemini-2.5-flash', 'perplexity',
+        'search-gpt', 'gpt-5', 'google-ai-mode', 'google-ai-overview', 'microsoft-copilot',
+      ];
+      const previous = [];
+      const current = models.map((model) => answer({ model }));
+      expect(diffDayExecutions(current, previous)).to.have.lengthOf(10);
+    });
+
+    it('tolerates absent or non-array inputs', () => {
+      expect(diffDayExecutions(undefined, undefined)).to.deep.equal([]);
+      expect(diffDayExecutions(null, null)).to.deep.equal([]);
+      expect(diffDayExecutions([answer()], undefined)).to.have.lengthOf(1);
+    });
+
+    it('treats missing identity components as empty rather than throwing', () => {
+      expect(diffDayExecutions([{ prompt: 'p' }], [{ prompt: 'p' }])).to.deep.equal([]);
+      expect(diffDayExecutions([{}], [])).to.have.lengthOf(1);
+    });
+  });
+});

--- a/test/support/elements/definitions/response-feed.test.js
+++ b/test/support/elements/definitions/response-feed.test.js
@@ -218,6 +218,26 @@ describe('response-feed join', () => {
     // returns [] for any prompt that also ran earlier in the window — verified against two live
     // adjacent-day captures, where a set difference gave 0 rows and a multiset difference gave
     // 4 and 5. [] is indistinguishable from "nothing ran", the data-loss outcome we forbid.
+    it('does not let a U+001F inside a prompt forge a key boundary', () => {
+      // U+001F is the vector a separator-joined key is most exposed to, since it is the
+      // character such a key would use. These two tuples are DIFFERENT executions but would
+      // join to one identical string under any separator scheme:
+      //   ('p', 'a<US>b', 'm')  vs  ('p', 'a', 'b<US>m')
+      // They must remain distinct, so neither can consume the other's row in the difference.
+      const sneaky = answer({ projectId: 'p', prompt: 'a\u001Fb', model: 'm' });
+      const other = answer({ projectId: 'p', prompt: 'a', model: 'b\u001Fm' });
+
+      // If the keys collided, `other` would consume `sneaky`'s prior row and this would be 0.
+      expect(diffDayExecutions([sneaky], [other])).to.have.lengthOf(1);
+      expect(diffDayExecutions([other], [sneaky])).to.have.lengthOf(1);
+    });
+
+    it('keeps a pipe inside a prompt from forging a key boundary', () => {
+      const a = answer({ projectId: 'p', prompt: 'a|b', model: 'm' });
+      const b = answer({ projectId: 'p', prompt: 'a', model: 'b|m' });
+      expect(diffDayExecutions([a], [b])).to.have.lengthOf(1);
+    });
+
     it('counts repeats: a daily prompt already in the D-1 page still reports its day-D row', () => {
       // Same (project, prompt, model) 3x on D-1 and 4x on D: exactly one execution on day D.
       const prev = [answer(), answer(), answer()];

--- a/test/support/elements/definitions/response-sources.test.js
+++ b/test/support/elements/definitions/response-sources.test.js
@@ -143,6 +143,29 @@ describe('response-sources definitions', () => {
       });
     });
 
+    // Regression: the live element returns `date` as a FULL TIMESTAMP
+    // (`2026-09-03T00:00:00Z`, measured 2026-09-04), not the bare `YYYY-MM-DD` the fixtures
+    // above use. `date` is a join-key component and the answer side supplies a bare day, so
+    // an untruncated value never matches: every record would come back with an empty
+    // `sources` array — indistinguishable from the legitimate "cited nothing that day" case,
+    // and therefore silent data loss rather than an error.
+    it('truncates the live full-timestamp date to a calendar day', () => {
+      const [row] = transformResponseSourcesResponse(
+        rawWith(sourceRow({ date: '2026-09-03T00:00:00Z' })),
+      );
+      expect(row.date).to.equal('2026-09-03');
+    });
+
+    it('leaves an already-bare calendar day unchanged', () => {
+      const [row] = transformResponseSourcesResponse(rawWith(sourceRow({ date: '2026-08-24' })));
+      expect(row.date).to.equal('2026-08-24');
+    });
+
+    it('normalises a non-string date to the empty day rather than throwing', () => {
+      const [row] = transformResponseSourcesResponse(rawWith(sourceRow({ date: 20260824 })));
+      expect(row.date).to.equal('');
+    });
+
     it('falls back to source when url_cbf is absent', () => {
       const [row] = transformResponseSourcesResponse(rawWith(sourceRow({ url_cbf: null })));
       expect(row.url).to.equal('runnersworld.com');

--- a/test/support/elements/definitions/response-sources.test.js
+++ b/test/support/elements/definitions/response-sources.test.js
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  buildResponseSourcesPayload,
+  transformResponseSourcesResponse,
+} from '../../../../src/support/elements/definitions/response-sources.js';
+import {
+  DEFAULT_RESPONSE_PAGE_SIZE,
+  MAX_RESPONSE_PAGE_SIZE,
+} from '../../../../src/support/elements/definitions/prompt-responses.js';
+import { DEFAULT_ELEMENT_MODEL } from '../../../../src/support/elements/constants.js';
+
+const sourceRow = (overrides = {}) => ({
+  execution_id: 'proj-1|2026-08-24|chatgpt-paid|best running shoes',
+  project_id: 'proj-1',
+  prompt: 'best running shoes',
+  date: '2026-08-24',
+  model: 'chatgpt-paid',
+  source: 'runnersworld.com',
+  url_cbf: 'https://runnersworld.com/best-shoes',
+  position: 1,
+  domain_type: 'Earned',
+  tags: '$abv_tags$type__branded',
+  ...overrides,
+});
+
+const rawWith = (...rows) => ({ blocks: { data: rows } });
+
+describe('response-sources definitions', () => {
+  describe('buildResponseSourcesPayload', () => {
+    it('falls back to the default model when no params are provided', () => {
+      const payload = buildResponseSourcesPayload();
+      expect(payload.filters.advanced.filters[0]).to.deep.equal({
+        op: 'or', filters: [{ op: 'eq', val: DEFAULT_ELEMENT_MODEL, col: 'CBF_model' }],
+      });
+    });
+
+    it('translates a UI platform code to its Semrush model name', () => {
+      const payload = buildResponseSourcesPayload({ platform: 'copilot' });
+      expect(payload.filters.advanced.filters[0].filters[0].val).to.equal('microsoft-copilot');
+    });
+
+    it('prefers model over platform when both are supplied', () => {
+      const payload = buildResponseSourcesPayload({ model: 'perplexity', platform: 'copilot' });
+      expect(payload.filters.advanced.filters[0].filters[0].val).to.equal('perplexity');
+    });
+
+    it('sends the date bounds in BOTH the simple and advanced blocks', () => {
+      const payload = buildResponseSourcesPayload({ endDate: '2026-08-24' });
+      expect(payload.filters.simple).to.deep.equal({
+        CBF_date__start: '2026-08-24', CBF_date__end: '2026-08-24',
+      });
+      expect(payload.filters.advanced.filters).to.deep.include({
+        op: 'gte', val: '2026-08-24', col: 'CBF_date__start',
+      });
+      expect(payload.filters.advanced.filters).to.deep.include({
+        op: 'lte', val: '2026-08-24', col: 'CBF_date__end',
+      });
+    });
+
+    it('never emits the silently-ignored start_date/end_date spellings', () => {
+      const payload = buildResponseSourcesPayload({ endDate: '2026-08-24' });
+      expect(payload).to.not.have.property('start_date');
+      expect(payload).to.not.have.property('end_date');
+      expect(payload.filters).to.not.have.property('start_date');
+      expect(payload.filters).to.not.have.property('end_date');
+    });
+
+    it('omits the date blocks entirely when no endDate is given', () => {
+      const payload = buildResponseSourcesPayload();
+      expect(payload.filters).to.not.have.property('simple');
+      const cols = payload.filters.advanced.filters.map((f) => f.col);
+      expect(cols).to.not.include('CBF_date__end');
+    });
+
+    it('includes a top-level project_id when provided', () => {
+      expect(buildResponseSourcesPayload({ projectId: 'proj-42' }).project_id).to.equal('proj-42');
+    });
+
+    it('omits project_id when not provided', () => {
+      expect(buildResponseSourcesPayload()).to.not.have.property('project_id');
+    });
+
+    it('sorts by prompt then position so an answer\'s citations stay contiguous', () => {
+      expect(buildResponseSourcesPayload().pagination.sort_columns)
+        .to.deep.equal(['prompt asc', 'position asc']);
+    });
+
+    it('defaults the page size and offset', () => {
+      const { pagination } = buildResponseSourcesPayload();
+      expect(pagination.limit).to.equal(DEFAULT_RESPONSE_PAGE_SIZE);
+      expect(pagination.offset).to.equal(0);
+    });
+
+    it('honours an explicit limit and offset', () => {
+      const { pagination } = buildResponseSourcesPayload({ limit: 25, offset: 75 });
+      expect(pagination.limit).to.equal(25);
+      expect(pagination.offset).to.equal(75);
+    });
+
+    it('clamps the limit to the ceiling and floor', () => {
+      expect(buildResponseSourcesPayload({ limit: 99999 }).pagination.limit)
+        .to.equal(MAX_RESPONSE_PAGE_SIZE);
+      expect(buildResponseSourcesPayload({ limit: 0 }).pagination.limit).to.equal(1);
+    });
+
+    it('falls back to defaults for non-numeric pagination values', () => {
+      const { pagination } = buildResponseSourcesPayload({ limit: 'abc', offset: 'xyz' });
+      expect(pagination.limit).to.equal(DEFAULT_RESPONSE_PAGE_SIZE);
+      expect(pagination.offset).to.equal(0);
+    });
+
+    it('floors a negative offset at 0', () => {
+      expect(buildResponseSourcesPayload({ offset: -10 }).pagination.offset).to.equal(0);
+    });
+  });
+
+  describe('transformResponseSourcesResponse', () => {
+    it('maps the element columns onto the normalised row shape', () => {
+      const [row] = transformResponseSourcesResponse(rawWith(sourceRow()));
+      expect(row).to.deep.equal({
+        projectId: 'proj-1',
+        prompt: 'best running shoes',
+        model: 'chatgpt-paid',
+        date: '2026-08-24',
+        url: 'https://runnersworld.com/best-shoes',
+        source: 'runnersworld.com',
+        position: 1,
+        domainType: 'Earned',
+        executionId: 'proj-1|2026-08-24|chatgpt-paid|best running shoes',
+        tags: '$abv_tags$type__branded',
+      });
+    });
+
+    it('falls back to source when url_cbf is absent', () => {
+      const [row] = transformResponseSourcesResponse(rawWith(sourceRow({ url_cbf: null })));
+      expect(row.url).to.equal('runnersworld.com');
+    });
+
+    it('drops rows missing either join-key component', () => {
+      const rows = transformResponseSourcesResponse(rawWith(
+        sourceRow(),
+        sourceRow({ prompt: null }),
+        sourceRow({ date: null }),
+      ));
+      expect(rows).to.have.lengthOf(1);
+    });
+
+    it('drops null rows', () => {
+      expect(transformResponseSourcesResponse(rawWith(null, sourceRow()))).to.have.lengthOf(1);
+    });
+
+    it('coerces a non-numeric position to 0 rather than NaN', () => {
+      const [row] = transformResponseSourcesResponse(rawWith(sourceRow({ position: 'x' })));
+      expect(row.position).to.equal(0);
+    });
+
+    it('defaults absent optional fields to empty strings', () => {
+      const [row] = transformResponseSourcesResponse(rawWith({ prompt: 'p', date: '2026-08-24' }));
+      expect(row.projectId).to.equal('');
+      expect(row.model).to.equal('');
+      expect(row.url).to.equal('');
+      expect(row.source).to.equal('');
+      expect(row.domainType).to.equal('');
+      expect(row.executionId).to.equal('');
+      expect(row.tags).to.equal('');
+    });
+
+    it('returns an empty array for absent, empty or malformed payloads', () => {
+      expect(transformResponseSourcesResponse(undefined)).to.deep.equal([]);
+      expect(transformResponseSourcesResponse({})).to.deep.equal([]);
+      expect(transformResponseSourcesResponse({ blocks: {} })).to.deep.equal([]);
+      expect(transformResponseSourcesResponse(rawWith())).to.deep.equal([]);
+    });
+  });
+});

--- a/test/support/elements/response-feed-service.test.js
+++ b/test/support/elements/response-feed-service.test.js
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { createElementsService } from '../../../src/support/elements/elements-service.js';
+import { ELEMENT_IDS } from '../../../src/support/elements/element-ids.js';
+
+use(sinonChai);
+
+const WS = 'ws-1';
+const PROJECT = 'proj-1';
+
+/** Builds a raw answer-element page (141adc88 — no date column). */
+const answerPage = (rows) => ({ blocks: { data: rows } });
+
+/** Builds one answer row. */
+const answer = (over = {}) => ({
+  project_id: PROJECT,
+  prompt: 'best running shoes',
+  model: 'chatgpt-paid',
+  response: 'Some answer text',
+  position: 1,
+  tags: '',
+  ...over,
+});
+
+/** Builds one source row. The live element returns a full timestamp for `date`. */
+const source = (over = {}) => ({
+  project_id: PROJECT,
+  prompt: 'best running shoes',
+  model: 'chatgpt-paid',
+  date: '2026-08-24T00:00:00Z',
+  url_cbf: 'https://runnersworld.com/best',
+  source: 'runnersworld.com',
+  position: 1,
+  domain_type: 'Earned',
+  execution_id: 'exec-1',
+  tags: '',
+  ...over,
+});
+
+describe('createElementsService#getResponseFeed', () => {
+  let transport;
+  let service;
+
+  beforeEach(() => {
+    transport = { fetchElement: sinon.stub() };
+    transport.fetchElement.resolves(answerPage([]));
+    service = createElementsService(transport);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  /** All `endDate` values the answer element was called with, in call order. */
+  const answerBoundaries = () => transport.fetchElement
+    .getCalls()
+    .filter((c) => c.args[1] === ELEMENT_IDS.CITATIONS_SOURCES)
+    .map((c) => c.args[2].filters.simple.CBF_date__end);
+
+  describe('boundary amortisation', () => {
+    // The reason this endpoint is range-based rather than per-day. Recovering N days needs
+    // N+1 boundaries because consecutive days SHARE one: executions(D) = end(D) - end(D-1),
+    // so end(D) is also the subtrahend for day D+1. Fetching per-day would cost 2N.
+    it('costs N+1 boundary pulls per element for an N-day range, not 2N', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-20',
+        endDate: '2026-08-24',
+      });
+
+      // 5 days -> 6 boundaries per element. Naive per-day would be 10.
+      expect(answerBoundaries()).to.have.lengthOf(6);
+      // Two elements, one call each per boundary.
+      expect(transport.fetchElement.callCount).to.equal(12);
+    });
+
+    it('fetches each boundary exactly once, never re-pulling a shared one', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-20',
+        endDate: '2026-08-24',
+      });
+
+      const boundaries = answerBoundaries();
+      expect(new Set(boundaries).size).to.equal(boundaries.length);
+    });
+
+    it('includes the D-1 boundary before the first requested day', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-20',
+        endDate: '2026-08-22',
+      });
+
+      expect(answerBoundaries()).to.deep.equal([
+        '2026-08-19', '2026-08-20', '2026-08-21', '2026-08-22',
+      ]);
+    });
+
+    it('costs 2 pulls per element for a single-day range (the degenerate case)', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(answerBoundaries()).to.deep.equal(['2026-08-23', '2026-08-24']);
+    });
+  });
+
+  describe('the join', () => {
+    it('pairs an answer with the sources cited in the same execution', async () => {
+      transport.fetchElement.callsFake((ws, elementId, payload) => {
+        const end = payload.filters.simple.CBF_date__end;
+        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
+          // Present on day D, absent on D-1 -> a genuine day-D execution.
+          return Promise.resolve(answerPage(end === '2026-08-24' ? [answer()] : []));
+        }
+        return Promise.resolve(answerPage(end === '2026-08-24' ? [source()] : []));
+      });
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.records).to.have.lengthOf(1);
+      expect(result.records[0].sources).to.have.lengthOf(1);
+      expect(result.records[0].date).to.equal('2026-08-24');
+      expect(result.records[0].model).to.equal('chatgpt-paid');
+    });
+
+    // ABSENCE IS MEANINGFUL: a tuple runs on a median 61 of 74 days, so a model that did
+    // not run is routine and must never read as an error or as lost data.
+    it('returns an answer with an empty source list rather than dropping it', async () => {
+      transport.fetchElement.callsFake((ws, elementId, payload) => {
+        const end = payload.filters.simple.CBF_date__end;
+        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
+          return Promise.resolve(answerPage(end === '2026-08-24' ? [answer()] : []));
+        }
+        return Promise.resolve(answerPage([]));
+      });
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.records).to.have.lengthOf(1);
+      expect(result.records[0].sources).to.deep.equal([]);
+    });
+
+    it('reports no records for a day on which nothing ran, without erroring', async () => {
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.records).to.deep.equal([]);
+      expect(result.unmatchedSourceKeyCount).to.equal(0);
+    });
+
+    // Guards the `?? []` fallbacks: an element answering with no `blocks.data` at all is a
+    // legitimate empty read, not a malformed response, and must not throw mid-join.
+    it('tolerates an element page with no data block', async () => {
+      transport.fetchElement.resolves({});
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-23',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.records).to.deep.equal([]);
+      expect(result.days).to.deep.equal(['2026-08-23', '2026-08-24']);
+    });
+
+    // A row present on BOTH boundaries is carried-over history, not a day-D execution.
+    it('excludes an answer already present on the previous boundary', async () => {
+      transport.fetchElement.resolves(answerPage([answer()]));
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.records).to.deep.equal([]);
+    });
+
+    it('selects source rows by their own date rather than by difference', async () => {
+      transport.fetchElement.callsFake((ws, elementId, payload) => {
+        const end = payload.filters.simple.CBF_date__end;
+        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
+          return Promise.resolve(answerPage(end === '2026-08-24' ? [answer()] : []));
+        }
+        // The page holds the whole rolling window; only the day's own rows must join.
+        return Promise.resolve(answerPage([
+          source({ date: '2026-08-23T00:00:00Z', url_cbf: 'https://old.example' }),
+          source(),
+        ]));
+      });
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.records[0].sources).to.have.lengthOf(1);
+      expect(result.records[0].sources[0].url).to.equal('https://runnersworld.com/best');
+    });
+
+    it('counts source rows whose answer was not in the page', async () => {
+      transport.fetchElement.callsFake((ws, elementId) => {
+        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
+          return Promise.resolve(answerPage([]));
+        }
+        return Promise.resolve(answerPage([source()]));
+      });
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.unmatchedSourceKeyCount).to.equal(1);
+    });
+  });
+
+  describe('project (market) fan-out', () => {
+    it('issues an independent boundary walk per project', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: ['p1', 'p2'],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      // 2 projects x 2 boundaries x 2 elements.
+      expect(transport.fetchElement.callCount).to.equal(8);
+      const scoped = transport.fetchElement.getCalls().map((c) => c.args[2].project_id);
+      expect(new Set(scoped)).to.deep.equal(new Set(['p1', 'p2']));
+    });
+
+    it('deduplicates repeated project ids so a market is not walked twice', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: ['p1', 'p1'],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(transport.fetchElement.callCount).to.equal(4);
+    });
+
+    it('omits project_id entirely when no project is supplied', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(transport.fetchElement.callCount).to.equal(4);
+      expect(transport.fetchElement.firstCall.args[2]).to.not.have.property('project_id');
+    });
+
+    it('treats a missing projectIds as workspace-wide rather than throwing', async () => {
+      const result = await service.getResponseFeed(WS, {
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.projectIds).to.deep.equal([]);
+    });
+
+    it('ignores blank project ids', async () => {
+      const result = await service.getResponseFeed(WS, {
+        projectIds: ['', '  '],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.projectIds).to.deep.equal([]);
+    });
+
+    it('ignores a null project id without throwing', async () => {
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [null, undefined],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.projectIds).to.deep.equal([]);
+    });
+  });
+
+  describe('envelope', () => {
+    it('reports the days covered and the resolved page size', async () => {
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-23',
+        endDate: '2026-08-24',
+      });
+
+      expect(result.days).to.deep.equal(['2026-08-23', '2026-08-24']);
+      expect(result.pageSize).to.equal(5000);
+      expect(result.truncated).to.equal(false);
+    });
+
+    it('honours a caller-supplied limit in the resolved page size', async () => {
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+        limit: 10,
+      });
+
+      expect(result.pageSize).to.equal(10);
+    });
+
+    // A full page means the window was clipped, so the difference may be incomplete. That
+    // must be visible: silently serving a partial day as whole is the data-loss shape.
+    it('flags truncation when an upstream page comes back full', async () => {
+      transport.fetchElement.resolves(answerPage([answer(), answer()]));
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+        limit: 2,
+      });
+
+      expect(result.truncated).to.equal(true);
+    });
+
+    it('does not flag truncation on a partial page', async () => {
+      transport.fetchElement.resolves(answerPage([answer()]));
+
+      const result = await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+        limit: 500,
+      });
+
+      expect(result.truncated).to.equal(false);
+    });
+  });
+
+  describe('upstream payloads', () => {
+    it('reads both halves of the record from their own elements', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      const ids = new Set(transport.fetchElement.getCalls().map((c) => c.args[1]));
+      expect(ids).to.deep.equal(new Set([
+        ELEMENT_IDS.CITATIONS_SOURCES,
+        ELEMENT_IDS.SOURCES_DATES,
+      ]));
+    });
+
+    it('passes the model filter through to both elements', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+        model: 'perplexity',
+      });
+
+      for (const call of transport.fetchElement.getCalls()) {
+        const modelFilter = call.args[2].filters.advanced.filters
+          .find((f) => f.op === 'or');
+        expect(modelFilter.filters[0].val).to.equal('perplexity');
+      }
+    });
+
+    it('targets the resolved workspace, which the caller never supplies', async () => {
+      await service.getResponseFeed(WS, {
+        projectIds: [PROJECT],
+        startDate: '2026-08-24',
+        endDate: '2026-08-24',
+      });
+
+      for (const call of transport.fetchElement.getCalls()) {
+        expect(call.args[0]).to.equal(WS);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Activates two element ids that have been **declared but never referenced** since they were added, and adds the join the Brand Claims Semrush feed is built on.

```
element-ids.js:125  CITATIONS_SOURCES: 141adc88-…   ← dead until now
element-ids.js:137  SOURCES_DATES:     404fb017-…   ← dead until now
```

Support layer only — **no endpoints, no controllers, no change to any existing behaviour.** Purely additive.

| File | Element | Returns |
|---|---|---|
| `definitions/prompt-responses.js` | `141adc88` | per-response rows: `prompt` + `response`, **no date** |
| `definitions/response-sources.js` | `404fb017` | per-citation rows: sources + `date`, **no answer** |
| `definitions/response-feed.js` | — | `joinResponsesToSources` + `diffDayExecutions` |

Neither element alone can produce a response feed: one has the answer without a date, the other has the date and sources without the answer. Joining them on `(project_id, prompt, model, date)` yields an answer with its own source set.

## Why the join is sound

At most one execution exists per `(project_id, prompt, model, date)`, so the tuple cannot conflate executions. A model may contribute **zero** on a given day; never two. This closes the objection raised in [serenity-docs#420](https://github.com/adobe/serenity-docs/issues/420), which was that a `(project, model, prompt)` join conflates repeats — correct for *that* key, which is why `date` is part of this one.

**Absence is meaningful throughout.** A missing tuple means that model did not run that day — never an error, never data loss.

## Date grammar (verified live, and full of traps)

- `CBF_date__start` / `CBF_date__end` must be duplicated in **both** `filters.simple` and `filters.advanced`. `definitions/cited-domains.js` is the known-good precedent.
- **`start_date` / `end_date` are silently ignored and FAIL OPEN** — they return a full-width result that looks like a successful narrow query. An invented key behaves identically. There are explicit negative assertions that this shape is never emitted.
- `CBF_date__start` is **ignored** by the element; `CBF_date__end` is an upper bound over a **rolling ~50-day** window. So one day is recovered as `responses(end=D) − responses(end=D−1)`.

## The subtle part: multiset, not set

`diffDayExecutions` is a **multiset** difference, and the distinction is load-bearing.

`141adc88` returns one row *per execution* and carries no date, so a single page holds the entire window. Measured on a live 400-row page: **10 distinct `(prompt, model)` pairs, one of them repeated 54 times.** A prompt that runs daily is therefore already present in the `D−1` page, so a distinct-set difference filters its day-D row out and returns `[]` — indistinguishable from "nothing ran".

Confirmed against two live adjacent-day captures: a set difference returned **0 rows both times**, where the multiset difference returned 4 and 5. Two regression tests fail against the set version and pass against this one.

This was caught in review, not in the first draft.

## Cost

Two calls per day per project, against a **100 req/hr, 400/day, 2 TB/day budget that is per-workspace and shared across all of a brand's markets**. At ~41 markets that budget, not this join, is the binding constraint on any consumer. A Semrush fix honouring `CBF_date__start` would halve the call count and make `diffDayExecutions` unnecessary rather than merely cheaper.

## Validation

- 73 tests, **100% statements / branches / functions / lines** on all three new files
- Lint clean; full suite passing
- Regression tests verified to **fail** against the pre-fix implementation

## Not in scope

No controller or endpoint consumes this yet. `sort_columns` wire format is `[unverified]` — no existing definition in this repo sends pagination, so it is encoded from live observation and should be confirmed against a real call before an endpoint depends on it.

Design of record: [mysticat-architecture#248](https://github.com/adobe/mysticat-architecture/pull/248) · requirements: [serenity-docs#436](https://github.com/adobe/serenity-docs/pull/436)

> Supersedes the withdrawn approach in #3100, which was built on the AI-Visibility catalog keyed by domain and did not return the customer's configured prompt roster. `LLMO-7026`/`7027`/`7030` still describe that withdrawn scope and need rescoping.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: no-impact
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Purely additive support-layer code (new join/definitions); no controller or endpoint consumes it yet, so no production behavior changes."
```