### PR TITLE
fix: set CloudFront connector presign TTL to 12h | LLMO-7074

### DIFF
--- a/src/controllers/llmo/llmo-cloudfront.js
+++ b/src/controllers/llmo/llmo-cloudfront.js
@@ -144,11 +144,11 @@ function LlmoCloudFrontController(ctx) {
       const region = 'us-east-1';
       const roleName = env.EDGE_OPTIMIZE_ROLE_NAME || 'AdobeLLMOptimizerCloudFrontConnectorRole';
       const stackName = env.EDGE_OPTIMIZE_STACK_NAME || 'adobe-edgeoptimize-connector-role';
-      // TEMP (chore/observe-presign-ttl — do NOT merge): default bumped to 2 days to empirically
-      // test whether the presigned URL actually survives past the STS session ceiling (~12h). The
-      // signer uses temporary session-token creds, so the URL likely dies well before 172800s.
+      // Presign TTL capped at 12h (43200s) — the max the signer's STS session can back. The
+      // api-service Lambda signs with temporary (session-token) credentials, so a longer expiresIn
+      // is silently truncated when the session token expires; 12h is the practical ceiling.
       // Override via env.
-      const presignTtlSeconds = Number(env.EDGE_OPTIMIZE_PRESIGN_TTL || 172800);
+      const presignTtlSeconds = Number(env.EDGE_OPTIMIZE_PRESIGN_TTL || 43200);
       // Server-derived external ID (site's IMS org id) baked into the connector-role trust policy
       // below; never client-supplied. See resolveConnectorExternalId.
       const externalId = await resolveConnectorExternalId(site);
@@ -161,17 +161,6 @@ function LlmoCloudFrontController(ctx) {
       const trustedPrincipalArn = env.SPACECAT_CDN_CLOUDFRONT_TRUSTED_PRINCIPAL_ARN;
       if (!hasText(trustedPrincipalArn)) {
         return badRequest('CloudFront connector is not configured for this environment (missing trusted principal)');
-      }
-
-      // TEMP DIAGNOSTIC (chore/observe-presign-ttl — do NOT merge): log the signer credentials'
-      // real expiration, which is the true ceiling a presign can't outlive (vs the requested TTL).
-      try {
-        const creds = await s3.s3Client.config.credentials();
-        log.info(`[cf-presign] signerExpiration=${creds?.expiration?.toISOString?.() ?? 'none (long-lived)'} `
-          + `remainingSec=${creds?.expiration ? Math.round((creds.expiration.getTime() - Date.now()) / 1000) : 'n/a'} `
-          + `requestedTtl=${presignTtlSeconds} hasSessionToken=${Boolean(creds?.sessionToken)}`);
-      } catch (e) {
-        log.info(`[cf-presign] could not resolve signer creds: ${e.message}`);
       }
 
       // Presign the (private) template so the customer's CloudFormation can read it

--- a/src/controllers/llmo/llmo-cloudfront.js
+++ b/src/controllers/llmo/llmo-cloudfront.js
@@ -162,6 +162,17 @@ function LlmoCloudFrontController(ctx) {
         return badRequest('CloudFront connector is not configured for this environment (missing trusted principal)');
       }
 
+      // TEMP DIAGNOSTIC (chore/observe-presign-ttl — do NOT merge): log the signer credentials'
+      // real expiration, which is the true ceiling a presign can't outlive (vs the requested TTL).
+      try {
+        const creds = await s3.s3Client.config.credentials();
+        log.info(`[cf-presign] signerExpiration=${creds?.expiration?.toISOString?.() ?? 'none (long-lived)'} `
+          + `remainingSec=${creds?.expiration ? Math.round((creds.expiration.getTime() - Date.now()) / 1000) : 'n/a'} `
+          + `requestedTtl=${presignTtlSeconds} hasSessionToken=${Boolean(creds?.sessionToken)}`);
+      } catch (e) {
+        log.info(`[cf-presign] could not resolve signer creds: ${e.message}`);
+      }
+
       // Presign the (private) template so the customer's CloudFormation can read it
       // cross-account via the signature — no public bucket, no customer S3 access.
       const templateUrl = await s3.getSignedUrl(

--- a/src/controllers/llmo/llmo-cloudfront.js
+++ b/src/controllers/llmo/llmo-cloudfront.js
@@ -144,10 +144,11 @@ function LlmoCloudFrontController(ctx) {
       const region = 'us-east-1';
       const roleName = env.EDGE_OPTIMIZE_ROLE_NAME || 'AdobeLLMOptimizerCloudFrontConnectorRole';
       const stackName = env.EDGE_OPTIMIZE_STACK_NAME || 'adobe-edgeoptimize-connector-role';
-      // Short-lived presign: the customer opens the link immediately, so a tight TTL
-      // shrinks the exposure window if the URL leaks (it only grants GetObject on this
-      // one template object until expiry — see security notes). Override via env.
-      const presignTtlSeconds = Number(env.EDGE_OPTIMIZE_PRESIGN_TTL || 900);
+      // TEMP (chore/observe-presign-ttl — do NOT merge): default bumped to 2 days to empirically
+      // test whether the presigned URL actually survives past the STS session ceiling (~12h). The
+      // signer uses temporary session-token creds, so the URL likely dies well before 172800s.
+      // Override via env.
+      const presignTtlSeconds = Number(env.EDGE_OPTIMIZE_PRESIGN_TTL || 172800);
       // Server-derived external ID (site's IMS org id) baked into the connector-role trust policy
       // below; never client-supplied. See resolveConnectorExternalId.
       const externalId = await resolveConnectorExternalId(site);


### PR DESCRIPTION
## What

Raise the CloudFront quick-create template presign default from **15 min → 12h** (`43200s`), so the "Create role in AWS" link stays usable for the full life of the signing session.

## Why 12h

The api-service Lambda (`spacecat-role-lambda-generic`) signs the presigned S3 template URL with **temporary STS session-token credentials**. A SigV4 presign can't outlive that session, so 12h is the ceiling. Confirmed via **CloudTrail** — the role's AssumeRole credential `expiration` is ~12h out. Setting the default to 43200 matches the session life; a larger value gains nothing once the session ends.

## Change

- `createBootstrapUrl`: default `EDGE_OPTIMIZE_PRESIGN_TTL` `900` → `43200`. Still env-overridable.
- Removed the temporary `[cf-presign]` signer-expiration diagnostic used to determine this ceiling.

## Verification

- CloudTrail shows the signer session's `expiration` at ~12h; a presigned link generated on dev stayed valid across that window.
- `createBootstrapUrl` unit tests pass (11); lint + type-check clean. No new endpoint; only the default TTL value changes.

## Related Issues

LLMO-7074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Nitin Gupta", "Dominique Jäggi"]
rationale: "Config default TTL bump (15min to 12h, env-overridable) on a presigned bootstrap URL; tiny diff, matches verified STS session ceiling, fully reversible."
```