### PR TITLE
fix: restrict PLG skip Slack alert to cwv, alt-text, broken-backlinks

### DIFF
--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -266,14 +266,9 @@ async function postPlgSuggestionSkipAlert(site, opportunity, suggestion, context
 
     message += `\n• *Opportunity Type:* \`${opportunityType}\`\n`
       + `• *Opportunity ID:* \`${opportunityId}\`\n`
-      + `• *Suggestion ID:* \`${suggestionId}\``;
-
-    if (skipReason) {
-      message += `\n• *Skip Reason:* \`${skipReason}\``;
-    }
-    if (skipDetail) {
-      message += `\n• *Skip Detail:* \`${skipDetail}\``;
-    }
+      + `• *Suggestion ID:* \`${suggestionId}\`\n`
+      + `• *Skip Reason:* \`${skipReason ?? ''}\`\n`
+      + `• *Skip Detail:* \`${skipDetail ?? ''}\``;
 
     if (organizationId) {
       const experienceUrl = env.EXPERIENCE_URL || 'https://experience.adobe.com';

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -80,6 +80,7 @@ import { getImsTokenFromPromiseToken } from '../support/edge-routing-auth.js';
 import { isImsGroupMember } from '../support/ims-group.js';
 import { postSlackMessage } from '../utils/slack/base.js';
 import { createAtomicStrategy, deleteAtomicStrategy } from '../support/atomic-strategy-helper.js';
+import { PLG_OPPORTUNITY_TYPES } from './plg/plg-onboarding/displacement.js';
 
 const VALIDATION_ERROR_NAME = 'ValidationError';
 
@@ -228,13 +229,17 @@ async function postPlgSuggestionSkipAlert(site, opportunity, suggestion, context
   }
 
   try {
+    const opportunityType = opportunity.getType?.() ?? 'unknown';
+    if (!PLG_OPPORTUNITY_TYPES.includes(opportunityType)) {
+      return;
+    }
+
     const plg = isPlgTier !== undefined ? isPlgTier : await isSitePlgTier(site, log);
     if (!plg) {
       return;
     }
 
     const siteBaseURL = site.getBaseURL?.() ?? site.getId();
-    const opportunityType = opportunity.getType?.() ?? 'unknown';
     const opportunityId = opportunity.getId?.() ?? 'unknown';
     const suggestionId = suggestion.getId?.() ?? 'unknown';
     const skipReason = suggestion.getSkipReason?.() ?? null;

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -3776,6 +3776,37 @@ describe('Suggestions Controller', () => {
       expect(postSlackMessageStub.firstCall.args[1]).to.include('TOO_RISKY');
     });
 
+    it('includes empty Skip Reason and Skip Detail lines when neither is provided', async () => {
+      const postSlackMessageStub = sandbox.stub().resolves();
+      const ControllerWithSlack = await esmock.p('../../src/controllers/suggestions.js', {
+        '../../src/utils/slack/base.js': { postSlackMessage: postSlackMessageStub },
+      });
+
+      const plgSite = makePlgSite('PLG');
+      const da = { ...mockSuggestionDataAccess, Site: { findById: sandbox.stub().resolves(plgSite) } };
+      const ctrl = ControllerWithSlack({
+        dataAccess: da, pathInfo: { headers: {} }, ...authContext,
+      }, mockSqs, {
+      AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+      LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+    });
+
+      const response = await ctrl.patchSuggestion({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
+        data: { status: 'SKIPPED' },
+        env: { SLACK_PLG_SKIP_CHANNEL_ID: 'C_SKIP', SLACK_BOT_TOKEN: 'xoxb-token' },
+        ...context,
+        dataAccess: da,
+      });
+      await new Promise(setImmediate);
+
+      expect(response.status).to.equal(200);
+      expect(postSlackMessageStub).to.have.been.calledOnce;
+      const slackBody = postSlackMessageStub.firstCall.args[1];
+      expect(slackBody).to.include('*Skip Reason:* ``');
+      expect(slackBody).to.include('*Skip Detail:* ``');
+    });
+
     it('does not send PLG skip alert when patchSuggestion skips for a PAID site', async () => {
       const postSlackMessageStub = sandbox.stub().resolves();
       const ControllerWithSlack = await esmock.p('../../src/controllers/suggestions.js', {

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -3705,6 +3705,24 @@ describe('Suggestions Controller', () => {
   });
 
   describe('PLG skip Slack alert', () => {
+    beforeEach(() => {
+      // The skip alert is now gated to PLG-relevant opportunity types
+      // (cwv, alt-text, broken-backlinks); mockSuggestionEntity's getOpportunity()
+      // otherwise reports a generic 'test-opportunity-type' that the gate excludes.
+      mockSuggestion.findById.callsFake((id) => {
+        const s = suggs.find((sg) => sg.id === id);
+        if (!s) {
+          return Promise.resolve(null);
+        }
+        const entity = mockSuggestionEntity(s, removeStub);
+        entity.getOpportunity = () => ({
+          getSiteId: () => SITE_ID,
+          getType: () => 'broken-backlinks',
+        });
+        return Promise.resolve(entity);
+      });
+    });
+
     const makePlgSite = (tier) => {
       const entitlement = { getProductCode: () => 'ASO', getTier: () => tier };
       const enrollment = { getEntitlement: sandbox.stub().resolves(entitlement) };
@@ -3835,6 +3853,44 @@ describe('Suggestions Controller', () => {
         ...context,
         dataAccess: da,
       });
+
+      expect(response.status).to.equal(200);
+      expect(postSlackMessageStub).to.not.have.been.called;
+    });
+
+    it('does not send PLG skip alert when opportunity type is outside the PLG allow-list (cwv, alt-text, broken-backlinks)', async () => {
+      const postSlackMessageStub = sandbox.stub().resolves();
+      const ControllerWithSlack = await esmock.p('../../src/controllers/suggestions.js', {
+        '../../src/utils/slack/base.js': { postSlackMessage: postSlackMessageStub },
+      });
+
+      mockSuggestion.findById.callsFake((id) => {
+        const s = suggs.find((sg) => sg.id === id);
+        const entity = mockSuggestionEntity(s, removeStub);
+        entity.getOpportunity = () => ({
+          getSiteId: () => SITE_ID,
+          getType: () => 'meta-tags',
+        });
+        return Promise.resolve(entity);
+      });
+
+      const plgSite = makePlgSite('PLG');
+      const da = { ...mockSuggestionDataAccess, Site: { findById: sandbox.stub().resolves(plgSite) } };
+      const ctrl = ControllerWithSlack({
+        dataAccess: da, pathInfo: { headers: {} }, ...authContext,
+      }, mockSqs, {
+      AUTOFIX_JOBS_QUEUE: 'https://autofix-jobs-queue',
+      LLMO_EXPERIMENTATION_ENGINE_QUEUE_URL: 'https://llmo-experimentation-engine-queue',
+    });
+
+      const response = await ctrl.patchSuggestion({
+        params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0] },
+        data: { status: 'SKIPPED', skipReason: 'TOO_RISKY' },
+        env: { SLACK_PLG_SKIP_CHANNEL_ID: 'C_SKIP', SLACK_BOT_TOKEN: 'xoxb-token' },
+        ...context,
+        dataAccess: da,
+      });
+      await new Promise(setImmediate);
 
       expect(response.status).to.equal(200);
       expect(postSlackMessageStub).to.not.have.been.called;
@@ -15218,7 +15274,8 @@ describe('Suggestions Controller', () => {
         const opportunityWithGetId = {
           getSiteId: () => SITE_ID,
           getId: () => 'covered-opp-id',
-          // intentionally NO getType — exercises line 83 `?.` undefined branch
+          // PLG-gated type so the alert path is reached; getId is exercised below
+          getType: () => 'broken-backlinks',
         };
 
         const minimalSuggestion = {
@@ -15275,8 +15332,6 @@ describe('Suggestions Controller', () => {
         const slackBody = postSlackMessageStub.firstCall.args[1];
         // siteBaseURL fell back to site.getId()
         expect(slackBody).to.include(SITE_ID);
-        // opportunityType fell back to 'unknown' (getType missing)
-        expect(slackBody).to.include('unknown');
         // opportunityId resolved from opportunity.getId?.() (defined branch)
         expect(slackBody).to.include('covered-opp-id');
       });


### PR DESCRIPTION
## Summary
- The PLG suggestion-skip Slack notification (`postPlgSuggestionSkipAlert`) previously fired for a PLG-tier site regardless of opportunity type.
- Restrict the alert to only fire for the PLG-relevant opportunity types: `cwv`, `alt-text`, and `broken-backlinks`, reusing the existing `PLG_OPPORTUNITY_TYPES` constant from `src/controllers/plg/plg-onboarding/displacement.js` instead of duplicating the list.

## Test plan
- [x] `npm run lint` passes
- [x] `npx mocha test/controllers/suggestions.test.js` — 578 passing, including a new test asserting non-PLG opportunity types (e.g. `meta-tags`) no longer trigger the alert on a PLG site
- [x] Updated existing PLG skip-alert tests whose mock suggestions returned a generic opportunity type to use PLG-eligible types, so the new gate doesn't silently break existing coverage


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: no-impact
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Narrows an internal Slack notification's trigger condition to reuse an existing constant; no customer-facing behavior change, test-covered."
```