### PR TITLE
feat(brand-claims): trigger prerequisite audits before an on-demand claims run (LLMO-7263)

### DIFF
--- a/src/controllers/llmo/brand-claims.js
+++ b/src/controllers/llmo/brand-claims.js
@@ -27,6 +27,12 @@ const WEEK_RE = /^\d{4}-W\d{2}$/;
 // bypassable). Kept in step with project-elmo-ui's BRAND_CLAIMS_REQUEST_COOLDOWN_MS.
 const BRAND_CLAIMS_AUDIT_TYPE = 'brand-claims';
 const BRAND_CLAIMS_REQUEST_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+// Prerequisite audits fired before an on-demand claims run (LLMO-7263) so their
+// fresh outputs (off-site brand presence, Wikipedia facts) are available to
+// mystique's claims extraction. They share the audit queue with the claims
+// trigger; the audit-worker delays the claims ready-signal (onDemand) to let
+// these land first.
+const BRAND_CLAIMS_PREREQUISITE_AUDIT_TYPES = ['offsite-brand-presence', 'wikipedia-analysis'];
 // `model` is interpolated into the S3 key, so constrain it to alphanumerics,
 // dots, hyphens, underscores — no `/` — to prevent using HeadObject as an
 // object-existence probe across arbitrary key paths.
@@ -227,6 +233,17 @@ export async function handleRequestBrandClaims(context, site) {
   }
 
   try {
+    // Fire the prerequisite audits first so mystique has fresh inputs when it runs
+    // claims; the audit-worker delays the claims ready-signal (onDemand) to let these
+    // complete. All three land on the same audit queue.
+    for (const type of BRAND_CLAIMS_PREREQUISITE_AUDIT_TYPES) {
+      // eslint-disable-next-line no-await-in-loop
+      await sqs.sendMessage(queueUrl, {
+        type,
+        siteId: site.getId(),
+        auditContext: { trigger: 'on-demand-brand-claims' },
+      });
+    }
     await sqs.sendMessage(queueUrl, {
       type: 'brand-claims',
       siteId: site.getId(),
@@ -239,7 +256,7 @@ export async function handleRequestBrandClaims(context, site) {
     log.error(`Brand Claims on-demand: failed to enqueue audit for site ${site.getId()}: ${sqsError.message}`);
     return internalServerError('Brand Claims on-demand is temporarily unavailable');
   }
-  log.info(`Brand Claims on-demand: triggered brand-claims audit for site ${site.getId()}`);
+  log.info(`Brand Claims on-demand: triggered ${BRAND_CLAIMS_PREREQUISITE_AUDIT_TYPES.join(', ')} + brand-claims audits for site ${site.getId()}`);
 
   // Dedicated channel for on-demand Brand Claims request alerts (LLMO-7263),
   // set in Vault, so these can be routed/muted independently of other LLMO alerts.

--- a/src/controllers/llmo/brand-claims.js
+++ b/src/controllers/llmo/brand-claims.js
@@ -13,6 +13,7 @@
 import {
   badRequest, notFound, accepted, internalServerError, createResponse,
 } from '@adobe/spacecat-shared-http-utils';
+import { hasText } from '@adobe/spacecat-shared-utils';
 import { HeadObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { cachedOk } from '../../support/cached-response.js';
 import { dateToIsoWeek } from '../../support/elements/week-utils.js';
@@ -174,6 +175,35 @@ export async function handleBrandClaims(context) {
 }
 
 /**
+ * Human-readable identity of the caller who triggered the request, for the Slack alert.
+ * Mirrors user-details.js: prefer the RFC-5322 address (trial_email, then preferred_username)
+ * over profile.email, which is an IMS user GUID; include the name when present. Returns
+ * 'unknown' when no profile is available.
+ *
+ * @param {object} context - Request context (attributes.authInfo).
+ * @returns {string} e.g. "Ada Lovelace (ada@example.com)", "ada@example.com", or "unknown".
+ */
+function getRequesterLabel(context) {
+  try {
+    const authInfo = context?.attributes?.authInfo;
+    const profile = authInfo?.getProfile?.() ?? authInfo?.profile ?? {};
+    const email = [profile.trial_email, profile.preferred_username, profile.email]
+      .find((v) => hasText(v));
+    const first = profile.first_name || profile.given_name;
+    const last = profile.last_name || profile.family_name;
+    const name = [first, last].filter((v) => hasText(v)).join(' ').trim();
+    if (name && email) {
+      return `${name} (${email})`;
+    }
+    return name || email || 'unknown';
+  } catch {
+    // Best-effort label only — never let requester lookup throw into the (already
+    // queued) run or the Slack alert.
+    return 'unknown';
+  }
+}
+
+/**
  * On-demand Brand Claims trigger for trial customers (LLMO-7263). Triggers the
  * audit-worker `brand-claims` audit for the site with `onDemand: true`, which
  * finds the latest Brand Presence sheet and publishes a one-shot
@@ -266,7 +296,7 @@ export async function handleRequestBrandClaims(context, site) {
     try {
       await postSlackMessage(
         slackChannel,
-        `:rocket: On-demand Brand Claims requested for *${site.getBaseURL()}* (${site.getId()}).`,
+        `:rocket: On-demand Brand Claims requested for *${site.getBaseURL()}* (${site.getId()}) by ${getRequesterLabel(context)}.`,
         slackToken,
       );
     } catch (slackError) {

--- a/src/controllers/llmo/brand-claims.js
+++ b/src/controllers/llmo/brand-claims.js
@@ -13,7 +13,6 @@
 import {
   badRequest, notFound, accepted, internalServerError, createResponse,
 } from '@adobe/spacecat-shared-http-utils';
-import { hasText } from '@adobe/spacecat-shared-utils';
 import { HeadObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { cachedOk } from '../../support/cached-response.js';
 import { dateToIsoWeek } from '../../support/elements/week-utils.js';
@@ -175,35 +174,6 @@ export async function handleBrandClaims(context) {
 }
 
 /**
- * Human-readable identity of the caller who triggered the request, for the Slack alert.
- * Mirrors user-details.js: prefer the RFC-5322 address (trial_email, then preferred_username)
- * over profile.email, which is an IMS user GUID; include the name when present. Returns
- * 'unknown' when no profile is available.
- *
- * @param {object} context - Request context (attributes.authInfo).
- * @returns {string} e.g. "Ada Lovelace (ada@example.com)", "ada@example.com", or "unknown".
- */
-function getRequesterLabel(context) {
-  try {
-    const authInfo = context?.attributes?.authInfo;
-    const profile = authInfo?.getProfile?.() ?? authInfo?.profile ?? {};
-    const email = [profile.trial_email, profile.preferred_username, profile.email]
-      .find((v) => hasText(v));
-    const first = profile.first_name || profile.given_name;
-    const last = profile.last_name || profile.family_name;
-    const name = [first, last].filter((v) => hasText(v)).join(' ').trim();
-    if (name && email) {
-      return `${name} (${email})`;
-    }
-    return name || email || 'unknown';
-  } catch {
-    // Best-effort label only — never let requester lookup throw into the (already
-    // queued) run or the Slack alert.
-    return 'unknown';
-  }
-}
-
-/**
  * On-demand Brand Claims trigger for trial customers (LLMO-7263). Triggers the
  * audit-worker `brand-claims` audit for the site with `onDemand: true`, which
  * finds the latest Brand Presence sheet and publishes a one-shot
@@ -296,7 +266,7 @@ export async function handleRequestBrandClaims(context, site) {
     try {
       await postSlackMessage(
         slackChannel,
-        `:rocket: On-demand Brand Claims requested for *${site.getBaseURL()}* (${site.getId()}) by ${getRequesterLabel(context)}.`,
+        `:rocket: On-demand Brand Claims requested for *${site.getBaseURL()}* (${site.getId()}).`,
         slackToken,
       );
     } catch (slackError) {

--- a/test/controllers/llmo/brand-claims.test.js
+++ b/test/controllers/llmo/brand-claims.test.js
@@ -392,16 +392,22 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
 
   afterEach(() => sandbox.restore());
 
-  it('triggers the brand-claims audit with onDemand and notifies Slack (202)', async () => {
+  it('triggers the prerequisite audits then the brand-claims audit (onDemand) and notifies Slack (202)', async () => {
     const result = await handleRequestBrandClaims(context, site);
     expect(result.status).to.equal(202);
-    expect(sqsSend).to.have.been.calledOnce;
-    const [queueUrl, msg] = sqsSend.getCall(0).args;
-    expect(queueUrl).to.equal('audit-q');
-    expect(msg.type).to.equal('brand-claims');
-    expect(msg.siteId).to.equal('site-1');
-    expect(msg.onDemand).to.equal(true);
-    expect(msg.auditContext).to.deep.equal({ trigger: 'on-demand-brand-claims' });
+    // offsite-brand-presence + wikipedia-analysis fire before brand-claims.
+    expect(sqsSend).to.have.been.calledThrice;
+    const types = sqsSend.getCalls().map((c) => c.args[1].type);
+    expect(types).to.deep.equal(['offsite-brand-presence', 'wikipedia-analysis', 'brand-claims']);
+    sqsSend.getCalls().forEach((c) => {
+      expect(c.args[0]).to.equal('audit-q');
+      expect(c.args[1].siteId).to.equal('site-1');
+      expect(c.args[1].auditContext).to.deep.equal({ trigger: 'on-demand-brand-claims' });
+    });
+    // Only the claims trigger carries onDemand; the prerequisite audits are plain triggers.
+    expect(sqsSend.getCall(0).args[1].onDemand).to.equal(undefined);
+    expect(sqsSend.getCall(1).args[1].onDemand).to.equal(undefined);
+    expect(sqsSend.getCall(2).args[1].onDemand).to.equal(true);
     expect(postSlackMessage).to.have.been.calledOnce;
   });
 
@@ -423,14 +429,14 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
     postSlackMessage.rejects(new Error('slack down'));
     const result = await handleRequestBrandClaims(context, site);
     expect(result.status).to.equal(202);
-    expect(sqsSend).to.have.been.calledOnce;
+    expect(sqsSend).to.have.been.calledThrice;
   });
 
   it('skips Slack when not configured but still triggers the audit', async () => {
     context.env.SLACK_BOT_TOKEN = undefined;
     const result = await handleRequestBrandClaims(context, site);
     expect(result.status).to.equal(202);
-    expect(sqsSend).to.have.been.calledOnce;
+    expect(sqsSend).to.have.been.calledThrice;
     expect(postSlackMessage).to.not.have.been.called;
   });
 
@@ -453,7 +459,7 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
     getLatestAudit.resolves({ getAuditedAt: () => ranAt });
     const result = await handleRequestBrandClaims(context, site);
     expect(result.status).to.equal(202);
-    expect(sqsSend).to.have.been.calledOnce;
+    expect(sqsSend).to.have.been.calledThrice;
   });
 
   it('proceeds (202) at the 7-day boundary (cooldown uses strict <)', async () => {
@@ -463,14 +469,14 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
     getLatestAudit.resolves({ getAuditedAt: () => ranAt });
     const result = await handleRequestBrandClaims(context, site);
     expect(result.status).to.equal(202);
-    expect(sqsSend).to.have.been.calledOnce;
+    expect(sqsSend).to.have.been.calledThrice;
   });
 
   it('fails open (202) when the cooldown lookup throws', async () => {
     getLatestAudit.rejects(new Error('db down'));
     const result = await handleRequestBrandClaims(context, site);
     expect(result.status).to.equal(202);
-    expect(sqsSend).to.have.been.calledOnce;
+    expect(sqsSend).to.have.been.calledThrice;
     expect(context.log.warn).to.have.been.called;
   });
 });

--- a/test/controllers/llmo/brand-claims.test.js
+++ b/test/controllers/llmo/brand-claims.test.js
@@ -387,11 +387,6 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
         SLACK_BRAND_CLAIMS_REQUEST_CHANNEL_ID: 'C123',
         SLACK_BOT_TOKEN: 'xoxb-1',
       },
-      attributes: {
-        authInfo: {
-          getProfile: () => ({ trial_email: 'ada@example.com', first_name: 'Ada', last_name: 'Lovelace' }),
-        },
-      },
     };
   });
 
@@ -414,21 +409,6 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
     expect(sqsSend.getCall(1).args[1].onDemand).to.equal(undefined);
     expect(sqsSend.getCall(2).args[1].onDemand).to.equal(true);
     expect(postSlackMessage).to.have.been.calledOnce;
-    // The alert names who triggered it (name + human-readable email).
-    expect(postSlackMessage.getCall(0).args[1]).to.include('by Ada Lovelace (ada@example.com)');
-  });
-
-  it('falls back to the IMS email, then "unknown", for the requester label', async () => {
-    // preferred_username (RFC-5322) is preferred over the profile.email GUID.
-    site.getLatestAuditByAuditType = () => null;
-    context.attributes.authInfo.getProfile = () => ({ preferred_username: 'grace@example.com' });
-    await handleRequestBrandClaims(context, site);
-    expect(postSlackMessage.getCall(0).args[1]).to.include('by grace@example.com');
-
-    postSlackMessage.resetHistory();
-    delete context.attributes;
-    await handleRequestBrandClaims(context, site);
-    expect(postSlackMessage.getCall(0).args[1]).to.include('by unknown');
   });
 
   it('returns 500 when AUDIT_JOBS_QUEUE_URL is not configured', async () => {

--- a/test/controllers/llmo/brand-claims.test.js
+++ b/test/controllers/llmo/brand-claims.test.js
@@ -387,6 +387,11 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
         SLACK_BRAND_CLAIMS_REQUEST_CHANNEL_ID: 'C123',
         SLACK_BOT_TOKEN: 'xoxb-1',
       },
+      attributes: {
+        authInfo: {
+          getProfile: () => ({ trial_email: 'ada@example.com', first_name: 'Ada', last_name: 'Lovelace' }),
+        },
+      },
     };
   });
 
@@ -409,6 +414,21 @@ describe('handleRequestBrandClaims (on-demand, LLMO-7263)', () => {
     expect(sqsSend.getCall(1).args[1].onDemand).to.equal(undefined);
     expect(sqsSend.getCall(2).args[1].onDemand).to.equal(true);
     expect(postSlackMessage).to.have.been.calledOnce;
+    // The alert names who triggered it (name + human-readable email).
+    expect(postSlackMessage.getCall(0).args[1]).to.include('by Ada Lovelace (ada@example.com)');
+  });
+
+  it('falls back to the IMS email, then "unknown", for the requester label', async () => {
+    // preferred_username (RFC-5322) is preferred over the profile.email GUID.
+    site.getLatestAuditByAuditType = () => null;
+    context.attributes.authInfo.getProfile = () => ({ preferred_username: 'grace@example.com' });
+    await handleRequestBrandClaims(context, site);
+    expect(postSlackMessage.getCall(0).args[1]).to.include('by grace@example.com');
+
+    postSlackMessage.resetHistory();
+    delete context.attributes;
+    await handleRequestBrandClaims(context, site);
+    expect(postSlackMessage.getCall(0).args[1]).to.include('by unknown');
   });
 
   it('returns 500 when AUDIT_JOBS_QUEUE_URL is not configured', async () => {

--- a/test/controllers/llmo/llmo.test.js
+++ b/test/controllers/llmo/llmo.test.js
@@ -4542,10 +4542,13 @@ describe('LlmoController', () => {
       };
     });
 
-    it('validates LLMO access, triggers the audit, and returns 202', async () => {
+    it('validates LLMO access, triggers the prerequisite + claims audits, and returns 202', async () => {
       const result = await controller.requestBrandClaims(reqCtx);
       expect(result.status).to.equal(202);
-      expect(reqCtx.sqs.sendMessage).to.have.been.calledOnce;
+      // Prerequisite audits (offsite-brand-presence, wikipedia-analysis) fire before brand-claims.
+      expect(reqCtx.sqs.sendMessage).to.have.been.calledThrice;
+      const types = reqCtx.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(types).to.deep.equal(['offsite-brand-presence', 'wikipedia-analysis', 'brand-claims']);
     });
 
     it('returns 403 when LLMO access validation fails', async () => {


### PR DESCRIPTION
## What

When a trial customer requests an on-demand Brand Claims run (`POST /sites/:siteId/llmo/brand-claims/request`, LLMO-7263), fire the `offsite-brand-presence` and `wikipedia-analysis` audits **before** the `brand-claims` trigger, so mystique has fresh inputs when it runs claims extraction.

All three enqueue to `AUDIT_JOBS_QUEUE_URL`. The prerequisites are plain audit triggers (`{ type, siteId, auditContext }`); only the claims trigger carries `onDemand: true`. The audit-worker delays the on-demand claims ready-signal (850s) so the prerequisites land first - see adobe/spacecat-audit-worker#2943.

## Coordination

No deploy-order dependency with the audit-worker change:
- If this ships first, claims simply runs without the added delay.
- If the audit-worker ships first, a claims run with no prerequisites is merely delayed 850s for nothing.

Neither order breaks.

## Testing

- `test/controllers/llmo/brand-claims.test.js` and `test/controllers/llmo/llmo.test.js` - updated for the 3 sends, assert order (`offsite-brand-presence`, `wikipedia-analysis`, `brand-claims`), and that only the claims trigger carries `onDemand`. Existing cooldown/Slack paths unchanged.
- Tests passing, eslint clean. IT (`test/it/postgres/brand-claims-request.test.js`) does not exercise the 202 happy path, so no IT change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
