### PR TITLE
fix: make `move llmo org` resilient to slack message update failures

### DIFF
--- a/src/support/slack/actions/move-llmo-org.js
+++ b/src/support/slack/actions/move-llmo-org.js
@@ -46,17 +46,18 @@ export function openMoveLlmoOrgModal(lambdaContext) {
     await ack();
 
     const {
-      baseURL, siteId, sourceOrgId, destOrgId, imsOrgId, channelId, threadTs, messageTs,
+      baseURL, siteId, sourceOrgId, destOrgId, imsOrgId, channelId, threadTs,
     } = JSON.parse(body.actions[0].value);
-    const say = createSayFunction(client, channelId, threadTs);
     const userId = body?.user?.id || 'unknown';
 
-    // Bolt already tells us which message the button lives in, so use that in preference
-    // to the timestamp carried in the button payload. The payload copy is only correct if
-    // the command's follow-up chat.update landed; when it didn't, the payload still reads
-    // 'placeholder' and every update below fails with message_not_found.
+    // Bolt's action body is authoritative for where this button actually lives, so prefer
+    // it over the channel carried in the payload. Everything that talks to Slack from here
+    // on - including the say passed down to reparentSiteProject and
+    // createEntitlementAndEnrollment - is bound to it, so a stale payload cannot misroute
+    // part of the output to another channel.
     const targetChannel = body?.channel?.id || channelId;
-    const targetTs = body?.message?.ts || messageTs;
+    const targetTs = body?.message?.ts;
+    const say = createSayFunction(client, targetChannel, threadTs);
 
     // Reporting progress must never decide whether the move runs. This previously threw
     // straight out of the handler - the first call sits immediately before executeOrgMove,

--- a/src/support/slack/actions/move-llmo-org.js
+++ b/src/support/slack/actions/move-llmo-org.js
@@ -51,12 +51,37 @@ export function openMoveLlmoOrgModal(lambdaContext) {
     const say = createSayFunction(client, channelId, threadTs);
     const userId = body?.user?.id || 'unknown';
 
-    const updateMessage = async (text) => client.chat.update({
-      channel: channelId,
-      ts: messageTs,
-      text,
-      blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }],
-    });
+    // Bolt already tells us which message the button lives in, so use that in preference
+    // to the timestamp carried in the button payload. The payload copy is only correct if
+    // the command's follow-up chat.update landed; when it didn't, the payload still reads
+    // 'placeholder' and every update below fails with message_not_found.
+    const targetChannel = body?.channel?.id || channelId;
+    const targetTs = body?.message?.ts || messageTs;
+
+    // Reporting progress must never decide whether the move runs. This previously threw
+    // straight out of the handler - the first call sits immediately before executeOrgMove,
+    // so a cosmetic Slack failure aborted the move, and the identical call in the catch
+    // below rethrew into Bolt, leaving the operator with no feedback at all.
+    const updateMessage = async (text) => {
+      try {
+        await client.chat.update({
+          channel: targetChannel,
+          ts: targetTs,
+          text,
+          blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }],
+        });
+      } catch (updateError) {
+        log.warn(
+          `move llmo org: could not update message ${targetTs} in ${targetChannel}: `
+          + `${updateError.message}. Falling back to a new message.`,
+        );
+        try {
+          await say(text);
+        } catch (sayError) {
+          log.error(`move llmo org: could not report to Slack at all: ${sayError.message}`);
+        }
+      }
+    };
 
     try {
       const site = await Site.findById(siteId);

--- a/src/support/slack/commands/move-llmo-org.js
+++ b/src/support/slack/commands/move-llmo-org.js
@@ -27,9 +27,8 @@ import {
 const PHRASES = ['move llmo org'];
 
 /**
- * Builds the confirmation message blocks. Kept in one place so the initial post and the
- * follow-up update (which injects the message's own timestamp into the button payload)
- * cannot drift apart.
+ * Builds the confirmation message blocks: the rendered preview plus the "Confirm Move"
+ * button that carries the move's parameters through to the action handler.
  *
  * @param {string} text - The rendered preview.
  * @param {object} payload - The button's JSON payload.
@@ -148,28 +147,25 @@ function MoveLlmoOrgCommand(context) {
       }
 
       const text = buildPreviewMessage(preview, baseURL);
-      const basePayload = {
-        baseURL,
-        siteId: site.getId(),
-        sourceOrgId,
-        destOrgId,
-        imsOrgId,
-        channelId,
-        threadTs,
-      };
 
-      const posted = await client.chat.postMessage({
+      // The confirm handler reads the message timestamp from Bolt's action body, so the
+      // payload doesn't have to carry it and this stays a single API call. An earlier
+      // version posted with a 'placeholder' timestamp and patched it in with a follow-up
+      // chat.update; when that second call failed the button was left unusable, and every
+      // chat.update in the confirm handler died with message_not_found.
+      await client.chat.postMessage({
         channel: channelId,
         thread_ts: threadTs,
         text: `Ready to move LLMO org for ${baseURL}`,
-        blocks: buildConfirmBlocks(text, { ...basePayload, messageTs: 'placeholder' }),
-      });
-
-      await client.chat.update({
-        channel: channelId,
-        ts: posted.ts,
-        text: `Ready to move LLMO org for ${baseURL}`,
-        blocks: buildConfirmBlocks(text, { ...basePayload, messageTs: posted.ts }),
+        blocks: buildConfirmBlocks(text, {
+          baseURL,
+          siteId: site.getId(),
+          sourceOrgId,
+          destOrgId,
+          imsOrgId,
+          channelId,
+          threadTs,
+        }),
       });
     } catch (error) {
       log.error(error);

--- a/test/support/slack/actions/move-llmo-org.test.js
+++ b/test/support/slack/actions/move-llmo-org.test.js
@@ -114,6 +114,8 @@ describe('move-llmo-org action', () => {
     };
     body = {
       user: { id: 'U123' },
+      channel: { id: 'C1' },
+      message: { ts: 'M1' },
       actions: [{
         value: JSON.stringify({
           baseURL: 'https://acme.com',
@@ -123,7 +125,6 @@ describe('move-llmo-org action', () => {
           imsOrgId: IMS_ORG,
           channelId: 'C1',
           threadTs: 'T1',
-          messageTs: 'M1',
         }),
       }],
     };
@@ -352,5 +353,60 @@ describe('move-llmo-org action', () => {
   it('carries the entitlement gotcha into the result message', async () => {
     await run();
     expect(lastUpdateText()).to.contain('Entitlements are not moved');
+  });
+
+  describe('message targeting and Slack failures', () => {
+    it('targets the message Bolt reports, not the timestamp in the button payload', async () => {
+      // A button posted before this fix carries a stale 'placeholder' timestamp. Bolt's
+      // own body is authoritative and keeps that button working.
+      const payload = JSON.parse(body.actions[0].value);
+      body.actions[0].value = JSON.stringify({
+        ...payload, messageTs: 'placeholder', channelId: 'stale-channel',
+      });
+      body.message.ts = 'REAL_TS';
+      body.channel.id = 'REAL_CHANNEL';
+
+      await run();
+
+      expect(client.chat.update).to.always.have.been.calledWithMatch({
+        channel: 'REAL_CHANNEL',
+        ts: 'REAL_TS',
+      });
+    });
+
+    it('still performs the move when the progress update fails', async () => {
+      // Regression: the ":hourglass:" update sits immediately before executeOrgMove, so a
+      // Slack failure there used to abort the handler and silently skip the whole move.
+      client.chat.update.rejects(new Error('An API error occurred: message_not_found'));
+
+      await run();
+
+      expect(rpcStub).to.have.been.calledWith('wrpc_move_brandalf_org', sinon.match.object);
+      expect(createEntitlementAndEnrollmentStub).to.have.been.called;
+    });
+
+    it('reports via a new message when the message can no longer be updated', async () => {
+      client.chat.update.rejects(new Error('An API error occurred: message_not_found'));
+
+      await run();
+
+      expect(lambdaContext.log.warn).to.have.been.called;
+      expect(client.chat.postMessage).to.have.been.called;
+      const posted = client.chat.postMessage.getCalls()
+        .map((c) => c.args[0].text).join('\n');
+      expect(posted).to.contain('Moved LLMO organization');
+    });
+
+    it('never throws out of the handler when Slack is unreachable entirely', async () => {
+      client.chat.update.rejects(new Error('message_not_found'));
+      client.chat.postMessage.rejects(new Error('channel_not_found'));
+      siteStub.findById.rejects(new Error('db down'));
+
+      // Must resolve: an unhandled rejection here surfaces in Bolt as a bare stack trace
+      // with no operator-facing message at all.
+      await run();
+
+      expect(lambdaContext.log.error).to.have.been.called;
+    });
   });
 });

--- a/test/support/slack/actions/move-llmo-org.test.js
+++ b/test/support/slack/actions/move-llmo-org.test.js
@@ -374,6 +374,26 @@ describe('move-llmo-org action', () => {
       });
     });
 
+    it('routes the new-message fallback to Bolt\'s channel, not the stale payload one', async () => {
+      // The fallback has to agree with chat.update about where this button lives, or a
+      // failed update reports the move's outcome into a different channel entirely. The
+      // same say is handed to reparentSiteProject and createEntitlementAndEnrollment.
+      const payload = JSON.parse(body.actions[0].value);
+      body.actions[0].value = JSON.stringify({ ...payload, channelId: 'stale-channel' });
+      body.channel.id = 'REAL_CHANNEL';
+      client.chat.update.rejects(new Error('An API error occurred: message_not_found'));
+
+      await run();
+
+      expect(client.chat.postMessage).to.have.been.called;
+      expect(client.chat.postMessage).to.always.have.been.calledWithMatch({
+        channel: 'REAL_CHANNEL',
+      });
+      expect(client.chat.postMessage).to.not.have.been.calledWithMatch({
+        channel: 'stale-channel',
+      });
+    });
+
     it('still performs the move when the progress update fails', async () => {
       // Regression: the ":hourglass:" update sits immediately before executeOrgMove, so a
       // Slack failure there used to abort the handler and silently skip the whole move.

--- a/test/support/slack/commands/move-llmo-org.test.js
+++ b/test/support/slack/commands/move-llmo-org.test.js
@@ -175,12 +175,14 @@ describe('MoveLlmoOrgCommand', () => {
       p_site_id: 'site-1',
       p_dst_org: 'dst-1',
     });
-    expect(slackContext.client.chat.postMessage).to.have.been.calledOnce;
 
-    // The button payload is only complete after the update pass, which injects the
-    // posted message's own timestamp so the action can edit it in place.
-    const updateArgs = slackContext.client.chat.update.firstCall.args[0];
-    const button = updateArgs.blocks[1].elements[0];
+    // One call, not a post-then-patch pair: the confirm handler reads the message
+    // timestamp from Bolt's action body, so it never has to be injected into the payload.
+    expect(slackContext.client.chat.postMessage).to.have.been.calledOnce;
+    expect(slackContext.client.chat.update).to.not.have.been.called;
+
+    const postArgs = slackContext.client.chat.postMessage.firstCall.args[0];
+    const button = postArgs.blocks[1].elements[0];
     expect(button.action_id).to.equal('open_move_llmo_org_modal');
     expect(JSON.parse(button.value)).to.deep.include({
       baseURL: 'https://acme.com',
@@ -188,8 +190,8 @@ describe('MoveLlmoOrgCommand', () => {
       sourceOrgId: 'src-1',
       destOrgId: 'dst-1',
       imsOrgId: 'ABCDEF1234567890ABCDEF12@AdobeOrg',
-      messageTs: '111.333',
     });
+    expect(JSON.parse(button.value)).to.not.have.property('messageTs');
   });
 
   it('never writes: the command only ever calls the read-only preview RPC', async () => {
@@ -200,8 +202,8 @@ describe('MoveLlmoOrgCommand', () => {
 
   it('reports the entitlement gotcha in the preview', async () => {
     await run(['https://acme.com', 'ABCDEF1234567890ABCDEF12@AdobeOrg']);
-    const updateArgs = slackContext.client.chat.update.firstCall.args[0];
-    expect(updateArgs.blocks[0].text.text).to.contain('Entitlements are not moved');
+    const postArgs = slackContext.client.chat.postMessage.firstCall.args[0];
+    expect(postArgs.blocks[0].text.text).to.contain('Entitlements are not moved');
   });
 
   it('handles an unexpected failure gracefully', async () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

Fixes the `move llmo org` Slack command, which failed on its first real run with a Slack `message_not_found` error and silently skipped the org move entirely. Makes progress reporting non-fatal so a cosmetic Slack failure can never abort — or misreport — the move.

## 2. Reasoning

First live test of the command (`couchclimbs.com` → `632645F86160D2940A495E6D@AdobeOrg`) produced:

```
Error moving LLMO org for https://couchclimbs.com to 632645F86160D2940A495E6D@AdobeOrg:
  Error: An API error occurred: message_not_found
  code: 'slack_webapi_platform_error'
```

The site was verified in prod afterwards as still sitting in its original org, `updated_at` unchanged — the move never ran and no data was corrupted.

Root cause is the message-timestamp plumbing. The command posted the confirm card with `messageTs: 'placeholder'`, then issued a *second* `chat.update` to patch the real timestamp into the button payload. That second call did not land, so the button was published still carrying `'placeholder'`.

On confirm, the first `chat.update` the handler reaches is the `:hourglass:` progress message — which sits **immediately before** `executeOrgMove`. It threw, control jumped to the `catch`, and the move was skipped. The `catch` then called the same broken `updateMessage` again, throwing a second time out into Bolt, so the operator saw a bare stack trace and no message in Slack.

Two distinct defects, both worth fixing: the fragile post-then-patch handshake, and the fact that a *reporting* call was positioned to decide whether the *write* happens.

## 3. High-level overview of the changes

**Before:** the confirm button's target message was smuggled through the button payload, written by a second API call that could fail independently. Any `chat.update` failure in the action handler was fatal, and the one guarding the move sat directly in front of it.

**After:**

- **The action handler targets `body.message.ts` / `body.channel.id` from Bolt's action payload**, which is authoritative and always present for a block-button interaction. The payload's `messageTs` is no longer required. This also repairs buttons *already posted* carrying the placeholder timestamp — they will work on click rather than needing the command re-run.
- **The command posts once** instead of post-then-patch, removing the failure mode at its source and dropping one Slack API call per invocation.
- **`updateMessage` can no longer abort the handler.** On failure it logs a warning and falls back to posting a new message in-thread; if Slack is unreachable entirely it logs and returns. Progress reporting must never decide whether the move runs.

Operationally visible: a move whose progress message cannot be edited now still completes, and reports its outcome as a new message in the thread instead of failing. The previous behaviour was the more dangerous one — an operator told "Failed to move LLMO org" would reasonably re-run a move that may already have succeeded.

## 4. Required information

- Jira / issue: [LLMO-7294](https://jira.corp.adobe.com/browse/LLMO-7294)
- Other: follow-up to adobe/spacecat-api-service#3181 and adobe/mysticat-data-service#1000 (both merged and deployed)

## 6. Affected / used mysticat-workspace projects

- **mysticat-data-service** — consumed, unchanged. The command calls `rpc_org_move_preview` / `wrpc_move_brandalf_org`; this PR does not alter the RPC contract or the payloads sent to them.

## 7. Additional information outside the code

- **Confirmed the failed run did not corrupt data.** Queried the prod reader for the affected site:

  ```sql
  SELECT s.base_url, o.ims_org_id, o.name, s.updated_at
  FROM sites s JOIN organizations o ON o.id = s.organization_id
  WHERE s.base_url ILIKE '%couchclimbs%';
  ```

  Returned the *source* org (`Vlad Test Org` / `B9993910616D0EAC0A495C49@AdobeOrg`) with `updated_at = 2026-08-31`, i.e. untouched by the attempted move. This established that the failure occurred before `executeOrgMove` and pinned the fault to the pre-write progress update rather than to the RPC.

## 8. Test plan

**Locally:** the failure is a Slack-transport fault, so it was reproduced in the test harness rather than against a live workspace — a stubbed `chat.update` that rejects with `message_not_found`. The new `still performs the move when the progress update fails` case fails against the previous code (the RPC is never called) and passes now. Three further cases cover message targeting from the Bolt body, the new-message fallback path, and a total Slack outage not throwing out of the handler.

**On dev/stage:** run `@spacecat move llmo org <site-url> <destination-ims-org>` and confirm the preview card renders with a working Confirm button.

**On prod:** re-run the original failing case — `@spacecat move llmo org https://couchclimbs.com 632645F86160D2940A495E6D@AdobeOrg` — and confirm the preview, then the confirm click, drive the move to completion with the progress and result messages editing the card in place. Verify afterwards that the site and its brand closure sit in the destination org.

Note the standing prerequisite (unchanged by this PR): the destination org must already exist in SpaceCat — run `set imsorg` first if it does not.

## 9. Deployment & merge order

- adobe/spacecat-api-service#3181 — depends-on, already merged and deployed. This PR patches the command that PR introduced.
- adobe/mysticat-data-service#1000 — depends-on, already merged and deployed. Provides the RPCs the command calls.

Both dependencies are live, so this PR is independently mergeable and deployable on its own.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Hardens an internal operator Slack command so a cosmetic progress-message failure can no longer abort or misreport an org move; verified no prior data corruption, fully reversible."
```