### PR TITLE
fix(brands): resolve real LLMO entitlement tier for activate-brand's schedule (LLMO-7366)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -2833,6 +2833,18 @@ function BrandsController(ctx, log, env) {
           }
         }
 
+        // Resolve the site + real LLMO entitlement tier once, up front: needed both for
+        // the schedule's tier param (step 4, immediately below) and the post-activation
+        // side-effects (step 5/6). This route (LLMO-6634) intentionally has no paid gate
+        // on activation itself — a free/PLG org can reach this whole block as long as the
+        // brand already resolves to a valid primary site — so the schedule created below
+        // must NOT hardcode tier: 'PAID'; that would grant ChatGPT Paid / Copilot
+        // regardless of the org's real entitlement (LLMO-7366).
+        const activatedSite = await Site.findById(baseSiteId);
+        const isPaying = (drsConfigured && activatedSite)
+          ? await isPayingLlmoSite(activatedSite, context)
+          : false;
+
         // 4) Schedule — prompts-gated. Create the weekly brand-presence schedule only
         // when prompts were generated now or the brand already has prompts (a promptless
         // schedule is a weekly no-op). Idempotent: createBrandPresenceSchedule POSTs and
@@ -2854,12 +2866,12 @@ function BrandsController(ctx, log, env) {
             siteId: baseSiteId,
             brandId: brandUuid,
             orgId: spaceCatId,
+            // @ts-ignore tier not yet in the published drs-client type; pending the
+            // release of the spacecat-shared companion fix (LLMO-7366, PR #1915)
+            tier: isPaying ? 'PAID' : 'FREE_TRIAL',
           });
           scheduleId = schedule?.scheduleId;
         }
-
-        // Resolve the site once for the post-activation side-effects below.
-        const activatedSite = await Site.findById(baseSiteId);
 
         // 5) Brand-profile agent ("Brandaid"). The create→activate path never triggered it
         // (only full/PLG/Slack onboarding did), so brands added to an existing org had no
@@ -2903,7 +2915,7 @@ function BrandsController(ctx, log, env) {
         // throws, so a failure here degrades gracefully without failing activation.
         if (drsConfigured) {
           if (activatedSite) {
-            const isPaying = await isPayingLlmoSite(activatedSite, context);
+            // isPaying already resolved once, above, alongside the schedule's tier param.
             const { results, allSucceeded } = await ensurePromptSuggestionSchedules({
               drsClient, siteId: baseSiteId, isPaying, log,
             });

--- a/src/support/prompt-suggestion-schedules.js
+++ b/src/support/prompt-suggestion-schedules.js
@@ -75,7 +75,14 @@ export async function isPayingLlmoSite(site, context) {
     }
     return entitlement.getTier() === EntitlementModel.TIERS.PAID;
   } catch (error) {
-    log.warn(`Failed to read LLMO tier for site ${site.getId()}; `
+    // log.error (not .warn): unlike the "no entitlement found" branch above (a normal,
+    // expected state for many orgs), a THROWN lookup failure is a real operational
+    // problem -- and since activateBrandForOrg also uses this result to decide the
+    // brand-presence schedule's tier param (LLMO-7366), a swallowed failure here can
+    // silently mis-tier a paying org's schedule with no other signal. .error surfaces
+    // it in normal log-based alerting without changing this function's boolean-only
+    // contract for any of its callers.
+    log.error(`Failed to read LLMO tier for site ${site.getId()}; `
       + `defaulting to one-time (trial) prompt-suggestion runs: ${error.message}`);
     return false;
   }

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -8944,11 +8944,52 @@ describe('Brands Controller', () => {
       expect(submitArg.siteId).to.equal(SITE_ID);
       expect(submitArg.imsOrgId).to.equal(IMS_ORG_ID);
 
-      // createBrandPresenceSchedule must be called with correct ids
+      // createBrandPresenceSchedule must be called with correct ids, and tier:
+      // 'FREE_TRIAL' (this route has no paid gate on activation itself — LLMO-6634 —
+      // so the tier must be resolved from the org's real LLMO entitlement rather than
+      // hardcoded; isPayingLlmoSiteStub defaults to resolving false).
       expect(scheduleStub).to.have.been.calledOnceWith({
         siteId: SITE_ID,
         brandId: BRAND_UUID,
         orgId: ORGANIZATION_ID,
+        tier: 'FREE_TRIAL',
+      });
+    });
+
+    it('passes tier: PAID through to createBrandPresenceSchedule for a paying site', async () => {
+      // Regression test for LLMO-7366 x LLMO-6634: activation has no paid gate, so a
+      // hardcoded tier: 'PAID' would wrongly restrict a genuinely paying org, and a
+      // hardcoded tier: 'FREE_TRIAL' would wrongly restrict a genuinely paying org too.
+      // The tier must track the real per-org LLMO entitlement either way.
+      const scheduleStub = sinon.stub().resolves({ scheduleId: 'sch-paid' });
+      const fakeDrs = {
+        isConfigured: () => true,
+        listJobs: sinon.stub().resolves([]),
+        submitPromptGenerationJob: sinon.stub().resolves({ job_id: 'pg-1' }),
+        createBrandPresenceSchedule: scheduleStub,
+      };
+      const { controller } = await buildActivateController({
+        getBrandByIdResult: {
+          id: BRAND_UUID,
+          name: 'Acme',
+          baseSiteId: SITE_ID,
+          baseUrl: 'https://site1.com',
+          region: ['us'],
+          status: 'pending',
+          urls: [],
+        },
+        updateBrandResult: { id: BRAND_UUID },
+        fakeDrsClient: fakeDrs,
+        isPayingLlmoSiteStub: sinon.stub().resolves(true),
+      });
+
+      await controller.activateBrandForOrg(buildActivateRequest({ generatePrompts: true }));
+
+      expect(scheduleStub).to.have.been.calledOnceWith({
+        siteId: SITE_ID,
+        brandId: BRAND_UUID,
+        orgId: ORGANIZATION_ID,
+        tier: 'PAID',
       });
     });
 

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -6430,7 +6430,10 @@ describe('LLMO Onboarding Functions', () => {
       ]);
     });
 
-    it('defaults to one-time runs (trial) and WARNs when the tier cannot be read', async () => {
+    it('defaults to one-time runs (trial) and ERRORs when the tier cannot be read', async () => {
+      // .error, not .warn (LLMO-7366): a thrown lookup failure is a real operational
+      // problem, distinct from "no entitlement found" below, and this result also
+      // decides a customer-visible schedule's tier param elsewhere -- must be alertable.
       const mockDrsClient = createMockDrsClient(sandbox);
       // TierClient whose entitlement lookup throws → tier indeterminate.
       const failingTierClient = {
@@ -6453,8 +6456,8 @@ describe('LLMO Onboarding Functions', () => {
       // Fail-safe: no recurring schedule for a site of unknown paying status.
       expect(instance.createSchedule).to.not.have.been.called;
       expect(instance.submitJob.callCount).to.equal(4); // Brandalf + 3 one-shots
-      const warnLogs = context.log.warn.getCalls().map((c) => c.args[0]);
-      expect(warnLogs.some((m) => m.includes('Failed to read LLMO tier for site site-123'))).to.be.true;
+      const errorLogs = context.log.error.getCalls().map((c) => c.args[0]);
+      expect(errorLogs.some((m) => m.includes('Failed to read LLMO tier for site site-123'))).to.be.true;
     });
 
     it('defaults to one-time runs (trial) and WARNs when no entitlement exists', async () => {

--- a/test/support/prompt-suggestion-schedules.test.js
+++ b/test/support/prompt-suggestion-schedules.test.js
@@ -180,14 +180,17 @@ describe('prompt-suggestion-schedules support module', () => {
       expect(log.warn).to.have.been.calledWithMatch(/no entitlement found/);
     });
 
-    it('fails safe to false (with a warning) when the lookup throws', async () => {
+    it('fails safe to false (with an ERROR log, not a warning) when the lookup throws', async () => {
+      // .error, not .warn: a thrown lookup failure is a real operational problem (unlike
+      // the "no entitlement found" branch above, a normal state), and this result also
+      // decides a customer-visible schedule's tier param elsewhere -- must be alertable.
       tierClientStub = {
         checkValidEntitlement: sandbox.stub().rejects(new Error('tier service down')),
       };
       const log = buildLog();
       const result = await module.isPayingLlmoSite(buildSite(), { log });
       expect(result).to.equal(false);
-      expect(log.warn).to.have.been.calledWithMatch(/tier service down/);
+      expect(log.error).to.have.been.calledWithMatch(/tier service down/);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `activateBrandForOrg`'s call to `createBrandPresenceSchedule` was made with no tier, so activation granted the full platform set — including paid-tier-only ChatGPT Paid / Copilot — to every org regardless of entitlement.
- **Found during this fix**: LLMO-6634 (merged 2026-07-30, PR #2952) deliberately removed this route's paid gate on activation itself — a free/PLG org can reach this call as long as the brand already resolves to a valid primary site. That means hardcoding `tier: 'PAID'` here (the initially-planned fix) would have silently reintroduced the exact bug for this call site.
- Resolves the site once, up front, and reuses the existing `isPayingLlmoSite` helper (previously called one step later, only for prompt-suggestion provisioning) to pass `tier: 'PAID' | 'FREE_TRIAL'` through — correct for both paying and non-paying orgs. Also removes a duplicate `Site.findById` + entitlement lookup that existed before this change.
- `tier` is `@ts-ignore`d at the call site — the published `drs-client` type doesn't have it yet, pending the `spacecat-shared` companion release (PR #1915).
- Companion fixes: `spacecat-shared` (PR #1915), `spacecat-audit-worker` (PR #2942), DRS (`llmo-data-retrieval-service` PR #3178).

## Test plan
- [x] `npx mocha test/controllers/brands.test.js` — 457/457 passing, including new `tier: 'PAID'` / `tier: 'FREE_TRIAL'` cases for `activateBrandForOrg`
- [x] `npm run type-check` — clean
- [x] `npx eslint src/controllers/brands.js test/controllers/brands.test.js` — clean

Introduced by: N/A

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Entitlement/tier business-logic fix (passes correct tier instead of none) on brand-schedule creation; test-covered, reversible via redeploy, not an auth/security-boundary change."
```