### PR TITLE
fix(ci): give type-check a push fallback so it can't lose its required verdict

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
 on:
   push:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened, edited]
+    types: [opened, synchronize, ready_for_review, reopened]
   workflow_dispatch:
     inputs:
       environment:
@@ -35,24 +35,60 @@ jobs:
   # `// @ts-check`-annotated files (currently src/support/serenity/**). Blocking.
   # The reusable service-ci workflow has no type-check seam yet, so this runs as
   # a self-contained job here. See docs/decisions/005-opt-in-type-checking.md.
+  #
+  # Also runs on `push` (adobe/spacecat-api-service#3199): the reusable
+  # service-ci workflow's own concurrency group (mysticat-ci service-ci.yaml,
+  # keyed on ${{ github.workflow }}-${{ github.ref }} with cancel-in-progress
+  # on non-main refs) can cancel a PR's `pull_request`-triggered run of this
+  # job, leaving its head commit with no completed run. The `push` run is a
+  # fallback, skipped when no open PR exists yet for the branch (nothing to
+  # protect on `main` or a pre-PR branch). If the PR-existence lookup itself
+  # fails, it runs anyway rather than skip -- this is a required blocking
+  # check, and defaulting an inconclusive lookup to "skip" risks reproducing
+  # the exact bug being fixed.
   type-check:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: read
     steps:
+      - name: Check for open PR (push only)
+        id: pr-check
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PR_COUNT=$(gh pr list --head "$REF_NAME" --state open --repo "$REPO" \
+            --json number --jq 'length' 2>/dev/null) || true
+          if [ "$PR_COUNT" = "0" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No open PR found for branch ${REF_NAME} — skipping type-check on this push"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            if [ -z "$PR_COUNT" ]; then
+              echo "::warning::Could not determine whether an open PR exists for ${REF_NAME} (gh pr list failed) — running type-check anyway rather than risk skipping the only completed run for this commit"
+            fi
+          fi
+
       - name: Check out
+        if: steps.pr-check.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup Node & NPM
+        if: steps.pr-check.outputs.skip != 'true'
         uses: adobe/mysticat-ci/.github/actions/setup-node-npm@v1
         env:
           MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN: ${{ secrets.MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN }}
 
       - name: Type-check
+        if: steps.pr-check.outputs.skip != 'true'
         run: npm run type-check
 
   # serenity-job-runner WORKER Lambda deploy (adobe/serenity-docs#186). Rationale

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,10 @@ jobs:
   # fails, it runs anyway rather than skip -- this is a required blocking
   # check, and defaulting an inconclusive lookup to "skip" risks reproducing
   # the exact bug being fixed.
+  #
+  # No concurrency group on this job: the push and pull_request runs are meant
+  # to complete independently (that's the whole fix), so nothing here should
+  # cancel either one.
   type-check:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main')
     runs-on: ubuntu-latest
@@ -65,14 +69,19 @@ jobs:
           set -euo pipefail
           PR_COUNT=$(gh pr list --head "$REF_NAME" --state open --repo "$REPO" \
             --json number --jq 'length') || true
-          if [ "$PR_COUNT" = "0" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::No open PR found for the current branch — skipping type-check on this push"
+          # Match strictly-numeric output, not just non-empty: unexpected stdout
+          # ahead of a `gh` failure (e.g. a CLI notice) would otherwise slip past
+          # a bare `-z` check and skip the warning below.
+          if [[ "$PR_COUNT" =~ ^[0-9]+$ ]]; then
+            if [ "$PR_COUNT" = "0" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::No open PR found for the current branch — skipping type-check on this push"
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            if [ -z "$PR_COUNT" ]; then
-              echo "::warning::Could not determine whether an open PR exists for the current branch (gh pr list failed, see log above) — running type-check anyway rather than risk skipping the only completed run for this commit"
-            fi
+            echo "::warning::Could not determine whether an open PR exists for the current branch (gh pr list failed, see log above) — running type-check anyway rather than risk skipping the only completed run for this commit"
           fi
 
       # steps.pr-check.outputs.skip is an empty string (not 'false') on pull_request

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,17 +64,20 @@ jobs:
         run: |
           set -euo pipefail
           PR_COUNT=$(gh pr list --head "$REF_NAME" --state open --repo "$REPO" \
-            --json number --jq 'length' 2>/dev/null) || true
+            --json number --jq 'length') || true
           if [ "$PR_COUNT" = "0" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::No open PR found for branch ${REF_NAME} — skipping type-check on this push"
+            echo "::notice::No open PR found for the current branch — skipping type-check on this push"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
             if [ -z "$PR_COUNT" ]; then
-              echo "::warning::Could not determine whether an open PR exists for ${REF_NAME} (gh pr list failed) — running type-check anyway rather than risk skipping the only completed run for this commit"
+              echo "::warning::Could not determine whether an open PR exists for the current branch (gh pr list failed, see log above) — running type-check anyway rather than risk skipping the only completed run for this commit"
             fi
           fi
 
+      # steps.pr-check.outputs.skip is an empty string (not 'false') on pull_request
+      # events, since the step above doesn't run there -- the '!= true' checks below
+      # rely on that negative match; do not refactor them to '== false'.
       - name: Check out
         if: steps.pr-check.outputs.skip != 'true'
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
 on:
   push:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, edited]
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds a `push`-triggered fallback run of the `type-check` required status check, keyed on the branch ref rather than the PR's merge ref, so a `pull_request`-triggered run cancelled by the shared workflow's concurrency group can no longer leave a PR's head commit with zero completed verdicts for that check.

## 2. Reasoning
`type-check` is a required, blocking status check that only ran under the `pull_request` event. The shared `adobe/mysticat-ci` reusable workflow's own concurrency group can cancel a PR's in-flight `pull_request`-triggered run on a subsequent trigger for the same PR — most plausibly a `pull_request` `edited` event (a PR title/body edit) racing a `synchronize` push into that same group. When that happens, the PR's final head commit is left with no completed `type-check` run at all: the cancelled run never finishes, and the `push`-triggered `CI` run reports `type-check` as `skipping` since it never ran under that event. Filed as the linked issue below, with confirmed evidence of exactly this sequence on a real PR.

## 3. High-level overview of the changes
Before: `type-check` ran only when `github.event_name == 'pull_request'`. If that run got cancelled by the shared workflow's concurrency group, nothing else could ever produce a verdict for that commit.

After:
- `type-check` also runs under `push`, but only when an open PR already exists for that branch (checked via a new `pr-check` step using `gh pr list`) — a push to `main` or to a branch with no PR yet skips the job entirely, so nothing extra runs where there's nothing to protect. The push event is keyed by branch ref in the shared workflow's concurrency group, independent of the PR's merge ref, so it covers the original race regardless of what triggers the `pull_request`-side cancellation.
- If the PR-existence lookup itself fails, the job runs anyway rather than skipping, since silently skipping on an inconclusive lookup could reproduce the same bug for a required check.
- `pull-requests: read` was added to the job's permissions for the new lookup call.
- `pull_request.types` is unchanged (still includes `edited`) — an earlier version of this PR dropped it, but that also stops the reusable workflow's `validate-pr-title` job (which shares this same workflow-level trigger) from re-running after a title fix. The push fallback covers the original bug on its own, so `edited` didn't need to move.

Scope decision: the shared `adobe/mysticat-ci` reusable workflow's concurrency-group key (the structural root cause, shared by ~30 services) is intentionally left unchanged. A SHA-scoped concurrency-group fix there was considered and would have closed the race completely, but at the cost of losing the existing "auto-cancel a stale superseded `pull_request` run" optimization fleet-wide. This PR takes the narrower, single-repo fix instead.

### Pre-PR review decisions
- Reuse: the new `pr-check` step's `gh pr list --head <branch>` lookup duplicates a similar inline lookup already used in `adobe/mysticat-ci`'s `service-ci.yaml` (`branch-deploy` job). No shared helper exists to call instead; extracting one would require changes in that separate, shared repo, which is out of scope here. Left as a follow-up.
- Altitude: considered splitting `type-check` into two jobs to get a single job-level `if:` instead of three repeated step-level guards. Declined — this repo's own established convention for this kind of conditional (mirrored from `mysticat-ci`'s `branch-deploy`/`main-check` step) is step-level gating within one job; a job split adds real structural complexity disproportionate to a three-step job.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-api-service/issues/3199

Closes #3199

## 7. Additional information outside the code
- Ran `actionlint` (with its bundled shellcheck pass over the new `run:` script) locally against `.github/workflows/ci.yaml` and every other workflow file in this repo, validating the new job's GitHub Actions expression syntax, context usage, and shell-script correctness — no CI job in this repo runs this tool today, so this is otherwise-unverified surface area.
- Live-probed the exact `gh pr list --head <branch> --state open --repo <repo> --json number --jq 'length'` command the new `pr-check` step uses, against the real `adobe/spacecat-api-service` API — both against this PR's own branch (no PR existed yet at probe time) and a deliberately nonexistent branch name — confirming it resolves to `0` for "no open PR," the exact signal the new step's skip path depends on.
- Simulated the `pr-check` step's three-way branch (lookup failure / zero PRs / PR found) in an isolated bash script under `set -euo pipefail` with faked `gh` outcomes, confirming the `|| true` + empty-string-check pattern degrades to "run anyway" on a lookup failure without the script aborting under `errexit`.
- Live evidence on this PR's own branch: the push made before this PR existed triggered a real `push`-event CI run in which the new `pr-check` step correctly found no open PR yet and skipped checkout/setup/type-check (job completed in ~4s); the `pull_request: opened` run that followed executed the full `type-check` job exactly as before (~2m). Both behaved as designed.

## 8. Test plan
(a) No local end-to-end run applies — this change is CI workflow configuration, not application code; local verification was the actionlint / live-probe / shell-simulation evidence in section 7.
(b) Verify directly on this PR and branch, since GitHub Actions is the only environment this change runs in: once this PR is open, confirm the `pull_request`-triggered `type-check` run behaves exactly as before (unaffected by this change). Separately, watch any `push`-triggered `CI` run on this branch (each new commit pushed here triggers one): the `type-check` job should show its new `pr-check` step running and resolving `skip=true` while no PR is open yet, then `skip=false` once this PR exists, with the `Type-check` step actually executing on that later push.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: no-impact
risk: minor
scope: single-repo
relatedPRs: []
rationale: "CI-workflow-only change (.github/workflows/ci.yaml): no application/runtime code, no infra, no data path touched. The new lookup uses the ephemeral read-only github.token scoped to pull-requests:read, no write capability and no secrets exposure. Fully reversible with a plain git revert; no redeploy needed since it only affects this repo's own CI pipeline."
backout: "git revert this commit; the next push/PR run picks up the reverted workflow immediately, no deploy required."
```

