### PR TITLE
fix(plg-onboard): only treat a 401 as auth when WWW-Authenticate is present

### DIFF
--- a/src/support/detect-auth-wall.js
+++ b/src/support/detect-auth-wall.js
@@ -21,9 +21,11 @@
  *
  * The classifier is deliberately HIGH-PRECISION: a false positive waitlists a legitimate
  * public customer, which is worse than missing an edge case. We only flag on a strong
- * signal — an explicit 401, a front door that resolves to a login/SSO URL or IdP host, or
- * a landing page that is unambiguously a login form (password field + a login title/URL).
- * A public homepage with an incidental account/login widget is NOT flagged.
+ * signal — a 401 carrying a WWW-Authenticate header (genuine HTTP auth, not a bare WAF/bot
+ * 401), a front door that resolves to a login/SSO URL or IdP host, or a landing page that is
+ * unambiguously a login form (password field + a login title/URL). A public homepage with an
+ * incidental account/login widget, or a bot-protection 401 without WWW-Authenticate, is NOT
+ * flagged.
  *
  * SSRF guard: the front door is fetched with redirects followed MANUALLY, and every hop's
  * host is validated with `isSafeDomain()` before it is requested. A public domain under
@@ -183,7 +185,11 @@ export async function detectAuthWall({ baseUrl, log }, { fetch = globalThis.fetc
     const { response, finalUrl } = probe;
     const status = response.status ?? null;
 
-    if (status === 401) {
+    // A 401 is only a genuine auth wall when it carries WWW-Authenticate (RFC 7235 requires the
+    // header for HTTP authentication). WAF/bot protection (e.g. Akamai) returns a bare 401 with
+    // no such header to non-browser clients — that is a bot block, not a login wall (real users
+    // pass), so it must NOT be treated as authenticated.
+    if (status === 401 && response.headers?.get?.('www-authenticate')) {
       return {
         authenticated: true, signal: 'status-401', finalUrl, status,
       };

--- a/test/support/detect-auth-wall.test.js
+++ b/test/support/detect-auth-wall.test.js
@@ -36,7 +36,9 @@ describe('detectAuthWall', () => {
       const r = routes[url] || routes.default || {};
       const location = r.location ?? null;
       const contentType = r.contentType ?? 'text/html';
-      const headers = { location, 'content-type': contentType };
+      const headers = {
+        location, 'content-type': contentType, 'www-authenticate': r.wwwAuthenticate ?? null,
+      };
       return {
         status: r.status ?? 200,
         url,
@@ -57,11 +59,24 @@ describe('detectAuthWall', () => {
     sandbox.restore();
   });
 
-  it('flags a 401 response as authenticated', async () => {
-    const fetch = routedFetch(sandbox, { 'https://example.com': { status: 401 } });
+  it('flags a 401 with a WWW-Authenticate header (genuine HTTP auth) as authenticated', async () => {
+    const fetch = routedFetch(sandbox, {
+      'https://example.com': { status: 401, wwwAuthenticate: 'Basic realm="Restricted"' },
+    });
     const result = await detectAuthWall({ baseUrl: 'https://example.com', log }, { fetch });
     expect(result.authenticated).to.equal(true);
     expect(result.signal).to.equal('status-401');
+  });
+
+  it('does NOT flag a 401 without WWW-Authenticate (WAF/bot block, e.g. Akamai)', async () => {
+    // Akamai and similar WAFs return 401 to non-browser clients with NO WWW-Authenticate header
+    // and a tiny "unauthorized" block page. That is a bot block, not an auth wall — real users
+    // pass. Only a 401 carrying WWW-Authenticate (RFC 7235) is genuine HTTP authentication.
+    const body = '<html><head><title>unauthorized</title></head><body></body></html>';
+    const fetch = routedFetch(sandbox, { 'https://example.com': { status: 401, body } });
+    const result = await detectAuthWall({ baseUrl: 'https://example.com', log }, { fetch });
+    expect(result.authenticated).to.equal(false);
+    expect(result.signal).to.equal(null);
   });
 
   it('flags a front door that redirects to a login URL as authenticated', async () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Tightens PLG auth-wall detection so a `401` only counts as a login wall when it carries a `WWW-Authenticate` header. Follow-up to the merged auth-wall detection work (SITES-47346, PR https://github.com/adobe/spacecat-api-service/pull/3142).

## 2. Reasoning
The shipped `detectAuthWall` probe flagged **any** `401` as an auth wall. WAF/bot protection — Akamai in particular — returns a bare `401` (no `WWW-Authenticate` header, a tiny "unauthorized" block page) to non-browser clients while real users pass. Since auth-detected sites are now **rejected** at onboarding, such a site is wrongly rejected. This was found while scanning already-onboarded PLG sites for auth walls: `www.msccruises.co.uk` — a legitimate public site already onboarded — came back "authenticated" purely on an Akamai `401`.

## 3. High-level overview of the changes
- The `status-401` signal now requires a `WWW-Authenticate` response header. RFC 7235 mandates that header for genuine HTTP authentication, so its presence distinguishes a real auth challenge (Basic/Bearer/Negotiate) from a WAF/bot block. A bare `401` with no such header falls through to the other signals (login-URL / IdP-host / login-form) and, absent those, is treated as public.
- No other signal changes; the SSRF-safe manual redirect following and URL sanitization are untouched. A genuine HTTP-auth `401` is still detected; a bot-protection `401` is not.

## 4. Required information
- Jira / issue: [SITES-47346](https://jira.corp.adobe.com/browse/SITES-47346)

## 7. Additional information outside the code
Verified live with the real (updated) probe:
- `www.msccruises.co.uk` → **public** now (returns `401` from Akamai with `set-cookie: AKA_A2` / `akamai-grn` and **no** `WWW-Authenticate`; body `<title>unauthorized</title>`). Previously mis-flagged.
- `sampoornanxt.tatasteel.com` → still **authenticated** via `login-url` (redirect to `/sampoorna/login.html`) — unaffected.
- `httpbin.org/basic-auth/user/pass` (real `HTTP 401` + `WWW-Authenticate: Basic realm="Fake Realm"`) → still **authenticated** via `status-401`.
- `www.adobe.com` → public (control).

## 8. Test plan
(a) Unit: added a case for a bot/WAF `401` **without** `WWW-Authenticate` (not flagged) and updated the genuine-auth case to send `WWW-Authenticate` (flagged); plus the live checks above. (b) Per-environment: onboarding a real site fronted by Akamai/WAF that `401`s our crawler should now proceed on the auth-wall basis (no longer rejected as authenticated) — the bot-blocker step still governs true crawl blocks. A site behind real HTTP Basic/Bearer auth, or one that redirects to a login/SSO page, is still detected and rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Tightens an onboarding heuristic for classifying external sites; not an access-control change to our own system, reversible by redeploy."
```