### PR TITLE
fix(deps): bump @adobe/spacecat-shared-drs-client to 1.15.1 (LLMO-7366)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
         "@adobe/spacecat-shared-content-client": "1.10.0",
         "@adobe/spacecat-shared-data-access": "4.28.0",
-        "@adobe/spacecat-shared-drs-client": "1.14.0",
+        "@adobe/spacecat-shared-drs-client": "1.15.1",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
         "@adobe/spacecat-shared-http-utils": "1.36.0",
         "@adobe/spacecat-shared-ims-client": "1.16.0",
@@ -4149,7 +4149,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-drs-client": {
-      "version": "1.14.0",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.15.1.tgz",
+      "integrity": "sha512-fL7f+u19RRyvos/ZEwziWyt+hCAVNFPxkjGPpInAMldB9R31zAnlC9tFkaG1wFNBxy5FIDRyjojqkcQPtv9UFQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@adobe/spacecat-shared-cloudflare-client": "1.3.0",
     "@adobe/spacecat-shared-content-client": "1.10.0",
     "@adobe/spacecat-shared-data-access": "4.28.0",
-    "@adobe/spacecat-shared-drs-client": "1.14.0",
+    "@adobe/spacecat-shared-drs-client": "1.15.1",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
     "@adobe/spacecat-shared-http-utils": "1.36.0",
     "@adobe/spacecat-shared-ims-client": "1.16.0",

--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -2866,8 +2866,6 @@ function BrandsController(ctx, log, env) {
             siteId: baseSiteId,
             brandId: brandUuid,
             orgId: spaceCatId,
-            // @ts-ignore tier not yet in the published drs-client type; pending the
-            // release of the spacecat-shared companion fix (LLMO-7366, PR #1915)
             tier: isPaying ? 'PAID' : 'FREE_TRIAL',
           });
           scheduleId = schedule?.scheduleId;


### PR DESCRIPTION
## Summary
- Activates client-side tier-aware platform filtering for the activate-brand route. PR #3206 (already merged) resolves and passes `tier` on schedule creation, but the previously-pinned `1.14.0` client silently drops unknown fields, so the filtering never actually took effect — DRS's own server-side guard was covering the gap in the meantime.
- Verified the full version delta between `1.14.0` and `1.15.1`: exactly two changes — the tier-aware fail-safe fix itself (spacecat-shared #1915) and a purely-additive `updateSchedule`/`disableSchedule` method pair (spacecat-shared #1908) that this repo doesn't call. No existing method's signature or behavior changed.
- Removed the now-unnecessary `@ts-ignore` on the `tier` field (the published type now declares it: `tier?: string`). Left the two pre-existing, unrelated stale `@ts-ignore`s on the same call alone — out of scope for a dependency bump.

## Test plan
- [x] Full unit suite (`npm test`): 18103 passing, 0 failing
- [x] `npm run type-check`: clean
- [x] `npx eslint src/controllers/brands.js`: clean
- [x] Targeted rerun (`test/controllers/brands.test.js`, `test/support/prompt-suggestion-schedules.test.js`, `test/controllers/llmo/llmo-onboarding.test.js`): 647 passing

Introduced by: N/A