### PR TITLE
fix(security): scope AsyncJob readers to the caller (SEC-5 IDOR) (#3203)

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -14,10 +14,11 @@ import {
   hasText, isNonEmptyObject, isValidUUID, isValidUrl, isNonEmptyArray,
 } from '@adobe/spacecat-shared-utils';
 import {
-  badRequest, internalServerError, notFound, ok, accepted,
+  badRequest, internalServerError, ok, accepted,
 } from '@adobe/spacecat-shared-http-utils';
 import { AsyncJob } from '@adobe/spacecat-shared-data-access';
 import { ErrorWithStatusCode } from '../support/utils.js';
+import { loadJobScopedToCaller } from '../support/async-job-access.js';
 import { getHeader } from '../support/http-headers.js';
 import {
   MISSING_X_PROMISE_TOKEN_MESSAGE,
@@ -331,17 +332,33 @@ function PreflightController(ctx, log, env) {
     }
 
     try {
-      const job = await dataAccess.AsyncJob.findById(jobId);
+      // Scope the read to the caller: preflight-only jobType filter + ownership of
+      // the job's site. Without this, any caller with any job UUID could read
+      // another tenant's job (IDOR), including token-bearing job types.
+      const { job, error: accessError } = await loadJobScopedToCaller(ctx, {
+        jobId,
+        allowedJobTypes: ['preflight'],
+        resolveOwnerSiteId: (j) => j.getMetadata()?.payload?.siteId,
+      });
 
-      if (!job) {
-        log.error(`Job with ID ${jobId} not found`);
-        return notFound(`Job with ID ${jobId} not found`);
+      if (accessError) {
+        return accessError;
       }
 
-      log.debug(`getPreflightJobStatusAndResult returning job: ${JSON.stringify(job)}`);
+      // Never log the full job record — a token-bearing job's metadata could leak
+      // into logs and survive any response-level scoping.
+      log.debug(`getPreflightJobStatusAndResult jobId=${jobId} status=${job.getStatus()}`);
 
       // Emit the terminal-state observability log (shared with the Mystique path).
       logPreflightOutcome(log, PREFLIGHT_PROCESS_AUDW, job);
+
+      // Preflight-shaped metadata allowlist. Retains `metadata.payload` (a superset
+      // of what the ASO preflight MFE reads: payload.{step,reason,errorCode,...}),
+      // plus jobType/tags, but never any top-level token field (e.g. promiseToken).
+      // Preflight jobs carry no token — it travels on the SQS message, not the
+      // record — so returning the payload leaks nothing. Metadata is guaranteed
+      // present: loadJobScopedToCaller admitted this job by its metadata.jobType.
+      const metadata = job.getMetadata();
 
       return ok({
         jobId: job.getId(),
@@ -355,7 +372,11 @@ function PreflightController(ctx, log, env) {
         resultType: job.getResultType(),
         result: job.getResult(),
         error: job.getError(),
-        metadata: job.getMetadata(),
+        metadata: {
+          jobType: metadata.jobType,
+          tags: metadata.tags,
+          payload: metadata.payload,
+        },
       });
     } catch (error) {
       log.error(`Failed to get preflight job status: ${error.message}`);

--- a/src/controllers/site-detection.js
+++ b/src/controllers/site-detection.js
@@ -17,9 +17,10 @@ import {
   isValidUUID,
 } from '@adobe/spacecat-shared-utils';
 import {
-  accepted, badRequest, internalServerError, notFound, ok,
+  accepted, badRequest, internalServerError, ok,
 } from '@adobe/spacecat-shared-http-utils';
 import { AsyncJob } from '@adobe/spacecat-shared-data-access';
+import { loadJobScopedToCaller } from '../support/async-job-access.js';
 
 // RFC 1035 caps a fully-qualified domain name at 253 octets.
 const MAX_DOMAIN_LENGTH = 253;
@@ -170,11 +171,17 @@ function SiteDetectionController(ctx, log, env) {
     }
 
     try {
-      const job = await dataAccess.AsyncJob.findById(jobId);
+      // Scope the read to a site-detection job (jobType allowlist). site-detection
+      // jobs have no owning site (metadata carries { domain, hlxVersion }), so this
+      // hardens the reader against being used to fetch other job types (e.g.
+      // token-bearing serenity-classify jobs) through a shared AsyncJob table.
+      const { job, error: accessError } = await loadJobScopedToCaller(ctx, {
+        jobId,
+        allowedJobTypes: ['site-detection'],
+      });
 
-      if (!job) {
-        log.warn(`Job with ID ${jobId} not found`);
-        return notFound(`Job with ID ${jobId} not found`);
+      if (accessError) {
+        return accessError;
       }
 
       const result = job.getResult();

--- a/src/support/async-job-access.js
+++ b/src/support/async-job-access.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasText } from '@adobe/spacecat-shared-utils';
+import { notFound } from '@adobe/spacecat-shared-http-utils';
+import AccessControlUtil from './access-control-util.js';
+
+/**
+ * Loads an {@link AsyncJob} by id, scoped to the calling tenant, for the generic
+ * `GET .../jobs/:jobId` readers.
+ *
+ * `AsyncJob` is a single polymorphic table keyed only by a UUID: `findById` alone
+ * is an IDOR — any authenticated caller holding any job UUID can read any other
+ * tenant's job, including token-bearing job types (e.g. `serenity-classify-prompts`,
+ * which persists a live promise token on `metadata`). This primitive is the shared
+ * enforcement point that closes that exposure:
+ *
+ *  1. **jobType allowlist** — a job whose `metadata.jobType` is not in
+ *     `allowedJobTypes` is reported as *not found* (404), never revealing that a job
+ *     of a different type exists. An endpoint scoped to `['preflight']` therefore can
+ *     never be used to read a `serenity-classify-prompts` (token-bearing) job.
+ *  2. **owner scoping** — when `resolveOwnerSiteId` yields a siteId, the caller must
+ *     hold access to that site (the same org-membership check `site:read` routes
+ *     already enforce via {@link AccessControlUtil#hasAccess}). A caller without
+ *     access gets 404 (again, no existence disclosure). Job types with no owning
+ *     site (e.g. `site-detection`, whose metadata carries `{ domain, hlxVersion }`
+ *     and no siteId) omit the resolver and are scoped by jobType only.
+ *
+ * The caller projects a response DTO from the returned job — this primitive never
+ * returns raw metadata to the client.
+ *
+ * @param {object} context - The universal request context (dataAccess, attributes,
+ *   pathInfo). Also used to build the {@link AccessControlUtil}.
+ * @param {object} params
+ * @param {string} params.jobId - The AsyncJob UUID (already format-validated by the caller).
+ * @param {string[]} params.allowedJobTypes - Job types this endpoint may return.
+ * @param {(job: object) => (string|undefined)} [params.resolveOwnerSiteId] - Resolves the
+ *   owning siteId from the job; omit for ownerless job types.
+ * @returns {Promise<{ job?: object, error?: object }>} Exactly one of `job`
+ *   (authorized) or `error` (an HTTP response to return as-is).
+ */
+export async function loadJobScopedToCaller(context, {
+  jobId,
+  allowedJobTypes,
+  resolveOwnerSiteId,
+}) {
+  const { dataAccess, log } = context;
+
+  const job = await dataAccess.AsyncJob.findById(jobId);
+
+  const jobType = job?.getMetadata?.()?.jobType;
+  if (!job || !allowedJobTypes.includes(jobType)) {
+    // Do not disclose the existence of a job of a different type / another tenant.
+    return { error: notFound(`Job with ID ${jobId} not found`) };
+  }
+
+  const siteId = resolveOwnerSiteId ? resolveOwnerSiteId(job) : undefined;
+  if (hasText(siteId)) {
+    const site = await dataAccess.Site.findById(siteId);
+    if (!site) {
+      log?.warn?.(`[async-job-access] job ${jobId} references missing site ${siteId}; denying`);
+      return { error: notFound(`Job with ID ${jobId} not found`) };
+    }
+    const accessControlUtil = AccessControlUtil.fromContext(context);
+    if (!await accessControlUtil.hasAccess(site)) {
+      log?.warn?.(`[async-job-access] caller lacks access to site ${siteId} owning job ${jobId}; denying`);
+      return { error: notFound(`Job with ID ${jobId} not found`) };
+    }
+  }
+
+  return { job };
+}

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -71,6 +71,9 @@ describe('Preflight Controller', () => {
     save: sandbox.stub().resolves(),
   };
 
+  // A caller who belongs to the job's owning org (hasOrganization -> true), so the
+  // ownership check in loadJobScopedToCaller passes. Security tests below build a
+  // non-owner variant (hasOrganization -> false).
   const mockAuthInfo = {
     getProfile: () => ({
       email: 'user@example.com',
@@ -78,11 +81,17 @@ describe('Preflight Controller', () => {
       last_name: 'User',
       name: 'Test User',
     }),
+    getType: () => 'ims',
+    getScopes: () => [],
+    isAdmin: () => false,
+    isReadOnlyAdmin: () => false,
+    hasOrganization: () => true,
   };
 
   const mockSite = {
     getId: () => 'test-site-123',
     getOrganizationId: () => 'org-123',
+    getOrganization: () => ({ getImsOrgId: () => 'ims-org-123' }),
     getAuthoringType: () => SiteModel.AUTHORING_TYPES.SP,
     // Default site identity getters for the mock. Per-test AEM CS / EDS site
     // fixtures override as needed.
@@ -1422,6 +1431,110 @@ describe('Preflight Controller', () => {
       expect(result).to.deep.equal({
         message: 'Something went wrong',
       });
+    });
+
+    // ── SEC-5: cross-tenant credential-exposure (IDOR) regression tests ────────
+
+    it('returns 404 (not 200) for a non-preflight, token-bearing job and never leaks its token', async () => {
+      const PROMISE_TOKEN = 'SECRET-PROMISE-TOKEN-do-not-leak';
+      const serenityJob = {
+        getId: () => jobId,
+        getStatus: () => 'IN_PROGRESS',
+        getResult: () => null,
+        getError: () => null,
+        // A serenity-classify-prompts job persists a live promise token on metadata.
+        getMetadata: () => ({
+          jobType: 'serenity-classify-prompts',
+          promiseToken: PROMISE_TOKEN,
+          payload: { siteId: 'test-site-123' },
+        }),
+      };
+      mockDataAccess.AsyncJob.findById = sandbox.stub().resolves(serenityJob);
+      loggerStub.debug.resetHistory();
+      loggerStub.info.resetHistory();
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+
+      // Existence of a job of another type is not revealed.
+      expect(response.status).to.equal(404);
+      const body = await response.json();
+      expect(body).to.deep.equal({ message: `Job with ID ${jobId} not found` });
+
+      // The token appears in neither the response body nor any log line.
+      expect(JSON.stringify(body)).to.not.include(PROMISE_TOKEN);
+      const allLogArgs = [
+        ...loggerStub.debug.getCalls(),
+        ...loggerStub.info.getCalls(),
+        ...loggerStub.warn.getCalls(),
+        ...loggerStub.error.getCalls(),
+      ].map((c) => JSON.stringify(c.args)).join(' ');
+      expect(allLogArgs).to.not.include(PROMISE_TOKEN);
+    });
+
+    it('returns 404 for a preflight job owned by a different tenant (no cross-tenant read)', async () => {
+      const nonOwnerAuthInfo = {
+        getProfile: () => ({ email: 'attacker@example.com' }),
+        getType: () => 'ims',
+        getScopes: () => [],
+        isAdmin: () => false,
+        isReadOnlyAdmin: () => false,
+        hasOrganization: () => false, // not a member of the job's owning org
+      };
+      const nonOwnerController = PreflightController(
+        {
+          dataAccess: mockDataAccess,
+          sqs: mockSqs,
+          attributes: { authInfo: nonOwnerAuthInfo },
+          pathInfo: { headers: {} },
+        },
+        loggerStub,
+        { AUDIT_JOBS_QUEUE_URL: 'https://sqs.test.amazonaws.com/audit-queue', AWS_ENV: 'prod' },
+      );
+      mockDataAccess.AsyncJob.findById = sandbox.stub().resolves(mockJob);
+      mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
+
+      const context = { params: { jobId } };
+      const response = await nonOwnerController.getPreflightJobStatusAndResult(context);
+
+      expect(response.status).to.equal(404);
+      const body = await response.json();
+      expect(body).to.deep.equal({ message: `Job with ID ${jobId} not found` });
+    });
+
+    it('preserves metadata.payload.step for the legitimate preflight consumer (MFE contract)', async () => {
+      // Even if a token were ever present at the metadata top level, the DTO must
+      // never surface it; the MFE reads metadata.payload.{step,reason,errorCode}.
+      const jobWithToken = {
+        ...mockJob,
+        getMetadata: () => ({
+          jobType: 'preflight',
+          tags: ['preflight'],
+          promiseToken: 'should-never-be-returned',
+          payload: {
+            siteId: 'test-site-123',
+            urls: ['https://main--example-site.aem.page/test.html'],
+            step: 'suggest',
+            reason: 'user cancelled',
+            errorCode: 'CANCELLED',
+          },
+        }),
+      };
+      mockDataAccess.AsyncJob.findById = sandbox.stub().resolves(jobWithToken);
+      mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const body = await response.json();
+      // MFE contract fields survive.
+      expect(body.metadata.payload.step).to.equal('suggest');
+      expect(body.metadata.payload.reason).to.equal('user cancelled');
+      expect(body.metadata.payload.errorCode).to.equal('CANCELLED');
+      // Top-level token must not be echoed back.
+      expect(body.metadata.promiseToken).to.be.undefined;
+      expect(JSON.stringify(body)).to.not.include('should-never-be-returned');
     });
   });
 });

--- a/test/controllers/site-detection.test.js
+++ b/test/controllers/site-detection.test.js
@@ -43,6 +43,11 @@ describe('SiteDetectionController', () => {
     getUpdatedAt: sandbox.stub().returns('2025-01-01T00:00:01Z'),
     getResult: sandbox.stub().returns(null),
     getError: sandbox.stub().returns(null),
+    getMetadata: sandbox.stub().returns({
+      jobType: 'site-detection',
+      payload: { domain: 'www.example.com', hlxVersion: 5 },
+      tags: ['site-detection'],
+    }),
     remove: sandbox.stub().resolves(),
     setStatus: sandbox.stub(),
     setError: sandbox.stub(),
@@ -331,6 +336,27 @@ describe('SiteDetectionController', () => {
 
       const resp = await controller.getSiteDetectionJobStatus({ params: { jobId: JOB_ID } });
       expect(resp.status).to.equal(500);
+    });
+
+    // ── SEC-5: jobType scoping — this reader must not fetch other job types ─────
+    it('returns 404 for a non-site-detection (e.g. token-bearing) job and never leaks its metadata', async () => {
+      const PROMISE_TOKEN = 'SECRET-PROMISE-TOKEN-do-not-leak';
+      mockDataAccess.AsyncJob.findById.resolves({
+        getId: () => JOB_ID,
+        getStatus: () => 'IN_PROGRESS',
+        getResult: () => null,
+        getError: () => null,
+        getMetadata: () => ({
+          jobType: 'serenity-classify-prompts',
+          promiseToken: PROMISE_TOKEN,
+          payload: {},
+        }),
+      });
+
+      const resp = await controller.getSiteDetectionJobStatus({ params: { jobId: JOB_ID } });
+      expect(resp.status).to.equal(404);
+      const body = await resp.json();
+      expect(JSON.stringify(body)).to.not.include(PROMISE_TOKEN);
     });
   });
 });

--- a/test/support/async-job-access.test.js
+++ b/test/support/async-job-access.test.js
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+
+import { loadJobScopedToCaller } from '../../src/support/async-job-access.js';
+
+use(sinonChai);
+
+describe('loadJobScopedToCaller', () => {
+  const sandbox = sinon.createSandbox();
+  const jobId = '123e4567-e89b-12d3-a456-426614174000';
+  const siteId = 'test-site-123';
+
+  const makeJob = (metadata) => ({
+    getId: () => jobId,
+    getMetadata: () => metadata,
+  });
+
+  const makeSite = () => ({
+    getId: () => siteId,
+    getOrganization: () => ({ getImsOrgId: () => 'ims-org-123' }),
+  });
+
+  // A caller who belongs to the owning org.
+  const ownerAuthInfo = {
+    getProfile: () => ({ email: 'user@example.com' }),
+    getType: () => 'ims',
+    getScopes: () => [],
+    isAdmin: () => false,
+    isReadOnlyAdmin: () => false,
+    hasOrganization: () => true,
+  };
+
+  const makeContext = (overrides = {}) => ({
+    log: {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    },
+    attributes: { authInfo: ownerAuthInfo },
+    pathInfo: { method: 'GET', suffix: `/preflight/jobs/${jobId}`, headers: {} },
+    dataAccess: {
+      AsyncJob: { findById: sandbox.stub() },
+      Site: { findById: sandbox.stub() },
+    },
+    ...overrides,
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('returns the job when jobType matches and caller owns the site', async () => {
+    const context = makeContext();
+    const job = makeJob({ jobType: 'preflight', payload: { siteId } });
+    context.dataAccess.AsyncJob.findById.resolves(job);
+    context.dataAccess.Site.findById.resolves(makeSite());
+
+    const result = await loadJobScopedToCaller(context, {
+      jobId,
+      allowedJobTypes: ['preflight'],
+      resolveOwnerSiteId: (j) => j.getMetadata().payload.siteId,
+    });
+
+    expect(result.job).to.equal(job);
+    expect(result.error).to.be.undefined;
+  });
+
+  it('returns 404 when the job does not exist', async () => {
+    const context = makeContext();
+    context.dataAccess.AsyncJob.findById.resolves(null);
+
+    const result = await loadJobScopedToCaller(context, {
+      jobId,
+      allowedJobTypes: ['preflight'],
+      resolveOwnerSiteId: () => siteId,
+    });
+
+    expect(result.job).to.be.undefined;
+    expect(result.error.status).to.equal(404);
+  });
+
+  it('returns 404 (no existence disclosure) when the jobType is not allowed', async () => {
+    const context = makeContext();
+    // A token-bearing job of another type must be indistinguishable from "not found".
+    context.dataAccess.AsyncJob.findById.resolves(
+      makeJob({ jobType: 'serenity-classify-prompts', promiseToken: 'SECRET', payload: { siteId } }),
+    );
+
+    const result = await loadJobScopedToCaller(context, {
+      jobId,
+      allowedJobTypes: ['preflight'],
+      resolveOwnerSiteId: (j) => j.getMetadata().payload.siteId,
+    });
+
+    expect(result.job).to.be.undefined;
+    expect(result.error.status).to.equal(404);
+    // The site lookup / access check must never run for a disallowed type.
+    expect(context.dataAccess.Site.findById).to.not.have.been.called;
+  });
+
+  it('returns 404 when the caller does not own the job\'s site', async () => {
+    const nonOwner = { ...ownerAuthInfo, hasOrganization: () => false };
+    const context = makeContext({ attributes: { authInfo: nonOwner } });
+    context.dataAccess.AsyncJob.findById.resolves(makeJob({ jobType: 'preflight', payload: { siteId } }));
+    context.dataAccess.Site.findById.resolves(makeSite());
+
+    const result = await loadJobScopedToCaller(context, {
+      jobId,
+      allowedJobTypes: ['preflight'],
+      resolveOwnerSiteId: (j) => j.getMetadata().payload.siteId,
+    });
+
+    expect(result.job).to.be.undefined;
+    expect(result.error.status).to.equal(404);
+  });
+
+  it('returns 404 when the resolved site no longer exists', async () => {
+    const context = makeContext();
+    context.dataAccess.AsyncJob.findById.resolves(makeJob({ jobType: 'preflight', payload: { siteId } }));
+    context.dataAccess.Site.findById.resolves(null);
+
+    const result = await loadJobScopedToCaller(context, {
+      jobId,
+      allowedJobTypes: ['preflight'],
+      resolveOwnerSiteId: (j) => j.getMetadata().payload.siteId,
+    });
+
+    expect(result.error.status).to.equal(404);
+  });
+
+  it('scopes by jobType only (no ownership) when no resolver is supplied', async () => {
+    const context = makeContext();
+    const job = makeJob({ jobType: 'site-detection', payload: { domain: 'www.example.com' } });
+    context.dataAccess.AsyncJob.findById.resolves(job);
+
+    const result = await loadJobScopedToCaller(context, {
+      jobId,
+      allowedJobTypes: ['site-detection'],
+    });
+
+    expect(result.job).to.equal(job);
+    // Ownerless job types never touch the Site table or the access-control layer.
+    expect(context.dataAccess.Site.findById).to.not.have.been.called;
+  });
+
+  it('skips the ownership check when the resolver returns no siteId', async () => {
+    const context = makeContext();
+    const job = makeJob({ jobType: 'site-detection', payload: {} });
+    context.dataAccess.AsyncJob.findById.resolves(job);
+
+    const result = await loadJobScopedToCaller(context, {
+      jobId,
+      allowedJobTypes: ['site-detection'],
+      resolveOwnerSiteId: (j) => j.getMetadata().payload.siteId, // undefined
+    });
+
+    expect(result.job).to.equal(job);
+    expect(context.dataAccess.Site.findById).to.not.have.been.called;
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

Security fix for SEC-5: a shared `loadJobScopedToCaller` primitive that scopes the two generic `AsyncJob` HTTP readers (`GET /preflight/jobs/:jobId` and `GET /sites/detect/jobs/:jobId`) to the calling tenant, and a preflight response DTO that replaces the previously-verbatim job metadata.

## 2. Reasoning

`GET /preflight/jobs/:jobId` did an unscoped `AsyncJob.findById(jobId)` with no ownership check and no jobType filter, returned `metadata` verbatim, and logged the whole record via `JSON.stringify(job)`. `AsyncJob` is a single polymorphic table keyed only by a UUID, and the `serenity-classify-prompts` job persists a live Semrush promise token on `AsyncJob.metadata`. So any authenticated caller holding any job UUID could read another tenant's token-bearing job metadata — a usable delegated credential, a live cross-tenant exposure (IDOR) in production today. This is the standalone SEC-5 fix (issue #3203), to land independently and ahead of any promise-token-bearing job type shipping onto the endpoint.

## 3. High-level overview of the changes

New shared primitive `loadJobScopedToCaller` (`src/support/async-job-access.js`) that every generic `AsyncJob` reader routes through:

- **jobType allowlist** — a job whose `metadata.jobType` is not in `allowedJobTypes` is reported **404**, never disclosing that a job of another type exists. An endpoint scoped to `['preflight']` can therefore never return a token-bearing `serenity-classify-prompts` job.
- **owner scoping** — when the job resolves an owning `siteId`, the caller must hold access to that site, enforced with the same `site:read` org-membership check (`AccessControlUtil.hasAccess`) the route already requires. No access → 404 (no existence disclosure).

Behaviour deltas:

- **`GET /preflight/jobs/:jobId`** — before: returned any job by UUID with `metadata` verbatim and logged the full record. After: preflight-only + owner-scoped; the response `metadata` is a preflight-shaped allowlist that retains `metadata.payload` (a superset of the ASO preflight MFE contract) plus `jobType`/`tags`, but never a top-level token field. The `JSON.stringify(job)` debug log is replaced with a `jobId` + `status` line (a token in a log survives response-level scoping).
- **`GET /sites/detect/jobs/:jobId`** — aligned onto the same primitive with `allowedJobTypes: ['site-detection']`. These jobs have no owning site (metadata is `{ domain, hlxVersion }`), so this is jobType-scoped hardening/de-duplication — the response shape is unchanged.

Why the one legitimate consumer is unaffected: the ASO preflight MFE (`aem-sites-optimizer-preflight-mfe`, `pollPreflightJob`) reads `metadata.payload.step` every poll, `metadata.payload.{reason,errorCode}` on cancel, plus `status`, `result`, `error.message`, `jobId`, and its `PreflightJobMetadata` type reads `jobType`/`tags`/`payload.{siteId,urls,step,reason,errorCode,checks}` — all retained by the DTO. A preflight job carries no token (it travels on the SQS message, not the record), so keeping `metadata.payload` leaks nothing, and the MFE polls its own same-org job so the ownership check admits it.

## 4. Required information

- Jira / issue: [adobe/spacecat-api-service#3203](https://github.com/adobe/spacecat-api-service/issues/3203) (Fixes #3203)

## 5. Affected / used mysticat-workspace projects

- `aem-sites-optimizer-preflight-mfe` — runtime **consumer / contract**. The sole legitimate caller of `GET /preflight/jobs/:jobId`; this PR preserves the `metadata.payload.*` fields it reads, so no MFE change is required. A follow-up regression fixture there (Phase 5) is tracked in #3203.

## 6. Additional information outside the code

- Verified the consumer contract by reading `aem-sites-optimizer-preflight-mfe/src/services/spacecatService.ts` (`pollPreflightJob` and the `PreflightJobMetadata` type) in the local OneAdobe checkout: it reads `status`, `result`, `error.message`, `jobId`, `metadata.jobType`, `metadata.tags`, and `metadata.payload.{siteId,urls,step,reason,errorCode,checks}` — all present in the new DTO (superset).
- Re-verified every anchor against `origin/main` before editing (the issue warned line numbers had drifted): the unscoped `findById`, the verbatim `metadata` return, and the `JSON.stringify(job)` log were confirmed by symbol grep, not by the issue's line numbers.

## 7. Test plan

- Automated coverage was added for the exposure and the consumer contract (unit tests for the primitive; controller regression tests asserting a non-preflight token-bearing job returns 404 with no token in the response body or any log line, a cross-tenant preflight job returns 404, and the MFE fields `metadata.payload.{step,reason,errorCode}` survive). CI runs these.
- Per-environment verification once deployed:
  - **dev/stage**: as a caller with access to a site, `GET /preflight/jobs/:jobId` for that site's preflight job returns 200 with `metadata.payload.step` present; confirm the ASO preflight MFE polls a preflight run to completion unchanged.
  - **dev/stage**: `GET /preflight/jobs/:jobId` for a job owned by a different org returns 404; `GET /preflight/jobs/:jobId` against a non-preflight (e.g. serenity-classify) job UUID returns 404 and no promise token appears in the response or in Splunk logs for that request.

## Follow-ups (out of scope)

- **Phase 4** — make `AUTOFIX_CRYPT_SECRET` / `AUTOFIX_CRYPT_SALT` an enable-time precondition for token-bearing job types, so a promise token is never persisted in plaintext (defense-in-depth).
- **Phase 5** — MFE regression fixture in `OneAdobe/aem-sites-optimizer-preflight-mfe` asserting `metadata.payload.step` survives the DTO (different repo).
- A dedicated serenity/Semrush-market scoped status route is only needed when that feature ships.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "Security IDOR fix scoping two AsyncJob readers to the caller (jobType allowlist + existing site:read ownership) and removing an unsafe full-job log. A security-boundary change, but it only tightens access, is CI/test/review-gated, and is fully reversible by redeploying the previous release; the sole legitimate consumer (ASO preflight MFE) contract is preserved via a superset DTO and covered by tests."
recommendations: "After deploy, watch for a spike in 404s on GET /preflight/jobs/:jobId (would indicate the ownership check is over-blocking legitimate polling) and confirm the ASO preflight MFE still polls to completion."
backout: "Redeploy the previous release."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
